### PR TITLE
fix(dagql): hold ownership of canonical-equivalent results during publication

### DIFF
--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -3946,6 +3946,14 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		if existingRes := oc.val.cacheSharedResult(); existingRes != nil && existingRes.id != 0 {
 			c.egraphMu.Lock()
 			oc.res = c.canonicalEquivalentSharedResultLocked(sessionID, existingRes, time.Now().Unix())
+			// Take the publication handoff hold inside the same critical
+			// section as the canonical pick: the adopted result may be owned
+			// only by another session, and a concurrent session release must
+			// not be able to collect it (running its OnRelease) before this
+			// call re-acquires the lock and its waiters claim session
+			// ownership.
+			c.incrementIncomingOwnershipLocked(ctx, oc.res)
+			oc.handoffHoldActive = true
 			c.egraphMu.Unlock()
 			if objVal, ok := oc.val.(AnyObjectResult); ok {
 				oc.res.setObjClass(objVal.ObjectType())
@@ -4220,8 +4228,12 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 	if oc.isPersistable {
 		c.upsertPersistedEdgeLocked(ctx, oc.res, candidateSharedResultExpiryUnix(now.Unix(), oc.ttlSeconds), false)
 	}
-	c.incrementIncomingOwnershipLocked(ctx, oc.res)
-	oc.handoffHoldActive = true
+	// The cache-backed path already took the handoff hold when it adopted the
+	// canonical result above; only fresh results take it here.
+	if !oc.handoffHoldActive {
+		c.incrementIncomingOwnershipLocked(ctx, oc.res)
+		oc.handoffHoldActive = true
+	}
 	if !resWasCacheBacked {
 		oc.res.attachDepsMu.Lock()
 		oc.res.attachDepsWaitCh = make(chan struct{})

--- a/dagql/cache_canonical_race_test.go
+++ b/dagql/cache_canonical_race_test.go
@@ -1,0 +1,179 @@
+package dagql
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
+)
+
+// TestCacheCanonicalEquivalentSwapRacesSessionRelease reproduces a race between
+// initCompletedResult's canonical-equivalent swap and ReleaseSession.
+//
+// When a call's fn returns an already-attached result, initCompletedResult
+// swaps oc.res to canonicalEquivalentSharedResultLocked(...) and then drops
+// egraphMu without taking any ownership hold on the adopted sibling. The
+// handoff-hold increment only happens later, after egraphMu is re-acquired. If
+// the sibling's only owner (another session) is released in that window, the
+// sibling is collected and its OnRelease runs — but the completing call still
+// adopts it: indexWaitResultInEgraphLocked re-registers the collected result
+// (resultsByID[res.id] = res) and the caller is handed a result whose payload
+// has already been released.
+//
+// The test choreographs that interleaving deterministically:
+//
+//  1. Session A publishes resultA (recipe A, content digest D). Session B
+//     publishes resultB (recipe B, same content digest D). Both land in one
+//     output eq-class; resultA has the lower shared result ID, so it is the
+//     canonical pick.
+//  2. Session B starts call C whose fn returns the attached resultB. The fn
+//     parks until the test holds egraphMu, so call C's initCompletedResult
+//     blocks at the canonicalization Lock while the test owns the mutex.
+//  3. A ReleaseSession(session-a) goroutine queues on egraphMu behind call C.
+//  4. The test forces the mutex into starvation mode (unlock+relock makes the
+//     woken call-C goroutine observe a held lock after waiting >1ms), then
+//     unlocks. Starvation mode hands the mutex FIFO: call C canonicalizes
+//     (picks the still-live resultA) and unlocks; the release goroutine then
+//     collects resultA and runs its OnRelease; call C re-acquires and
+//     resurrects the corpse.
+//
+// The orchestration can misfire (the test's re-lock races the woken
+// goroutine), so it retries a bounded number of attempts; misfires produce a
+// benign ordering that the test detects and skips.
+func TestCacheCanonicalEquivalentSwapRacesSessionRelease(t *testing.T) {
+	const attempts = 50
+
+	var sawBenign, sawAdoptedAlive int
+	for attempt := range attempts {
+		adopted, released := runCanonicalSwapReleaseAttempt(t, attempt)
+		switch {
+		case adopted && released:
+			t.Logf("attempt %d: reproduced after %d benign orderings: session B was handed the adopted sibling after its OnRelease ran", attempt, sawBenign)
+			t.Fatalf("call adopted a canonical-equivalent result whose payload was already released (use-after-release of the sibling's payload)")
+		case adopted:
+			// Adopted the sibling and it is still live: the release must have
+			// happened after the call took ownership. Correct behavior.
+			sawAdoptedAlive++
+		default:
+			// The release won the race entirely (sibling collected before the
+			// canonicalization pick), so the call kept its own result. Correct
+			// behavior, but not the interleaving under test.
+			sawBenign++
+		}
+	}
+	t.Logf("no reproduction in %d attempts (%d benign release-first orderings, %d adopted-alive orderings)", attempts, sawBenign, sawAdoptedAlive)
+}
+
+// runCanonicalSwapReleaseAttempt runs one choreographed attempt. It reports
+// whether call C's returned result adopted session A's sibling result, and
+// whether that sibling's OnRelease had run by the time both goroutines
+// finished.
+func runCanonicalSwapReleaseAttempt(t *testing.T, attempt int) (adoptedSibling bool, siblingReleased bool) {
+	t.Helper()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	ctx = ContextWithCache(ctx, c)
+
+	contentDigest := digest.FromString("canonical-swap-race-content")
+
+	// Session A publishes the canonical sibling: lowest shared result ID,
+	// owned only by session A's session edge.
+	var releasedA atomic.Bool
+	callA := cacheTestIntCall("canonical-swap-race-a")
+	resA, err := c.GetOrInitCall(ctx, "session-a", noopTypeResolver{}, &CallRequest{ResultCall: callA}, func(ctx context.Context) (AnyResult, error) {
+		detached := cacheTestDetachedResult(callA, cacheTestOnReleaseInt{
+			Int: NewInt(1),
+			onRelease: func(context.Context) error {
+				releasedA.Store(true)
+				return nil
+			},
+		})
+		return detached.WithContentDigest(ctx, contentDigest)
+	})
+	assert.NilError(t, err)
+	sharedA := resA.cacheSharedResult()
+	assert.Assert(t, sharedA != nil && sharedA.id != 0)
+
+	// Session B publishes an equivalent result (same content digest, different
+	// recipe), merging both into one output eq-class.
+	callB := cacheTestIntCall("canonical-swap-race-b")
+	resB, err := c.GetOrInitCall(ctx, "session-b", noopTypeResolver{}, &CallRequest{ResultCall: callB}, func(ctx context.Context) (AnyResult, error) {
+		detached := cacheTestDetachedResult(callB, NewInt(2))
+		return detached.WithContentDigest(ctx, contentDigest)
+	})
+	assert.NilError(t, err)
+	sharedB := resB.cacheSharedResult()
+	assert.Assert(t, sharedB != nil && sharedB.id != 0)
+	assert.Assert(t, sharedA.id < sharedB.id, "result A must be the canonical (lowest-ID) sibling")
+
+	// Call C in session B: fn returns the already-attached resultB, which
+	// drives initCompletedResult through the canonical-equivalent swap.
+	fnEntered := make(chan struct{})
+	fnRelease := make(chan struct{})
+	type callOutcome struct {
+		res AnyResult
+		err error
+	}
+	callDone := make(chan callOutcome, 1)
+	callC := cacheTestIntCall("canonical-swap-race-c")
+	go func() {
+		res, err := c.GetOrInitCall(ctx, "session-b", noopTypeResolver{}, &CallRequest{ResultCall: callC}, func(ctx context.Context) (AnyResult, error) {
+			close(fnEntered)
+			<-fnRelease
+			return resB, nil
+		})
+		callDone <- callOutcome{res, err}
+	}()
+	<-fnEntered
+
+	// Park call C's initCompletedResult at its first egraphMu acquisition (the
+	// canonicalization Lock) by holding the mutex before letting fn return.
+	c.egraphMu.Lock()
+	close(fnRelease)
+	time.Sleep(5 * time.Millisecond)
+
+	// Queue the session-A release behind call C.
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- c.ReleaseSession(context.WithoutCancel(ctx), "session-a")
+	}()
+	time.Sleep(5 * time.Millisecond)
+
+	// Force the mutex into starvation mode so the upcoming unlocks hand off
+	// FIFO and call C cannot barge back in between its canonicalization unlock
+	// and its publication re-lock: briefly unlock and immediately re-lock so
+	// the woken call-C goroutine observes a held lock after waiting >1ms and
+	// re-parks with the starvation bit set.
+	c.egraphMu.Unlock()
+	c.egraphMu.Lock()
+	time.Sleep(5 * time.Millisecond)
+
+	// Let the interleaving run: call C canonicalizes (picking resultA), the
+	// release collects resultA, then call C resurrects it.
+	c.egraphMu.Unlock()
+
+	assert.NilError(t, <-releaseDone)
+	got := <-callDone
+	assert.NilError(t, got.err)
+	gotShared := got.res.cacheSharedResult()
+	assert.Assert(t, gotShared != nil)
+
+	adoptedSibling = gotShared == sharedA
+	siblingReleased = releasedA.Load()
+
+	if adoptedSibling {
+		c.egraphMu.Lock()
+		registered := c.resultsByID[sharedA.id] == sharedA
+		ownership := sharedA.incomingOwnershipCount
+		c.egraphMu.Unlock()
+		t.Logf("attempt %d: call C adopted result A (id=%d): payloadReleased=%v reRegistered=%v ownership=%d",
+			attempt, sharedA.id, siblingReleased, registered, ownership)
+	}
+
+	return adoptedSibling, siblingReleased
+}

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -1414,6 +1414,14 @@ func (c *Cache) indexWaitResultInEgraphLocked(
 ) error {
 	c.initEgraphLocked()
 
+	// A result that carries an ID but is no longer registered was collected
+	// after its last owner released it: its OnRelease already ran, so its
+	// payload may reference released resources. Refuse to resurrect it rather
+	// than re-publish a dead payload into the cache.
+	if res.id != 0 && c.resultsByID[res.id] != res {
+		return fmt.Errorf("index result %d: result was already collected", res.id)
+	}
+
 	digestSet := make(map[string]struct{}, 6)
 	addDigest := func(dig string) {
 		if dig == "" {


### PR DESCRIPTION
## Symptom

`test-split:test-workspaces` flaked in CI ([trace](https://dagger.cloud/dagger/checks/github.com/dagger/dagger@a9de2e85486451fce824d7372d105c56998dd9d9?check=test-split:test-workspaces&run=c0b4ec6c-0cfb-4b8a-91ca-9342202ddd00)) with:

```
Directory.entries ERROR
! invalid immutable ref 0x394b61490180: invalid
```

in `TestWorkspace/TestCurrentWorkspaceRootAndCwd/detection_starts_below_workspace_root/workspace_cwd`. A `Directory` result handed to a live session was wrapping a snapshot ref handle that had already been `Release()`d — `immutableRef.Mount` fails with exactly this error when the handle's `released` flag is set.

## Root cause

When a resolver returns an already-attached result, `initCompletedResult` swaps it for a canonical equivalent sibling via `canonicalEquivalentSharedResultLocked`, but then **released `egraphMu` without taking any ownership hold on the adopted result**. The publication handoff hold was only taken much later, after re-acquiring the lock.

If the adopted sibling was owned solely by *another* session, a concurrent `ReleaseSession` could drain its ownership inside that unlocked window:

1. Call C (session B) completes; its resolver returned an attached result, so publication picks the canonical equivalent sibling — a result owned only by session A — and drops the lock.
2. Session A is released: the sibling's ownership hits zero, it is collected (removed from `resultsByID` and all e-graph indexes), and its `OnRelease` runs — for a `Directory`, that releases the snapshot ref handle stored in its payload.
3. Call C re-acquires the lock and **resurrects the corpse**: `indexWaitResultInEgraphLocked` unconditionally re-registered it (`resultsByID[res.id] = res`) and re-indexed its digests, so the dead payload was both returned to call C's caller and republished where future lookups could hit it.
4. The next field call on that receiver mounts the released handle → `invalid immutable ref`.

In the failing trace, the test's parallel subtests query the same fixture directory from separate clients, so their per-client `host.directory` results share one content-digest eq-class — exactly the setup for the canonical swap to adopt a sibling owned by a different session. The failing `Workspace.directory` publication stalled ~215ms on `egraphMu` contention behind the sibling-owning session's release (which removed its cache refs 27ms before the failing call completed), landing it squarely in the race window.

This race is why the failure is so rare: with digest derivations memoized, the unlocked window is normally sub-microsecond, and it only matters when an equivalent sibling's owning session is concurrently torn down.

## Fix

- `initCompletedResult` now takes the publication handoff hold **inside the same `egraphMu` critical section as the canonical pick**, so the adopted result cannot lose its last owner before the call's waiters claim session ownership. This mirrors what the lookup-hit path and `sharedResultByResultID` already do (canonicalize and bind ownership atomically). The hold taken at the end of publication is now conditional so the cache-backed path doesn't double-count; error paths after the early hold are already cleaned up by `wait()`'s existing handoff release paths.
- `indexWaitResultInEgraphLocked` now refuses to re-register a result that carries an ID but is no longer present in `resultsByID`, turning any remaining collected-result publication into an error instead of resurrecting a payload whose `OnRelease` already ran. With the first fix in place this is defense-in-depth: it can only fire if a resolver returns an already-dead result.

## Reproduction & testing

New `TestCacheCanonicalEquivalentSwapRacesSessionRelease` reproduces the race deterministically rather than statistically: it parks the completing call at the canonicalization lock by holding `egraphMu` from the test, queues the `ReleaseSession` behind it, and forces the mutex into starvation mode (an unlock + immediate re-lock makes the woken waiter observe a held lock after waiting >1ms) so the FIFO handoffs run the exact pick → collect → resurrect interleaving.

- **Before the fix**: failed on the first attempt of every run, including under `-race` — the returned result's payload had `OnRelease` already run, and the corpse was re-registered with resurrected ownership.
- **After the fix**: every choreographed attempt still adopts the sibling, but the early hold keeps it alive through the concurrent release (payload never released); the full `dagql` suite passes with and without `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
