### PR TITLE
fix(core): use externally-callable _asModule for check scale-out

### DIFF
--- a/core/modtree.go
+++ b/core/modtree.go
@@ -536,7 +536,10 @@ func (node *ModTreeNode) buildScaleOutModuleQuery(query *querybuilder.Selection)
 		query = query.Select("asModuleSource").
 			Arg("sourceRootPath", modSrc.DirSrc.OriginalSourceRootSubpath)
 	}
-	query = query.Select("asModule")
+	// _asModule rather than asModule: this query executes on the remote
+	// engine as an external GraphQL request, where the legacy compat
+	// arguments below would be rejected as internal-only.
+	query = query.Select("_asModule")
 	if mod.Name() != "" && mod.Name() != modSrc.ModuleName {
 		query = query.Arg("legacyNameOverride", mod.Name())
 	}

--- a/core/modtree_test.go
+++ b/core/modtree_test.go
@@ -80,7 +80,15 @@ func (s *ModTreeNodeTestSuite) TestBuildScaleOutModuleQueryForModuleLoadedFromDi
 		}
 
 		type ModuleSource {
-			asModule: Module!
+			_asModule(
+				legacyDefaultPath: Boolean = false,
+				legacyNameOverride: String = "",
+				legacyWorkspaceConfigJson: String = "",
+				legacyDefaultsFromDotEnv: Boolean = false,
+				legacyArgCustomizationsJson: String = "",
+				defaultPathContextSourceRef: String = "",
+				defaultPathContextSourcePin: String = "",
+			): Module!
 		}
 
 		type Module {
@@ -145,6 +153,12 @@ func (s *ModTreeNodeTestSuite) TestBuildScaleOutModuleQueryPreservesAsModuleOpti
 	require.Contains(t, generated, `legacyDefaultsFromDotEnv: true`)
 	require.Contains(t, generated, `legacyArgCustomizationsJson:`)
 	require.Contains(t, generated, `selectModule`)
+
+	// The query executes on the remote engine as an external request, where
+	// internal arguments are rejected: the legacy options must go through
+	// _asModule, which accepts them as ordinary arguments.
+	require.Contains(t, generated, `_asModule(`)
+	require.NotContains(t, generated, ` asModule(`)
 }
 
 func (s *ModTreeNodeTestSuite) TestModuleLocalPathString(ctx context.Context, t *testctx.T) {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -226,6 +226,9 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 		dagql.NodeFunc("asModule", s.moduleSourceAsModule).
 			WithInput(dagql.PerClientInput).
 			Doc(`Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation`),
+		dagql.NodeFunc("_asModule", s.moduleSourceAsScaleOutModule).
+			WithInput(dagql.PerClientInput).
+			Doc(`Engine-internal variant of asModule that exposes the legacy workspace compat options to engine-to-engine callers (e.g. check scale-out), which submit them over the wire where internal arguments are rejected. Not part of the public API.`),
 		dagql.NodeFunc("_implementationScoped", s.moduleSourceImplementationScoped).
 			Doc(`The module source scoped to implementation identity only, i.e. source code and dependency content rather than client-specific provenance.`),
 		dagql.NodeFunc("introspectionSchemaJSON", s.moduleSourceIntrospectionSchemaJSON).
@@ -3051,45 +3054,74 @@ func (s *moduleSourceSchema) moduleSourceImplementationScoped(
 	}
 	return inst.WithContentDigest(ctx, scopedDigest)
 }
+
+// asModuleArgs are the arguments to ModuleSource.asModule. They are
+// internal-only: in-engine callers (e.g. the legacy workspace projection)
+// set them directly via selectors.
+type asModuleArgs struct {
+	// This internal-only flag allows us to force SDK modules to enable default function
+	// caching even when they are on older modules, which ensures they don't see a regression
+	// right after function caching is enabled. It can be removed after SDKs have been updated
+	// to latest engine versions.
+	ForceDefaultFunctionCaching bool `internal:"true" default:"false"`
+
+	// LegacyDefaultPath marks modules projected from legacy workspace fields.
+	// The caller should also pass DefaultPathContextSourceRef so
+	// +defaultPath inputs resolve from the legacy project/workspace context.
+	LegacyDefaultPath bool `internal:"true" default:"false"`
+
+	// LegacyArgCustomizationsJSON is a JSON-encoded []*modules.ModuleConfigArgument
+	// carrying arg customizations from the workspace dagger.json.
+	// Applied after type defs are populated so constructor arg metadata
+	// (Ignore, DefaultPath, etc.) can be overridden before Install.
+	LegacyArgCustomizationsJSON string `internal:"true" default:""`
+
+	// LegacyNameOverride, when non-empty, overrides the module name.
+	LegacyNameOverride string `internal:"true" default:""`
+
+	// LegacyWorkspaceConfigJSON is a JSON-encoded map[string]any
+	// carrying workspace config defaults from the workspace dagger.json.
+	LegacyWorkspaceConfigJSON string `internal:"true" default:""`
+
+	// LegacyDefaultsFromDotEnv, when true and workspace config is set,
+	// also load .env defaults for args not found in WorkspaceConfig.
+	LegacyDefaultsFromDotEnv bool `internal:"true" default:"false"`
+
+	// DefaultPathContextSourceRef, when set, loads implementation code from
+	// the receiver but resolves +defaultPath inputs from this source ref.
+	DefaultPathContextSourceRef string `internal:"true" default:""`
+
+	// DefaultPathContextSourcePin pins DefaultPathContextSourceRef when set.
+	DefaultPathContextSourcePin string `internal:"true" default:""`
+}
+
+// asScaleOutModuleArgs mirrors asModuleArgs without the internal markers.
+// Scale-out submits module loading to a remote engine as a regular GraphQL
+// query, where internal arguments are rejected at parse time, so
+// ModuleSource._asModule accepts them as ordinary (hidden) arguments.
+type asScaleOutModuleArgs struct {
+	ForceDefaultFunctionCaching bool   `default:"false"`
+	LegacyDefaultPath           bool   `default:"false"`
+	LegacyArgCustomizationsJSON string `default:""`
+	LegacyNameOverride          string `default:""`
+	LegacyWorkspaceConfigJSON   string `default:""`
+	LegacyDefaultsFromDotEnv    bool   `default:"false"`
+	DefaultPathContextSourceRef string `default:""`
+	DefaultPathContextSourcePin string `default:""`
+}
+
+func (s *moduleSourceSchema) moduleSourceAsScaleOutModule(
+	ctx context.Context,
+	src dagql.ObjectResult[*core.ModuleSource],
+	args asScaleOutModuleArgs,
+) (dagql.ObjectResult[*core.Module], error) {
+	return s.moduleSourceAsModule(ctx, src, asModuleArgs(args))
+}
+
 func (s *moduleSourceSchema) moduleSourceAsModule(
 	ctx context.Context,
 	src dagql.ObjectResult[*core.ModuleSource],
-	args struct {
-		// This internal-only flag allows us to force SDK modules to enable default function
-		// caching even when they are on older modules, which ensures they don't see a regression
-		// right after function caching is enabled. It can be removed after SDKs have been updated
-		// to latest engine versions.
-		ForceDefaultFunctionCaching bool `internal:"true" default:"false"`
-
-		// LegacyDefaultPath marks modules projected from legacy workspace fields.
-		// The caller should also pass DefaultPathContextSourceRef so
-		// +defaultPath inputs resolve from the legacy project/workspace context.
-		LegacyDefaultPath bool `internal:"true" default:"false"`
-
-		// LegacyArgCustomizationsJSON is a JSON-encoded []*modules.ModuleConfigArgument
-		// carrying arg customizations from the workspace dagger.json.
-		// Applied after type defs are populated so constructor arg metadata
-		// (Ignore, DefaultPath, etc.) can be overridden before Install.
-		LegacyArgCustomizationsJSON string `internal:"true" default:""`
-
-		// LegacyNameOverride, when non-empty, overrides the module name.
-		LegacyNameOverride string `internal:"true" default:""`
-
-		// LegacyWorkspaceConfigJSON is a JSON-encoded map[string]any
-		// carrying workspace config defaults from the workspace dagger.json.
-		LegacyWorkspaceConfigJSON string `internal:"true" default:""`
-
-		// LegacyDefaultsFromDotEnv, when true and workspace config is set,
-		// also load .env defaults for args not found in WorkspaceConfig.
-		LegacyDefaultsFromDotEnv bool `internal:"true" default:"false"`
-
-		// DefaultPathContextSourceRef, when set, loads implementation code from
-		// the receiver but resolves +defaultPath inputs from this source ref.
-		DefaultPathContextSourceRef string `internal:"true" default:""`
-
-		// DefaultPathContextSourcePin pins DefaultPathContextSourceRef when set.
-		DefaultPathContextSourcePin string `internal:"true" default:""`
-	},
+	args asModuleArgs,
 ) (inst dagql.ObjectResult[*core.Module], err error) {
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {


### PR DESCRIPTION
## Problem

`dagger check --scale-out` fails for every check and generator in legacy (`dagger.json`) projects with errors like:

```
cannot use internal argument "legacyDefaultPath" in selector for ModuleSource.asModule
```

`buildScaleOutModuleQuery` serializes module loading into a GraphQL query that passes `asModule`'s legacy workspace compat options (`legacyDefaultPath`, `legacyNameOverride`, `legacyWorkspaceConfigJson`, ...). Those arguments are declared `internal:"true"`, and the scale-out query executes on the remote engine as an **external** request, where dagql rejects internal arguments at parse time. Local runs never hit this because module loading happens in-engine. Legacy projects always hit it because every projected toolchain gets `legacyDefaultPath: true`.

## Solution

Add `ModuleSource._asModule`, a wire-callable twin of `asModule` that accepts the same compat options as ordinary arguments, following the existing underscore convention (`_builtinContainer`, `_implementationScoped`) for fields callable over the wire but hidden from SDK codegen and docs. It converts the args struct and calls the same resolver, so behavior and caching semantics are identical. The scale-out query builder now selects `_asModule`, with internal-arg hygiene on the public `asModule` left intact.

## Tests

- `TestBuildScaleOutModuleQueryPreservesAsModuleOptions` now also asserts the legacy options ride on `_asModule` (the previous test checked the args were present, but not that they were externally usable — which is how this slipped through).
- Verified e2e against a dev engine: external `asModule(legacyDefaultPath:true)` is still rejected, while the same query through `_asModule` loads the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)