### PR TITLE
engine: increase default CNI pool size

### DIFF
--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -84,6 +84,6 @@ func setNetworkDefaults(cfg *bkconfig.NetworkConfig, cniConfigPath string) {
 		cfg.CNIBinaryPath = appdefaults.DefaultCNIBinDir
 	}
 	if cfg.CNIPoolSize == 0 {
-		cfg.CNIPoolSize = 16
+		cfg.CNIPoolSize = 128
 	}
 }


### PR DESCRIPTION
## Summary

Increase the default OCI CNI network namespace pool size from 16 to 128.

## Why

Data gathered in #13393 suggests we may still be seeing `exec.setupNetwork` tail latency consistent with CNI netns pool exhaustion. This draft PR tries a larger default pool to see whether it has any practical impact on that bottleneck.

Leaving this as a draft while we evaluate whether the higher default measurably improves real workloads.

## Validation

- `go test ./cmd/engine`