### PR TITLE
cli: add --skip flag to dagger check

### DIFF
--- a/cmd/dagger/checks.go
+++ b/cmd/dagger/checks.go
@@ -29,6 +29,7 @@ var (
 	checksPast         bool
 	checksNoPast       bool
 	checksRun          bool
+	checksSkip         []string
 )
 
 //go:embed checks.graphql
@@ -42,8 +43,12 @@ func init() {
 	checksCmd.Flags().BoolVar(&checksPast, "past", false, "Only replay past Cloud Checks results")
 	checksCmd.Flags().BoolVar(&checksNoPast, "no-past", false, "Disable past Cloud Checks lookup")
 	checksCmd.Flags().BoolVar(&checksRun, "run", false, "Run checks even when past Cloud Checks results are replayed")
+	checksCmd.Flags().StringArrayVar(&checksSkip, "skip", nil, "Skip checks matching the specified patterns")
 	checksCmd.MarkFlagsMutuallyExclusive("no-generate", "generate")
 	checksCmd.MarkFlagsMutuallyExclusive("past", "no-past", "run")
+	// Past Cloud results can't be filtered by skip patterns, so --skip always
+	// runs checks live.
+	checksCmd.MarkFlagsMutuallyExclusive("past", "skip")
 }
 
 var checksCmd = &cobra.Command{
@@ -59,6 +64,7 @@ Examples:
   dagger check                    # Run all checks
   dagger check -l                 # List all available checks
   dagger check go:lint            # Run the go:lint check and any subchecks
+  dagger check --skip '**e2e'     # Run all checks except those matching '**e2e'
   dagger -W github.com/acme/ws check go:lint  # Run check(s) against explicit workspace
 `,
 	Args: cobra.ArbitraryArgs,
@@ -66,7 +72,7 @@ Examples:
 }
 
 func runChecksCommand(cmd *cobra.Command, args []string) error {
-	if !checksListMode {
+	if !checksListMode && len(checksSkip) == 0 {
 		replayed, shouldRun, err := maybeReplayPastChecks(cmd, args)
 		if !shouldRun {
 			return err
@@ -167,6 +173,7 @@ func runChecksNow(cmd *cobra.Command, args []string) error {
 			ws := dag.CurrentWorkspace()
 			checks := ws.Checks(dagger.WorkspaceChecksOpts{
 				Include:      args,
+				Skip:         checksSkip,
 				NoGenerate:   checksNoGenerate,
 				OnlyGenerate: checksOnlyGenerate,
 			})

--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -251,6 +251,75 @@ func (ChecksSuite) TestChecksGenerateAsCheck(ctx context.Context, t *testctx.T) 
 	})
 }
 
+func (ChecksSuite) TestChecksSkipFlag(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := checksTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-checks")
+
+	t.Run("list with skip excludes matching checks", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("check", "-l", "--skip", "failing-*")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.Contains(t, out, "passing-container")
+		require.Contains(t, out, "test:lint")
+		require.Contains(t, out, "test:unit")
+		require.NotContains(t, out, "failing-check")
+		require.NotContains(t, out, "failing-container")
+	})
+
+	t.Run("list with glob skip pattern", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("check", "-l", "--skip", "**:unit")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "test:lint")
+		require.NotContains(t, out, "test:unit")
+	})
+
+	t.Run("list with prefix skip pattern", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("check", "-l", "--skip", "test")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "passing-check")
+		require.NotContains(t, out, "test:lint")
+		require.NotContains(t, out, "test:unit")
+	})
+
+	t.Run("list with include and skip combined", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExec("check", "-l", "test", "--skip", "**:unit")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "test:lint")
+		require.NotContains(t, out, "test:unit")
+		require.NotContains(t, out, "passing-check")
+	})
+
+	t.Run("run with skip excludes matching checks", func(ctx context.Context, t *testctx.T) {
+		// Should pass because the failing checks are skipped
+		out, err := modGen.
+			With(daggerExec("--progress=report", "check", "--skip", "failing-*")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Regexp(t, `passing-check.*OK`, out)
+		require.Regexp(t, `passing-container.*OK`, out)
+		require.NotContains(t, out, "failing-check")
+		require.NotContains(t, out, "failing-container")
+	})
+
+	t.Run("past and skip are mutually exclusive", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerExecFail("check", "--past", "--skip", "failing-*")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "if any flags in the group [past skip] are set none of the others can be")
+	})
+}
+
 func (ChecksSuite) TestWorkspaceCheckSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	modGen, err := checksTestEnv(t, c)

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -151,6 +151,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Doc("Return all checks from modules loaded in the workspace.").
 			Args(
 				dagql.Arg("include").Doc("Only include checks matching the specified patterns"),
+				dagql.Arg("skip").Doc("Skip checks matching the specified patterns"),
 				dagql.Arg("noGenerate").Doc("When true, only return annotated check functions; exclude generate-as-checks"),
 				dagql.Arg("onlyGenerate").Doc("When true, only return generate-as-checks; exclude annotated check functions"),
 			),
@@ -783,6 +784,7 @@ func (s *workspaceSchema) checks(
 	parent *core.Workspace,
 	args struct {
 		Include      dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Skip         dagql.Optional[dagql.ArrayInput[dagql.String]]
 		NoGenerate   dagql.Optional[dagql.Boolean]
 		OnlyGenerate dagql.Optional[dagql.Boolean]
 	},
@@ -792,6 +794,7 @@ func (s *workspaceSchema) checks(
 	}
 
 	include := workspaceIncludePatterns(args.Include)
+	skip := workspaceIncludePatterns(args.Skip)
 
 	ctx, err := s.withWorkspaceClientContext(ctx, parent)
 	if err != nil {
@@ -829,6 +832,20 @@ func (s *workspaceSchema) checks(
 		)
 		if err != nil {
 			return nil, err
+		}
+		// Apply caller-requested skip patterns.
+		if len(skip) > 0 {
+			filtered, err = filterNodesByExclude(
+				ctx,
+				filtered,
+				skip,
+				func(check *core.Check) *core.ModTreeNode { return check.Node },
+				func(check *core.Check) string { return check.Name() },
+				"check",
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 		// Apply ignoreChecks exclusion for this toolchain's checks.
 		if exclude := ignoreChecks[mod.Self().Name()]; len(exclude) > 0 {

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -165,6 +165,7 @@ Examples:
   dagger check                    # Run all checks
   dagger check -l                 # List all available checks
   dagger check go:lint            # Run the go:lint check and any subchecks
+  dagger check --skip '**e2e'     # Run all checks except those matching '**e2e'
   dagger -W github.com/acme/ws check go:lint  # Run check(s) against explicit workspace
 
 
@@ -185,6 +186,7 @@ dagger check [options] [pattern...]
       --no-past             Disable past Cloud Checks lookup
       --past                Only replay past Cloud Checks results
       --run                 Run checks even when past Cloud Checks results are replayed
+      --skip stringArray    Skip checks matching the specified patterns
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5840,6 +5840,9 @@ type Workspace implements Node {
     """Only include checks matching the specified patterns"""
     include: [String!]
 
+    """Skip checks matching the specified patterns"""
+    skip: [String!]
+
     """
     When true, only return annotated check functions; exclude generate-as-checks
     """

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -13472,6 +13472,10 @@
                                 <p>Only include checks matching the specified patterns</p>
                               </div>
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>skip</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                                <p>Skip checks matching the specified patterns</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>noGenerate</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
                                 <p>When true, only return annotated check functions; exclude generate-as-checks</p>
                               </div>

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -156,7 +156,7 @@
                     <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_checks">checks</a>(array|null $include = null, bool|null $noGenerate = null, bool|null $onlyGenerate = null)
+                    <a href="#method_checks">checks</a>(array|null $include = null, array|null $skip = null, bool|null $noGenerate = null, bool|null $onlyGenerate = null)
         
                                             <p><p>Return all checks from modules loaded in the workspace.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -512,7 +512,7 @@
                     <h3 id="method_checks">
         <div class="location">at line 28</div>
         <code>                    <a href="../Dagger/CheckGroup.html"><abbr title="Dagger\CheckGroup">CheckGroup</abbr></a>
-    <strong>checks</strong>(array|null $include = null, bool|null $noGenerate = null, bool|null $onlyGenerate = null)
+    <strong>checks</strong>(array|null $include = null, array|null $skip = null, bool|null $noGenerate = null, bool|null $onlyGenerate = null)
         </code>
     </h3>
     <div class="details">    
@@ -529,6 +529,11 @@
                     <tr>
                 <td>array|null</td>
                 <td>$include</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>array|null</td>
+                <td>$skip</td>
                 <td></td>
             </tr>
                     <tr>
@@ -562,7 +567,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_clientId">
-        <div class="location">at line 46</div>
+        <div class="location">at line 53</div>
         <code>                    string
     <strong>clientId</strong>()
         </code>
@@ -594,7 +599,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_configFile">
-        <div class="location">at line 55</div>
+        <div class="location">at line 62</div>
         <code>                    string
     <strong>configFile</strong>()
         </code>
@@ -626,7 +631,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_configRead">
-        <div class="location">at line 70</div>
+        <div class="location">at line 77</div>
         <code>                    string
     <strong>configRead</strong>(string|null $key = &#039;&#039;)
         </code>
@@ -670,7 +675,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_configWrite">
-        <div class="location">at line 82</div>
+        <div class="location">at line 89</div>
         <code>                    string
     <strong>configWrite</strong>(string $key, string $value, bool|null $here = false)
         </code>
@@ -722,7 +727,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_cwd">
-        <div class="location">at line 100</div>
+        <div class="location">at line 107</div>
         <code>                    string
     <strong>cwd</strong>()
         </code>
@@ -755,7 +760,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 111</div>
+        <div class="location">at line 118</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>(string $path, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false)
         </code>
@@ -812,7 +817,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envCreate">
-        <div class="location">at line 134</div>
+        <div class="location">at line 141</div>
         <code>                    string
     <strong>envCreate</strong>(string $name, bool|null $here = false)
         </code>
@@ -859,7 +864,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envList">
-        <div class="location">at line 147</div>
+        <div class="location">at line 154</div>
         <code>                    array
     <strong>envList</strong>()
         </code>
@@ -891,7 +896,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envRemove">
-        <div class="location">at line 156</div>
+        <div class="location">at line 163</div>
         <code>                    string
     <strong>envRemove</strong>(string $name, bool|null $here = false)
         </code>
@@ -938,7 +943,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 171</div>
+        <div class="location">at line 178</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path)
         </code>
@@ -980,7 +985,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_findUp">
-        <div class="location">at line 187</div>
+        <div class="location">at line 194</div>
         <code>                    string
     <strong>findUp</strong>(string $name, string|null $from = &#039;.&#039;)
         </code>
@@ -1029,7 +1034,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generators">
-        <div class="location">at line 200</div>
+        <div class="location">at line 207</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>generators</strong>(array|null $include = null)
         </code>
@@ -1071,7 +1076,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_git">
-        <div class="location">at line 212</div>
+        <div class="location">at line 219</div>
         <code>                    <a href="../Dagger/WorkspaceGit.html"><abbr title="Dagger\WorkspaceGit">WorkspaceGit</abbr></a>
     <strong>git</strong>()
         </code>
@@ -1103,7 +1108,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 221</div>
+        <div class="location">at line 228</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1135,7 +1140,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_init">
-        <div class="location">at line 230</div>
+        <div class="location">at line 237</div>
         <code>                    string
     <strong>init</strong>(bool|null $here = false)
         </code>
@@ -1177,7 +1182,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_install">
-        <div class="location">at line 242</div>
+        <div class="location">at line 249</div>
         <code>                    string
     <strong>install</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -1229,7 +1234,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_migrate">
-        <div class="location">at line 260</div>
+        <div class="location">at line 267</div>
         <code>                    <a href="../Dagger/WorkspaceMigration.html"><abbr title="Dagger\WorkspaceMigration">WorkspaceMigration</abbr></a>
     <strong>migrate</strong>(bool|null $force = false)
         </code>
@@ -1271,7 +1276,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleInit">
-        <div class="location">at line 272</div>
+        <div class="location">at line 279</div>
         <code>                    string
     <strong>moduleInit</strong>(string $name, string|null $sdk = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], bool|null $selfCalls = false, bool|null $here = false)
         </code>
@@ -1338,7 +1343,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleList">
-        <div class="location">at line 303</div>
+        <div class="location">at line 310</div>
         <code>                    array
     <strong>moduleList</strong>(string|null $module = &#039;&#039;)
         </code>
@@ -1380,7 +1385,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 315</div>
+        <div class="location">at line 322</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1422,7 +1427,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_uninstall">
-        <div class="location">at line 327</div>
+        <div class="location">at line 334</div>
         <code>                    string
     <strong>uninstall</strong>(string $name, bool|null $here = false)
         </code>
@@ -1469,7 +1474,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_update">
-        <div class="location">at line 342</div>
+        <div class="location">at line 349</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>update</strong>()
         </code>

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -31,6 +31,7 @@ defmodule Dagger.Workspace do
   """
   @spec checks(t(), [
           {:include, [String.t()]},
+          {:skip, [String.t()]},
           {:no_generate, boolean() | nil},
           {:only_generate, boolean() | nil}
         ]) :: Dagger.CheckGroup.t()
@@ -39,6 +40,7 @@ defmodule Dagger.Workspace do
       workspace.query_builder
       |> QB.select("checks")
       |> QB.maybe_put_arg("include", optional_args[:include])
+      |> QB.maybe_put_arg("skip", optional_args[:skip])
       |> QB.maybe_put_arg("noGenerate", optional_args[:no_generate])
       |> QB.maybe_put_arg("onlyGenerate", optional_args[:only_generate])
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16308,6 +16308,8 @@ func (r *Workspace) Address(ctx context.Context) (string, error) {
 type WorkspaceChecksOpts struct {
 	// Only include checks matching the specified patterns
 	Include []string
+	// Skip checks matching the specified patterns
+	Skip []string
 	// When true, only return annotated check functions; exclude generate-as-checks
 	NoGenerate bool
 	// When true, only return generate-as-checks; exclude annotated check functions
@@ -16321,6 +16323,10 @@ func (r *Workspace) Checks(opts ...WorkspaceChecksOpts) *CheckGroup {
 		// `include` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+		}
+		// `skip` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Skip) {
+			q = q.Arg("skip", opts[i].Skip)
 		}
 		// `noGenerate` optional argument
 		if !querybuilder.IsZeroValue(opts[i].NoGenerate) {

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -25,11 +25,18 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * Return all checks from modules loaded in the workspace.
      */
-    public function checks(?array $include = null, ?bool $noGenerate = null, ?bool $onlyGenerate = null): CheckGroup
-    {
+    public function checks(
+        ?array $include = null,
+        ?array $skip = null,
+        ?bool $noGenerate = null,
+        ?bool $onlyGenerate = null,
+    ): CheckGroup {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('checks');
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
+        }
+        if (null !== $skip) {
+        $innerQueryBuilder->setArgument('skip', $skip);
         }
         if (null !== $noGenerate) {
         $innerQueryBuilder->setArgument('noGenerate', $noGenerate);

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -16009,6 +16009,7 @@ class Workspace(Type):
         self,
         *,
         include: list[str] | None = None,
+        skip: list[str] | None = None,
         no_generate: bool | None = None,
         only_generate: bool | None = None,
     ) -> CheckGroup:
@@ -16018,6 +16019,8 @@ class Workspace(Type):
         ----------
         include:
             Only include checks matching the specified patterns
+        skip:
+            Skip checks matching the specified patterns
         no_generate:
             When true, only return annotated check functions; exclude
             generate-as-checks
@@ -16027,6 +16030,7 @@ class Workspace(Type):
         """
         _args = [
             Arg("include", include, None),
+            Arg("skip", skip, None),
             Arg("noGenerate", no_generate, None),
             Arg("onlyGenerate", only_generate, None),
         ]

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -16729,6 +16729,9 @@ pub struct WorkspaceChecksOpts<'a> {
     /// When true, only return generate-as-checks; exclude annotated check functions
     #[builder(setter(into, strip_option), default)]
     pub only_generate: Option<bool>,
+    /// Skip checks matching the specified patterns
+    #[builder(setter(into, strip_option), default)]
+    pub skip: Option<Vec<&'a str>>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceConfigReadOpts<'a> {
@@ -16885,6 +16888,9 @@ impl Workspace {
         let mut query = self.selection.select("checks");
         if let Some(include) = opts.include {
             query = query.arg("include", include);
+        }
+        if let Some(skip) = opts.skip {
+            query = query.arg("skip", skip);
         }
         if let Some(no_generate) = opts.no_generate {
             query = query.arg("noGenerate", no_generate);

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3000,6 +3000,11 @@ export type WorkspaceChecksOpts = {
   include?: string[]
 
   /**
+   * Skip checks matching the specified patterns
+   */
+  skip?: string[]
+
+  /**
    * When true, only return annotated check functions; exclude generate-as-checks
    */
   noGenerate?: boolean
@@ -15426,6 +15431,7 @@ export class Workspace extends BaseClient {
   /**
    * Return all checks from modules loaded in the workspace.
    * @param opts.include Only include checks matching the specified patterns
+   * @param opts.skip Skip checks matching the specified patterns
    * @param opts.noGenerate When true, only return annotated check functions; exclude generate-as-checks
    * @param opts.onlyGenerate When true, only return generate-as-checks; exclude annotated check functions
    */


### PR DESCRIPTION
## What

Adds a `--skip` flag to `dagger check` to exclude checks matching a pattern — the inverse of the existing inclusive pattern arguments:

```console
dagger check --skip '**e2e'        # run all checks except those matching **e2e
dagger check -l --skip 'failing-*' # preview what would run
dagger check go --skip 'go:lint'   # combines with include patterns
```

## How

- `Workspace.checks` gains a `skip: [String!]` argument. Skip patterns are applied with the same `filterNodesByExclude` helper already used for config-driven `[check] skip` patterns, so matching semantics are identical to the inclusive patterns (doublestar glob + path prefix + single-module compat fallback), just inverted. Include and skip compose: a check runs if it matches the include patterns and does not match any skip pattern.
- The CLI flag is repeatable and applies to both running and listing (`-l`).
- Past Cloud Checks results can't be filtered by skip patterns, so `--skip` always runs checks live: it bypasses the past-results replay and is mutually exclusive with `--past`.

## Testing

- New `TestChecksSkipFlag` integration tests covering list/run with `--skip`, glob (`**:unit`) and prefix (`test`) patterns, include+skip combined, and `--past`/`--skip` exclusivity.
- Verified end-to-end against a dev engine built from this branch, including include/skip parity: for every pattern form tested, whatever include matches, skip excludes.

Closes #13335

🤖 Generated with [Claude Code](https://claude.com/claude-code)