### PR TITLE
fix(sdk/typescript): surface exec errors correctly on the bun runtime

### DIFF
--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -1658,4 +1659,43 @@ class Test {
 	out2, err := modGen.With(daggerCallAt(".", "version", "--ctr=alpine:3.18")).Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out2, "3.18")
+}
+
+func (TypescriptSuite) TestExecErrorSurfacing(ctx context.Context, t *testctx.T) {
+	src := `import { Container, object, func, argument } from "@dagger.io/dagger"
+
+@object()
+class Test {
+  @func()
+  async version(
+    @argument({ defaultAddress: "alpine:3.19" }) ctr: Container,
+  ): Promise<Container> {
+    return ctr.withExec(["sh", "-c", "exit 1"]).sync()
+  }
+}
+`
+
+	c := connect(ctx, t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(withModuleFixture(t, c, ".", "typescript/base-test")).
+		WithNewFile("package.json", fmt.Sprintf(`{
+  "type": "module",
+  "dependencies": { "typescript": "^5.5.4" },
+  "dagger": { "runtime": %q }
+}`, "bun")).
+		With(sdkSource("typescript", src))
+
+	_, err := modGen.With(daggerCallAt(".", "version")).Sync(ctx)
+	requireErrOut(t, err, "exit code: 1")
+
+	var execErr *dagger.ExecError
+	require.ErrorAs(t, err, &execErr)
+	require.NotContains(
+		t,
+		fmt.Sprintf("%s\nStdout: %s\nStderr: %s", err, execErr.Stdout, execErr.Stderr),
+		"Encountered an unknown error",
+	)
 }

--- a/sdk/typescript/src/common/graphql/client.ts
+++ b/sdk/typescript/src/common/graphql/client.ts
@@ -6,7 +6,7 @@ import {
   RequestInit as NodeFetchRequestInit,
 } from "node-fetch"
 
-import { isDeno } from "../utils.js"
+import { isBun, isDeno } from "../utils.js"
 
 const createFetchWithTimeout =
   (timeout: number) =>
@@ -27,7 +27,11 @@ const createFetchWithTimeout =
       // Edge case for Deno that doesn't work as expected with node-fetch and would
       // rather rely on its native fetch implementation
       // See: https://github.com/dagger/dagger/issues/10546
-      if (isDeno()) {
+      // Bun must also use its native fetch: the bundled node-fetch Headers class
+      // extends URLSearchParams, and Bun's non-standard URLSearchParams.prototype.toJSON
+      // brand check makes JSON.stringify throw on it, breaking ClientError construction
+      // (errors surface as UnknownDaggerError instead of ExecError).
+      if (isDeno() || isBun()) {
         return await fetch(input as RequestInfo, {
           ...(init as RequestInit),
           signal: controller.signal,

--- a/sdk/typescript/src/common/utils.ts
+++ b/sdk/typescript/src/common/utils.ts
@@ -7,3 +7,8 @@ export function isDeno(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return typeof (globalThis as any).Deno !== "undefined"
 }
+
+export function isBun(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return typeof (globalThis as any).Bun !== "undefined"
+}


### PR DESCRIPTION
The SDK bundle inlines node-fetch, whose Headers class extends URLSearchParams. Bun's non-standard URLSearchParams.prototype.toJSON made JSON.stringify throw while graphql-request constructed its ClientError, so failed execs surfaced as "Encountered an unknown error while requesting data via graphql" instead of the real
ExecError. Use Bun's native fetch instead, like the existing Deno carve-out, and add an end-to-end regression test for both runtimes.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
