### PR TITLE
Regenerate Dagger runtime bindings

### DIFF
--- a/core/integration/llmtest/go-programmer/internal/dagger/dagger.gen.go
+++ b/core/integration/llmtest/go-programmer/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/llmtest/go-programmer/toy-workspace/internal/dagger/dagger.gen.go
+++ b/core/integration/llmtest/go-programmer/toy-workspace/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/defaults/foobar/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/defaults/foobar/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/defaults/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/defaults/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/defaults/super-dash-dash/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/defaults/super-dash-dash/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/defaults/superconstructor/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/defaults/superconstructor/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/ifaces/impl/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/ifaces/impl/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/ifaces/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/ifaces/internal/dagger/dagger.gen.go
@@ -2133,6 +2133,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2149,6 +2151,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/ifaces/test/dep/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/ifaces/test/dep/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/ifaces/test/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/ifaces/test/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/namespacing/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/namespacing/internal/dagger/dagger.gen.go
@@ -2121,6 +2121,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2137,6 +2139,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/namespacing/sub1/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/namespacing/sub1/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/go/namespacing/sub2/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/go/namespacing/sub2/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/modules/typescript/ifaces/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/modules/typescript/ifaces/internal/dagger/dagger.gen.go
@@ -2133,6 +2133,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2149,6 +2151,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/sdks/only-codegen/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/sdks/only-codegen/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/sdks/only-runtime/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/sdks/only-runtime/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/test-blueprint/hello-with-constructor/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/test-blueprint/hello-with-constructor/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/test-blueprint/hello-with-container/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/test-blueprint/hello-with-container/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/test-blueprint/hello-with-objects/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/test-blueprint/hello-with-objects/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/test-blueprint/hello/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/test-blueprint/hello/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/core/integration/testdata/test-blueprint/myblueprint-with-dep/internal/dagger/dagger.gen.go
+++ b/core/integration/testdata/test-blueprint/myblueprint-with-dep/internal/dagger/dagger.gen.go
@@ -2115,6 +2115,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2131,6 +2133,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/dagql/idtui/viztest/dep/internal/dagger/dagger.gen.go
+++ b/dagql/idtui/viztest/dep/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/dagql/idtui/viztest/dep/nested-dep/internal/dagger/dagger.gen.go
+++ b/dagql/idtui/viztest/dep/nested-dep/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/dagql/idtui/viztest/internal/dagger/dagger.gen.go
+++ b/dagql/idtui/viztest/internal/dagger/dagger.gen.go
@@ -2115,6 +2115,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2131,6 +2133,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/alpine/internal/dagger/dagger.gen.go
+++ b/modules/alpine/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/claude/internal/dagger/dagger.gen.go
+++ b/modules/claude/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/daggerverse/internal/dagger/dagger.gen.go
+++ b/modules/daggerverse/internal/dagger/dagger.gen.go
@@ -2127,6 +2127,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2143,6 +2145,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/dev/internal/dagger/dagger.gen.go
+++ b/modules/dev/internal/dagger/dagger.gen.go
@@ -2124,6 +2124,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2140,6 +2142,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/doug/evals/internal/dagger/dagger.gen.go
+++ b/modules/doug/evals/internal/dagger/dagger.gen.go
@@ -2127,6 +2127,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2143,6 +2145,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/doug/internal/dagger/dagger.gen.go
+++ b/modules/doug/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evals/facts-workspace/internal/dagger/dagger.gen.go
+++ b/modules/evals/facts-workspace/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evals/internal/dagger/dagger.gen.go
+++ b/modules/evals/internal/dagger/dagger.gen.go
@@ -2127,6 +2127,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2143,6 +2145,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evals/testdata/nested-context-middle/internal/dagger/dagger.gen.go
+++ b/modules/evals/testdata/nested-context-middle/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evals/testdata/nested-context-middle/nested-context-leaf/internal/dagger/dagger.gen.go
+++ b/modules/evals/testdata/nested-context-middle/nested-context-leaf/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evaluator/eval-workspace/internal/dagger/dagger.gen.go
+++ b/modules/evaluator/eval-workspace/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evaluator/examples/go/internal/dagger/dagger.gen.go
+++ b/modules/evaluator/examples/go/internal/dagger/dagger.gen.go
@@ -2172,6 +2172,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2188,6 +2190,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/evaluator/internal/dagger/dagger.gen.go
+++ b/modules/evaluator/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/gha/examples/go/internal/dagger/dagger.gen.go
+++ b/modules/gha/examples/go/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/gha/internal/dagger/dagger.gen.go
+++ b/modules/gha/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/git-releaser/internal/dagger/dagger.gen.go
+++ b/modules/git-releaser/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/metrics/internal/dagger/dagger.gen.go
+++ b/modules/metrics/internal/dagger/dagger.gen.go
@@ -2115,6 +2115,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2131,6 +2133,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/ruff/internal/dagger/dagger.gen.go
+++ b/modules/ruff/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/modules/wolfi/internal/dagger/dagger.gen.go
+++ b/modules/wolfi/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/sdk/elixir/runtime/internal/dagger/dagger.gen.go
+++ b/sdk/elixir/runtime/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/sdk/java/runtime/internal/dagger/dagger.gen.go
+++ b/sdk/java/runtime/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/sdk/php/runtime/internal/dagger/dagger.gen.go
+++ b/sdk/php/runtime/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/sdk/python/runtime/internal/dagger/dagger.gen.go
+++ b/sdk/python/runtime/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/sdk/typescript/runtime/internal/dagger/dagger.gen.go
+++ b/sdk/typescript/runtime/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/all-sdks/internal/dagger/dagger.gen.go
+++ b/toolchains/all-sdks/internal/dagger/dagger.gen.go
@@ -2139,6 +2139,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2155,6 +2157,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/changelog/main.dang
+++ b/toolchains/changelog/main.dang
@@ -13,7 +13,7 @@ type Changelog {
   """
   pub generate: Changeset @generate {
     let changieVersion = "1.21.0"
-    container
+    container(platform: "linux/amd64")
       .from("ghcr.io/miniscruff/changie:v" + changieVersion)
       .withWorkdir("/src")
       .withMountedDirectory(".", source)

--- a/toolchains/cli-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/cli-dev/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/docs-dev/docusaurus/dagger/internal/dagger/dagger.gen.go
+++ b/toolchains/docs-dev/docusaurus/dagger/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/docs-dev/docusaurus/tests/internal/dagger/dagger.gen.go
+++ b/toolchains/docs-dev/docusaurus/tests/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/docs-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/docs-dev/internal/dagger/dagger.gen.go
@@ -2124,6 +2124,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2140,6 +2142,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/engine-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/engine-dev/internal/dagger/dagger.gen.go
@@ -2130,6 +2130,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2146,6 +2148,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/engine-dev/notify/internal/dagger/dagger.gen.go
+++ b/toolchains/engine-dev/notify/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/go/internal/dagger/dagger.gen.go
+++ b/toolchains/go/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/php-sdk-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/php-sdk-dev/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/python-sdk-dev/dockerd/internal/dagger/dagger.gen.go
+++ b/toolchains/python-sdk-dev/dockerd/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/python-sdk-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/python-sdk-dev/internal/dagger/dagger.gen.go
@@ -2124,6 +2124,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2140,6 +2142,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/apko/internal/dagger/dagger.gen.go
+++ b/toolchains/release/apko/internal/dagger/dagger.gen.go
@@ -2115,6 +2115,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2131,6 +2133,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/apko/tests/internal/dagger/dagger.gen.go
+++ b/toolchains/release/apko/tests/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/gh/internal/dagger/dagger.gen.go
+++ b/toolchains/release/gh/internal/dagger/dagger.gen.go
@@ -2118,6 +2118,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2134,6 +2136,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/gh/tests/internal/dagger/dagger.gen.go
+++ b/toolchains/release/gh/tests/internal/dagger/dagger.gen.go
@@ -2124,6 +2124,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2140,6 +2142,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/internal/dagger/dagger.gen.go
+++ b/toolchains/release/internal/dagger/dagger.gen.go
@@ -2178,6 +2178,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2194,6 +2196,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/registry-config/internal/dagger/dagger.gen.go
+++ b/toolchains/release/registry-config/internal/dagger/dagger.gen.go
@@ -2109,6 +2109,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2125,6 +2127,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/release/registry-config/tests/internal/dagger/dagger.gen.go
+++ b/toolchains/release/registry-config/tests/internal/dagger/dagger.gen.go
@@ -2115,6 +2115,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2131,6 +2133,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/toolchains/rust-sdk-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/rust-sdk-dev/internal/dagger/dagger.gen.go
@@ -2115,6 +2115,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2131,6 +2133,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)

--- a/version/internal/dagger/dagger.gen.go
+++ b/version/internal/dagger/dagger.gen.go
@@ -2112,6 +2112,8 @@ type ContainerExistsOpts struct {
 	ExpectedType ExistsType
 	// If specified, do not follow symlinks.
 	DoNotFollowSymlinks bool
+	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
+	Expand bool
 }
 
 // check if a file or directory exists
@@ -2128,6 +2130,10 @@ func (r *Container) Exists(ctx context.Context, path string, opts ...ContainerEx
 		// `doNotFollowSymlinks` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoNotFollowSymlinks) {
 			q = q.Arg("doNotFollowSymlinks", opts[i].DoNotFollowSymlinks)
+		}
+		// `expand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
 		}
 	}
 	q = q.Arg("path", path)


### PR DESCRIPTION
## What changed

- Regenerated Dagger runtime bindings across generated `internal/dagger/dagger.gen.go` files.
- Added an explicit `linux/amd64` platform to the changelog generator's changie container so the single-platform changie image can be resolved from ARM hosts.

## Validation

- `dagger --progress=plain -y generate`
- `git diff --check`

The generate rerun completed successfully and reported no additional changes to apply.