### PR TITLE
CLI 1.0 phase 0: rename --mod to --load-module

### DIFF
--- a/cmd/dagger/cloud_test.go
+++ b/cmd/dagger/cloud_test.go
@@ -64,7 +64,7 @@ func TestCloudEngineWithCloudToken(t *testing.T) {
 	}
 
 	env := []string{"DAGGER_CLOUD_TOKEN=" + daggerCloudToken}
-	args := []string{"--cloud", "--mod", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "functions"}
+	args := []string{"--cloud", "--load-module", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "functions"}
 
 	daggerCloudWithEnv(t, env, args, func(t *testing.T, err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
 		require.NoError(t, err, fmt.Sprintf(
@@ -86,7 +86,7 @@ func TestCloudEngineEnvWithCloudToken(t *testing.T) {
 	}
 
 	env := []string{"DAGGER_CLOUD_TOKEN=" + daggerCloudToken, "DAGGER_CLOUD_ENGINE=true"}
-	args := []string{"--mod", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "functions"}
+	args := []string{"--load-module", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "functions"}
 
 	daggerCloudWithEnv(t, env, args, func(t *testing.T, err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
 		require.NoError(t, err, fmt.Sprintf(

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -35,12 +35,12 @@ func addWorkspaceInstallFlags(cmd *cobra.Command) {
 }
 
 // moduleAddFlags adds common module-loading flags to a command.
-// If optional is true, it also adds the --no-mod flag and marks --mod and --no-mod as mutually exclusive.
+// If optional is true, it also adds the --no-load-module flag and marks --load-module and --no-load-module as mutually exclusive.
 func moduleAddFlags(cmd *cobra.Command, flags *pflag.FlagSet, optional bool) {
-	flags.StringVarP(&moduleURL, "mod", "m", "", "Module reference to load, either a local path, a remote git repo, or 'core' (defaults to current directory)")
+	flags.StringVarP(&moduleURL, "load-module", "m", "", "Use a one-off module (local path or git ref)")
 	if optional {
-		flags.BoolVarP(&moduleNoURL, "no-mod", "M", false, "Don't automatically load a module (mutually exclusive with --mod)")
-		cmd.MarkFlagsMutuallyExclusive("mod", "no-mod")
+		flags.BoolVarP(&moduleNoURL, "no-load-module", "M", false, "Don't load any module for this command")
+		cmd.MarkFlagsMutuallyExclusive("load-module", "no-load-module")
 	}
 
 	var defaultAllowLLM []string
@@ -184,7 +184,7 @@ func getModuleSourceRefWithDefault() (string, error) {
 		return v, nil
 	}
 	if moduleNoURL {
-		return "", fmt.Errorf("cannot use default module source with --no-mod")
+		return "", fmt.Errorf("cannot use default module source with --no-load-module")
 	}
 	return moduleURLDefault, nil
 }

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -227,7 +227,7 @@ func (h *shellCallHandler) Initialize(ctx context.Context) error {
 		}
 	}
 
-	// Could be `--no-mod` or module not found from current dir
+	// Could be `--no-load-module` or module not found from current dir
 	if def == nil {
 		def, err = initializeCore(ctx, h.dag)
 		if err != nil {

--- a/cmd/dagger/workspace_test.go
+++ b/cmd/dagger/workspace_test.go
@@ -19,7 +19,7 @@ func TestInstallAndUpdateCommandFlags(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"install"})
 	require.NoError(t, err)
 	require.True(t, cmd.Hidden)
-	require.Nil(t, cmd.Flags().Lookup("mod"))
+	require.Nil(t, cmd.Flags().Lookup("load-module"))
 	require.Nil(t, cmd.Flags().Lookup("compat"))
 	require.NotNil(t, cmd.Flags().Lookup("name"))
 	require.Contains(t, cmd.Long, "If no workspace config is selected")
@@ -27,20 +27,20 @@ func TestInstallAndUpdateCommandFlags(t *testing.T) {
 	cmd, _, err = rootCmd.Find([]string{"workspace", "install"})
 	require.NoError(t, err)
 	require.False(t, cmd.Hidden)
-	require.Nil(t, cmd.Flags().Lookup("mod"))
+	require.Nil(t, cmd.Flags().Lookup("load-module"))
 	require.Nil(t, cmd.Flags().Lookup("compat"))
 	require.NotNil(t, cmd.Flags().Lookup("name"))
 
 	cmd, _, err = rootCmd.Find([]string{"update"})
 	require.NoError(t, err)
 	require.True(t, cmd.Hidden)
-	require.Nil(t, cmd.Flags().Lookup("mod"))
+	require.Nil(t, cmd.Flags().Lookup("load-module"))
 	require.Nil(t, cmd.Flags().Lookup("compat"))
 
 	cmd, _, err = rootCmd.Find([]string{"workspace", "update"})
 	require.NoError(t, err)
 	require.False(t, cmd.Hidden)
-	require.Nil(t, cmd.Flags().Lookup("mod"))
+	require.Nil(t, cmd.Flags().Lookup("load-module"))
 	require.Nil(t, cmd.Flags().Lookup("compat"))
 }
 
@@ -405,7 +405,7 @@ func TestConfigAliasFlags(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"config"})
 	require.NoError(t, err)
 	require.Same(t, configCmd, cmd)
-	require.Nil(t, cmd.Flags().Lookup("mod"))
+	require.Nil(t, cmd.Flags().Lookup("load-module"))
 	require.Nil(t, cmd.Flags().Lookup("json"))
 }
 

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -54,11 +54,11 @@ func (CallSuite) TestHelp(ctx context.Context, t *testctx.T) {
 		require.Contains(t, out, "dagger call container directory [arguments] <function>")
 	})
 
-	t.Run("flag conflict", func(ctx context.Context, t *testctx.T) {
-		// The function's --mod argument shadows the parent's persistent
-		// --mod/-m flag. Cobra/pflag allows this — the child's local flag
-		// takes precedence. Verify the command works (shows help) rather
-		// than erroring.
+	t.Run("function arg named mod", func(ctx context.Context, t *testctx.T) {
+		// A function may declare an argument named `mod` even though the
+		// global module-loading flag uses `--load-module`/`-m`. Verify
+		// the command works (shows help) and the function's --mod flag
+		// is visible.
 		out, err := modGen.With(daggerCallAt(".", "conflict", "--help")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "--mod")

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -167,9 +167,9 @@ entrypoint = true
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "--mod=.", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "--load-module=.", "./dep")
 		require.Error(t, err)
-		requireErrOut(t, err, "unknown flag: --mod")
+		requireErrOut(t, err, "unknown flag: --load-module")
 	})
 
 	t.Run("install rejects non-module refs without corrupting config", func(ctx context.Context, t *testctx.T) {

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -24,10 +24,10 @@ dagger [options] [subcommand | file...]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
-  -m, --mod string                   Module reference to load, either a local path, a remote git repo, or 'core' (defaults to current directory)
+  -m, --load-module string           Use a one-off module (local path or git ref)
       --model string                 LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
   -E, --no-exit                      Leave the TUI running after completion
-  -M, --no-mod                       Don't automatically load a module (mutually exclusive with --mod)
+  -M, --no-load-module           Don't load any module for this command
       --org string                   Dagger Cloud org name for Cloud-scoped commands
       --progress string              Progress output format (auto, plain, tty, dots, logs) (default "auto")
   -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
@@ -123,8 +123,8 @@ EOF
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --doc string          Read query from file (defaults to reading from stdin)
       --eager-runtime       load module runtime eagerly
-  -m, --mod string          Module reference to load, either a local path, a remote git repo, or 'core' (defaults to current directory)
-  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
+  -m, --load-module string  Use a one-off module (local path or git ref)
+  -M, --no-load-module  Don't load any module for this command
       --var strings         List of query variables, in key=value format
       --var-json string     Query variables in JSON format (overrides --var)
 ```
@@ -180,7 +180,7 @@ dagger check [options] [pattern...]
       --failfast            Cancel remaining checks on first failure
       --generate            Only run generate-as-checks, skip annotated check functions
   -l, --list                List available checks
-  -m, --mod string          Module reference to load, either a local path, a remote git repo, or 'core' (defaults to current directory)
+  -m, --load-module string  Use a one-off module (local path or git ref)
       --no-generate         Only run annotated check functions, skip generate-as-checks
       --no-past             Disable past Cloud Checks lookup
       --past                Only replay past Cloud Checks results
@@ -813,8 +813,8 @@ dagger function call [options] [function]...
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --eager-runtime       load module runtime eagerly
   -j, --json                Present result as JSON
-  -m, --mod string          Module reference to load, either a local path, a remote git repo, or 'core' (defaults to current directory)
-  -M, --no-mod              Don't automatically load a module (mutually exclusive with --mod)
+  -m, --load-module string  Use a one-off module (local path or git ref)
+  -M, --no-load-module  Don't load any module for this command
   -o, --output string       Save the result to a local file or directory
 ```
 
@@ -870,7 +870,7 @@ dagger function list [options] [function]...
 ```
       --allow-llm strings   List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
       --eager-runtime       load module runtime eagerly
-  -m, --mod string          Module reference to load, either a local path, a remote git repo, or 'core' (defaults to current directory)
+  -m, --load-module string  Use a one-off module (local path or git ref)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary

Renames `--mod`/`-m` to `--load-module`/`-m`, and `--no-mod`/`-M` to `--no-load-module`/`-M`. Short forms (`-m`, `-M`) preserved.

The old `--mod` carried two unrelated meanings: "load a module for this invocation" (consumer) and "select a module to operate on" (author). This conflation is the root cause that got PR #13226's deps/engine commands rolled back before merge — they reused `--mod` to mean "module to edit," which collided with the existing consumer meaning.

`--load-module` names the flag's actual job. The authoring commands will be added under a separate `dagger module` group in a follow-up phase; they take no module-targeting flag at all (cwd is the implicit subject).

## What this changes

| Before | After |
|--------|-------|
| `-m`, `--mod string` | `-m`, `--load-module string` |
| `-M`, `--no-mod` | `-M`, `--no-load-module` |

Also updates the descriptions to match the design doc:

- `--load-module`: "Use a one-off module (local path or git ref)"
- `--no-load-module`: "Don't load any module for this command"

## Why this is phase 0

This is the first concrete change in the [CLI 1.0 redesign](https://github.com/dagger/dagger/pull/13392). Phase 0 is intentionally small, low-risk, and unblocks everything later — every subsequent CLI change reads cleaner once the flag stops carrying overloaded meanings.

## Files touched

- `cmd/dagger/module.go` — rename in `moduleAddFlags` (single funnel point) + error message
- `cmd/dagger/shell.go` — comment update
- `cmd/dagger/cloud_test.go` — test args
- `cmd/dagger/workspace_test.go` — `Flags().Lookup("mod")` → `Flags().Lookup("load-module")`
- `core/integration/workspace_modules_test.go` — flag arg + expected error message
- `core/integration/module_call_test.go` — flag-conflict subtest renamed + comment updated (the global flag no longer collides with function args named "mod")
- `docs/current_docs/reference/cli/index.mdx` — help-text snippets

## Verification

Local:
- `go build ./cmd/dagger/` ✓
- `dagger --help` shows new flag ✓
- `-m` short form works ✓
- `dagger --mod=. functions` rejected with "unknown flag" ✓

Tests will run in CI (darwin can't build the full test binary due to a pre-existing Linux-only dependency in `engine/engineutil`).

## Breaking change

Yes. `--mod` and `--no-mod` are no longer accepted. Per the design doc, the 1.0 redesign explicitly trades backwards compat for UX cleanup. Users who relied on the old long-form will get a clear "unknown flag" error and need to switch to `--load-module` / `--no-load-module` (or just use `-m` / `-M`, which are unchanged).