### PR TITLE
fix(core): keep .env user defaults when constructor args are passed explicitly

### DIFF
--- a/core/integration/workspace_compat_env_test.go
+++ b/core/integration/workspace_compat_env_test.go
@@ -597,6 +597,39 @@ type Test struct{}
 	require.NotContains(t, out, "topsecret")
 }
 
+func (WorkspaceCompatSuite) TestConstructorExplicitArgKeepsUserDefaults(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ctr := pythonModInit(t, c, `
+import dagger
+from dagger import function, object_type
+
+
+@object_type
+class Test:
+    foo: str = "bar"
+    optional_secret: dagger.Secret | None = None
+
+    @function
+    async def reveal(self) -> str:
+        if self.optional_secret is None:
+            return "no secret"
+        return await self.optional_secret.plaintext()
+`).
+		WithNewFile(".env", "Test_OptionalSecret=cmd://echo -n shhh")
+
+	t.Run("without constructor flag", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(daggerCall("reveal")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "shhh", out)
+	})
+
+	t.Run("with constructor flag", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(daggerCall("--foo", "baz", "reveal")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "shhh", out)
+	})
+}
+
 func (WorkspaceCompatSuite) TestConstructorRequired(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	base := nestedDaggerContainer(t, c, "go", "defaults/superconstructor").

--- a/core/object.go
+++ b/core/object.go
@@ -1174,9 +1174,23 @@ func (obj *ModuleObject) installEntrypointMethods(ctx context.Context, dag *dagq
 				if !ok {
 					return nil, fmt.Errorf("expected *Query, got %T", self)
 				}
+				// store only the args the caller actually provided — found in
+				// the call frame, built from the query AST — so the
+				// constructor still applies its own defaults, including .env
+				// user defaults, to the rest.
+				var explicit map[string]bool
+				if frame := dagql.CurrentCall(ctx); frame != nil {
+					explicit = make(map[string]bool, len(frame.Args))
+					for _, arg := range frame.Args {
+						explicit[arg.Name] = true
+					}
+				}
 				cp := query.Clone()
 				cp.ConstructorArgs = make(map[string]dagql.Input, len(args))
 				for k, v := range args {
+					if explicit != nil && !explicit[k] {
+						continue
+					}
 					cp.ConstructorArgs[k] = v
 				}
 				return dagql.NewObjectResultForCurrentCall(ctx, dag, cp)


### PR DESCRIPTION
Explicit constructor flags route through Query.with, whose decoded args
map is padded with schema defaults (e.g. a Python "= None" object arg
arrives as an explicit null). Forwarding the whole map made the real
constructor treat those defaults as caller-provided and skip the .env
user defaults for them. Store only the args present in the call frame,
so the constructor still applies its own defaults to the rest.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
