### PR TITLE
Load workspace modules on demand

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -304,6 +304,216 @@ func (m *Consumer) SyncGenerators(ctx context.Context, workspace *dagger.Workspa
 	require.NotContains(t, out, "result *core.Changeset is detached")
 }
 
+// TestWorkspaceGenerateNarrowsToRequestedModule locks in that
+// `dagger generate <module>` only loads the named generator's module. The
+// workspace generators resolver loads modules on demand from its include
+// argument, so an unrelated broken/stale workspace module is never loaded just
+// to enumerate generators and cannot block regenerating a healthy module --
+// including the case where running generate is itself the fix for the broken
+// module.
+//
+// See also TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrokenModules
+// in workspace_test.go, which covers the root-field demand path for raw
+// queries.
+func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating only the healthy module succeeds", func(ctx context.Context, t *testctx.T) {
+		// generate -y is multi-request (list, then run+apply); the later
+		// requests must keep recognizing the already-loaded module instead of
+		// falling back to loading everything.
+		out, err := base.
+			With(daggerExec("generate", "good", "-y", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "no changes to apply")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCheckNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate or run a
+// healthy module's checks, so it cannot block checking that module.
+func (GeneratorsSuite) TestWorkspaceCheckNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("check", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("running only the healthy module's checks succeeds", func(ctx context.Context, t *testctx.T) {
+		// --no-generate runs only annotated checks; generate-as-checks are
+		// excluded because the healthy module's generator legitimately reports
+		// pending output (covered by the generate narrowing test), which is
+		// unrelated to whether the broken module was loaded.
+		out, err := base.
+			With(daggerExec("check", "good", "--no-generate", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("checking across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceUpNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger up`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate a healthy
+// module's services. `dagger up` starts services and blocks, so the assertions
+// use list mode (-l), which still loads workspace modules to enumerate services
+// and thus exercises the same narrowing.
+func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("up", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("up", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger call`: targeting a
+// healthy module's function must not load every workspace module just to build
+// the command tree. The CLI scopes its currentTypeDefs introspection to the
+// leading positional token, and the resolver loads only that module on demand,
+// so an unrelated broken/stale module cannot block the call.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("calling a healthy module's function skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good", "verify", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing the healthy module's functions skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsByCliNameAndEntrypoint covers the two demand shapes
+// TestWorkspaceCallNarrowsToRequestedModule cannot see with its single-word
+// module names:
+//
+//   - the CLI targets modules by their kebab-case command name, so a module
+//     declared as "goodMod" is called as `dagger call good-mod ...` and the
+//     engine must normalize both sides the same way to narrow loading;
+//   - with a workspace entrypoint configured, the first argument may be one of
+//     the entrypoint's root-proxied functions rather than a module name, in
+//     which case the entrypoint module must load — and suffice — to resolve
+//     the call.
+//
+// In both cases the broken sibling module must stay unloaded.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsByCliNameAndEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "call-narrowing")
+
+	t.Run("kebab-case module target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good-mod", "ping", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "pong from goodMod")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("entrypoint function target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "greet", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello from entrypoint")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case functions listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good-mod", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case generate listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		// The selector resolvers (generate/check/up) match include patterns
+		// kebab-normalized; on-demand loading must normalize the same way.
+		out, err := base.
+			With(daggerExec("generate", "-l", "good-mod")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "entry"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
@@ -1,0 +1,9 @@
+type Entry {
+  """
+  A trivial entrypoint function, proxied onto the Query root. Used to prove
+  the entrypoint module loaded when it is the first `dagger call` argument.
+  """
+  pub greet: String! {
+    "hello from entrypoint"
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "goodMod"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
@@ -1,0 +1,17 @@
+type GoodMod {
+  """
+  A trivial function. Used to prove the module loaded when targeted by its
+  kebab-case CLI command name (good-mod).
+  """
+  pub ping: String! {
+    "pong from goodMod"
+  }
+
+  """
+  Regenerate by writing a marker file. Used to prove the kebab-case name also
+  narrows the generate/check/up selector path.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from goodMod").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/dagger.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/dagger.toml
@@ -1,0 +1,9 @@
+[modules.goodMod]
+source = ".dagger/modules/goodMod"
+
+[modules.entry]
+source = ".dagger/modules/entry"
+entrypoint = true
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "good"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,0 +1,27 @@
+type Good {
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+
+  """
+  A trivial check. Used to prove the module loaded for `dagger check` and
+  `dagger call`.
+  """
+  pub verify: Void @check {
+    null
+  }
+
+  """
+  A trivial service. Used to prove the module loaded for `dagger up`.
+  """
+  @up
+  pub web: Service! {
+    container
+      .from("nginx:alpine")
+      .withExposedPort(80)
+      .asService
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken/dagger.toml
@@ -1,0 +1,5 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/query.go
+++ b/core/query.go
@@ -87,6 +87,15 @@ type Server interface {
 	// The cached workspace result from ensureWorkspaceLoaded.
 	CurrentWorkspace(context.Context) (*Workspace, error)
 
+	// Load pending workspace modules on demand; include narrows to the modules
+	// its patterns name ("module" or "module:item"), empty or unrecognized
+	// loads all.
+	EnsureWorkspaceModules(ctx context.Context, include []string) error
+
+	// Load the modules a targeted typedefs introspection demands (the named
+	// modules plus the configured entrypoint); empty include loads all.
+	EnsureWorkspaceModulesForTypeDefs(ctx context.Context, include []string) error
+
 	// A snapshot of the current workspace lockfile for ambient live locking.
 	// Returns ok=false when lock-backed workspace access is unavailable.
 	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -231,13 +231,28 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`The module currently being served in the session, if any.`),
 
 		dagql.Func("currentTypeDefs", s.currentTypeDefs).
-			WithInput(dagql.CurrentSchemaInput).
+			// PerClientInput is load-bearing: modules now load inside the
+			// resolver, so the schema digest no longer identifies the workspace
+			// and different workspaces would otherwise share a cache entry.
+			// CurrentSchemaInput refreshes as the served schema grows.
+			WithInput(dagql.CurrentSchemaInput, dagql.PerClientInput).
 			Args(
 				dagql.Arg("returnAllTypes").Doc(`Return the full referenced typedef closure instead of only top-level served typedefs.`),
 				dagql.Arg("hideCore").Doc(
 					`Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).`,
 					`Core types (Container, Directory, etc.) are kept so return types and method chaining still work.`,
 				),
+				// Gate out of the base schema view: a new public arg on a
+				// base-view field must be version-gated (TestBaseSchemaAllowlist).
+				dagql.Arg("include").
+					Doc(
+						`Narrow on-demand workspace module loading to the named modules (and their dependencies) before computing typedefs.`,
+						`Each pattern is a workspace module name or "module:item"; the workspace entrypoint module, when one is configured, is always loaded as well since the pattern may name one of its root-proxied functions.`,
+						`A pattern that does not name a workspace module loads every module, unless an entrypoint module can resolve it.`,
+						`Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.`,
+						`Modules already loaded in the session are always reflected; other pending workspace modules stay loadable by later requests.`,
+					).
+					View(AfterVersion("v1.0.0-0")),
 			).
 			Doc(`The TypeDef representations of the objects currently being served in the session.`),
 
@@ -2110,9 +2125,23 @@ func (s *moduleSchema) moduleServe(ctx context.Context, modMeta dagql.ObjectResu
 type currentTypeDefsArgs struct {
 	ReturnAllTypes bool `default:"false"`
 	HideCore       dagql.Optional[dagql.Boolean]
+	Include        dagql.Optional[dagql.ArrayInput[dagql.String]]
 }
 
 func (s *moduleSchema) currentTypeDefs(ctx context.Context, self *core.Query, args currentTypeDefsArgs) (dagql.ObjectResultArray[*core.TypeDef], error) {
+	// The query validates against the core schema, so module loading waits
+	// until here, where include narrows it.
+	var include []string
+	if args.Include.Valid {
+		include = make([]string, 0, len(args.Include.Value))
+		for _, pattern := range args.Include.Value {
+			include = append(include, pattern.String())
+		}
+	}
+	if err := self.Server.EnsureWorkspaceModulesForTypeDefs(ctx, include); err != nil {
+		return nil, fmt.Errorf("failed to load workspace modules: %w", err)
+	}
+
 	deps, err := self.CurrentServedDeps(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current module: %w", err)

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -53,6 +53,14 @@ func (s *currentTypeDefsTestServer) CurrentWorkspace(context.Context) (*core.Wor
 	return nil, nil
 }
 
+func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
+func (s *currentTypeDefsTestServer) EnsureWorkspaceModulesForTypeDefs(context.Context, []string) error {
+	return nil
+}
+
 func (s *currentTypeDefsTestServer) CurrentServedDeps(context.Context) (*core.SchemaBuilder, error) {
 	return s.deps, nil
 }

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1256,7 +1256,6 @@ func (s *workspaceSchema) checks(
 
 	noGenerate := args.NoGenerate.GetOr(false).Bool()
 	onlyGenerate := args.OnlyGenerate.GetOr(false).Bool()
-
 	cfg, err := workspaceConfigWithCompatFallback(ctx, parent)
 	if err != nil {
 		return nil, err
@@ -1266,6 +1265,9 @@ func (s *workspaceSchema) checks(
 		noGenerate = true
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1375,6 +1377,9 @@ func (s *workspaceSchema) generators(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1493,6 +1498,9 @@ func (s *workspaceSchema) services(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1645,6 +1653,17 @@ func matchWorkspaceIncludePath(
 		}
 	}
 	return false, nil
+}
+
+// ensureWorkspaceIncludeModulesLoaded loads the workspace modules the include
+// patterns demand (all when they don't narrow). Selector fields validate
+// against the core schema, so loading can wait until resolution.
+func ensureWorkspaceIncludeModulesLoaded(ctx context.Context, include []string) error {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	return query.Server.EnsureWorkspaceModules(ctx, include)
 }
 
 func currentWorkspacePrimaryModules(ctx context.Context) ([]dagql.ObjectResult[*core.Module], error) {

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -56,6 +56,14 @@ func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*M
 	return nil
 }
 
+func (ms *mockServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
+func (ms *mockServer) EnsureWorkspaceModulesForTypeDefs(context.Context, []string) error {
+	return nil
+}
+
 func (ms *mockServer) CurrentModule(_ context.Context) (dagql.ObjectResult[*Module], error) {
 	var zero dagql.ObjectResult[*Module]
 	if ms.moduleSource == nil {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5221,6 +5221,23 @@ type Query implements Node {
     Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
     """
     hideCore: Boolean
+
+    """
+    Narrow on-demand workspace module loading to the named modules (and their dependencies) before computing typedefs.
+
+    Each pattern is a workspace module name or "module:item"; the workspace
+    entrypoint module, when one is configured, is always loaded as well since
+    the pattern may name one of its root-proxied functions.
+
+    A pattern that does not name a workspace module loads every module, unless an entrypoint module can resolve it.
+
+    Used by clients (e.g. the CLI) that target a single module so an unrelated
+    broken or stale module cannot block building the command tree.
+
+    Modules already loaded in the session are always reflected; other pending
+    workspace modules stay loadable by later requests.
+    """
+    include: [String!]
   ): [TypeDef!]!
 
   """Detect and return the current workspace."""

--- a/docs/static/reference/php/Dagger/Client.html
+++ b/docs/static/reference/php/Dagger/Client.html
@@ -281,7 +281,7 @@
                     array
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_currentTypeDefs">currentTypeDefs</a>(bool|null $returnAllTypes = false, bool|null $hideCore = null)
+                    <a href="#method_currentTypeDefs">currentTypeDefs</a>(bool|null $returnAllTypes = false, bool|null $hideCore = null, array|null $include = null)
         
                                             <p><p>The TypeDef representations of the objects currently being served in the session.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1147,7 +1147,7 @@
                     <h3 id="method_currentTypeDefs">
         <div class="location">at line 133</div>
         <code>                    array
-    <strong>currentTypeDefs</strong>(bool|null $returnAllTypes = false, bool|null $hideCore = null)
+    <strong>currentTypeDefs</strong>(bool|null $returnAllTypes = false, bool|null $hideCore = null, array|null $include = null)
         </code>
     </h3>
     <div class="details">    
@@ -1171,6 +1171,11 @@
                 <td>$hideCore</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>array|null</td>
+                <td>$include</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1192,7 +1197,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_currentWorkspace">
-        <div class="location">at line 148</div>
+        <div class="location">at line 154</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>currentWorkspace</strong>()
         </code>
@@ -1224,7 +1229,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_defaultPlatform">
-        <div class="location">at line 157</div>
+        <div class="location">at line 163</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>defaultPlatform</strong>()
         </code>
@@ -1256,7 +1261,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 166</div>
+        <div class="location">at line 172</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>()
         </code>
@@ -1288,7 +1293,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_engine">
-        <div class="location">at line 175</div>
+        <div class="location">at line 181</div>
         <code>                    <a href="../Dagger/Engine.html"><abbr title="Dagger\Engine">Engine</abbr></a>
     <strong>engine</strong>()
         </code>
@@ -1320,7 +1325,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_env">
-        <div class="location">at line 184</div>
+        <div class="location">at line 190</div>
         <code>                    <a href="../Dagger/Env.html"><abbr title="Dagger\Env">Env</abbr></a>
     <strong>env</strong>(bool|null $privileged = false, bool|null $writable = false)
         </code>
@@ -1367,7 +1372,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envFile">
-        <div class="location">at line 199</div>
+        <div class="location">at line 205</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>envFile</strong>(bool|null $expand = null)
         </code>
@@ -1409,7 +1414,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_error">
-        <div class="location">at line 211</div>
+        <div class="location">at line 217</div>
         <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
     <strong>error</strong>(string $message)
         </code>
@@ -1451,7 +1456,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 221</div>
+        <div class="location">at line 227</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $name, string $contents, int|null $permissions = 420)
         </code>
@@ -1503,7 +1508,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_function">
-        <div class="location">at line 235</div>
+        <div class="location">at line 241</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>function</strong>(string $name, <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $returnType)
         </code>
@@ -1550,7 +1555,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedCode">
-        <div class="location">at line 246</div>
+        <div class="location">at line 252</div>
         <code>                    <a href="../Dagger/GeneratedCode.html"><abbr title="Dagger\GeneratedCode">GeneratedCode</abbr></a>
     <strong>generatedCode</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $code)
         </code>
@@ -1592,7 +1597,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_git">
-        <div class="location">at line 256</div>
+        <div class="location">at line 262</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>git</strong>(string $url, bool|null $keepGitDir = true, string|null $sshKnownHosts = &#039;&#039;, <abbr title="Dagger\Dagger\Socket">Socket</abbr>|null $sshAuthSocket = null, string|null $httpAuthUsername = &#039;&#039;, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $httpAuthToken = null, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $httpAuthHeader = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $experimentalServiceHost = null)
         </code>
@@ -1669,7 +1674,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_host">
-        <div class="location">at line 295</div>
+        <div class="location">at line 301</div>
         <code>                    <a href="../Dagger/Host.html"><abbr title="Dagger\Host">Host</abbr></a>
     <strong>host</strong>()
         </code>
@@ -1701,7 +1706,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_http">
-        <div class="location">at line 304</div>
+        <div class="location">at line 310</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>http</strong>(string $url, string|null $name = null, int|null $permissions = null, string|null $checksum = null, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $authHeader = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $experimentalServiceHost = null)
         </code>
@@ -1768,7 +1773,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 335</div>
+        <div class="location">at line 341</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1800,7 +1805,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_json">
-        <div class="location">at line 344</div>
+        <div class="location">at line 350</div>
         <code>                    <a href="../Dagger/JsonValue.html"><abbr title="Dagger\JsonValue">JsonValue</abbr></a>
     <strong>json</strong>()
         </code>
@@ -1832,7 +1837,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_llm">
-        <div class="location">at line 353</div>
+        <div class="location">at line 359</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>llm</strong>(string|null $model = null, int|null $maxAPICalls = null)
         </code>
@@ -1879,7 +1884,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_module">
-        <div class="location">at line 368</div>
+        <div class="location">at line 374</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>module</strong>()
         </code>
@@ -1911,7 +1916,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleRuntime">
-        <div class="location">at line 374</div>
+        <div class="location">at line 380</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>moduleRuntime</strong>(<a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a> $modSource, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $introspectionJson)
         </code>
@@ -1959,7 +1964,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleSource">
-        <div class="location">at line 385</div>
+        <div class="location">at line 391</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>moduleSource</strong>(string $refString, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
         </code>
@@ -2021,7 +2026,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_node">
-        <div class="location">at line 412</div>
+        <div class="location">at line 418</div>
         <code>                    <a href="../Dagger/Node.html"><abbr title="Dagger\Node">Node</abbr></a>
     <strong>node</strong>(<a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
         </code>
@@ -2063,7 +2068,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_secret">
-        <div class="location">at line 422</div>
+        <div class="location">at line 428</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>secret</strong>(string $uri, string|null $cacheKey = null)
         </code>
@@ -2110,7 +2115,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecret">
-        <div class="location">at line 437</div>
+        <div class="location">at line 443</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecret</strong>(string $name, string $plaintext)
         </code>
@@ -2157,7 +2162,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceDir">
-        <div class="location">at line 445</div>
+        <div class="location">at line 451</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>sourceDir</strong>()
         </code>
@@ -2190,7 +2195,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceMap">
-        <div class="location">at line 454</div>
+        <div class="location">at line 460</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>sourceMap</strong>(string $filename, int $line, int $column)
         </code>
@@ -2242,7 +2247,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 466</div>
+        <div class="location">at line 472</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>
@@ -2274,7 +2279,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 475</div>
+        <div class="location">at line 481</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -2306,7 +2311,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_with">
-        <div class="location">at line 484</div>
+        <div class="location">at line 490</div>
         <code>                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
     <strong>with</strong>(<abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $sdkSourceDir = null)
         </code>

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -214,10 +214,20 @@ type daggerClient struct {
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
 	modulesMu           sync.Mutex
-	modulesLoaded       bool
-	modulesErr          error
-	singleQueryMu       sync.Mutex
-	singleQueryServed   bool
+	extraModulesLoaded  bool
+	extraModulesErr     error
+	// load failures by moduleProgressName; failed modules stay pending to keep
+	// reporting their error
+	failedModules map[string]error
+	// whether an entrypoint module has been served (extras outrank ambient)
+	entrypointServed bool
+	// resolved identities already served, for cross-batch deduplication
+	servedModuleKeys map[string]struct{}
+	// served workspace module names, so demand filters recognize them without
+	// reloading
+	servedWorkspaceModuleNames map[string]struct{}
+	singleQueryMu              sync.Mutex
+	singleQueryServed          bool
 
 	// NOTE: do not use this field directly as it may not be open
 	// after the client has shutdown; use TelemetryDB() instead
@@ -992,7 +1002,7 @@ func (srv *Server) getOrInitClient(
 		}
 		// ExtraModules may arrive on a later request (e.g. /init) after the
 		// session attachable request already created the client without them.
-		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.modulesLoaded {
+		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.extraModulesLoaded {
 			client.clientMetadata.ExtraModules = opts.ExtraModules
 			client.pendingExtraModules = opts.ExtraModules
 		}
@@ -1466,26 +1476,18 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 		return gqlErr(err, http.StatusBadRequest)
 	}
 
-	peekRootFieldsOK, peekRootFields, err := peekSingleQueryRootFields(r, client.clientMetadata)
-	if err != nil {
-		return gqlErr(fmt.Errorf("peeking single-query root fields: %w", err), http.StatusBadRequest)
-	}
-
 	// Load workspace modules and extra modules (e.g. from -m flag). These are
 	// deferred from initializeDaggerClient because they need the client's
 	// session attachables, which only become available after the session
 	// attachables handshake completes (after init locks are released).
 	wsCtx, wsOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.workspaceLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureWorkspaceLoaded(wsCtx, client)
+	err := srv.ensureWorkspaceLoaded(wsCtx, client)
 	wsOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading workspace: %w", err), http.StatusInternalServerError)
 	}
-	if peekRootFieldsOK {
-		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
-	}
 	modCtx, modOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.modulesLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureModulesLoaded(modCtx, client)
+	err = srv.ensureRequestModulesLoaded(modCtx, client, r)
 	modOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1532,11 +1534,26 @@ func (client *daggerClient) claimSingleQueryRequest() error {
 	return nil
 }
 
-func peekSingleQueryRootFields(r *http.Request, clientMD *engine.ClientMetadata) (bool, []string, error) {
-	if clientMD == nil || !clientMD.SingleQuery || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
-		return false, nil, nil
+// ensureRequestModulesLoaded loads the modules this request demands: root
+// fields naming pending modules demand just those; full-schema fields (and
+// anything unrecognized) demand everything. The rest stay pending for later.
+func (srv *Server) ensureRequestModulesLoaded(ctx context.Context, client *daggerClient, r *http.Request) error {
+	var filter func([]pendingModule) []pendingModule
+	if client.hasPendingWorkspaceModules() {
+		if ok, rootFields, err := dagql.PeekRootFields(r); err == nil && ok {
+			filter = func(mods []pendingModule) []pendingModule {
+				// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+				return filterPendingWorkspaceModulesForRootFields(mods, client.servedWorkspaceModuleNames, rootFields)
+			}
+		}
 	}
-	return dagql.PeekRootFields(r)
+	return srv.ensureModulesLoaded(ctx, client, filter)
+}
+
+func (client *daggerClient) hasPendingWorkspaceModules() bool {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+	return len(client.pendingModules) > 0
 }
 
 func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *daggerClient) (rerr error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -222,14 +222,14 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 	t.Run("constructor match loads only matching module", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"foo"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"foo"})
 		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("unknown root field with multiple entrypoints loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"doThing"})
 		require.Equal(t, mods, filtered)
 	})
 
@@ -237,36 +237,277 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		oneEntrypoint := []pendingModule{mods[0], mods[1]}
-		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, []string{"doThing"})
 		require.Equal(t, []pendingModule{mods[1]}, filtered)
 	})
 
 	t.Run("introspection loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"__schema"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"__schema"})
 		require.Equal(t, mods, filtered)
 	})
 
-	t.Run("current typedefs loads all", func(t *testing.T) {
+	t.Run("current typedefs loads none (resolver loads on demand)", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentTypeDefs"})
-		require.Equal(t, mods, filtered)
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentTypeDefs"})
+		require.Empty(t, filtered)
 	})
 
 	t.Run("current module loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentModule"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentModule"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("core-only query loads none", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"container", "version"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"container", "version"})
 		require.Empty(t, filtered)
+	})
+
+	t.Run("current workspace loads none (resolvers load on demand)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentWorkspace"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("already-served root field loads none", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served field combined with pending field loads only pending", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod", "foo"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("env loads all (resolver snapshots served deps)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"env"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("unrecognized loadFromID field loads all", func(t *testing.T) {
+		t.Parallel()
+
+		// The type name in load<Type>FromID needn't embed the module name, so
+		// only a full load can guarantee the field exists.
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"loadSomethingFromID"})
+		require.Equal(t, mods, filtered)
+	})
+}
+
+func TestFilterPendingWorkspaceModulesBySelectorInclude(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "go-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "rust-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "php-sdk"},
+	}
+
+	t.Run("module:generator selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("module:item works for checks and services too", func(t *testing.T) {
+		t.Parallel()
+
+		// The module-name resolution is identical across generate/check/up: the
+		// segment before ':' is the module name regardless of the item kind.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"rust-sdk:lint", "php-sdk:web"})
+		require.Equal(t, []pendingModule{mods[1], mods[2]}, filtered)
+	})
+
+	t.Run("bare module name selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("multiple patterns select each named module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk", "php-sdk:api"})
+		require.Equal(t, []pendingModule{mods[0], mods[2]}, filtered)
+	})
+
+	t.Run("bare token not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// e.g. an item served by the entrypoint module.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("module:item not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"typo-sdk:generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("empty include selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, nil)
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("already-served module is recognized and selects nothing", func(t *testing.T) {
+		t.Parallel()
+
+		// A re-evaluated selector (e.g. loading a GeneratorGroup from its ID
+		// on a later request) names a module that already loaded; it must not
+		// fall back to loading everything.
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served and pending patterns select only the pending module", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk:generate", "go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("camelCase pattern selects the kebab-case module", func(t *testing.T) {
+		t.Parallel()
+
+		// Name matching is kebab-normalized on both sides, like the include
+		// matchers the selector resolvers use (ModTreePath.Glob/CliCase).
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"goSdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("kebab-case pattern selects the camelCase module", func(t *testing.T) {
+		t.Parallel()
+
+		// The CLI presents module commands in kebab-case, so a module declared
+		// as "myMod" (or "mod1", which kebab-cases to "mod-1") is targeted by
+		// its kebab-case name.
+		camelMods := []pendingModule{
+			{Kind: moduleLoadKindAmbient, Name: "myMod"},
+			{Kind: moduleLoadKindAmbient, Name: "mod1"},
+			{Kind: moduleLoadKindAmbient, Name: "other"},
+		}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(camelMods, nil, []string{"my-mod", "mod-1:generate"})
+		require.Equal(t, []pendingModule{camelMods[0], camelMods[1]}, filtered)
+	})
+
+	t.Run("glob pattern selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// Glob metacharacters survive normalization and never equal a module
+		// name, so glob patterns conservatively load everything.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-*"})
+		require.Equal(t, mods, filtered)
+	})
+}
+
+func TestFilterPendingWorkspaceModulesForTypeDefsTarget(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "goodMod"},
+		{Kind: moduleLoadKindAmbient, Name: "other"},
+	}
+	withEntrypoint := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "goodMod"},
+		{Kind: moduleLoadKindAmbient, Name: "other"},
+		{Kind: moduleLoadKindAmbient, Name: "entry", Entrypoint: true},
+	}
+
+	t.Run("module target selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, false, []string{"goodMod"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("kebab-case target selects the camelCase module", func(t *testing.T) {
+		t.Parallel()
+
+		// `dagger call good-mod ...`: the CLI command name for module
+		// "goodMod" is its kebab-case form.
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, false, []string{"good-mod"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("unknown target without entrypoint selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, false, []string{"nope"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("module target also selects the pending entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		// The entrypoint's functions live on the Query root next to module
+		// constructors, so a targeted command tree always needs it.
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, []string{"good-mod"})
+		require.Equal(t, []pendingModule{withEntrypoint[0], withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("unknown target with pending entrypoint selects only the entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		// `dagger call container-echo ...` where container-echo is an
+		// entrypoint function: only the entrypoint module can resolve it.
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, []string{"container-echo"})
+		require.Equal(t, []pendingModule{withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("unknown target with served entrypoint selects nothing", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, true, []string{"container-echo"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served module target selects only the entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		// goodMod already loaded on an earlier request: the target is
+		// recognized (no fall back to loading everything) and only the
+		// pending entrypoint still needs to load.
+		served := map[string]struct{}{"goodMod": {}}
+		stillPending := []pendingModule{withEntrypoint[1], withEntrypoint[2]}
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(stillPending, served, false, []string{"good-mod"})
+		require.Equal(t, []pendingModule{withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("entrypoint target selects it once", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, []string{"entry"})
+		require.Equal(t, []pendingModule{withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("empty include selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, nil)
+		require.Equal(t, withEntrypoint, filtered)
 	})
 }
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -890,33 +890,144 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 	return tree, gitRef, nil
 }
 
-// ensureModulesLoaded loads all pending modules (from workspace discovery,
-// compat parsing, and -m flags). Called from serveQuery after
-// ensureWorkspaceLoaded. Uses a mutex+flag instead of sync.Once so that
-// transient failures (e.g. session not yet registered) can be retried.
-func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient) error {
-	if len(client.pendingModules) == 0 && len(client.pendingExtraModules) == 0 {
-		return nil
-	}
-
+// ensureModulesLoaded loads pending modules (workspace, compat, and -m) on
+// demand. filter picks which pending workspace modules this request needs (nil
+// = all); the rest stay pending for a later request or resolver. Loading is
+// additive, so narrowing is deferral, not exclusion. Mutex+flags (not
+// sync.Once) keep transient failures retriable.
+func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule) error {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
 
-	if client.modulesLoaded {
-		return client.modulesErr
+	if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
+		return err
+	}
+
+	if len(client.pendingModules) == 0 {
+		return nil
+	}
+
+	demand := client.pendingModules
+	if filter != nil {
+		demand = filter(client.pendingModules)
+	}
+	// Multiple ambient entrypoint declarations may dedupe to one module; load
+	// everything so the existing conflict detection still runs.
+	if len(demand) > 0 && len(pendingWorkspaceEntrypointIndexes(client.pendingModules)) > 1 {
+		demand = client.pendingModules
+	}
+	if len(demand) == 0 {
+		return nil
+	}
+
+	// A failed module stays pending; surface its recorded error rather than
+	// reloading it.
+	for _, mod := range demand {
+		if err, ok := client.failedModules[moduleProgressName(mod)]; ok {
+			return err
+		}
 	}
 
 	// Wait for the client's session attachables to be available.
-	// Don't mark as loaded on failure — allow retry on next request.
+	// Transient failure — allow retry on next request.
 	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
 		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
-	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules)
+	loads := gatherModuleLoadRequests(demand, nil)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			loadErr := moduleLoadErr(load, resolveErrs[i])
+			client.recordFailedModule(load.mod, loadErr)
+			if firstErr == nil {
+				firstErr = loadErr
+			}
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := client.arbitrateAmbientEntrypoints(loads, resolvedLoads); err != nil {
+		return err
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return err
+	}
+	client.markEntrypointServed(resolvedLoads)
+	client.removePendingModules(demand)
+	return nil
+}
+
+// ensureExtraModulesLoadedLocked loads -m modules. They are explicitly
+// requested, so they load eagerly with sticky failures (unlike on-demand
+// workspace modules). client.modulesMu must be held.
+func (srv *Server) ensureExtraModulesLoadedLocked(ctx context.Context, client *daggerClient) error {
+	if client.extraModulesLoaded {
+		return client.extraModulesErr
+	}
+	if len(client.pendingExtraModules) == 0 {
+		return nil
+	}
+
+	// Wait for the client's session attachables to be available.
+	// Transient failure — allow retry on next request.
+	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		return fmt.Errorf("waiting for client session attachables: %w", err)
+	}
+
+	stick := func(err error) error {
+		client.extraModulesErr = err
+		client.extraModulesLoaded = true
+		return err
+	}
+
+	loads := gatherModuleLoadRequests(nil, client.pendingExtraModules)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return stick(err)
+	}
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			return stick(moduleLoadErr(load, resolveErrs[i]))
+		}
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+	client.markEntrypointServed(resolvedLoads)
+
+	client.extraModulesLoaded = true
+	return nil
+}
+
+// resolveModuleLoadBatch resolves the loads in parallel but reports per-load
+// errors positionally, so callers stay deterministic.
+func (srv *Server) resolveModuleLoadBatch(
+	ctx context.Context,
+	client *daggerClient,
+	loads []moduleLoadRequest,
+) ([]resolvedModuleLoad, []error, error) {
 	resolvedLoads := make([]resolvedModuleLoad, len(loads))
 	resolveErrs := make([]error, len(loads))
 
-	// Load modules in parallel, then apply to client state in deterministic order.
 	jobs := parallel.New().
 		WithContextualTracer(true).
 		WithLimit(moduleLoadParallelism(len(loads)))
@@ -934,57 +1045,241 @@ func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient
 		})
 	}
 	if err := jobs.Run(ctx); err != nil {
-		client.modulesErr = fmt.Errorf("resolving modules: %w", err)
-		client.modulesLoaded = true
-		return client.modulesErr
+		return nil, nil, fmt.Errorf("resolving modules: %w", err)
 	}
+	return resolvedLoads, resolveErrs, nil
+}
 
-	for i, load := range loads {
-		if resolveErrs[i] != nil {
-			client.modulesErr = moduleLoadErr(load, resolveErrs[i])
-			client.modulesLoaded = true
-			return client.modulesErr
+// arbitrateAmbientEntrypoints picks whether this ambient batch's entrypoint
+// candidate wins: only when none is served yet (extras outrank ambient).
+// Multiple candidates in one batch are a workspace configuration error.
+func (client *daggerClient) arbitrateAmbientEntrypoints(loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+	var candidates []int
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			candidates = append(candidates, i)
 		}
 	}
-
-	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
-	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if len(candidates) > 1 {
+		return entrypointConflictError(moduleLoadKindAmbient, candidates, loads)
 	}
-
-	client.stateMu.Lock()
-	defer client.stateMu.Unlock()
-	if err := srv.serveAllResolvedModuleLoads(client, loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if client.entrypointServed {
+		for _, i := range candidates {
+			resolved[i].primaryEntrypoint = false
+		}
 	}
-
-	client.modulesLoaded = true
 	return nil
 }
 
-func (client *daggerClient) narrowPendingWorkspaceModulesForSingleQuery(rootFields []string) {
-	client.modulesMu.Lock()
-	defer client.modulesMu.Unlock()
-
-	if client.modulesLoaded || len(client.pendingModules) == 0 {
-		return
+// markEntrypointServed flags that an entrypoint (primary or blueprint) was
+// served, so later ambient candidates are demoted. client.modulesMu must be held.
+func (client *daggerClient) markEntrypointServed(resolved []resolvedModuleLoad) {
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			client.entrypointServed = true
+			return
+		}
+		for _, related := range resolved[i].related {
+			if related.entrypoint {
+				client.entrypointServed = true
+				return
+			}
+		}
 	}
-	client.pendingModules = filterPendingWorkspaceModulesForRootFields(client.pendingModules, rootFields)
 }
 
-func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields []string) []pendingModule {
+func (client *daggerClient) recordFailedModule(mod pendingModule, err error) {
+	// Cancellation/deadline is the request's fault, not the module's; keep it
+	// retriable.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	if client.failedModules == nil {
+		client.failedModules = make(map[string]error)
+	}
+	client.failedModules[moduleProgressName(mod)] = err
+}
+
+// removePendingModules drops served modules from the pending set and records
+// their names so demand filters still recognize them. Failed modules stay
+// pending to keep reporting their error. client.modulesMu must be held.
+func (client *daggerClient) removePendingModules(served []pendingModule) {
+	names := make(map[string]struct{}, len(served))
+	for _, mod := range served {
+		names[moduleProgressName(mod)] = struct{}{}
+	}
+	remaining := client.pendingModules[:0]
+	for _, mod := range client.pendingModules {
+		if _, ok := names[moduleProgressName(mod)]; ok {
+			if client.servedWorkspaceModuleNames == nil {
+				client.servedWorkspaceModuleNames = make(map[string]struct{})
+			}
+			client.servedWorkspaceModuleNames[moduleProgressName(mod)] = struct{}{}
+			continue
+		}
+		remaining = append(remaining, mod)
+	}
+	client.pendingModules = remaining
+}
+
+// EnsureWorkspaceModules loads the pending workspace modules a selector
+// resolver (checks/generators/services) demands. Those fields validate against
+// the core schema, so loading waits until resolution where include is native.
+func (srv *Server) EnsureWorkspaceModules(ctx context.Context, include []string) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return srv.ensureModulesLoaded(ctx, client, func(mods []pendingModule) []pendingModule {
+		// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+		return filterPendingWorkspaceModulesBySelectorInclude(mods, client.servedWorkspaceModuleNames, include)
+	})
+}
+
+// EnsureWorkspaceModulesForTypeDefs loads the modules a targeted typedefs
+// introspection demands: those the target names, plus the entrypoint module
+// (its functions are proxied onto the Query root, so the target may be one of
+// them).
+func (srv *Server) EnsureWorkspaceModulesForTypeDefs(ctx context.Context, include []string) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return srv.ensureModulesLoaded(ctx, client, func(mods []pendingModule) []pendingModule {
+		// runs under client.modulesMu, which also guards
+		// servedWorkspaceModuleNames and entrypointServed
+		return filterPendingWorkspaceModulesForTypeDefsTarget(mods, client.servedWorkspaceModuleNames, client.entrypointServed, include)
+	})
+}
+
+// canonicalWorkspaceModuleName kebab-normalizes a name or pattern segment for
+// comparison, matching the include matchers (ModTreePath.Glob/CliCase) and CLI
+// command names: "myMod", "my-mod", "MyMod" are the same module. Glob
+// metacharacters survive, so a glob never equals a module name.
+func canonicalWorkspaceModuleName(name string) string {
+	return strcase.ToKebab(name)
+}
+
+// pendingModuleCliName is the canonical name an include pattern matches against.
+func pendingModuleCliName(mod pendingModule) string {
+	if mod.Name != "" {
+		return canonicalWorkspaceModuleName(mod.Name)
+	}
+	return canonicalWorkspaceModuleName(moduleProgressName(mod))
+}
+
+// knownWorkspaceModuleNames is the canonical-name set of all pending and
+// already-served workspace modules.
+func knownWorkspaceModuleNames(mods []pendingModule, served map[string]struct{}) map[string]struct{} {
+	known := make(map[string]struct{}, len(mods)+len(served))
+	for _, mod := range mods {
+		known[pendingModuleCliName(mod)] = struct{}{}
+	}
+	for name := range served {
+		known[canonicalWorkspaceModuleName(name)] = struct{}{}
+	}
+	return known
+}
+
+// resolveIncludePatternModules maps each pattern's leading segment (before ':')
+// to a known module name. It returns the demanded names and whether any pattern
+// matched nothing known; the caller decides the fallback.
+func resolveIncludePatternModules(mods []pendingModule, served map[string]struct{}, include []string) (wanted map[string]struct{}, unknown bool) {
+	known := knownWorkspaceModuleNames(mods, served)
+	wanted = make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		modName, _, _ := strings.Cut(pattern, ":")
+		modName = canonicalWorkspaceModuleName(modName)
+		if _, ok := known[modName]; !ok {
+			unknown = true
+			continue
+		}
+		wanted[modName] = struct{}{}
+	}
+	return wanted, unknown
+}
+
+// filterPendingWorkspaceModulesBySelectorInclude selects the modules named by
+// `dagger generate`/`check`/`up` patterns ("module" or "module:item"). A
+// pattern naming no known module (an entrypoint-proxied item, or a typo)
+// selects all, so the usual error surfaces. served modules are recognized but
+// contribute nothing to load.
+func filterPendingWorkspaceModulesBySelectorInclude(mods []pendingModule, served map[string]struct{}, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	wanted, unknown := resolveIncludePatternModules(mods, served, include)
+	if unknown {
+		return mods
+	}
+
+	// Already-served wanted modules contribute nothing; result may be empty.
+	filtered := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if _, ok := wanted[pendingModuleCliName(mod)]; ok {
+			filtered = append(filtered, mod)
+		}
+	}
+	return filtered
+}
+
+// filterPendingWorkspaceModulesForTypeDefsTarget selects the modules a targeted
+// typedefs introspection demands: those the patterns name, plus any pending
+// entrypoint (the target may be one of its root-proxied functions). A pattern
+// naming nothing known selects only the entrypoint when one exists (pending or
+// served), else all so the unknown-command error surfaces.
+func filterPendingWorkspaceModulesForTypeDefsTarget(mods []pendingModule, served map[string]struct{}, entrypointServed bool, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	wanted, unknown := resolveIncludePatternModules(mods, served, include)
+
+	entrypoints := pendingWorkspaceEntrypointIndexes(mods)
+	if unknown && !entrypointServed && len(entrypoints) == 0 {
+		return mods
+	}
+
+	selected := make([]bool, len(mods))
+	for i, mod := range mods {
+		if _, ok := wanted[pendingModuleCliName(mod)]; ok {
+			selected[i] = true
+		}
+	}
+	for _, i := range entrypoints {
+		selected[i] = true
+	}
+
+	filtered := make([]pendingModule, 0, len(mods))
+	for i, mod := range mods {
+		if selected[i] {
+			filtered = append(filtered, mod)
+		}
+	}
+	return filtered
+}
+
+// filterPendingWorkspaceModulesForRootFields selects the pending modules a
+// request's root fields reference. served modules are recognized without
+// loading.
+func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods
+	}
+
+	servedFields := make(map[string]struct{}, len(served))
+	for name := range served {
+		servedFields[strcase.ToLowerCamel(name)] = struct{}{}
 	}
 
 	selected := make([]bool, len(mods))
 	unknownRootField := false
 	for _, field := range rootFields {
 		if isCoreRootField(field) {
+			continue
+		}
+		if _, ok := servedFields[field]; ok {
 			continue
 		}
 		matched := false
@@ -995,6 +1290,11 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields
 			}
 		}
 		if !matched {
+			// load<Type>FromID can reference a module type without naming the
+			// module, so load everything to be safe.
+			if strings.HasPrefix(field, "load") && strings.HasSuffix(field, "FromID") {
+				return mods
+			}
 			unknownRootField = true
 		}
 	}
@@ -1031,8 +1331,8 @@ func rootFieldsRequireFullWorkspaceSchema(fields []string) bool {
 			"__workspaceModule",
 			"currentEnv",
 			"currentModule",
-			"currentTypeDefs",
-			"currentWorkspace":
+			// env's resolver snapshots the served deps, so it needs every module
+			"env":
 			return true
 		}
 	}
@@ -1087,10 +1387,15 @@ func isCoreRootField(field string) bool {
 		"currentEnv",
 		"currentFunctionCall",
 		"currentModule",
+		// currentTypeDefs and currentWorkspace load on demand inside their
+		// resolvers, so the root fields demand nothing here
+		"currentTypeDefs",
+		"currentWorkspace",
 		"defaultPlatform",
 		"directory",
 		"engine",
-		"env",
+		// NOTE: "env" is intentionally absent — it needs the full workspace
+		// (see rootFieldsRequireFullWorkspaceSchema)
 		"envFile",
 		"error",
 		"file",
@@ -1177,8 +1482,10 @@ func (srv *Server) resolveModuleLoad(
 	return resolved, nil
 }
 
-// serveAllResolvedModuleLoads serves all resolved primary modules and their
-// related modules (blueprints, toolchains-of-toolchains).
+// serveResolvedModuleLoadsLocked serves resolved primary modules and their
+// related modules (blueprints, toolchains-of-toolchains), skipping any whose
+// identity an earlier batch already served. client.stateMu and client.modulesMu
+// must be held.
 //
 // Transitive dependencies are only served for the entrypoint module — the one
 // the user is interacting with via `dagger call` or `dagger shell`. This is
@@ -1186,9 +1493,13 @@ func (srv *Server) resolveModuleLoad(
 // (e.g. a Mallard backing a Duck). Toolchain deps are NOT served globally;
 // each module's deps are available in its own internal schema (mod.Deps) for
 // type resolution during function calls.
-func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+func (srv *Server) serveResolvedModuleLoadsLocked(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
 	for i := range loads {
 		load := resolved[i]
+		key := resolvedModuleLoadIdentity(load.primary)
+		if _, ok := client.servedModuleKeys[key]; ok {
+			continue
+		}
 		for _, related := range load.related {
 			if err := srv.serveModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: related.entrypoint}); err != nil {
 				return fmt.Errorf("error serving related module %s: %w", related.mod.Self().Name(), err)
@@ -1208,6 +1519,10 @@ func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []mod
 				}
 			}
 		}
+		if client.servedModuleKeys == nil {
+			client.servedModuleKeys = make(map[string]struct{})
+		}
+		client.servedModuleKeys[key] = struct{}{}
 	}
 
 	return nil

--- a/hack/designs/demand-driven-module-loading.md
+++ b/hack/designs/demand-driven-module-loading.md
@@ -1,0 +1,282 @@
+# Demand-Driven Workspace Module Loading
+
+*Alternative to [#13380](https://github.com/dagger/dagger/pull/13380) (`workspace-load-single-module`)*
+
+## Table of Contents
+
+- [Problem](#problem)
+- [Solution](#solution)
+- [Why this is safe without SingleQuery](#why-this-is-safe-without-singlequery)
+- [Core Concept](#core-concept)
+- [What each command gains](#what-each-command-gains)
+- [Phase 2: `dagger call` / `dagger functions`](#phase-2-dagger-call--dagger-functions)
+- [Comparison with #13380](#comparison-with-13380)
+- [Implementation](#implementation)
+- [Edge cases](#edge-cases)
+- [Status](#status)
+
+## Problem
+
+1. **One-shot loading** — the first schema-needing request loads *every* workspace
+   module (`ensureModulesLoaded`, sticky `modulesLoaded` flag in
+   `engine/server/session_workspaces.go`). `dagger call good verify` pays for
+   every module in the workspace.
+2. **Fragility** — one broken module fails the whole load, for every request in
+   the session. For `dagger generate` this includes the module you were trying
+   to fix by running generate.
+3. **Narrowing is SingleQuery-only** — `narrowPendingWorkspaceModulesForSingleQuery`
+   drops pending modules based on root fields, which is only safe under the
+   one-request promise. `call`/`generate`/`check`/`up` are structurally
+   multi-request and can't use it.
+4. **#13380 pushes the signal client-side** — it adds a public
+   `currentTypeDefs(include:)` argument plus CLI changes to send hints,
+   requiring a full multi-SDK regen. Feedback: too much client-side, and
+   "if they don't declare SingleQuery, how do you know it's safe to narrow?"
+
+## Solution
+
+Make workspace module loading **additive and demand-driven** instead of
+one-shot. The engine computes the **demand set** — the modules a request can
+possibly touch — loads only those, and serves them additively into the
+client's schema. The demand source is the natural one for each query shape:
+the `currentWorkspace` resolvers' own typed `include` arguments (no request
+inspection at all), or a root-field peek (the parse already exists:
+`dagql.PeekRootFields`) for queries whose schema depends on the module.
+Modules are never dropped: anything not yet demanded stays *pending* and
+loads when a later request needs it.
+
+Narrowing becomes **deferral, not exclusion**. No client contract, no API
+change, no SDK regen for phase 1.
+
+## Why this is safe without SingleQuery
+
+The schema is already rebuilt per request from whatever is served
+(`client.servedMods.Schema(ctx)`, `engine/server/session.go:1397`), and
+`serveModule` is per-module, idempotent, and conflict-checked
+(`session.go:1570`). So the session schema is allowed to *grow* between
+requests today — module SDKs and `Module.serve` rely on this.
+
+With one-shot loading, narrowing is a bet that no later request needs the
+dropped modules — only SingleQuery can keep that promise. With additive
+loading there is no bet: a later request that references a not-yet-loaded
+module triggers its load before validation. The schema is monotonically
+increasing and every request sees at least what it demands.
+
+## Core Concept
+
+Demand-driven loading has two entry points, depending on whether the request
+can even *validate* without the modules:
+
+**1. Resolution-time loading — the entire `currentWorkspace` API.** Every
+`Workspace` field returns core types (`GeneratorGroup`, `CheckGroup`,
+`WorkspaceModule`, …): a `currentWorkspace { generators(include: ["good"]) }`
+request validates against the core schema with zero modules loaded. So these
+need **no request peeking at all** — the `generators`/`checks`/`services`
+resolvers already receive `include` as a native typed argument
+(`core/schema/workspace.go:784`), and they enumerate modules through
+`currentWorkspacePrimaryModules` → `CurrentServedDeps(ctx)`
+(`workspace.go:1173`), which reads whatever is served *at resolution time*.
+The resolvers just gain a load hook at entry:
+
+```go
+// top of checks/generators/services resolvers:
+if err := query.Server.EnsureWorkspaceModules(ctx, include); err != nil { ... }
+// existing enumeration via currentWorkspacePrimaryModules picks up
+// the freshly served modules — no further resolver changes.
+```
+
+`EnsureWorkspaceModules` matches the patterns against pending module *names*
+(known from config without loading): a pattern whose first segment names a
+module demands just that module; a bare token that isn't a module name (an
+entrypoint-proxied item) or an unmatched pattern falls back to loading
+everything — same semantics as #13380's filter. Empty `include` loads all.
+This follows the existing `Query.Server` hook precedent (`CurrentWorkspace`).
+GraphQL has already resolved variables into the args, so the peek's variable
+handling disappears too.
+
+**2. Pre-request loading — module root fields.** For execution queries like
+`{ good { verify } }` the *schema itself* depends on the module, so loading
+must happen before validation. `serveQuery` keeps a (generalized) root-field
+peek for this path only:
+
+```go
+// serveQuery, per request (only while client.pendingModules is non-empty):
+ensureWorkspaceLoaded(ctx, client)          // unchanged: detect + gather pending
+demand := computeModuleDemand(r, client)    // peek root fields → pending subset
+ensureModulesLoaded(ctx, client, demand)    // load + serve only the demand set
+schema := client.servedMods.Schema(ctx)     // unchanged: rebuilt per request
+```
+
+| Request shape | Mechanism | Demand |
+|---|---|---|
+| Root field matches a pending module name | peek | that module |
+| Root field unknown (entrypoint-proxied item) | peek | entrypoint module (existing fallback logic) |
+| `currentWorkspace { generators\|checks\|services(include: [...]) }` | resolver | modules matching the patterns |
+| `currentWorkspace { generators() }` bare, `dagger generate` no args | resolver | all pending |
+| `currentWorkspace { moduleList \| cwd \| file \| directory \| config* \| ... }` | — | none — these read config/host state, not modules |
+| `currentTypeDefs`, `__schema`, `__type` | peek | all pending |
+| Unparseable body, non-query operation, anything unrecognized | peek | all pending (conservative) |
+
+`currentWorkspace` drops off the `rootFieldsRequireFullWorkspaceSchema`
+denylist entirely: its resolvers are the demand source.
+
+A mid-request load mutates `client.servedMods` while the request executes;
+that's safe because the request that triggered it cannot reference module
+fields (they weren't in its validated schema), and the next request rebuilds
+the schema as always. The hook takes the same locks as module loading today.
+
+State machine in `session_workspaces.go`:
+
+- Replace `modulesLoaded bool` + sticky `modulesErr` with per-module state
+  (*pending → loading → served | failed*), singleflight keyed by module
+  identity so concurrent requests don't double-load.
+- A failed module only fails requests that demand it. Full-schema requests
+  (bare `dagger functions`, `__schema`) still surface it — same UX as #13380's
+  "full listing loads everything" behavior, but it falls out of the model
+  instead of being a special case.
+- Extra modules (`-m`) stay eagerly loaded: they were explicitly requested.
+- Entrypoint arbitration needs no loading: ambient entrypoint flags are static
+  workspace config, and blueprint nomination only happens for extras
+  (`resolveModuleLoad` expands blueprints/toolchains for `Kind == Extra` only),
+  which are eager. The arbitration winner is computable up front.
+
+## What each command gains
+
+**Phase 1 is engine-only.** Zero CLI changes, zero API changes:
+
+| Command | Today (main) | Phase 1 |
+|---|---|---|
+| `dagger generate good` | loads all | loads `good` — the CLI **already sends** `generators(include: ["good"])` as the command's functional argument; the resolver narrows from it, no peek involved |
+| `dagger check good:*` / `dagger up good` | loads all | loads `good` (same: `include` is already in the query) |
+| `dagger query '{ good { verify } }'` | narrowed only with `--single-query` | narrowed for every client, root-field demand |
+| `dagger call good verify` | loads all | unchanged (see phase 2) — but a broken sibling module still breaks it only at the `currentTypeDefs` step, same as today |
+| bare `dagger functions`, `shell`, `mcp` | loads all | loads all (correct: they need everything) |
+
+The SingleQuery narrowing path is subsumed: `claimSingleQueryRequest` stays
+(it's a protocol contract), but the narrowing logic unifies into demand
+computation.
+
+## Phase 2: `dagger call` / `dagger functions`
+
+`call`/`functions <module>` build their command tree from a
+`currentTypeDefs(returnAllTypes: true, hideCore: true)` introspection
+(`cmd/dagger/typedefs.graphql`). That request genuinely carries no module
+signal — no engine-side cleverness can extract one. The signal must enter the
+request; the question is where. Options, all riding safely on phase 1:
+
+1. **`currentTypeDefs(include:)`** — #13380's approach. Cleanest read, but a
+   core API change: `currentTypeDefs` is in every SDK's generated client
+   (public + runtime), so it costs a full multi-SDK regen.
+2. **Workspace-scoped introspection** — give the experimental Workspace API a
+   per-module typedefs path, e.g. `currentWorkspace { moduleList(module:
+   "good") { typeDefs {...} } }`, resolved through the same config-aware
+   pendingModule load path (settings, entrypoint, legacy policy intact —
+   plain `moduleSource().asModule` would lose `dagger.toml` settings and
+   double-load under a different dagql identity). Demand peek: `[good]`.
+   CLI swaps its typedefs query for the targeted case. Keeps the change off
+   `currentTypeDefs` and inside the experimental surface.
+3. **Pure-CLI composition** — `moduleList` → `moduleSource(src).asModule.serve()`
+   → `currentTypeDefs` (which already returns only *served* deps). Zero engine
+   change, but re-implements engine load policy client-side and loses settings
+   fidelity. Rejected: this is exactly the "too much CLI-side" direction.
+
+Recommendation: ship phase 1 alone first — it covers `generate`/`check`/`up`
+and execution queries with no client change — then decide between (1) and (2)
+for `call`. Note that `currentTypeDefs` returning only served deps means
+whichever option is picked, the resolver itself needs no change: loading the
+right module before resolution is sufficient.
+
+Option (1) is implemented, with three demand rules learned the hard way:
+
+- **Name normalization** — the CLI's first positional token is the *command*
+  name, i.e. kebab-case (`cliName`): module `goodMod` is called as
+  `dagger call good-mod ...`. Demand matching kebab-normalizes both sides
+  (same canonical form as `ModTreePath.Glob`/`CliCase`); raw comparison only
+  works for single-word module names, which is exactly what made the original
+  tests pass while real workspaces loaded everything.
+- **Entrypoint demand** — when a workspace entrypoint is configured, its
+  functions are proxied onto the Query root, so the first token may be one of
+  them rather than a module name. The typedefs demand therefore always
+  includes the entrypoint module, and a token naming no module narrows to the
+  entrypoint alone instead of loading everything (no entrypoint → load all,
+  as before). Selector (`generate`/`check`/`up`) demand is unchanged: items
+  there are module-namespaced, so an unmatched pattern still loads all.
+- **Engine compatibility** — engines predating `currentTypeDefs(include:)`
+  reject any document naming the argument at validation, even with a null
+  variable. The CLI keeps the plain typedefs document for unscoped
+  introspections, sends a derived include-scoped document only when a hint
+  exists, and falls back to the plain document (load-everything, the old
+  behavior) when the engine reports the argument as unknown.
+
+## Comparison with #13380
+
+| | #13380 | This design |
+|---|---|---|
+| Narrowing signal | `include` hint args, incl. new `currentTypeDefs(include:)` | the query itself (root fields + existing `include` args) |
+| Safety in open sessions | narrowing drops pending modules; relies on the hint being right | deferral — later requests load on demand |
+| Request peeking | AST peek incl. variable resolution for `currentWorkspace` and `currentTypeDefs` shapes | only for module root fields; `generate`/`check`/`up` narrow from typed resolver args, no AST inspection |
+| CLI changes | `generate`/`check`/`up`/`call` pass hints | none (phase 1) |
+| API changes | `currentTypeDefs(include:)` | none (phase 1) |
+| SDK regen | all SDKs + runtimes | none (phase 1) |
+| `call`/`functions` narrowed | yes | phase 2 decision |
+| Broken module blocks | fixed for hinted commands | fixed for any request not demanding it |
+| `dagger query` (non-single) | not covered | covered |
+
+The two are complementary rather than competing: #13380's
+`PeekWorkspaceSelectorInclude` is reused verbatim as a demand rule, and its
+`currentTypeDefs(include:)` becomes phase 2 option 1 — with the additive
+engine underneath answering the safety objection.
+
+## Implementation
+
+1. `engine/server/session.go` — peek every request while pending modules
+   exist (skip entirely once drained, and for clients with
+   `LoadWorkspaceModules=false`); replace the SingleQuery-only narrowing call
+   with demand computation.
+2. `engine/server/session_workspaces.go` — `ensureModulesLoaded(ctx, client,
+   demand)`: per-module load state + singleflight; serve incrementally via the
+   existing `serveModule`; per-module (non-sticky) errors; precomputed
+   entrypoint arbitration.
+3. `core/schema/workspace.go` + `core/*.go` — add the
+   `Query.Server.EnsureWorkspaceModules(ctx, include)` hook (implemented by
+   `daggerClient`, precedent: `CurrentWorkspace`) and call it at the top of
+   the `checks`/`generators`/`services` resolvers. No dagql AST peek for
+   include args is needed — the resolvers' typed args carry them. Drop
+   `currentWorkspace` from `rootFieldsRequireFullWorkspaceSchema`.
+4. Tests — reuse #13380's `TestWorkspace{Generate,Check,Up}NarrowsToRequestedModule`
+   fixtures; add multi-request session tests (narrow request → broaden
+   request → full introspection), concurrent-demand tests, and broken-module
+   tests asserting failure is scoped to demanding requests.
+
+## Edge cases
+
+- **Resolver-time loading shifts cache identity** (found the hard way): a
+  resolver cached with `CurrentSchemaInput` (e.g. `currentTypeDefs`) keys on
+  the schema digest *before* it runs. With pre-request loading that digest
+  reflected the workspace's modules and was unique per workspace; with
+  resolver-time loading it is always the core schema, so sessions in
+  different workspaces issuing the same introspection would share a cache
+  entry. Any field that both loads modules in its resolver and caches its
+  result must mix the client into its cache key (`PerClientInput`) — or
+  already be per-call, as the `currentWorkspace` chain is.
+- **Peek cost**: one GraphQL parse per request, only while pending modules
+  exist; body already read+restored by the existing peek helper.
+- **Aliases/fragments**: `collectRootFields` resolves fragments and uses field
+  names, not aliases; anything unrecognized falls back to demand-all.
+- **Schema determinism**: serve order may differ from config order across
+  demand patterns; `SchemaBuilder.With` dedup/conflict semantics are
+  order-stable for distinct names, and same-name conflicts error identically
+  regardless of order (`isSameModuleReference`). Tests should pin this.
+- **Nested clients**: inherit the parent workspace binding; module-runtime
+  clients don't load workspace modules and never peek.
+- **Variables**: root field names can't be variables in GraphQL; `include`
+  values can — the #13380 peek already resolves them.
+
+## Status
+
+Prototyped as a 7-patch series on the `module-loading` branch — phase 1
+(engine-only) and phase 2 option 1 (`currentTypeDefs(include:)` + CLI hint)
+in independently revertible patches. Verified against a dev engine: the
+narrowing integration tests plus the full `TestWorkspace`/`TestGenerators`
+suites pass. SDK client regeneration for the new argument is deliberately
+left out of the series.

--- a/internal/cmd/dagger/call.go
+++ b/internal/cmd/dagger/call.go
@@ -98,7 +98,7 @@ func runFunctionList(cmd *cobra.Command, args []string) error {
 			mod, err = initializeCore(ctx, engineClient.Dagger())
 		} else {
 			// -m modules are loaded at engine connect time as extra modules.
-			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true})
+			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true, Include: workspaceModuleScope(args)})
 		}
 		if err != nil {
 			return err

--- a/internal/cmd/dagger/function_name_test.go
+++ b/internal/cmd/dagger/function_name_test.go
@@ -59,3 +59,45 @@ func TestFunctionName(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadTypeDefsScopedQuery checks the two query variants differ only by the
+// include argument.
+func TestLoadTypeDefsScopedQuery(t *testing.T) {
+	require.Contains(t, loadTypeDefsScopedQuery, "$include: [String!]")
+	require.Contains(t, loadTypeDefsScopedQuery, "include: $include")
+	require.NotContains(t, loadTypeDefsQuery, "$include")
+}
+
+func TestWorkspaceModuleScope(t *testing.T) {
+	type example struct {
+		name string
+		args []string
+		want []string
+	}
+	for _, test := range []example{
+		{
+			name: "first positional token is the scope",
+			args: []string{"my-mod", "container-echo", "--string-arg", "hi"},
+			want: []string{"my-mod"},
+		},
+		{
+			name: "self-contained flags are skipped",
+			args: []string{"--json=true", "my-mod", "fn"},
+			want: []string{"my-mod"},
+		},
+		{
+			name: "ambiguous flag sends no scope",
+			args: []string{"-o", "out.txt", "my-mod", "fn"},
+			want: nil,
+		},
+		{
+			name: "no args sends no scope",
+			args: nil,
+			want: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, workspaceModuleScope(test.args))
+		})
+	}
+}

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -323,7 +323,7 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		mod, err = initializeCore(ctx, fc.c.Dagger())
 	} else {
 		// -m modules are loaded at engine connect time as extra modules.
-		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true})
+		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true, Include: workspaceModuleScope(a)})
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/dagger/module_inspect.go
+++ b/internal/cmd/dagger/module_inspect.go
@@ -32,6 +32,17 @@ func initializeCore(ctx context.Context, dag *dagger.Client) (rdef *moduleDef, r
 	return def, nil
 }
 
+// workspaceModuleScope returns the leading positional token as a currentTypeDefs
+// include hint — only the first token can name a workspace module. A token that
+// isn't a module (entrypoint function, typo) or no token at all loads every
+// module, as before.
+func workspaceModuleScope(args []string) []string {
+	if name := functionName(args); name != "" {
+		return []string{name}
+	}
+	return nil
+}
+
 // initializeWorkspace loads type definitions from the workspace.
 // Modules are already served by the engine at connect time.
 //
@@ -154,7 +165,24 @@ func (m *moduleDef) Short() string {
 var loadModConfQuery string
 
 //go:embed typedefs.graphql
-var loadTypeDefsQuery string
+var typeDefsFragments string
+
+// typeDefsOp is the TypeDefs operation, with %s holes for the optional include
+// argument (its variable declaration and the field argument). It rides on the
+// fragments embedded above.
+const typeDefsOp = `query TypeDefs($hideCore: Boolean%s) {
+	typeDefs: currentTypeDefs(returnAllTypes: true, hideCore: $hideCore%s) {
+		...TypeDefParts
+	}
+}`
+
+var (
+	loadTypeDefsQuery = typeDefsFragments + fmt.Sprintf(typeDefsOp, "", "")
+	// The include-scoped variant is sent only when a scope hint exists: engines
+	// predating the argument reject any document that names it, even with a
+	// null variable.
+	loadTypeDefsScopedQuery = typeDefsFragments + fmt.Sprintf(typeDefsOp, ", $include: [String!]", ", include: $include")
+)
 
 func inspectModule(ctx context.Context, dag *dagger.Client, source *dagger.ModuleSource) (rdef *moduleDef, rerr error) {
 	ctx, span := Tracer().Start(ctx, "inspecting module metadata", telemetry.Encapsulate())
@@ -260,6 +288,20 @@ type loadTypeDefsOpts struct {
 	// HideCore strips core API functions from the Query type, leaving
 	// only module-sourced functions (constructors, entrypoint proxies).
 	HideCore bool
+
+	// Include narrows on-demand workspace module loading before introspecting,
+	// so an unrelated broken or stale module can't block building the command
+	// tree.
+	Include []string
+}
+
+// errIsUnknownIncludeArgument reports whether the engine rejected the scoped
+// query because it predates the include argument. The validation message
+// arrives parsed or as raw JSON, so match the quoted name loosely.
+func errIsUnknownIncludeArgument(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "Unknown argument") &&
+		(strings.Contains(msg, `"include"`) || strings.Contains(msg, `\"include\"`))
 }
 
 // loadTypeDefs loads the objects defined by the given module in an easier to use data structure.
@@ -276,12 +318,28 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client, opts .
 		TypeDefs []*modTypeDef
 	}
 
+	query := loadTypeDefsQuery
+	vars := map[string]any{"hideCore": o.HideCore}
+	if len(o.Include) > 0 {
+		query = loadTypeDefsScopedQuery
+		vars["include"] = o.Include
+	}
 	err := dag.Do(ctx, &dagger.Request{
-		Query:     loadTypeDefsQuery,
-		Variables: map[string]any{"hideCore": o.HideCore},
+		Query:     query,
+		Variables: vars,
 	}, &dagger.Response{
 		Data: &res,
 	})
+	if err != nil && query != loadTypeDefsQuery && errIsUnknownIncludeArgument(err) {
+		// Engine predates the argument; retry unscoped (loads every module, as before).
+		delete(vars, "include")
+		err = dag.Do(ctx, &dagger.Request{
+			Query:     loadTypeDefsQuery,
+			Variables: vars,
+		}, &dagger.Response{
+			Data: &res,
+		})
+	}
 	if err != nil {
 		return fmt.Errorf("query module objects: %w", err)
 	}

--- a/internal/cmd/dagger/typedefs.graphql
+++ b/internal/cmd/dagger/typedefs.graphql
@@ -1,3 +1,7 @@
+# Fragments for the TypeDefs introspection. The query operation is built in
+# module_inspect.go (plain and include-scoped variants) so the two only differ
+# in the optional include argument.
+
 fragment TypeDefRefParts on TypeDef {
 	name
 	optional
@@ -23,64 +27,62 @@ fragment FunctionParts on Function {
 }
 
 fragment FieldParts on FieldTypeDef {
-  name
-  description
-  typeDef {
-    ...TypeDefRefParts
-  }
+	name
+	description
+	typeDef {
+		...TypeDefRefParts
+	}
 }
 
-query TypeDefs($hideCore: Boolean) {
-	typeDefs: currentTypeDefs(returnAllTypes: true, hideCore: $hideCore) {
+fragment TypeDefParts on TypeDef {
+	name
+	kind
+	optional
+	asObject {
 		name
-		kind
-		optional
-		asObject {
+		description
+		sourceModuleName
+		constructor {
+			...FunctionParts
+		}
+		functions {
+			...FunctionParts
+		}
+		fields {
+			...FieldParts
+		}
+	}
+	asScalar {
+		name
+		description
+		sourceModuleName
+	}
+	asEnum {
+		name
+		description
+		sourceModuleName
+		members {
 			name
 			description
-			sourceModuleName
-			constructor {
-				...FunctionParts
-			}
-			functions {
-				...FunctionParts
-			}
-			fields {
-				...FieldParts
-			}
 		}
-		asScalar {
-			name
-			description
-			sourceModuleName
+	}
+	asInterface {
+		name
+		description
+		sourceModuleName
+		functions {
+			...FunctionParts
 		}
-		asEnum {
-			name
-			description
-			sourceModuleName
-			members {
-				name
-				description
-			}
+	}
+	asInput {
+		name
+		fields {
+			...FieldParts
 		}
-		asInterface {
-			name
-			description
-			sourceModuleName
-			functions {
-				...FunctionParts
-			}
-		}
-		asInput {
-			name
-			fields {
-				...FieldParts
-			}
-		}
-		asList {
-			elementTypeDef {
-				...TypeDefRefParts
-			}
+	}
+	asList {
+		elementTypeDef {
+			...TypeDefRefParts
 		}
 	}
 }

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -158,7 +158,8 @@ defmodule Dagger.Client do
   """
   @spec current_type_defs(t(), [
           {:return_all_types, boolean() | nil},
-          {:hide_core, boolean() | nil}
+          {:hide_core, boolean() | nil},
+          {:include, [String.t()]}
         ]) :: {:ok, [Dagger.TypeDef.t()]} | {:error, term()}
   def current_type_defs(%__MODULE__{} = client, optional_args \\ []) do
     query_builder =
@@ -166,6 +167,7 @@ defmodule Dagger.Client do
       |> QB.select("currentTypeDefs")
       |> QB.maybe_put_arg("returnAllTypes", optional_args[:return_all_types])
       |> QB.maybe_put_arg("hideCore", optional_args[:hide_core])
+      |> QB.maybe_put_arg("include", optional_args[:include])
       |> QB.select("id")
 
     with {:ok, items} <- Client.execute(client.client, query_builder) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -13383,6 +13383,16 @@ type CurrentTypeDefsOpts struct {
 	//
 	// Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
 	HideCore bool
+	// Narrow on-demand workspace module loading to the named modules (and their dependencies) before computing typedefs.
+	//
+	// Each pattern is a workspace module name or "module:item"; the workspace entrypoint module, when one is configured, is always loaded as well since the pattern may name one of its root-proxied functions.
+	//
+	// A pattern that does not name a workspace module loads every module, unless an entrypoint module can resolve it.
+	//
+	// Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+	//
+	// Modules already loaded in the session are always reflected; other pending workspace modules stay loadable by later requests.
+	Include []string
 }
 
 // The TypeDef representations of the objects currently being served in the session.
@@ -13396,6 +13406,10 @@ func (r *Query) CurrentTypeDefs(ctx context.Context, opts ...CurrentTypeDefsOpts
 		// `hideCore` optional argument
 		if !querybuilder.IsZeroValue(opts[i].HideCore) {
 			q = q.Arg("hideCore", opts[i].HideCore)
+		}
+		// `include` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Include) {
+			q = q.Arg("include", opts[i].Include)
 		}
 	}
 

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -130,14 +130,20 @@ class Client extends Client\AbstractClient implements Client\IdAble, Node
     /**
      * The TypeDef representations of the objects currently being served in the session.
      */
-    public function currentTypeDefs(?bool $returnAllTypes = false, ?bool $hideCore = null): array
-    {
+    public function currentTypeDefs(
+        ?bool $returnAllTypes = false,
+        ?bool $hideCore = null,
+        ?array $include = null,
+    ): array {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('currentTypeDefs');
         if (null !== $returnAllTypes) {
         $leafQueryBuilder->setArgument('returnAllTypes', $returnAllTypes);
         }
         if (null !== $hideCore) {
         $leafQueryBuilder->setArgument('hideCore', $hideCore);
+        }
+        if (null !== $include) {
+        $leafQueryBuilder->setArgument('include', $include);
         }
         return (array)$this->queryLeaf($leafQueryBuilder, 'currentTypeDefs');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -13431,6 +13431,7 @@ class Query(Root):
         *,
         return_all_types: bool | None = False,
         hide_core: bool | None = None,
+        include: list[str] | None = None,
     ) -> list["TypeDef"]:
         """The TypeDef representations of the objects currently being served in
         the session.
@@ -13445,10 +13446,25 @@ class Query(Root):
             sourced functions (constructors, entrypoint proxies, etc.).
             Core types (Container, Directory, etc.) are kept so return types
             and method chaining still work.
+        include:
+            Narrow on-demand workspace module loading to the named modules
+            (and their dependencies) before computing typedefs.
+            Each pattern is a workspace module name or "module:item"; the
+            workspace entrypoint module, when one is configured, is always
+            loaded as well since the pattern may name one of its root-proxied
+            functions.
+            A pattern that does not name a workspace module loads every
+            module, unless an entrypoint module can resolve it.
+            Used by clients (e.g. the CLI) that target a single module so an
+            unrelated broken or stale module cannot block building the command
+            tree.
+            Modules already loaded in the session are always reflected; other
+            pending workspace modules stay loadable by later requests.
         """
         _args = [
             Arg("returnAllTypes", return_all_types, False),
             Arg("hideCore", hide_core, None),
+            Arg("include", include, None),
         ]
         _ctx = self._select("currentTypeDefs", _args)
         return await _ctx.execute_object_list(TypeDef)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -13547,11 +13547,18 @@ pub struct QueryContainerOpts {
     pub platform: Option<Platform>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct QueryCurrentTypeDefsOpts {
+pub struct QueryCurrentTypeDefsOpts<'a> {
     /// Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
     /// Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
     #[builder(setter(into, strip_option), default)]
     pub hide_core: Option<bool>,
+    /// Narrow on-demand workspace module loading to the named modules (and their dependencies) before computing typedefs.
+    /// Each pattern is a workspace module name or "module:item"; the workspace entrypoint module, when one is configured, is always loaded as well since the pattern may name one of its root-proxied functions.
+    /// A pattern that does not name a workspace module loads every module, unless an entrypoint module can resolve it.
+    /// Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+    /// Modules already loaded in the session are always reflected; other pending workspace modules stay loadable by later requests.
+    #[builder(setter(into, strip_option), default)]
+    pub include: Option<Vec<&'a str>>,
     /// Return the full referenced typedef closure instead of only top-level served typedefs.
     #[builder(setter(into, strip_option), default)]
     pub return_all_types: Option<bool>,
@@ -13833,9 +13840,9 @@ impl Query {
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn current_type_defs_opts(
+    pub async fn current_type_defs_opts<'a>(
         &self,
-        opts: QueryCurrentTypeDefsOpts,
+        opts: QueryCurrentTypeDefsOpts<'a>,
     ) -> Result<Vec<TypeDef>, DaggerError> {
         let mut query = self.selection.select("currentTypeDefs");
         if let Some(return_all_types) = opts.return_all_types {
@@ -13843,6 +13850,9 @@ impl Query {
         }
         if let Some(hide_core) = opts.hide_core {
             query = query.arg("hideCore", hide_core);
+        }
+        if let Some(include) = opts.include {
+            query = query.arg("include", include);
         }
         let query = query.select("id");
         let ids: Vec<Id> = query.execute(self.graphql_client.clone()).await?;

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2158,6 +2158,19 @@ export type ClientCurrentTypeDefsOpts = {
    * Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
    */
   hideCore?: boolean
+
+  /**
+   * Narrow on-demand workspace module loading to the named modules (and their dependencies) before computing typedefs.
+   *
+   * Each pattern is a workspace module name or "module:item"; the workspace entrypoint module, when one is configured, is always loaded as well since the pattern may name one of its root-proxied functions.
+   *
+   * A pattern that does not name a workspace module loads every module, unless an entrypoint module can resolve it.
+   *
+   * Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+   *
+   * Modules already loaded in the session are always reflected; other pending workspace modules stay loadable by later requests.
+   */
+  include?: string[]
 }
 
 export type ClientEnvOpts = {
@@ -13141,6 +13154,15 @@ export class Client extends BaseClient {
    * @param opts.hideCore Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
    *
    * Core types (Container, Directory, etc.) are kept so return types and method chaining still work.
+   * @param opts.include Narrow on-demand workspace module loading to the named modules (and their dependencies) before computing typedefs.
+   *
+   * Each pattern is a workspace module name or "module:item"; the workspace entrypoint module, when one is configured, is always loaded as well since the pattern may name one of its root-proxied functions.
+   *
+   * A pattern that does not name a workspace module loads every module, unless an entrypoint module can resolve it.
+   *
+   * Used by clients (e.g. the CLI) that target a single module so an unrelated broken or stale module cannot block building the command tree.
+   *
+   * Modules already loaded in the session are always reflected; other pending workspace modules stay loadable by later requests.
    */
   currentTypeDefs = async (
     opts?: ClientCurrentTypeDefsOpts,


### PR DESCRIPTION
## Problem

Workspace module loading is one-shot: the first schema-needing request loads **every** configured module, so `dagger generate|check|up|call|functions <module>` pays for all its siblings, and a single broken or stale module blocks operating on any other module — for `generate`, including the very module you were trying to fix. The existing narrowing (peek root fields → drop pending modules) is restricted to `SingleQuery` clients because dropped modules can't come back in a later request.

Alternative design to #13380, which extends the request peeks and hints instead. Design doc included: `hack/designs/demand-driven-module-loading.md`.

## Fix

Make loading **additive and demand-driven**: each request loads only the modules it can possibly touch; the rest stay *pending* and load when a later request demands them. The dagql schema is already rebuilt from the served set per request, so the session schema grows monotonically — narrowing becomes deferral rather than exclusion, safe for open multi-request sessions, and the root-field demand generalizes from `SingleQuery` to every client.

The demand source is the natural one for each query shape:

- **Root fields** naming a pending module load just that module (existing entrypoint fallback preserved); full-schema fields (`__schema`, …) load everything; anything unrecognized conservatively loads everything.
- **`currentWorkspace { checks|generators|services(include: …) }`** validates against the core schema, so loading moves *into the resolvers* via a new `Query.Server.EnsureWorkspaceModules` hook — they receive `include` natively, no request peeking or variable resolution. Since the CLI already sends `include` as the command's functional argument, `dagger generate|check|up <module>` narrows with **zero CLI change**.
- **`currentTypeDefs`** gains an optional `include` load hint consumed at resolver entry through the same hook; the CLI passes its leading positional token, narrowing `dagger call`/`functions <module>`. Because loading now happens inside the resolver, the result cache also mixes in the client ID (the pre-request load previously made the schema-digest key workspace-unique as a side effect).

Other behavior consequences:

- Extra (`-m`) modules keep loading eagerly with sticky errors (explicitly requested).
- Ambient module failures are per-module and non-sticky: a broken module only fails requests that demand it, and stays pending so later demands report its load error. Full listings still load everything and surface it.
- Entrypoint arbitration is split across batches: extras outrank ambient candidates; multiple ambient entrypoint declarations load together to preserve the existing conflict detection.

The `currentTypeDefs(include:)` phase (the API addition, the CLI hint, its tests, and the SDK/docs regeneration commit) is independent and can be dropped to keep only the engine-side phase. Two engine-only refactors close the series: per-module load state consolidated into a single lifecycle map (*pending → served | failed*), and the shared dedupe→arbitrate→serve tail of ambient/extra batch loading extracted into one helper.

## Tests

- **Unit:** demand filters — root-field selection with served-module recognition, selector-include module-name resolution (`module`, `module:item`, entrypoint/typo fallbacks, already-served patterns).
- **Integration:** `TestWorkspace{Generate,Check,Up,Call}NarrowsToRequestedModule` against a new `generators-broken` fixture (healthy `dang` module with a generator, a check, and a service, alongside a module with invalid source): targeting the healthy module never loads the broken one — `generate -y` exercising the multi-request path — while full listings still surface it. The existing single-query narrowing test passes unchanged on the generalized path, as do the full `TestWorkspace`/`TestGenerators` suites against a dev engine.
