### PR TITLE
fix(core): clone implementation-scoped module payloads

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -295,6 +295,10 @@ func (src ModuleSource) Clone() *ModuleSource {
 	src.ConfigClients = make([]*modules.ModuleConfigClient, len(oriConfigClients))
 	copy(src.ConfigClients, oriConfigClients)
 
+	if src.SDKImpl != nil {
+		src.SDKImpl = src.SDKImpl.CloneForModuleSource(&src)
+	}
+
 	return &src
 }
 
@@ -476,6 +480,18 @@ type persistedModuleSourceLazySDK struct {
 
 var _ SDK = (*persistedModuleSourceLazySDK)(nil)
 var _ selfCallsAlwaysEnabler = (*persistedModuleSourceLazySDK)(nil)
+
+func (sdk *persistedModuleSourceLazySDK) CloneForModuleSource(src *ModuleSource) SDK {
+	if sdk == nil {
+		return nil
+	}
+	cp := *sdk
+	if sdk.config != nil {
+		cp.config = sdk.config.Clone()
+	}
+	cp.src = src
+	return &cp
+}
 
 func (sdk *persistedModuleSourceLazySDK) AlwaysEnablesSelfCalls() bool {
 	return sdk != nil && sdk.capabilities.SelfCallsAlways

--- a/core/modulesource_test.go
+++ b/core/modulesource_test.go
@@ -37,6 +37,14 @@ func (sdk *moduleSourceAttachTestSDK) AsClientGenerator() (ClientGenerator, bool
 	return nil, false
 }
 
+func (sdk *moduleSourceAttachTestSDK) CloneForModuleSource(*ModuleSource) SDK {
+	if sdk == nil {
+		return nil
+	}
+	cp := *sdk
+	return &cp
+}
+
 func (sdk *moduleSourceAttachTestSDK) AttachDependencyResults(
 	ctx context.Context,
 	attach func(dagql.AnyResult) (dagql.AnyResult, error),

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -3034,7 +3034,7 @@ func (s *moduleSchema) moduleImplementationScoped(
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
-	inst, err = dagql.NewObjectResultForCurrentCall(ctx, dag, parentMod.Self())
+	inst, err = dagql.NewObjectResultForCurrentCall(ctx, dag, parentMod.Self().Clone())
 	if err != nil {
 		return inst, err
 	}

--- a/core/schema/module_implementation_scoped_test.go
+++ b/core/schema/module_implementation_scoped_test.go
@@ -1,0 +1,105 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+)
+
+func TestModuleImplementationScopedDoesNotLeaveStaleSelfDependency(t *testing.T) {
+	ctx := t.Context()
+
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	ctx = dagql.ContextWithCache(ctx, cache)
+
+	srv := &currentTypeDefsTestServer{}
+	root := core.NewRoot(srv)
+	dag, err := dagql.NewServer(ctx, root)
+	require.NoError(t, err)
+	srv.dag = dag
+	ctx = core.ContextWithQuery(ctx, root)
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*core.Module]{Typed: &core.Module{}}))
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*core.ModuleSource]{Typed: &core.ModuleSource{}}))
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*core.Directory]{Typed: &core.Directory{}}))
+	dagql.Fields[*core.Module]{
+		dagql.NodeFunc("_implementationScoped", (&moduleSchema{}).moduleImplementationScoped),
+	}.Install(dag)
+	dagql.Fields[*core.Directory]{
+		dagql.NodeFunc("digest", func(context.Context, dagql.ObjectResult[*core.Directory], struct{}) (dagql.String, error) {
+			return dagql.String("test-directory-digest"), nil
+		}),
+	}.Install(dag)
+
+	const (
+		parentSession      = "module-implementation-scoped-parent"
+		firstScopedSession = "module-implementation-scoped-first"
+		nextScopedSession  = "module-implementation-scoped-next"
+	)
+	t.Cleanup(func() {
+		_ = cache.ReleaseSession(context.Background(), parentSession)
+		_ = cache.ReleaseSession(context.Background(), firstScopedSession)
+		_ = cache.ReleaseSession(context.Background(), nextScopedSession)
+	})
+
+	parentCtx := engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+		ClientID:  parentSession,
+		SessionID: parentSession,
+	})
+	firstScopedCtx := engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+		ClientID:  firstScopedSession,
+		SessionID: firstScopedSession,
+	})
+	nextScopedCtx := engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+		ClientID:  nextScopedSession,
+		SessionID: nextScopedSession,
+	})
+
+	dir := &core.Directory{}
+	dirDetached, err := dagql.NewObjectResultForCall(dir, dag, implementationScopedTestSyntheticCall("implementation-scoped-dir", dir))
+	require.NoError(t, err)
+	src := &core.ModuleSource{
+		ModuleName:         "codegen",
+		ModuleOriginalName: "codegen",
+		ContextDirectory:   dirDetached,
+	}
+	srcDetached, err := dagql.NewObjectResultForCall(src, dag, implementationScopedTestSyntheticCall("implementation-scoped-source", src))
+	require.NoError(t, err)
+	parentMod := &core.Module{
+		NameField:         "codegen",
+		OriginalName:      "codegen",
+		Source:            dagql.NonNull(srcDetached),
+		Deps:              core.NewSchemaBuilder(root, nil),
+		IncludeSelfInDeps: true,
+	}
+	parentCall := implementationScopedTestSyntheticCall("implementation-scoped-parent", parentMod)
+	parentDetached, err := dagql.NewObjectResultForCall(parentMod, dag, parentCall)
+	require.NoError(t, err)
+
+	parentAny, err := cache.GetOrInitCall(parentCtx, parentSession, dag, &dagql.CallRequest{
+		ResultCall: parentCall,
+	}, dagql.ValueFunc(parentDetached))
+	require.NoError(t, err)
+	parent, ok := parentAny.(dagql.ObjectResult[*core.Module])
+	require.Truef(t, ok, "expected attached module result, got %T", parentAny)
+
+	_, err = core.ImplementationScopedModule(firstScopedCtx, parent)
+	require.NoError(t, err)
+	require.NoError(t, cache.ReleaseSession(firstScopedCtx, firstScopedSession))
+
+	_, err = core.ImplementationScopedModule(nextScopedCtx, parent)
+	require.NoError(t, err)
+}
+
+func implementationScopedTestSyntheticCall(op string, typ dagql.Typed) *dagql.ResultCall {
+	return &dagql.ResultCall{
+		Kind:        dagql.ResultCallKindSynthetic,
+		SyntheticOp: op,
+		Type:        dagql.NewResultCallType(typ.Type()),
+	}
+}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3045,7 +3045,7 @@ func (s *moduleSourceSchema) moduleSourceImplementationScoped(
 	if err != nil {
 		return inst, fmt.Errorf("failed to get dag server: %w", err)
 	}
-	inst, err = dagql.NewObjectResultForCurrentCall(ctx, dag, src.Self())
+	inst, err = dagql.NewObjectResultForCurrentCall(ctx, dag, src.Self().Clone())
 	if err != nil {
 		return inst, err
 	}

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -23,6 +23,7 @@ import (
 
 type currentTypeDefsTestServer struct {
 	deps             *core.SchemaBuilder
+	dag              *dagql.Server
 	workspaceLock    *workspace.Lock
 	workspaceLockOK  bool
 	workspaceLockErr error
@@ -81,7 +82,7 @@ func (s *currentTypeDefsTestServer) TelemetrySeenKeyStore(context.Context) (dagq
 }
 
 func (s *currentTypeDefsTestServer) Server(context.Context) (*dagql.Server, error) {
-	return nil, nil
+	return s.dag, nil
 }
 
 func (s *currentTypeDefsTestServer) MuxEndpoint(context.Context, string, http.Handler) error {

--- a/core/sdk.go
+++ b/core/sdk.go
@@ -337,6 +337,12 @@ type SDK interface {
 	// Transform the SDK into a ClientGenerator if it implements it.
 	AsClientGenerator() (ClientGenerator, bool)
 
+	// CloneForModuleSource returns an SDK implementation copy owned by the cloned
+	// ModuleSource. SDK implementations may hold cache-backed result wrappers and
+	// rewrite them during AttachDependencyResults, so ModuleSource clones must not
+	// share mutable SDK implementation state.
+	CloneForModuleSource(*ModuleSource) SDK
+
 	// AttachDependencyResults attaches any cache-backed results embedded in the
 	// SDK implementation and returns the results the owning ModuleSource must
 	// retain.

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -16,6 +16,20 @@ type dangSDK struct {
 	rawConfig map[string]any
 }
 
+func (sdk *dangSDK) CloneForModuleSource(*core.ModuleSource) core.SDK {
+	if sdk == nil {
+		return nil
+	}
+	cp := *sdk
+	if sdk.rawConfig != nil {
+		cp.rawConfig = make(map[string]any, len(sdk.rawConfig))
+		for k, v := range sdk.rawConfig {
+			cp.rawConfig[k] = v
+		}
+	}
+	return &cp
+}
+
 // dangImpl is implemented by each supported Dang major version
 // (core/sdk/dang/v1, v2, ...). Unlike core.ModuleTypes, ModuleTypes takes
 // already-scoped values: the scoping helpers are unexported in this package

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -50,6 +50,20 @@ type goSDKConfig struct {
 	GoPrivate string `json:"goprivate,omitempty"`
 }
 
+func (sdk *goSDK) CloneForModuleSource(*core.ModuleSource) core.SDK {
+	if sdk == nil {
+		return nil
+	}
+	cp := *sdk
+	if sdk.rawConfig != nil {
+		cp.rawConfig = make(map[string]any, len(sdk.rawConfig))
+		for k, v := range sdk.rawConfig {
+			cp.rawConfig[k] = v
+		}
+	}
+	return &cp
+}
+
 func (sdk *goSDK) AsRuntime() (core.Runtime, bool) {
 	return sdk, true
 }

--- a/core/sdk/module.go
+++ b/core/sdk/module.go
@@ -49,6 +49,26 @@ func newModuleSDK(
 	return sdk, nil
 }
 
+func (sdk *module) CloneForModuleSource(*core.ModuleSource) core.SDK {
+	if sdk == nil {
+		return nil
+	}
+	cp := *sdk
+	if sdk.rawConfig != nil {
+		cp.rawConfig = make(map[string]any, len(sdk.rawConfig))
+		for k, v := range sdk.rawConfig {
+			cp.rawConfig[k] = v
+		}
+	}
+	if sdk.funcs != nil {
+		cp.funcs = make(map[string]*core.Function, len(sdk.funcs))
+		for k, v := range sdk.funcs {
+			cp.funcs[k] = v
+		}
+	}
+	return &cp
+}
+
 func (sdk *module) instantiate(ctx context.Context) (*moduleInstance, error) {
 	dag, err := dagql.NewServer(ctx, sdk.root)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes a cache lifetime bug seen in CI while generating type definitions:

```text
add explicit dependency: dep result <id> missing from cache
```

The failure happened while resolving module provenance for an implementation-scoped module. The `_implementationScoped` resolvers were creating a new result identity around `parentMod.Self()` / `src.Self()` directly. Publishing that scoped result runs `AttachDependencyResults`, which rewrites embedded result wrappers in place. Because the scoped result shared the parent payload pointer, publishing it could mutate the parent payload after the parent result's cache dependency closure had already been recorded.

If the scoped result's session was then released, pruning could collect the scoped result while the parent payload still held a stale wrapper for it. A later implementation-scoped publication would walk that stale wrapper and fail when adding an explicit dependency to a missing result ID.

## Changes

- Clone `Module` and `ModuleSource` payloads before wrapping them in implementation-scoped result identities.
- Add `SDK.CloneForModuleSource` so `ModuleSource.Clone` does not share mutable SDK implementation state that may hold cache-backed result wrappers.
- Add a schema-level regression test that scopes a self-dependency module, releases the scoped session, then scopes the same parent again.

## Validation

- `go test ./core -run 'TestModuleSourceAttachDependencyResultsRetainsSDKImpl|TestModuleSourcePersistenceRetainsSelfCallsCapability' -count=1 -v`\n- `go test ./core/sdk -run TestModuleSDKAttachDependencyResultsRetainsImplementationModuleAndSourceDir -count=1 -v`\n- `go test ./core/schema -run TestModuleImplementationScopedDoesNotLeaveStaleSelfDependency -count=1 -v`\n- `go test ./core/schema -count=1`