### PR TITLE
Global module settings: configuration-only entries in dagger.toml

### DIFF
--- a/.changes/unreleased/Added-20260611-160000.yaml
+++ b/.changes/unreleased/Added-20260611-160000.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Configure modules without installing them with configuration-only entries in dagger.toml — a `modules` entry keyed by a module source ref with no `source` field applies its settings to any load of that source, including transitive dependencies and toolchains
+time: 2026-06-11T16:00:00.000000000+02:00
+custom:
+    Author: eunomie
+    PR: "13422"

--- a/core/globalmodulesettings.go
+++ b/core/globalmodulesettings.go
@@ -1,0 +1,138 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/core/gitref"
+)
+
+// Global module settings are the configuration-only entries of the workspace
+// dagger.toml: `[modules."<source ref>".settings]` entries with no source
+// field. They are carried through module loading as a (canonical key ->
+// settings) map and applied to any module whose resolved source matches a
+// key, at any depth of the dependency tree.
+
+// EncodeGlobalSettings encodes the global settings map as the JSON carried by
+// the asModule globalSettingsJson argument. json.Marshal sorts map keys, so
+// equal maps produce byte-identical encodings and one module identity.
+func EncodeGlobalSettings(settings map[string]map[string]any) (string, error) {
+	if len(settings) == 0 {
+		return "", nil
+	}
+	encoded, err := json.Marshal(settings)
+	if err != nil {
+		return "", fmt.Errorf("encoding global module settings: %w", err)
+	}
+	return string(encoded), nil
+}
+
+// DecodeGlobalSettings decodes the asModule globalSettingsJson argument.
+func DecodeGlobalSettings(encoded string) (map[string]map[string]any, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	var settings map[string]map[string]any
+	if err := json.Unmarshal([]byte(encoded), &settings); err != nil {
+		return nil, fmt.Errorf("decoding global module settings: %w", err)
+	}
+	return settings, nil
+}
+
+// MergeModuleSettings merges matched global settings under a module's own
+// instance settings: every key of instance wins over a case-insensitive
+// equivalent in global.
+func MergeModuleSettings(global, instance map[string]any) map[string]any {
+	merged := make(map[string]any, len(global)+len(instance))
+	for key, value := range global {
+		hasInstanceKey := false
+		for instanceKey := range instance {
+			if strings.EqualFold(instanceKey, key) {
+				hasInstanceKey = true
+				break
+			}
+		}
+		if !hasInstanceKey {
+			merged[key] = value
+		}
+	}
+	for key, value := range instance {
+		merged[key] = value
+	}
+	return merged
+}
+
+// CanonicalGlobalSettingsKey returns the canonical matching key for a
+// configuration-only module settings entry key. Local keys must already be
+// resolved to an absolute path by the caller. Git keys are normalized so that
+// scheme and user variants of the same ref produce the same key.
+func CanonicalGlobalSettingsKey(ctx context.Context, key string) (string, error) {
+	if FastModuleSourceKindCheck(key, "") == ModuleSourceKindLocal {
+		return filepath.Clean(key), nil
+	}
+	parsed, err := gitref.Parse(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	version := ""
+	if parsed.HasVersion {
+		version = parsed.ModVersion
+	}
+	return GitRefString(normalizeCloneRef(parsed.CloneRef), parsed.RepoRootSubdir, version), nil
+}
+
+// GlobalSettingsForSource returns the settings of the most specific
+// configuration-only entry matching src, or nil. Git sources match their
+// version-restricted key first, then the version-agnostic one; local sources
+// match by context directory + subpath.
+func GlobalSettingsForSource(src *ModuleSource, settings map[string]map[string]any) map[string]any {
+	if len(settings) == 0 {
+		return nil
+	}
+	for _, key := range globalSettingsMatchKeys(src) {
+		if matched, ok := settings[key]; ok {
+			return matched
+		}
+	}
+	return nil
+}
+
+// globalSettingsMatchKeys returns the canonical keys a loaded module source is
+// matched under, most specific first.
+func globalSettingsMatchKeys(src *ModuleSource) []string {
+	switch src.Kind {
+	case ModuleSourceKindLocal:
+		return []string{filepath.Clean(src.AsString())}
+	case ModuleSourceKindGit:
+		cloneRef := normalizeCloneRef(src.Git.CloneRef)
+		var keys []string
+		if src.Git.Version != "" {
+			keys = append(keys, GitRefString(cloneRef, src.SourceRootSubpath, src.Git.Version))
+		}
+		return append(keys, GitRefString(cloneRef, src.SourceRootSubpath, ""))
+	default:
+		return nil
+	}
+}
+
+// normalizeCloneRef reduces the scheme, user and ".git" variants of a git
+// clone ref to one canonical form, e.g. "https://github.com/dagger/dagger",
+// "git@github.com:dagger/dagger" and "github.com/dagger/dagger.git" all
+// normalize to "github.com/dagger/dagger".
+func normalizeCloneRef(cloneRef string) string {
+	ref := cloneRef
+	for _, scheme := range []gitref.SchemeType{gitref.SchemeHTTPS, gitref.SchemeHTTP, gitref.SchemeSSH} {
+		if strings.HasPrefix(ref, scheme.Prefix()) {
+			ref = strings.TrimPrefix(ref, scheme.Prefix())
+			break
+		}
+	}
+	if user, rest, ok := strings.Cut(ref, "@"); ok && !strings.ContainsAny(user, "/:") {
+		ref = rest
+	}
+	ref = strings.Replace(ref, ":", "/", 1)
+	return strings.TrimSuffix(ref, ".git")
+}

--- a/core/globalmodulesettings_test.go
+++ b/core/globalmodulesettings_test.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalGlobalSettingsKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "git ref with subpath",
+			key:  "github.com/dagger/dagger/modules/go",
+			want: "github.com/dagger/dagger/modules/go",
+		},
+		{
+			name: "git ref without subpath",
+			key:  "github.com/shykes/hello",
+			want: "github.com/shykes/hello",
+		},
+		{
+			name: "git ref with version",
+			key:  "github.com/dagger/dagger/modules/go@v0.19",
+			want: "github.com/dagger/dagger/modules/go@v0.19",
+		},
+		{
+			name: "https scheme normalizes to plain ref",
+			key:  "https://github.com/dagger/dagger/modules/go",
+			want: "github.com/dagger/dagger/modules/go",
+		},
+		{
+			name: "dot git suffix normalizes to plain ref",
+			key:  "github.com/dagger/dagger.git/modules/go",
+			want: "github.com/dagger/dagger/modules/go",
+		},
+		{
+			name: "scp-like ssh ref normalizes to plain ref",
+			key:  "git@github.com:dagger/dagger/modules/go",
+			want: "github.com/dagger/dagger/modules/go",
+		},
+		{
+			name: "absolute local path",
+			key:  "/work/vendored/go-toolchain",
+			want: "/work/vendored/go-toolchain",
+		},
+		{
+			name: "absolute local path is cleaned",
+			key:  "/work/vendored/../vendored/go-toolchain/",
+			want: "/work/vendored/go-toolchain",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := CanonicalGlobalSettingsKey(ctx, tc.key)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGlobalSettingsForSource(t *testing.T) {
+	t.Parallel()
+
+	gitSrc := func(cloneRef, subpath, version string) *ModuleSource {
+		return &ModuleSource{
+			Kind:              ModuleSourceKindGit,
+			SourceRootSubpath: subpath,
+			Git: &GitModuleSource{
+				CloneRef: cloneRef,
+				Version:  version,
+			},
+		}
+	}
+	localSrc := func(contextPath, subpath string) *ModuleSource {
+		return &ModuleSource{
+			Kind:              ModuleSourceKindLocal,
+			SourceRootSubpath: subpath,
+			Local: &LocalModuleSource{
+				ContextDirectoryPath: contextPath,
+			},
+		}
+	}
+
+	t.Run("matches a git source on any version", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go": {"version": "1.25"},
+		}
+		require.Equal(t, map[string]any{"version": "1.25"},
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", "v0.19.0"), settings))
+		require.Equal(t, map[string]any{"version": "1.25"},
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", "main"), settings))
+	})
+
+	t.Run("matches scheme variants of the same git ref", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go": {"version": "1.25"},
+		}
+		require.Equal(t, map[string]any{"version": "1.25"},
+			GlobalSettingsForSource(gitSrc("https://github.com/dagger/dagger", "modules/go", ""), settings))
+	})
+
+	t.Run("a version in the key restricts the match", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go@v0.19.0": {"version": "1.25"},
+		}
+		require.Equal(t, map[string]any{"version": "1.25"},
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", "v0.19.0"), settings))
+		require.Nil(t,
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", "v0.20.0"), settings))
+	})
+
+	t.Run("a versioned entry wins over a version-agnostic one", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go":         {"version": "1.24"},
+			"github.com/dagger/dagger/modules/go@v0.19.0": {"version": "1.25"},
+		}
+		require.Equal(t, map[string]any{"version": "1.25"},
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", "v0.19.0"), settings))
+		require.Equal(t, map[string]any{"version": "1.24"},
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", "v0.20.0"), settings))
+	})
+
+	t.Run("does not match a different subpath", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go": {"version": "1.25"},
+		}
+		require.Nil(t,
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/wolfi", ""), settings))
+	})
+
+	t.Run("matches a local source by context directory and subpath", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]map[string]any{
+			"/work/vendored/go-toolchain": {"version": "1.25"},
+		}
+		require.Equal(t, map[string]any{"version": "1.25"},
+			GlobalSettingsForSource(localSrc("/work", "vendored/go-toolchain"), settings))
+		require.Nil(t,
+			GlobalSettingsForSource(localSrc("/work", "vendored/other"), settings))
+	})
+
+	t.Run("returns nil when there are no settings", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t,
+			GlobalSettingsForSource(gitSrc("github.com/dagger/dagger", "modules/go", ""), nil))
+	})
+}

--- a/core/integration/workspace_global_settings_test.go
+++ b/core/integration/workspace_global_settings_test.go
@@ -1,0 +1,229 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// Global module settings: configuration-only entries in dagger.toml — a
+// `modules` entry keyed by a module source ref, with no source field —
+// inject their settings as constructor defaults into any load of that
+// source in the session, at any depth of the dependency tree.
+
+func (WorkspaceSuite) TestGlobalModuleSettings(ctx context.Context, t *testctx.T) {
+	t.Run("configures a dependency of an installed module", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.app]
+source = "./app"
+
+[modules."./lib".settings]
+greeting = "configured"
+`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "app", "greet")
+		require.NoError(t, err)
+		require.Equal(t, "configured", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("explicit caller argument wins", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.app]
+source = "./app"
+
+[modules."./lib".settings]
+greeting = "configured"
+`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "app", "greet-explicit")
+		require.NoError(t, err)
+		require.Equal(t, "explicit", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("reaches dependencies at any depth", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.deep-app]
+source = "./deep-app"
+
+[modules."./lib".settings]
+greeting = "configured"
+`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "deep-app", "deep-greet")
+		require.NoError(t, err)
+		require.Equal(t, "configured", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("installed instance settings win, the rest still applies", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.lib]
+source = "./lib"
+
+[modules.lib.settings]
+greeting = "instance"
+
+[modules."./lib".settings]
+greeting = "configured"
+suffix = "!"
+`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "lib", "message")
+		require.NoError(t, err)
+		require.Equal(t, "instance!", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("applies to modules loaded with -m", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules."./lib".settings]
+greeting = "configured"
+
+[env.ci.modules."./lib".settings]
+greeting = "from-ci"
+`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "-m", "./lib", "call", "message")
+		require.NoError(t, err)
+		require.Equal(t, "configured", strings.TrimSpace(string(out)))
+
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "-m", "./lib", "call", "--help")
+		require.NoError(t, err)
+		require.Regexp(t, `--greeting string *\(default "configured"\)`, string(out))
+
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "-m", "./lib", "call", "message")
+		require.NoError(t, err)
+		require.Equal(t, "from-ci", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("env overlays apply to configuration-only entries", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.app]
+source = "./app"
+
+[modules."./lib".settings]
+greeting = "configured"
+
+[env.ci.modules."./lib".settings]
+greeting = "from-ci"
+`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "app", "greet")
+		require.NoError(t, err)
+		require.Equal(t, "configured", strings.TrimSpace(string(out)))
+
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "call", "app", "greet")
+		require.NoError(t, err)
+		require.Equal(t, "from-ci", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("rejects a bare name without source", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.app]
+source = "./app"
+
+[modules.lib.settings]
+greeting = "configured"
+`)
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "app", "greet")
+		requireErrOut(t, err, `workspace module "lib" has no source`)
+	})
+
+	t.Run("rejects non-settings fields on configuration-only entries", func(ctx context.Context, t *testctx.T) {
+		workdir := newGlobalSettingsWorkdir(ctx, t, `[modules.app]
+source = "./app"
+
+[modules."./lib"]
+entrypoint = true
+
+[modules."./lib".settings]
+greeting = "configured"
+`)
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "app", "greet")
+		requireErrOut(t, err, `configuration-only module entry "./lib" must only carry settings`)
+	})
+}
+
+// newGlobalSettingsWorkdir scaffolds a workspace with the given dagger.toml
+// and a small module tree: app depends on lib, deep-app depends on mid which
+// depends on lib. lib's constructor args are optional so callers leave them
+// unset and settings can inject them.
+func newGlobalSettingsWorkdir(ctx context.Context, t *testctx.T, configTOML string) string {
+	t.Helper()
+
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+
+	writeGlobalSettingsFiles(t, workdir, map[string]string{
+		"lib/dagger.json": `{"name":"lib","engineVersion":"latest","sdk":{"source":"go"}}`,
+		"lib/main.go": `package main
+
+type Lib struct {
+	GreetingValue string
+	SuffixValue   string
+}
+
+func New(
+	// +optional
+	greeting string,
+	// +optional
+	suffix string,
+) *Lib {
+	return &Lib{GreetingValue: greeting, SuffixValue: suffix}
+}
+
+func (m *Lib) Message() string {
+	return m.GreetingValue + m.SuffixValue
+}
+`,
+		"app/dagger.json": `{"name":"app","engineVersion":"latest","sdk":{"source":"go"},"dependencies":[{"name":"lib","source":"../lib"}]}`,
+		"app/main.go": `package main
+
+import (
+	"context"
+
+	"dagger/app/internal/dagger"
+)
+
+type App struct{}
+
+func (m *App) Greet(ctx context.Context) (string, error) {
+	return dag.Lib().Message(ctx)
+}
+
+func (m *App) GreetExplicit(ctx context.Context) (string, error) {
+	return dag.Lib(dagger.LibOpts{Greeting: "explicit"}).Message(ctx)
+}
+`,
+		"mid/dagger.json": `{"name":"mid","engineVersion":"latest","sdk":{"source":"go"},"dependencies":[{"name":"lib","source":"../lib"}]}`,
+		"mid/main.go": `package main
+
+import "context"
+
+type Mid struct{}
+
+func (m *Mid) Relay(ctx context.Context) (string, error) {
+	return dag.Lib().Message(ctx)
+}
+`,
+		"deep-app/dagger.json": `{"name":"deep-app","engineVersion":"latest","sdk":{"source":"go"},"dependencies":[{"name":"mid","source":"../mid"}]}`,
+		"deep-app/main.go": `package main
+
+import "context"
+
+type DeepApp struct{}
+
+func (m *DeepApp) DeepGreet(ctx context.Context) (string, error) {
+	return dag.Mid().Relay(ctx)
+}
+`,
+	})
+	writeWorkspaceConfigFile(t, workdir, configTOML)
+	return workdir
+}
+
+func writeGlobalSettingsFiles(t *testctx.T, workdir string, files map[string]string) {
+	t.Helper()
+	for path, contents := range files {
+		fullPath := filepath.Join(workdir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(contents), 0o644))
+	}
+}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2435,7 +2435,9 @@ func (s *moduleSourceSchema) runCodegen(
 	}
 
 	// load the deps as actual Modules
-	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
+	// Codegen output must not depend on workspace settings, so no global
+	// settings are threaded here.
+	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst, "")
 	if err != nil {
 		return res, fmt.Errorf("failed to load dependencies as modules: %w", err)
 	}
@@ -2643,7 +2645,7 @@ func (s *moduleSourceSchema) runClientGenerator(
 		return genDirInst, fmt.Errorf("failed to add module source required files: %w", err)
 	}
 
-	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
+	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst, "")
 	if err != nil {
 		return genDirInst, fmt.Errorf("failed to load dependencies of this modules: %w", err)
 	}
@@ -3003,7 +3005,7 @@ func (s *moduleSourceSchema) moduleSourceIntrospectionSchemaJSON(
 	src dagql.ObjectResult[*core.ModuleSource],
 	args struct{},
 ) (inst dagql.Result[*core.File], rerr error) {
-	deps, err := s.loadDependencyModules(ctx, src, src)
+	deps, err := s.loadDependencyModules(ctx, src, src, "")
 	if err != nil {
 		return inst, err
 	}
@@ -3089,6 +3091,14 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 
 		// DefaultPathContextSourcePin pins DefaultPathContextSourceRef when set.
 		DefaultPathContextSourcePin string `internal:"true" default:""`
+
+		// GlobalSettingsJSON is a JSON-encoded map[string]map[string]any keyed
+		// by canonical module source ref, carrying the workspace's
+		// configuration-only settings. A module whose resolved source matches
+		// a key receives the settings as constructor defaults, and the map is
+		// threaded down into dependency and toolchain loads so it reaches any
+		// depth of the tree.
+		GlobalSettingsJSON string `internal:"true" default:""`
 	},
 ) (inst dagql.ObjectResult[*core.Module], err error) {
 	dag, err := core.CurrentDagqlServer(ctx)
@@ -3168,7 +3178,7 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 		mod.SDKConfig = &core.SDKConfig{}
 	}
 
-	mod.Deps, err = s.loadDependencyModules(ctx, execSrc, defaultPathContextSrc)
+	mod.Deps, err = s.loadDependencyModules(ctx, execSrc, defaultPathContextSrc, args.GlobalSettingsJSON)
 	if err != nil {
 		return inst, fmt.Errorf("failed to load dependencies as modules: %w", err)
 	}
@@ -3195,6 +3205,7 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 		args.LegacyWorkspaceConfigJSON,
 		fmt.Sprintf("%t", args.LegacyDefaultsFromDotEnv),
 		args.LegacyArgCustomizationsJSON,
+		args.GlobalSettingsJSON,
 	).String()
 
 	// Apply legacy settings that must be set before Install runs.
@@ -3204,13 +3215,8 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	if args.LegacyDefaultPath {
 		mod.LegacyDefaultPath = true
 	}
-	if args.LegacyWorkspaceConfigJSON != "" {
-		var wsConfig map[string]any
-		if err := json.Unmarshal([]byte(args.LegacyWorkspaceConfigJSON), &wsConfig); err != nil {
-			return inst, fmt.Errorf("decoding legacy workspace config: %w", err)
-		}
-		mod.WorkspaceConfig = wsConfig
-		mod.DefaultsFromDotEnv = args.LegacyDefaultsFromDotEnv
+	if err := applyModuleWorkspaceSettings(mod, originalSrc.Self(), args.LegacyWorkspaceConfigJSON, args.LegacyDefaultsFromDotEnv, args.GlobalSettingsJSON); err != nil {
+		return inst, err
 	}
 
 	// Initialize module based on SDK presence
@@ -3229,7 +3235,7 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 
 	// Apply legacy arg customizations and workspace defaults after type defs
 	// are populated (SDK codegen has run) but before the result is cached.
-	if args.LegacyWorkspaceConfigJSON != "" {
+	if mod.WorkspaceConfig != nil {
 		if err := mod.ApplyWorkspaceDefaultsToTypeDefs(ctx, dag); err != nil {
 			return inst, err
 		}
@@ -3252,6 +3258,28 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	return inst, nil
 }
 
+// applyModuleWorkspaceSettings sets the module's workspace settings from its
+// instance config and any matched configuration-only settings, merged so that
+// explicit args and installed-entry settings win over global ones.
+func applyModuleWorkspaceSettings(mod *core.Module, src *core.ModuleSource, legacyWorkspaceConfigJSON string, legacyDefaultsFromDotEnv bool, globalSettingsJSON string) error {
+	if legacyWorkspaceConfigJSON != "" {
+		var wsConfig map[string]any
+		if err := json.Unmarshal([]byte(legacyWorkspaceConfigJSON), &wsConfig); err != nil {
+			return fmt.Errorf("decoding legacy workspace config: %w", err)
+		}
+		mod.WorkspaceConfig = wsConfig
+		mod.DefaultsFromDotEnv = legacyDefaultsFromDotEnv
+	}
+	globalSettings, err := core.DecodeGlobalSettings(globalSettingsJSON)
+	if err != nil {
+		return err
+	}
+	if matched := core.GlobalSettingsForSource(src, globalSettings); matched != nil {
+		mod.WorkspaceConfig = core.MergeModuleSettings(matched, mod.WorkspaceConfig)
+	}
+	return nil
+}
+
 // load the given module source's dependencies as modules
 // BuildLegacyAsModuleArgs is the single builder for the asModule args salted
 // into AsModuleVariantDigest, so every load path yields one module identity.
@@ -3263,6 +3291,7 @@ func BuildLegacyAsModuleArgs(
 	configDefaults map[string]any,
 	defaultsFromDotEnv bool,
 	argCustomizations []*modules.ModuleConfigArgument,
+	globalSettingsJSON string,
 ) ([]dagql.NamedInput, error) {
 	args := []dagql.NamedInput{}
 	if nameOverride != "" {
@@ -3308,6 +3337,11 @@ func BuildLegacyAsModuleArgs(
 			Name: "legacyArgCustomizationsJson", Value: dagql.String(string(custJSON)),
 		})
 	}
+	if globalSettingsJSON != "" {
+		args = append(args, dagql.NamedInput{
+			Name: "globalSettingsJson", Value: dagql.String(globalSettingsJSON),
+		})
+	}
 	return args, nil
 }
 
@@ -3315,6 +3349,7 @@ func (s *moduleSourceSchema) loadDependencyModules(
 	ctx context.Context,
 	src dagql.ObjectResult[*core.ModuleSource],
 	defaultPathContextSrc dagql.ObjectResult[*core.ModuleSource],
+	globalSettingsJSON string,
 ) (_ *core.SchemaBuilder, rerr error) {
 	ctx, span := core.Tracer(ctx).Start(ctx, "load dep modules", telemetry.Internal())
 	defer telemetry.EndWithCause(span, &rerr)
@@ -3328,12 +3363,19 @@ func (s *moduleSourceSchema) loadDependencyModules(
 		return nil, fmt.Errorf("failed to get dag server: %w", err)
 	}
 
+	var depAsModuleArgs []dagql.NamedInput
+	if globalSettingsJSON != "" {
+		depAsModuleArgs = append(depAsModuleArgs, dagql.NamedInput{
+			Name: "globalSettingsJson", Value: dagql.String(globalSettingsJSON),
+		})
+	}
+
 	var eg errgroup.Group
 	depMods := make([]dagql.ObjectResult[*core.Module], len(src.Self().Dependencies))
 	for i, depSrc := range src.Self().Dependencies {
 		eg.Go(func() error {
 			return dag.Select(ctx, depSrc, &depMods[i],
-				dagql.Selector{Field: "asModule"},
+				dagql.Selector{Field: "asModule", Args: depAsModuleArgs},
 			)
 		})
 	}
@@ -3368,6 +3410,7 @@ func (s *moduleSourceSchema) loadDependencyModules(
 				configDefaults,
 				false, // DefaultsFromDotEnv is not set for related modules
 				argCustomizations,
+				globalSettingsJSON,
 			)
 			if err != nil {
 				return fmt.Errorf("build toolchain asModule args: %w", err)

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -124,6 +124,48 @@ func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 	return applied, nil
 }
 
+// GlobalModuleSettings validates and collects the configuration-only entries
+// in cfg: entries with no source, keyed by a module source ref, carrying only
+// settings. Such an entry loads nothing; its settings apply to any load of the
+// matching source in the session. Keys are returned as written in dagger.toml;
+// callers canonicalize them before matching.
+func GlobalModuleSettings(cfg *Config) (map[string]map[string]any, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	var settings map[string]map[string]any
+	for name, entry := range cfg.Modules {
+		if entry.Source != "" {
+			continue
+		}
+		if !isModuleSourceRefKey(name) {
+			return nil, fmt.Errorf("workspace module %q has no source; configuration-only entries must be keyed by a module source ref (git ref or local path)", name)
+		}
+		if entry.Entrypoint || entry.LegacyDefaultPath ||
+			len(entry.Up.Skip) > 0 || len(entry.Generate.Skip) > 0 || len(entry.Check.Skip) > 0 {
+			return nil, fmt.Errorf("configuration-only module entry %q must only carry settings", name)
+		}
+		if len(entry.Settings) == 0 {
+			continue
+		}
+		if settings == nil {
+			settings = map[string]map[string]any{}
+		}
+		settings[name] = entry.Settings
+	}
+	return settings, nil
+}
+
+// isModuleSourceRefKey reports whether a configuration-only entry key looks
+// like a module source ref rather than a bare module name: an explicit local
+// path or a git-style ref with a path component.
+func isModuleSourceRefKey(key string) bool {
+	if len(key) > 0 && (key[0] == '/' || key[0] == '.') {
+		return true
+	}
+	return strings.Contains(key, "/")
+}
+
 // EnvNames returns the configured environment names in deterministic order.
 func EnvNames(cfg *Config) []string {
 	if cfg == nil || len(cfg.Env) == 0 {
@@ -274,7 +316,10 @@ func writeModuleEntries(b *strings.Builder, modules map[string]ModuleEntry) bool
 		entry := modules[name]
 		modulePath := "modules." + formatConfigPathSegment(name)
 		fmt.Fprintf(b, "[%s]\n", modulePath)
-		fmt.Fprintf(b, "source = %q\n", entry.Source)
+		// Configuration-only entries have no source.
+		if entry.Source != "" {
+			fmt.Fprintf(b, "source = %q\n", entry.Source)
+		}
 		if entry.Entrypoint {
 			b.WriteString("entrypoint = true\n")
 		}

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -97,8 +97,10 @@ func configDocumentMap(cfg *Config) map[string]any {
 	if len(cfg.Modules) > 0 {
 		modules := make(map[string]any, len(cfg.Modules))
 		for name, entry := range cfg.Modules {
-			module := map[string]any{
-				"source": entry.Source,
+			module := map[string]any{}
+			// Configuration-only entries have no source.
+			if entry.Source != "" {
+				module["source"] = entry.Source
 			}
 			if entry.Entrypoint {
 				module["entrypoint"] = true

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -689,3 +689,139 @@ func TestResolveModuleEntrySource(t *testing.T) {
 		require.Equal(t, "github.com/dagger/dagger/modules/wolfi", ResolveModuleEntrySource(LockDirName, "github.com/dagger/dagger/modules/wolfi"))
 	})
 }
+
+func TestGlobalModuleSettings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects configuration-only entries keyed by source ref", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte(`[modules.my-app]
+source = "./my-app"
+entrypoint = true
+
+[modules.my-app.settings]
+greeting = "hello"
+
+[modules."github.com/dagger/dagger/modules/go".settings]
+version = "1.25"
+
+[modules."./vendored/go-toolchain".settings]
+extraPackages = ["git"]
+`))
+		require.NoError(t, err)
+
+		settings, err := GlobalModuleSettings(cfg)
+		require.NoError(t, err)
+		require.Equal(t, map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go": {
+				"version": "1.25",
+			},
+			"./vendored/go-toolchain": {
+				"extraPackages": []any{"git"},
+			},
+		}, settings)
+	})
+
+	t.Run("returns nothing when all entries are installed", func(t *testing.T) {
+		t.Parallel()
+
+		settings, err := GlobalModuleSettings(&Config{
+			Modules: map[string]ModuleEntry{
+				"my-app": {Source: "./my-app", Settings: map[string]any{"greeting": "hello"}},
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, settings)
+	})
+
+	t.Run("skips configuration-only entries without settings", func(t *testing.T) {
+		t.Parallel()
+
+		settings, err := GlobalModuleSettings(&Config{
+			Modules: map[string]ModuleEntry{
+				"github.com/dagger/dagger/modules/go": {},
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, settings)
+	})
+
+	t.Run("rejects a bare name without source", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := GlobalModuleSettings(&Config{
+			Modules: map[string]ModuleEntry{
+				"go": {Settings: map[string]any{"version": "1.25"}},
+			},
+		})
+		require.EqualError(t, err, `workspace module "go" has no source; configuration-only entries must be keyed by a module source ref (git ref or local path)`)
+	})
+
+	t.Run("rejects non-settings fields on configuration-only entries", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := GlobalModuleSettings(&Config{
+			Modules: map[string]ModuleEntry{
+				"github.com/dagger/dagger/modules/go": {
+					Entrypoint: true,
+					Settings:   map[string]any{"version": "1.25"},
+				},
+			},
+		})
+		require.EqualError(t, err, `configuration-only module entry "github.com/dagger/dagger/modules/go" must only carry settings`)
+
+		_, err = GlobalModuleSettings(&Config{
+			Modules: map[string]ModuleEntry{
+				"./vendored/go-toolchain": {
+					Up: ModuleSkip{Skip: []string{"redis"}},
+				},
+			},
+		})
+		require.EqualError(t, err, `configuration-only module entry "./vendored/go-toolchain" must only carry settings`)
+	})
+
+	t.Run("env overlays apply to configuration-only entries", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte(`[modules."github.com/dagger/dagger/modules/dev".settings]
+githubToken = "op://infra/github/token"
+
+[env.ci.modules."github.com/dagger/dagger/modules/dev".settings]
+githubToken = "env://GITHUB_TOKEN"
+`))
+		require.NoError(t, err)
+
+		applied, err := ApplyEnvOverlay(cfg, "ci")
+		require.NoError(t, err)
+
+		settings, err := GlobalModuleSettings(applied)
+		require.NoError(t, err)
+		require.Equal(t, map[string]map[string]any{
+			"github.com/dagger/dagger/modules/dev": {
+				"githubToken": "env://GITHUB_TOKEN",
+			},
+		}, settings)
+	})
+}
+
+func TestSerializeConfigConfigurationOnlyEntries(t *testing.T) {
+	t.Parallel()
+
+	out := SerializeConfig(&Config{
+		Modules: map[string]ModuleEntry{
+			"my-app": {Source: "./my-app"},
+			"github.com/dagger/dagger/modules/go": {
+				Settings: map[string]any{"version": "1.25"},
+			},
+		},
+	})
+	require.NotContains(t, string(out), `source = ""`)
+
+	cfg, err := ParseConfig(out)
+	require.NoError(t, err)
+	require.Equal(t, ModuleEntry{
+		Settings: map[string]any{"version": "1.25"},
+	}, cfg.Modules["github.com/dagger/dagger/modules/go"])
+	require.Equal(t, "./my-app", cfg.Modules["my-app"].Source)
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -206,11 +206,14 @@ type daggerClient struct {
 
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
-	modulesMu           sync.Mutex
-	modulesLoaded       bool
-	modulesErr          error
-	singleQueryMu       sync.Mutex
-	singleQueryServed   bool
+	// Configuration-only settings from dagger.toml, keyed by canonical module
+	// source ref. Attached to every module load of the session.
+	globalModuleSettings map[string]map[string]any
+	modulesMu            sync.Mutex
+	modulesLoaded        bool
+	modulesErr           error
+	singleQueryMu        sync.Mutex
+	singleQueryServed    bool
 
 	// NOTE: do not use this field directly as it may not be open
 	// after the client has shutdown; use TelemetryDB() instead
@@ -1549,7 +1552,7 @@ func (srv *Server) ServeModule(ctx context.Context, mod dagql.ObjectResult[*core
 				if i < len(src.Self().ConfigToolchains) {
 					cfg = src.Self().ConfigToolchains[i]
 				}
-				pending := pendingRelatedModule(defaultPathContextSrc, tcSrc.Self(), cfg, false)
+				pending := pendingRelatedModule(defaultPathContextSrc, tcSrc.Self(), cfg, false, client.globalModuleSettings)
 				tcMod, err := srv.resolveModuleSourceAsModule(ctx, client.dag, tcSrc, pending)
 				if err != nil {
 					return fmt.Errorf("error resolving toolchain module: %w", err)

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1125,6 +1125,9 @@ func TestGatherModuleLoadRequests(t *testing.T) {
 			{Ref: "github.com/acme/extra1", Name: "extra1", Entrypoint: true},
 			{Ref: "github.com/acme/extra2", Name: "extra2"},
 		},
+		map[string]map[string]any{
+			"github.com/acme/lib": {"greeting": "hello"},
+		},
 	)
 
 	require.Len(t, loads, 4)
@@ -1138,6 +1141,11 @@ func TestGatherModuleLoadRequests(t *testing.T) {
 	require.Equal(t, "github.com/acme/extra1", loads[2].mod.Ref)
 	require.Equal(t, "github.com/acme/extra2", loads[3].mod.Ref)
 	require.True(t, loads[2].mod.Entrypoint)
+	for _, load := range loads {
+		require.Equal(t, map[string]map[string]any{
+			"github.com/acme/lib": {"greeting": "hello"},
+		}, load.mod.GlobalSettings)
+	}
 }
 
 func TestModuleLoadParallelism(t *testing.T) {
@@ -1346,4 +1354,93 @@ func sessionTestModuleResult(t *testing.T, name string) dagql.ObjectResult[*core
 	)
 	require.NoError(t, err)
 	return res
+}
+
+func TestWorkspaceConfigPendingModulesSkipsConfigOnlyEntries(t *testing.T) {
+	t.Parallel()
+
+	ws := &workspace.Workspace{
+		Root:       "/repo",
+		Cwd:        ".",
+		ConfigFile: workspace.ConfigFileName,
+	}
+	resolveLocalRef := func(_ *workspace.Workspace, relPath string) string {
+		return filepath.Join("/resolved", relPath)
+	}
+
+	pending := workspaceConfigPendingModules(ws, &workspace.Config{
+		Modules: map[string]workspace.ModuleEntry{
+			"my-app": {
+				Source:     "./my-app",
+				Entrypoint: true,
+			},
+			"github.com/dagger/dagger/modules/go": {
+				Settings: map[string]any{"version": "1.25"},
+			},
+		},
+	}, resolveLocalRef)
+
+	require.Len(t, pending, 1)
+	require.Equal(t, "my-app", pending[0].Name)
+}
+
+func TestWorkspaceGlobalModuleSettings(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ws := &workspace.Workspace{
+		Root:       "/repo",
+		Cwd:        ".",
+		ConfigFile: workspace.ConfigFileName,
+	}
+	resolveLocalRef := func(_ *workspace.Workspace, relPath string) string {
+		return filepath.Join("/repo", relPath)
+	}
+
+	t.Run("canonicalizes keys and resolves local refs", func(t *testing.T) {
+		t.Parallel()
+
+		settings, err := workspaceGlobalModuleSettings(ctx, ws, &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"my-app": {
+					Source:   "./my-app",
+					Settings: map[string]any{"greeting": "hello"},
+				},
+				"https://github.com/dagger/dagger/modules/go@v0.19": {
+					Settings: map[string]any{"version": "1.25"},
+				},
+				"./vendored/go-toolchain": {
+					Settings: map[string]any{"extraPackages": []any{"git"}},
+				},
+			},
+		}, resolveLocalRef)
+		require.NoError(t, err)
+		require.Equal(t, map[string]map[string]any{
+			"github.com/dagger/dagger/modules/go@v0.19": {"version": "1.25"},
+			"/repo/vendored/go-toolchain":               {"extraPackages": []any{"git"}},
+		}, settings)
+	})
+
+	t.Run("returns nothing without configuration-only entries", func(t *testing.T) {
+		t.Parallel()
+
+		settings, err := workspaceGlobalModuleSettings(ctx, ws, &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"my-app": {Source: "./my-app"},
+			},
+		}, resolveLocalRef)
+		require.NoError(t, err)
+		require.Empty(t, settings)
+	})
+
+	t.Run("rejects a bare name without source", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := workspaceGlobalModuleSettings(ctx, ws, &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"go": {Settings: map[string]any{"version": "1.25"}},
+			},
+		}, resolveLocalRef)
+		require.ErrorContains(t, err, `workspace module "go" has no source`)
+	})
 }

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -380,6 +380,11 @@ type pendingModule struct {
 	DefaultsFromDotEnv bool
 	ArgCustomizations  []*modules.ModuleConfigArgument
 
+	// Configuration-only settings from dagger.toml, keyed by canonical module
+	// source ref. Threaded into the module load so any matching source in the
+	// dependency tree receives its settings.
+	GlobalSettings map[string]map[string]any
+
 	// If set, load this module's implementation from Ref but resolve
 	// +defaultPath inputs from this source ref instead.
 	DefaultPathContextSourceRef string
@@ -464,6 +469,11 @@ func workspaceConfigPendingModules(
 	pending := make([]pendingModule, 0, len(names))
 	for _, name := range names {
 		entry := cfg.Modules[name]
+		if entry.Source == "" {
+			// Configuration-only entry: loads nothing, its settings are
+			// collected by workspaceGlobalModuleSettings.
+			continue
+		}
 		mod := pendingModule{
 			Kind:               moduleLoadKindAmbient,
 			Ref:                entry.Source,
@@ -492,6 +502,39 @@ func workspaceConfigPendingModules(
 	}
 
 	return pending
+}
+
+// workspaceGlobalModuleSettings collects the configuration-only entries of the
+// workspace config as a (canonical source ref -> settings) map. Relative local
+// keys are resolved from the config directory, like installed entry sources.
+func workspaceGlobalModuleSettings(
+	ctx context.Context,
+	ws *workspace.Workspace,
+	cfg *workspace.Config,
+	resolveLocalRef func(ws *workspace.Workspace, relPath string) string,
+) (map[string]map[string]any, error) {
+	raw, err := workspace.GlobalModuleSettings(cfg)
+	if err != nil || len(raw) == 0 {
+		return nil, err
+	}
+	configDir := filepath.Dir(ws.ConfigFile)
+
+	settings := make(map[string]map[string]any, len(raw))
+	for key, entrySettings := range raw {
+		ref := key
+		if core.FastModuleSourceKindCheck(key, "") == core.ModuleSourceKindLocal {
+			ref = workspace.ResolveModuleEntrySource(configDir, key)
+			if !filepath.IsAbs(ref) {
+				ref = resolveLocalRef(ws, ref)
+			}
+		}
+		canonical, err := core.CanonicalGlobalSettingsKey(ctx, ref)
+		if err != nil {
+			return nil, fmt.Errorf("configuration-only module entry %q: %w", key, err)
+		}
+		settings[canonical] = entrySettings
+	}
+	return settings, nil
 }
 
 func pendingLegacyModule(
@@ -670,7 +713,9 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	coreWS.SetCompatWorkspace(compatWorkspace)
 	client.workspace = coreWS
 
-	if !loadModules {
+	// Config-management sessions (migrate, lock, workspace install, config)
+	// load no modules at all and must keep working on an invalid config.
+	if clientMD != nil && clientMD.SkipWorkspaceModules {
 		return nil
 	}
 
@@ -688,10 +733,19 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 		}
 	}
 
-	// --- Gather all modules to load ---
-	var pending []pendingModule
+	// Configuration-only settings apply to every module load of the session,
+	// including -m loads when ambient workspace modules are not loaded.
+	client.globalModuleSettings, err = workspaceGlobalModuleSettings(ctx, ws, wsConfig, resolveLocalRef)
+	if err != nil {
+		return err
+	}
 
-	pending = workspaceConfigPendingModules(ws, wsConfig, resolveLocalRef)
+	if !loadModules {
+		return nil
+	}
+
+	// --- Gather all modules to load ---
+	pending := workspaceConfigPendingModules(ws, wsConfig, resolveLocalRef)
 	resolveCompatRef := resolveLocalRef
 	if compatWorkspace != nil {
 		configWS := *ws
@@ -858,7 +912,7 @@ func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient
 		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
-	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules)
+	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules, client.globalModuleSettings)
 	resolvedLoads := make([]resolvedModuleLoad, len(loads))
 	resolveErrs := make([]error, len(loads))
 
@@ -1096,7 +1150,7 @@ func (srv *Server) resolveModuleLoad(
 		if i < len(src.Self().ConfigToolchains) {
 			cfg = src.Self().ConfigToolchains[i]
 		}
-		pending := pendingRelatedModule(defaultPathContextSrc, toolchainSrc.Self(), cfg, false)
+		pending := pendingRelatedModule(defaultPathContextSrc, toolchainSrc.Self(), cfg, false, load.mod.GlobalSettings)
 		toolchainMod, err := srv.resolveModuleSourceAsModule(ctx, dag, toolchainSrc, pending)
 		if err != nil {
 			return resolvedModuleLoad{}, fmt.Errorf("resolving toolchain module: %w", err)
@@ -1108,7 +1162,7 @@ func (srv *Server) resolveModuleLoad(
 	}
 
 	if src.Self().Blueprint.Self() != nil {
-		pending := pendingRelatedModule(defaultPathContextSrc, src.Self().Blueprint.Self(), src.Self().ConfigBlueprint, true)
+		pending := pendingRelatedModule(defaultPathContextSrc, src.Self().Blueprint.Self(), src.Self().ConfigBlueprint, true, load.mod.GlobalSettings)
 		blueprintMod, err := srv.resolveModuleSourceAsModule(ctx, dag, src.Self().Blueprint, pending)
 		if err != nil {
 			return resolvedModuleLoad{}, fmt.Errorf("resolving blueprint module: %w", err)
@@ -1159,18 +1213,20 @@ func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []mod
 	return nil
 }
 
-func gatherModuleLoadRequests(pending []pendingModule, extras []engine.ExtraModule) []moduleLoadRequest {
+func gatherModuleLoadRequests(pending []pendingModule, extras []engine.ExtraModule, globalSettings map[string]map[string]any) []moduleLoadRequest {
 	loads := make([]moduleLoadRequest, 0, len(pending)+len(extras))
 	for _, mod := range pending {
+		mod.GlobalSettings = globalSettings
 		loads = append(loads, moduleLoadRequest{mod: mod})
 	}
 	for _, extra := range extras {
 		loads = append(loads, moduleLoadRequest{
 			mod: pendingModule{
-				Kind:       moduleLoadKindExtra,
-				Ref:        extra.Ref,
-				Name:       extra.Name,
-				Entrypoint: extra.Entrypoint,
+				Kind:           moduleLoadKindExtra,
+				Ref:            extra.Ref,
+				Name:           extra.Name,
+				Entrypoint:     extra.Entrypoint,
+				GlobalSettings: globalSettings,
 			},
 		})
 	}
@@ -1431,12 +1487,14 @@ func pendingRelatedModule(
 	related *core.ModuleSource,
 	cfg *modules.ModuleConfigDependency,
 	entrypoint bool,
+	globalSettings map[string]map[string]any,
 ) pendingModule {
 	mod := pendingModule{
-		Kind:       moduleLoadKindExtra,
-		Ref:        related.AsString(),
-		RefPin:     related.Pin(),
-		Entrypoint: entrypoint,
+		Kind:           moduleLoadKindExtra,
+		Ref:            related.AsString(),
+		RefPin:         related.Pin(),
+		Entrypoint:     entrypoint,
+		GlobalSettings: globalSettings,
 		// LegacyDefaultPath is intentionally not set here. Related modules
 		// are loaded as siblings of an explicit -m entrypoint: their
 		// +defaultPath must resolve against that entrypoint's repo (the
@@ -1495,6 +1553,10 @@ func (srv *Server) resolveModuleSourceAsModule(
 }
 
 func asModuleArgsForPendingModule(mod pendingModule) ([]dagql.NamedInput, error) {
+	globalSettingsJSON, err := core.EncodeGlobalSettings(mod.GlobalSettings)
+	if err != nil {
+		return nil, fmt.Errorf("build asModule args for %q: %w", mod.Ref, err)
+	}
 	// Delegates to the shared builder so the workspace entrypoint path and the
 	// dependency-graph toolchain load path (loadDependencyModules) produce a
 	// byte-identical AsModuleVariantDigest salt for the same logical module.
@@ -1506,6 +1568,7 @@ func asModuleArgsForPendingModule(mod pendingModule) ([]dagql.NamedInput, error)
 		mod.ConfigDefaults,
 		mod.DefaultsFromDotEnv,
 		mod.ArgCustomizations,
+		globalSettingsJSON,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build asModule args for %q: %w", mod.Ref, err)


### PR DESCRIPTION
Configuration-only entries in `dagger.toml`: a `modules` entry keyed by a module source ref, with no `source` field, loads nothing — its settings apply as constructor argument defaults to any load of that source in the session, at any depth of the dependency tree (root modules, `-m` loads, toolchains, transitive dependencies).

```toml
[modules.my-app]
source = "./my-app"

# loads nothing; applies to any load of this source in the session
[modules."github.com/dagger/dagger/modules/go".settings]
version = "1.25"
```

How it works:

- Matching is by canonical resolved source (clone ref + subpath, scheme/user/`.git` variants normalized; local keys resolve from the config dir). Version-agnostic unless the key carries `@version`.
- Precedence: explicit argument > installed entry settings > configuration-only settings > schema defaults.
- `[env.*]` overlays apply to configuration-only entries like to installed ones.
- The settings map is threaded into `asModule` as an internal argument and down through dependency and toolchain loads, keeping cache identity correct (the `legacyWorkspaceConfigJson` pattern, salted into `AsModuleVariantDigest`).
- Codegen paths intentionally receive no settings, so generated code never depends on workspace config.
- Follow-up, not in this PR: threading through the SDK loader, so settings reach SDK runtime modules themselves.

Design doc: [hack/designs/global-module-settings.md](https://github.com/eunomie/dagger/blob/java-private-registry-config/hack/designs/global-module-settings.md)
