### PR TITLE
fix(dagql): drop lazy-eval dep preflight; mark blocked resumptions instead

### DIFF
--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
+	"github.com/dagger/dagger/engine/telemetryattrs"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -2803,6 +2804,12 @@ func (c *Cache) waitForLazyEvaluation(ctx context.Context, shared *sharedResult,
 			shared.lazyEvalErr = nil
 		}
 		shared.lazyMu.Unlock()
+		// Tag the failure with the result it belongs to so that an enclosing
+		// lazy callback's resume span can tell "a prerequisite failed" apart
+		// from "my own deferred work failed". See blockedOnPrerequisite.
+		if waitErr != nil {
+			waitErr = &prerequisiteEvalError{err: waitErr, resultID: shared.id}
+		}
 	case <-ctx.Done():
 		waitErr = context.Cause(ctx)
 		shared.lazyMu.Lock()
@@ -2817,37 +2824,27 @@ func (c *Cache) waitForLazyEvaluation(ctx context.Context, shared *sharedResult,
 	return waitErr
 }
 
-// evaluateLivenessDeps forces all of resultID's parent.deps before its own
-// lazy callback fires. This keeps chained downstream calls pending instead
-// of firing redundant resume spans when an upstream prerequisite fails:
-// the failing dep's resume span attributes via its install_spans, and our
-// own resume span never starts to forward the cascaded error.
-func (c *Cache) evaluateLivenessDeps(ctx context.Context, resultID sharedResultID) error {
-	if c == nil || resultID == 0 {
-		return nil
+// prerequisiteEvalError wraps a lazy-evaluation failure with the identity of
+// the result whose evaluation failed. It does not change the error message;
+// it only carries provenance so enclosing evaluations can classify cascaded
+// failures without forcing prerequisite evaluation order.
+type prerequisiteEvalError struct {
+	err      error
+	resultID sharedResultID
+}
+
+func (e *prerequisiteEvalError) Error() string { return e.err.Error() }
+func (e *prerequisiteEvalError) Unwrap() error { return e.err }
+
+// blockedOnPrerequisite reports whether err originated from evaluating a
+// result other than selfID — i.e. the current result's lazy callback was
+// blocked by a failing prerequisite rather than failing its own work.
+func blockedOnPrerequisite(err error, selfID sharedResultID) bool {
+	var prereq *prerequisiteEvalError
+	if !errors.As(err, &prereq) {
+		return false
 	}
-	c.egraphMu.RLock()
-	res := c.resultsByID[resultID]
-	if res == nil || len(res.deps) == 0 {
-		c.egraphMu.RUnlock()
-		return nil
-	}
-	deps := make([]AnyResult, 0, len(res.deps))
-	for depID := range res.deps {
-		dep := c.resultsByID[depID]
-		if dep == nil {
-			c.egraphMu.RUnlock()
-			return fmt.Errorf("evaluate liveness dep: result %d depends on missing result %d", resultID, depID)
-		}
-		deps = append(deps, Result[Typed]{shared: dep})
-	}
-	c.egraphMu.RUnlock()
-	for _, dep := range deps {
-		if err := c.evaluateOne(ctx, dep); err != nil {
-			return err
-		}
-	}
-	return nil
+	return prereq.resultID != selfID
 }
 
 func (c *Cache) Evaluate(ctx context.Context, results ...AnyResult) error {
@@ -2900,16 +2897,6 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		return nil
 	}
 	shared.lazyMu.Unlock()
-
-	// Preflight liveness deps before claiming the lazy state. Each parent.deps
-	// edge is a prerequisite: if it fails, our lazy callback shouldn't fire
-	// (and shouldn't create a resume span that mis-attributes the cascade).
-	// Attribution is direct lookup against install_spans, so the failing dep
-	// is responsible for cause-linking its own owners — no need to fire a
-	// resume span here just to forward the same error.
-	if err := c.evaluateLivenessDeps(stackCtx, shared.id); err != nil {
-		return err
-	}
 
 	shared.lazyMu.Lock()
 	currentLazyEval := lazyEvalFuncOfResult(res)
@@ -2985,7 +2972,19 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		// race with the caller's flush/read of exported spans.
 		runEval := func() {
 			if resumeSpan != nil {
-				defer telemetry.EndWithCause(resumeSpan, &err)
+				defer func() {
+					// If the callback failed only because a prerequisite
+					// result's evaluation failed, this result's own deferred
+					// work never ran. Mark the resume span blocked so the UI
+					// returns the owning API spans to pending instead of
+					// marking them caused-failed with the cascaded error. The
+					// failing prerequisite's own resume span carries the real
+					// failure and its install-span cause links.
+					if err != nil && blockedOnPrerequisite(err, shared.id) {
+						resumeSpan.SetAttributes(attribute.Bool(telemetryattrs.DagBlockedAttr, true))
+					}
+					telemetry.EndWithCause(resumeSpan, &err)
+				}()
 			}
 
 			leaseCtx, release, leaseErr := withOperationLease(withoutOperationLease(callbackCtx))

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -495,59 +495,82 @@ func (c *Cache) captureSessionResultInstallSpan(ctx context.Context, sessionID s
 		return
 	}
 
-	// Direct install: this call returned this result.
-	c.recordSessionResultInstallSpanLocked(sessionID, shared.id, spanCtx)
-
-	// If this is a module API call return, propagate the install span to the
-	// entire transitive liveness closure. Module-returned values are typically
-	// constructed by inner SDK calls whose own install spans aren't visible to
-	// the user; attributing failures anywhere in the construction chain back to
-	// the module API span is the right thing.
+	// Module API call returns own their result's entire transitive dep
+	// closure: module-returned values are typically constructed by inner SDK
+	// calls whose own install spans aren't visible to the user, so failures
+	// anywhere in the construction chain attribute back to the module API
+	// span. Closure ownership is recorded once on the returned result and
+	// resolved on demand by walking dep edges upward from the result being
+	// evaluated (installAncestorIDsLocked), rather than eagerly fanning the
+	// span out across every result in the closure.
 	call := CurrentCall(ctx)
-	if call == nil || call.Module == nil {
-		return
-	}
-
-	c.egraphMu.RLock()
-	depIDs := c.transitiveDepIDsLocked(shared.id)
-	c.egraphMu.RUnlock()
-
-	for _, depID := range depIDs {
-		c.recordSessionResultInstallSpanLocked(sessionID, depID, spanCtx)
-	}
+	ownsClosure := call != nil && call.Module != nil
+	c.recordSessionResultInstallSpanLocked(sessionID, shared.id, spanCtx, ownsClosure)
 }
 
-func (c *Cache) recordSessionResultInstallSpanLocked(sessionID string, resultID sharedResultID, spanCtx trace.SpanContext) {
+// sessionResultInstallSpan is one recorded install site for a result in a
+// session: the span context of the API call that returned/owns the result,
+// plus whether that ownership extends over the result's transitive dep
+// closure (module API call returns).
+type sessionResultInstallSpan struct {
+	spanCtx     trace.SpanContext
+	ownsClosure bool
+}
+
+func (c *Cache) recordSessionResultInstallSpanLocked(sessionID string, resultID sharedResultID, spanCtx trace.SpanContext, ownsClosure bool) {
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
 	if c.sessionResultInstallSpans == nil {
-		c.sessionResultInstallSpans = make(map[string]map[sharedResultID]map[string]trace.SpanContext)
+		c.sessionResultInstallSpans = make(map[string]map[sharedResultID]map[string]sessionResultInstallSpan)
 	}
 	bySession := c.sessionResultInstallSpans[sessionID]
 	if bySession == nil {
-		bySession = make(map[sharedResultID]map[string]trace.SpanContext)
+		bySession = make(map[sharedResultID]map[string]sessionResultInstallSpan)
 		c.sessionResultInstallSpans[sessionID] = bySession
 	}
 	byResult := bySession[resultID]
 	if byResult == nil {
-		byResult = make(map[string]trace.SpanContext)
+		byResult = make(map[string]sessionResultInstallSpan)
 		bySession[resultID] = byResult
 	}
-	byResult[spanContextKey(spanCtx)] = spanCtx
+	key := spanContextKey(spanCtx)
+	install := byResult[key]
+	install.spanCtx = spanCtx
+	install.ownsClosure = install.ownsClosure || ownsClosure
+	byResult[key] = install
 }
 
-// transitiveDepIDsLocked returns the cached liveness closure of rootID via
-// parent.deps, excluding rootID itself. Caller must hold egraphMu at least for
-// read. The returned IDs are sorted for deterministic install-span recording.
-func (c *Cache) transitiveDepIDsLocked(rootID sharedResultID) []sharedResultID {
+// installAncestorIDsLocked returns the IDs of results that transitively
+// depend on rootID, found by walking direct dep edges upward via depParents.
+// rootID itself is excluded. Caller must hold egraphMu at least for read.
+func (c *Cache) installAncestorIDsLocked(rootID sharedResultID) []sharedResultID {
 	if rootID == 0 {
 		return nil
 	}
-	res := c.resultsByID[rootID]
-	if res == nil || res.transitiveDeps == nil || res.transitiveDeps.Empty() {
+	root := c.resultsByID[rootID]
+	if root == nil || root.depParents == nil || root.depParents.Empty() {
 		return nil
 	}
-	return res.transitiveDeps.Slice()
+	seen := map[sharedResultID]struct{}{rootID: {}}
+	queue := []sharedResultID{rootID}
+	var out []sharedResultID
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		res := c.resultsByID[id]
+		if res == nil || res.depParents == nil {
+			continue
+		}
+		for parentID := range res.depParents.Items() {
+			if _, ok := seen[parentID]; ok {
+				continue
+			}
+			seen[parentID] = struct{}{}
+			out = append(out, parentID)
+			queue = append(queue, parentID)
+		}
+	}
+	return out
 }
 
 // ResultInstallSpans returns install span contexts recorded for res in the
@@ -566,11 +589,18 @@ func (c *Cache) ResultInstallSpans(sessionID string, res AnyResult) []trace.Span
 }
 
 // sessionResultInstallSpanContexts returns the install span contexts for
-// resultID in the given session. Direct map lookup — no graph walk.
+// resultID in the given session: the spans recorded directly for the result,
+// plus closure-owning install spans (module API call returns) recorded for
+// any result that transitively depends on it. The upward walk happens here,
+// on demand, instead of eagerly materializing the closure at install time.
 func (c *Cache) sessionResultInstallSpanContexts(sessionID string, resultID sharedResultID) []trace.SpanContext {
 	if c == nil || sessionID == "" || resultID == 0 {
 		return nil
 	}
+
+	c.egraphMu.RLock()
+	ancestorIDs := c.installAncestorIDsLocked(resultID)
+	c.egraphMu.RUnlock()
 
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
@@ -578,15 +608,29 @@ func (c *Cache) sessionResultInstallSpanContexts(sessionID string, resultID shar
 	if byResult == nil {
 		return nil
 	}
-	spans := byResult[resultID]
-	if len(spans) == 0 {
-		return nil
-	}
-	out := make([]trace.SpanContext, 0, len(spans))
-	for _, spanCtx := range spans {
-		if spanCtx.IsValid() {
-			out = append(out, spanCtx)
+	seen := make(map[string]struct{})
+	var out []trace.SpanContext
+	appendInstalls := func(id sharedResultID, closureOwnersOnly bool) {
+		for key, install := range byResult[id] {
+			if closureOwnersOnly && !install.ownsClosure {
+				continue
+			}
+			if !install.spanCtx.IsValid() {
+				continue
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, install.spanCtx)
 		}
+	}
+	appendInstalls(resultID, false)
+	for _, ancestorID := range ancestorIDs {
+		appendInstalls(ancestorID, true)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	slices.SortFunc(out, compareSpanContexts)
 	return out
@@ -901,7 +945,6 @@ func (c *Cache) collectUnownedResultsLocked(ctx context.Context, queue []*shared
 		}
 		res.deps = nil
 		res.depParents = nil
-		res.transitiveDeps = nil
 
 		for _, depID := range depIDs {
 			c.forgetDependencyEdgeLocked(res.id, depID)
@@ -1273,13 +1316,14 @@ type Cache struct {
 	sessionArbitraryCallKeysBySession map[string]map[string]struct{}
 	sessionLazySpansBySession         map[string]map[sharedResultID]trace.SpanContext
 	// sessionResultInstallSpans records which API spans returned/own which
-	// results in a session. On lazy failure, the resume span cause-links the
-	// install spans of the failed result so dagui marks them caused-failed.
-	// Membership is expanded eagerly at install time over the owned-dependency
-	// closure (HasDependencyResults / HasDependencyResultsKinds with Owned=true),
-	// and over the cached transitive parent.deps closure for module API call
-	// returns — no graph walk at install or failure time.
-	sessionResultInstallSpans    map[string]map[sharedResultID]map[string]trace.SpanContext
+	// results in a session. Lazy resume spans cause-link the install spans of
+	// the result being evaluated so dagui can resolve pending state and mark
+	// owners caused-failed. Direct installs are recorded per result (owned
+	// dependency edges copy the owning span onto the dep at attach time);
+	// module API call returns are recorded once on the returned result with
+	// ownsClosure set, and lookups resolve closure ownership on demand by
+	// walking dep edges upward via depParents.
+	sessionResultInstallSpans    map[string]map[sharedResultID]map[string]sessionResultInstallSpan
 	sessionResourcesBySession    map[string]map[SessionResourceHandle]*sessionResourceBindings
 	sessionHandlesBySession      map[string]*set.TreeSet[SessionResourceHandle]
 	sessionVolatileVarsBySession map[string]map[string]string
@@ -1416,11 +1460,10 @@ type sharedResult struct {
 	// explicit out-of-band deps and exact resultCall refs mirrored into deps
 	// during materialization.
 	deps map[sharedResultID]struct{}
-	// depParents is the reverse index for direct deps. transitiveDeps caches the
-	// full parent.deps closure so module-return install-span propagation can copy
-	// a sorted set instead of re-walking the egraph under lock on every return.
-	depParents     *set.TreeSet[sharedResultID]
-	transitiveDeps *set.TreeSet[sharedResultID]
+	// depParents is the reverse index for direct deps. It lets install-span
+	// lookups walk dep edges upward on demand to find closure-owning installs
+	// (module API call returns) for the result being evaluated.
+	depParents *set.TreeSet[sharedResultID]
 	// sessionResourceHandle is set when this result is itself an attached
 	// session-resource handle leaf. requiredSessionResources is the flattened
 	// transitive set of handle requirements for cache-hit validation.
@@ -2040,41 +2083,6 @@ func (c *Cache) rememberDependencyEdgeLocked(parentRes *sharedResult, depRes *sh
 		depRes.depParents = newSharedResultIDSet()
 	}
 	depRes.depParents.Insert(parentRes.id)
-
-	delta := newSharedResultIDSet()
-	delta.Insert(depRes.id)
-	if depRes.transitiveDeps != nil {
-		delta.InsertSet(depRes.transitiveDeps)
-	}
-	c.propagateTransitiveDepDeltaLocked(parentRes, delta)
-}
-
-func (c *Cache) propagateTransitiveDepDeltaLocked(res *sharedResult, delta *set.TreeSet[sharedResultID]) {
-	if res == nil || delta == nil || delta.Empty() {
-		return
-	}
-	if res.transitiveDeps == nil {
-		res.transitiveDeps = newSharedResultIDSet()
-	}
-	inserted := newSharedResultIDSet()
-	for depID := range delta.Items() {
-		if depID == 0 || depID == res.id {
-			continue
-		}
-		if res.transitiveDeps.Insert(depID) {
-			inserted.Insert(depID)
-		}
-	}
-	if inserted.Empty() || res.depParents == nil || res.depParents.Empty() {
-		return
-	}
-	for parentID := range res.depParents.Items() {
-		parent := c.resultsByID[parentID]
-		if parent == nil {
-			continue
-		}
-		c.propagateTransitiveDepDeltaLocked(parent, inserted)
-	}
 }
 
 func (c *Cache) forgetDependencyEdgeLocked(parentID sharedResultID, depID sharedResultID) {

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -401,35 +401,75 @@ func TestSessionResultInstallSpanContextsSorted(t *testing.T) {
 		SpanID:  trace.SpanID{1},
 	})
 
-	c.recordSessionResultInstallSpanLocked("test-session", 1, spanCtxB)
-	c.recordSessionResultInstallSpanLocked("test-session", 1, spanCtxA)
-	c.recordSessionResultInstallSpanLocked("test-session", 1, spanCtxB)
+	c.recordSessionResultInstallSpanLocked("test-session", 1, spanCtxB, false)
+	c.recordSessionResultInstallSpanLocked("test-session", 1, spanCtxA, false)
+	c.recordSessionResultInstallSpanLocked("test-session", 1, spanCtxB, false)
 
 	got := c.sessionResultInstallSpanContexts("test-session", 1)
 	assert.DeepEqual(t, got, []trace.SpanContext{spanCtxA, spanCtxB})
 }
 
-func TestTransitiveDepIDsLockedUpdatesAncestors(t *testing.T) {
+// Install-span lookups walk dep edges upward: a result sees its own direct
+// install spans plus closure-owning (module API call return) install spans of
+// results that transitively depend on it. Non-owning installs on ancestors
+// (plain chained API calls) must not propagate downward.
+func TestInstallSpanLookupWalksClosureOwnersUpward(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	c := &Cache{resultsByID: map[sharedResultID]*sharedResult{}}
-	parent := &sharedResult{id: 1}
-	child := &sharedResult{id: 2}
-	grandchild := &sharedResult{id: 3}
-	c.resultsByID[parent.id] = parent
-	c.resultsByID[child.id] = child
-	c.resultsByID[grandchild.id] = grandchild
+	moduleReturn := &sharedResult{id: 1}
+	chained := &sharedResult{id: 2}
+	leaf := &sharedResult{id: 3}
+	c.resultsByID[moduleReturn.id] = moduleReturn
+	c.resultsByID[chained.id] = chained
+	c.resultsByID[leaf.id] = leaf
 
 	c.egraphMu.Lock()
-	assert.NilError(t, c.addExplicitDependencyLocked(ctx, parent, child, "test"))
-	assert.NilError(t, c.addExplicitDependencyLocked(ctx, child, grandchild, "test"))
-	parentDeps := c.transitiveDepIDsLocked(parent.id)
-	childDeps := c.transitiveDepIDsLocked(child.id)
+	assert.NilError(t, c.addExplicitDependencyLocked(ctx, moduleReturn, chained, "test"))
+	assert.NilError(t, c.addExplicitDependencyLocked(ctx, chained, leaf, "test"))
+	moduleReturnAncestors := c.installAncestorIDsLocked(moduleReturn.id)
+	leafAncestors := c.installAncestorIDsLocked(leaf.id)
 	c.egraphMu.Unlock()
 
-	assert.DeepEqual(t, parentDeps, []sharedResultID{child.id, grandchild.id})
-	assert.DeepEqual(t, childDeps, []sharedResultID{grandchild.id})
+	assert.DeepEqual(t, moduleReturnAncestors, []sharedResultID(nil))
+	assert.DeepEqual(t, leafAncestors, []sharedResultID{chained.id, moduleReturn.id})
+
+	moduleSpanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{1},
+	})
+	chainedSpanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{2},
+		SpanID:  trace.SpanID{2},
+	})
+	leafSpanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{3},
+		SpanID:  trace.SpanID{3},
+	})
+
+	// The module API call returned moduleReturn: closure-owning install.
+	c.recordSessionResultInstallSpanLocked("test-session", moduleReturn.id, moduleSpanCtx, true)
+	// chained was returned by a plain API call: direct install only.
+	c.recordSessionResultInstallSpanLocked("test-session", chained.id, chainedSpanCtx, false)
+	// leaf was returned by a plain API call too.
+	c.recordSessionResultInstallSpanLocked("test-session", leaf.id, leafSpanCtx, false)
+
+	// leaf sees its own install plus the module span via closure ownership,
+	// but not the chained result's plain install.
+	assert.DeepEqual(t,
+		c.sessionResultInstallSpanContexts("test-session", leaf.id),
+		[]trace.SpanContext{moduleSpanCtx, leafSpanCtx})
+
+	// chained likewise sees itself plus the module span.
+	assert.DeepEqual(t,
+		c.sessionResultInstallSpanContexts("test-session", chained.id),
+		[]trace.SpanContext{moduleSpanCtx, chainedSpanCtx})
+
+	// moduleReturn has no ancestors; it sees only its own install.
+	assert.DeepEqual(t,
+		c.sessionResultInstallSpanContexts("test-session", moduleReturn.id),
+		[]trace.SpanContext{moduleSpanCtx})
 }
 
 func TestEvaluateLazyUsesOriginalSpanForLogsAndNestedSpans(t *testing.T) {

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/dagger/dagger/engine"
 	snapshots "github.com/dagger/dagger/engine/snapshots"
+	"github.com/dagger/dagger/engine/telemetryattrs"
 	telemetry "github.com/dagger/otel-go"
 	set "github.com/hashicorp/go-set/v3"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
+	"go.opentelemetry.io/otel/codes"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -511,6 +513,184 @@ func TestEvaluateLazyUsesOriginalSpanForLogsAndNestedSpans(t *testing.T) {
 	}
 	assert.Assert(t, sawChild, "expected nested lazy child span to be recorded")
 	assert.Assert(t, sawResume, "expected hidden resume span to be recorded")
+}
+
+// When a lazy callback fails only because a prerequisite result's evaluation
+// failed, the callback's own resume span must be marked blocked
+// (dagger.io/dag.blocked) so the UI returns the owning API spans to pending.
+// The prerequisite's own resume span carries the real failure unmarked.
+func TestEvaluateLazyPrerequisiteFailureMarksResumeBlocked(t *testing.T) {
+	t.Parallel()
+
+	baseCtx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(baseCtx, "", nil, nil)
+	assert.NilError(t, err)
+	ctx := ContextWithCache(baseCtx, cacheIface)
+	c := cacheIface
+	srv := cacheTestServer(t)
+
+	spanExporter := &cacheTestSpanExporter{}
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExporter))
+	defer tracerProvider.Shutdown(t.Context())
+
+	originalCtx, originalSpan := tracerProvider.Tracer("dagger.io/test").Start(ctx, "original")
+
+	depErr := errors.New("dep exploded")
+	depCall := &ResultCall{
+		Type: NewResultCallType(&ast.Type{
+			NamedType: "CacheTestObject",
+			NonNull:   true,
+		}),
+		Field: "lazyDep",
+	}
+	depRes, err := c.GetOrInitCall(originalCtx, "test-session", srv, &CallRequest{ResultCall: depCall}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResultWithValue(t, srv, depCall, &cacheTestObject{
+			Value: 1,
+			lazyEval: func(context.Context) error {
+				return depErr
+			},
+		}), nil
+	})
+	assert.NilError(t, err)
+
+	tipCall := &ResultCall{
+		Type: NewResultCallType(&ast.Type{
+			NamedType: "CacheTestObject",
+			NonNull:   true,
+		}),
+		Field: "lazyTip",
+	}
+	tipRes, err := c.GetOrInitCall(originalCtx, "test-session", srv, &CallRequest{ResultCall: tipCall}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResultWithValue(t, srv, tipCall, &cacheTestObject{
+			Value: 2,
+			lazyEval: func(ctx context.Context) error {
+				return c.Evaluate(ctx, depRes)
+			},
+		}), nil
+	})
+	assert.NilError(t, err)
+
+	triggerCtx, triggerSpan := tracerProvider.Tracer("dagger.io/test").Start(ctx, "trigger")
+	evalErr := c.Evaluate(triggerCtx, tipRes)
+	assert.Assert(t, evalErr != nil)
+	assert.ErrorContains(t, evalErr, "dep exploded")
+	triggerSpan.End()
+	originalSpan.End()
+
+	assert.NilError(t, tracerProvider.ForceFlush(t.Context()))
+
+	spanExporter.mu.Lock()
+	spans := append([]sdktrace.ReadOnlySpan(nil), spanExporter.spans...)
+	spanExporter.mu.Unlock()
+
+	spanBlocked := func(span sdktrace.ReadOnlySpan) bool {
+		for _, attr := range span.Attributes() {
+			if string(attr.Key) == telemetryattrs.DagBlockedAttr {
+				return attr.Value.AsBool()
+			}
+		}
+		return false
+	}
+
+	var sawTipResume, sawDepResume bool
+	for _, span := range spans {
+		switch span.Name() {
+		case "resume lazyTip":
+			sawTipResume = true
+			assert.Equal(t, span.Status().Code, codes.Error)
+			assert.Assert(t, spanBlocked(span), "tip resume span should be marked blocked")
+		case "resume lazyDep":
+			sawDepResume = true
+			assert.Equal(t, span.Status().Code, codes.Error)
+			assert.Assert(t, !spanBlocked(span), "dep resume span carries the real failure and must not be blocked")
+			assert.Equal(t, span.Status().Description, "dep exploded")
+		}
+	}
+	assert.Assert(t, sawTipResume, "expected tip resume span to be recorded")
+	assert.Assert(t, sawDepResume, "expected dep resume span to be recorded")
+}
+
+// A lazy callback that fails its own work (no prerequisite involved) must not
+// be classified as blocked, even when other evaluations happened earlier.
+func TestEvaluateLazyOwnFailureNotMarkedBlocked(t *testing.T) {
+	t.Parallel()
+
+	baseCtx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(baseCtx, "", nil, nil)
+	assert.NilError(t, err)
+	ctx := ContextWithCache(baseCtx, cacheIface)
+	c := cacheIface
+	srv := cacheTestServer(t)
+
+	spanExporter := &cacheTestSpanExporter{}
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExporter))
+	defer tracerProvider.Shutdown(t.Context())
+
+	originalCtx, originalSpan := tracerProvider.Tracer("dagger.io/test").Start(ctx, "original")
+
+	depCall := &ResultCall{
+		Type: NewResultCallType(&ast.Type{
+			NamedType: "CacheTestObject",
+			NonNull:   true,
+		}),
+		Field: "okDep",
+	}
+	depRes, err := c.GetOrInitCall(originalCtx, "test-session", srv, &CallRequest{ResultCall: depCall}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResultWithValue(t, srv, depCall, &cacheTestObject{
+			Value: 1,
+			lazyEval: func(context.Context) error {
+				return nil
+			},
+		}), nil
+	})
+	assert.NilError(t, err)
+
+	tipCall := &ResultCall{
+		Type: NewResultCallType(&ast.Type{
+			NamedType: "CacheTestObject",
+			NonNull:   true,
+		}),
+		Field: "ownFailTip",
+	}
+	tipRes, err := c.GetOrInitCall(originalCtx, "test-session", srv, &CallRequest{ResultCall: tipCall}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResultWithValue(t, srv, tipCall, &cacheTestObject{
+			Value: 2,
+			lazyEval: func(ctx context.Context) error {
+				if err := c.Evaluate(ctx, depRes); err != nil {
+					return err
+				}
+				return errors.New("my own work failed")
+			},
+		}), nil
+	})
+	assert.NilError(t, err)
+
+	triggerCtx, triggerSpan := tracerProvider.Tracer("dagger.io/test").Start(ctx, "trigger")
+	evalErr := c.Evaluate(triggerCtx, tipRes)
+	assert.Assert(t, evalErr != nil)
+	assert.ErrorContains(t, evalErr, "my own work failed")
+	triggerSpan.End()
+	originalSpan.End()
+
+	assert.NilError(t, tracerProvider.ForceFlush(t.Context()))
+
+	spanExporter.mu.Lock()
+	spans := append([]sdktrace.ReadOnlySpan(nil), spanExporter.spans...)
+	spanExporter.mu.Unlock()
+
+	var sawTipResume bool
+	for _, span := range spans {
+		if span.Name() != "resume ownFailTip" {
+			continue
+		}
+		sawTipResume = true
+		assert.Equal(t, span.Status().Code, codes.Error)
+		for _, attr := range span.Attributes() {
+			assert.Assert(t, string(attr.Key) != telemetryattrs.DagBlockedAttr,
+				"own failure must not be marked blocked")
+		}
+	}
+	assert.Assert(t, sawTipResume, "expected tip resume span to be recorded")
 }
 
 func (*cacheTestObject) Type() *ast.Type {

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -258,6 +258,12 @@ type SpanSnapshot struct {
 	Cached   bool `json:",omitempty"`
 	Pending  bool `json:",omitempty"`
 
+	// Blocked marks a lazy-evaluation resume span that aborted because a
+	// prerequisite failed. A blocked resumption is treated as if the deferred
+	// work never ran: it neither resolves the owning span's pending state nor
+	// propagates failure to it.
+	Blocked bool `json:",omitempty"`
+
 	// An extra flag to indicate that a span was canceled because the root span
 	// completed while the span was still running.
 	LeftRunning bool `json:",omitempty"`
@@ -347,6 +353,9 @@ func (snapshot *SpanSnapshot) ProcessAttribute(name string, val any) { //nolint:
 
 	case telemetry.PendingAttr:
 		snapshot.Pending = val.(bool)
+
+	case telemetryattrs.DagBlockedAttr:
+		snapshot.Blocked = val.(bool)
 
 	case telemetry.UIEncapsulateAttr:
 		snapshot.Encapsulate = val.(bool)
@@ -473,7 +482,11 @@ func (span *Span) PropagateStatusToParentsAndLinks() {
 		} else {
 			changed = parent.RunningSpans.Remove(span)
 		}
-		if causal && span.IsFailed() {
+		if causal && span.IsFailed() && !span.Blocked {
+			// Blocked resumptions carry a cascaded prerequisite failure, not a
+			// failure of the parent's own work; they don't mark the parent
+			// caused-failed. The prerequisite's own resume span propagates the
+			// real failure to its own causal targets.
 			changed = parent.FailedLinks.Add(span) || changed
 			// Propagate error origins across explicit causal links so the
 			// caused-failed span renders the leaf error rather than its own
@@ -829,7 +842,19 @@ func (span *Span) IsPending() bool {
 		return false
 	}
 	if span.Pending || (span.Final && span.Pending_) {
-		return len(span.effectsViaLinks.Order) == 0
+		return !span.hasResolvedEffects()
+	}
+	return false
+}
+
+// hasResolvedEffects reports whether any causal continuation of this span
+// actually ran its deferred work. Blocked resumptions (aborted because a
+// prerequisite failed) don't count: the work is still pending.
+func (span *Span) hasResolvedEffects() bool {
+	for _, effect := range span.effectsViaLinks.Order {
+		if !effect.Blocked {
+			return true
+		}
 	}
 	return false
 }
@@ -846,8 +871,11 @@ func (span *Span) PendingReason() (bool, []string) {
 		return false, reasons
 	}
 	if span.Pending || (span.Final && span.Pending_) {
-		if len(span.effectsViaLinks.Order) > 0 {
+		if span.hasResolvedEffects() {
 			return false, []string{"span has resumed via causal continuation"}
+		}
+		if len(span.effectsViaLinks.Order) > 0 {
+			return true, []string{"span only has blocked resumptions; work is still pending"}
 		}
 		return true, []string{"span says it is pending"}
 	}

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -135,9 +135,14 @@ entrypoint = true
 			"stdout",
 		}, Fail: true},
 		{Function: "module-type-return-fail", Args: []string{"container", "sync"}, Fail: true, FuzzyTest: func(t *testctx.T, out string) {
-			require.Contains(t, out, ".moduleTypeReturnFail")
+			// The module API span owns the returned object's whole construction
+			// closure, so the inner container failure must attribute to it.
+			require.Contains(t, out, "✘ .moduleTypeReturnFail")
 			require.Contains(t, out, "module type container failing")
-			require.Contains(t, out, "withExec sh -c 'echo module type container failing; exit 1'")
+			require.Contains(t, out, "✘ withExec sh -c 'echo module type container failing; exit 1'")
+			// Chained calls downstream of the failure never ran; they must stay
+			// pending rather than rendering the cascaded error.
+			require.Contains(t, out, "○ withEnvVariable AFTER=should stay pending")
 		}},
 		{Function: "revealed-spans"},
 

--- a/engine/telemetryattrs/attrs.go
+++ b/engine/telemetryattrs/attrs.go
@@ -2,4 +2,11 @@ package telemetryattrs
 
 const (
 	UIResumeOutputAttr = "dagger.io/ui.resume.output"
+
+	// DagBlockedAttr marks a lazy-evaluation resume span that aborted because a
+	// prerequisite result's evaluation failed, rather than because the result's
+	// own deferred work failed. The UI treats a blocked resumption as if the
+	// deferred work never ran: the owning API spans return to pending instead
+	// of being marked caused-failed.
+	DagBlockedAttr = "dagger.io/dag.blocked"
 )


### PR DESCRIPTION
## Background

While working on remote caching, we noticed that `evaluateLivenessDeps` in `dagql/cache.go` forces evaluation of **every result in a result's `parent.deps`** — recursively, across the whole transitive closure — before that result's own lazy callback is allowed to run.

That is a direct obstacle for remote caching, which depends on staying lazy as long as possible — if a result can be satisfied directly (e.g. pulled by content), we don't want to touch its upstream closure at all. A preflight that unconditionally walks and evaluates the full closure makes that impossible.

So the goal here was not just to delete the preflight, but to remove the *need* for it — while keeping the telemetry output it was protecting just as coherent as before.

## Root cause

The preflight existed for exactly one observable reason, which is easiest to see in the `pending` telemetry test (`from → withExec(false) → withExec(sleep 1)`, then `sync`):

Lazy evaluation telemetry is built around hidden `resume <field>` spans. These are best understood not as ordinary spans but as **state-transition signals** for a result's deferred work — their children and logs are re-homed onto the original API call span, and their only real job is what their cause-links communicate:

- resume span **started** → the owning API spans show as running
- ended **OK** → the owning spans' `pending` state resolves
- ended **ERROR** → the owning spans are marked caused-failed

The problem: once a resume span has started, those are its only two endings, and **neither is correct when the callback aborted because a prerequisite failed**. Ending OK would falsely resolve the span to success; ending ERROR attributes someone else's failure to it. Without the preflight, forcing the tip of a failed chain made the upstream error unwind through every downstream callback, and every downstream call rendered `✘ ERROR / exit code: 1` instead of `○` pending.

The preflight worked around the missing state by making sure the transition never started: evaluate all deps first, so an upstream failure surfaces before the downstream resume span exists. But it used `parent.deps` as the prerequisite set, and that's the **liveness/retention closure** (receiver chains, arg results, module context, provenance edges) — a superset of what a lazy callback actually needs, knowable only by the callback itself.

## The fix: represent the missing state

This PR adds the missing state to the model instead of preventing the transition:

- **Engine**: failures returned by `Cache.Evaluate` are tagged with the identity of the result whose evaluation failed (a transparent error wrapper; messages are unchanged). When a resume span ends with an error that originated from a *different* result's evaluation, it's stamped `dagger.io/dag.blocked=true`: "this evaluation attempt aborted because a prerequisite failed; the deferred work is still pending."
- **Client (dagui)**: a blocked resumption is treated as if the deferred work never ran — it neither resolves the owning span's pending state nor propagates failure/error origins to it. The failing prerequisite's own resume span (unmarked) still carries the real failure and its install-span cause links, so attribution lands where it belongs.

With the state represented, the preflight is no longer needed at all: lazy callbacks evaluate exactly what they need, nested evaluation failures classify themselves wherever they surface, and downstream chained calls return to `○` pending just like before.

End result: **telemetry output is unchanged** (no goldens needed updating), but evaluating one result no longer forces its transitive closure — evaluation is fully lazy again, and the path is clear for remote caching.

## Related: install-span closure bookkeeping made on-demand

While in here we also addressed a closely-related cost that existed for the same telemetry feature. Module API call returns attribute construction-chain failures back to the module call's span, and this was implemented eagerly: every `sharedResult` maintained a `transitiveDeps` set caching its full dep closure (deltas propagated up a `depParents` reverse index on **every dependency edge insert**), so a module return could copy its span onto every closure member.

That's now inverted: closure ownership is recorded once on the returned result (`ownsClosure` on the install-table entry), and lookups resolve it on demand by walking dep edges *upward* via the existing `depParents` index — collecting the result's own direct installs plus closure-owning installs of results that transitively depend on it. Plain chained API call installs aren't closure-owning, so receiver chains still don't propagate install spans across links, while module ownership still flows through them.

Edge inserts are now a single reverse-index insert, the per-result closure sets are gone entirely, and the walk runs only at resume-span creation and service-origin lookup — bounded by actual lazy evaluations and service starts rather than by graph construction.

## Test hardening

The `module-type-return-fail` telemetry test is the only coverage for module-closure failure attribution, but it used a fuzzy check that only required the call name and error text to appear somewhere in the output — it would have passed even with attribution fully broken. It now also asserts that the module span renders failed (`✘ .moduleTypeReturnFail`) and that chained calls downstream of the failure stay pending (`○ withEnvVariable AFTER=should stay pending`), locking in both behaviors this PR touches.

## Validation

- Deleting the preflight with no replacement breaks exactly 4 goldens (`pending` across Go/Python/TypeScript, `docker-build-fail`), all with the same diff: downstream chained calls render `✘ ERROR` with the cascaded error instead of `○`. This confirmed the preflight's sole observable role before designing the replacement.
- With this PR, the **full `TestTelemetry` suite passes with no golden changes**, including the previously-failing four plus `fail-effect`, `service-error-attribution`, `cached-execs`, and the strengthened `module-type-return-fail`.
- New unit tests cover the classification (`TestEvaluateLazyPrerequisiteFailureMarksResumeBlocked`, `TestEvaluateLazyOwnFailureNotMarkedBlocked`) and the upward install-span walk (`TestInstallSpanLookupWalksClosureOwnersUpward`).

One known limit worth stating: blocked classification relies on lazy callbacks propagating dep-evaluation errors with their chains intact (bare returns or `%w`, which is what current implementations do). A callback that rewraps opaquely degrades to the previous cascade rendering for that link only — no worse than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
