### PR TITLE
wcprof: experimental wall-clock profiler + counterfactual bottleneck analyzer

### DIFF
--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
@@ -81,10 +83,52 @@ func setupDebugHandlers(addr string, eng *server.Server) error {
 			logrus.WithError(err).Warn("failed streaming dagql cache debug snapshot")
 		}
 	}))
+	// Engine-global profiling toggle: GET reports state, POST "on"/"off"
+	// (or any strconv.ParseBool value) flips it. Disabling keeps buffered
+	// events dumpable and does not stop sessions that opted in via --profile.
+	m.Handle("/debug/wcprof/enabled", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPost {
+			body, err := io.ReadAll(io.LimitReader(req.Body, 64))
+			if err != nil {
+				http.Error(rw, err.Error(), http.StatusBadRequest)
+				return
+			}
+			val := strings.TrimSpace(string(body))
+			if val == "" {
+				val = req.URL.Query().Get("v")
+			}
+			var on bool
+			switch strings.ToLower(val) {
+			case "on":
+				on = true
+			case "off":
+				on = false
+			default:
+				var err error
+				on, err = strconv.ParseBool(val)
+				if err != nil {
+					http.Error(rw, fmt.Sprintf("POST body must be on/off or a boolean, got %q", val), http.StatusBadRequest)
+					return
+				}
+			}
+			if on {
+				wcprof.EnableGlobal()
+				logrus.Info("wcprof global recording enabled via debug endpoint")
+			} else {
+				wcprof.DisableGlobal()
+				logrus.Info("wcprof global recording disabled via debug endpoint")
+			}
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(rw).Encode(map[string]bool{ //nolint:errcheck,errchkjson
+			"global_enabled":  wcprof.GloballyEnabled(),
+			"recorder_active": wcprof.Active() != nil,
+		})
+	}))
 	m.Handle("/debug/wcprof/dump", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rec := wcprof.Active()
 		if rec == nil {
-			http.Error(rw, "wcprof not enabled (connect a client with --profile or set _DAGGER_WCPROF=1)", http.StatusServiceUnavailable)
+			http.Error(rw, "wcprof was never enabled (POST 'on' to /debug/wcprof/enabled, connect a client with --profile, start the engine with --wcprof, or set _DAGGER_WCPROF=1)", http.StatusServiceUnavailable)
 			return
 		}
 		// flush by default; pass ?flush=0 to keep events buffered

--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/dagger/dagger/engine/server"
+	"github.com/dagger/dagger/engine/wcprof"
 )
 
 func setupDebugHandlers(addr string, eng *server.Server) error {
@@ -78,6 +79,19 @@ func setupDebugHandlers(addr string, eng *server.Server) error {
 		rw.Header().Set("Content-Type", "application/json")
 		if err := eng.WriteDagqlCacheDebugSnapshot(rw); err != nil {
 			logrus.WithError(err).Warn("failed streaming dagql cache debug snapshot")
+		}
+	}))
+	m.Handle("/debug/wcprof/dump", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rec := wcprof.Active()
+		if rec == nil {
+			http.Error(rw, "wcprof not enabled (connect a client with --profile or set _DAGGER_WCPROF=1)", http.StatusServiceUnavailable)
+			return
+		}
+		// flush by default; pass ?flush=0 to keep events buffered
+		flush := req.URL.Query().Get("flush") != "0"
+		rw.Header().Set("Content-Type", "application/x-ndjson")
+		if err := rec.WriteDump(rw, flush); err != nil {
+			logrus.WithError(err).Warn("failed streaming wcprof dump")
 		}
 	}))
 

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/dagger/dagger/engine/engineutil/cacerts"
 	"github.com/dagger/dagger/engine/server"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/dagger/dagger/network"
 	"github.com/dagger/dagger/network/netinst"
 	telemetry "github.com/dagger/otel-go"
@@ -160,6 +161,11 @@ func addFlags(app *cli.App) {
 		cli.BoolFlag{
 			Name:  "extra-debug",
 			Usage: "enable extra debug output in logs",
+		},
+		cli.BoolFlag{
+			Name:   "wcprof",
+			Usage:  "enable experimental wall-clock profiling for all work on the engine (also enabled by the _DAGGER_WCPROF env var; toggleable at runtime via the /debug/wcprof/enabled debug endpoint)",
+			Hidden: true,
 		},
 		cli.BoolFlag{
 			Name:  "trace",
@@ -312,6 +318,10 @@ func main() { //nolint:gocyclo
 	app.Action = func(c *cli.Context) error {
 		bklog.G(ctx).Info("starting dagger engine version:", engineVersion)
 		defer cancel(errors.New("main done"))
+
+		if c.GlobalBool("wcprof") {
+			wcprof.EnableGlobal()
+		}
 		// TODO: On Windows this always returns -1. The actual "are you admin" check is very Windows-specific.
 		// See https://github.com/golang/go/issues/28804#issuecomment-505326268 for the "short" version.
 		if os.Geteuid() > 0 {

--- a/cmd/wcprof-analyze/main.go
+++ b/cmd/wcprof-analyze/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -29,8 +30,9 @@ func main() {
 	)
 	flag.Parse()
 
-	if flag.NArg() != 1 {
-		fmt.Fprintf(os.Stderr, "usage: wcprof-analyze [flags] <dump-file>\n")
+	if flag.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "usage: wcprof-analyze [flags] <dump-file> [more-dump-files...]\n")
+		fmt.Fprintf(os.Stderr, "multiple dumps from periodic drains of the same engine run are merged\n")
 		flag.PrintDefaults()
 		os.Exit(2)
 	}
@@ -45,7 +47,7 @@ func main() {
 		factors = append(factors, f)
 	}
 
-	if err := run(flag.Arg(0), wcanalyze.ReportOptions{
+	if err := run(flag.Args(), wcanalyze.ReportOptions{
 		TopClasses:     *topClasses,
 		WhatIfFactors:  factors,
 		MinClassSelfNS: int64(*minSelf),
@@ -57,16 +59,20 @@ func main() {
 	}
 }
 
-func run(path string, opts wcanalyze.ReportOptions) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
+func run(paths []string, opts wcanalyze.ReportOptions) error {
+	readers := make([]io.Reader, 0, len(paths))
+	for _, path := range paths {
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		readers = append(readers, f)
 	}
-	defer f.Close()
 
-	graph, err := wcanalyze.Load(f)
+	graph, err := wcanalyze.LoadMulti(readers)
 	if err != nil {
-		return fmt.Errorf("load dump: %w", err)
+		return fmt.Errorf("load dumps: %w", err)
 	}
 	return wcanalyze.WriteReport(os.Stdout, graph, opts)
 }

--- a/cmd/wcprof-analyze/main.go
+++ b/cmd/wcprof-analyze/main.go
@@ -1,0 +1,72 @@
+// wcprof-analyze reads a wcprof dump (from the engine's /debug/wcprof/dump
+// endpoint) and reports wall-clock bottleneck analysis: per-class self time,
+// counterfactual what-if rankings, blocking chains, and dead air.
+//
+// Usage:
+//
+//	curl -s http://localhost:6060/debug/wcprof/dump > /tmp/wcprof.dump
+//	go run ./cmd/wcprof-analyze /tmp/wcprof.dump
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dagger/dagger/engine/wcprof/wcanalyze"
+)
+
+func main() {
+	var (
+		topClasses = flag.Int("top", 30, "number of classes to show in rankings")
+		factorsStr = flag.String("factors", "0,0.5,0.9", "comma-separated self-time scaling factors for what-if simulation")
+		minSelf    = flag.Duration("min-self", time.Millisecond, "ignore classes with less total self-time than this in what-ifs")
+		deadAirMin = flag.Duration("dead-air-min", 50*time.Millisecond, "minimum gap to report as dead air")
+		chainDepth = flag.Int("chain-depth", 25, "max length of the blocking chain to print")
+	)
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "usage: wcprof-analyze [flags] <dump-file>\n")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	var factors []float64
+	for _, part := range strings.Split(*factorsStr, ",") {
+		f, err := strconv.ParseFloat(strings.TrimSpace(part), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid factor %q: %v\n", part, err)
+			os.Exit(2)
+		}
+		factors = append(factors, f)
+	}
+
+	if err := run(flag.Arg(0), wcanalyze.ReportOptions{
+		TopClasses:     *topClasses,
+		WhatIfFactors:  factors,
+		MinClassSelfNS: int64(*minSelf),
+		DeadAirMinNS:   int64(*deadAirMin),
+		ChainDepth:     *chainDepth,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(path string, opts wcanalyze.ReportOptions) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	graph, err := wcanalyze.Load(f)
+	if err != nil {
+		return fmt.Errorf("load dump: %w", err)
+	}
+	return wcanalyze.WriteReport(os.Stdout, graph, opts)
+}

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/dagger/dagger/network"
 	telemetry "github.com/dagger/otel-go"
 	"go.opentelemetry.io/otel/trace"
@@ -590,7 +591,9 @@ func lockMountedCaches(ctx context.Context, mounts []ContainerMount) (func(), er
 	}
 	sort.Strings(lockKeys)
 	for _, lockKey := range lockKeys {
+		profWait := wcprof.BeginWaitIdent(ctx, "cachelock:"+lockKey, wcprof.WaitReasonLock)
 		locker.Lock(lockKey)
+		profWait.End()
 	}
 	return func() {
 		for i := len(lockKeys) - 1; i >= 0; i-- {
@@ -1576,6 +1579,8 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			return fmt.Errorf("failed to prepare mounts: %w", err)
 		}
 
+		profPrepareStartNS := wcprof.NowNS()
+
 		rootState := &execMountState{
 			Dest:        pb.RootMount,
 			Selector:    "/",
@@ -1728,6 +1733,10 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		sort.Slice(execMounts, func(i, j int) bool {
 			return execMounts[i].Dest < execMounts[j].Dest
 		})
+
+		if wcprof.Active() != nil {
+			wcprof.RecordOp(ctx, wcprof.OpKindExecPhase, "withExec.prepareMounts", wcprof.OpOpts{}, profPrepareStartNS, wcprof.NowNS(), wcprof.OutcomeOK)
+		}
 
 		defer func() {
 			_ = releaseActives()
@@ -2108,6 +2117,11 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			)
 		}()
 
+		// NB: no explicit wcprof wait is recorded for the exec itself: the
+		// executor's exec.run op is a child of the current op (ctx flows into
+		// the goroutine), which both subtracts it from self-time and gives
+		// the replay an exact join. Ident-based waits were tried first and
+		// can mis-resolve when call digests are shared across execs.
 		var execErr error
 		select {
 		case execErr = <-execErrCh:
@@ -2154,8 +2168,17 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		if invalidateErr != nil {
 			return invalidateErr
 		}
-		if err := applyOutputs(); err != nil {
-			return err
+		profApplyStartNS := wcprof.NowNS()
+		applyErr := applyOutputs()
+		if wcprof.Active() != nil {
+			outcome := wcprof.OutcomeOK
+			if applyErr != nil {
+				outcome = wcprof.OutcomeError
+			}
+			wcprof.RecordOp(ctx, wcprof.OpKindExecPhase, "withExec.applyOutputs", wcprof.OpOpts{}, profApplyStartNS, wcprof.NowNS(), outcome)
+		}
+		if applyErr != nil {
+			return applyErr
 		}
 
 		container.Lazy = nil

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -590,8 +590,12 @@ func lockMountedCaches(ctx context.Context, mounts []ContainerMount) (func(), er
 		lockKeys = append(lockKeys, lockKey)
 	}
 	sort.Strings(lockKeys)
+	profiling := wcprof.Enabled(ctx)
 	for _, lockKey := range lockKeys {
-		profWait := wcprof.BeginWaitIdent(ctx, "cachelock:"+lockKey, wcprof.WaitReasonLock)
+		var profWait *wcprof.Wait
+		if profiling {
+			profWait = wcprof.BeginWaitIdent(ctx, "cachelock:"+lockKey, wcprof.WaitReasonLock)
+		}
 		locker.Lock(lockKey)
 		profWait.End()
 	}
@@ -1734,7 +1738,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			return execMounts[i].Dest < execMounts[j].Dest
 		})
 
-		if wcprof.Active() != nil {
+		if wcprof.Enabled(ctx) {
 			wcprof.RecordOp(ctx, wcprof.OpKindExecPhase, "withExec.prepareMounts", wcprof.OpOpts{}, profPrepareStartNS, wcprof.NowNS(), wcprof.OutcomeOK)
 		}
 
@@ -2170,7 +2174,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		}
 		profApplyStartNS := wcprof.NowNS()
 		applyErr := applyOutputs()
-		if wcprof.Active() != nil {
+		if wcprof.Enabled(ctx) {
 			outcome := wcprof.OutcomeOK
 			if applyErr != nil {
 				outcome = wcprof.OutcomeError

--- a/core/services.go
+++ b/core/services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/dagger/dagger/internal/buildkit/util/bklog"
 	"github.com/dagger/dagger/network"
@@ -51,6 +52,10 @@ type startingService struct {
 
 	done chan struct{}
 	err  error
+
+	// profOpID is the wcprof op for this service start, when profiling is
+	// enabled. Waiters record wait events against it.
+	profOpID uint64
 }
 
 // RunningService represents a service that is actively running.
@@ -328,10 +333,13 @@ func (ss *Services) Get(ctx context.Context, dig digest.Digest, clientSpecific b
 		case isRunning:
 			return running, nil
 		case isStarting:
+			profWait := wcprof.BeginWait(ctx, starting.profOpID, wcprof.WaitReasonService)
 			select {
 			case <-ctx.Done():
+				profWait.End()
 				return nil, context.Cause(ctx)
 			case <-starting.done:
+				profWait.End()
 			}
 		default:
 			return nil, notRunningErr
@@ -944,11 +952,14 @@ func (ss *Services) startWithKey(
 			suppress(starting.running)
 			ss.l.Unlock()
 			starting.running.addOriginSpanContexts(opts.OriginSpanContexts)
+			profWait := wcprof.BeginWait(ctx, starting.profOpID, wcprof.WaitReasonService)
 			select {
 			case <-ctx.Done():
+				profWait.End()
 				releaseSuppression()
 				return nil, nil, context.Cause(ctx)
 			case <-starting.done:
+				profWait.End()
 			}
 		default:
 			running := &RunningService{
@@ -958,11 +969,18 @@ func (ss *Services) startWithKey(
 			running.addOriginSpanContexts(opts.OriginSpanContexts)
 			suppress(running)
 			svcCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
+			var profOp *wcprof.Op
+			if wcprof.Active() != nil {
+				svcCtx, profOp = wcprof.BeginOp(svcCtx, wcprof.OpKindServiceStart, "service.start", wcprof.OpOpts{
+					Ident: key.Digest.String(),
+				})
+			}
 			start := &startingService{
-				running: running,
-				ctx:     svcCtx,
-				cancel:  cancel,
-				done:    make(chan struct{}),
+				running:  running,
+				ctx:      svcCtx,
+				cancel:   cancel,
+				done:     make(chan struct{}),
+				profOpID: profOp.ID(),
 			}
 			ss.starting[key] = start
 			ss.l.Unlock()
@@ -971,6 +989,7 @@ func (ss *Services) startWithKey(
 
 			if err := svc.Start(svcCtx, running, key.Digest, opts); err != nil {
 				start.err = err
+				profOp.End(wcprof.OutcomeError)
 				releaseSuppression()
 				_ = running.releaseTrackedRefsOnce(context.WithoutCancel(ctx))
 				ss.l.Lock()
@@ -982,6 +1001,7 @@ func (ss *Services) startWithKey(
 			if running.Wait == nil {
 				err := fmt.Errorf("service %s started without Wait callback", network.HostHash(key.Digest))
 				start.err = err
+				profOp.End(wcprof.OutcomeError)
 				releaseSuppression()
 				_ = running.stopFromManager(context.WithoutCancel(ctx), true)
 				ss.l.Lock()
@@ -995,6 +1015,7 @@ func (ss *Services) startWithKey(
 			delete(ss.starting, key)
 			if context.Cause(svcCtx) != nil {
 				ss.l.Unlock()
+				profOp.End(wcprof.OutcomeCanceled)
 				releaseSuppression()
 				_ = running.stopFromManager(context.WithoutCancel(ctx), true)
 				return nil, nil, context.Cause(svcCtx)
@@ -1002,6 +1023,7 @@ func (ss *Services) startWithKey(
 			ss.running[key] = running
 			ss.bindings[key] = 1
 			ss.l.Unlock()
+			profOp.End(wcprof.OutcomeOK)
 
 			go func() {
 				if running.Wait == nil {

--- a/core/services.go
+++ b/core/services.go
@@ -970,7 +970,7 @@ func (ss *Services) startWithKey(
 			suppress(running)
 			svcCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 			var profOp *wcprof.Op
-			if wcprof.Active() != nil {
+			if wcprof.Enabled(svcCtx) {
 				svcCtx, profOp = wcprof.BeginOp(svcCtx, wcprof.OpKindServiceStart, "service.start", wcprof.OpOpts{
 					Ident: key.Digest.String(),
 				})

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 	"github.com/dagger/dagger/engine/telemetryattrs"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -1510,6 +1511,10 @@ type sharedResult struct {
 	lazyEvalCancel   context.CancelCauseFunc
 	lazyEvalWaiters  int
 	lazyEvalErr      error
+	// lazyEvalProfOpID is the wcprof op for the in-flight lazy evaluation
+	// (guarded by lazyMu alongside lazyEvalWaitCh). Waiters record wait
+	// events against it.
+	lazyEvalProfOpID uint64
 }
 
 type sharedResultPayloadState struct {
@@ -1760,6 +1765,10 @@ type ongoingCall struct {
 	sharedWorkCtx              context.Context
 	releaseSharedWorkLeaseFn   func(context.Context) error
 	releaseSharedWorkLeaseOnce sync.Once
+
+	// profOpID is the wcprof op for the shared execution of this call, when
+	// profiling is enabled. Waiters record wait events against it.
+	profOpID uint64
 
 	res *sharedResult
 }
@@ -2925,9 +2934,13 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 	}
 	if shared.lazyEvalWaitCh != nil {
 		waitCh := shared.lazyEvalWaitCh
+		lazyOpID := shared.lazyEvalProfOpID
 		shared.lazyEvalWaiters++
 		shared.lazyMu.Unlock()
-		return c.waitForLazyEvaluation(stackCtx, shared, waitCh)
+		profWait := wcprof.BeginWait(stackCtx, lazyOpID, wcprof.WaitReasonLazy)
+		waitErr := c.waitForLazyEvaluation(stackCtx, shared, waitCh)
+		profWait.End()
+		return waitErr
 	}
 
 	waitCh := make(chan struct{})
@@ -2936,6 +2949,15 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 	resultCall := shared.loadResultCall()
 	if resultCall != nil {
 		evalCtx = ContextWithCall(evalCtx, resultCall)
+	}
+	var lazyOp *wcprof.Op
+	if wcprof.Active() != nil {
+		// the run of this result's lazy evaluation callback; the class ties
+		// the cost back to the call that created the lazy value
+		evalCtx, lazyOp = wcprof.BeginOp(evalCtx, wcprof.OpKindLazy, profCallClass(resultCall), wcprof.OpOpts{
+			ClientID: profClientID(stackCtx),
+		})
+		shared.lazyEvalProfOpID = lazyOp.ID()
 	}
 	shared.lazyEvalWaitCh = waitCh
 	shared.lazyEvalCancel = cancel
@@ -3011,6 +3033,7 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 			}
 		}
 		runEval()
+		lazyOp.EndWithResult(profErrOutcome(err), uint64(shared.id))
 
 		shared.lazyMu.Lock()
 		shared.lazyEvalErr = err
@@ -3029,7 +3052,10 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		close(waitCh)
 	}()
 
-	return c.waitForLazyEvaluation(stackCtx, shared, waitCh)
+	profWait := wcprof.BeginWait(stackCtx, lazyOp.ID(), wcprof.WaitReasonLazy)
+	waitErr := c.waitForLazyEvaluation(stackCtx, shared, waitCh)
+	profWait.End()
+	return waitErr
 }
 
 func (c *Cache) Close(ctx context.Context) error {
@@ -3476,13 +3502,43 @@ func (c *Cache) GetOrInitCall(
 	return c.getOrInitCall(ctx, sessionID, resolver, req, fn)
 }
 
-//nolint:gocyclo // Core cache lookup/insert flow is intentionally centralized here.
 func (c *Cache) getOrInitCall(
 	ctx context.Context,
 	sessionID string,
 	resolver TypeResolver,
 	req *CallRequest,
 	fn func(context.Context) (AnyResult, error),
+) (AnyResult, error) {
+	if wcprof.Active() == nil || req == nil || req.ResultCall == nil {
+		return c.getOrInitCallInner(ctx, sessionID, resolver, req, fn, nil)
+	}
+	ctx, profOp := wcprof.BeginOp(ctx, wcprof.OpKindCall, profCallClass(req.ResultCall), wcprof.OpOpts{
+		ClientID: profClientID(ctx),
+	})
+	res, err := c.getOrInitCallInner(ctx, sessionID, resolver, req, fn, profOp)
+	outcome := profOp.OutcomeHint()
+	switch {
+	case err != nil:
+		outcome = profErrOutcome(err)
+	case req.DoNotCache:
+		outcome = wcprof.OutcomeDoNotCache
+	case res != nil && res.HitCache():
+		outcome = wcprof.OutcomeHit
+	case outcome == wcprof.OutcomeNone:
+		outcome = wcprof.OutcomeOK
+	}
+	profOp.EndWithResult(outcome, profResultID(res))
+	return res, err
+}
+
+//nolint:gocyclo // Core cache lookup/insert flow is intentionally centralized here.
+func (c *Cache) getOrInitCallInner(
+	ctx context.Context,
+	sessionID string,
+	resolver TypeResolver,
+	req *CallRequest,
+	fn func(context.Context) (AnyResult, error),
+	profOp *wcprof.Op,
 ) (AnyResult, error) {
 	if sessionID == "" {
 		return nil, errors.New("get or init call: empty session ID")
@@ -3564,6 +3620,7 @@ func (c *Cache) getOrInitCall(
 		requestInputs = append(requestInputs, dig)
 	}
 	callKey := callDigest.String()
+	profOp.SetIdent(callKey)
 	if ctx.Value(cacheContextKey{callKey}) != nil {
 		return nil, ErrCacheRecursiveCall
 	}
@@ -3595,7 +3652,8 @@ func (c *Cache) getOrInitCall(
 			// already an ongoing call
 			oc.waiters++
 			c.callsMu.Unlock()
-			return c.wait(ctx, sessionID, resolver, oc, req)
+			profOp.SetOutcomeHint(wcprof.OutcomeJoined)
+			return c.wait(ctx, sessionID, resolver, oc, req, true)
 		}
 	}
 
@@ -3608,9 +3666,19 @@ func (c *Cache) getOrInitCall(
 	// make a new call with ctx that's only canceled when all caller contexts are canceled
 	callCtx := context.WithValue(ctx, cacheContextKey{callKey}, struct{}{})
 	callCtx, cancel := context.WithCancelCause(context.WithoutCancel(callCtx))
+	var execOp *wcprof.Op
+	if wcprof.Active() != nil {
+		// the shared execution of this call's resolver; all singleflighted
+		// callers wait on this op
+		callCtx, execOp = wcprof.BeginOp(callCtx, wcprof.OpKindCallExec, profCallClass(req.ResultCall), wcprof.OpOpts{
+			Ident:    callKey,
+			ClientID: profClientID(ctx),
+		})
+	}
 	sharedWorkCtx, releaseSharedWorkLease, err := withOperationLease(withoutOperationLease(callCtx))
 	if err != nil {
 		c.callsMu.Unlock()
+		execOp.End(wcprof.OutcomeError)
 		return nil, fmt.Errorf("acquire shared operation lease: %w", err)
 	}
 	oc := &ongoingCall{
@@ -3622,6 +3690,7 @@ func (c *Cache) getOrInitCall(
 		waiters:                  1,
 		sharedWorkCtx:            sharedWorkCtx,
 		releaseSharedWorkLeaseFn: releaseSharedWorkLease,
+		profOpID:                 execOp.ID(),
 	}
 
 	if req.ConcurrencyKey != "" {
@@ -3633,6 +3702,7 @@ func (c *Cache) getOrInitCall(
 		val, err := fn(oc.sharedWorkCtx)
 		oc.err = err
 		oc.val = val
+		execOp.EndWithResult(profErrOutcome(err), profResultID(val))
 
 		c.callsMu.Lock()
 		noWaiters := oc.waiters == 0
@@ -3643,7 +3713,8 @@ func (c *Cache) getOrInitCall(
 	}()
 
 	c.callsMu.Unlock()
-	return c.wait(ctx, sessionID, resolver, oc, req)
+	profOp.SetOutcomeHint(wcprof.OutcomeExecuted)
+	return c.wait(ctx, sessionID, resolver, oc, req, false)
 }
 
 func (c *Cache) lookupCallRequest(
@@ -3785,6 +3856,7 @@ func (c *Cache) wait(
 	resolver TypeResolver,
 	oc *ongoingCall,
 	req *CallRequest,
+	joined bool,
 ) (AnyResult, error) {
 	var (
 		completionErr error
@@ -3792,12 +3864,21 @@ func (c *Cache) wait(
 		completed     bool
 	)
 
+	var profWait *wcprof.Wait
+	if wcprof.Active() != nil {
+		reason := wcprof.WaitReasonCallExec
+		if joined {
+			reason = wcprof.WaitReasonSingleflight
+		}
+		profWait = wcprof.BeginWait(ctx, oc.profOpID, reason)
+	}
 	select {
 	case <-oc.waitCh:
 		completed = true
 	case <-ctx.Done():
 		canceledErr = context.Cause(ctx)
 	}
+	profWait.End()
 
 	if completed {
 		completionErr = oc.err
@@ -3842,7 +3923,23 @@ func (c *Cache) wait(
 		defer func() {
 			_ = oc.releaseSharedWorkLease(context.WithoutCancel(oc.sharedWorkCtx))
 		}()
+		var pubOp *wcprof.Op
+		if wcprof.Active() != nil {
+			// result publication (indexing, dependency attachment) parented
+			// under the shared execution op
+			_, pubOp = wcprof.BeginOp(
+				wcprof.ContextWithOpID(context.Background(), oc.profOpID),
+				wcprof.OpKindInternal, "dagql.publishResult", wcprof.OpOpts{},
+			)
+		}
 		oc.initCompletedResultErr = c.initCompletedResult(context.WithoutCancel(oc.sharedWorkCtx), resolver, oc, req, sessionID)
+		if pubOp != nil {
+			var resID uint64
+			if oc.res != nil {
+				resID = uint64(oc.res.id)
+			}
+			pubOp.EndWithResult(profErrOutcome(oc.initCompletedResultErr), resID)
+		}
 		c.callsMu.Lock()
 		delete(c.ongoingCalls, oc.callConcurrencyKeys)
 		c.callsMu.Unlock()

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -2951,7 +2951,7 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		evalCtx = ContextWithCall(evalCtx, resultCall)
 	}
 	var lazyOp *wcprof.Op
-	if wcprof.Active() != nil {
+	if wcprof.Enabled(evalCtx) {
 		// the run of this result's lazy evaluation callback; the class ties
 		// the cost back to the call that created the lazy value
 		evalCtx, lazyOp = wcprof.BeginOp(evalCtx, wcprof.OpKindLazy, profCallClass(resultCall), wcprof.OpOpts{
@@ -3509,7 +3509,7 @@ func (c *Cache) getOrInitCall(
 	req *CallRequest,
 	fn func(context.Context) (AnyResult, error),
 ) (AnyResult, error) {
-	if wcprof.Active() == nil || req == nil || req.ResultCall == nil {
+	if !wcprof.Enabled(ctx) || req == nil || req.ResultCall == nil {
 		return c.getOrInitCallInner(ctx, sessionID, resolver, req, fn, nil)
 	}
 	ctx, profOp := wcprof.BeginOp(ctx, wcprof.OpKindCall, profCallClass(req.ResultCall), wcprof.OpOpts{
@@ -3667,7 +3667,7 @@ func (c *Cache) getOrInitCallInner(
 	callCtx := context.WithValue(ctx, cacheContextKey{callKey}, struct{}{})
 	callCtx, cancel := context.WithCancelCause(context.WithoutCancel(callCtx))
 	var execOp *wcprof.Op
-	if wcprof.Active() != nil {
+	if wcprof.Enabled(ctx) {
 		// the shared execution of this call's resolver; all singleflighted
 		// callers wait on this op
 		callCtx, execOp = wcprof.BeginOp(callCtx, wcprof.OpKindCallExec, profCallClass(req.ResultCall), wcprof.OpOpts{
@@ -3865,7 +3865,7 @@ func (c *Cache) wait(
 	)
 
 	var profWait *wcprof.Wait
-	if wcprof.Active() != nil {
+	if wcprof.Enabled(ctx) {
 		reason := wcprof.WaitReasonCallExec
 		if joined {
 			reason = wcprof.WaitReasonSingleflight
@@ -3924,9 +3924,10 @@ func (c *Cache) wait(
 			_ = oc.releaseSharedWorkLease(context.WithoutCancel(oc.sharedWorkCtx))
 		}()
 		var pubOp *wcprof.Op
-		if wcprof.Active() != nil {
+		if oc.profOpID != 0 {
 			// result publication (indexing, dependency attachment) parented
-			// under the shared execution op
+			// under the shared execution op; recorded iff the execution was
+			// (the op ID carried by the context opts this into recording)
 			_, pubOp = wcprof.BeginOp(
 				wcprof.ContextWithOpID(context.Background(), oc.profOpID),
 				wcprof.OpKindInternal, "dagql.publishResult", wcprof.OpOpts{},

--- a/dagql/wcprof_hooks.go
+++ b/dagql/wcprof_hooks.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Wall-clock profiling (wcprof) hooks for the dagql cache. These are no-ops
-// unless profiling is enabled; call sites gate on wcprof.Active() before
+// unless profiling is enabled; call sites gate on wcprof.Enabled(ctx) before
 // computing class strings so the disabled path stays an atomic load.
 
 // profCallClass derives the operation class for a call frame, e.g.

--- a/dagql/wcprof_hooks.go
+++ b/dagql/wcprof_hooks.go
@@ -1,0 +1,86 @@
+package dagql
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/wcprof"
+)
+
+// Wall-clock profiling (wcprof) hooks for the dagql cache. These are no-ops
+// unless profiling is enabled; call sites gate on wcprof.Active() before
+// computing class strings so the disabled path stays an atomic load.
+
+// profCallClass derives the operation class for a call frame, e.g.
+// "Container.withExec" or "myModule:Foo.bar" for module-provided fields.
+func profCallClass(frame *ResultCall) string {
+	if frame == nil {
+		return "?"
+	}
+	field := frame.Field
+	if field == "" {
+		field = frame.SyntheticOp
+	}
+	if field == "" {
+		field = "?"
+	}
+	recv := "Query"
+	if frame.Receiver != nil {
+		recv = ""
+		if frame.Receiver.Call != nil {
+			recv = profNamedType(frame.Receiver.Call.Type)
+		}
+		if recv == "" && frame.Receiver.shared != nil {
+			if rc := frame.Receiver.shared.loadResultCall(); rc != nil {
+				recv = profNamedType(rc.Type)
+			}
+		}
+		if recv == "" {
+			recv = "?"
+		}
+	}
+	if frame.Module != nil && frame.Module.Name != "" {
+		return frame.Module.Name + ":" + recv + "." + field
+	}
+	return recv + "." + field
+}
+
+func profNamedType(typ *ResultCallType) string {
+	for typ != nil {
+		if typ.NamedType != "" {
+			return typ.NamedType
+		}
+		typ = typ.Elem
+	}
+	return ""
+}
+
+func profClientID(ctx context.Context) string {
+	if md, err := engine.ClientMetadataFromContext(ctx); err == nil {
+		return md.ClientID
+	}
+	return ""
+}
+
+func profResultID(res AnyResult) uint64 {
+	if res == nil {
+		return 0
+	}
+	shared := res.cacheSharedResult()
+	if shared == nil {
+		return 0
+	}
+	return uint64(shared.id)
+}
+
+func profErrOutcome(err error) wcprof.Outcome {
+	switch {
+	case err == nil:
+		return wcprof.OutcomeOK
+	case errors.Is(err, context.Canceled):
+		return wcprof.OutcomeCanceled
+	default:
+		return wcprof.OutcomeError
+	}
+}

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -147,6 +147,9 @@ type Params struct {
 
 	CloudAuth           *auth.Cloud
 	EnableCloudScaleOut bool
+
+	// Profile enables engine wall-clock profiling (wcprof) for this session.
+	Profile bool
 }
 
 type Client struct {
@@ -1447,6 +1450,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		EnableCloudScaleOut:            c.EnableCloudScaleOut,
 		CloudScaleOutEngineID:          remoteEngineID,
 		LockMode:                       c.LockMode,
+		Profile:                        c.Profile,
 	}
 
 	if c.Module != "" {

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -114,7 +114,7 @@ func (c *Client) Run(
 	)
 
 	var execOp *wcprof.Op
-	if wcprof.Active() != nil {
+	if wcprof.Enabled(ctx) {
 		ident := state.id
 		if execMD != nil && execMD.CallDigest != "" {
 			ident = execMD.CallDigest.String()
@@ -185,7 +185,7 @@ func (c *Client) run(
 		}
 	}()
 
-	profiling := wcprof.Active() != nil
+	profiling := wcprof.Enabled(ctx)
 	for _, f := range setupFuncs {
 		phaseCtx := ctx
 		var phaseOp *wcprof.Op

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -24,6 +24,7 @@ import (
 	runc "github.com/containerd/go-runc"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/dagger/dagger/internal/buildkit/executor"
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
 	gatewayapi "github.com/dagger/dagger/internal/buildkit/frontend/gateway/pb"
@@ -111,30 +112,56 @@ func (c *Client) Run(
 		nestedClientFunctionCall,
 		nestedClientEnv,
 	)
-	return c.run(ctx, state,
-		c.setupNetwork,
-		c.injectInit,
-		c.generateBaseSpec,
-		c.filterEnvs,
-		c.setupRootfs,
-		c.setUserGroup,
-		c.setExitCodePath,
-		c.setupStdio,
-		c.setupOTel,
-		c.setupSecretScrubbing,
-		c.setProxyEnvs,
-		c.enableGPU,
-		c.createCWD,
-		c.setupNestedClient,
-		c.installCACerts,
-		c.runContainer,
+
+	var execOp *wcprof.Op
+	if wcprof.Active() != nil {
+		ident := state.id
+		if execMD != nil && execMD.CallDigest != "" {
+			ident = execMD.CallDigest.String()
+		}
+		ctx, execOp = wcprof.BeginOp(ctx, wcprof.OpKindExec, "exec.run", wcprof.OpOpts{
+			Ident:    ident,
+			ClientID: callerClientID,
+		})
+		if nestedClientMetadata != nil && nestedClientMetadata.ClientID != "" {
+			// nested client calls back into the API under this client ID; the
+			// analyzer stitches its ops under this exec via this link
+			wcprof.Link(ctx, wcprof.LinkKindNestedClient, 0, 0, nestedClientMetadata.ClientID, 0)
+		}
+	}
+	err := c.run(ctx, state,
+		namedSetupFunc{"setupNetwork", c.setupNetwork},
+		namedSetupFunc{"injectInit", c.injectInit},
+		namedSetupFunc{"generateBaseSpec", c.generateBaseSpec},
+		namedSetupFunc{"filterEnvs", c.filterEnvs},
+		namedSetupFunc{"setupRootfs", c.setupRootfs},
+		namedSetupFunc{"setUserGroup", c.setUserGroup},
+		namedSetupFunc{"setExitCodePath", c.setExitCodePath},
+		namedSetupFunc{"setupStdio", c.setupStdio},
+		namedSetupFunc{"setupOTel", c.setupOTel},
+		namedSetupFunc{"setupSecretScrubbing", c.setupSecretScrubbing},
+		namedSetupFunc{"setProxyEnvs", c.setProxyEnvs},
+		namedSetupFunc{"enableGPU", c.enableGPU},
+		namedSetupFunc{"createCWD", c.createCWD},
+		namedSetupFunc{"setupNestedClient", c.setupNestedClient},
+		namedSetupFunc{"installCACerts", c.installCACerts},
+		namedSetupFunc{"runContainer", c.runContainer},
 	)
+	execOp.EndErr(err)
+	return err
+}
+
+// namedSetupFunc pairs an executor setup phase with a stable name used for
+// profiling and logging.
+type namedSetupFunc struct {
+	name string
+	fn   executorSetupFunc
 }
 
 func (c *Client) run(
 	ctx context.Context,
 	state *execState,
-	setupFuncs ...executorSetupFunc,
+	setupFuncs ...namedSetupFunc,
 ) (rerr error) {
 	c.runningMu.Lock()
 	c.running[state.id] = state
@@ -158,8 +185,18 @@ func (c *Client) run(
 		}
 	}()
 
+	profiling := wcprof.Active() != nil
 	for _, f := range setupFuncs {
-		if err := f(ctx, state); err != nil {
+		phaseCtx := ctx
+		var phaseOp *wcprof.Op
+		if profiling {
+			phaseCtx, phaseOp = wcprof.BeginOp(ctx, wcprof.OpKindExecPhase, "exec."+f.name, wcprof.OpOpts{
+				Ident: state.id,
+			})
+		}
+		err := f.fn(phaseCtx, state)
+		phaseOp.EndErr(err)
+		if err != nil {
 			bklog.G(ctx).WithError(err).Error("executor run")
 			return err
 		}

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/mount"
@@ -49,6 +50,7 @@ import (
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/engine/engineutil/cacerts"
 	"github.com/dagger/dagger/engine/engineutil/containerfs"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/dagger/dagger/network"
 	telemetry "github.com/dagger/otel-go"
 )
@@ -166,8 +168,32 @@ func newExecState(
 
 type executorSetupFunc func(context.Context, *execState) error
 
+// wcprofInjectNetNSDelayFile is a wcprof validation aid: when this file
+// exists in the engine container and profiling is enabled, setupNetwork
+// sleeps for the number of milliseconds it contains before doing real work.
+// Used to verify the offline analyzer detects an injected per-exec
+// bottleneck (the original motivating case was un-pooled CNI setup).
+const wcprofInjectNetNSDelayFile = "/tmp/wcprof-inject-netns-delay-ms"
+
+func wcprofInjectNetNSDelay() {
+	if wcprof.Active() == nil {
+		return
+	}
+	data, err := os.ReadFile(wcprofInjectNetNSDelayFile)
+	if err != nil {
+		return
+	}
+	ms, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || ms <= 0 {
+		return
+	}
+	time.Sleep(time.Duration(ms) * time.Millisecond)
+}
+
 //nolint:gocyclo
 func (c *Client) setupNetwork(ctx context.Context, state *execState) error {
+	wcprofInjectNetNSDelay()
+
 	provider, ok := c.NetworkProviders[state.procInfo.Meta.NetMode]
 	if !ok {
 		return fmt.Errorf("unknown network mode %s", state.procInfo.Meta.NetMode)
@@ -1134,7 +1160,7 @@ func (c *Client) installCACerts(ctx context.Context, state *execState) error {
 		caExecState.spec.Process.Cwd = "/"
 		caExecState.spec.Process.Terminal = false
 
-		if err := c.run(ctx, caExecState, c.runContainer); err != nil {
+		if err := c.run(ctx, caExecState, namedSetupFunc{"runContainer", c.runContainer}); err != nil {
 			return fmt.Errorf("installer command failed: %w, output: %s", err, output.String())
 		}
 		return nil
@@ -1265,9 +1291,14 @@ func (c *Client) runContainer(ctx context.Context, state *execState) (rerr error
 		})
 	}
 
+	profStartNS := wcprof.NowNS()
+	var profStartedNS atomic.Int64
 	startedCallback := func() {
 		state.startedOnce.Do(func() {
 			trace.SpanFromContext(ctx).AddEvent("Container started")
+			if wcprof.Active() != nil {
+				profStartedNS.Store(wcprof.NowNS())
+			}
 			if state.startedCh != nil {
 				close(state.startedCh)
 			}
@@ -1388,5 +1419,21 @@ func (c *Client) runContainer(ctx context.Context, state *execState) (rerr error
 		return eg.Wait()
 	}
 
-	return exitError(ctx, state.exitCodePath, c.callWithIO(ctx, state.procInfo, startedCallback, killer, runcCall), state.procInfo.Meta.ValidExitCodes)
+	runErr := c.callWithIO(ctx, state.procInfo, startedCallback, killer, runcCall)
+	if wcprof.Active() != nil {
+		// split engine overhead (creating/starting the container) from the
+		// user's process runtime
+		endNS := wcprof.NowNS()
+		outcome := wcprof.OutcomeOK
+		if runErr != nil {
+			outcome = wcprof.OutcomeError
+		}
+		if startedNS := profStartedNS.Load(); startedNS > 0 {
+			wcprof.RecordOp(ctx, wcprof.OpKindExecPhase, "exec.containerStart", wcprof.OpOpts{Ident: state.id}, profStartNS, startedNS, wcprof.OutcomeOK)
+			wcprof.RecordOp(ctx, wcprof.OpKindExecPhase, "exec.processRun", wcprof.OpOpts{Ident: state.id, WorkType: wcprof.WorkTypeUser}, startedNS, endNS, outcome)
+		} else {
+			wcprof.RecordOp(ctx, wcprof.OpKindExecPhase, "exec.containerStart", wcprof.OpOpts{Ident: state.id}, profStartNS, endNS, outcome)
+		}
+	}
+	return exitError(ctx, state.exitCodePath, runErr, state.procInfo.Meta.ValidExitCodes)
 }

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -168,32 +168,8 @@ func newExecState(
 
 type executorSetupFunc func(context.Context, *execState) error
 
-// wcprofInjectNetNSDelayFile is a wcprof validation aid: when this file
-// exists in the engine container and profiling is enabled, setupNetwork
-// sleeps for the number of milliseconds it contains before doing real work.
-// Used to verify the offline analyzer detects an injected per-exec
-// bottleneck (the original motivating case was un-pooled CNI setup).
-const wcprofInjectNetNSDelayFile = "/tmp/wcprof-inject-netns-delay-ms"
-
-func wcprofInjectNetNSDelay() {
-	if wcprof.Active() == nil {
-		return
-	}
-	data, err := os.ReadFile(wcprofInjectNetNSDelayFile)
-	if err != nil {
-		return
-	}
-	ms, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || ms <= 0 {
-		return
-	}
-	time.Sleep(time.Duration(ms) * time.Millisecond)
-}
-
 //nolint:gocyclo
 func (c *Client) setupNetwork(ctx context.Context, state *execState) error {
-	wcprofInjectNetNSDelay()
-
 	provider, ok := c.NetworkProviders[state.procInfo.Meta.NetMode]
 	if !ok {
 		return fmt.Errorf("unknown network mode %s", state.procInfo.Meta.NetMode)
@@ -1296,7 +1272,7 @@ func (c *Client) runContainer(ctx context.Context, state *execState) (rerr error
 	startedCallback := func() {
 		state.startedOnce.Do(func() {
 			trace.SpanFromContext(ctx).AddEvent("Container started")
-			if wcprof.Active() != nil {
+			if wcprof.Enabled(ctx) {
 				profStartedNS.Store(wcprof.NowNS())
 			}
 			if state.startedCh != nil {
@@ -1420,7 +1396,7 @@ func (c *Client) runContainer(ctx context.Context, state *execState) (rerr error
 	}
 
 	runErr := c.callWithIO(ctx, state.procInfo, startedCallback, killer, runcCall)
-	if wcprof.Active() != nil {
+	if wcprof.Enabled(ctx) {
 		// split engine overhead (creating/starting the container) from the
 		// user's process runtime
 		endNS := wcprof.NowNS()

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -151,6 +151,11 @@ type ClientMetadata struct {
 	// request explicitly passes a recipe argument. This is engine-internal
 	// nested-client state and must not be forwarded through client headers.
 	UseRecipeIDsByDefault bool `json:"-"`
+
+	// Profile enables engine wall-clock profiling (wcprof) for the duration
+	// of this client's work. Experimental; the recorded events are retrieved
+	// via the engine debug endpoints.
+	Profile bool `json:"profile,omitempty"`
 }
 
 type clientMetadataCtxKey struct{}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -54,6 +54,7 @@ import (
 	serverresolver "github.com/dagger/dagger/engine/server/resolver"
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
+	"github.com/dagger/dagger/engine/wcprof"
 	"github.com/dagger/dagger/util/cleanups"
 )
 
@@ -1350,6 +1351,10 @@ func (srv *Server) serveSessionAttachables(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *daggerClient) (rerr error) {
+	if md := client.clientMetadata; md != nil && md.Profile {
+		wcprof.EnsureEnabled()
+	}
+
 	sess := client.daggerSession
 	sess.dagqlMu.Lock()
 	if sess.dagqlClosing {
@@ -1420,10 +1425,24 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	// make query available via context to all APIs
 	ctx = core.ContextWithQuery(ctx, client.dagqlRoot)
 
+	profiling := wcprof.Active() != nil
+	var profServeOp *wcprof.Op
+	if profiling {
+		ctx, profServeOp = wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.serveQuery", wcprof.OpOpts{
+			ClientID: client.clientID,
+		})
+		defer func() {
+			profServeOp.EndErr(rerr)
+		}()
+	}
+
 	r = r.WithContext(ctx)
 
 	if client.hostServiceProxyClientID == "" {
-		if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		profWait := wcprof.BeginWaitIdent(ctx, "session:attachables", wcprof.WaitReasonIO)
+		_, err := client.getClientCaller(ctx, client.clientID)
+		profWait.End()
+		if err != nil {
 			return gqlErr(fmt.Errorf("waiting for client session attachables: %w", err), http.StatusInternalServerError)
 		}
 	}
@@ -1441,18 +1460,26 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	// deferred from initializeDaggerClient because they need the client's
 	// session attachables, which only become available after the session
 	// attachables handshake completes (after init locks are released).
-	if err := srv.ensureWorkspaceLoaded(ctx, client); err != nil {
+	wsCtx, wsOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.workspaceLoad", wcprof.OpOpts{ClientID: client.clientID})
+	err = srv.ensureWorkspaceLoaded(wsCtx, client)
+	wsOp.EndErr(err)
+	if err != nil {
 		return gqlErr(fmt.Errorf("loading workspace: %w", err), http.StatusInternalServerError)
 	}
 	if peekRootFieldsOK {
 		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
 	}
-	if err := srv.ensureModulesLoaded(ctx, client); err != nil {
+	modCtx, modOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.modulesLoad", wcprof.OpOpts{ClientID: client.clientID})
+	err = srv.ensureModulesLoaded(modCtx, client)
+	modOp.EndErr(err)
+	if err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
 	}
 
 	// get the schema we're gonna serve to this client based on which modules they have loaded, if any
-	schema, err := client.servedMods.Schema(ctx)
+	schemaCtx, schemaOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.schemaBuild", wcprof.OpOpts{ClientID: client.clientID})
+	schema, err := client.servedMods.Schema(schemaCtx)
+	schemaOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("failed to get schema: %w", err), http.StatusBadRequest)
 	}
@@ -1465,6 +1492,12 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	// 	slog.Debug("graphql response", "response", string(pl), "error", err)
 	// 	return res
 	// })
+
+	if profiling {
+		queryCtx, queryOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.query", wcprof.OpOpts{ClientID: client.clientID})
+		defer queryOp.End(wcprof.OutcomeOK)
+		r = r.WithContext(queryCtx)
+	}
 
 	gqlSrv.ServeHTTP(w, r)
 	return nil

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -62,6 +62,12 @@ type daggerSession struct {
 	sessionID          string
 	mainClientCallerID string
 
+	// wcprofEnabled means this session opted into wall-clock profiling
+	// (ClientMetadata.Profile); work for all its clients (including nested
+	// module/SDK clients) is recorded even when engine-global recording is
+	// off.
+	wcprofEnabled bool
+
 	state   daggerSessionState
 	stateMu sync.RWMutex
 
@@ -324,6 +330,7 @@ func (srv *Server) initializeDaggerSession(
 
 	sess.sessionID = clientMetadata.SessionID
 	sess.mainClientCallerID = clientMetadata.ClientID
+	sess.wcprofEnabled = clientMetadata.Profile
 	sess.clients = map[string]*daggerClient{}
 	sess.attachables = newSessionAttachableManager()
 	sess.endpoints = map[string]http.Handler{}
@@ -1351,11 +1358,17 @@ func (srv *Server) serveSessionAttachables(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *daggerClient) (rerr error) {
-	if md := client.clientMetadata; md != nil && md.Profile {
-		wcprof.EnsureEnabled()
-	}
-
 	sess := client.daggerSession
+
+	// Profiling is recorded for this request if the engine is recording
+	// globally, or this session opted in (in which case contexts are marked
+	// so only this session's work records).
+	profiledSession := sess.wcprofEnabled ||
+		(client.clientMetadata != nil && client.clientMetadata.Profile)
+	if profiledSession {
+		wcprof.EnsureRecorder()
+	}
+	profiling := profiledSession || wcprof.GloballyEnabled()
 	sess.dagqlMu.Lock()
 	if sess.dagqlClosing {
 		sess.dagqlMu.Unlock()
@@ -1425,9 +1438,11 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 	// make query available via context to all APIs
 	ctx = core.ContextWithQuery(ctx, client.dagqlRoot)
 
-	profiling := wcprof.Active() != nil
 	var profServeOp *wcprof.Op
 	if profiling {
+		if profiledSession {
+			ctx = wcprof.ContextWithProfiling(ctx)
+		}
 		ctx, profServeOp = wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.serveQuery", wcprof.OpOpts{
 			ClientID: client.clientID,
 		})

--- a/engine/wcprof/README.md
+++ b/engine/wcprof/README.md
@@ -1,0 +1,98 @@
+# wcprof: engine wall-clock profiling
+
+`wcprof` is an experimental, cheap wall-clock profiler for the Dagger engine,
+built to find latency bottlenecks that CPU/memory profiles can't see (e.g. a
+300ms serial tax before every container start). It is intentionally separate
+from OTel: events are fixed-size structs appended to sharded in-memory
+buffers with interned strings, and all heavy analysis happens offline.
+
+## What it records
+
+Three event types, written by hooks at the engine's blocking choke points:
+
+- **ops**: timed intervals with a *kind* (`call`, `call_exec`, `lazy`, `exec`,
+  `exec_phase`, `service_start`, `session_phase`, ...), a *class* (e.g.
+  `Container.withExec`, `exec.setupNetwork`), an instance ident (recipe
+  digest, exec ID), a structural parent (from context), and an outcome
+  (`hit`/`executed`/`joined`/...).
+- **waits**: exact blocked-on intervals — who waited, on which op (or named
+  resource, e.g. a cache-volume lock), why, from when to when. These are
+  recorded *at the choke points themselves* (dagql singleflight, lazy-eval
+  waiters, service starts, exec completion), not inferred from span nesting.
+- **links**: non-blocking correlations, most importantly "exec op X hosts
+  nested client Y" so module-function calls back into the API are stitched
+  under the exec that made them.
+
+Current hook points:
+
+- `dagql/cache.go getOrInitCall`: one `call` op per caller (cache hits and
+  do-not-cache calls included — this deliberately records what OTel
+  suppresses), one shared `call_exec` op per actual resolver execution,
+  wait edges from every caller to it, and a `dagql.publishResult` op for
+  publication cost.
+- `dagql/cache.go evaluateOne`: one `lazy` op per lazy-evaluation run, classed
+  by the call that created the lazy value, with wait edges from the
+  triggering and joining ops.
+- `engine/engineutil/executor.go`: one `exec` op per container run, one
+  `exec_phase` op per setup phase (`exec.setupNetwork`, `exec.setupRootfs`,
+  ..., `exec.runContainer`), plus a split of `exec.containerStart`
+  (engine overhead) vs `exec.processRun` (user work).
+- `core/container_exec.go`: cache-volume lock waits, mount preparation and
+  output-commit phases, and the wait on the executor.
+- `core/services.go`: `service_start` ops with singleflight wait edges.
+- `engine/server/session.go serveQuery`: per-query `session_phase` ops
+  (attachables wait, workspace load, module load, schema build, query).
+
+## Enabling and dumping
+
+- CLI: `dagger --profile <anything>` sets `ClientMetadata.Profile`, which
+  enables the engine-global recorder for the rest of the engine's lifetime.
+- Engine env: `_DAGGER_WCPROF=1` enables at startup;
+  `_DAGGER_WCPROF_MAX_EVENTS=N` overrides the event cap (default ~4M).
+- Dump: `GET http://<engine-debug-addr>/debug/wcprof/dump` streams a JSON
+  header line (string tables, open ops) followed by one JSON event per line,
+  and flushes the buffer (pass `?flush=0` to keep it).
+
+Typical dev-engine workflow:
+
+```bash
+./hack/dev   # build + start dagger-engine.dev (publishes debug port 6060)
+./hack/with-dev ./bin/dagger --profile call engine-dev container sync
+curl -s http://localhost:6060/debug/wcprof/dump > /tmp/wcprof.dump
+go run ./cmd/wcprof-analyze /tmp/wcprof.dump
+```
+
+## Analysis (`cmd/wcprof-analyze`, `engine/wcprof/wcanalyze`)
+
+The analyzer reconstructs the op graph (parents, waits, nested-client
+stitching) and reports:
+
+- **what-if rankings** (the headline): a replay-based discrete-event
+  simulation re-executes the recorded schedule under "class X self-time × f"
+  hypotheses (f ∈ {0, 0.5, 0.9} by default) and ranks classes by how much
+  end-to-end makespan each would actually save. This accounts for critical-
+  path shifts, dedup (singleflighted/lazy work counted once), and dependency
+  chains — unlike naive "total time per class" tables.
+- per-class self-time tables (self = duration − waits − child intervals),
+  with outcome counts and duplicate-execution detection.
+- the end-of-workload blocking chain.
+- dead air: trace gaps where no recorded op was running (= uninstrumented
+  blocking, or client-side stalls).
+
+Simulation assumptions (v1, deliberate): unlimited resources (never
+CPU-bound), recorded dependency structure is invariant under the hypothesis,
+waits on named resources (locks) are fixed delays. The simulated baseline
+makespan is reported against the actual makespan as a drift sanity check.
+
+## Status / caveats
+
+This is a prototype for validating the approach:
+
+- the recorder is engine-global (any profiled client enables it for
+  everyone); per-session scoping is future work.
+- events are kept until dumped; long sessions can hit the event cap (the
+  dump and the analyzer both surface the drop count loudly).
+- leaf I/O ops (git fetch, image pull, filesync) are not yet instrumented;
+  they currently show up as self-time of their calling op, and the
+  "dead air" / unexplained-self-time reports are the guide for where to add
+  hooks next.

--- a/engine/wcprof/README.md
+++ b/engine/wcprof/README.md
@@ -45,10 +45,33 @@ Current hook points:
 
 ## Enabling and dumping
 
-- CLI: `dagger --profile <anything>` sets `ClientMetadata.Profile`, which
-  enables the engine-global recorder for the rest of the engine's lifetime.
-- Engine env: `_DAGGER_WCPROF=1` enables at startup;
-  `_DAGGER_WCPROF_MAX_EVENTS=N` overrides the event cap (default ~4M).
+Two scopes:
+
+- **Per-session**: `dagger --profile <anything>` (hidden flag) sets
+  `ClientMetadata.Profile`. Only that session's work is recorded — including
+  its nested module/SDK clients — via a context mark applied by the session
+  server and propagated to derived contexts. Caveat: if a profiled call joins
+  in-flight identical work spawned by an *unprofiled* session, the join shows
+  up as an unresolved wait (modeled by the analyzer as a fixed delay) since
+  the other session's execution wasn't recorded.
+- **Engine-global**: record everything. Enable at startup with the engine's
+  `--wcprof` flag (hidden) or `_DAGGER_WCPROF=1`, or at runtime by POSTing to
+  the debug endpoint:
+
+  ```bash
+  curl -X POST -d on  http://<engine-debug-addr>/debug/wcprof/enabled
+  curl -X POST -d off http://<engine-debug-addr>/debug/wcprof/enabled
+  curl http://<engine-debug-addr>/debug/wcprof/enabled   # report state
+  ```
+
+  POSTing `off` stops engine-global recording but keeps buffered events
+  dumpable, lets `--profile` sessions keep recording, and lets in-flight
+  recorded ops finish; `on` re-enables on the same recorder (dumps from
+  before and after merge cleanly since the epoch is unchanged).
+
+`_DAGGER_WCPROF_MAX_EVENTS=N` overrides the event cap (default ~4M),
+read when the recorder is first created.
+
 - Dump: `GET http://<engine-debug-addr>/debug/wcprof/dump` streams a JSON
   header line (string tables, open ops) followed by one JSON event per line,
   and flushes the buffer (pass `?flush=0` to keep it).
@@ -88,8 +111,10 @@ makespan is reported against the actual makespan as a drift sanity check.
 
 This is a prototype for validating the approach:
 
-- the recorder is engine-global (any profiled client enables it for
-  everyone); per-session scoping is future work.
+- there is one engine-wide recorder and event buffer; per-session enablement
+  scopes what gets *recorded*, but all enabled sessions share the buffer and
+  dumps (the analyzer can group by client/root, but the dump endpoint has no
+  per-session filter).
 - events are kept until dumped; long sessions can hit the event cap (the
   dump and the analyzer both surface the drop count loudly).
 - leaf I/O ops (git fetch, image pull, filesync) are not yet instrumented;

--- a/engine/wcprof/dump.go
+++ b/engine/wcprof/dump.go
@@ -1,0 +1,191 @@
+package wcprof
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// DumpSchemaVersion identifies the dump wire format.
+const DumpSchemaVersion = 1
+
+// DumpHeader is the first line of a dump. The remaining lines are one
+// DumpEvent JSON object per line.
+type DumpHeader struct {
+	SchemaVersion  int      `json:"schema_version"`
+	EpochUnixNano  int64    `json:"epoch_unix_nano"`
+	DumpedUnixNano int64    `json:"dumped_unix_nano"`
+	DroppedEvents  uint64   `json:"dropped_events"`
+	EventCount     int      `json:"event_count"`
+	Strings        []string `json:"strings"`
+	// OpenOps are ops begun but not ended at dump time (e.g. in-flight or
+	// hung work).
+	OpenOps []DumpOpenOp `json:"open_ops,omitempty"`
+}
+
+// DumpOpenOp describes an in-progress op at dump time.
+type DumpOpenOp struct {
+	OpID     uint64 `json:"op_id"`
+	ParentID uint64 `json:"parent_id,omitempty"`
+	Kind     string `json:"kind"`
+	WorkType string `json:"work_type,omitempty"`
+	ClassID  uint32 `json:"class_id,omitempty"`
+	IdentID  uint32 `json:"ident_id,omitempty"`
+	ClientID uint32 `json:"client_id,omitempty"`
+	StartNS  int64  `json:"start_ns"`
+}
+
+// DumpEvent is the JSON form of an Event. Short keys keep dumps compact.
+type DumpEvent struct {
+	Type     string `json:"e"`
+	OpKind   string `json:"k,omitempty"`
+	WorkType string `json:"w,omitempty"`
+	Outcome  string `json:"o,omitempty"`
+	Reason   string `json:"rs,omitempty"`
+	LinkKind string `json:"lk,omitempty"`
+
+	OpID     uint64 `json:"id,omitempty"`
+	ParentID uint64 `json:"p,omitempty"`
+	TargetID uint64 `json:"t,omitempty"`
+	ResultID uint64 `json:"r,omitempty"`
+
+	ClassID  uint32 `json:"c,omitempty"`
+	IdentID  uint32 `json:"i,omitempty"`
+	ClientID uint32 `json:"cl,omitempty"`
+
+	StartNS int64 `json:"s"`
+	EndNS   int64 `json:"d"`
+}
+
+func eventTypeName(t EventType) string {
+	switch t {
+	case EventTypeOp:
+		return "op"
+	case EventTypeWait:
+		return "wait"
+	case EventTypeLink:
+		return "link"
+	default:
+		return "invalid"
+	}
+}
+
+func toDumpEvent(ev Event) DumpEvent {
+	out := DumpEvent{
+		Type:     eventTypeName(ev.Type),
+		OpID:     ev.OpID,
+		ParentID: ev.ParentID,
+		TargetID: ev.TargetID,
+		ResultID: ev.ResultID,
+		ClassID:  ev.ClassID,
+		IdentID:  ev.IdentID,
+		ClientID: ev.ClientID,
+		StartNS:  ev.StartNS,
+		EndNS:    ev.EndNS,
+	}
+	switch ev.Type {
+	case EventTypeOp:
+		out.OpKind = ev.OpKind.String()
+		out.WorkType = ev.WorkType.String()
+		out.Outcome = ev.Outcome.String()
+	case EventTypeWait:
+		out.Reason = ev.Reason.String()
+	case EventTypeLink:
+		out.LinkKind = ev.LinkKind.String()
+	}
+	return out
+}
+
+// WriteDump streams the recorder state to w: one DumpHeader JSON line, then
+// one DumpEvent JSON line per event. When flush is true, recorded events are
+// removed from the buffer (the string table, open ops, and op ID counter are
+// retained so later dumps remain consistent).
+func (r *Recorder) WriteDump(w io.Writer, flush bool) error {
+	if r == nil {
+		return fmt.Errorf("wcprof: recorder not enabled")
+	}
+
+	// Snapshot (and optionally flush) each shard.
+	var (
+		batches [numShards][]Event
+		open    []DumpOpenOp
+		total   int
+	)
+	for i := range r.shards {
+		sh := &r.shards[i]
+		sh.mu.Lock()
+		batches[i] = sh.events
+		if flush {
+			sh.events = nil
+		} else {
+			batches[i] = append([]Event(nil), sh.events...)
+		}
+		for id, oo := range sh.openOps {
+			open = append(open, DumpOpenOp{
+				OpID:     id,
+				ParentID: oo.parentID,
+				Kind:     oo.op.String(),
+				WorkType: oo.work.String(),
+				ClassID:  oo.classID,
+				IdentID:  oo.identID,
+				ClientID: oo.clientID,
+				StartNS:  oo.startNS,
+			})
+		}
+		sh.mu.Unlock()
+		total += len(batches[i])
+	}
+	if flush {
+		r.total.Add(int64(-total))
+	}
+
+	header := DumpHeader{
+		SchemaVersion:  DumpSchemaVersion,
+		EpochUnixNano:  r.wallEpoch,
+		DumpedUnixNano: time.Now().UnixNano(),
+		DroppedEvents:  r.dropped.Load(),
+		EventCount:     total,
+		Strings:        r.strings.snapshot(),
+		OpenOps:        open,
+	}
+
+	bw := bufio.NewWriterSize(w, 1<<20)
+	enc := json.NewEncoder(bw)
+	if err := enc.Encode(header); err != nil {
+		return fmt.Errorf("wcprof: encode dump header: %w", err)
+	}
+	for _, batch := range batches {
+		for _, ev := range batch {
+			if err := enc.Encode(toDumpEvent(ev)); err != nil {
+				return fmt.Errorf("wcprof: encode dump event: %w", err)
+			}
+		}
+	}
+	return bw.Flush()
+}
+
+// ReadDump parses a dump produced by WriteDump.
+func ReadDump(rd io.Reader) (*DumpHeader, []DumpEvent, error) {
+	dec := json.NewDecoder(rd)
+	var header DumpHeader
+	if err := dec.Decode(&header); err != nil {
+		return nil, nil, fmt.Errorf("wcprof: decode dump header: %w", err)
+	}
+	if header.SchemaVersion != DumpSchemaVersion {
+		return nil, nil, fmt.Errorf("wcprof: unsupported dump schema version %d (want %d)", header.SchemaVersion, DumpSchemaVersion)
+	}
+	events := make([]DumpEvent, 0, header.EventCount)
+	for {
+		var ev DumpEvent
+		if err := dec.Decode(&ev); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, nil, fmt.Errorf("wcprof: decode dump event: %w", err)
+		}
+		events = append(events, ev)
+	}
+	return &header, events, nil
+}

--- a/engine/wcprof/record.go
+++ b/engine/wcprof/record.go
@@ -6,6 +6,8 @@ import (
 
 type opCtxKey struct{}
 
+type profCtxKey struct{}
+
 // CurrentOpID returns the profiling op ID carried by ctx, or 0.
 func CurrentOpID(ctx context.Context) uint64 {
 	id, _ := ctx.Value(opCtxKey{}).(uint64)
@@ -20,6 +22,42 @@ func ContextWithOpID(ctx context.Context, opID uint64) context.Context {
 		return ctx
 	}
 	return context.WithValue(ctx, opCtxKey{}, opID)
+}
+
+// ContextWithProfiling marks ctx (and any context derived from it) for
+// recording even when engine-global recording is off. The session server
+// applies this to contexts of sessions that opted into profiling.
+func ContextWithProfiling(ctx context.Context) context.Context {
+	return context.WithValue(ctx, profCtxKey{}, true)
+}
+
+// Enabled reports whether work running under ctx should be recorded. Call
+// sites use it to skip computing op metadata (class/ident strings) when
+// profiling is off. When profiling has never been enabled this is a single
+// atomic load + nil check.
+func Enabled(ctx context.Context) bool {
+	return recorderFor(ctx) != nil
+}
+
+// recorderFor returns the recorder if work under ctx should be recorded:
+// either engine-global recording is on, or ctx belongs to a profiled flow
+// (it carries a recorded op as its current op, or a per-session profiling
+// mark from ContextWithProfiling).
+func recorderFor(ctx context.Context) *Recorder {
+	r := global.Load()
+	if r == nil {
+		return nil
+	}
+	if globalOn.Load() {
+		return r
+	}
+	if CurrentOpID(ctx) != 0 {
+		return r
+	}
+	if on, _ := ctx.Value(profCtxKey{}).(bool); on {
+		return r
+	}
+	return nil
 }
 
 // Op is a handle for an in-progress operation. A nil *Op is valid and all
@@ -53,7 +91,7 @@ type OpOpts struct {
 // it), and a handle to end it. When profiling is disabled it returns ctx
 // unchanged and a nil handle.
 func BeginOp(ctx context.Context, kind OpKind, class string, opts OpOpts) (context.Context, *Op) {
-	r := Active()
+	r := recorderFor(ctx)
 	if r == nil {
 		return ctx, nil
 	}
@@ -182,7 +220,7 @@ func BeginWaitIdent(ctx context.Context, ident string, reason WaitReason) *Wait 
 }
 
 func beginWait(ctx context.Context, targetOpID uint64, ident string, reason WaitReason) *Wait {
-	r := Active()
+	r := recorderFor(ctx)
 	if r == nil {
 		return nil
 	}
@@ -238,7 +276,7 @@ func NowNS() int64 {
 // callbacks where holding an *Op handle would race. Returns the op ID, or 0
 // when profiling is disabled.
 func RecordOp(ctx context.Context, kind OpKind, class string, opts OpOpts, startNS, endNS int64, outcome Outcome) uint64 {
-	r := Active()
+	r := recorderFor(ctx)
 	if r == nil {
 		return 0
 	}
@@ -263,7 +301,7 @@ func RecordOp(ctx context.Context, kind OpKind, class string, opts OpOpts, start
 // Link records a non-blocking correlation from fromOpID (0 means the current
 // op in ctx) to an op, an interned ident, and/or a dagql result ID.
 func Link(ctx context.Context, kind LinkKind, fromOpID, targetOpID uint64, ident string, resultID uint64) {
-	r := Active()
+	r := recorderFor(ctx)
 	if r == nil {
 		return
 	}

--- a/engine/wcprof/record.go
+++ b/engine/wcprof/record.go
@@ -1,0 +1,285 @@
+package wcprof
+
+import (
+	"context"
+)
+
+type opCtxKey struct{}
+
+// CurrentOpID returns the profiling op ID carried by ctx, or 0.
+func CurrentOpID(ctx context.Context) uint64 {
+	id, _ := ctx.Value(opCtxKey{}).(uint64)
+	return id
+}
+
+// ContextWithOpID returns a context carrying the given op ID as the current
+// op. Useful when handing work to a goroutine that should be attributed to an
+// existing op.
+func ContextWithOpID(ctx context.Context, opID uint64) context.Context {
+	if opID == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, opCtxKey{}, opID)
+}
+
+// Op is a handle for an in-progress operation. A nil *Op is valid and all
+// methods are no-ops, so call sites do not need to check whether profiling is
+// enabled.
+type Op struct {
+	r           *Recorder
+	id          uint64
+	parentID    uint64
+	kind        OpKind
+	work        WorkType
+	classID     uint32
+	identID     uint32
+	clientID    uint32
+	startNS     int64
+	outcomeHint Outcome
+}
+
+// OpOpts carries optional per-op metadata.
+type OpOpts struct {
+	// Ident is an instance identity for the op (e.g. recipe digest, exec ID).
+	Ident string
+	// ClientID is the dagger client this op serves, when known.
+	ClientID string
+	// ResultID may be set at Begin time when already known.
+	WorkType WorkType
+}
+
+// BeginOp starts recording an operation. It returns a derived context that
+// carries the new op as the current op (so nested ops and waits parent to
+// it), and a handle to end it. When profiling is disabled it returns ctx
+// unchanged and a nil handle.
+func BeginOp(ctx context.Context, kind OpKind, class string, opts OpOpts) (context.Context, *Op) {
+	r := Active()
+	if r == nil {
+		return ctx, nil
+	}
+	op := &Op{
+		r:        r,
+		id:       r.newOpID(),
+		parentID: CurrentOpID(ctx),
+		kind:     kind,
+		work:     opts.WorkType,
+		classID:  r.Intern(class),
+		identID:  r.Intern(opts.Ident),
+		clientID: r.Intern(opts.ClientID),
+		startNS:  r.Now(),
+	}
+	sh := r.shardFor(op.id)
+	sh.mu.Lock()
+	sh.openOps[op.id] = openOp{
+		op:       kind,
+		work:     opts.WorkType,
+		classID:  op.classID,
+		identID:  op.identID,
+		clientID: op.clientID,
+		parentID: op.parentID,
+		startNS:  op.startNS,
+	}
+	sh.mu.Unlock()
+	return ContextWithOpID(ctx, op.id), op
+}
+
+// ID returns the op's ID, or 0 for a nil handle.
+func (op *Op) ID() uint64 {
+	if op == nil {
+		return 0
+	}
+	return op.id
+}
+
+// SetIdent updates the op's instance identity (useful when it only becomes
+// known after the op began, e.g. a recipe digest derived mid-call). Must be
+// called from the goroutine that owns the op, before End.
+func (op *Op) SetIdent(ident string) {
+	if op == nil {
+		return
+	}
+	op.identID = op.r.Intern(ident)
+}
+
+// outcomeHint carries an outcome decided mid-op (e.g. joined vs executed),
+// read back by the code that ends the op.
+func (op *Op) SetOutcomeHint(outcome Outcome) {
+	if op == nil {
+		return
+	}
+	op.outcomeHint = outcome
+}
+
+// OutcomeHint returns the hint set by SetOutcomeHint, or OutcomeNone.
+func (op *Op) OutcomeHint() Outcome {
+	if op == nil {
+		return OutcomeNone
+	}
+	return op.outcomeHint
+}
+
+// End records the op's completion.
+func (op *Op) End(outcome Outcome) {
+	op.EndWithResult(outcome, 0)
+}
+
+// EndErr records completion with OutcomeOK or OutcomeError based on err.
+func (op *Op) EndErr(err error) {
+	if err != nil {
+		op.End(OutcomeError)
+		return
+	}
+	op.End(OutcomeOK)
+}
+
+// EndWithResult records the op's completion, associating it with a dagql
+// shared result ID when non-zero.
+func (op *Op) EndWithResult(outcome Outcome, resultID uint64) {
+	if op == nil {
+		return
+	}
+	sh := op.r.shardFor(op.id)
+	sh.mu.Lock()
+	delete(sh.openOps, op.id)
+	sh.mu.Unlock()
+	op.r.append(sh, Event{
+		Type:     EventTypeOp,
+		OpKind:   op.kind,
+		WorkType: op.work,
+		Outcome:  outcome,
+		OpID:     op.id,
+		ParentID: op.parentID,
+		ResultID: resultID,
+		ClassID:  op.classID,
+		IdentID:  op.identID,
+		ClientID: op.clientID,
+		StartNS:  op.startNS,
+		EndNS:    op.r.Now(),
+	})
+}
+
+// Wait is a handle for an in-progress wait interval. A nil *Wait is valid
+// and End is a no-op.
+type Wait struct {
+	r        *Recorder
+	waiterID uint64
+	targetID uint64
+	identID  uint32
+	reason   WaitReason
+	startNS  int64
+}
+
+// BeginWait starts recording that the current op (from ctx) is blocked on
+// targetOpID for the given reason. Returns nil when profiling is disabled.
+func BeginWait(ctx context.Context, targetOpID uint64, reason WaitReason) *Wait {
+	return beginWait(ctx, targetOpID, "", reason)
+}
+
+// BeginWaitIdent is BeginWait for waits on a named resource (e.g. a lock)
+// rather than another op.
+func BeginWaitIdent(ctx context.Context, ident string, reason WaitReason) *Wait {
+	return beginWait(ctx, 0, ident, reason)
+}
+
+func beginWait(ctx context.Context, targetOpID uint64, ident string, reason WaitReason) *Wait {
+	r := Active()
+	if r == nil {
+		return nil
+	}
+	return &Wait{
+		r:        r,
+		waiterID: CurrentOpID(ctx),
+		targetID: targetOpID,
+		identID:  r.Intern(ident),
+		reason:   reason,
+		startNS:  r.Now(),
+	}
+}
+
+// SetTarget updates the awaited op (useful when the target becomes known
+// only after the wait began).
+func (w *Wait) SetTarget(targetOpID uint64) {
+	if w == nil {
+		return
+	}
+	w.targetID = targetOpID
+}
+
+// End records the wait interval.
+func (w *Wait) End() {
+	if w == nil {
+		return
+	}
+	endNS := w.r.Now()
+	sh := w.r.shardFor(w.waiterID)
+	w.r.append(sh, Event{
+		Type:     EventTypeWait,
+		Reason:   w.reason,
+		ParentID: w.waiterID,
+		TargetID: w.targetID,
+		IdentID:  w.identID,
+		StartNS:  w.startNS,
+		EndNS:    endNS,
+	})
+}
+
+// NowNS returns the current recorder-relative timestamp, or 0 when profiling
+// is disabled.
+func NowNS() int64 {
+	r := Active()
+	if r == nil {
+		return 0
+	}
+	return r.Now()
+}
+
+// RecordOp records an already-completed op interval with explicit
+// timestamps (from NowNS). Useful when an op's boundaries are observed from
+// callbacks where holding an *Op handle would race. Returns the op ID, or 0
+// when profiling is disabled.
+func RecordOp(ctx context.Context, kind OpKind, class string, opts OpOpts, startNS, endNS int64, outcome Outcome) uint64 {
+	r := Active()
+	if r == nil {
+		return 0
+	}
+	id := r.newOpID()
+	sh := r.shardFor(id)
+	r.append(sh, Event{
+		Type:     EventTypeOp,
+		OpKind:   kind,
+		WorkType: opts.WorkType,
+		Outcome:  outcome,
+		OpID:     id,
+		ParentID: CurrentOpID(ctx),
+		ClassID:  r.Intern(class),
+		IdentID:  r.Intern(opts.Ident),
+		ClientID: r.Intern(opts.ClientID),
+		StartNS:  startNS,
+		EndNS:    endNS,
+	})
+	return id
+}
+
+// Link records a non-blocking correlation from fromOpID (0 means the current
+// op in ctx) to an op, an interned ident, and/or a dagql result ID.
+func Link(ctx context.Context, kind LinkKind, fromOpID, targetOpID uint64, ident string, resultID uint64) {
+	r := Active()
+	if r == nil {
+		return
+	}
+	if fromOpID == 0 {
+		fromOpID = CurrentOpID(ctx)
+	}
+	sh := r.shardFor(fromOpID)
+	now := r.Now()
+	r.append(sh, Event{
+		Type:     EventTypeLink,
+		LinkKind: kind,
+		ParentID: fromOpID,
+		TargetID: targetOpID,
+		IdentID:  r.Intern(ident),
+		ResultID: resultID,
+		StartNS:  now,
+		EndNS:    now,
+	})
+}

--- a/engine/wcprof/wcanalyze/graph.go
+++ b/engine/wcprof/wcanalyze/graph.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"slices"
 	"sort"
+	"sync"
 
 	"github.com/dagger/dagger/engine/wcprof"
 )
@@ -72,6 +73,10 @@ type Graph struct {
 	// TraceStartNS/TraceEndNS bound all recorded activity.
 	TraceStartNS int64
 	TraceEndNS   int64
+
+	// prog is the compiled replay program, built once on first simulation.
+	progOnce sync.Once
+	prog     *replayProgram
 }
 
 // ClassKey identifies an operation class for aggregation: ops are grouped by
@@ -92,6 +97,48 @@ func Load(r io.Reader) (*Graph, error) {
 		return nil, err
 	}
 	return Build(header, events)
+}
+
+// LoadMulti reads multiple dumps taken from the same recorder (periodic
+// drains of one engine run) and reconstructs one combined op graph.
+//
+// This relies on recorder guarantees across flushes: the string table only
+// grows (IDs are stable), op IDs are globally unique, the epoch is fixed,
+// and the dropped-event counter is cumulative. The merge keeps the header
+// with the longest string table and latest open-ops view, and concatenates
+// all events.
+func LoadMulti(readers []io.Reader) (*Graph, error) {
+	if len(readers) == 0 {
+		return nil, fmt.Errorf("no dumps to load")
+	}
+	var (
+		merged    *wcprof.DumpHeader
+		allEvents []wcprof.DumpEvent
+	)
+	for i, r := range readers {
+		header, events, err := wcprof.ReadDump(r)
+		if err != nil {
+			return nil, fmt.Errorf("dump %d: %w", i, err)
+		}
+		if merged == nil {
+			merged = header
+		} else {
+			if header.EpochUnixNano != merged.EpochUnixNano {
+				return nil, fmt.Errorf("dump %d: epoch mismatch (%d != %d): dumps are from different recorder runs", i, header.EpochUnixNano, merged.EpochUnixNano)
+			}
+			if len(header.Strings) >= len(merged.Strings) {
+				merged.Strings = header.Strings
+			}
+			if header.DumpedUnixNano >= merged.DumpedUnixNano {
+				merged.DumpedUnixNano = header.DumpedUnixNano
+				merged.OpenOps = header.OpenOps
+			}
+			merged.DroppedEvents = max(merged.DroppedEvents, header.DroppedEvents)
+		}
+		allEvents = append(allEvents, events...)
+	}
+	merged.EventCount = len(allEvents)
+	return Build(merged, allEvents)
 }
 
 // Build reconstructs the op graph from parsed dump data.

--- a/engine/wcprof/wcanalyze/graph.go
+++ b/engine/wcprof/wcanalyze/graph.go
@@ -1,0 +1,361 @@
+// Package wcanalyze reconstructs an operation graph from a wcprof dump and
+// runs offline wall-clock bottleneck analysis over it: self-time accounting,
+// a replay-based counterfactual simulator, and per-class what-if rankings.
+package wcanalyze
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+
+	"github.com/dagger/dagger/engine/wcprof"
+)
+
+// Op is one reconstructed operation interval.
+type Op struct {
+	ID       uint64
+	ParentID uint64
+	Kind     string
+	WorkType string
+	Outcome  string
+	Class    string
+	Ident    string
+	ClientID string
+	ResultID uint64
+	StartNS  int64
+	EndNS    int64
+	// Open marks ops that had not ended at dump time; EndNS is the dump time.
+	Open bool
+
+	Parent   *Op
+	Children []*Op // sorted by StartNS
+	Waits    []*WaitEdge
+	// Reparented marks ops whose parent was assigned via a nested-client
+	// link rather than a recorded parent ID.
+	Reparented bool
+
+	// selfSegments is the op interval minus child intervals and waits,
+	// computed lazily by the analysis.
+	selfSegments []segment
+}
+
+func (op *Op) Duration() int64 {
+	return op.EndNS - op.StartNS
+}
+
+// WaitEdge is one recorded blocked-on interval.
+type WaitEdge struct {
+	Waiter      *Op // nil if the waiting code had no profiled op
+	Target      *Op // nil for unresolved or resource waits
+	TargetIdent string
+	Reason      string
+	StartNS     int64
+	EndNS       int64
+}
+
+func (w *WaitEdge) Duration() int64 {
+	return w.EndNS - w.StartNS
+}
+
+// Graph is the reconstructed op graph for one dump.
+type Graph struct {
+	Ops   map[uint64]*Op
+	Roots []*Op // ops with no (resolved) parent, sorted by StartNS
+
+	// OrphanWaits are waits whose waiter op is unknown.
+	OrphanWaits []*WaitEdge
+
+	DroppedEvents uint64
+	OpenOps       int
+
+	// TraceStartNS/TraceEndNS bound all recorded activity.
+	TraceStartNS int64
+	TraceEndNS   int64
+}
+
+// ClassKey identifies an operation class for aggregation: ops are grouped by
+// kind+class (e.g. call_exec / "Container.withExec").
+type ClassKey struct {
+	Kind  string
+	Class string
+}
+
+func (k ClassKey) String() string {
+	return k.Kind + ":" + k.Class
+}
+
+// Load reads a wcprof dump and reconstructs the op graph.
+func Load(r io.Reader) (*Graph, error) {
+	header, events, err := wcprof.ReadDump(r)
+	if err != nil {
+		return nil, err
+	}
+	return Build(header, events)
+}
+
+// Build reconstructs the op graph from parsed dump data.
+//
+//nolint:gocyclo // linear reconstruction flow over the event union
+func Build(header *wcprof.DumpHeader, events []wcprof.DumpEvent) (*Graph, error) {
+	str := func(id uint32) string {
+		if int(id) >= len(header.Strings) {
+			return fmt.Sprintf("<bad-string-%d>", id)
+		}
+		return header.Strings[id]
+	}
+
+	g := &Graph{
+		Ops:           make(map[uint64]*Op),
+		DroppedEvents: header.DroppedEvents,
+	}
+
+	dumpRelNS := header.DumpedUnixNano - header.EpochUnixNano
+
+	type rawWait struct {
+		waiterID uint64
+		targetID uint64
+		ident    string
+		reason   string
+		startNS  int64
+		endNS    int64
+	}
+	type rawLink struct {
+		fromID   uint64
+		targetID uint64
+		ident    string
+		kind     string
+		resultID uint64
+	}
+	var waits []rawWait
+	var links []rawLink
+
+	for _, ev := range events {
+		switch ev.Type {
+		case "op":
+			g.Ops[ev.OpID] = &Op{
+				ID:       ev.OpID,
+				ParentID: ev.ParentID,
+				Kind:     ev.OpKind,
+				WorkType: ev.WorkType,
+				Outcome:  ev.Outcome,
+				Class:    str(ev.ClassID),
+				Ident:    str(ev.IdentID),
+				ClientID: str(ev.ClientID),
+				ResultID: ev.ResultID,
+				StartNS:  ev.StartNS,
+				EndNS:    max(ev.EndNS, ev.StartNS),
+			}
+		case "wait":
+			waits = append(waits, rawWait{
+				waiterID: ev.ParentID,
+				targetID: ev.TargetID,
+				ident:    str(ev.IdentID),
+				reason:   ev.Reason,
+				startNS:  ev.StartNS,
+				endNS:    max(ev.EndNS, ev.StartNS),
+			})
+		case "link":
+			links = append(links, rawLink{
+				fromID:   ev.ParentID,
+				targetID: ev.TargetID,
+				ident:    str(ev.IdentID),
+				kind:     ev.LinkKind,
+				resultID: ev.ResultID,
+			})
+		}
+	}
+
+	// Ops still open at dump time get the dump timestamp as their end.
+	for _, oo := range header.OpenOps {
+		if _, exists := g.Ops[oo.OpID]; exists {
+			continue
+		}
+		g.Ops[oo.OpID] = &Op{
+			ID:       oo.OpID,
+			ParentID: oo.ParentID,
+			Kind:     oo.Kind,
+			WorkType: oo.WorkType,
+			Class:    str(oo.ClassID),
+			Ident:    str(oo.IdentID),
+			ClientID: str(oo.ClientID),
+			StartNS:  oo.StartNS,
+			EndNS:    max(dumpRelNS, oo.StartNS),
+			Open:     true,
+		}
+		g.OpenOps++
+	}
+
+	// Index exec ops by ident so exec-reason ident waits can resolve to them.
+	execByIdent := make(map[string]*Op)
+	for _, op := range g.Ops {
+		if op.Kind == wcprof.OpKindExec.String() && op.Ident != "" {
+			// prefer the longest-running exec for an ident if duplicated
+			if cur, ok := execByIdent[op.Ident]; !ok || op.Duration() > cur.Duration() {
+				execByIdent[op.Ident] = op
+			}
+		}
+	}
+
+	// Attach waits.
+	for _, rw := range waits {
+		w := &WaitEdge{
+			TargetIdent: rw.ident,
+			Reason:      rw.reason,
+			StartNS:     rw.startNS,
+			EndNS:       rw.endNS,
+		}
+		if t, ok := g.Ops[rw.targetID]; ok {
+			w.Target = t
+		} else if rw.reason == "exec" && rw.ident != "" {
+			if t, ok := execByIdent[rw.ident]; ok {
+				w.Target = t
+			}
+		}
+		if waiter, ok := g.Ops[rw.waiterID]; ok {
+			w.Waiter = waiter
+			waiter.Waits = append(waiter.Waits, w)
+		} else {
+			g.OrphanWaits = append(g.OrphanWaits, w)
+		}
+	}
+
+	// Nested-client links: clientID -> hosting exec op.
+	nestedClientExec := make(map[string]*Op)
+	for _, rl := range links {
+		if rl.kind != "nested_client" || rl.ident == "" {
+			continue
+		}
+		if from, ok := g.Ops[rl.fromID]; ok {
+			nestedClientExec[rl.ident] = from
+		}
+	}
+
+	// Wire parents. Roots belonging to a nested client get re-parented under
+	// the exec op hosting that client.
+	for _, op := range g.Ops {
+		if op.ParentID != 0 {
+			if parent, ok := g.Ops[op.ParentID]; ok && parent != op {
+				op.Parent = parent
+				continue
+			}
+		}
+		if hostExec, ok := nestedClientExec[op.ClientID]; ok && hostExec != op {
+			op.Parent = hostExec
+			op.Reparented = true
+		}
+	}
+	for _, op := range g.Ops {
+		if op.Parent != nil {
+			op.Parent.Children = append(op.Parent.Children, op)
+		} else {
+			g.Roots = append(g.Roots, op)
+		}
+	}
+	for _, op := range g.Ops {
+		slices.SortFunc(op.Children, func(a, b *Op) int {
+			if a.StartNS != b.StartNS {
+				return int(a.StartNS - b.StartNS)
+			}
+			return int(a.ID - b.ID)
+		})
+		slices.SortFunc(op.Waits, func(a, b *WaitEdge) int {
+			return int(a.StartNS - b.StartNS)
+		})
+	}
+	slices.SortFunc(g.Roots, func(a, b *Op) int {
+		if a.StartNS != b.StartNS {
+			return int(a.StartNS - b.StartNS)
+		}
+		return int(a.ID - b.ID)
+	})
+
+	first := true
+	for _, op := range g.Ops {
+		if first {
+			g.TraceStartNS, g.TraceEndNS = op.StartNS, op.EndNS
+			first = false
+			continue
+		}
+		g.TraceStartNS = min(g.TraceStartNS, op.StartNS)
+		g.TraceEndNS = max(g.TraceEndNS, op.EndNS)
+	}
+
+	return g, nil
+}
+
+// segment is a half-open interval [Start, End).
+type segment struct {
+	Start, End int64
+}
+
+// subtractIntervals returns base minus the union of cuts (cuts may overlap
+// and extend beyond base).
+func subtractIntervals(base segment, cuts []segment) []segment {
+	if len(cuts) == 0 {
+		if base.End > base.Start {
+			return []segment{base}
+		}
+		return nil
+	}
+	sorted := slices.Clone(cuts)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Start < sorted[j].Start })
+
+	var out []segment
+	cursor := base.Start
+	for _, cut := range sorted {
+		if cut.End <= cursor || cut.Start >= base.End {
+			continue
+		}
+		if cut.Start > cursor {
+			out = append(out, segment{cursor, min(cut.Start, base.End)})
+		}
+		cursor = max(cursor, cut.End)
+		if cursor >= base.End {
+			return out
+		}
+	}
+	if cursor < base.End {
+		out = append(out, segment{cursor, base.End})
+	}
+	return out
+}
+
+func sumSegments(segs []segment) int64 {
+	var total int64
+	for _, s := range segs {
+		total += s.End - s.Start
+	}
+	return total
+}
+
+// SelfSegments returns the op's interval minus its children's intervals and
+// its own wait intervals: the time the op was plausibly doing its own work.
+func (op *Op) SelfSegments() []segment {
+	if op.selfSegments != nil {
+		return op.selfSegments
+	}
+	cuts := make([]segment, 0, len(op.Children)+len(op.Waits))
+	for _, c := range op.Children {
+		cuts = append(cuts, segment{c.StartNS, c.EndNS})
+	}
+	for _, w := range op.Waits {
+		cuts = append(cuts, segment{w.StartNS, w.EndNS})
+	}
+	segs := subtractIntervals(segment{op.StartNS, op.EndNS}, cuts)
+	if segs == nil {
+		segs = []segment{}
+	}
+	op.selfSegments = segs
+	return segs
+}
+
+// SelfNS is the total self time of the op.
+func (op *Op) SelfNS() int64 {
+	return sumSegments(op.SelfSegments())
+}
+
+// Key returns the op's aggregation class key.
+func (op *Op) Key() ClassKey {
+	return ClassKey{Kind: op.Kind, Class: op.Class}
+}

--- a/engine/wcprof/wcanalyze/replay.go
+++ b/engine/wcprof/wcanalyze/replay.go
@@ -1,0 +1,527 @@
+package wcanalyze
+
+import (
+	"fmt"
+	"slices"
+	"time"
+)
+
+// The replay simulator re-executes the recorded op graph as a discrete-event
+// schedule under counterfactual hypotheses ("class X's self-time scaled by
+// f"), assuming unlimited resources (never CPU/disk bound).
+//
+// Each op is replayed as its chronological timeline of actions:
+//
+//   - self segments: advance the op's clock by the (scaled) duration
+//   - child spawns: anchor the child's simulated start at the current clock
+//   - waits: clock = max(clock, simulated finish of the target); waits on
+//     named resources (locks etc.) are kept as fixed delays
+//   - implicit joins: whenever the op reaches an action at original time t,
+//     it first joins every child that had originally ended by t. This bakes
+//     the observed ordering in as a constraint, which correctly models
+//     synchronous child calls (no explicit wait edge exists for plain
+//     function calls) and is conservatively safe for async children.
+//
+// Roots are chained by preserving original idle gaps between strictly
+// sequential roots (e.g. successive queries from the CLI).
+type Simulation struct {
+	g *Graph
+	// Factors scales self-time per class; missing keys mean 1.0.
+	Factors map[ClassKey]float64
+
+	simStart  map[uint64]int64
+	simFinish map[uint64]int64
+	inFlight  map[uint64]bool
+
+	// lastConstraint records, per op, which action finally set its clock:
+	// the op ID of the joined child / wait target, or 0 for self/fixed time.
+	lastConstraint map[uint64]uint64
+
+	// CycleWarnings counts wait/join cycles broken during replay.
+	CycleWarnings int
+	// FallbackAnchors counts ops anchored without their parent's replay
+	// reaching their spawn (parent in flight or inconsistent data). Large
+	// counts degrade counterfactual propagation.
+	FallbackAnchors int
+	// FallbackAnchorOps holds a sample of fallback-anchored ops.
+	FallbackAnchorOps []*Op
+}
+
+// NewSimulation prepares a replay over g with the given per-class self-time
+// factors (nil means baseline).
+func NewSimulation(g *Graph, factors map[ClassKey]float64) *Simulation {
+	return &Simulation{
+		g:              g,
+		Factors:        factors,
+		simStart:       make(map[uint64]int64, len(g.Ops)),
+		simFinish:      make(map[uint64]int64, len(g.Ops)),
+		inFlight:       make(map[uint64]bool),
+		lastConstraint: make(map[uint64]uint64),
+	}
+}
+
+func (s *Simulation) factor(op *Op) float64 {
+	if s.Factors == nil {
+		return 1
+	}
+	if f, ok := s.Factors[op.Key()]; ok {
+		return f
+	}
+	return 1
+}
+
+// Run replays all roots and returns the simulated makespan: the latest root
+// finish minus the earliest root start.
+func (s *Simulation) Run() (makespanNS int64, err error) {
+	if len(s.g.Roots) == 0 {
+		return 0, fmt.Errorf("no root ops to simulate")
+	}
+
+	// The simulation runs in the original trace's time frame (the first root
+	// keeps its recorded start). Mixing frames would corrupt the schedule:
+	// ops reached through cross-tree wait targets are anchored at original
+	// times when their own root has not been replayed yet.
+	chainOrigEnd := s.g.Roots[0].StartNS
+	chainSimEnd := s.g.Roots[0].StartNS
+	firstStart := int64(-1)
+	var lastFinish int64
+
+	for _, root := range s.g.Roots {
+		var start int64
+		if root.StartNS >= chainOrigEnd {
+			// strictly after the previous chained root finished: preserve the
+			// original idle gap (client think-time) but inherit any shift
+			start = chainSimEnd + (root.StartNS - chainOrigEnd)
+		} else {
+			// overlaps the previous root: keep the same displacement
+			start = root.StartNS + (chainSimEnd - chainOrigEnd)
+		}
+		s.setSimStart(root, start)
+		finish := s.finish(root)
+		if firstStart < 0 || start < firstStart {
+			firstStart = start
+		}
+		lastFinish = max(lastFinish, finish)
+		if root.EndNS >= chainOrigEnd {
+			chainOrigEnd = root.EndNS
+			chainSimEnd = finish
+		}
+	}
+	return lastFinish - firstStart, nil
+}
+
+func (s *Simulation) setSimStart(op *Op, start int64) {
+	if _, ok := s.simStart[op.ID]; !ok {
+		s.simStart[op.ID] = start
+	}
+}
+
+// finish returns the simulated completion time of op, replaying it (and
+// transitively everything it depends on) on first use.
+func (s *Simulation) finish(op *Op) int64 {
+	if f, ok := s.simFinish[op.ID]; ok {
+		return f
+	}
+
+	// Make sure the op has a simulated start: anchored by its parent's
+	// replay at the spawn point. Replaying the parent may recursively replay
+	// op itself (via an implicit join), which the memo check above handles
+	// when we come back around.
+	if _, ok := s.simStart[op.ID]; !ok {
+		if op.Parent != nil && !s.inFlight[op.Parent.ID] {
+			s.finish(op.Parent)
+			if f, ok := s.simFinish[op.ID]; ok {
+				return f
+			}
+		}
+		if _, ok := s.simStart[op.ID]; !ok {
+			// fallback: anchor in the parent's shifted frame, preserving the
+			// op's recorded offset within its parent (recorded start for
+			// true roots). Happens when the parent is mid-replay or data is
+			// inconsistent.
+			anchor := op.StartNS
+			if op.Parent != nil {
+				if ps, ok := s.simStart[op.Parent.ID]; ok {
+					anchor = ps + (op.StartNS - op.Parent.StartNS)
+				}
+			}
+			s.simStart[op.ID] = anchor
+			s.FallbackAnchors++
+			if len(s.FallbackAnchorOps) < 10 {
+				s.FallbackAnchorOps = append(s.FallbackAnchorOps, op)
+			}
+		}
+	}
+
+	if s.inFlight[op.ID] {
+		// cycle: break it by assuming original duration from the anchored start
+		s.CycleWarnings++
+		return s.simStart[op.ID] + op.Duration()
+	}
+	s.inFlight[op.ID] = true
+	defer delete(s.inFlight, op.ID)
+
+	clock := s.simStart[op.ID]
+	factor := s.factor(op)
+
+	// Build the chronological action list.
+	type action struct {
+		at   int64
+		kind int // 0=self, 1=spawn, 2=wait
+		self segment
+		ch   *Op
+		w    *WaitEdge
+	}
+	selfSegs := op.SelfSegments()
+	actions := make([]action, 0, len(selfSegs)+len(op.Children)+len(op.Waits))
+	for _, seg := range selfSegs {
+		actions = append(actions, action{at: seg.Start, kind: 0, self: seg})
+	}
+	for _, c := range op.Children {
+		actions = append(actions, action{at: c.StartNS, kind: 1, ch: c})
+	}
+	for _, w := range op.Waits {
+		actions = append(actions, action{at: w.StartNS, kind: 2, w: w})
+	}
+	slices.SortStableFunc(actions, func(a, b action) int {
+		if a.at != b.at {
+			if a.at < b.at {
+				return -1
+			}
+			return 1
+		}
+		return a.kind - b.kind
+	})
+
+	// children pending an implicit join, in original end order
+	pending := slices.Clone(op.Children)
+	slices.SortFunc(pending, func(a, b *Op) int {
+		if a.EndNS != b.EndNS {
+			return int(a.EndNS - b.EndNS)
+		}
+		return int(a.ID - b.ID)
+	})
+	joinUpTo := func(t int64) {
+		for len(pending) > 0 && pending[0].EndNS <= t {
+			c := pending[0]
+			pending = pending[1:]
+			if _, started := s.simStart[c.ID]; !started {
+				// child never anchored (e.g. spawn outside op interval);
+				// anchor at current clock
+				s.setSimStart(c, clock)
+			}
+			if f := s.finish(c); f > clock {
+				clock = f
+				s.lastConstraint[op.ID] = c.ID
+			}
+		}
+	}
+
+	for _, a := range actions {
+		joinUpTo(a.at)
+		switch a.kind {
+		case 0:
+			dur := a.self.End - a.self.Start
+			clock += int64(float64(dur) * factor)
+			s.lastConstraint[op.ID] = 0
+		case 1:
+			s.setSimStart(a.ch, clock)
+		case 2:
+			w := a.w
+			// Only model the wait as a join when the waiter actually stayed
+			// until the target completed. A wait that ended earlier was
+			// abandoned (cancellation) or points at the wrong op (ident
+			// mis-resolution); constraining on the target's full finish
+			// would inflate the schedule.
+			const joinEpsilonNS = int64(time.Millisecond)
+			if w.Target != nil && w.Target != op && w.EndNS >= w.Target.EndNS-joinEpsilonNS {
+				if f := s.finish(w.Target); f > clock {
+					clock = f
+					s.lastConstraint[op.ID] = w.Target.ID
+				}
+			} else if w.Target == nil {
+				// resource wait (lock, attachables...) or unresolved target:
+				// keep as a fixed delay
+				clock += w.Duration()
+				s.lastConstraint[op.ID] = 0
+			}
+			// abandoned waits on known targets contribute nothing: the op
+			// moved on at its own pace, captured by later actions
+		}
+	}
+	joinUpTo(op.EndNS)
+
+	s.simFinish[op.ID] = clock
+	return clock
+}
+
+// ExplainFinish walks the constraint chain from op downward through the
+// dependency (child/wait-target) with the latest simulated finish at each
+// step. Used for debugging replay-model fidelity and as a simulated critical
+// chain.
+func (s *Simulation) ExplainFinish(op *Op, maxDepth int) []*Op {
+	chain := []*Op{op}
+	seen := map[uint64]bool{op.ID: true}
+	for len(chain) < maxDepth {
+		var next *Op
+		var nextFinish int64
+		consider := func(cand *Op) {
+			if cand == nil || seen[cand.ID] {
+				return
+			}
+			f, ok := s.simFinish[cand.ID]
+			if !ok {
+				return
+			}
+			if f > nextFinish {
+				next, nextFinish = cand, f
+			}
+		}
+		for _, c := range op.Children {
+			consider(c)
+		}
+		for _, w := range op.Waits {
+			consider(w.Target)
+		}
+		if next == nil {
+			break
+		}
+		chain = append(chain, next)
+		seen[next.ID] = true
+		op = next
+	}
+	return chain
+}
+
+// SimTimes returns the simulated start/finish for an op.
+func (s *Simulation) SimTimes(op *Op) (startNS, finishNS int64) {
+	return s.simStart[op.ID], s.simFinish[op.ID]
+}
+
+// WhatIfResult is the simulated impact of scaling one class's self-time.
+type WhatIfResult struct {
+	Key ClassKey
+	// SavedNS[f] is baseline makespan minus the makespan with the class
+	// scaled by factor f.
+	SavedNS map[float64]int64
+}
+
+// ActualMakespanNS returns the observed makespan over root ops.
+func ActualMakespanNS(g *Graph) int64 {
+	if len(g.Roots) == 0 {
+		return 0
+	}
+	start := g.Roots[0].StartNS
+	var end int64
+	for _, r := range g.Roots {
+		start = min(start, r.StartNS)
+		end = max(end, r.EndNS)
+	}
+	return end - start
+}
+
+// maxWhatIfClasses bounds how many classes are simulated (each class costs
+// one full replay per factor); the candidates are the top classes by total
+// self-time.
+const maxWhatIfClasses = 200
+
+// RunWhatIfs computes baseline makespan and, for every class with total self
+// time >= minSelfNS (up to maxWhatIfClasses, by total self-time), the
+// makespan saving when scaling that class's self time by each factor.
+func RunWhatIfs(g *Graph, factors []float64, minSelfNS int64) (baselineNS int64, results []WhatIfResult, err error) {
+	baseSim := NewSimulation(g, nil)
+	baselineNS, err = baseSim.Run()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	totalSelf := make(map[ClassKey]int64)
+	for _, op := range g.Ops {
+		totalSelf[op.Key()] += op.SelfNS()
+	}
+
+	keys := make([]ClassKey, 0, len(totalSelf))
+	for key, self := range totalSelf {
+		if self >= minSelfNS {
+			keys = append(keys, key)
+		}
+	}
+	slices.SortFunc(keys, func(a, b ClassKey) int {
+		if totalSelf[a] != totalSelf[b] {
+			return int(totalSelf[b] - totalSelf[a])
+		}
+		if a.Kind != b.Kind {
+			if a.Kind < b.Kind {
+				return -1
+			}
+			return 1
+		}
+		if a.Class < b.Class {
+			return -1
+		}
+		if a.Class > b.Class {
+			return 1
+		}
+		return 0
+	})
+	if len(keys) > maxWhatIfClasses {
+		keys = keys[:maxWhatIfClasses]
+	}
+
+	for _, key := range keys {
+		res := WhatIfResult{Key: key, SavedNS: make(map[float64]int64, len(factors))}
+		for _, f := range factors {
+			sim := NewSimulation(g, map[ClassKey]float64{key: f})
+			makespan, err := sim.Run()
+			if err != nil {
+				return 0, nil, err
+			}
+			res.SavedNS[f] = baselineNS - makespan
+		}
+		results = append(results, res)
+	}
+	return baselineNS, results, nil
+}
+
+// OpDrift describes how far an op's simulated schedule diverged from its
+// recorded one in a baseline replay (factor 1 everywhere). Large positive
+// drift indicates the replay model over-constrains that op.
+type OpDrift struct {
+	Op           *Op
+	SimStartNS   int64
+	SimFinishNS  int64
+	StartDriftNS int64 // simStart - origStart
+	DurDriftNS   int64 // (simFinish-simStart) - origDuration
+}
+
+// BaselineDrift replays at factor 1 and returns the ops whose simulated
+// duration grew the most versus their recorded duration, plus the ops whose
+// simulated start moved latest. Used to debug replay-model fidelity.
+func BaselineDrift(g *Graph, topN int) (durDrift, startDrift []OpDrift) {
+	sim := NewSimulation(g, nil)
+	if _, err := sim.Run(); err != nil {
+		return nil, nil
+	}
+	drifts := make([]OpDrift, 0, len(g.Ops))
+	for _, op := range g.Ops {
+		finish, ok := sim.simFinish[op.ID]
+		if !ok {
+			continue
+		}
+		start := sim.simStart[op.ID]
+		drifts = append(drifts, OpDrift{
+			Op:           op,
+			SimStartNS:   start,
+			SimFinishNS:  finish,
+			StartDriftNS: start - op.StartNS,
+			DurDriftNS:   (finish - start) - op.Duration(),
+		})
+	}
+	byDur := slices.Clone(drifts)
+	slices.SortFunc(byDur, func(a, b OpDrift) int { return int(b.DurDriftNS - a.DurDriftNS) })
+	if len(byDur) > topN {
+		byDur = byDur[:topN]
+	}
+	byStart := drifts
+	slices.SortFunc(byStart, func(a, b OpDrift) int { return int(b.StartDriftNS - a.StartDriftNS) })
+	if len(byStart) > topN {
+		byStart = byStart[:topN]
+	}
+	return byDur, byStart
+}
+
+// DriftOrigin is an op whose baseline-simulated duration inflated beyond its
+// recorded duration by more than its dependencies' inflation explains: the
+// place where replay-model error is introduced (rather than inherited).
+type DriftOrigin struct {
+	Op         *Op
+	DurDriftNS int64
+	// OwnDriftNS is DurDrift minus the largest drift among children and wait
+	// targets.
+	OwnDriftNS int64
+}
+
+// DriftOrigins finds where baseline replay error originates, comparing each
+// op's simulated finish lateness (vs its recorded end, after removing the
+// global root shift) against the worst lateness among its dependencies.
+func DriftOrigins(g *Graph, minOwnDriftNS int64, topN int) []DriftOrigin {
+	sim := NewSimulation(g, nil)
+	if _, err := sim.Run(); err != nil {
+		return nil
+	}
+	finishDrift := func(op *Op) int64 {
+		finish, ok := sim.simFinish[op.ID]
+		if !ok {
+			return 0
+		}
+		return finish - op.EndNS
+	}
+	var origins []DriftOrigin
+	for _, op := range g.Ops {
+		d := finishDrift(op)
+		if d < minOwnDriftNS {
+			continue
+		}
+		var maxDep int64
+		for _, c := range op.Children {
+			maxDep = max(maxDep, finishDrift(c))
+		}
+		for _, w := range op.Waits {
+			if w.Target != nil {
+				maxDep = max(maxDep, finishDrift(w.Target))
+			}
+		}
+		if op.Parent != nil {
+			// start lateness inherited from the parent's anchor
+			maxDep = max(maxDep, sim.simStart[op.ID]-op.StartNS)
+		}
+		own := d - maxDep
+		if own >= minOwnDriftNS {
+			origins = append(origins, DriftOrigin{Op: op, DurDriftNS: d, OwnDriftNS: own})
+		}
+	}
+	slices.SortFunc(origins, func(a, b DriftOrigin) int { return int(b.OwnDriftNS - a.OwnDriftNS) })
+	if len(origins) > topN {
+		origins = origins[:topN]
+	}
+	return origins
+}
+
+// BlockingChain walks back from the op that finishes last in the baseline
+// simulation, at each step following the child or wait whose interval ends
+// latest, yielding an approximate end-of-workload critical chain.
+func BlockingChain(g *Graph, maxDepth int) []*Op {
+	if len(g.Roots) == 0 {
+		return nil
+	}
+	last := g.Roots[0]
+	for _, r := range g.Roots {
+		if r.EndNS > last.EndNS {
+			last = r
+		}
+	}
+	chain := []*Op{last}
+	cur := last
+	seen := map[uint64]bool{last.ID: true}
+	for len(chain) < maxDepth {
+		var next *Op
+		var nextEnd int64
+		for _, c := range cur.Children {
+			if c.EndNS > nextEnd && !seen[c.ID] {
+				next, nextEnd = c, c.EndNS
+			}
+		}
+		for _, w := range cur.Waits {
+			if w.Target != nil && w.Target.EndNS > nextEnd && !seen[w.Target.ID] {
+				next, nextEnd = w.Target, w.Target.EndNS
+			}
+		}
+		if next == nil {
+			break
+		}
+		chain = append(chain, next)
+		seen[next.ID] = true
+		cur = next
+	}
+	return chain
+}

--- a/engine/wcprof/wcanalyze/replay.go
+++ b/engine/wcprof/wcanalyze/replay.go
@@ -2,7 +2,9 @@ package wcanalyze
 
 import (
 	"fmt"
+	"runtime"
 	"slices"
+	"sync"
 	"time"
 )
 
@@ -15,7 +17,9 @@ import (
 //   - self segments: advance the op's clock by the (scaled) duration
 //   - child spawns: anchor the child's simulated start at the current clock
 //   - waits: clock = max(clock, simulated finish of the target); waits on
-//     named resources (locks etc.) are kept as fixed delays
+//     named resources (locks etc.) are kept as fixed delays; waits that
+//     ended before their target's recorded end were abandoned
+//     (cancellation) or mis-resolved and contribute nothing
 //   - implicit joins: whenever the op reaches an action at original time t,
 //     it first joins every child that had originally ended by t. This bakes
 //     the observed ordering in as a constraint, which correctly models
@@ -23,25 +27,205 @@ import (
 //     function calls) and is conservatively safe for async children.
 //
 // Roots are chained by preserving original idle gaps between strictly
-// sequential roots (e.g. successive queries from the CLI).
+// sequential roots (e.g. successive queries from the CLI). The simulation
+// runs in the original trace's time frame (the first root keeps its
+// recorded start); mixing frames would corrupt the schedule because ops
+// reached through cross-tree wait targets are anchored at original times
+// when their own root has not been replayed yet.
+//
+// The timeline of every op is factor-independent, so it is compiled once
+// per graph into a flat action program (replayProgram); each simulation is
+// then a pure array-based DP over that program, cheap enough to run
+// hundreds of counterfactuals over multi-million-op traces.
+
+const joinEpsilonNS = int64(time.Millisecond)
+
+// action kinds in the compiled program.
+const (
+	actSelf uint8 = iota
+	actSpawn
+	actWaitJoin
+	// actWaitNoop is an abandoned wait on a known target: it contributes no
+	// time (the op moved on at its own pace) but still marks an action point
+	// for implicit joins.
+	actWaitNoop
+	actWaitFixed
+)
+
+type action struct {
+	at   int64
+	dur  int64 // self duration or fixed-wait duration (unscaled)
+	ref  int32 // child / wait-target op index
+	kind uint8
+}
+
+// replayProgram is the per-graph compiled form of every op's timeline.
+type replayProgram struct {
+	ops     []*Op
+	idxByID map[uint64]int32
+
+	classKeys []ClassKey
+	classOf   []int32
+
+	startNS []int64
+	endNS   []int64
+	parent  []int32 // -1 when none
+
+	// actions[actOff[i]:actOff[i+1]] is op i's timeline, sorted by
+	// (at, self<spawn<wait) to match replay ordering rules.
+	actions []action
+	actOff  []int32
+
+	// pendIdx[pendOff[i]:pendOff[i+1]] is op i's children sorted by
+	// (EndNS, ID): the implicit-join order.
+	pendIdx []int32
+	pendOff []int32
+
+	roots []int32
+}
+
+func (g *Graph) program() *replayProgram {
+	g.progOnce.Do(func() {
+		g.prog = compileProgram(g)
+	})
+	return g.prog
+}
+
+func compileProgram(g *Graph) *replayProgram {
+	n := len(g.Ops)
+	p := &replayProgram{
+		ops:     make([]*Op, 0, n),
+		idxByID: make(map[uint64]int32, n),
+		classOf: make([]int32, n),
+		startNS: make([]int64, n),
+		endNS:   make([]int64, n),
+		parent:  make([]int32, n),
+		actOff:  make([]int32, n+1),
+		pendOff: make([]int32, n+1),
+	}
+
+	// deterministic dense indexing by op ID
+	for _, op := range g.Ops {
+		p.ops = append(p.ops, op)
+	}
+	slices.SortFunc(p.ops, func(a, b *Op) int {
+		return int(a.ID - b.ID)
+	})
+	for i, op := range p.ops {
+		p.idxByID[op.ID] = int32(i)
+	}
+
+	classIdx := make(map[ClassKey]int32)
+	totalActions := 0
+	totalPend := 0
+	for i, op := range p.ops {
+		p.startNS[i] = op.StartNS
+		p.endNS[i] = op.EndNS
+		p.parent[i] = -1
+		if op.Parent != nil {
+			if pi, ok := p.idxByID[op.Parent.ID]; ok {
+				p.parent[i] = pi
+			}
+		}
+		key := op.Key()
+		ci, ok := classIdx[key]
+		if !ok {
+			ci = int32(len(p.classKeys))
+			classIdx[key] = ci
+			p.classKeys = append(p.classKeys, key)
+		}
+		p.classOf[i] = ci
+		totalActions += len(op.SelfSegments()) + len(op.Children) + len(op.Waits)
+		totalPend += len(op.Children)
+	}
+
+	p.actions = make([]action, 0, totalActions)
+	p.pendIdx = make([]int32, 0, totalPend)
+	actionRank := func(kind uint8) int {
+		switch kind {
+		case actSelf:
+			return 0
+		case actSpawn:
+			return 1
+		default:
+			return 2
+		}
+	}
+	for i, op := range p.ops {
+		p.actOff[i] = int32(len(p.actions))
+		for _, seg := range op.SelfSegments() {
+			p.actions = append(p.actions, action{at: seg.Start, kind: actSelf, dur: seg.End - seg.Start})
+		}
+		for _, c := range op.Children {
+			p.actions = append(p.actions, action{at: c.StartNS, kind: actSpawn, ref: p.idxByID[c.ID]})
+		}
+		for _, w := range op.Waits {
+			a := action{at: w.StartNS}
+			switch {
+			case w.Target != nil && w.Target != op && w.EndNS >= w.Target.EndNS-joinEpsilonNS:
+				a.kind = actWaitJoin
+				a.ref = p.idxByID[w.Target.ID]
+			case w.Target == nil:
+				a.kind = actWaitFixed
+				a.dur = w.Duration()
+			default:
+				a.kind = actWaitNoop
+			}
+			p.actions = append(p.actions, a)
+		}
+		span := p.actions[p.actOff[i]:]
+		slices.SortStableFunc(span, func(a, b action) int {
+			if a.at != b.at {
+				if a.at < b.at {
+					return -1
+				}
+				return 1
+			}
+			return actionRank(a.kind) - actionRank(b.kind)
+		})
+
+		p.pendOff[i] = int32(len(p.pendIdx))
+		pend := slices.Clone(op.Children)
+		slices.SortFunc(pend, func(a, b *Op) int {
+			if a.EndNS != b.EndNS {
+				return int(a.EndNS - b.EndNS)
+			}
+			return int(a.ID - b.ID)
+		})
+		for _, c := range pend {
+			p.pendIdx = append(p.pendIdx, p.idxByID[c.ID])
+		}
+	}
+	p.actOff[n] = int32(len(p.actions))
+	p.pendOff[n] = int32(len(p.pendIdx))
+
+	p.roots = make([]int32, 0, len(g.Roots))
+	for _, r := range g.Roots {
+		p.roots = append(p.roots, p.idxByID[r.ID])
+	}
+	return p
+}
+
+// Simulation replays the compiled program under per-class self-time factors.
 type Simulation struct {
 	g *Graph
+	p *replayProgram
 	// Factors scales self-time per class; missing keys mean 1.0.
 	Factors map[ClassKey]float64
 
-	simStart  map[uint64]int64
-	simFinish map[uint64]int64
-	inFlight  map[uint64]bool
+	factorOf []float64
 
-	// lastConstraint records, per op, which action finally set its clock:
-	// the op ID of the joined child / wait target, or 0 for self/fixed time.
-	lastConstraint map[uint64]uint64
+	started   []bool
+	finished  []bool
+	inFlight  []bool
+	simStart  []int64
+	simFinish []int64
 
 	// CycleWarnings counts wait/join cycles broken during replay.
 	CycleWarnings int
 	// FallbackAnchors counts ops anchored without their parent's replay
-	// reaching their spawn (parent in flight or inconsistent data). Large
-	// counts degrade counterfactual propagation.
+	// reaching their spawn (parent in flight or inconsistent data). They
+	// anchor in the parent's shifted frame at their recorded offset.
 	FallbackAnchors int
 	// FallbackAnchorOps holds a sample of fallback-anchored ops.
 	FallbackAnchorOps []*Op
@@ -50,209 +234,183 @@ type Simulation struct {
 // NewSimulation prepares a replay over g with the given per-class self-time
 // factors (nil means baseline).
 func NewSimulation(g *Graph, factors map[ClassKey]float64) *Simulation {
-	return &Simulation{
-		g:              g,
-		Factors:        factors,
-		simStart:       make(map[uint64]int64, len(g.Ops)),
-		simFinish:      make(map[uint64]int64, len(g.Ops)),
-		inFlight:       make(map[uint64]bool),
-		lastConstraint: make(map[uint64]uint64),
+	p := g.program()
+	n := len(p.ops)
+	s := &Simulation{
+		g:         g,
+		p:         p,
+		Factors:   factors,
+		factorOf:  make([]float64, len(p.classKeys)),
+		started:   make([]bool, n),
+		finished:  make([]bool, n),
+		inFlight:  make([]bool, n),
+		simStart:  make([]int64, n),
+		simFinish: make([]int64, n),
 	}
-}
-
-func (s *Simulation) factor(op *Op) float64 {
-	if s.Factors == nil {
-		return 1
+	for i := range s.factorOf {
+		s.factorOf[i] = 1
 	}
-	if f, ok := s.Factors[op.Key()]; ok {
-		return f
+	for key, f := range factors {
+		for ci, ck := range p.classKeys {
+			if ck == key {
+				s.factorOf[ci] = f
+			}
+		}
 	}
-	return 1
+	return s
 }
 
 // Run replays all roots and returns the simulated makespan: the latest root
 // finish minus the earliest root start.
 func (s *Simulation) Run() (makespanNS int64, err error) {
-	if len(s.g.Roots) == 0 {
+	if len(s.p.roots) == 0 {
 		return 0, fmt.Errorf("no root ops to simulate")
 	}
 
-	// The simulation runs in the original trace's time frame (the first root
-	// keeps its recorded start). Mixing frames would corrupt the schedule:
-	// ops reached through cross-tree wait targets are anchored at original
-	// times when their own root has not been replayed yet.
-	chainOrigEnd := s.g.Roots[0].StartNS
-	chainSimEnd := s.g.Roots[0].StartNS
+	chainOrigEnd := s.p.startNS[s.p.roots[0]]
+	chainSimEnd := chainOrigEnd
 	firstStart := int64(-1)
 	var lastFinish int64
 
-	for _, root := range s.g.Roots {
+	for _, r := range s.p.roots {
 		var start int64
-		if root.StartNS >= chainOrigEnd {
+		if s.p.startNS[r] >= chainOrigEnd {
 			// strictly after the previous chained root finished: preserve the
 			// original idle gap (client think-time) but inherit any shift
-			start = chainSimEnd + (root.StartNS - chainOrigEnd)
+			start = chainSimEnd + (s.p.startNS[r] - chainOrigEnd)
 		} else {
 			// overlaps the previous root: keep the same displacement
-			start = root.StartNS + (chainSimEnd - chainOrigEnd)
+			start = s.p.startNS[r] + (chainSimEnd - chainOrigEnd)
 		}
-		s.setSimStart(root, start)
-		finish := s.finish(root)
-		if firstStart < 0 || start < firstStart {
-			firstStart = start
+		s.setStart(r, start)
+		finish := s.finish(r)
+		if firstStart < 0 || s.simStart[r] < firstStart {
+			firstStart = s.simStart[r]
 		}
 		lastFinish = max(lastFinish, finish)
-		if root.EndNS >= chainOrigEnd {
-			chainOrigEnd = root.EndNS
+		if s.p.endNS[r] >= chainOrigEnd {
+			chainOrigEnd = s.p.endNS[r]
 			chainSimEnd = finish
 		}
 	}
 	return lastFinish - firstStart, nil
 }
 
-func (s *Simulation) setSimStart(op *Op, start int64) {
-	if _, ok := s.simStart[op.ID]; !ok {
-		s.simStart[op.ID] = start
+func (s *Simulation) setStart(i int32, v int64) {
+	if !s.started[i] {
+		s.started[i] = true
+		s.simStart[i] = v
 	}
 }
 
-// finish returns the simulated completion time of op, replaying it (and
+// finish returns the simulated completion time of op i, replaying it (and
 // transitively everything it depends on) on first use.
-func (s *Simulation) finish(op *Op) int64 {
-	if f, ok := s.simFinish[op.ID]; ok {
-		return f
+func (s *Simulation) finish(i int32) int64 {
+	if s.finished[i] {
+		return s.simFinish[i]
 	}
 
 	// Make sure the op has a simulated start: anchored by its parent's
 	// replay at the spawn point. Replaying the parent may recursively replay
 	// op itself (via an implicit join), which the memo check above handles
 	// when we come back around.
-	if _, ok := s.simStart[op.ID]; !ok {
-		if op.Parent != nil && !s.inFlight[op.Parent.ID] {
-			s.finish(op.Parent)
-			if f, ok := s.simFinish[op.ID]; ok {
-				return f
+	if !s.started[i] {
+		if par := s.p.parent[i]; par >= 0 && !s.inFlight[par] {
+			s.finish(par)
+			if s.finished[i] {
+				return s.simFinish[i]
 			}
 		}
-		if _, ok := s.simStart[op.ID]; !ok {
+		if !s.started[i] {
 			// fallback: anchor in the parent's shifted frame, preserving the
 			// op's recorded offset within its parent (recorded start for
 			// true roots). Happens when the parent is mid-replay or data is
 			// inconsistent.
-			anchor := op.StartNS
-			if op.Parent != nil {
-				if ps, ok := s.simStart[op.Parent.ID]; ok {
-					anchor = ps + (op.StartNS - op.Parent.StartNS)
-				}
+			anchor := s.p.startNS[i]
+			if par := s.p.parent[i]; par >= 0 && s.started[par] {
+				anchor = s.simStart[par] + (s.p.startNS[i] - s.p.startNS[par])
 			}
-			s.simStart[op.ID] = anchor
+			s.setStart(i, anchor)
 			s.FallbackAnchors++
 			if len(s.FallbackAnchorOps) < 10 {
-				s.FallbackAnchorOps = append(s.FallbackAnchorOps, op)
+				s.FallbackAnchorOps = append(s.FallbackAnchorOps, s.p.ops[i])
 			}
 		}
 	}
 
-	if s.inFlight[op.ID] {
+	if s.inFlight[i] {
 		// cycle: break it by assuming original duration from the anchored start
 		s.CycleWarnings++
-		return s.simStart[op.ID] + op.Duration()
+		return s.simStart[i] + (s.p.endNS[i] - s.p.startNS[i])
 	}
-	s.inFlight[op.ID] = true
-	defer delete(s.inFlight, op.ID)
+	s.inFlight[i] = true
 
-	clock := s.simStart[op.ID]
-	factor := s.factor(op)
+	clock := s.simStart[i]
+	factor := s.factorOf[s.p.classOf[i]]
 
-	// Build the chronological action list.
-	type action struct {
-		at   int64
-		kind int // 0=self, 1=spawn, 2=wait
-		self segment
-		ch   *Op
-		w    *WaitEdge
-	}
-	selfSegs := op.SelfSegments()
-	actions := make([]action, 0, len(selfSegs)+len(op.Children)+len(op.Waits))
-	for _, seg := range selfSegs {
-		actions = append(actions, action{at: seg.Start, kind: 0, self: seg})
-	}
-	for _, c := range op.Children {
-		actions = append(actions, action{at: c.StartNS, kind: 1, ch: c})
-	}
-	for _, w := range op.Waits {
-		actions = append(actions, action{at: w.StartNS, kind: 2, w: w})
-	}
-	slices.SortStableFunc(actions, func(a, b action) int {
-		if a.at != b.at {
-			if a.at < b.at {
-				return -1
-			}
-			return 1
-		}
-		return a.kind - b.kind
-	})
-
-	// children pending an implicit join, in original end order
-	pending := slices.Clone(op.Children)
-	slices.SortFunc(pending, func(a, b *Op) int {
-		if a.EndNS != b.EndNS {
-			return int(a.EndNS - b.EndNS)
-		}
-		return int(a.ID - b.ID)
-	})
+	pendCur := s.p.pendOff[i]
+	pendEnd := s.p.pendOff[i+1]
 	joinUpTo := func(t int64) {
-		for len(pending) > 0 && pending[0].EndNS <= t {
-			c := pending[0]
-			pending = pending[1:]
-			if _, started := s.simStart[c.ID]; !started {
+		for pendCur < pendEnd {
+			c := s.p.pendIdx[pendCur]
+			if s.p.endNS[c] > t {
+				return
+			}
+			pendCur++
+			if !s.started[c] {
 				// child never anchored (e.g. spawn outside op interval);
 				// anchor at current clock
-				s.setSimStart(c, clock)
+				s.setStart(c, clock)
 			}
 			if f := s.finish(c); f > clock {
 				clock = f
-				s.lastConstraint[op.ID] = c.ID
 			}
 		}
 	}
 
-	for _, a := range actions {
+	for ai := s.p.actOff[i]; ai < s.p.actOff[i+1]; ai++ {
+		a := s.p.actions[ai]
 		joinUpTo(a.at)
 		switch a.kind {
-		case 0:
-			dur := a.self.End - a.self.Start
-			clock += int64(float64(dur) * factor)
-			s.lastConstraint[op.ID] = 0
-		case 1:
-			s.setSimStart(a.ch, clock)
-		case 2:
-			w := a.w
-			// Only model the wait as a join when the waiter actually stayed
-			// until the target completed. A wait that ended earlier was
-			// abandoned (cancellation) or points at the wrong op (ident
-			// mis-resolution); constraining on the target's full finish
-			// would inflate the schedule.
-			const joinEpsilonNS = int64(time.Millisecond)
-			if w.Target != nil && w.Target != op && w.EndNS >= w.Target.EndNS-joinEpsilonNS {
-				if f := s.finish(w.Target); f > clock {
-					clock = f
-					s.lastConstraint[op.ID] = w.Target.ID
-				}
-			} else if w.Target == nil {
-				// resource wait (lock, attachables...) or unresolved target:
-				// keep as a fixed delay
-				clock += w.Duration()
-				s.lastConstraint[op.ID] = 0
+		case actSelf:
+			clock += int64(float64(a.dur) * factor)
+		case actSpawn:
+			s.setStart(a.ref, clock)
+		case actWaitJoin:
+			if f := s.finish(a.ref); f > clock {
+				clock = f
 			}
-			// abandoned waits on known targets contribute nothing: the op
-			// moved on at its own pace, captured by later actions
+		case actWaitFixed:
+			clock += a.dur
+		case actWaitNoop:
+			// abandoned wait: action point only
 		}
 	}
-	joinUpTo(op.EndNS)
+	joinUpTo(s.p.endNS[i])
 
-	s.simFinish[op.ID] = clock
+	s.simFinish[i] = clock
+	s.finished[i] = true
+	s.inFlight[i] = false
 	return clock
+}
+
+// SimTimes returns the simulated start/finish for an op (zero values when
+// the op was not reached by the replay).
+func (s *Simulation) SimTimes(op *Op) (startNS, finishNS int64) {
+	i, ok := s.p.idxByID[op.ID]
+	if !ok || !s.finished[i] {
+		return 0, 0
+	}
+	return s.simStart[i], s.simFinish[i]
+}
+
+// simTimesOK is SimTimes plus whether the op completed in the replay.
+func (s *Simulation) simTimesOK(op *Op) (startNS, finishNS int64, ok bool) {
+	i, found := s.p.idxByID[op.ID]
+	if !found || !s.finished[i] {
+		return 0, 0, false
+	}
+	return s.simStart[i], s.simFinish[i], true
 }
 
 // ExplainFinish walks the constraint chain from op downward through the
@@ -269,7 +427,7 @@ func (s *Simulation) ExplainFinish(op *Op, maxDepth int) []*Op {
 			if cand == nil || seen[cand.ID] {
 				return
 			}
-			f, ok := s.simFinish[cand.ID]
+			_, f, ok := s.simTimesOK(cand)
 			if !ok {
 				return
 			}
@@ -291,11 +449,6 @@ func (s *Simulation) ExplainFinish(op *Op, maxDepth int) []*Op {
 		op = next
 	}
 	return chain
-}
-
-// SimTimes returns the simulated start/finish for an op.
-func (s *Simulation) SimTimes(op *Op) (startNS, finishNS int64) {
-	return s.simStart[op.ID], s.simFinish[op.ID]
 }
 
 // WhatIfResult is the simulated impact of scaling one class's self-time.
@@ -328,6 +481,7 @@ const maxWhatIfClasses = 200
 // RunWhatIfs computes baseline makespan and, for every class with total self
 // time >= minSelfNS (up to maxWhatIfClasses, by total self-time), the
 // makespan saving when scaling that class's self time by each factor.
+// Simulations run in parallel.
 func RunWhatIfs(g *Graph, factors []float64, minSelfNS int64) (baselineNS int64, results []WhatIfResult, err error) {
 	baseSim := NewSimulation(g, nil)
 	baselineNS, err = baseSim.Run()
@@ -368,123 +522,48 @@ func RunWhatIfs(g *Graph, factors []float64, minSelfNS int64) (baselineNS int64,
 		keys = keys[:maxWhatIfClasses]
 	}
 
-	for _, key := range keys {
-		res := WhatIfResult{Key: key, SavedNS: make(map[float64]int64, len(factors))}
-		for _, f := range factors {
-			sim := NewSimulation(g, map[ClassKey]float64{key: f})
-			makespan, err := sim.Run()
-			if err != nil {
-				return 0, nil, err
+	results = make([]WhatIfResult, len(keys))
+	for ki, key := range keys {
+		results[ki] = WhatIfResult{Key: key, SavedNS: make(map[float64]int64, len(factors))}
+	}
+
+	// each (class, factor) simulation is independent; bound parallelism to
+	// keep per-sim state memory in check on huge traces
+	type job struct{ ki, fi int }
+	jobs := make(chan job)
+	workers := min(runtime.GOMAXPROCS(0), 8)
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				sim := NewSimulation(g, map[ClassKey]float64{keys[j.ki]: factors[j.fi]})
+				makespan, simErr := sim.Run()
+				mu.Lock()
+				if simErr != nil && err == nil {
+					err = simErr
+				} else {
+					results[j.ki].SavedNS[factors[j.fi]] = baselineNS - makespan
+				}
+				mu.Unlock()
 			}
-			res.SavedNS[f] = baselineNS - makespan
+		}()
+	}
+	for ki := range keys {
+		for fi := range factors {
+			jobs <- job{ki, fi}
 		}
-		results = append(results, res)
+	}
+	close(jobs)
+	wg.Wait()
+	if err != nil {
+		return 0, nil, err
 	}
 	return baselineNS, results, nil
-}
-
-// OpDrift describes how far an op's simulated schedule diverged from its
-// recorded one in a baseline replay (factor 1 everywhere). Large positive
-// drift indicates the replay model over-constrains that op.
-type OpDrift struct {
-	Op           *Op
-	SimStartNS   int64
-	SimFinishNS  int64
-	StartDriftNS int64 // simStart - origStart
-	DurDriftNS   int64 // (simFinish-simStart) - origDuration
-}
-
-// BaselineDrift replays at factor 1 and returns the ops whose simulated
-// duration grew the most versus their recorded duration, plus the ops whose
-// simulated start moved latest. Used to debug replay-model fidelity.
-func BaselineDrift(g *Graph, topN int) (durDrift, startDrift []OpDrift) {
-	sim := NewSimulation(g, nil)
-	if _, err := sim.Run(); err != nil {
-		return nil, nil
-	}
-	drifts := make([]OpDrift, 0, len(g.Ops))
-	for _, op := range g.Ops {
-		finish, ok := sim.simFinish[op.ID]
-		if !ok {
-			continue
-		}
-		start := sim.simStart[op.ID]
-		drifts = append(drifts, OpDrift{
-			Op:           op,
-			SimStartNS:   start,
-			SimFinishNS:  finish,
-			StartDriftNS: start - op.StartNS,
-			DurDriftNS:   (finish - start) - op.Duration(),
-		})
-	}
-	byDur := slices.Clone(drifts)
-	slices.SortFunc(byDur, func(a, b OpDrift) int { return int(b.DurDriftNS - a.DurDriftNS) })
-	if len(byDur) > topN {
-		byDur = byDur[:topN]
-	}
-	byStart := drifts
-	slices.SortFunc(byStart, func(a, b OpDrift) int { return int(b.StartDriftNS - a.StartDriftNS) })
-	if len(byStart) > topN {
-		byStart = byStart[:topN]
-	}
-	return byDur, byStart
-}
-
-// DriftOrigin is an op whose baseline-simulated duration inflated beyond its
-// recorded duration by more than its dependencies' inflation explains: the
-// place where replay-model error is introduced (rather than inherited).
-type DriftOrigin struct {
-	Op         *Op
-	DurDriftNS int64
-	// OwnDriftNS is DurDrift minus the largest drift among children and wait
-	// targets.
-	OwnDriftNS int64
-}
-
-// DriftOrigins finds where baseline replay error originates, comparing each
-// op's simulated finish lateness (vs its recorded end, after removing the
-// global root shift) against the worst lateness among its dependencies.
-func DriftOrigins(g *Graph, minOwnDriftNS int64, topN int) []DriftOrigin {
-	sim := NewSimulation(g, nil)
-	if _, err := sim.Run(); err != nil {
-		return nil
-	}
-	finishDrift := func(op *Op) int64 {
-		finish, ok := sim.simFinish[op.ID]
-		if !ok {
-			return 0
-		}
-		return finish - op.EndNS
-	}
-	var origins []DriftOrigin
-	for _, op := range g.Ops {
-		d := finishDrift(op)
-		if d < minOwnDriftNS {
-			continue
-		}
-		var maxDep int64
-		for _, c := range op.Children {
-			maxDep = max(maxDep, finishDrift(c))
-		}
-		for _, w := range op.Waits {
-			if w.Target != nil {
-				maxDep = max(maxDep, finishDrift(w.Target))
-			}
-		}
-		if op.Parent != nil {
-			// start lateness inherited from the parent's anchor
-			maxDep = max(maxDep, sim.simStart[op.ID]-op.StartNS)
-		}
-		own := d - maxDep
-		if own >= minOwnDriftNS {
-			origins = append(origins, DriftOrigin{Op: op, DurDriftNS: d, OwnDriftNS: own})
-		}
-	}
-	slices.SortFunc(origins, func(a, b DriftOrigin) int { return int(b.OwnDriftNS - a.OwnDriftNS) })
-	if len(origins) > topN {
-		origins = origins[:topN]
-	}
-	return origins
 }
 
 // BlockingChain walks back from the op that finishes last in the baseline
@@ -524,4 +603,109 @@ func BlockingChain(g *Graph, maxDepth int) []*Op {
 		cur = next
 	}
 	return chain
+}
+
+// OpDrift describes how far an op's simulated schedule diverged from its
+// recorded one in a baseline replay (factor 1 everywhere). Large positive
+// drift indicates the replay model over-constrains that op.
+type OpDrift struct {
+	Op           *Op
+	SimStartNS   int64
+	SimFinishNS  int64
+	StartDriftNS int64 // simStart - origStart
+	DurDriftNS   int64 // (simFinish-simStart) - origDuration
+}
+
+// BaselineDrift replays at factor 1 and returns the ops whose simulated
+// duration grew the most versus their recorded duration, plus the ops whose
+// simulated start moved latest. Used to debug replay-model fidelity.
+func BaselineDrift(g *Graph, topN int) (durDrift, startDrift []OpDrift) {
+	sim := NewSimulation(g, nil)
+	if _, err := sim.Run(); err != nil {
+		return nil, nil
+	}
+	drifts := make([]OpDrift, 0, len(g.Ops))
+	for _, op := range g.Ops {
+		start, finish, ok := sim.simTimesOK(op)
+		if !ok {
+			continue
+		}
+		drifts = append(drifts, OpDrift{
+			Op:           op,
+			SimStartNS:   start,
+			SimFinishNS:  finish,
+			StartDriftNS: start - op.StartNS,
+			DurDriftNS:   (finish - start) - op.Duration(),
+		})
+	}
+	byDur := slices.Clone(drifts)
+	slices.SortFunc(byDur, func(a, b OpDrift) int { return int(b.DurDriftNS - a.DurDriftNS) })
+	if len(byDur) > topN {
+		byDur = byDur[:topN]
+	}
+	byStart := drifts
+	slices.SortFunc(byStart, func(a, b OpDrift) int { return int(b.StartDriftNS - a.StartDriftNS) })
+	if len(byStart) > topN {
+		byStart = byStart[:topN]
+	}
+	return byDur, byStart
+}
+
+// DriftOrigin is an op whose baseline-simulated duration inflated beyond its
+// recorded duration by more than its dependencies' inflation explains: the
+// place where replay-model error is introduced (rather than inherited).
+type DriftOrigin struct {
+	Op         *Op
+	DurDriftNS int64
+	// OwnDriftNS is DurDrift minus the largest drift among children and wait
+	// targets.
+	OwnDriftNS int64
+}
+
+// DriftOrigins finds where baseline replay error originates, comparing each
+// op's simulated finish lateness (vs its recorded end) against the worst
+// lateness among its dependencies.
+func DriftOrigins(g *Graph, minOwnDriftNS int64, topN int) []DriftOrigin {
+	sim := NewSimulation(g, nil)
+	if _, err := sim.Run(); err != nil {
+		return nil
+	}
+	finishDrift := func(op *Op) int64 {
+		_, finish, ok := sim.simTimesOK(op)
+		if !ok {
+			return 0
+		}
+		return finish - op.EndNS
+	}
+	var origins []DriftOrigin
+	for _, op := range g.Ops {
+		d := finishDrift(op)
+		if d < minOwnDriftNS {
+			continue
+		}
+		var maxDep int64
+		for _, c := range op.Children {
+			maxDep = max(maxDep, finishDrift(c))
+		}
+		for _, w := range op.Waits {
+			if w.Target != nil {
+				maxDep = max(maxDep, finishDrift(w.Target))
+			}
+		}
+		if op.Parent != nil {
+			// start lateness inherited from the parent's anchor
+			if start, _, ok := sim.simTimesOK(op); ok {
+				maxDep = max(maxDep, start-op.StartNS)
+			}
+		}
+		own := d - maxDep
+		if own >= minOwnDriftNS {
+			origins = append(origins, DriftOrigin{Op: op, DurDriftNS: d, OwnDriftNS: own})
+		}
+	}
+	slices.SortFunc(origins, func(a, b DriftOrigin) int { return int(b.OwnDriftNS - a.OwnDriftNS) })
+	if len(origins) > topN {
+		origins = origins[:topN]
+	}
+	return origins
 }

--- a/engine/wcprof/wcanalyze/replay_test.go
+++ b/engine/wcprof/wcanalyze/replay_test.go
@@ -1,0 +1,319 @@
+package wcanalyze
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/dagger/dagger/engine/wcprof"
+)
+
+const ms = int64(time.Millisecond)
+
+// fixtureStrings builds a string table and a lookup from value to ID.
+type fixtureStrings struct {
+	values []string
+	ids    map[string]uint32
+}
+
+func newFixtureStrings() *fixtureStrings {
+	return &fixtureStrings{values: []string{""}, ids: map[string]uint32{"": 0}}
+}
+
+func (s *fixtureStrings) id(v string) uint32 {
+	if id, ok := s.ids[v]; ok {
+		return id
+	}
+	id := uint32(len(s.values))
+	s.values = append(s.values, v)
+	s.ids[v] = id
+	return id
+}
+
+func opEvent(s *fixtureStrings, id, parent uint64, kind, class, ident, outcome string, startNS, endNS int64) wcprof.DumpEvent {
+	return wcprof.DumpEvent{
+		Type: "op", OpKind: kind, WorkType: "engine", Outcome: outcome,
+		OpID: id, ParentID: parent,
+		ClassID: s.id(class), IdentID: s.id(ident),
+		StartNS: startNS, EndNS: endNS,
+	}
+}
+
+func waitEvent(s *fixtureStrings, waiter, target uint64, ident, reason string, startNS, endNS int64) wcprof.DumpEvent {
+	return wcprof.DumpEvent{
+		Type: "wait", Reason: reason,
+		ParentID: waiter, TargetID: target, IdentID: s.id(ident),
+		StartNS: startNS, EndNS: endNS,
+	}
+}
+
+// sequentialFixture: a root session op running two sequential calls; each
+// call op waits on its call_exec child.
+//
+//	R [0,1000ms]
+//	├── C1 call (executed) [0,400] ── waits on E1
+//	│    └── E1 call_exec Container.withExec [0,400] (self 400ms)
+//	└── C2 call (executed) [400,1000] ── waits on E2
+//	     └── E2 call_exec Container.from [400,1000] (self 600ms)
+func sequentialFixture(t *testing.T) *Graph {
+	t.Helper()
+	s := newFixtureStrings()
+	events := []wcprof.DumpEvent{
+		opEvent(s, 1, 0, "session_phase", "session.query", "", "ok", 0, 1000*ms),
+		opEvent(s, 2, 1, "call", "Container.withExec", "d1", "executed", 0, 400*ms),
+		opEvent(s, 3, 2, "call_exec", "Container.withExec", "d1", "ok", 0, 400*ms),
+		waitEvent(s, 2, 3, "", "call_exec", 0, 400*ms),
+		opEvent(s, 4, 1, "call", "Container.from", "d2", "executed", 400*ms, 1000*ms),
+		opEvent(s, 5, 4, "call_exec", "Container.from", "d2", "ok", 400*ms, 1000*ms),
+		waitEvent(s, 4, 5, "", "call_exec", 400*ms, 1000*ms),
+	}
+	header := &wcprof.DumpHeader{
+		SchemaVersion: wcprof.DumpSchemaVersion,
+		Strings:       s.values,
+		EventCount:    len(events),
+	}
+	g, err := Build(header, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+func TestSelfTime(t *testing.T) {
+	g := sequentialFixture(t)
+
+	if got := g.Ops[3].SelfNS(); got != 400*ms {
+		t.Fatalf("E1 self = %v, want 400ms", time.Duration(got))
+	}
+	if got := g.Ops[5].SelfNS(); got != 600*ms {
+		t.Fatalf("E2 self = %v, want 600ms", time.Duration(got))
+	}
+	// the call op's time is fully covered by its child + wait
+	if got := g.Ops[2].SelfNS(); got != 0 {
+		t.Fatalf("C1 self = %v, want 0", time.Duration(got))
+	}
+	// the root's time is fully covered by its children
+	if got := g.Ops[1].SelfNS(); got != 0 {
+		t.Fatalf("R self = %v, want 0", time.Duration(got))
+	}
+}
+
+func TestBaselineMatchesActual(t *testing.T) {
+	g := sequentialFixture(t)
+	if got := ActualMakespanNS(g); got != 1000*ms {
+		t.Fatalf("actual makespan = %v, want 1s", time.Duration(got))
+	}
+	sim := NewSimulation(g, nil)
+	makespan, err := sim.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if makespan != 1000*ms {
+		t.Fatalf("baseline makespan = %v, want 1s", time.Duration(makespan))
+	}
+	if sim.CycleWarnings != 0 {
+		t.Fatalf("unexpected cycle warnings: %d", sim.CycleWarnings)
+	}
+}
+
+func TestWhatIfSequential(t *testing.T) {
+	g := sequentialFixture(t)
+
+	cases := []struct {
+		class  string
+		factor float64
+		want   int64
+	}{
+		// halving withExec's 400ms self saves 200ms end to end (C2 starts earlier)
+		{"Container.withExec", 0.5, 200 * ms},
+		// eliminating it saves the full 400ms
+		{"Container.withExec", 0, 400 * ms},
+		// halving from's 600ms saves 300ms
+		{"Container.from", 0.5, 300 * ms},
+	}
+	for _, tc := range cases {
+		sim := NewSimulation(g, map[ClassKey]float64{
+			{Kind: "call_exec", Class: tc.class}: tc.factor,
+		})
+		makespan, err := sim.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+		saved := 1000*ms - makespan
+		if saved != tc.want {
+			t.Fatalf("whatif %s x%v: saved %v, want %v", tc.class, tc.factor, time.Duration(saved), time.Duration(tc.want))
+		}
+	}
+}
+
+// singleflight: two callers join one execution; speeding the class up should
+// count the shared work once.
+func TestWhatIfSingleflight(t *testing.T) {
+	s := newFixtureStrings()
+	events := []wcprof.DumpEvent{
+		opEvent(s, 1, 0, "session_phase", "session.query", "", "ok", 0, 400*ms),
+		opEvent(s, 2, 1, "call", "Container.withExec", "d1", "executed", 0, 400*ms),
+		opEvent(s, 3, 2, "call_exec", "Container.withExec", "d1", "ok", 0, 400*ms),
+		waitEvent(s, 2, 3, "", "call_exec", 0, 400*ms),
+		opEvent(s, 4, 1, "call", "Container.withExec", "d1", "joined", 0, 400*ms),
+		waitEvent(s, 4, 3, "", "singleflight", 0, 400*ms),
+	}
+	header := &wcprof.DumpHeader{SchemaVersion: wcprof.DumpSchemaVersion, Strings: s.values, EventCount: len(events)}
+	g, err := Build(header, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sim := NewSimulation(g, nil)
+	baseline, err := sim.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseline != 400*ms {
+		t.Fatalf("baseline = %v, want 400ms", time.Duration(baseline))
+	}
+
+	sim = NewSimulation(g, map[ClassKey]float64{
+		{Kind: "call_exec", Class: "Container.withExec"}: 0.5,
+	})
+	makespan, err := sim.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved := baseline - makespan; saved != 200*ms {
+		t.Fatalf("singleflight saved = %v, want 200ms", time.Duration(saved))
+	}
+}
+
+// Two sequential roots with an idle gap between them: the gap is preserved,
+// and savings in the first root pull the second root earlier.
+func TestRootChaining(t *testing.T) {
+	s := newFixtureStrings()
+	events := []wcprof.DumpEvent{
+		opEvent(s, 1, 0, "session_phase", "session.query", "", "ok", 0, 100*ms),
+		opEvent(s, 2, 0, "session_phase", "session.query2", "", "ok", 150*ms, 250*ms),
+	}
+	header := &wcprof.DumpHeader{SchemaVersion: wcprof.DumpSchemaVersion, Strings: s.values, EventCount: len(events)}
+	g, err := Build(header, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sim := NewSimulation(g, nil)
+	baseline, err := sim.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseline != 250*ms {
+		t.Fatalf("baseline = %v, want 250ms", time.Duration(baseline))
+	}
+
+	sim = NewSimulation(g, map[ClassKey]float64{
+		{Kind: "session_phase", Class: "session.query"}: 0,
+	})
+	makespan, err := sim.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// first root drops to 0; the 50ms think-time gap is preserved; second
+	// root still takes 100ms => 150ms total
+	if makespan != 150*ms {
+		t.Fatalf("makespan = %v, want 150ms", time.Duration(makespan))
+	}
+}
+
+// exec-reason waits with no target op ID resolve to the exec op by ident.
+func TestExecIdentWaitResolution(t *testing.T) {
+	s := newFixtureStrings()
+	events := []wcprof.DumpEvent{
+		opEvent(s, 1, 0, "session_phase", "session.query", "", "ok", 0, 500*ms),
+		opEvent(s, 2, 1, "lazy", "Container.withExec", "", "ok", 0, 500*ms),
+		opEvent(s, 3, 2, "exec", "exec.run", "callDigest1", "ok", 100*ms, 500*ms),
+		waitEvent(s, 2, 0, "callDigest1", "exec", 100*ms, 500*ms),
+	}
+	header := &wcprof.DumpHeader{SchemaVersion: wcprof.DumpSchemaVersion, Strings: s.values, EventCount: len(events)}
+	g, err := Build(header, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lazyOp := g.Ops[2]
+	if len(lazyOp.Waits) != 1 {
+		t.Fatalf("lazy op waits = %d, want 1", len(lazyOp.Waits))
+	}
+	if lazyOp.Waits[0].Target == nil || lazyOp.Waits[0].Target.ID != 3 {
+		t.Fatalf("exec ident wait did not resolve to exec op: %+v", lazyOp.Waits[0])
+	}
+	// lazy self: 500 - exec child(100..500) - wait(100..500) = first 100ms
+	if got := lazyOp.SelfNS(); got != 100*ms {
+		t.Fatalf("lazy self = %v, want 100ms", time.Duration(got))
+	}
+}
+
+// nested-client link reparents the nested session root under the exec op.
+func TestNestedClientReparenting(t *testing.T) {
+	s := newFixtureStrings()
+	events := []wcprof.DumpEvent{
+		opEvent(s, 1, 0, "session_phase", "session.query", "", "ok", 0, 500*ms),
+		opEvent(s, 2, 1, "exec", "exec.run", "dig", "ok", 0, 500*ms),
+		{Type: "link", LinkKind: "nested_client", ParentID: 2, IdentID: s.id("nested-client-1")},
+		// nested client's own query root: no recorded parent, but carries the
+		// nested client ID
+		{
+			Type: "op", OpKind: "session_phase", WorkType: "engine", Outcome: "ok",
+			OpID: 3, ParentID: 0, ClassID: s.id("session.serveQuery"), ClientID: s.id("nested-client-1"),
+			StartNS: 100 * ms, EndNS: 400 * ms,
+		},
+	}
+	header := &wcprof.DumpHeader{SchemaVersion: wcprof.DumpSchemaVersion, Strings: s.values, EventCount: len(events)}
+	g, err := Build(header, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nested := g.Ops[3]
+	if nested.Parent == nil || nested.Parent.ID != 2 {
+		t.Fatalf("nested root not reparented under exec, parent=%+v", nested.Parent)
+	}
+	if !nested.Reparented {
+		t.Fatal("expected Reparented flag")
+	}
+	if len(g.Roots) != 1 {
+		t.Fatalf("roots = %d, want 1", len(g.Roots))
+	}
+}
+
+func TestRunWhatIfsRanking(t *testing.T) {
+	g := sequentialFixture(t)
+	baseline, results, err := RunWhatIfs(g, []float64{0, 0.5}, ms)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseline != 1000*ms {
+		t.Fatalf("baseline = %v", time.Duration(baseline))
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected >=2 classes, got %d", len(results))
+	}
+	bySaving := map[string]int64{}
+	for _, res := range results {
+		if res.Key.Kind == "call_exec" {
+			bySaving[res.Key.Class] = res.SavedNS[0.5]
+		}
+	}
+	if bySaving["Container.from"] != 300*ms || bySaving["Container.withExec"] != 200*ms {
+		t.Fatalf("unexpected what-if savings: %+v", bySaving)
+	}
+}
+
+func TestReportRenders(t *testing.T) {
+	g := sequentialFixture(t)
+	var buf bytes.Buffer
+	if err := WriteReport(&buf, g, ReportOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"what-if", "Container.withExec", "top classes", "blocking chain"} {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Fatalf("report missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/engine/wcprof/wcanalyze/replay_test.go
+++ b/engine/wcprof/wcanalyze/replay_test.go
@@ -2,6 +2,9 @@ package wcanalyze
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -302,6 +305,80 @@ func TestRunWhatIfsRanking(t *testing.T) {
 	if bySaving["Container.from"] != 300*ms || bySaving["Container.withExec"] != 200*ms {
 		t.Fatalf("unexpected what-if savings: %+v", bySaving)
 	}
+}
+
+func TestLoadMultiMergesDrains(t *testing.T) {
+	// simulate two periodic drains of one recorder: the second drain has a
+	// longer string table (superset) and the op events split across drains
+	s := newFixtureStrings()
+	events1 := []wcprof.DumpEvent{
+		opEvent(s, 1, 0, "session_phase", "session.query", "", "ok", 0, 1000*ms),
+		opEvent(s, 2, 1, "call", "Container.withExec", "d1", "executed", 0, 400*ms),
+		opEvent(s, 3, 2, "call_exec", "Container.withExec", "d1", "ok", 0, 400*ms),
+		waitEvent(s, 2, 3, "", "call_exec", 0, 400*ms),
+	}
+	strings1 := append([]string(nil), s.values...)
+	events2 := []wcprof.DumpEvent{
+		opEvent(s, 4, 1, "call", "Container.from", "d2", "executed", 400*ms, 1000*ms),
+		opEvent(s, 5, 4, "call_exec", "Container.from", "d2", "ok", 400*ms, 1000*ms),
+		waitEvent(s, 4, 5, "", "call_exec", 400*ms, 1000*ms),
+	}
+
+	var buf1, buf2 bytes.Buffer
+	enc := func(buf *bytes.Buffer, header wcprof.DumpHeader, events []wcprof.DumpEvent) {
+		t.Helper()
+		raw, err := jsonMarshalLines(header, events)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.WriteString(raw)
+	}
+	enc(&buf1, wcprof.DumpHeader{
+		SchemaVersion: wcprof.DumpSchemaVersion, EpochUnixNano: 42,
+		DumpedUnixNano: 100, Strings: strings1, EventCount: len(events1),
+	}, events1)
+	enc(&buf2, wcprof.DumpHeader{
+		SchemaVersion: wcprof.DumpSchemaVersion, EpochUnixNano: 42,
+		DumpedUnixNano: 200, Strings: s.values, EventCount: len(events2),
+	}, events2)
+
+	g, err := LoadMulti([]io.Reader{&buf1, &buf2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Ops) != 5 {
+		t.Fatalf("merged ops = %d, want 5", len(g.Ops))
+	}
+	sim := NewSimulation(g, nil)
+	makespan, err := sim.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if makespan != 1000*ms {
+		t.Fatalf("merged baseline = %v, want 1s", time.Duration(makespan))
+	}
+
+	// mismatched epochs must be rejected
+	var buf3, buf4 bytes.Buffer
+	enc(&buf3, wcprof.DumpHeader{SchemaVersion: wcprof.DumpSchemaVersion, EpochUnixNano: 42, Strings: strings1}, nil)
+	enc(&buf4, wcprof.DumpHeader{SchemaVersion: wcprof.DumpSchemaVersion, EpochUnixNano: 43, Strings: strings1}, nil)
+	if _, err := LoadMulti([]io.Reader{&buf3, &buf4}); err == nil {
+		t.Fatal("expected epoch mismatch error")
+	}
+}
+
+func jsonMarshalLines(header wcprof.DumpHeader, events []wcprof.DumpEvent) (string, error) {
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	if err := enc.Encode(header); err != nil {
+		return "", err
+	}
+	for _, ev := range events {
+		if err := enc.Encode(ev); err != nil {
+			return "", err
+		}
+	}
+	return sb.String(), nil
 }
 
 func TestReportRenders(t *testing.T) {

--- a/engine/wcprof/wcanalyze/report.go
+++ b/engine/wcprof/wcanalyze/report.go
@@ -1,0 +1,292 @@
+package wcanalyze
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ClassStats aggregates ops of one class.
+type ClassStats struct {
+	Key      ClassKey
+	WorkType string
+	Count    int
+	Outcomes map[string]int
+
+	TotalWallNS int64
+	TotalSelfNS int64
+	MaxSelfNS   int64
+	P50SelfNS   int64
+	P95SelfNS   int64
+
+	// DupExecuted counts ops beyond the first execution per ident (same
+	// operation executed more than once).
+	DupExecuted int
+}
+
+// AggregateClasses computes per-class statistics over all ops.
+func AggregateClasses(g *Graph) []*ClassStats {
+	byKey := make(map[ClassKey]*ClassStats)
+	selfSamples := make(map[ClassKey][]int64)
+	executedIdents := make(map[ClassKey]map[string]int)
+
+	for _, op := range g.Ops {
+		key := op.Key()
+		st := byKey[key]
+		if st == nil {
+			st = &ClassStats{Key: key, Outcomes: make(map[string]int), WorkType: op.WorkType}
+			byKey[key] = st
+		}
+		st.Count++
+		st.Outcomes[op.Outcome]++
+		st.TotalWallNS += op.Duration()
+		self := op.SelfNS()
+		st.TotalSelfNS += self
+		st.MaxSelfNS = max(st.MaxSelfNS, self)
+		selfSamples[key] = append(selfSamples[key], self)
+		if op.Outcome == "executed" || op.Kind == "call_exec" {
+			if op.Ident != "" {
+				if executedIdents[key] == nil {
+					executedIdents[key] = make(map[string]int)
+				}
+				executedIdents[key][op.Ident]++
+			}
+		}
+	}
+
+	out := make([]*ClassStats, 0, len(byKey))
+	for key, st := range byKey {
+		samples := selfSamples[key]
+		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+		if len(samples) > 0 {
+			st.P50SelfNS = samples[len(samples)/2]
+			st.P95SelfNS = samples[(len(samples)*95)/100]
+		}
+		for _, n := range executedIdents[key] {
+			if n > 1 {
+				st.DupExecuted += n - 1
+			}
+		}
+		out = append(out, st)
+	}
+	slices.SortFunc(out, func(a, b *ClassStats) int {
+		if a.TotalSelfNS != b.TotalSelfNS {
+			return int(b.TotalSelfNS - a.TotalSelfNS)
+		}
+		return strings.Compare(a.Key.String(), b.Key.String())
+	})
+	return out
+}
+
+// DeadAir returns gaps (longer than threshold) inside the trace where no
+// recorded op was running.
+func DeadAir(g *Graph, thresholdNS int64) []segment {
+	intervals := make([]segment, 0, len(g.Ops))
+	for _, op := range g.Ops {
+		intervals = append(intervals, segment{op.StartNS, op.EndNS})
+	}
+	if len(intervals) == 0 {
+		return nil
+	}
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i].Start < intervals[j].Start })
+	var gaps []segment
+	cursor := intervals[0].Start
+	for _, iv := range intervals {
+		if iv.Start > cursor && iv.Start-cursor >= thresholdNS {
+			gaps = append(gaps, segment{cursor, iv.Start})
+		}
+		cursor = max(cursor, iv.End)
+	}
+	return gaps
+}
+
+func fmtDur(ns int64) string {
+	d := time.Duration(ns)
+	switch {
+	case d >= time.Second:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	case d >= time.Millisecond:
+		return fmt.Sprintf("%.1fms", float64(d.Microseconds())/1000)
+	case d >= time.Microsecond:
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	default:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	}
+}
+
+// ReportOptions controls WriteReport.
+type ReportOptions struct {
+	TopClasses     int
+	WhatIfFactors  []float64
+	MinClassSelfNS int64
+	DeadAirMinNS   int64
+	ChainDepth     int
+}
+
+func (o *ReportOptions) defaults() {
+	if o.TopClasses == 0 {
+		o.TopClasses = 30
+	}
+	if len(o.WhatIfFactors) == 0 {
+		o.WhatIfFactors = []float64{0, 0.5, 0.9}
+	}
+	if o.MinClassSelfNS == 0 {
+		o.MinClassSelfNS = int64(time.Millisecond)
+	}
+	if o.DeadAirMinNS == 0 {
+		o.DeadAirMinNS = int64(50 * time.Millisecond)
+	}
+	if o.ChainDepth == 0 {
+		o.ChainDepth = 25
+	}
+}
+
+// WriteReport renders the full human-readable analysis.
+func WriteReport(w io.Writer, g *Graph, opts ReportOptions) error {
+	opts.defaults()
+
+	fmt.Fprintf(w, "wcprof analysis\n")
+	fmt.Fprintf(w, "===============\n\n")
+	fmt.Fprintf(w, "ops: %d  roots: %d  open at dump: %d  dropped events: %d\n",
+		len(g.Ops), len(g.Roots), g.OpenOps, g.DroppedEvents)
+	if g.DroppedEvents > 0 {
+		fmt.Fprintf(w, "WARNING: %d events were dropped (buffer cap); analysis is incomplete\n", g.DroppedEvents)
+	}
+	actual := ActualMakespanNS(g)
+	fmt.Fprintf(w, "trace span: %s   makespan over roots: %s\n\n", fmtDur(g.TraceEndNS-g.TraceStartNS), fmtDur(actual))
+
+	// Baseline + what-ifs.
+	baseSim := NewSimulation(g, nil)
+	if _, err := baseSim.Run(); err == nil && (baseSim.CycleWarnings > 0 || baseSim.FallbackAnchors > 0) {
+		fmt.Fprintf(w, "sim diagnostics: %d broken cycles, %d fallback anchors\n", baseSim.CycleWarnings, baseSim.FallbackAnchors)
+	}
+	baseline, whatIfs, err := RunWhatIfs(g, opts.WhatIfFactors, opts.MinClassSelfNS)
+	if err != nil {
+		fmt.Fprintf(w, "simulation unavailable: %v\n\n", err)
+	} else {
+		drift := float64(0)
+		if actual > 0 {
+			drift = 100 * float64(baseline-actual) / float64(actual)
+		}
+		fmt.Fprintf(w, "simulated baseline makespan: %s (drift vs actual: %+.1f%%)\n\n", fmtDur(baseline), drift)
+
+		fmt.Fprintf(w, "what-if: makespan saved if a class's self-time is scaled by factor f\n")
+		fmt.Fprintf(w, "(ranked by saving at f=%.2g; this is the bottleneck candidate list)\n\n", midFactor(opts.WhatIfFactors))
+		fmt.Fprintf(w, "%-55s %-8s", "class", "worktype")
+		for _, f := range opts.WhatIfFactors {
+			fmt.Fprintf(w, " %12s", fmt.Sprintf("save@%.2g", f))
+		}
+		fmt.Fprintf(w, "\n")
+
+		stats := AggregateClasses(g)
+		workTypeByKey := make(map[ClassKey]string, len(stats))
+		for _, st := range stats {
+			workTypeByKey[st.Key] = st.WorkType
+		}
+
+		mid := midFactor(opts.WhatIfFactors)
+		slices.SortFunc(whatIfs, func(a, b WhatIfResult) int {
+			if a.SavedNS[mid] != b.SavedNS[mid] {
+				return int(b.SavedNS[mid] - a.SavedNS[mid])
+			}
+			return strings.Compare(a.Key.String(), b.Key.String())
+		})
+		shown := 0
+		for _, res := range whatIfs {
+			if shown >= opts.TopClasses {
+				break
+			}
+			if res.SavedNS[mid] <= 0 && shown > 5 {
+				continue
+			}
+			fmt.Fprintf(w, "%-55s %-8s", truncate(res.Key.String(), 55), workTypeByKey[res.Key])
+			for _, f := range opts.WhatIfFactors {
+				fmt.Fprintf(w, " %12s", fmtDur(res.SavedNS[f]))
+			}
+			fmt.Fprintf(w, "\n")
+			shown++
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Class table.
+	fmt.Fprintf(w, "top classes by total self-time\n\n")
+	fmt.Fprintf(w, "%-55s %-8s %8s %12s %12s %10s %10s %10s %s\n",
+		"class", "worktype", "count", "total-self", "total-wall", "p50-self", "p95-self", "max-self", "outcomes")
+	stats := AggregateClasses(g)
+	for i, st := range stats {
+		if i >= opts.TopClasses {
+			break
+		}
+		var outcomes []string
+		for o, n := range st.Outcomes {
+			if o == "" {
+				o = "?"
+			}
+			outcomes = append(outcomes, fmt.Sprintf("%s:%d", o, n))
+		}
+		sort.Strings(outcomes)
+		dup := ""
+		if st.DupExecuted > 0 {
+			dup = fmt.Sprintf(" dup-exec:%d", st.DupExecuted)
+		}
+		fmt.Fprintf(w, "%-55s %-8s %8d %12s %12s %10s %10s %10s %s%s\n",
+			truncate(st.Key.String(), 55), st.WorkType, st.Count,
+			fmtDur(st.TotalSelfNS), fmtDur(st.TotalWallNS),
+			fmtDur(st.P50SelfNS), fmtDur(st.P95SelfNS), fmtDur(st.MaxSelfNS),
+			strings.Join(outcomes, " "), dup)
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Blocking chain.
+	chain := BlockingChain(g, opts.ChainDepth)
+	if len(chain) > 1 {
+		fmt.Fprintf(w, "end-of-workload blocking chain (latest-finishing path)\n\n")
+		for _, op := range chain {
+			fmt.Fprintf(w, "  %-12s %-50s dur=%-10s self=%-10s [%s..%s]\n",
+				op.Kind, truncate(op.Class, 50), fmtDur(op.Duration()), fmtDur(op.SelfNS()),
+				fmtDur(op.StartNS-g.TraceStartNS), fmtDur(op.EndNS-g.TraceStartNS))
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Dead air.
+	gaps := DeadAir(g, opts.DeadAirMinNS)
+	if len(gaps) > 0 {
+		fmt.Fprintf(w, "dead air (no recorded op running; uninstrumented blocking or client-side stalls)\n\n")
+		for _, gap := range gaps {
+			fmt.Fprintf(w, "  %s gap at +%s\n", fmtDur(gap.End-gap.Start), fmtDur(gap.Start-g.TraceStartNS))
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Orphans / diagnostics.
+	if len(g.OrphanWaits) > 0 {
+		var total int64
+		for _, ow := range g.OrphanWaits {
+			total += ow.Duration()
+		}
+		fmt.Fprintf(w, "diagnostics: %d waits with no owning op (total %s)\n", len(g.OrphanWaits), fmtDur(total))
+	}
+	return nil
+}
+
+func midFactor(factors []float64) float64 {
+	if len(factors) == 0 {
+		return 0.5
+	}
+	return factors[len(factors)/2]
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/engine/wcprof/wcprof.go
+++ b/engine/wcprof/wcprof.go
@@ -1,0 +1,423 @@
+// Package wcprof implements cheap wall-clock profiling for the engine.
+//
+// It records operation intervals, wait (blocked-on) intervals, and link
+// events into an in-memory buffer, for offline analysis of where wall-clock
+// time goes and which operation classes are bottlenecks. It is intentionally
+// not OTel: events are fixed-size structs appended to sharded in-memory
+// buffers, with all strings interned. The expensive work (graph
+// reconstruction, counterfactual simulation) happens offline after dumping
+// the buffer via the engine debug endpoint.
+//
+// Recording is disabled until EnsureEnabled is called (triggered by a client
+// connecting with ClientMetadata.Profile set, or the
+// _DAGGER_WCPROF environment variable on the engine). When disabled, all
+// recording calls are nil-checks that compile to a few instructions.
+package wcprof
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// EventType discriminates the union in Event.
+type EventType uint8
+
+const (
+	EventTypeInvalid EventType = iota
+	// EventTypeOp is a completed operation interval.
+	EventTypeOp
+	// EventTypeWait is a completed wait interval: an op was blocked on
+	// another op (or named resource) from Start to End.
+	EventTypeWait
+	// EventTypeLink is a non-blocking correlation between an op and another
+	// op or an interned identifier.
+	EventTypeLink
+)
+
+// OpKind classifies operations.
+type OpKind uint8
+
+const (
+	OpKindInvalid OpKind = iota
+	// OpKindCall is one dagql GetOrInitCall invocation (per caller,
+	// including cache hits and singleflight joiners).
+	OpKindCall
+	// OpKindCallExec is the shared execution of a call's resolver function.
+	// Singleflighted callers all wait on one of these.
+	OpKindCallExec
+	// OpKindLazy is one run of a lazy evaluation callback for a result.
+	OpKindLazy
+	// OpKindExecPhase is a setup/run phase of a container exec
+	// (e.g. exec.setupNetwork, exec.runContainer).
+	OpKindExecPhase
+	// OpKindExec is the overall run of a container by the executor.
+	OpKindExec
+	// OpKindServiceStart is the start (incl. health check) of a service.
+	OpKindServiceStart
+	// OpKindSessionPhase is a per-query session serving phase
+	// (e.g. session.workspaceLoad, session.query).
+	OpKindSessionPhase
+	// OpKindIO is a leaf I/O operation (git fetch, image pull, filesync...).
+	OpKindIO
+	// OpKindInternal is engine-internal background work (gc, persistence).
+	OpKindInternal
+)
+
+var opKindNames = map[OpKind]string{
+	OpKindCall:         "call",
+	OpKindCallExec:     "call_exec",
+	OpKindLazy:         "lazy",
+	OpKindExecPhase:    "exec_phase",
+	OpKindExec:         "exec",
+	OpKindServiceStart: "service_start",
+	OpKindSessionPhase: "session_phase",
+	OpKindIO:           "io",
+	OpKindInternal:     "internal",
+}
+
+func (k OpKind) String() string {
+	if s, ok := opKindNames[k]; ok {
+		return s
+	}
+	return "invalid"
+}
+
+// WorkType is a coarse attribution of an op's self-time, used by analysis to
+// separate actionable engine overhead from user workload time and external
+// I/O time.
+type WorkType uint8
+
+const (
+	WorkTypeEngine WorkType = iota
+	// WorkTypeUser is time running user-controlled work (e.g. the container
+	// process itself).
+	WorkTypeUser
+	// WorkTypeExternal is time bound on external systems (registry pulls,
+	// git remotes, host filesync...).
+	WorkTypeExternal
+)
+
+var workTypeNames = map[WorkType]string{
+	WorkTypeEngine:   "engine",
+	WorkTypeUser:     "user",
+	WorkTypeExternal: "external",
+}
+
+func (w WorkType) String() string {
+	if s, ok := workTypeNames[w]; ok {
+		return s
+	}
+	return "invalid"
+}
+
+// Outcome describes how an op completed.
+type Outcome uint8
+
+const (
+	OutcomeNone Outcome = iota
+	// OutcomeHit: dagql call satisfied from cache.
+	OutcomeHit
+	// OutcomeExecuted: dagql call missed cache and this caller spawned the
+	// execution.
+	OutcomeExecuted
+	// OutcomeJoined: dagql call missed cache and joined an in-flight
+	// execution started by another caller.
+	OutcomeJoined
+	// OutcomeDoNotCache: dagql call executed inline without caching.
+	OutcomeDoNotCache
+	// OutcomeOK: generic success for non-call ops.
+	OutcomeOK
+	// OutcomeError: op failed.
+	OutcomeError
+	// OutcomeCanceled: op canceled.
+	OutcomeCanceled
+)
+
+var outcomeNames = map[Outcome]string{
+	OutcomeNone:       "",
+	OutcomeHit:        "hit",
+	OutcomeExecuted:   "executed",
+	OutcomeJoined:     "joined",
+	OutcomeDoNotCache: "do_not_cache",
+	OutcomeOK:         "ok",
+	OutcomeError:      "error",
+	OutcomeCanceled:   "canceled",
+}
+
+func (o Outcome) String() string {
+	if s, ok := outcomeNames[o]; ok {
+		return s
+	}
+	return "invalid"
+}
+
+// WaitReason describes why an op was blocked.
+type WaitReason uint8
+
+const (
+	WaitReasonInvalid WaitReason = iota
+	// WaitReasonCallExec: blocked waiting for a call's resolver execution
+	// (the caller that spawned it).
+	WaitReasonCallExec
+	// WaitReasonSingleflight: blocked joining another caller's in-flight
+	// execution of the same call.
+	WaitReasonSingleflight
+	// WaitReasonLazy: blocked waiting for a lazy evaluation to finish.
+	WaitReasonLazy
+	// WaitReasonService: blocked waiting for a service to start/be healthy.
+	WaitReasonService
+	// WaitReasonLock: blocked acquiring a lock (target is an interned
+	// resource name, not an op).
+	WaitReasonLock
+	// WaitReasonExec: blocked waiting for a container exec to finish.
+	WaitReasonExec
+	// WaitReasonIO: blocked on external I/O.
+	WaitReasonIO
+)
+
+var waitReasonNames = map[WaitReason]string{
+	WaitReasonCallExec:     "call_exec",
+	WaitReasonSingleflight: "singleflight",
+	WaitReasonLazy:         "lazy",
+	WaitReasonService:      "service",
+	WaitReasonLock:         "lock",
+	WaitReasonExec:         "exec",
+	WaitReasonIO:           "io",
+}
+
+func (r WaitReason) String() string {
+	if s, ok := waitReasonNames[r]; ok {
+		return s
+	}
+	return "invalid"
+}
+
+// LinkKind classifies link events.
+type LinkKind uint8
+
+const (
+	LinkKindInvalid LinkKind = iota
+	// LinkKindNestedClient: op (an exec) hosts a nested client whose ID is
+	// the link's interned ident. Ops recorded for that client belong under
+	// this exec.
+	LinkKindNestedClient
+	// LinkKindResult: op produced or returned the dagql result with
+	// ResultID.
+	LinkKindResult
+	// LinkKindReusedResult: op was satisfied by reusing the dagql result
+	// with ResultID (cache hit).
+	LinkKindReusedResult
+)
+
+var linkKindNames = map[LinkKind]string{
+	LinkKindNestedClient: "nested_client",
+	LinkKindResult:       "result",
+	LinkKindReusedResult: "reused_result",
+}
+
+func (k LinkKind) String() string {
+	if s, ok := linkKindNames[k]; ok {
+		return s
+	}
+	return "invalid"
+}
+
+// Event is one fixed-size profiling record. Field meaning varies by Type:
+//
+//   - Op: OpID/ParentID identify the op and its structural parent. StartNS
+//     and EndNS bound the interval. ClassID/IdentID/ClientID are interned
+//     strings. ResultID is the dagql shared result ID when known.
+//   - Wait: ParentID is the waiting op, TargetID the awaited op (or 0 when
+//     waiting on a named resource, in which case IdentID names it).
+//   - Link: ParentID is the from-op, TargetID an op (optional), IdentID an
+//     interned identifier (optional), ResultID a dagql result (optional).
+type Event struct {
+	Type     EventType
+	OpKind   OpKind
+	WorkType WorkType
+	Outcome  Outcome
+	Reason   WaitReason
+	LinkKind LinkKind
+
+	OpID     uint64
+	ParentID uint64
+	TargetID uint64
+	ResultID uint64
+
+	ClassID  uint32
+	IdentID  uint32
+	ClientID uint32
+
+	StartNS int64
+	EndNS   int64
+}
+
+const defaultMaxEvents = 4 << 20 // ~4M events ≈ 300MB
+
+const numShards = 16
+
+type shard struct {
+	mu     sync.Mutex
+	events []Event
+	// openOps tracks begun-but-unfinished ops for dump-time visibility.
+	openOps map[uint64]openOp
+}
+
+type openOp struct {
+	op       OpKind
+	work     WorkType
+	classID  uint32
+	identID  uint32
+	clientID uint32
+	parentID uint64
+	startNS  int64
+}
+
+// Recorder collects profiling events. Safe for concurrent use.
+type Recorder struct {
+	epoch     time.Time // monotonic anchor
+	wallEpoch int64     // wall-clock unix nanos at epoch
+
+	nextOpID atomic.Uint64
+	dropped  atomic.Uint64
+	maxTotal int64
+	total    atomic.Int64
+
+	strings stringTable
+
+	shards [numShards]shard
+}
+
+// NewRecorder returns a recorder with the given event cap (<=0 means
+// default).
+func NewRecorder(maxEvents int64) *Recorder {
+	if maxEvents <= 0 {
+		maxEvents = defaultMaxEvents
+	}
+	now := time.Now()
+	r := &Recorder{
+		epoch:     now,
+		wallEpoch: now.UnixNano(),
+		maxTotal:  maxEvents,
+	}
+	r.strings.init()
+	for i := range r.shards {
+		r.shards[i].openOps = make(map[uint64]openOp)
+	}
+	return r
+}
+
+// Now returns the current recorder-relative timestamp in nanoseconds.
+func (r *Recorder) Now() int64 {
+	return int64(time.Since(r.epoch))
+}
+
+// Intern interns s and returns its table ID.
+func (r *Recorder) Intern(s string) uint32 {
+	return r.strings.intern(s)
+}
+
+func (r *Recorder) newOpID() uint64 {
+	return r.nextOpID.Add(1)
+}
+
+func (r *Recorder) shardFor(id uint64) *shard {
+	return &r.shards[id%numShards]
+}
+
+func (r *Recorder) append(sh *shard, ev Event) {
+	if r.total.Add(1) > r.maxTotal {
+		r.total.Add(-1)
+		r.dropped.Add(1)
+		return
+	}
+	sh.mu.Lock()
+	sh.events = append(sh.events, ev)
+	sh.mu.Unlock()
+}
+
+//
+// global enablement
+//
+
+var global atomic.Pointer[Recorder]
+
+func init() {
+	if os.Getenv("_DAGGER_WCPROF") != "" {
+		EnsureEnabled()
+	}
+}
+
+// Active returns the global recorder, or nil when profiling is disabled.
+func Active() *Recorder {
+	return global.Load()
+}
+
+// EnsureEnabled enables the global recorder if it is not already enabled.
+func EnsureEnabled() {
+	if global.Load() != nil {
+		return
+	}
+	maxEvents := int64(0)
+	if v := os.Getenv("_DAGGER_WCPROF_MAX_EVENTS"); v != "" {
+		// best-effort parse; ignore malformed values
+		var parsed int64
+		for _, c := range v {
+			if c < '0' || c > '9' {
+				parsed = 0
+				break
+			}
+			parsed = parsed*10 + int64(c-'0')
+		}
+		maxEvents = parsed
+	}
+	global.CompareAndSwap(nil, NewRecorder(maxEvents))
+}
+
+//
+// string interning
+//
+
+type stringTable struct {
+	mu      sync.RWMutex
+	byValue map[string]uint32
+	values  []string
+}
+
+func (t *stringTable) init() {
+	t.byValue = make(map[string]uint32)
+	// ID 0 is always the empty string so 0 can mean "none".
+	t.values = []string{""}
+	t.byValue[""] = 0
+}
+
+func (t *stringTable) intern(s string) uint32 {
+	if s == "" {
+		return 0
+	}
+	t.mu.RLock()
+	id, ok := t.byValue[s]
+	t.mu.RUnlock()
+	if ok {
+		return id
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if id, ok := t.byValue[s]; ok {
+		return id
+	}
+	id = uint32(len(t.values))
+	t.values = append(t.values, s)
+	t.byValue[s] = id
+	return id
+}
+
+func (t *stringTable) snapshot() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]string, len(t.values))
+	copy(out, t.values)
+	return out
+}

--- a/engine/wcprof/wcprof.go
+++ b/engine/wcprof/wcprof.go
@@ -8,10 +8,20 @@
 // reconstruction, counterfactual simulation) happens offline after dumping
 // the buffer via the engine debug endpoint.
 //
-// Recording is disabled until EnsureEnabled is called (triggered by a client
-// connecting with ClientMetadata.Profile set, or the
-// _DAGGER_WCPROF environment variable on the engine). When disabled, all
-// recording calls are nil-checks that compile to a few instructions.
+// Recording can be enabled two ways:
+//
+//   - Engine-global: the _DAGGER_WCPROF environment variable, the engine's
+//     --wcprof flag, or POSTing "on" to the /debug/wcprof/enabled endpoint.
+//     All work on the engine is recorded until "off" is POSTed to the same
+//     endpoint.
+//   - Per-session: a client connecting with ClientMetadata.Profile set (the
+//     hidden --profile CLI flag). Only work attributable to that session
+//     (including its nested module/SDK clients) is recorded: the session
+//     server marks the session's contexts via ContextWithProfiling, and the
+//     mark propagates to derived contexts.
+//
+// When profiling has never been enabled, all recording calls are a single
+// atomic load + nil check.
 package wcprof
 
 import (
@@ -339,24 +349,55 @@ func (r *Recorder) append(sh *shard, ev Event) {
 }
 
 //
-// global enablement
+// enablement
 //
 
-var global atomic.Pointer[Recorder]
+var (
+	// global is the recorder, created the first time any profiling is enabled
+	// and retained from then on (so buffered events survive a disable and
+	// periodic-drain dumps from one engine run always share an epoch).
+	global atomic.Pointer[Recorder]
+	// globalOn means record all work on the engine, regardless of whether
+	// the context is marked for per-session profiling.
+	globalOn atomic.Bool
+)
 
 func init() {
 	if os.Getenv("_DAGGER_WCPROF") != "" {
-		EnsureEnabled()
+		EnableGlobal()
 	}
 }
 
-// Active returns the global recorder, or nil when profiling is disabled.
+// Active returns the recorder, or nil if profiling was never enabled. The
+// recorder outlives DisableGlobal so buffered events can still be dumped;
+// use GloballyEnabled/Enabled to ask whether work is being recorded.
 func Active() *Recorder {
 	return global.Load()
 }
 
-// EnsureEnabled enables the global recorder if it is not already enabled.
-func EnsureEnabled() {
+// GloballyEnabled reports whether engine-global recording is on.
+func GloballyEnabled() bool {
+	return globalOn.Load()
+}
+
+// EnableGlobal turns on recording of all work on the engine.
+func EnableGlobal() {
+	EnsureRecorder()
+	globalOn.Store(true)
+}
+
+// DisableGlobal turns off engine-global recording. The recorder and its
+// buffered events are retained for dumping, sessions that explicitly enabled
+// profiling keep recording, and already-recording flows (contexts carrying a
+// recorded op) run to completion.
+func DisableGlobal() {
+	globalOn.Store(false)
+}
+
+// EnsureRecorder creates the recorder if it does not exist yet, without
+// turning on engine-global recording. Used when a session opts into
+// profiling.
+func EnsureRecorder() {
 	if global.Load() != nil {
 		return
 	}

--- a/engine/wcprof/wcprof_test.go
+++ b/engine/wcprof/wcprof_test.go
@@ -9,15 +9,18 @@ import (
 	"testing"
 )
 
-// withTestRecorder installs a fresh global recorder for the duration of the
-// test.
+// withTestRecorder installs a fresh global recorder (in engine-global
+// recording mode) for the duration of the test.
 func withTestRecorder(t *testing.T, maxEvents int64) *Recorder {
 	t.Helper()
 	prev := global.Load()
+	prevOn := globalOn.Load()
 	r := NewRecorder(maxEvents)
 	global.Store(r)
+	globalOn.Store(true)
 	t.Cleanup(func() {
 		global.Store(prev)
+		globalOn.Store(prevOn)
 	})
 	return r
 }
@@ -53,6 +56,62 @@ func TestDisabledIsNoop(t *testing.T) {
 	}
 	w.End() // must not panic
 	Link(ctx, LinkKindResult, 0, 0, "", 1)
+}
+
+func TestSessionScoping(t *testing.T) {
+	r := withTestRecorder(t, 0)
+	globalOn.Store(false) // recorder exists, but only marked contexts record
+
+	ctx := context.Background()
+
+	// unmarked context: no recording
+	opCtx, op := BeginOp(ctx, OpKindCall, "Container.withExec", OpOpts{})
+	if op != nil {
+		t.Fatal("expected nil op for unmarked ctx in session mode")
+	}
+	if opCtx != ctx {
+		t.Fatal("expected unchanged ctx for unmarked ctx in session mode")
+	}
+	if w := BeginWait(ctx, 1, WaitReasonLazy); w != nil {
+		t.Fatal("expected nil wait for unmarked ctx in session mode")
+	}
+	if id := RecordOp(ctx, OpKindExecPhase, "exec.x", OpOpts{}, 1, 2, OutcomeOK); id != 0 {
+		t.Fatal("expected RecordOp to no-op for unmarked ctx in session mode")
+	}
+
+	// marked context: records, and the mark propagates through derived
+	// contexts (here via the op ID the returned ctx carries)
+	marked := ContextWithProfiling(ctx)
+	childCtx, op2 := BeginOp(marked, OpKindCall, "Container.withExec", OpOpts{})
+	if op2 == nil {
+		t.Fatal("expected op for marked ctx in session mode")
+	}
+	op2.End(OutcomeOK)
+	_, op3 := BeginOp(childCtx, OpKindCallExec, "Container.withExec", OpOpts{})
+	if op3 == nil {
+		t.Fatal("expected op for ctx derived from a recorded op")
+	}
+	op3.End(OutcomeOK)
+
+	// a context attributed to a recorded op records too (e.g. background
+	// publish work parented under a recorded exec)
+	if _, op4 := BeginOp(ContextWithOpID(ctx, op2.ID()), OpKindInternal, "x", OpOpts{}); op4 == nil {
+		t.Fatal("expected op for ctx carrying a recorded op ID")
+	} else {
+		op4.End(OutcomeOK)
+	}
+
+	// flipping engine-global recording back on records unmarked contexts
+	globalOn.Store(true)
+	if _, op5 := BeginOp(ctx, OpKindCall, "x", OpOpts{}); op5 == nil {
+		t.Fatal("expected op for unmarked ctx in global mode")
+	} else {
+		op5.End(OutcomeOK)
+	}
+
+	if got := len(drainEvents(r)); got != 4 {
+		t.Fatalf("expected exactly 4 recorded ops, got %d", got)
+	}
 }
 
 func TestOpWaitLinkRoundtrip(t *testing.T) {

--- a/engine/wcprof/wcprof_test.go
+++ b/engine/wcprof/wcprof_test.go
@@ -1,0 +1,284 @@
+package wcprof
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// withTestRecorder installs a fresh global recorder for the duration of the
+// test.
+func withTestRecorder(t *testing.T, maxEvents int64) *Recorder {
+	t.Helper()
+	prev := global.Load()
+	r := NewRecorder(maxEvents)
+	global.Store(r)
+	t.Cleanup(func() {
+		global.Store(prev)
+	})
+	return r
+}
+
+func drainEvents(r *Recorder) []Event {
+	var out []Event
+	for i := range r.shards {
+		sh := &r.shards[i]
+		sh.mu.Lock()
+		out = append(out, sh.events...)
+		sh.mu.Unlock()
+	}
+	return out
+}
+
+func TestDisabledIsNoop(t *testing.T) {
+	prev := global.Load()
+	global.Store(nil)
+	t.Cleanup(func() { global.Store(prev) })
+
+	ctx := context.Background()
+	opCtx, op := BeginOp(ctx, OpKindCall, "Container.withExec", OpOpts{})
+	if op != nil {
+		t.Fatal("expected nil op when disabled")
+	}
+	if opCtx != ctx {
+		t.Fatal("expected unchanged ctx when disabled")
+	}
+	op.End(OutcomeOK) // must not panic
+	w := BeginWait(ctx, 1, WaitReasonLazy)
+	if w != nil {
+		t.Fatal("expected nil wait when disabled")
+	}
+	w.End() // must not panic
+	Link(ctx, LinkKindResult, 0, 0, "", 1)
+}
+
+func TestOpWaitLinkRoundtrip(t *testing.T) {
+	r := withTestRecorder(t, 0)
+	ctx := context.Background()
+
+	parentCtx, parent := BeginOp(ctx, OpKindSessionPhase, "session.query", OpOpts{ClientID: "client1"})
+	childCtx, child := BeginOp(parentCtx, OpKindCall, "Container.withExec", OpOpts{Ident: "sha256:abc"})
+	if CurrentOpID(childCtx) != child.ID() {
+		t.Fatalf("child ctx should carry child op ID")
+	}
+
+	w := BeginWait(childCtx, 42, WaitReasonSingleflight)
+	w.End()
+	Link(childCtx, LinkKindReusedResult, 0, 0, "", 7)
+	child.EndWithResult(OutcomeHit, 7)
+	parent.End(OutcomeOK)
+
+	events := drainEvents(r)
+	var ops, waits, links int
+	var childEv, parentEv *Event
+	for i := range events {
+		ev := &events[i]
+		switch ev.Type {
+		case EventTypeOp:
+			ops++
+			switch ev.OpID {
+			case child.ID():
+				childEv = ev
+			case parent.ID():
+				parentEv = ev
+			}
+		case EventTypeWait:
+			waits++
+			if ev.ParentID != child.ID() || ev.TargetID != 42 || ev.Reason != WaitReasonSingleflight {
+				t.Fatalf("unexpected wait event: %+v", ev)
+			}
+		case EventTypeLink:
+			links++
+			if ev.ParentID != child.ID() || ev.ResultID != 7 || ev.LinkKind != LinkKindReusedResult {
+				t.Fatalf("unexpected link event: %+v", ev)
+			}
+		}
+	}
+	if ops != 2 || waits != 1 || links != 1 {
+		t.Fatalf("expected 2 ops, 1 wait, 1 link; got %d, %d, %d", ops, waits, links)
+	}
+	if childEv == nil || parentEv == nil {
+		t.Fatal("missing op events")
+	}
+	if childEv.ParentID != parent.ID() {
+		t.Fatalf("child parent = %d, want %d", childEv.ParentID, parent.ID())
+	}
+	if childEv.Outcome != OutcomeHit || childEv.ResultID != 7 {
+		t.Fatalf("unexpected child op: %+v", childEv)
+	}
+	if childEv.EndNS < childEv.StartNS {
+		t.Fatalf("child end %d < start %d", childEv.EndNS, childEv.StartNS)
+	}
+	strs := r.strings.snapshot()
+	if strs[childEv.ClassID] != "Container.withExec" {
+		t.Fatalf("class = %q", strs[childEv.ClassID])
+	}
+	if strs[childEv.IdentID] != "sha256:abc" {
+		t.Fatalf("ident = %q", strs[childEv.IdentID])
+	}
+	if strs[parentEv.ClientID] != "client1" {
+		t.Fatalf("client = %q", strs[parentEv.ClientID])
+	}
+}
+
+func TestConcurrentRecording(t *testing.T) {
+	r := withTestRecorder(t, 0)
+	ctx := context.Background()
+
+	const goroutines = 16
+	const perG = 500
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				opCtx, op := BeginOp(ctx, OpKindCall, "Class.field", OpOpts{Ident: "id"})
+				w := BeginWait(opCtx, 1, WaitReasonLazy)
+				w.End()
+				op.End(OutcomeOK)
+			}
+		}()
+	}
+	wg.Wait()
+
+	events := drainEvents(r)
+	want := goroutines * perG * 2
+	if len(events) != want {
+		t.Fatalf("got %d events, want %d", len(events), want)
+	}
+	seen := make(map[uint64]bool)
+	for _, ev := range events {
+		if ev.Type != EventTypeOp {
+			continue
+		}
+		if seen[ev.OpID] {
+			t.Fatalf("duplicate op ID %d", ev.OpID)
+		}
+		seen[ev.OpID] = true
+	}
+}
+
+func TestEventCapDrops(t *testing.T) {
+	r := withTestRecorder(t, 10)
+	ctx := context.Background()
+	for i := 0; i < 50; i++ {
+		_, op := BeginOp(ctx, OpKindCall, "x", OpOpts{})
+		op.End(OutcomeOK)
+	}
+	events := drainEvents(r)
+	if len(events) != 10 {
+		t.Fatalf("got %d events, want cap 10", len(events))
+	}
+	if r.dropped.Load() != 40 {
+		t.Fatalf("dropped = %d, want 40", r.dropped.Load())
+	}
+}
+
+func TestDumpRoundtripAndFlush(t *testing.T) {
+	r := withTestRecorder(t, 0)
+	ctx := context.Background()
+
+	_, op1 := BeginOp(ctx, OpKindCall, "Query.container", OpOpts{Ident: "dig1", ClientID: "c1"})
+	op1.End(OutcomeExecuted)
+	_, op2 := BeginOp(ctx, OpKindLazy, "Container.withExec", OpOpts{})
+	_ = op2 // left open intentionally
+
+	var buf bytes.Buffer
+	if err := r.WriteDump(&buf, true); err != nil {
+		t.Fatal(err)
+	}
+
+	header, events, err := ReadDump(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header.SchemaVersion != DumpSchemaVersion {
+		t.Fatalf("schema version = %d", header.SchemaVersion)
+	}
+	if header.EventCount != 1 || len(events) != 1 {
+		t.Fatalf("event count = %d / %d, want 1", header.EventCount, len(events))
+	}
+	ev := events[0]
+	if ev.Type != "op" || ev.OpKind != "call" || ev.Outcome != "executed" {
+		t.Fatalf("unexpected event: %+v", ev)
+	}
+	if header.Strings[ev.ClassID] != "Query.container" {
+		t.Fatalf("class = %q", header.Strings[ev.ClassID])
+	}
+	if len(header.OpenOps) != 1 || header.OpenOps[0].OpID != op2.ID() || header.OpenOps[0].Kind != "lazy" {
+		t.Fatalf("open ops = %+v", header.OpenOps)
+	}
+
+	// Flush removed buffered events; a second dump is empty but keeps the
+	// string table and open ops.
+	var buf2 bytes.Buffer
+	if err := r.WriteDump(&buf2, true); err != nil {
+		t.Fatal(err)
+	}
+	header2, events2, err := ReadDump(bytes.NewReader(buf2.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events2) != 0 {
+		t.Fatalf("expected empty second dump, got %d events", len(events2))
+	}
+	if len(header2.OpenOps) != 1 {
+		t.Fatalf("expected open op to persist, got %+v", header2.OpenOps)
+	}
+	if header2.Strings[1] == "" && len(header2.Strings) < len(header.Strings) {
+		t.Fatal("string table should be retained across flush")
+	}
+
+	// Ending the open op after a flush still records an event.
+	op2.End(OutcomeOK)
+	events3 := drainEvents(r)
+	if len(events3) != 1 || events3[0].OpID != op2.ID() {
+		t.Fatalf("expected op2 end event after flush, got %+v", events3)
+	}
+}
+
+func TestInternStability(t *testing.T) {
+	r := withTestRecorder(t, 0)
+	var wg sync.WaitGroup
+	ids := make([]uint32, 64)
+	for i := range ids {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ids[i] = r.Intern("same-string")
+		}(i)
+	}
+	wg.Wait()
+	for _, id := range ids {
+		if id != ids[0] {
+			t.Fatal("interning the same string returned different IDs")
+		}
+	}
+	if r.Intern("") != 0 {
+		t.Fatal("empty string must intern to 0")
+	}
+}
+
+func TestNowMonotonic(t *testing.T) {
+	r := NewRecorder(0)
+	var last atomic.Int64
+	for i := 0; i < 1000; i++ {
+		now := r.Now()
+		if now < last.Load() {
+			t.Fatal("Now went backwards")
+		}
+		last.Store(now)
+	}
+}
+
+func TestDumpDisabledRecorder(t *testing.T) {
+	var r *Recorder
+	err := r.WriteDump(&bytes.Buffer{}, false)
+	if err == nil || !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("expected not-enabled error, got %v", err)
+	}
+}

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -138,6 +138,8 @@ func withEngine(
 
 		params.AllowedLLMModules = allowedLLMModules
 
+		params.Profile = profileFlag
+
 		params.CloudURLCallback = Frontend.SetCloudURL
 
 		params.EngineTrace = telemetry.SpanForwarder{

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -75,6 +75,7 @@ var (
 	autoApply                bool
 	_, useCloudEngine        = os.LookupEnv("DAGGER_CLOUD_ENGINE")
 	enableScaleOut           bool
+	profileFlag              bool
 
 	dotOutputFilePath string
 	dotFocusField     string
@@ -394,6 +395,11 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	// this flag enables scale-out for a few commands, e.g. checks
 	flags.BoolVar(&enableScaleOut, "scale-out", false, "Enable scale-out to cloud engines for each check executed")
 	flags.Lookup("scale-out").Hidden = true
+
+	// experimental: enable engine wall-clock profiling (wcprof) for this
+	// session; recorded events are retrieved from the engine debug endpoint
+	flags.BoolVar(&profileFlag, "profile", false, "Enable experimental engine wall-clock profiling for this session")
+	flags.Lookup("profile").Hidden = true
 
 	for _, fl := range []string{
 		"dot-output",


### PR DESCRIPTION
Adds **wcprof**: an experimental, cheap wall-clock profiling system for the engine, plus an offline analyzer that finds latency bottlenecks by counterfactual simulation.

This is built to systematically catch the class of problem that CPU/memory profiles can't see: serial wall-clock taxes like the ~300ms un-pooled CNI netns setup that used to run before every container start while nothing else made progress.

## Design

The engine is unusually well-shaped for this: since evaluation became dagql-native, every cross-operation blocking relationship flows through a handful of choke points we own (dagql singleflight, lazy-eval waiters, service starts, cache-volume locks, exec completion channels, the nested-client boundary). That means the true waits-for graph can be **recorded** at the choke points rather than inferred from span nesting. And since the recipe digest is already computed for every call, op identity is free.

wcprof records three fixed-size event types into sharded in-memory buffers with interned strings (~72B/event, default cap ~4M events; when profiling is off, every hook is a single atomic load + nil check):

- **ops** — timed intervals with kind (`call`, `call_exec`, `lazy`, `exec`, `exec_phase`, `service_start`, `session_phase`, `internal`), class (e.g. `Container.withExec`, `exec.setupNetwork`), instance ident (recipe digest / exec id), structural parent (via context), outcome (`hit`/`executed`/`joined`/`do_not_cache`/...), and a work-type tag separating engine overhead from user work (container process runtime) and external I/O.
- **waits** — exact blocked-on intervals (who waited on which op or named resource, why, from when to when), recorded by the waiter at the choke point itself.
- **links** — non-blocking correlations, most importantly exec op ↔ nested client ID, so module-function calls back into the API stitch under the exec that hosts them.

Hook points:

- **dagql `getOrInitCall`**: one `call` op per caller (cache hits and DoNotCache included — deliberately recording what OTel suppresses), one shared `call_exec` op per resolver execution (waiters record singleflight join edges against it), and a publish op for result publication cost.
- **dagql `evaluateOne`**: `lazy` ops classed by the call that *created* the lazy value (cost attribution) with wait edges from the triggering/joining ops (blocking attribution) — the two views stay separate.
- **engineutil executor**: per-exec op + named phase ops (`setupNetwork`, `setupRootfs`, ..., `runContainer`), plus an `exec.containerStart` vs `exec.processRun` split so engine overhead and user process time are distinguishable.
- **core container exec**: cache-volume lock waits, `prepareMounts` / `applyOutputs` phases.
- **core services**: `service_start` ops with waiter join edges (start singleflight + health checks).
- **engine server `serveQuery`**: per-query session phases (attachables wait, workspace load, module load, schema build, query root).

### Enabling and dumping

Two scopes:

- **Per-session**: the hidden `dagger --profile` flag records only that session's work — including its nested module/SDK clients — via a context mark applied at the session server and propagated through derived contexts.
- **Engine-global**: record everything. Enabled at startup via the engine's hidden `--wcprof` flag or `_DAGGER_WCPROF=1`, or toggled at runtime through the debug endpoint: `POST on|off` to `/debug/wcprof/enabled` (GET reports state). Disabling keeps buffered events dumpable and re-enabling reuses the same recorder, so dumps from before/after merge cleanly.

`GET /debug/wcprof/dump` streams a JSON header line (string table, open ops for hang visibility) followed by one JSON event per line, flushing the buffer by default; periodic drains of long runs merge losslessly at analysis time.

### Why not OTel

The existing telemetry path is unsuitable for this both in cost and in shape: AroundFunc proto-encodes the full call DAG per span, every span is written to per-client SQLite databases (fanned out to all parent clients), and repeated/cache-hit calls are deliberately suppressed via ShouldEmitTelemetry, so most calls never appear at all. Spans also only give a tree + timestamps; they can't say *why* an op was idle mid-flight.

## Analyzer (`cmd/wcprof-analyze`, `engine/wcprof/wcanalyze`)

Reconstructs the op graph (parents, waits, nested-client re-parenting), computes self-time (duration minus waits minus child intervals), then runs a replay-based discrete-event simulation of the recorded schedule under counterfactual hypotheses: *"class X's self-time scaled by f"* for f ∈ {0, 0.5, 0.9}, assuming unlimited resources (never CPU-bound; v1 simplification). Classes are ranked by how much end-to-end makespan each would actually save — which handles critical-path shifts, singleflight dedup (shared work counted once), and dependency chains, unlike naive "total time per class" tables.

It also reports per-class stats with outcome histograms and duplicate-execution detection, an end-of-workload blocking chain, dead-air gaps (uninstrumented blocking), and drift diagnostics.

The replay is compiled once into flat action arrays and what-if simulations run in parallel, so large dumps stay tractable: a 9.7M-event dump analyzes in ~74s.

## How it worked in practice

Testbed: `dagger call engine-dev container sync`, cold cache, profiled via the dev engine. ~223s wall, ~169k ops, ~25MB dump, zero dropped events, ~1s to analyze. Also run against the full `TestModule` integration suite (12-way-parallel sessions, ~402s): 9.7M events / 1.3GB across periodic drains, merged and analyzed in ~74s.

The simulated baseline makespan is checked against the actual makespan as a fidelity metric, and that check earned its keep: it caught three real replay-model bugs during bring-up, found via the included diagnostics (DriftOrigins, ExplainFinish, fallback-anchor counters):

1. **Frame mixing**: normalizing the first root's sim time to 0 while ops reached through cross-tree wait targets anchored at original timestamps inflated makespan +53%. The simulation now stays entirely in the original trace's time frame.
2. **Ident-based exec waits** can resolve to the wrong exec when call digests are shared across execs; removed in favor of the exec op being a context-child plus the replay's implicit-join rule, which models the dependency exactly. (Waits that ended before their target's recorded end — abandoned/canceled — are also no longer treated as joins.)
3. **Fallback anchoring** at recorded start times silently re-pinned chains to original times whenever an op's finish was needed while its parent was mid-replay, collapsing counterfactual propagation (processRun×0 "saved" 55ms instead of 41.7s). Fallbacks now anchor at parent sim start + recorded offset.

After those fixes the baseline drift is **−0.0% on every dataset measured** (smoke, full builds, synthetic chains, the 9.7M-event integration suite).

Results on the testbed: the go build itself (`exec.processRun`, user work) dominates at ~42–69s recoverable; the top engine-actionable class is `Host.directory` (filesync) at ~4s; `HTTPState._resolve` has 207s of total self-time but correctly ranks as a non-bottleneck (parallel to the build) — exactly the *total time ≠ bottleneck* discrimination this is for. One real finding already: `exec.setupNetwork` has p50 125µs but p95 1.52s (44–55s total across ~230 execs) — a netns-pool exhaustion tail, the same class as the original CNI problem.

### Validation (known-answer test)

During bring-up, a temporary file-gated injection aid added an artificial delay in `setupNetwork` (removed before merge). On a strictly serial 10-exec chain with 300ms injected: the analyzer ranked `exec_phase:exec.setupNetwork` #1 and predicted save@0 = 3.32s; disarming the injection and re-running measured the chain section shrink from 3.57s to 0.46s (actual recovery 3.11s — prediction within ~7%, which also covers the organic tail it zeroes). With the injection disarmed the class dropped out of the rankings entirely — no false positive. On the engine-dev build the same injection predicted only ~2.4s saved despite ~48s wall growth: execs there start in parallel with the build/download chains, so per-exec start taxes mostly don't serialize in that workload (and cross-run wall comparisons are polluted by network variance — validate within-run via the sim, or on serial synthetic chains).

## Known v1 limitations (deliberate)

- Lock waits are modeled as fixed delays (no release→acquire causality).
- Unlimited-resources assumption; parallel self-time includes mutex contention and scheduler queueing (e.g. egraphMu pressure shows up as `dagql.publishResult` self-time — itself a useful signal).
- Leaf I/O internals (git fetch, image pull, filesync) are not yet sub-instrumented; they appear as self-time of their calling op, and the unexplained-self-time/dead-air reports are the guide for where to hook next.
- One engine-wide recorder and event buffer: per-session enablement scopes what gets recorded, but all enabled sessions share the buffer and dumps.
- What-if rankings operate on per-class *self* time, so "umbrella" ops whose time is correctly decomposed into children (e.g. `ModuleSource.asModule`) don't rank as a unit yet — see direction below.

## Status & direction

This is a usable first cut: the collection path is cheap and safe to leave in the engine, and the analyzer's counterfactual rankings have been validated against known-answer injections and real workloads. The plan is to keep iterating in-tree rather than grow this branch. Rough laundry list of where we want to take it:

- **Higher-level/subtree analysis**: what-ifs and attribution over spans that encapsulate other spans (e.g. "module loading as a whole", per-`dagger call` latency decomposition), not just leaf-class self-time.
- **A lot more data**: leaf I/O ops (git/registry/filesync internals), lock release→acquire causality, finer exec phases, richer op metadata (e.g. distinguishing internal SDK/codegen execs from user execs).
- **Multiple data sources, one model**: ingest OTel spans, Go pprof data (e.g. mutex-contention profiles), and eBPF-derived signals for what happens *inside* user execs (so user work stops being a black box) — alongside wcprof's native events, all for the same workflow run, compiled down to the same op/wait graph so the same counterfactual analysis runs over the union.
- **Resource-capacity awareness**: model that CPUs, disk bandwidth, and network bandwidth are finite, so simulated speedups stop assuming infinite parallelism and contention shows up as such in rankings.
- **Cross-run workflows**: comparing profiles between runs/versions to catch wall-clock regressions, and per-session scoping of dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
