### PR TITLE
fix(telemetry): reduce telemetry volume streamed back from scale-out engines

### DIFF
--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -81,6 +81,8 @@ const (
 	cacheExportsConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_EXPORT_CONFIG"
 	// allow enabling scale-out of checks to support cloud
 	enableChecksScaleOutEnvName = "_EXPERIMENTAL_DAGGER_CHECKS_SCALE_OUT"
+	// how much telemetry scaled-out cloud engines stream back ("" or "full")
+	scaleOutTelemetryEnvName = "DAGGER_SCALEOUT_TELEMETRY"
 	// shutdown timeout, default is 10s
 	shutdownTimeoutEnvName = "_EXPERIMENTAL_DAGGER_SHUTDOWN_TIMEOUT"
 )
@@ -147,6 +149,11 @@ type Params struct {
 
 	CloudAuth           *auth.Cloud
 	EnableCloudScaleOut bool
+
+	// ScaleOutTelemetry controls how much telemetry scaled-out cloud engines
+	// stream back through this session: "" (default) filters out data hidden
+	// at normal verbosity, "full" streams everything.
+	ScaleOutTelemetry string
 }
 
 type Client struct {
@@ -218,6 +225,9 @@ func Connect(ctx context.Context, params Params) (_ *Client, rerr error) {
 	}
 
 	c.EnableCloudScaleOut = c.EnableCloudScaleOut || os.Getenv(enableChecksScaleOutEnvName) != ""
+	if c.ScaleOutTelemetry == "" {
+		c.ScaleOutTelemetry = os.Getenv(scaleOutTelemetryEnvName)
+	}
 
 	// NB: decouple from the originator's cancel ctx
 	c.internalCtx, c.internalCancel = context.WithCancelCause(context.WithoutCancel(ctx))
@@ -1445,6 +1455,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		SuppressCompatWorkspaceWarning: c.SuppressCompatWorkspaceWarning,
 		CloudAuth:                      c.CloudAuth,
 		EnableCloudScaleOut:            c.EnableCloudScaleOut,
+		ScaleOutTelemetry:              c.ScaleOutTelemetry,
 		CloudScaleOutEngineID:          remoteEngineID,
 		LockMode:                       c.LockMode,
 	}

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -106,6 +106,12 @@ type ClientMetadata struct {
 	// If true, this client enables scaling checks out to cloud engines
 	EnableCloudScaleOut bool `json:"enable_cloud_scale_out,omitempty"`
 
+	// ScaleOutTelemetry controls how much telemetry from scaled-out cloud
+	// engines is streamed back through this client's session. Empty (the
+	// default) filters out data hidden at normal verbosity (internal spans,
+	// verbose logs); "full" streams everything.
+	ScaleOutTelemetry string `json:"scale_out_telemetry,omitempty"`
+
 	// if set, this client is another engine scaling out to the current one, and the current
 	// one has this ID. Should be included in OTEL span sttrs so we can correlate spans to engine.
 	// TODO: This is a bit convoluted; it would be nicer if an engine could figure out its own ID

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2218,6 +2218,19 @@ func (srv *Server) CloudEngineClient(
 
 	// TODO: cloud support for "run on yourself", return (nil, false, nil) in that case
 
+	// By default, filter the telemetry streamed back from the cloud engine
+	// down to what the UI shows at normal verbosity. Large scale-outs (e.g.
+	// `dagger check` fanning out to one engine per check) otherwise firehose
+	// the full telemetry of every remote engine through this session to the
+	// client. The complete stream is always available in Dagger Cloud.
+	engineTrace := parentClient.spanExporter
+	engineLogs := parentClient.logExporter
+	if parentClient.clientMetadata.ScaleOutTelemetry != ScaleOutTelemetryFull {
+		filter := newScaleOutTelemetryFilter()
+		engineTrace = filter.Spans(engineTrace)
+		engineLogs = filter.Logs(engineLogs)
+	}
+
 	engineClient, err := engineclient.ConnectEngineToEngine(ctx, engineclient.EngineToEngineParams{
 		Params: engineclient.Params{
 			RunnerHost: engine.DefaultCloudRunnerHost,
@@ -2228,8 +2241,8 @@ func (srv *Server) CloudEngineClient(
 
 			CloudAuth: parentClient.clientMetadata.CloudAuth,
 
-			EngineTrace:   parentClient.spanExporter,
-			EngineLogs:    parentClient.logExporter,
+			EngineTrace:   engineTrace,
+			EngineLogs:    engineLogs,
 			EngineMetrics: []sdkmetric.Exporter{parentClient.metricExporter},
 
 			// FIXME: for now, disable recursive scale out to prevent any

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -402,14 +402,24 @@ func (ps clientSpans) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 	}
 	defer db.Close()
 
+	// Insert the whole batch in one transaction; per-span transactions are
+	// prohibitively expensive when many nested/remote clients stream spans
+	// through this client at once.
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin span insert: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+
+	qtx := db.Queries.WithTx(tx)
 	for _, insert := range inserts {
-		_, err = db.InsertSpan(ctx, *insert)
+		_, err = qtx.InsertSpan(ctx, *insert)
 		if err != nil {
 			return fmt.Errorf("insert span: %w", err)
 		}
 	}
 
-	return nil
+	return tx.Commit()
 }
 
 func (ps clientSpans) ForceFlush(ctx context.Context) error { return nil }
@@ -465,14 +475,24 @@ func (ps clientLogs) Export(ctx context.Context, logs []sdklog.Record) error {
 	}
 	defer db.Close()
 
+	// Insert the whole batch in one transaction; per-log transactions are
+	// prohibitively expensive when many nested/remote clients stream logs
+	// through this client at once.
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin log insert: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+
+	qtx := db.Queries.WithTx(tx)
 	for _, insert := range inserts {
-		if _, err := db.InsertLog(ctx, *insert); err != nil {
+		if _, err := qtx.InsertLog(ctx, *insert); err != nil {
 			slog.Warn("failed to insert log record", "error", err)
 			continue
 		}
 	}
 
-	return nil
+	return tx.Commit()
 }
 
 func (ps clientLogs) Enabled(context.Context, sdklog.EnabledParameters) bool { return true }

--- a/engine/server/telemetry_scaleout.go
+++ b/engine/server/telemetry_scaleout.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"context"
+	"sync"
+
+	telemetry "github.com/dagger/otel-go"
+	"go.opentelemetry.io/otel/codes"
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Scale-out sessions stream the full telemetry of every remote engine back
+// through the parent chain to the client. For large check fan-outs that
+// firehose can overwhelm the client machine, so by default we drop data the
+// UI would never show at normal verbosity before it enters the parent's
+// telemetry DB:
+//
+//   - internal spans (dagger.io/ui.internal), unless they errored
+//   - logs belonging to those dropped spans
+//   - verbose logs (dagger.io/logs.verbose), e.g. function call results
+//
+// The full stream is always available in Dagger Cloud, which receives
+// telemetry from the remote engine directly. Clients opt out of filtering
+// with DAGGER_SCALEOUT_TELEMETRY=full (plumbed via ClientMetadata).
+const ScaleOutTelemetryFull = "full"
+
+// maxTrackedDroppedSpans bounds the memory used to correlate logs with
+// dropped spans. If a session somehow exceeds it, tracking resets: logs for
+// previously-dropped spans then pass through unfiltered, which is harmless.
+const maxTrackedDroppedSpans = 1 << 20
+
+type scaleOutTelemetryFilter struct {
+	mu      sync.Mutex
+	dropped map[trace.SpanID]struct{}
+}
+
+func newScaleOutTelemetryFilter() *scaleOutTelemetryFilter {
+	return &scaleOutTelemetryFilter{
+		dropped: make(map[trace.SpanID]struct{}),
+	}
+}
+
+func (f *scaleOutTelemetryFilter) Spans(next sdktrace.SpanExporter) sdktrace.SpanExporter {
+	return &scaleOutSpanFilter{filter: f, next: next}
+}
+
+func (f *scaleOutTelemetryFilter) Logs(next sdklog.Exporter) sdklog.Exporter {
+	return &scaleOutLogFilter{filter: f, next: next}
+}
+
+type scaleOutSpanFilter struct {
+	filter *scaleOutTelemetryFilter
+	next   sdktrace.SpanExporter
+}
+
+var _ sdktrace.SpanExporter = (*scaleOutSpanFilter)(nil)
+
+func (f *scaleOutSpanFilter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	kept := make([]sdktrace.ReadOnlySpan, 0, len(spans))
+	f.filter.mu.Lock()
+	for _, span := range spans {
+		spanID := span.SpanContext().SpanID()
+		if dropSpan(span) {
+			if len(f.filter.dropped) >= maxTrackedDroppedSpans {
+				f.filter.dropped = make(map[trace.SpanID]struct{})
+			}
+			f.filter.dropped[spanID] = struct{}{}
+			continue
+		}
+		// spans are exported live, in snapshots: an earlier snapshot may have
+		// been dropped (e.g. before the span errored), so un-drop it
+		delete(f.filter.dropped, spanID)
+		kept = append(kept, span)
+	}
+	f.filter.mu.Unlock()
+	if len(kept) == 0 {
+		return nil
+	}
+	return f.next.ExportSpans(ctx, kept)
+}
+
+func (f *scaleOutSpanFilter) ForceFlush(ctx context.Context) error {
+	if ff, ok := f.next.(interface{ ForceFlush(context.Context) error }); ok {
+		return ff.ForceFlush(ctx)
+	}
+	return nil
+}
+
+func (f *scaleOutSpanFilter) Shutdown(ctx context.Context) error {
+	return f.next.Shutdown(ctx)
+}
+
+// dropSpan reports whether a span is hidden at normal verbosity and safe to
+// drop at the scale-out boundary. Errored spans are always kept since the UI
+// reveals failures regardless of verbosity.
+func dropSpan(span sdktrace.ReadOnlySpan) bool {
+	if span.Status().Code == codes.Error {
+		return false
+	}
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == telemetry.UIInternalAttr && attr.Value.AsBool() {
+			return true
+		}
+	}
+	return false
+}
+
+type scaleOutLogFilter struct {
+	filter *scaleOutTelemetryFilter
+	next   sdklog.Exporter
+}
+
+var _ sdklog.Exporter = (*scaleOutLogFilter)(nil)
+
+func (f *scaleOutLogFilter) Export(ctx context.Context, records []sdklog.Record) error {
+	kept := make([]sdklog.Record, 0, len(records))
+	for _, rec := range records {
+		if f.dropLog(rec) {
+			continue
+		}
+		kept = append(kept, rec)
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return f.next.Export(ctx, kept)
+}
+
+func (f *scaleOutLogFilter) dropLog(rec sdklog.Record) bool {
+	verbose := false
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		if kv.Key == telemetry.LogsVerboseAttr && kv.Value.AsBool() {
+			verbose = true
+			return false
+		}
+		return true
+	})
+	if verbose {
+		return true
+	}
+	f.filter.mu.Lock()
+	_, dropped := f.filter.dropped[rec.SpanID()]
+	f.filter.mu.Unlock()
+	return dropped
+}
+
+func (f *scaleOutLogFilter) ForceFlush(ctx context.Context) error {
+	return f.next.ForceFlush(ctx)
+}
+
+func (f *scaleOutLogFilter) Shutdown(ctx context.Context) error {
+	return f.next.Shutdown(ctx)
+}

--- a/engine/server/telemetry_scaleout_test.go
+++ b/engine/server/telemetry_scaleout_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	telemetry "github.com/dagger/otel-go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type capturedLogs struct {
+	records []sdklog.Record
+}
+
+func (c *capturedLogs) Export(_ context.Context, records []sdklog.Record) error {
+	c.records = append(c.records, records...)
+	return nil
+}
+
+func (c *capturedLogs) ForceFlush(context.Context) error { return nil }
+func (c *capturedLogs) Shutdown(context.Context) error   { return nil }
+
+func spanStub(spanID byte, internal bool, status codes.Code) tracetest.SpanStub {
+	stub := tracetest.SpanStub{
+		Name: "test-span",
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: trace.TraceID{1},
+			SpanID:  trace.SpanID{spanID},
+		}),
+		Status: sdktrace.Status{Code: status},
+	}
+	if internal {
+		stub.Attributes = []attribute.KeyValue{
+			attribute.Bool(telemetry.UIInternalAttr, true),
+		}
+	}
+	return stub
+}
+
+func logRecord(spanID byte, verbose bool) sdklog.Record {
+	var rec sdklog.Record
+	rec.SetSpanID(trace.SpanID{spanID})
+	rec.SetBody(otellog.StringValue("hello"))
+	if verbose {
+		rec.SetAttributes(otellog.Bool(telemetry.LogsVerboseAttr, true))
+	}
+	return rec
+}
+
+func TestScaleOutTelemetryFilterSpans(t *testing.T) {
+	ctx := context.Background()
+	filter := newScaleOutTelemetryFilter()
+	spanSink := tracetest.NewInMemoryExporter()
+	spans := filter.Spans(spanSink)
+
+	require.NoError(t, spans.ExportSpans(ctx, []sdktrace.ReadOnlySpan{
+		spanStub(1, false, codes.Unset).Snapshot(), // ordinary span: kept
+		spanStub(2, true, codes.Unset).Snapshot(),  // internal span: dropped
+		spanStub(3, true, codes.Error).Snapshot(),  // internal but errored: kept
+	}))
+
+	kept := spanSink.GetSpans()
+	require.Len(t, kept, 2)
+	require.Equal(t, trace.SpanID{1}, kept[0].SpanContext.SpanID())
+	require.Equal(t, trace.SpanID{3}, kept[1].SpanContext.SpanID())
+}
+
+func TestScaleOutTelemetryFilterLogs(t *testing.T) {
+	ctx := context.Background()
+	filter := newScaleOutTelemetryFilter()
+	spanSink := tracetest.NewInMemoryExporter()
+	logSink := &capturedLogs{}
+	spans := filter.Spans(spanSink)
+	logs := filter.Logs(logSink)
+
+	require.NoError(t, spans.ExportSpans(ctx, []sdktrace.ReadOnlySpan{
+		spanStub(1, false, codes.Unset).Snapshot(),
+		spanStub(2, true, codes.Unset).Snapshot(),
+	}))
+
+	require.NoError(t, logs.Export(ctx, []sdklog.Record{
+		logRecord(1, false), // log for kept span: kept
+		logRecord(2, false), // log for dropped span: dropped
+		logRecord(1, true),  // verbose log: dropped even for kept span
+	}))
+
+	require.Len(t, logSink.records, 1)
+	require.Equal(t, trace.SpanID{1}, logSink.records[0].SpanID())
+}
+
+func TestScaleOutTelemetryFilterUndropsErroredSpans(t *testing.T) {
+	ctx := context.Background()
+	filter := newScaleOutTelemetryFilter()
+	spanSink := tracetest.NewInMemoryExporter()
+	logSink := &capturedLogs{}
+	spans := filter.Spans(spanSink)
+	logs := filter.Logs(logSink)
+
+	// live telemetry exports spans in snapshots: first while running...
+	require.NoError(t, spans.ExportSpans(ctx, []sdktrace.ReadOnlySpan{
+		spanStub(2, true, codes.Unset).Snapshot(),
+	}))
+	require.Empty(t, spanSink.GetSpans())
+
+	// ...then a final snapshot, here with an error: the span must come back
+	require.NoError(t, spans.ExportSpans(ctx, []sdktrace.ReadOnlySpan{
+		spanStub(2, true, codes.Error).Snapshot(),
+	}))
+	require.Len(t, spanSink.GetSpans(), 1)
+
+	// and its logs must flow again too
+	require.NoError(t, logs.Export(ctx, []sdklog.Record{logRecord(2, false)}))
+	require.Len(t, logSink.records, 1)
+}


### PR DESCRIPTION
## Problem

Each scaled-out check runs on its own cloud engine, and every engine streams its complete telemetry back through the parent engine to the client. On repos with many heavy checks this firehose can overwhelm the client machine:

- Spans and logs were inserted into the parent engine's telemetry DB one SQLite transaction (and fsync) per row.
- Everything was transported and stored regardless of whether the UI would ever show it — filtering only happened at render time.

## Solution

- **Batch inserts**: span/log exports now insert in a single transaction per batch in the engine's telemetry pubsub.
- **Filter at the scale-out boundary**: telemetry re-exported from scale-out engine sessions is filtered down to what the UI shows at normal verbosity — internal spans are dropped (kept if they errored), along with logs belonging to dropped spans and verbose logs (e.g. function call results). Errors and check progress still stream live, and the complete trace remains available in Dagger Cloud, which receives telemetry from the remote engine directly.

Clients opt out of filtering with `DAGGER_SCALEOUT_TELEMETRY=full`, plumbed through `ClientMetadata` so it works with containerized engines.

## Tests

Unit tests cover the filter semantics, including the live-span snapshot case: an internal span dropped while running is un-dropped when its final snapshot arrives with an error, and its logs flow again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)