### PR TITLE
tests: fix race condition in local cache test

### DIFF
--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -390,6 +390,7 @@ func (LocalCacheSuite) TestLocalCacheGCRunsDuringDiskPressureWithActiveSession(c
 		minFreeBytes        = 900 * 1024 * 1024
 		seedMB              = 192
 		pressureMB          = 512
+		pressureBytes       = pressureMB * 1024 * 1024
 		seedSignalBytes     = 96 * 1024 * 1024
 	)
 
@@ -508,7 +509,7 @@ func (LocalCacheSuite) TestLocalCacheGCRunsDuringDiskPressureWithActiveSession(c
 	activeClient := newNestedClient()
 	t.Cleanup(func() { _ = activeClient.Close() })
 
-	pressureSvc, err := activeClient.
+	activePressure, err := activeClient.
 		Container().
 		From(alpineImage).
 		WithEnvVariable("GC_PRESSURE_ACTIVE", identity.NewID()).
@@ -516,19 +517,26 @@ func (LocalCacheSuite) TestLocalCacheGCRunsDuringDiskPressureWithActiveSession(c
 			"sh", "-ec",
 			fmt.Sprintf("dd if=/dev/zero of=/pressure bs=1M count=%d status=none", pressureMB),
 		}).
-		WithDefaultArgs([]string{"sh", "-ec", "sleep 300"}).
-		AsService().
-		Start(ctx)
+		Sync(ctx)
 	require.NoError(t, err)
-	t.Cleanup(func() { _, _ = pressureSvc.Stop(ctx, dagger.ServiceStopOpts{Kill: true}) })
+	require.NotNil(t, activePressure)
 
-	usedWithPressure := waitForUsageAtLeast("active pressure cache", usedAfterNoPressureGC+seedSignalBytes, 30*time.Second)
+	waitForUsageAtLeast("active pressure cache", usedAfterNoPressureGC+seedSignalBytes, 30*time.Second)
+
+	// Disk-pressure GC may prune the inactive seed before we observe the
+	// post-pressure high-water mark, so use the known pressure size as the
+	// target instead of deriving it from usedWithPressure.
+	prunedSeedTarget := usedAfterNoPressureGC + pressureBytes - seedSignalBytes
 
 	waitForUsageBelow(
 		"disk-pressure gc with active session",
-		usedWithPressure-seedSignalBytes,
+		prunedSeedTarget,
 		45*time.Second,
 	)
+
+	pressureSize, err := activePressure.File("/pressure").Size(ctx)
+	require.NoError(t, err)
+	require.Equal(t, pressureBytes, pressureSize)
 }
 
 func (LocalCacheSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
## Summary

- fix a race in `TestLocalCacheGCRunsDuringDiskPressureWithActiveSession`
- keep the active pressure container retained by the active client session without using service startup
- compute the final GC target from the known pressure payload size instead of a racy sampled high-water mark
- verify the active `/pressure` file remains usable after disk-pressure GC

## Root Cause

This was a test-only issue, not a production cache or GC bug. The test started an active service and then derived its expected post-GC target from cache usage sampled after service startup. On slower/shared CI workers, service startup can take long enough for background disk-pressure GC to prune the inactive seed entry before that sample is taken. The test then waits for another seed-sized usage drop that should not happen because the active pressure result is correctly retained.

## Validation

Ran the full `TestLocalCache` suite three separate times via fresh `dagger call engine-dev` invocations:

```
dagger --progress=plain call engine-dev test --pkg ./core/integration --run="TestLocalCache"
```

Results:

- Run 1: 40 passed, 133.298s
- Run 2: 40 passed, 144.964s
- Run 3: 40 passed, 99.445s

Also ran `git diff --check`.
