### PR TITLE
fix(dang): rehydrate Map fields in v2 SDK

### DIFF
--- a/core/integration/module_dang_test.go
+++ b/core/integration/module_dang_test.go
@@ -204,6 +204,47 @@ func (DangSuite) TestPrivateArg(_ context.Context, t *testctx.T) {
 	})
 }
 
+func (DangSuite) TestMapFields(_ context.Context, t *testctx.T) {
+	t.Run("map field survives rehydration", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-map-field").
+			With(daggerCall("env-json")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"PATH": "/usr/local/bin:/usr/bin:/bin"}`, out)
+	})
+
+	t.Run("map field mutation across calls", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-map-field").
+			With(daggerCall("with-env", "--name", "HOME", "--value", "/root", "env-json")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"PATH": "/usr/local/bin:/usr/bin:/bin", "HOME": "/root"}`, out)
+	})
+
+	t.Run("map nested in anonymous object field", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-map-field").
+			With(daggerCall("nested-json")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"FOO": "bar"}`, out)
+	})
+
+	t.Run("exposing a map via GraphQL errors", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		_, err := dangModule(t, c, "test-map-pub").
+			With(daggerCall("env")).
+			Stdout(ctx)
+		requireErrOut(t, err, "cannot be exposed via GraphQL")
+	})
+}
+
 func (DangSuite) TestScalars(_ context.Context, t *testctx.T) {
 	t.Run("timestamp", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/core/integration/testdata/modules/dang/test-map-field/dagger.json
+++ b/core/integration/testdata/modules/dang/test-map-field/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-map-field",
+  "engineVersion": "v0.21.5",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-map-field/main.dang
+++ b/core/integration/testdata/modules/dang/test-map-field/main.dang
@@ -9,16 +9,16 @@ type TestMapField {
     environment: ["FOO": "bar"]
   }}
 
-  pub withEnv(name: String!, value: String!): TestMapField! {
+  withEnv(name: String!, value: String!): TestMapField! {
     self.env = env.with(name, value)
     self
   }
 
-  pub envJson: String! {
+  envJson: String! {
     toJSON(env)
   }
 
-  pub nestedJson: String! {
+  nestedJson: String! {
     toJSON(config.environment)
   }
 }

--- a/core/integration/testdata/modules/dang/test-map-field/main.dang
+++ b/core/integration/testdata/modules/dang/test-map-field/main.dang
@@ -1,0 +1,24 @@
+"""
+Exercises Map values stored in private fields surviving the serialization
+round-trip between function calls.
+"""
+type TestMapField {
+  let env = ["PATH": "/usr/local/bin:/usr/bin:/bin"]
+
+  let config = {{
+    environment: ["FOO": "bar"]
+  }}
+
+  pub withEnv(name: String!, value: String!): TestMapField! {
+    self.env = env.with(name, value)
+    self
+  }
+
+  pub envJson: String! {
+    toJSON(env)
+  }
+
+  pub nestedJson: String! {
+    toJSON(config.environment)
+  }
+}

--- a/core/integration/testdata/modules/dang/test-map-pub/dagger.json
+++ b/core/integration/testdata/modules/dang/test-map-pub/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-map-pub",
+  "engineVersion": "v0.21.5",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/modules/dang/test-map-pub/main.dang
+++ b/core/integration/testdata/modules/dang/test-map-pub/main.dang
@@ -1,0 +1,8 @@
+"""
+A module that tries to expose a Map via GraphQL, which is unsupported.
+"""
+type TestMapPub {
+  pub env: Map[String!]! {
+    ["FOO": "bar"]
+  }
+}

--- a/core/integration/testdata/modules/dang/test-map-pub/main.dang
+++ b/core/integration/testdata/modules/dang/test-map-pub/main.dang
@@ -2,7 +2,7 @@
 A module that tries to expose a Map via GraphQL, which is unsupported.
 """
 type TestMapPub {
-  pub env: Map[String!]! {
+  env: Map[String!]! {
     ["FOO": "bar"]
   }
 }

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"path/filepath"
+	"slices"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/dagger/dagger/core"
@@ -795,6 +797,8 @@ func dangTypeToTypeDef(ctx context.Context, srv *dagql.Server, dangType hm.Type,
 	})
 
 	switch t := dangType.(type) {
+	case dang.MapType:
+		return res, fmt.Errorf("%s cannot be exposed via GraphQL; store maps in private (non-pub) fields instead", t)
 	case dang.ListType:
 		elemTypeDef, err := dangTypeToTypeDef(ctx, srv, t.Type, localTypes)
 		if err != nil {
@@ -1139,7 +1143,31 @@ func (c dangConverter) convertList(ctx context.Context, vals []any, fieldType hm
 	return listVal, nil
 }
 
+// convertMap rehydrates a Map-typed field from its serialized JSON object.
+// JSON decoding does not preserve key order, so keys are sorted to keep
+// rehydrated maps deterministic.
+func (c dangConverter) convertMap(ctx context.Context, vals map[string]any, mapT dang.MapType) (dang.Value, error) {
+	mapVal := dang.MapValue{
+		Keys:    make([]string, 0, len(vals)),
+		Entries: make(map[string]dang.Value, len(vals)),
+		ValType: mapT.Type,
+	}
+	for _, key := range slices.Sorted(maps.Keys(vals)) {
+		entryVal, err := c.convert(ctx, vals[key], mapT.Type)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert map entry %q: %w", key, err)
+		}
+		mapVal.Keys = append(mapVal.Keys, key)
+		mapVal.Entries[key] = entryVal
+	}
+	return mapVal, nil
+}
+
 func (c dangConverter) convertObject(ctx context.Context, vals map[string]any, fieldType hm.Type) (dang.Value, error) {
+	if mapT, isMap := fieldType.(dang.MapType); isMap {
+		return c.convertMap(ctx, vals, mapT)
+	}
+
 	mod, isMod := fieldType.(dang.TypeScope)
 	if !isMod {
 		return nil, fmt.Errorf("expected module type, got %T", fieldType)

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -798,7 +798,7 @@ func dangTypeToTypeDef(ctx context.Context, srv *dagql.Server, dangType hm.Type,
 
 	switch t := dangType.(type) {
 	case dang.MapType:
-		return res, fmt.Errorf("%s cannot be exposed via GraphQL; store maps in private (non-pub) fields instead", t)
+		return res, fmt.Errorf("%s cannot be exposed via GraphQL; store maps in private (let) fields instead", t)
 	case dang.ListType:
 		elemTypeDef, err := dangTypeToTypeDef(ctx, srv, t.Type, localTypes)
 		if err != nil {


### PR DESCRIPTION
## What

Dang modules can now store `Map` values in private (non-`pub`) fields and have them survive the serialization round-trip between function calls. Previously, calling any method on an object whose serialized state contained a map failed during rehydration:

```
❯ dagger -m mod/apko/ call wolfi --packages go with-exec --args ls stdout
✘ .wolfi(packages: ["go"]): Container! 0.0s ERROR
! convert field config: failed to convert map item "environment": expected module type, got dang.MapType
```

## Why

Dang recently gained a `Map` collection type, but the v2 runtime's state converter assumed every serialized JSON object was a module object. Maps still can't cross the GraphQL boundary — GraphQL has no way to express them — so exposing one as a `pub` field, return type, or argument now fails with an explicit error (`Map[String!] cannot be exposed via GraphQL; store maps in private (let) fields instead`) rather than `unknown type: dang.MapType`.

Note: JSON objects don't preserve key order, so rehydrated maps come back with sorted keys rather than insertion order, keeping them deterministic across calls.

## How

- `convertObject` checks for `dang.MapType` before assuming a module type and rebuilds the field as a `dang.MapValue` via a new `convertMap` helper, converting entries recursively against the map's value type.
- `dangTypeToTypeDef` rejects `dang.MapType` with a dedicated error message.
- Added `TestDang/TestMapFields` integration tests covering rehydration of a private map field, mutation across chained calls, a map nested inside an anonymous object field (the shape from the repro above), and the error when exposing a map publicly.

Only the v2 SDK is touched; v1 predates the Map type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
