### PR TITLE
fix(layercopy): tolerate missing excluded source entries

### DIFF
--- a/core/integration/local_test.go
+++ b/core/integration/local_test.go
@@ -9,9 +9,11 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"dagger.io/dagger"
@@ -628,6 +630,113 @@ func (LocalDirSuite) TestLocalImportParallel(ctx context.Context, t *testctx.T) 
 	require.Equal(t, dgst1A, dgst2A)
 	require.NotEqual(t, dgst2A, dgst3A)
 	require.Equal(t, dgst3A, dgst4A)
+}
+
+func (LocalDirSuite) TestLocalImportParallelFilteredOutMutableEntries(ctx context.Context, t *testctx.T) {
+	const (
+		volatileFiles   = 512
+		filteredFiles   = 1024
+		mutationRounds  = 8
+		filteredWorkers = 8
+	)
+
+	root := t.TempDir()
+	keepDir := "aa-keep"
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, keepDir), 0o755))
+	for i := range filteredFiles {
+		keepFile := fmt.Sprintf("needle-%04d.txt", i)
+		keepContents := fmt.Sprintf("stable contents %d\n", i)
+		require.NoError(t, os.WriteFile(filepath.Join(root, keepDir, keepFile), []byte(keepContents), 0o644))
+	}
+
+	volatilePath := func(i int) string {
+		return filepath.Join(root, fmt.Sprintf("zz-volatile-%04d.tmp", i))
+	}
+	writeVolatile := func(round int) error {
+		for i := range volatileFiles {
+			if err := os.WriteFile(volatilePath(i), []byte(fmt.Sprintf("round=%d file=%d\n", round, i)), 0o644); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	removeVolatile := func() error {
+		for i := range volatileFiles {
+			if err := os.Remove(volatilePath(i)); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+		return nil
+	}
+
+	c := connect(ctx, t)
+	require.NoError(t, writeVolatile(0))
+	_, err := c.Host().Directory(root, dagger.HostDirectoryOpts{NoCache: true}).Digest(ctx)
+	require.NoError(t, err)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	startCh := make(chan struct{})
+
+	eg.Go(func() error {
+		<-startCh
+
+		for round := range mutationRounds {
+			if err := writeVolatile(round); err != nil {
+				return fmt.Errorf("write volatile files round %d: %w", round, err)
+			}
+			if _, err := c.Host().Directory(root, dagger.HostDirectoryOpts{NoCache: true}).Digest(egCtx); err != nil {
+				return fmt.Errorf("populate mirror round %d: %w", round, err)
+			}
+			if err := removeVolatile(); err != nil {
+				return fmt.Errorf("remove volatile files round %d: %w", round, err)
+			}
+			if _, err := c.Host().Directory(root, dagger.HostDirectoryOpts{NoCache: true}).Digest(egCtx); err != nil {
+				return fmt.Errorf("delete from mirror round %d: %w", round, err)
+			}
+		}
+		return nil
+	})
+
+	var nextFiltered atomic.Int64
+	var filteredAttempts atomic.Int64
+	for worker := range filteredWorkers {
+		eg.Go(func() error {
+			<-startCh
+			for {
+				select {
+				case <-egCtx.Done():
+					return context.Cause(egCtx)
+				default:
+				}
+
+				idx := int(nextFiltered.Add(1) - 1)
+				if idx >= filteredFiles {
+					return nil
+				}
+				keepFile := fmt.Sprintf("needle-%04d.txt", idx)
+				keepPath := keepDir + "/" + keepFile
+				keepContents := fmt.Sprintf("stable contents %d\n", idx)
+				filteredOpts := dagger.HostDirectoryOpts{
+					Include: []string{keepPath},
+					NoCache: true,
+				}
+
+				got, err := c.Host().Directory(root, filteredOpts).File(keepPath).Contents(egCtx)
+				if err != nil {
+					return fmt.Errorf("filtered import worker %d: %w", worker, err)
+				}
+				if got != keepContents {
+					return fmt.Errorf("filtered import worker %d: got %q, want %q", worker, got, keepContents)
+				}
+				filteredAttempts.Add(1)
+			}
+		})
+	}
+
+	close(startCh)
+	require.NoError(t, eg.Wait())
+	require.Equal(t, int64(filteredFiles), filteredAttempts.Load())
 }
 
 func (LocalDirSuite) TestLocalHardlinks(ctx context.Context, t *testctx.T) {

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -181,6 +181,16 @@ func (c *Copier) copyEntry(
 		return err
 	}
 
+	if ent.Info == nil {
+		if !include {
+			return nil
+		}
+		if ent.StatErr != nil {
+			return fmt.Errorf("failed to stat source path %s: %w", ent.ViewPath, ent.StatErr)
+		}
+		return fmt.Errorf("source path %q missing file info", ent.ViewPath)
+	}
+
 	if ent.Info.IsDir() {
 		childPending := pending
 		var realDirPath string

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -215,6 +215,46 @@ func TestCopyDirectoryOnlyCopiesSparsePaths(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
+func TestCopyEntryMissingSourceAfterFilter(t *testing.T) {
+	t.Parallel()
+
+	missingErr := &os.PathError{Op: "lstat", Path: "/src/gone.txt", Err: os.ErrNotExist}
+
+	t.Run("excluded", func(t *testing.T) {
+		matcher, err := newMatcher("/src", Filter{
+			Only: map[string]struct{}{
+				"keep.txt": {},
+			},
+		})
+		require.NoError(t, err)
+
+		err = (&Copier{}).copyEntry(context.Background(), &source{}, matcher, sourceEntry{
+			Rel:      "gone.txt",
+			ViewPath: "/src/gone.txt",
+			RealPath: "/src/gone.txt",
+			StatErr:  missingErr,
+		}, "/dst/gone.txt", CopyOptions{}, matchState{}, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("included", func(t *testing.T) {
+		matcher, err := newMatcher("/src", Filter{
+			Only: map[string]struct{}{
+				"gone.txt": {},
+			},
+		})
+		require.NoError(t, err)
+
+		err = (&Copier{}).copyEntry(context.Background(), &source{}, matcher, sourceEntry{
+			Rel:      "gone.txt",
+			ViewPath: "/src/gone.txt",
+			RealPath: "/src/gone.txt",
+			StatErr:  missingErr,
+		}, "/dst/gone.txt", CopyOptions{}, matchState{}, nil)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
 func TestCopyDirectoryFollowsOverlayDestSymlinkDir(t *testing.T) {
 	t.Parallel()
 

--- a/util/layercopy/source_linux.go
+++ b/util/layercopy/source_linux.go
@@ -32,6 +32,7 @@ type sourceEntry struct {
 	ViewPath string
 	RealPath string
 	Info     os.FileInfo
+	StatErr  error
 }
 
 func newSource(m Mount) (*source, error) {
@@ -124,7 +125,16 @@ func (s *source) readBindDir(rel string) ([]sourceEntry, error) {
 		viewPath := filepath.Join(viewDir, name)
 		info, err := os.Lstat(viewPath)
 		if err != nil {
-			return nil, err
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+			entries = append(entries, sourceEntry{
+				Rel:      filepath.Join(rel, name),
+				ViewPath: viewPath,
+				RealPath: filepath.Join(realDir, name),
+				StatErr:  err,
+			})
+			continue
 		}
 		entries = append(entries, sourceEntry{
 			Rel:      filepath.Join(rel, name),


### PR DESCRIPTION
## Summary

Fix a layercopy race hit by filtered host directory imports when a mutable bind source changes while layercopy is preparing the final copied snapshot.

A CI flake failed with a missing source path during `layercopy.Copy`, even though the missing path was outside the requested filtered import. The source directory had been listed, but one of the listed entries disappeared before `readBindDir` could `lstat` it. Because layercopy statted every entry before applying `Only`/include/exclude/gitignore filters, the excluded missing entry became a hard failure.

## Root Cause

The previous fsutil copier evaluated filters even when source `Lstat` returned `ENOENT`, and ignored the missing source only if that path would not have been included in the copy. The newer layercopy path regressed that behavior by returning from `readBindDir` before `copyEntry` had enough context to decide whether the missing entry mattered.

## Fix

- Carry bind-source `ENOENT` through `sourceEntry` as `StatErr` instead of failing immediately.
- Evaluate filters in `copyEntry` before deciding how to handle a missing source entry.
- Skip missing entries only when they are filtered out.
- Preserve strict errors for missing entries that would be included, overlay source reads, and root path selection.
- Add a direct layercopy regression test plus an integration test that exercises filtered imports while volatile entries are concurrently synced and removed from the same mirror.

## Validation

- `dagger --progress=plain call engine-dev test --pkg ./util/layercopy --run='TestCopyEntryMissingSourceAfterFilter'`
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestLocalDir/TestLocalImportParallelFilteredOutMutableEntries'`
- `git diff --check`
