### PR TITLE
heartbeat status in report mode

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -35,6 +35,7 @@
           "ignore": [
             "bin",
             ".git",
+            "**/.git",
             "**/node_modules",
             "**/.venv",
             "**/__pycache__",

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -800,8 +800,11 @@ func (fe *frontendPretty) startReportHeartbeat() func() {
 
 	done := make(chan struct{})
 	var once sync.Once
+	var wg sync.WaitGroup
 	start := time.Now()
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -815,6 +818,7 @@ func (fe *frontendPretty) startReportHeartbeat() func() {
 	}()
 	return func() {
 		once.Do(func() { close(done) })
+		wg.Wait()
 	}
 }
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -757,7 +757,9 @@ func (fe *frontendPretty) Run(ctx context.Context, opts dagui.FrontendOpts, run 
 	fe.FrontendOpts = opts
 
 	if fe.reportOnly {
+		stopHeartbeat := fe.startReportHeartbeat()
 		cleanup, err := run(ctx)
+		stopHeartbeat()
 		if cleanup != nil {
 			err = errors.Join(err, cleanup())
 		}
@@ -776,6 +778,108 @@ func (fe *frontendPretty) Run(ctx context.Context, opts dagui.FrontendOpts, run 
 
 	// return original err
 	return normalizeFrontendExit(fe.err, fe.db)
+}
+
+// reportHeartbeatInterval is how often report mode prints a one-line
+// progress summary while work runs. Report mode is otherwise silent until
+// the final report, which leaves non-interactive consumers (e.g. coding
+// agents) with no liveness signal during long runs. Override with
+// DAGGER_REPORT_HEARTBEAT (a Go duration; 0 disables).
+const reportHeartbeatInterval = 30 * time.Second
+
+func (fe *frontendPretty) startReportHeartbeat() func() {
+	interval := reportHeartbeatInterval
+	if v := os.Getenv("DAGGER_REPORT_HEARTBEAT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			interval = d
+		}
+	}
+	if interval <= 0 || fe.Silent {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	var once sync.Once
+	start := time.Now()
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				fmt.Fprintln(fe.writer, fe.reportHeartbeatLine(time.Since(start)))
+			}
+		}
+	}()
+	return func() {
+		once.Do(func() { close(done) })
+	}
+}
+
+// reportHeartbeatLine summarizes in-flight work in a single line. Checks get
+// first-class treatment since `dagger check` over a large repo is the
+// longest-running everyday command.
+func (fe *frontendPretty) reportHeartbeatLine(elapsed time.Duration) string {
+	fe.reportMu.Lock()
+	defer fe.reportMu.Unlock()
+
+	now := time.Now()
+	var checksDone, checksFailed int
+	var runningChecks []string
+	var runningSteps int
+	for _, span := range fe.db.Spans.Order {
+		running := span.IsRunningOrEffectsRunning()
+		if running {
+			// only count leaves to approximate "things actually executing"
+			leaf := true
+			for _, child := range span.ChildSpans.Order {
+				if child.IsRunningOrEffectsRunning() {
+					leaf = false
+					break
+				}
+			}
+			if leaf {
+				runningSteps++
+			}
+		}
+		if span.CheckName == "" {
+			continue
+		}
+		switch {
+		case running:
+			runningChecks = append(runningChecks,
+				fmt.Sprintf("%s (%s)", span.CheckName, dagui.FormatDuration(span.Activity.Duration(now))))
+		case span.IsFailed():
+			checksDone++
+			checksFailed++
+		default:
+			checksDone++
+		}
+	}
+
+	line := fmt.Sprintf("[dagger] %s elapsed", dagui.FormatDuration(elapsed))
+	if total := checksDone + len(runningChecks); total > 0 {
+		line += fmt.Sprintf(" · checks: %d/%d done", checksDone, total)
+		if checksFailed > 0 {
+			line += fmt.Sprintf(" (%d failed)", checksFailed)
+		}
+		if len(runningChecks) > 0 {
+			const maxListed = 4
+			listed := runningChecks
+			if len(listed) > maxListed {
+				listed = listed[:maxListed]
+			}
+			line += " · running: " + strings.Join(listed, ", ")
+			if extra := len(runningChecks) - maxListed; extra > 0 {
+				line += fmt.Sprintf(" (+%d more)", extra)
+			}
+		}
+	} else if runningSteps > 0 {
+		line += fmt.Sprintf(" · %d steps running", runningSteps)
+	}
+	return line
 }
 
 func (fe *frontendPretty) HandlePrompt(ctx context.Context, title, prompt string, dest any) error {

--- a/dagql/idtui/frontend_report_heartbeat_test.go
+++ b/dagql/idtui/frontend_report_heartbeat_test.go
@@ -1,0 +1,65 @@
+package idtui
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/dagger/dagger/dagql/dagui"
+	telemetry "github.com/dagger/otel-go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func checkSpanStub(spanID byte, checkName string, start time.Time, end time.Time, status codes.Code) tracetest.SpanStub {
+	return tracetest.SpanStub{
+		Name: checkName,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: trace.TraceID{1},
+			SpanID:  trace.SpanID{spanID},
+		}),
+		StartTime: start,
+		EndTime:   end,
+		Status:    sdktrace.Status{Code: status},
+		Attributes: []attribute.KeyValue{
+			attribute.String(telemetry.CheckNameAttr, checkName),
+		},
+	}
+}
+
+func TestReportHeartbeatLine(t *testing.T) {
+	ctx := context.Background()
+	fe := NewWithDB(io.Discard, dagui.NewDB())
+	fe.reportOnly = true
+
+	now := time.Now()
+	exp := fe.SpanExporter()
+	require.NoError(t, exp.ExportSpans(ctx, []sdktrace.ReadOnlySpan{
+		// still running: no end time
+		checkSpanStub(1, "go:test", now.Add(-90*time.Second), time.Time{}, codes.Unset).Snapshot(),
+		// passed
+		checkSpanStub(2, "go:lint", now.Add(-2*time.Minute), now.Add(-time.Minute), codes.Unset).Snapshot(),
+		// failed
+		checkSpanStub(3, "docs:build", now.Add(-2*time.Minute), now.Add(-time.Minute), codes.Error).Snapshot(),
+	}))
+
+	line := fe.reportHeartbeatLine(2 * time.Minute)
+	require.Contains(t, line, "2m0s elapsed")
+	require.Contains(t, line, "checks: 2/3 done")
+	require.Contains(t, line, "(1 failed)")
+	require.Contains(t, line, "go:test")
+}
+
+func TestReportHeartbeatLineNoChecks(t *testing.T) {
+	fe := NewWithDB(io.Discard, dagui.NewDB())
+	fe.reportOnly = true
+
+	line := fe.reportHeartbeatLine(30 * time.Second)
+	require.Contains(t, line, "30.0s elapsed")
+	require.NotContains(t, line, "checks:")
+}

--- a/dagql/idtui/frontend_report_heartbeat_test.go
+++ b/dagql/idtui/frontend_report_heartbeat_test.go
@@ -3,6 +3,7 @@ package idtui
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,21 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
+
+type blockingHeartbeatWriter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *blockingHeartbeatWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.started)
+	})
+	// Hold the heartbeat inside Write until the test explicitly releases it.
+	<-w.release
+	return len(p), nil
+}
 
 func checkSpanStub(spanID byte, checkName string, start time.Time, end time.Time, status codes.Code) tracetest.SpanStub {
 	return tracetest.SpanStub{
@@ -29,6 +45,58 @@ func checkSpanStub(spanID byte, checkName string, start time.Time, end time.Time
 		Attributes: []attribute.KeyValue{
 			attribute.String(telemetry.CheckNameAttr, checkName),
 		},
+	}
+}
+
+func TestReportHeartbeatStopWaitsForInFlightWrite(t *testing.T) {
+	t.Setenv("DAGGER_REPORT_HEARTBEAT", "1ms")
+
+	writer := &blockingHeartbeatWriter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(writer.release)
+		})
+	}
+
+	fe := NewWithDB(writer, dagui.NewDB())
+	fe.reportOnly = true
+
+	stopHeartbeat := fe.startReportHeartbeat()
+	t.Cleanup(func() {
+		release()
+		stopHeartbeat()
+	})
+
+	// Wait until stopHeartbeat has an in-flight heartbeat write to wait for.
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat did not start")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		stopHeartbeat()
+		close(stopped)
+	}()
+
+	// The old implementation returned here as soon as it signaled done.
+	select {
+	case <-stopped:
+		t.Fatal("stopHeartbeat returned while heartbeat write was blocked")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("stopHeartbeat did not return after heartbeat write was released")
 	}
 }
 


### PR DESCRIPTION
This drops a heartbeat status while in report mode. Agents using report mode (the default if CLAUDECODE=1) dont get enough feedback that their checks are still running, so this is an attempt to solve that.

Every 30s during report mode, a heartbeat will print like so
```
[dagger] 5m30s elapsed · checks: 8/20 done (1 failed) · running: go:test (5m29s), docs:lint (2m01s) (+3 more)
```