### PR TITLE
fix(engine/client): retry cloud engine provisioning on transient errors

### DIFF
--- a/engine/client/drivers/cloud.go
+++ b/engine/client/drivers/cloud.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -96,7 +98,7 @@ func (d *daggerCloudDriver) Provision(ctx context.Context, _ *url.URL, opts *Dri
 		execCmd = opts.ExecCmd
 	}
 
-	engineSpec, err := client.Engine(ctx, cloud.EngineRequest{
+	engineSpec, err := provisionEngine(ctx, client, cloud.EngineRequest{
 		Module:   module,
 		Function: function,
 		ExecCmd:  execCmd,
@@ -110,6 +112,52 @@ func (d *daggerCloudDriver) Provision(ctx context.Context, _ *url.URL, opts *Dri
 	}
 
 	return &DaggerCloudConnector{EngineSpec: *engineSpec}, nil
+}
+
+// maxProvisionServerErrorRetries bounds retries on 500s, which may be
+// transient (e.g. cold-start races provisioning the org's very first
+// engines) but can also be persistent failures not worth hammering on.
+const maxProvisionServerErrorRetries = 3
+
+// provisionEngine requests a remote engine from the cloud API, retrying
+// while the API reports transient conditions. Capacity exhaustion (429) is
+// expected when many concurrent requests race for slots — e.g. a large
+// `dagger check` scale-out — and is retried for as long as ctx allows, since
+// slots free up as other clients finish. The overall retry budget is bounded
+// by ctx, which the caller caps (10 minutes by default).
+func provisionEngine(ctx context.Context, client *cloud.Client, req cloud.EngineRequest) (*cloud.EngineSpec, error) {
+	backoff := time.Second
+	const maxBackoff = 15 * time.Second
+	serverErrRetries := 0
+	for {
+		spec, err := client.Engine(ctx, req)
+		if err == nil {
+			return spec, nil
+		}
+
+		var provisionErr *cloud.EngineProvisionError
+		if !errors.As(err, &provisionErr) {
+			return nil, err
+		}
+		retryable := provisionErr.Retryable()
+		if !retryable && provisionErr.StatusCode == http.StatusInternalServerError &&
+			serverErrRetries < maxProvisionServerErrorRetries {
+			serverErrRetries++
+			retryable = true
+		}
+		if !retryable {
+			return nil, err
+		}
+
+		// full jitter up to half the backoff to spread out racing clients
+		wait := backoff + rand.N(backoff/2) //nolint:gosec
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("%w (gave up retrying: %w)", err, context.Cause(ctx))
+		case <-time.After(wait):
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
 }
 
 func (d *daggerCloudDriver) ImageLoader(ctx context.Context) imageload.Backend {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -184,6 +184,34 @@ type ErrResponse struct {
 	Message string `json:"message"`
 }
 
+// EngineProvisionError is returned when the cloud API rejects an engine
+// provisioning request. It carries the HTTP status code so callers can
+// decide whether the request is worth retrying.
+type EngineProvisionError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *EngineProvisionError) Error() string {
+	return fmt.Sprintf("failed to provision a remote Engine: %s", e.Message)
+}
+
+// Retryable reports whether the provisioning request may succeed if retried.
+// The API signals transient capacity exhaustion with 429 (e.g. a burst of
+// concurrent scale-out requests racing for slots), and gateway errors are
+// transient by nature.
+func (e *EngineProvisionError) Retryable() bool {
+	switch e.StatusCode {
+	case http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *Client) Engine(ctx context.Context, req EngineRequest) (*EngineSpec, error) {
 	// Remote Engine version defaults to the CLI version - this guarantees the best compatibility
 	tag := engine.Tag
@@ -228,9 +256,12 @@ func (c *Client) Engine(ctx context.Context, req EngineRequest) (*EngineSpec, er
 		errResponse := &ErrResponse{}
 		err = body.Decode(errResponse)
 		if err != nil {
-			return nil, fmt.Errorf("response body is not valid JSON: %w", err)
+			errResponse.Message = fmt.Sprintf("unexpected response (status %d)", resp.StatusCode)
 		}
-		return nil, fmt.Errorf("failed to provision a remote Engine: %s", errResponse.Message)
+		return nil, &EngineProvisionError{
+			StatusCode: resp.StatusCode,
+			Message:    errResponse.Message,
+		}
 	}
 
 	err = body.Decode(engineSpec)


### PR DESCRIPTION
## Problem

A large check scale-out fires one engine provisioning request per check. When the burst exceeds the org's available slot capacity, the cloud API rejects the overflow, and any provisioning failure immediately failed the check with no retry — so the first scale-out on a repo with many heavy checks reliably broke.

## Solution

- Type provisioning failures as `cloud.EngineProvisionError` carrying the HTTP status code.
- Retry in the `dagger-cloud` driver with exponential backoff + jitter:
  - **429/502/503/504**: retried for as long as the provisioning context allows (10 minutes by default). Capacity errors are expected during bursts and resolve as other clients finish and release slots — checks now queue for a slot instead of failing.
  - **500**: retried up to 3 times, absorbing transient cold-start failures (e.g. the org's first-ever engine provisioning) without hammering on persistent ones.

Pairs with a cloud-side change that returns 429 + `Retry-After` instead of 500 when the scheduler is out of capacity, and waits for slots to free up within its scheduling deadline rather than failing the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)