### PR TITLE
fix: allow single-platform image tags to resolve across platforms

### DIFF
--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -76,6 +76,32 @@ func (PlatformSuite) TestEmulatedExecAndPush(ctx context.Context, t *testctx.T) 
 	}
 }
 
+func (PlatformSuite) TestFromSinglePlatformTagWithoutExplicitPlatform(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	for _, platform := range []dagger.Platform{"linux/amd64", "linux/arm64"} {
+		platform := platform
+		t.Run(string(platform), func(ctx context.Context, t *testctx.T) {
+			marker := "hello from " + string(platform)
+			ref := registryRef("platform-single-tag-" + strings.ReplaceAll(string(platform), "/", "-"))
+
+			_, err := c.Container(dagger.ContainerOpts{Platform: platform}).
+				WithRootfs(c.Directory().WithNewFile("platform.txt", marker)).
+				Publish(ctx, ref)
+			require.NoError(t, err)
+
+			ctr := c.Container().From(ref)
+			ctrPlatform, err := ctr.Platform(ctx)
+			require.NoError(t, err)
+			require.Equal(t, platform, ctrPlatform)
+
+			contents, err := ctr.File("/platform.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, marker, contents)
+		})
+	}
+}
+
 func (PlatformSuite) TestCrossCompile(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t, dagger.WithWorkdir("../.."))
 

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -165,6 +165,108 @@ func (PlatformSuite) TestFromSinglePlatformTagWithoutExplicitPlatform(ctx contex
 	}
 }
 
+func (PlatformSuite) TestFromMultiPlatformTagWithFreshPullEngines(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const registryHost = "registry:5000"
+
+	registrySvc := c.Container().
+		From("registry:3").
+		WithMountedCache("/var/lib/registry", c.CacheVolume("platform-multi-tag-registry-"+identity.NewID())).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+		AsService()
+
+	startFreshEngine := func(ctx context.Context, t *testctx.T) (*dagger.Client, func()) {
+		t.Helper()
+
+		devEngine := devEngineContainer(c,
+			func(ctr *dagger.Container) *dagger.Container {
+				return ctr.WithServiceBinding("registry", registrySvc)
+			},
+			engineWithConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg engineconfig.Config) engineconfig.Config {
+				cfg.Registries = map[string]engineconfig.RegistryConfig{
+					registryHost: {PlainHTTP: ptr(true)},
+				}
+				return cfg
+			}),
+		)
+
+		engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(devEngine)).Start(ctx)
+		require.NoError(t, err)
+
+		endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+		require.NoError(t, err)
+
+		nestedClient, err := dagger.Connect(ctx,
+			dagger.WithRunnerHost(endpoint),
+			dagger.WithLogOutput(testutil.NewTWriter(t)),
+		)
+		require.NoError(t, err)
+
+		var cleanupOnce sync.Once
+		cleanup := func() {
+			cleanupOnce.Do(func() {
+				nestedClient.Close()
+				_, _ = engineSvc.Stop(ctx)
+			})
+		}
+		t.Cleanup(cleanup)
+		return nestedClient, cleanup
+	}
+
+	platforms := []dagger.Platform{"linux/amd64", "linux/arm64"}
+	markers := make(map[dagger.Platform]string, len(platforms))
+	variants := make([]*dagger.Container, 0, len(platforms))
+
+	pushClient, cleanupPushEngine := startFreshEngine(ctx, t)
+	for _, platform := range platforms {
+		marker := "hello from " + string(platform)
+		variants = append(variants, pushClient.Container(dagger.ContainerOpts{Platform: platform}).
+			WithRootfs(pushClient.Directory().WithNewFile("platform.txt", marker)))
+		markers[platform] = marker
+	}
+
+	ref := registryHost + "/platform-multi-tag:" + identity.NewID()
+	_, err := pushClient.Container().Publish(ctx, ref, dagger.ContainerPublishOpts{
+		PlatformVariants: variants,
+	})
+	require.NoError(t, err)
+	cleanupPushEngine()
+
+	assertPulled := func(ctx context.Context, t *testctx.T, ctr *dagger.Container, expectedPlatform dagger.Platform) {
+		t.Helper()
+
+		ctrPlatform, err := ctr.Platform(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expectedPlatform, ctrPlatform)
+
+		contents, err := ctr.File("/platform.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, markers[expectedPlatform], contents)
+	}
+
+	t.Run("default platform", func(ctx context.Context, t *testctx.T) {
+		pullClient, cleanupPullEngine := startFreshEngine(ctx, t)
+		defer cleanupPullEngine()
+
+		defaultPlatform, err := pullClient.DefaultPlatform(ctx)
+		require.NoError(t, err)
+		require.Contains(t, markers, defaultPlatform)
+
+		assertPulled(ctx, t, pullClient.Container().From(ref), defaultPlatform)
+	})
+
+	for _, platform := range platforms {
+		platform := platform
+		t.Run(string(platform), func(ctx context.Context, t *testctx.T) {
+			pullClient, cleanupPullEngine := startFreshEngine(ctx, t)
+			defer cleanupPullEngine()
+
+			assertPulled(ctx, t, pullClient.Container(dagger.ContainerOpts{Platform: platform}).From(ref), platform)
+		})
+	}
+}
+
 func (PlatformSuite) TestCrossCompile(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t, dagger.WithWorkdir("../.."))
 

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -10,9 +10,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
+	engineconfig "github.com/dagger/dagger/engine/config"
 	"github.com/dagger/dagger/internal/buildkit/identity"
+	"github.com/dagger/dagger/internal/testutil"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,25 +82,85 @@ func (PlatformSuite) TestEmulatedExecAndPush(ctx context.Context, t *testctx.T) 
 func (PlatformSuite) TestFromSinglePlatformTagWithoutExplicitPlatform(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	for _, platform := range []dagger.Platform{"linux/amd64", "linux/arm64"} {
+	const registryHost = "registry:5000"
+
+	registrySvc := c.Container().
+		From("registry:3").
+		WithMountedCache("/var/lib/registry", c.CacheVolume("platform-single-tag-registry-"+identity.NewID())).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.NetworkProtocolTcp}).
+		AsService()
+
+	startFreshEngine := func(ctx context.Context, t *testctx.T) (*dagger.Client, func()) {
+		t.Helper()
+
+		devEngine := devEngineContainer(c,
+			func(ctr *dagger.Container) *dagger.Container {
+				return ctr.WithServiceBinding("registry", registrySvc)
+			},
+			engineWithConfig(ctx, t, func(ctx context.Context, t *testctx.T, cfg engineconfig.Config) engineconfig.Config {
+				cfg.Registries = map[string]engineconfig.RegistryConfig{
+					registryHost: {PlainHTTP: ptr(true)},
+				}
+				return cfg
+			}),
+		)
+
+		engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(devEngine)).Start(ctx)
+		require.NoError(t, err)
+
+		endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+		require.NoError(t, err)
+
+		nestedClient, err := dagger.Connect(ctx,
+			dagger.WithRunnerHost(endpoint),
+			dagger.WithLogOutput(testutil.NewTWriter(t)),
+		)
+		require.NoError(t, err)
+
+		var cleanupOnce sync.Once
+		cleanup := func() {
+			cleanupOnce.Do(func() {
+				nestedClient.Close()
+				_, _ = engineSvc.Stop(ctx)
+			})
+		}
+		t.Cleanup(cleanup)
+		return nestedClient, cleanup
+	}
+
+	platforms := []dagger.Platform{"linux/amd64", "linux/arm64"}
+	refs := make(map[dagger.Platform]string, len(platforms))
+	markers := make(map[dagger.Platform]string, len(platforms))
+
+	pushClient, cleanupPushEngine := startFreshEngine(ctx, t)
+	for _, platform := range platforms {
+		marker := "hello from " + string(platform)
+		ref := registryHost + "/platform-single-tag-" + strings.ReplaceAll(string(platform), "/", "-") + ":" + identity.NewID()
+
+		_, err := pushClient.Container(dagger.ContainerOpts{Platform: platform}).
+			WithRootfs(pushClient.Directory().WithNewFile("platform.txt", marker)).
+			Publish(ctx, ref)
+		require.NoError(t, err)
+
+		refs[platform] = ref
+		markers[platform] = marker
+	}
+	cleanupPushEngine()
+
+	for _, platform := range platforms {
 		platform := platform
 		t.Run(string(platform), func(ctx context.Context, t *testctx.T) {
-			marker := "hello from " + string(platform)
-			ref := registryRef("platform-single-tag-" + strings.ReplaceAll(string(platform), "/", "-"))
+			pullClient, cleanupPullEngine := startFreshEngine(ctx, t)
+			defer cleanupPullEngine()
 
-			_, err := c.Container(dagger.ContainerOpts{Platform: platform}).
-				WithRootfs(c.Directory().WithNewFile("platform.txt", marker)).
-				Publish(ctx, ref)
-			require.NoError(t, err)
-
-			ctr := c.Container().From(ref)
+			ctr := pullClient.Container().From(refs[platform])
 			ctrPlatform, err := ctr.Platform(ctx)
 			require.NoError(t, err)
 			require.Equal(t, platform, ctrPlatform)
 
 			contents, err := ctr.File("/platform.txt").Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, marker, contents)
+			require.Equal(t, markers[platform], contents)
 		})
 	}
 }

--- a/engine/server/resolver/metadata.go
+++ b/engine/server/resolver/metadata.go
@@ -58,7 +58,7 @@ func (r *Resolver) tryLocalCanonicalConfigMetadata(
 		return "", "", nil, found, err
 	}
 
-	manifestDesc, manifest, found, err := tryResolveLocalManifestDescriptor(ctx, r.contentStore, rootDesc, imageConfigPlatformMatcher(opts.Platform))
+	manifestDesc, manifest, found, err := tryResolveLocalManifestDescriptor(ctx, r.contentStore, rootDesc, imageConfigPlatformMatcher(opts.Platform), false)
 	if err != nil || !found {
 		return "", "", nil, false, err
 	}
@@ -89,6 +89,7 @@ func (r *Resolver) ensureImageConfigMetadata(
 	rootDesc ocispecs.Descriptor,
 	fetcher remotes.Fetcher,
 	matcher platforms.MatchComparer,
+	checkRootManifestPlatform bool,
 ) (_ *imageConfigMetadata, rerr error) {
 	ctx = contentutil.RegisterContentPayloadTypes(ctx)
 	leaseCtx, release, err := bkcache.WithLease(ctx, r.leaseManager, leases.WithExpiration(imageMetadataLeaseTTL), bkcache.MakeTemporary)
@@ -139,7 +140,7 @@ func (r *Resolver) ensureImageConfigMetadata(
 		return nil, err
 	}
 
-	manifestDesc, manifest, err := resolveManifestDescriptor(leaseCtx, r.contentStore, rootDesc, matcher)
+	manifestDesc, manifest, err := resolveManifestDescriptor(leaseCtx, r.contentStore, rootDesc, matcher, checkRootManifestPlatform)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/server/resolver/resolver.go
+++ b/engine/server/resolver/resolver.go
@@ -192,7 +192,7 @@ func (r *Resolver) ResolveImageConfig(
 
 		platformMatcher := imageConfigPlatformMatcher(opts.Platform)
 		if opts.ResolveMode == ResolveModeDefault {
-			metadata, err := r.ensureImageConfigMetadata(ctx, resolvedRef, rootDesc, fetcher, platformMatcher)
+			metadata, err := r.ensureImageConfigMetadata(ctx, resolvedRef, rootDesc, fetcher, platformMatcher, false)
 			if err != nil {
 				return nil, err
 			}
@@ -283,7 +283,7 @@ func (r *Resolver) Pull(ctx context.Context, ref string, opts PullOpts) (_ *Pull
 	var manifestDesc ocispecs.Descriptor
 	var manifest ocispecs.Manifest
 	if opts.ResolveMode == ResolveModeDefault {
-		metadata, err := r.ensureImageConfigMetadata(ctx, resolvedRef, rootDesc, fetcher, platformMatcher)
+		metadata, err := r.ensureImageConfigMetadata(ctx, resolvedRef, rootDesc, fetcher, platformMatcher, true)
 		if err != nil {
 			return nil, err
 		}
@@ -292,7 +292,7 @@ func (r *Resolver) Pull(ctx context.Context, ref string, opts PullOpts) (_ *Pull
 	} else {
 		provider := contentutil.FromFetcher(fetcher)
 		var err error
-		manifestDesc, manifest, err = resolveManifestDescriptor(ctx, provider, rootDesc, platformMatcher)
+		manifestDesc, manifest, err = resolveManifestDescriptor(ctx, provider, rootDesc, platformMatcher, true)
 		if err != nil {
 			return nil, err
 		}
@@ -414,7 +414,7 @@ func (r *Resolver) tryLocalCanonicalClosure(
 		return nil, found, nil, err
 	}
 
-	manifestDesc, manifest, found, err := tryResolveLocalManifestDescriptor(ctx, r.contentStore, rootDesc, matcher)
+	manifestDesc, manifest, found, err := tryResolveLocalManifestDescriptor(ctx, r.contentStore, rootDesc, matcher, true)
 	if err != nil || !found {
 		return nil, false, nil, err
 	}
@@ -880,8 +880,9 @@ func tryResolveLocalManifestDescriptor(
 	provider content.Provider,
 	desc ocispecs.Descriptor,
 	matcher platforms.MatchComparer,
+	checkRootManifestPlatform bool,
 ) (ocispecs.Descriptor, ocispecs.Manifest, bool, error) {
-	manifestDesc, manifest, status, err := resolveLocalManifestDescriptor(ctx, provider, desc, matcher)
+	manifestDesc, manifest, status, err := resolveLocalManifestDescriptor(ctx, provider, desc, matcher, checkRootManifestPlatform)
 	if err != nil {
 		return ocispecs.Descriptor{}, ocispecs.Manifest{}, false, err
 	}
@@ -902,6 +903,7 @@ func resolveLocalManifestDescriptor(
 	provider content.Provider,
 	desc ocispecs.Descriptor,
 	matcher platforms.MatchComparer,
+	checkManifestPlatform bool,
 ) (ocispecs.Descriptor, ocispecs.Manifest, localManifestResolutionStatus, error) {
 	switch {
 	case images.IsManifestType(desc.MediaType):
@@ -916,10 +918,10 @@ func resolveLocalManifestDescriptor(
 		if err := json.Unmarshal(p, &manifest); err != nil {
 			return ocispecs.Descriptor{}, ocispecs.Manifest{}, 0, err
 		}
-		if desc.Platform != nil && !matcher.Match(*desc.Platform) {
+		if checkManifestPlatform && desc.Platform != nil && !matcher.Match(*desc.Platform) {
 			return ocispecs.Descriptor{}, ocispecs.Manifest{}, localManifestResolutionNoPlatformMatch, nil
 		}
-		if desc.Platform == nil {
+		if checkManifestPlatform && desc.Platform == nil {
 			imagePlatform, err := images.ConfigPlatform(ctx, provider, manifest.Config)
 			if err != nil {
 				if cerrdefs.IsNotFound(err) {
@@ -951,7 +953,7 @@ func resolveLocalManifestDescriptor(
 		}
 		incomplete := false
 		for _, candidate := range candidates {
-			manifestDesc, manifest, status, err := resolveLocalManifestDescriptor(ctx, provider, candidate, matcher)
+			manifestDesc, manifest, status, err := resolveLocalManifestDescriptor(ctx, provider, candidate, matcher, true)
 			if err != nil {
 				return ocispecs.Descriptor{}, ocispecs.Manifest{}, 0, err
 			}
@@ -1011,6 +1013,7 @@ func resolveManifestDescriptor(
 	provider content.Provider,
 	desc ocispecs.Descriptor,
 	matcher platforms.MatchComparer,
+	checkManifestPlatform bool,
 ) (ocispecs.Descriptor, ocispecs.Manifest, error) {
 	switch {
 	case images.IsManifestType(desc.MediaType):
@@ -1022,10 +1025,10 @@ func resolveManifestDescriptor(
 		if err := json.Unmarshal(p, &manifest); err != nil {
 			return ocispecs.Descriptor{}, ocispecs.Manifest{}, err
 		}
-		if desc.Platform != nil && !matcher.Match(*desc.Platform) {
+		if checkManifestPlatform && desc.Platform != nil && !matcher.Match(*desc.Platform) {
 			return ocispecs.Descriptor{}, ocispecs.Manifest{}, fmt.Errorf("manifest %s does not match requested platform", desc.Digest)
 		}
-		if desc.Platform == nil {
+		if checkManifestPlatform && desc.Platform == nil {
 			imagePlatform, err := images.ConfigPlatform(ctx, provider, manifest.Config)
 			if err != nil {
 				return ocispecs.Descriptor{}, ocispecs.Manifest{}, err
@@ -1050,7 +1053,7 @@ func resolveManifestDescriptor(
 			return ocispecs.Descriptor{}, ocispecs.Manifest{}, fmt.Errorf("no manifest matches requested platform for %s", desc.Digest)
 		}
 		for _, candidate := range candidates {
-			manifestDesc, manifest, err := resolveManifestDescriptor(ctx, provider, candidate, matcher)
+			manifestDesc, manifest, err := resolveManifestDescriptor(ctx, provider, candidate, matcher, true)
 			if err == nil {
 				return manifestDesc, manifest, nil
 			}


### PR DESCRIPTION
## Problem

Dagger v0.21.5 regressed a specific image-pull path after registry image metadata started being cached by default. A `Container().From(ref)` without an explicit platform can now fail when `ref` points directly at a single-platform image manifest whose config platform does not match the engine's default platform.

That breaks the case where a user publishes separate single-platform tags, such as one `linux/amd64` tag and one `linux/arm64` tag, then later pulls both tags from one machine without passing `ContainerOpts.Platform`. v0.21.4 accepted the foreign single-platform tag in this shape because config resolution could read the root manifest config first and then set the container platform from that config.

## Fix

Keep pull behavior strict, but restore the `images.Config` semantics for config resolution: when the registry tag resolves directly to a single image manifest, `ResolveImageConfig` may accept that root manifest even if it does not match the requested/default platform. Platform checks still apply when selecting a manifest from an index/list, and `Pull` continues enforcing the requested platform.

## Tests

Added fresh nested-engine integration coverage so the pull side starts with an empty cache:

- single-platform `linux/amd64` and `linux/arm64` tags pulled without explicit platform
- multi-platform tag pulled once with default platform and once per explicit platform, each from separate fresh engines

Validation run:

```sh
dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestPlatform/TestFrom.*PlatformTag'
```

Result: `8 passed`

Trace: https://dagger.cloud/dagger/traces/3dd615d4594fff95a1017dcff4a4a702
