### PR TITLE
feat(core): add rewriteTimestamp / SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/.changes/unreleased/Added-20260707-000000.yaml
+++ b/.changes/unreleased/Added-20260707-000000.yaml
@@ -1,0 +1,13 @@
+kind: Added
+body: |
+  Add `rewriteTimestamp` to `Container.publish`, `Container.export`, `Container.asTarball`, and `Directory.export`.
+
+  When set to a Unix epoch (in seconds), file and image timestamps newer than that value are clamped down to it, producing identical digests across runs — the standard `SOURCE_DATE_EPOCH` reproducible-builds workflow.
+
+  When omitted, the engine falls back to the caller's `SOURCE_DATE_EPOCH` environment variable (propagated automatically via `ClientMetadata`). When neither is set, wall-clock behaviour is unchanged.
+
+  `SOURCE_DATE_EPOCH` is also forwarded into each exec container's process environment so that build tools inside containers can produce reproducible outputs without additional wiring.
+time: 2026-07-07T00:00:00.000000000+00:00
+custom:
+  Author: danielwegener
+  PR: "13419"

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -730,7 +730,7 @@ func (ch *Changeset) Export(ctx context.Context, destPath string) (rerr error) {
 		if err != nil {
 			return err
 		}
-		return bk.LocalDirExport(ctx, root, destPath, true, paths.Removed)
+		return bk.LocalDirExport(ctx, root, destPath, true, paths.Removed, nil)
 	}, mountRefAsReadOnly)
 }
 

--- a/core/container.go
+++ b/core/container.go
@@ -6374,6 +6374,7 @@ func (container *Container) Publish(
 	mediaTypes ImageMediaTypes,
 	registryServices ServiceBindings,
 	registryTransport serverresolver.RegistryTransport,
+	sourceDateEpoch *int64,
 ) (string, error) {
 	variants := filterEmptyContainers(append([]*Container{container}, platformVariants...))
 	inputByPlatform, err := getVariantRefs(ctx, variants)
@@ -6395,7 +6396,7 @@ func (container *Container) Publish(
 	}
 	defer detach()
 
-	resp, err := bk.PublishContainerImage(ctx, inputByPlatform, ref, useOCIMediaTypes(mediaTypes), string(forcedCompression), network, registryTransport)
+	resp, err := bk.PublishContainerImage(ctx, inputByPlatform, ref, useOCIMediaTypes(mediaTypes), string(forcedCompression), network, registryTransport, sourceDateEpoch)
 	if err != nil {
 		return "", err
 	}
@@ -6419,6 +6420,7 @@ type ExportOpts struct {
 	MediaTypes        ImageMediaTypes
 	Tar               bool
 	LeaseID           string
+	SourceDateEpoch   *int64
 }
 
 func useOCIMediaTypes(mediaTypes ImageMediaTypes) bool {
@@ -6505,6 +6507,7 @@ func (container *Container) Export(ctx context.Context, opts ExportOpts) (*specs
 			opts.ForcedCompression,
 			opts.MediaTypes,
 			"container.tar",
+			opts.SourceDateEpoch,
 		)
 		if err != nil {
 			return nil, err
@@ -6541,7 +6544,7 @@ func (container *Container) Export(ctx context.Context, opts ExportOpts) (*specs
 		return nil, err
 	}
 
-	resp, err := bk.ExportContainerImage(ctx, opts.Dest, inputByPlatform, string(opts.ForcedCompression), opts.Tar, opts.LeaseID, useOCIMediaTypes(opts.MediaTypes))
+	resp, err := bk.ExportContainerImage(ctx, opts.Dest, inputByPlatform, string(opts.ForcedCompression), opts.Tar, opts.LeaseID, useOCIMediaTypes(opts.MediaTypes), opts.SourceDateEpoch)
 	if err != nil {
 		return nil, err
 	}

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -256,6 +256,7 @@ func (container *Container) execMeta(
 	execMD.RedirectStderrPath = opts.RedirectStderr
 	execMD.SystemEnvNames = container.SystemEnvNames
 	execMD.EnabledGPUs = container.EnabledGPUs
+	execMD.SourceDateEpoch = clientMetadata.SourceDateEpoch
 	if opts.NoInit {
 		execMD.NoInit = true
 	}
@@ -2082,6 +2083,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				AllowedLLMModules:     slices.Clone(clientMetadata.AllowedLLMModules),
 				LockMode:              clientMetadata.LockMode,
 				UseRecipeIDsByDefault: execMD != nil && execMD.UseRecipeIDsByDefault,
+				SourceDateEpoch:       clientMetadata.SourceDateEpoch,
 			}
 		}
 

--- a/core/container_image.go
+++ b/core/container_image.go
@@ -257,6 +257,7 @@ func (container *Container) AsTarball(
 	forcedCompression ImageLayerCompression,
 	mediaTypes ImageMediaTypes,
 	filePath string,
+	sourceDateEpoch *int64,
 ) (f *File, rerr error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
@@ -296,7 +297,7 @@ func (container *Container) AsTarball(
 			return err
 		}
 		defer file.Close()
-		return bk.WriteContainerImageTarball(ctx, file, inputByPlatform, useOCIMediaTypes(mediaTypes), string(forcedCompression))
+		return bk.WriteContainerImageTarball(ctx, file, inputByPlatform, useOCIMediaTypes(mediaTypes), string(forcedCompression), sourceDateEpoch)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("container image to tarball file conversion failed: %w", err)

--- a/core/directory.go
+++ b/core/directory.go
@@ -3202,7 +3202,7 @@ func (dir *Directory) Stat(ctx context.Context, self dagql.ObjectResult[*Directo
 	return stat, nil
 }
 
-func (dir *Directory) Export(ctx context.Context, self dagql.ObjectResult[*Directory], destPath string, merge bool) (rerr error) {
+func (dir *Directory) Export(ctx context.Context, self dagql.ObjectResult[*Directory], destPath string, merge bool, sourceDateEpoch *int64) (rerr error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return err
@@ -3232,7 +3232,7 @@ func (dir *Directory) Export(ctx context.Context, self dagql.ObjectResult[*Direc
 		if err != nil {
 			return err
 		}
-		return bk.LocalDirExport(ctx, root, destPath, merge, nil)
+		return bk.LocalDirExport(ctx, root, destPath, merge, nil, sourceDateEpoch)
 	})
 }
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3448,6 +3448,35 @@ func (ContainerSuite) TestAsTarballCached(ctx context.Context, t *testctx.T) {
 	require.Equal(t, first, second)
 }
 
+func (ContainerSuite) TestAsTarballRewriteTimestamp(ctx context.Context, t *testctx.T) {
+	const (
+		epoch  = 1100000000 // 2004-11-09
+		epoch2 = 1200000000 // 2008-01-10
+	)
+	c := connect(ctx, t)
+
+	build := func() *dagger.Container {
+		return c.Container().From(alpineImage).WithNewFile("/repro.txt", "reproducible builds")
+	}
+
+	tarballHash := func(opts dagger.ContainerAsTarballOpts) string {
+		t.Helper()
+		out, err := build().
+			WithMountedFile("/foo.tar", build().AsTarball(opts)).
+			WithExec([]string{"sha256sum", "/foo.tar"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return strings.Fields(out)[0]
+	}
+
+	h1 := tarballHash(dagger.ContainerAsTarballOpts{RewriteTimestamp: epoch})
+	h2 := tarballHash(dagger.ContainerAsTarballOpts{RewriteTimestamp: epoch})
+	require.Equal(t, h1, h2, "same rewriteTimestamp must yield identical tarball digest")
+
+	h3 := tarballHash(dagger.ContainerAsTarballOpts{RewriteTimestamp: epoch2})
+	require.NotEqual(t, h1, h3, "different rewriteTimestamp must change the tarball digest")
+}
+
 func (ContainerSuite) TestImport(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -736,6 +736,9 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("insecureSkipTLSVerify").Doc(`Allow HTTPS registry communication without verifying the server certificate.`).
 					View(AfterVersion("v1.0.0-0")),
+				dagql.Arg("rewriteTimestamp").Doc(
+					`Clamp file and image timestamps to this Unix epoch (in seconds) for reproducible digests.`,
+					`Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.`),
 			),
 
 		dagql.NodeFunc("platform", s.platform).
@@ -769,6 +772,9 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("expand").Doc(
 					`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 						`environment variables defined in the container (e.g. "/$VAR/foo").`),
+				dagql.Arg("rewriteTimestamp").Doc(
+					`Clamp file and image timestamps to this Unix epoch (in seconds) for reproducible digests.`,
+					`Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.`),
 			),
 		dagql.NodeFunc("export", s.exportLegacy).
 			WithInput(dagql.PerCallInput).
@@ -815,6 +821,9 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					`Defaults to OCI, which is largely compatible with most recent
 					container runtimes, but Docker may be needed for older runtimes without
 					OCI support.`),
+				dagql.Arg("rewriteTimestamp").Doc(
+					`Clamp file and image timestamps to this Unix epoch (in seconds) for reproducible digests.`,
+					`Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.`),
 			),
 
 		dagql.NodeFunc("import", s.import_).
@@ -2495,6 +2504,7 @@ type containerPublishArgs struct {
 	RegistryService       dagql.Optional[core.ServiceID]
 	Protocol              dagql.Optional[core.RegistryProtocol]
 	InsecureSkipTLSVerify bool `name:"insecureSkipTLSVerify" default:"false"`
+	RewriteTimestamp      dagql.Optional[dagql.Int]
 }
 
 func (s *containerSchema) publish(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerPublishArgs) (dagql.String, error) {
@@ -2549,6 +2559,7 @@ func (s *containerSchema) publish(ctx context.Context, parent dagql.ObjectResult
 		args.MediaTypes,
 		registryServices,
 		registryTransport,
+		resolveSourceDateEpoch(ctx, args.RewriteTimestamp),
 	)
 	if err != nil {
 		return "", err
@@ -3200,6 +3211,19 @@ func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult
 		DefaultArgs:        parent.Self().DefaultArgs,
 	}
 	return ctr, parentPendingLazy, nil
+}
+
+// resolveSourceDateEpoch returns the effective epoch for timestamp clamping:
+// explicit arg wins, else the client's SOURCE_DATE_EPOCH env, else nil (wall-clock).
+func resolveSourceDateEpoch(ctx context.Context, explicit dagql.Optional[dagql.Int]) *int64 {
+	if explicit.Valid {
+		v := explicit.Value.Int64()
+		return &v
+	}
+	if md, err := engine.ClientMetadataFromContext(ctx); err == nil && md.SourceDateEpoch != nil {
+		return md.SourceDateEpoch
+	}
+	return nil
 }
 
 func expandEnvVar(ctx context.Context, parent *core.Container, input string, expand bool) (string, error) {
@@ -3862,6 +3886,7 @@ type containerExportArgs struct {
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
 	MediaTypes        core.ImageMediaTypes `default:"OCI"`
 	Expand            bool                 `default:"false"`
+	RewriteTimestamp  dagql.Optional[dagql.Int]
 }
 
 func (s *containerSchema) export(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerExportArgs) (dagql.String, error) {
@@ -3911,6 +3936,7 @@ func (s *containerSchema) export(ctx context.Context, parent dagql.ObjectResult[
 			ForcedCompression: args.ForcedCompression.Value,
 			MediaTypes:        args.MediaTypes,
 			Tar:               true,
+			SourceDateEpoch:   resolveSourceDateEpoch(ctx, args.RewriteTimestamp),
 		},
 	)
 	if err != nil {
@@ -3939,6 +3965,7 @@ type containerAsTarballArgs struct {
 	PlatformVariants  []core.ContainerID `default:"[]"`
 	ForcedCompression dagql.Optional[core.ImageLayerCompression]
 	MediaTypes        core.ImageMediaTypes `default:"OCI"`
+	RewriteTimestamp  dagql.Optional[dagql.Int]
 }
 
 func (s *containerSchema) asTarball(
@@ -3983,6 +4010,7 @@ func (s *containerSchema) asTarball(
 		args.ForcedCompression.Value,
 		args.MediaTypes,
 		"container.tar",
+		resolveSourceDateEpoch(ctx, args.RewriteTimestamp),
 	)
 	if err != nil {
 		return inst, err

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -234,6 +234,9 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("path").Doc(`Location of the copied directory (e.g., "logs/").`),
 				dagql.Arg("wipe").Doc(`If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.`),
+				dagql.Arg("rewriteTimestamp").Doc(
+					`Clamp file timestamps to this Unix epoch (in seconds) for reproducible exports.`,
+					`Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.`),
 			),
 		dagql.NodeFunc("export", s.exportLegacy).
 			WithInput(dagql.PerClientInput).
@@ -1406,12 +1409,13 @@ func (s *directorySchema) changesetDiffStats(ctx context.Context, parent dagql.O
 }
 
 type dirExportArgs struct {
-	Path string
-	Wipe bool `default:"false"`
+	Path             string
+	Wipe             bool `default:"false"`
+	RewriteTimestamp dagql.Optional[dagql.Int]
 }
 
 func (s *directorySchema) export(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args dirExportArgs) (dagql.String, error) {
-	err := parent.Self().Export(ctx, parent, args.Path, !args.Wipe)
+	err := parent.Self().Export(ctx, parent, args.Path, !args.Wipe, resolveSourceDateEpoch(ctx, args.RewriteTimestamp))
 	if err != nil {
 		return "", err
 	}

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -1469,6 +1469,12 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		md.WorkspaceEnv = c.WorkspaceEnv
 	}
 
+	if epochStr := os.Getenv("SOURCE_DATE_EPOCH"); epochStr != "" {
+		if epoch, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
+			md.SourceDateEpoch = &epoch
+		}
+	}
+
 	return md
 }
 

--- a/engine/engineutil/containerimage.go
+++ b/engine/engineutil/containerimage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"time"
 
 	archiveexporter "github.com/containerd/containerd/v2/core/images/archive"
 	"github.com/containerd/platforms"
@@ -73,6 +74,7 @@ func (c *Client) buildExportRequest(
 func (c *Client) exportCommitOpts(
 	forceCompression string,
 	useOCIMediaTypes bool,
+	sourceDateEpoch *int64,
 ) (imageexport.CommitOpts, error) {
 	refCfg := cacheconfig.RefConfig{
 		Compression: compression.New(compression.Default),
@@ -94,10 +96,16 @@ func (c *Client) exportCommitOpts(
 		}
 		refCfg.Compression = compression.New(ctype).SetForce(true)
 	}
-	return imageexport.CommitOpts{
+	opts := imageexport.CommitOpts{
 		RefCfg:   refCfg,
 		OCITypes: useOCIMediaTypes,
-	}, nil
+	}
+	if sourceDateEpoch != nil {
+		epoch := time.Unix(*sourceDateEpoch, 0).UTC()
+		opts.Epoch = &epoch
+		opts.RewriteTimestamp = true
+	}
+	return opts, nil
 }
 
 func (c *Client) assembleExportedImage(
@@ -105,12 +113,13 @@ func (c *Client) assembleExportedImage(
 	inputByPlatform map[string]ContainerExport,
 	useOCIMediaTypes bool,
 	forceCompression string,
+	sourceDateEpoch *int64,
 ) (*imageexport.ExportedImage, error) {
 	req, err := c.buildExportRequest(inputByPlatform)
 	if err != nil {
 		return nil, err
 	}
-	commitOpts, err := c.exportCommitOpts(forceCompression, useOCIMediaTypes)
+	commitOpts, err := c.exportCommitOpts(forceCompression, useOCIMediaTypes, sourceDateEpoch)
 	if err != nil {
 		return nil, err
 	}
@@ -123,6 +132,7 @@ func (c *Client) WriteContainerImageTarball(
 	inputByPlatform map[string]ContainerExport,
 	useOCIMediaTypes bool,
 	forceCompression string,
+	sourceDateEpoch *int64,
 ) error {
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
@@ -130,7 +140,7 @@ func (c *Client) WriteContainerImageTarball(
 	}
 	defer cancel(errors.New("write container image tarball done"))
 
-	exported, err := c.assembleExportedImage(ctx, inputByPlatform, useOCIMediaTypes, forceCompression)
+	exported, err := c.assembleExportedImage(ctx, inputByPlatform, useOCIMediaTypes, forceCompression, sourceDateEpoch)
 	if err != nil {
 		return err
 	}
@@ -167,6 +177,7 @@ func (c *Client) PublishContainerImage(
 	forceCompression string,
 	network serverresolver.NetworkConfig,
 	registryTransport serverresolver.RegistryTransport,
+	sourceDateEpoch *int64,
 ) (*imageexport.ExportResponse, error) {
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
@@ -178,7 +189,7 @@ func (c *Client) PublishContainerImage(
 	if err != nil {
 		return nil, err
 	}
-	commitOpts, err := c.exportCommitOpts(forceCompression, useOCIMediaTypes)
+	commitOpts, err := c.exportCommitOpts(forceCompression, useOCIMediaTypes, sourceDateEpoch)
 	if err != nil {
 		return nil, err
 	}
@@ -208,6 +219,7 @@ func (c *Client) ExportContainerImage(
 	tarExport bool,
 	_ string,
 	useOCIMediaTypes bool,
+	sourceDateEpoch *int64,
 ) (*imageexport.ExportResponse, error) {
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
@@ -224,7 +236,7 @@ func (c *Client) ExportContainerImage(
 	if err != nil {
 		return nil, err
 	}
-	commitOpts, err := c.exportCommitOpts(forceCompression, useOCIMediaTypes)
+	commitOpts, err := c.exportCommitOpts(forceCompression, useOCIMediaTypes, sourceDateEpoch)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -71,6 +71,11 @@ type ExecutionMetadata struct {
 
 	// If true, skip injecting dagger-init into the container.
 	NoInit bool
+
+	// SourceDateEpoch, when non-nil, is injected as SOURCE_DATE_EPOCH into the
+	// container's process environment so that build tools can produce
+	// reproducible outputs. Propagated from ClientMetadata.SourceDateEpoch.
+	SourceDateEpoch *int64
 }
 
 func (c *Client) Run(
@@ -141,6 +146,7 @@ func (c *Client) Run(
 		namedSetupFunc{"setupOTel", c.setupOTel},
 		namedSetupFunc{"setupSecretScrubbing", c.setupSecretScrubbing},
 		namedSetupFunc{"setProxyEnvs", c.setProxyEnvs},
+		namedSetupFunc{"setupSourceDateEpoch", c.setupSourceDateEpoch},
 		namedSetupFunc{"enableGPU", c.enableGPU},
 		namedSetupFunc{"createCWD", c.createCWD},
 		namedSetupFunc{"setupNestedClient", c.setupNestedClient},

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -958,6 +958,20 @@ func (c *Client) setProxyEnvs(_ context.Context, state *execState) error {
 	return nil
 }
 
+func (c *Client) setupSourceDateEpoch(_ context.Context, state *execState) error {
+	if state.execMD == nil || state.execMD.SourceDateEpoch == nil {
+		return nil
+	}
+	const envKey = "SOURCE_DATE_EPOCH"
+	if _, ok := state.origEnvMap[envKey]; ok {
+		// respect explicit value set by the user via WithEnvVariable
+		return nil
+	}
+	state.spec.Process.Env = append(state.spec.Process.Env,
+		fmt.Sprintf("%s=%d", envKey, *state.execMD.SourceDateEpoch))
+	return nil
+}
+
 func (c *Client) enableGPU(_ context.Context, state *execState) error {
 	if state.execMD == nil {
 		return nil

--- a/engine/engineutil/filesync.go
+++ b/engine/engineutil/filesync.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/dagger/dagger/internal/buildkit/session/filesync"
 	"github.com/dagger/dagger/internal/fsutil"
@@ -92,6 +93,7 @@ func (c *Client) LocalDirExport(
 	destPath string,
 	merge bool,
 	removePaths []string,
+	sourceDateEpoch *int64,
 ) (rerr error) {
 	ctx = slog.WithLogger(ctx, slog.FromContext(ctx).With("export_path", destPath))
 	slog.DebugContext(ctx, "exporting local dir")
@@ -108,6 +110,21 @@ func (c *Client) LocalDirExport(
 	outputFS, err := fsutil.NewFS(srcPath)
 	if err != nil {
 		return err
+	}
+
+	if sourceDateEpoch != nil {
+		epochNano := *sourceDateEpoch * int64(time.Second)
+		outputFS, err = fsutil.NewFilterFS(outputFS, &fsutil.FilterOpt{
+			Map: func(_ string, stat *fsutiltypes.Stat) fsutil.MapResult {
+				if stat.ModTime > epochNano {
+					stat.ModTime = epochNano
+				}
+				return fsutil.MapResultKeep
+			},
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	caller, err := c.GetSessionCaller(ctx)

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -156,6 +156,11 @@ type ClientMetadata struct {
 	// of this client's work. Experimental; the recorded events are retrieved
 	// via the engine debug endpoints.
 	Profile bool `json:"profile,omitempty"`
+
+	// SourceDateEpoch, when set, is propagated to export/publish operations as
+	// the rewriteTimestamp default (clamp file/image timestamps to this Unix
+	// epoch). Populated from the client's SOURCE_DATE_EPOCH env var.
+	SourceDateEpoch *int64 `json:"source_date_epoch,omitempty"`
 }
 
 type clientMetadataCtxKey struct{}

--- a/hack/designs/reproducible-builds-source-date-epoch.md
+++ b/hack/designs/reproducible-builds-source-date-epoch.md
@@ -1,0 +1,182 @@
+# Reproducible Builds: `SOURCE_DATE_EPOCH` / `rewriteTimestamp`
+
+*Revives [#10318](https://github.com/dagger/dagger/pull/10318), addressing the review feedback. Tracks [discussion #12313](https://github.com/dagger/dagger/discussions/12313).*
+
+## Table of Contents
+- [Problem](#problem)
+- [Solution](#solution)
+- [Core Concept](#core-concept)
+- [API](#api)
+- [Implementation](#implementation)
+- [What's intentionally out of scope](#whats-intentionally-out-of-scope)
+- [Cache interaction](#cache-interaction)
+- [Testing](#testing)
+- [Status](#status)
+
+## Problem
+
+1. **Non-deterministic digests** — Exported/published images embed wall-clock timestamps (layer tar `mtime`, OCI config `created`, history entries), so identical sources produce different digests on every run.
+2. **No timestamp control** — There is no way to pin those timestamps to a fixed value, which blocks the standard [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) reproducible-builds workflow.
+3. **Directory export drifts too** — `Directory.export` streams files with their wall-clock `mtime`, so on-host exports are non-reproducible as well.
+
+The downstream effects: image pinning in k8s churns, digest-based change detection produces false positives, and binary reproducibility for security verification is impossible.
+
+## Solution
+
+Expose an optional `rewriteTimestamp` (a Unix timestamp in seconds) on the export/publish surface. When set, file and image timestamps **newer than** that epoch are clamped down to it — exactly the BuildKit `rewrite-timestamp` semantics. When omitted, it defaults to the client's `SOURCE_DATE_EPOCH` environment variable (propagated via `ClientMetadata`). When neither is present, behavior is unchanged (wall-clock).
+
+This is **export-time clamping**, which is all that reproducible digests require. The clamping machinery already exists in-tree — this change is almost entirely wiring it to the public API.
+
+## Core Concept
+
+The native exporter ([`engine/engineutil/imageexport/writer.go`](../../engine/engineutil/imageexport/writer.go)) already implements the full mechanism behind `CommitOpts{ Epoch, RewriteTimestamp }`:
+
+- `rewriteExportChainWithEpoch` clamps layer tar headers (`ModTime`/`AccessTime`/`ChangeTime`) via `util/converter.NewWithRewriteTimestamp`, skipping immutable base-image layers.
+- `patchImageConfig` normalizes the config `created` field and per-history `Created` entries to the epoch.
+
+But the one place that builds `CommitOpts` — `exportCommitOpts` in [`engine/engineutil/containerimage.go`](../../engine/engineutil/containerimage.go) — hardcoded `Epoch: nil`. The whole feature is feeding it a value from the caller.
+
+`Directory.export` takes a different path (`LocalDirExport` → fsutil `DiffCopy`) with no clamping; it gets a small new piece.
+
+## API
+
+```graphql
+extend type Container {
+  """
+  Package the container state as an OCI image, and publish it to a registry.
+  """
+  publish(
+    address: String!
+    platformVariants: [ContainerID!]
+    forcedCompression: ImageLayerCompression
+    mediaTypes: ImageMediaTypes = OCI
+    registryService: ServiceID
+
+    """
+    Clamp file and image timestamps newer than the given Unix timestamp
+    (in seconds) down to it, for reproducible image digests. Defaults to the
+    client's SOURCE_DATE_EPOCH when present; otherwise wall-clock is kept.
+    """
+    rewriteTimestamp: Int
+  ): String!
+
+  """Writes the container as an OCI tarball to the destination file path on the host."""
+  export(path: String!, "...": "...", rewriteTimestamp: Int): String!
+
+  """Package the container state as an OCI image, and return it as a tar archive."""
+  asTarball("...": "...", rewriteTimestamp: Int): File!
+}
+
+extend type Directory {
+  """Writes the contents of the directory to a path on the host."""
+  export(path: String!, wipe: Boolean = false, rewriteTimestamp: Int): String!
+}
+```
+
+`rewriteTimestamp` is a single optional `Int` (the explicit value), defaulting to `clientMetadata.SourceDateEpoch` — this is precisely the shape [@jedevc requested on #10318](https://github.com/dagger/dagger/pull/10318) (explicit value rather than a bool + separate client config), so module code can set it per-call without reconfiguring the client.
+
+## Implementation
+
+Resolution helper (schema layer), used by every handler:
+
+```go
+// explicit arg wins; else client's SOURCE_DATE_EPOCH; else nil (wall-clock).
+func resolveSourceDateEpoch(ctx context.Context, explicit dagql.Optional[dagql.Int]) *int64 {
+    if explicit.Valid {
+        v := explicit.Value.Int64()
+        return &v
+    }
+    if md, err := engine.ClientMetadataFromContext(ctx); err == nil && md.SourceDateEpoch != nil {
+        return md.SourceDateEpoch
+    }
+    return nil
+}
+```
+
+The image chokepoint — once this is set, layer + config clamping activates downstream:
+
+```go
+// engine/engineutil/containerimage.go
+if sourceDateEpoch != nil {
+    epoch := time.Unix(*sourceDateEpoch, 0).UTC()
+    opts.Epoch = &epoch
+    opts.RewriteTimestamp = true
+}
+```
+
+The only genuinely new clamp — non-mutating, applied as files stream to the caller (the immutable ref on disk is untouched):
+
+```go
+// engine/engineutil/filesync.go (LocalDirExport)
+if sourceDateEpoch != nil {
+    epochNano := *sourceDateEpoch * int64(time.Second)
+    outputFS, err = fsutil.NewFilterFS(outputFS, &fsutil.FilterOpt{
+        Map: func(_ string, stat *fsutiltypes.Stat) fsutil.MapResult {
+            if stat.ModTime > epochNano {
+                stat.ModTime = epochNano
+            }
+            return fsutil.MapResultKeep
+        },
+    })
+}
+```
+
+Touched files (`+~200/-15`):
+
+| Layer | File | Change |
+|-------|------|--------|
+| Schema | `core/schema/container.go` | `rewriteTimestamp` arg on publish/export/asTarball + `resolveSourceDateEpoch` helper |
+| Schema | `core/schema/directory.go` | `rewriteTimestamp` arg on export |
+| Core | `core/container.go` | `Publish` + `ExportOpts.SourceDateEpoch` threading |
+| Core | `core/container_image.go` | `AsTarball` threading |
+| Core | `core/directory.go` | `Directory.Export` threading |
+| Core | `core/changeset.go` | pass-through (`nil`) |
+| Engine | `engine/engineutil/containerimage.go` | populate `CommitOpts.Epoch`/`RewriteTimestamp` |
+| Engine | `engine/engineutil/filesync.go` | fsutil mtime clamp |
+| Engine | `engine/opts.go` | `ClientMetadata.SourceDateEpoch` field |
+| Client | `engine/client/client.go` | read `SOURCE_DATE_EPOCH` env |
+| Test | `core/integration/container_test.go` | digest-stability test |
+| SDK | `sdk/go/dagger.gen.go` | `RewriteTimestamp int` field on all four opts structs |
+| Design | `hack/designs/reproducible-builds-source-date-epoch.md` | this document |
+
+After schema changes: regenerate SDK bindings (`dagger call go-sdk generate export --path=.`, and equivalents for other SDKs). The Go SDK bindings (`sdk/go/dagger.gen.go`) in this PR have been hand-patched with the expected codegen output; a full `dagger call go-sdk generate` run will produce the same result.
+
+## What's intentionally out of scope
+
+- **Build-time mtime rewriting** — clamping every file's `mtime` as it's mutated mid-build. BuildKit deliberately doesn't do this, it's not needed for reproducible digests, and it would mean intercepting every exec/copy. Export-time clamping is sufficient.
+- **Git-checkout normalization** — already normalized to `1` ([`core/git.go`](../../core/git.go), #13151); making it epoch-aware is a separate concern (input vs. export normalization).
+- **`Container.exportImage`** (host image store) and **changeset export** — left on wall-clock for now; can adopt the same `*int64` plumbing later.
+
+## Cache interaction
+
+Safe by construction under the native (Project Theseus) cache:
+
+- publish/export/asTarball/dir-export are terminal **sink** operations, not cached build steps. The rewrite happens in `Assemble`/`LocalDirExport` at export time, *downstream* of the layer cache — so the epoch cannot poison upstream build cache or LLB/ref digests.
+- `rewriteTimestamp` is a normal dagql field arg, so it is part of the **export node's** cache key only. Changing it re-runs the export, not the build.
+- Rewritten layers yield new, deterministic blob digests → the image digest changes with the epoch as intended, identically across runs.
+
+## Testing
+
+`core/integration/container_test.go`:
+
+```go
+func (ContainerSuite) TestAsTarballRewriteTimestamp(ctx, t) {
+    // same epoch → identical digest (reproducible)
+    // different epoch → different digest (baked into layers + config)
+}
+```
+
+Run in a from-source engine (no local Go toolchain needed):
+
+```bash
+dagger call engine-dev test --run='TestContainer/TestAsTarballRewriteTimestamp' --pkg=./core/integration
+```
+
+## Status
+
+Source implemented and compile-clean. Pending: Go SDK regeneration + integration test run.
+
+---
+
+- Discussion: [#12313](https://github.com/dagger/dagger/discussions/12313)
+- Supersedes: [#10318](https://github.com/dagger/dagger/pull/10318)

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1775,6 +1775,10 @@ type ContainerAsTarballOpts struct {
 	//
 	// Default: OCIMediaTypes
 	MediaTypes ImageMediaTypes
+	// Clamp file and image timestamps to this Unix epoch (in seconds) for reproducible digests.
+	//
+	// Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.
+	RewriteTimestamp int
 }
 
 // Package the container state as an OCI image, and return it as a tar archive
@@ -1792,6 +1796,10 @@ func (r *Container) AsTarball(opts ...ContainerAsTarballOpts) *File {
 		// `mediaTypes` optional argument
 		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
 			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 
@@ -2013,6 +2021,10 @@ type ContainerExportOpts struct {
 	MediaTypes ImageMediaTypes
 	// Replace "${VAR}" or "$VAR" in the value of path according to the current environment variables defined in the container (e.g. "/$VAR/foo").
 	Expand bool
+	// Clamp file and image timestamps to this Unix epoch (in seconds) for reproducible digests.
+	//
+	// Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.
+	RewriteTimestamp int
 }
 
 // Writes the container as an OCI tarball to the destination file path on the host.
@@ -2039,6 +2051,10 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 		// `expand` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Expand) {
 			q = q.Arg("expand", opts[i].Expand)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 	q = q.Arg("path", path)
@@ -2361,6 +2377,10 @@ type ContainerPublishOpts struct {
 	Protocol RegistryProtocol
 	// Allow HTTPS registry communication without verifying the server certificate.
 	InsecureSkipTLSVerify bool
+	// Clamp file and image timestamps to this Unix epoch (in seconds) for reproducible digests.
+	//
+	// Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.
+	RewriteTimestamp int
 }
 
 // Package the container state as an OCI image, and publish it to a registry
@@ -2395,6 +2415,10 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 		// `insecureSkipTLSVerify` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureSkipTLSVerify) {
 			q = q.Arg("insecureSkipTLSVerify", opts[i].InsecureSkipTLSVerify)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 	q = q.Arg("address", address)
@@ -4722,6 +4746,10 @@ func (r *Directory) Exists(ctx context.Context, path string, opts ...DirectoryEx
 type DirectoryExportOpts struct {
 	// If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
 	Wipe bool
+	// Clamp file timestamps to this Unix epoch (in seconds) for reproducible exports.
+	//
+	// Defaults to the client's SOURCE_DATE_EPOCH environment variable when present.
+	RewriteTimestamp int
 }
 
 // Writes the contents of the directory to a path on the host.
@@ -4734,6 +4762,10 @@ func (r *Directory) Export(ctx context.Context, path string, opts ...DirectoryEx
 		// `wipe` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Wipe) {
 			q = q.Arg("wipe", opts[i].Wipe)
+		}
+		// `rewriteTimestamp` optional argument
+		if !querybuilder.IsZeroValue(opts[i].RewriteTimestamp) {
+			q = q.Arg("rewriteTimestamp", opts[i].RewriteTimestamp)
 		}
 	}
 	q = q.Arg("path", path)


### PR DESCRIPTION
Disclaimer: Sonnet 4.6

## Summary

Adds `rewriteTimestamp: Int` to `Container.publish`, `Container.export`, `Container.asTarball`, and `Directory.export`. When set, file and image timestamps newer than the given Unix epoch (seconds) are clamped to it, producing identical digests across runs. Also injects `SOURCE_DATE_EPOCH` into exec container environments so build tools inside containers can produce reproducible outputs without extra wiring.

When the explicit arg is omitted, both behaviors fall back to the client's `SOURCE_DATE_EPOCH` environment variable. When neither is present, wall-clock behaviour is unchanged.

## Changes

The image clamping machinery was already present in `engine/engineutil/imageexport/writer.go` (`CommitOpts.Epoch` + `RewriteTimestamp`). This change wires it to the public API and adds directory/exec support:

| Layer | File | Change |
|---|---|---|
| Engine | `engine/engineutil/containerimage.go` | `exportCommitOpts` sets `CommitOpts.Epoch/RewriteTimestamp` |
| Engine | `engine/engineutil/filesync.go` | `LocalDirExport` wraps outputFS with fsutil mtime clamp |
| Engine | `engine/engineutil/executor.go` | `ExecutionMetadata.SourceDateEpoch` field |
| Engine | `engine/engineutil/executor_spec.go` | `setupSourceDateEpoch` injects env var into container process |
| Engine | `engine/opts.go` | `ClientMetadata.SourceDateEpoch` field |
| Client | `engine/client/client.go` | reads `SOURCE_DATE_EPOCH` env into metadata |
| Schema | `core/schema/container.go` | `rewriteTimestamp` arg + `resolveSourceDateEpoch` helper |
| Schema | `core/schema/directory.go` | `rewriteTimestamp` arg on directory export |
| Core | `core/container.go`, `core/container_image.go`, `core/directory.go`, `core/changeset.go`, `core/container_exec.go` | threading |
| Test | `core/integration/container_test.go` | `TestAsTarballRewriteTimestamp` |

## Test plan

- [ ] `dagger call go-sdk generate export --path=.` — regenerate SDK bindings (adds `RewriteTimestamp int` to opts structs)
- [ ] `dagger call engine-dev test --run='TestContainer/TestAsTarballRewriteTimestamp' --pkg=./core/integration`

## Risk

Low. The epoch only enters at terminal sink operations (export/publish) and exec env injection. When `SOURCE_DATE_EPOCH` is unset and `rewriteTimestamp` is not passed, behaviour is bit-for-bit identical to today.

## Related

Closes https://github.com/dagger/dagger/discussions/12313
Supersedes https://github.com/dagger/dagger/pull/10318