### PR TITLE
fix(filesync): syncing a re-included file under a gitignored dir failed with `no such file or directory`

### DIFF
--- a/engine/filesync/localfs.go
+++ b/engine/filesync/localfs.go
@@ -213,8 +213,20 @@ func (local *localFS) Sync( //nolint:gocyclo
 		}
 	}()
 
+	// the paths to copy from the mirror into the final snapshot
 	only := map[string]struct{}{}
-	ignoredDirs := map[string]struct{}{}
+
+	// Gitignored dirs are not synced, but a re-included file inside one
+	// ("!foo/bar.txt") can only be written once its parent dir exists in the
+	// mirror. Track ignored dirs so they can be created on demand. They never
+	// enter `only`: ignored dirs are not synced content and should not affect
+	// the cache key.
+	type ignoredDir struct {
+		kind    ChangeKind
+		stat    *types.Stat
+		created bool
+	}
+	ignoredDirs := map[string]*ignoredDir{}
 	isIgnoredPath := func(path string) bool {
 		for {
 			if _, ok := ignoredDirs[path]; ok {
@@ -230,6 +242,30 @@ func (local *localFS) Sync( //nolint:gocyclo
 			path = next
 		}
 		return false
+	}
+	var ensureIgnoredParentDirs func(path string) error
+	ensureIgnoredParentDirs = func(path string) error {
+		dir := filepath.Dir(path)
+		if dir == "." { // paths are relative; "." means we reached the sync root
+			return nil
+		}
+		// create outermost ancestors first
+		if err := ensureIgnoredParentDirs(dir); err != nil {
+			return err
+		}
+		ignored, ok := ignoredDirs[dir]
+		if !ok || ignored.created {
+			return nil
+		}
+		appliedChange, err := local.Mkdir(egCtx, ignored.kind, dir, ignored.stat)
+		if err != nil {
+			return err
+		}
+		ignored.created = true
+		cachedResultsMu.Lock()
+		cachedResults = append(cachedResults, appliedChange)
+		cachedResultsMu.Unlock()
+		return nil
 	}
 
 	// We assert if we find a file/dir in the given relative path to correctly return
@@ -304,12 +340,15 @@ func (local *localFS) Sync( //nolint:gocyclo
 	doubleWalkDiff(egCtx, eg, local, remote, func(kind ChangeKind, path string, lowerStat, upperStat *types.Stat) error {
 		if upperStat != nil && upperStat.GitIgnored {
 			if upperStat.IsDir() {
-				ignoredDirs[path] = struct{}{}
+				ignoredDirs[path] = &ignoredDir{kind: kind, stat: upperStat}
 			}
 			return nil
 		}
 		switch kind {
 		case ChangeKindAdd, ChangeKindModify:
+			if err := ensureIgnoredParentDirs(path); err != nil {
+				return err
+			}
 			switch {
 			case upperStat.IsDir():
 				appliedChange, err := local.Mkdir(egCtx, kind, path, upperStat)

--- a/engine/filesync/localfs.go
+++ b/engine/filesync/localfs.go
@@ -251,6 +251,9 @@ func (local *localFS) Sync( //nolint:gocyclo
 
 	var ensureIgnoredParentDirs func(path string) error
 	ensureIgnoredParentDirs = func(path string) error {
+		if len(ignoredDirs) == 0 {
+			return nil
+		}
 		dir := filepath.Dir(path)
 		if dir == "." { // paths are relative; "." means we reached the sync root
 			return nil
@@ -518,6 +521,9 @@ func (local *localFS) Sync( //nolint:gocyclo
 			return nil
 
 		case ChangeKindNone:
+			if err := ensureIgnoredParentDirs(path); err != nil {
+				return err
+			}
 			appliedChange, err := local.GetPreviousChange(egCtx, path, lowerStat)
 			if err != nil {
 				return err

--- a/engine/filesync/localfs.go
+++ b/engine/filesync/localfs.go
@@ -220,7 +220,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 	// ("!foo/bar.txt") can only be written once its parent dir exists in the
 	// mirror. Track ignored dirs so they can be created on demand. They never
 	// enter `only`: ignored dirs are not synced content and should not affect
-	// the cache key.
+	// which files are copied from the mirror into the final snapshot.
 	type ignoredDir struct {
 		kind    ChangeKind
 		stat    *types.Stat
@@ -243,6 +243,12 @@ func (local *localFS) Sync( //nolint:gocyclo
 		}
 		return false
 	}
+
+	// We assert if we find a file/dir in the given relative path to correctly return
+	// an error if nothing exist in there.
+	// See explanations here: https://github.com/dagger/dagger/pull/10995#issuecomment-3347636652
+	var relPathFound atomic.Bool
+
 	var ensureIgnoredParentDirs func(path string) error
 	ensureIgnoredParentDirs = func(path string) error {
 		dir := filepath.Dir(path)
@@ -265,13 +271,21 @@ func (local *localFS) Sync( //nolint:gocyclo
 		cachedResultsMu.Lock()
 		cachedResults = append(cachedResults, appliedChange)
 		cachedResultsMu.Unlock()
+
+		doHandle := cacheCtx != nil
+		if local.copyPath != "" {
+			dir, doHandle = strings.CutPrefix(dir, local.copyPath)
+		}
+		if doHandle {
+			relPathFound.Store(true)
+			applied := appliedChange.result()
+			if err := cacheCtx.HandleChange(applied.kind, dir, applied.stat, nil); err != nil {
+				return fmt.Errorf("failed to handle change in content hasher: %w", err)
+			}
+		}
+
 		return nil
 	}
-
-	// We assert if we find a file/dir in the given relative path to correctly return
-	// an error if nothing exist in there.
-	// See explanations here: https://github.com/dagger/dagger/pull/10995#issuecomment-3347636652
-	relPathFound := false
 
 	// Hardlinks are a bit hard; we can't create them until their source file exists but we sync in files asynchronously.
 	// To deal with this we keep track of the hardlinks we need to make and apply them all at once after everything else
@@ -365,7 +379,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 					path, doHandle = strings.CutPrefix(path, local.copyPath)
 				}
 				if doHandle {
-					relPathFound = true
+					relPathFound.Store(true)
 					applied := appliedChange.result()
 					if err := cacheCtx.HandleChange(applied.kind, path, applied.stat, nil); err != nil {
 						return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -395,7 +409,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 					path, doHandle = strings.CutPrefix(path, local.copyPath)
 				}
 				if doHandle {
-					relPathFound = true
+					relPathFound.Store(true)
 					applied := appliedChange.result()
 					if err := cacheCtx.HandleChange(applied.kind, path, applied.stat, nil); err != nil {
 						return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -462,7 +476,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 						path, doHandle = strings.CutPrefix(path, local.copyPath)
 					}
 					if doHandle {
-						relPathFound = true
+						relPathFound.Store(true)
 						applied := appliedChange.result()
 						if err := cacheCtx.HandleChange(applied.kind, path, applied.stat, nil); err != nil {
 							return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -518,7 +532,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 				path, doHandle = strings.CutPrefix(path, local.copyPath)
 			}
 			if doHandle {
-				relPathFound = true
+				relPathFound.Store(true)
 				applied := appliedChange.result()
 				if err := cacheCtx.HandleChange(applied.kind, path, applied.stat, nil); err != nil {
 					return fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -551,7 +565,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 			path, doHandle = strings.CutPrefix(path, local.copyPath)
 		}
 		if doHandle {
-			relPathFound = true
+			relPathFound.Store(true)
 			applied := appliedChange.result()
 			if err := cacheCtx.HandleChange(applied.kind, path, applied.stat, nil); err != nil {
 				return nil, "", fmt.Errorf("failed to handle change in content hasher: %w", err)
@@ -568,7 +582,7 @@ func (local *localFS) Sync( //nolint:gocyclo
 	defer telemetry.EndWithCause(copySpan, &rerr)
 
 	// If we didn't find any files/dir in the given relative path, we can early return an error.
-	if local.copyPath != "" && !relPathFound {
+	if local.copyPath != "" && !relPathFound.Load() {
 		return nil, "", fmt.Errorf("%s: no such file or directory", local.copyPath)
 	}
 

--- a/engine/filesync/localfs_test.go
+++ b/engine/filesync/localfs_test.go
@@ -1,8 +1,14 @@
 package filesync
 
 import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/dagger/dagger/internal/fsutil"
+	"github.com/dagger/dagger/util/fsxutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -25,4 +31,59 @@ func TestLocalCopyOnlyPaths(t *testing.T) {
 		"README.md":   {},
 		"src/main.go": {},
 	}, got))
+}
+
+// Regression: with "foo/" ignored but "!foo/bar.txt" re-included, Sync skipped
+// creating foo/ in the mirror and then failed to write foo/bar.txt.
+func TestSyncReincludedFileUnderIgnoredParent(t *testing.T) {
+	t.Parallel()
+
+	clientRoot := writeTree(t, map[string]string{
+		".gitignore":      "foo/\n!foo/bar.txt\n",
+		"foo/bar.txt":     "keep",
+		"foo/ignored.txt": "drop",
+	})
+	base, err := fsutil.NewFS(clientRoot)
+	assert.NilError(t, err)
+	client, err := fsxutil.NewGitIgnoreMarkedFS(base, nil)
+	assert.NilError(t, err)
+
+	mirrorRoot := t.TempDir()
+	local, err := newLocalFS(NewMirrorSharedState(mirrorRoot), "", nil, nil, nil, "")
+	assert.NilError(t, err)
+
+	// Sync runs in two stages: write the client's files into the mirror, then
+	// copy the mirror into an immutable snapshot. The bug was in the first
+	// stage (foo/ was never created, so writing foo/bar.txt failed), so
+	// forParents=true stops Sync right after it, keeping the test simple:
+	// no cache manager needed (nil).
+	_, _, err = local.Sync(context.Background(), readFS{client}, nil, true)
+	assert.NilError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(mirrorRoot, "foo/bar.txt"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(got), "keep")
+
+	_, err = os.ReadFile(filepath.Join(mirrorRoot, "foo/ignored.txt"))
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+type readFS struct {
+	fsutil.FS
+}
+
+func (r readFS) ReadFile(_ context.Context, path string) (io.ReadCloser, error) {
+	return r.Open(path)
+}
+
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	for path, contents := range files {
+		fullPath := filepath.Join(root, path)
+		assert.NilError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+		assert.NilError(t, os.WriteFile(fullPath, []byte(contents), 0o644))
+	}
+	return root
 }

--- a/engine/filesync/localfs_test.go
+++ b/engine/filesync/localfs_test.go
@@ -105,15 +105,22 @@ func TestSyncReincludedFileUnderIgnoredParentCacheContext(t *testing.T) {
 		assert.NilError(t, cacheManager.Close())
 	})
 
-	ref, _, err := local.Sync(ctx, readFS{client}, cacheManager, false)
-	assert.NilError(t, err)
-	t.Cleanup(func() {
-		assert.NilError(t, ref.Release(context.Background()))
-	})
+	syncAndAssertParentChecksum := func() {
+		t.Helper()
 
-	dgst, err := bkcontenthash.Checksum(ctx, ref, "/foo", bkcontenthash.ChecksumOpts{})
-	assert.NilError(t, err)
-	assert.Assert(t, dgst != "")
+		ref, _, err := local.Sync(ctx, readFS{client}, cacheManager, false)
+		assert.NilError(t, err)
+		defer func() {
+			assert.NilError(t, ref.Release(context.Background()))
+		}()
+
+		dgst, err := bkcontenthash.Checksum(ctx, ref, "/foo", bkcontenthash.ChecksumOpts{})
+		assert.NilError(t, err)
+		assert.Assert(t, dgst != "")
+	}
+
+	syncAndAssertParentChecksum() // cold mirror
+	syncAndAssertParentChecksum() // warm mirror, re-included file is ChangeKindNone
 }
 
 type readFS struct {

--- a/engine/filesync/localfs_test.go
+++ b/engine/filesync/localfs_test.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/containerd/v2/plugins/snapshots/native"
+	bkcontenthash "github.com/dagger/dagger/engine/contenthash"
+	bkcache "github.com/dagger/dagger/engine/snapshots"
+	bkcontainerd "github.com/dagger/dagger/engine/snapshots/containerd"
 	"github.com/dagger/dagger/internal/fsutil"
 	"github.com/dagger/dagger/util/fsxutil"
 	"gotest.tools/v3/assert"
@@ -66,6 +70,50 @@ func TestSyncReincludedFileUnderIgnoredParent(t *testing.T) {
 
 	_, err = os.ReadFile(filepath.Join(mirrorRoot, "foo/ignored.txt"))
 	assert.Assert(t, os.IsNotExist(err))
+}
+
+// Verify that a full sync records the ignored parent directory it creates for
+// a re-included child, so parent checksums do not report "not found".
+func TestSyncReincludedFileUnderIgnoredParentCacheContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clientRoot := writeTree(t, map[string]string{
+		".gitignore":      "foo/\n!foo/bar.txt\n",
+		"foo/bar.txt":     "keep",
+		"foo/ignored.txt": "drop",
+	})
+	base, err := fsutil.NewFS(clientRoot)
+	assert.NilError(t, err)
+	client, err := fsxutil.NewGitIgnoreMarkedFS(base, nil)
+	assert.NilError(t, err)
+
+	local, err := newLocalFS(NewMirrorSharedState(t.TempDir()), "", nil, nil, nil, "")
+	assert.NilError(t, err)
+
+	snapshotter, err := native.NewSnapshotter(t.TempDir())
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		assert.NilError(t, snapshotter.Close())
+	})
+	cacheManager, err := bkcache.NewSnapshotManager(bkcache.SnapshotManagerOpt{
+		Snapshotter:   bkcontainerd.NewSnapshotter("native", snapshotter, "filesync-test"),
+		MountPoolRoot: t.TempDir(),
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		assert.NilError(t, cacheManager.Close())
+	})
+
+	ref, _, err := local.Sync(ctx, readFS{client}, cacheManager, false)
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		assert.NilError(t, ref.Release(context.Background()))
+	})
+
+	dgst, err := bkcontenthash.Checksum(ctx, ref, "/foo", bkcontenthash.ChecksumOpts{})
+	assert.NilError(t, err)
+	assert.Assert(t, dgst != "")
 }
 
 type readFS struct {


### PR DESCRIPTION
## Problem

A `.gitignore` that ignores a directory but re-includes a file inside it broke filesync:

```.gitignore
foo/
!foo/bar.txt
```

The receiver skips gitignored dirs, so it never created `foo/` in the engine-side mirror. And then, failed to write the re-included file:

```shell
open <mirror>/foo/bar.txt: no such file or directory
```

## Fix

Gitignored dirs are now _remembered_ instead of _dropped_.

When a visible file inside one needs to be written, its missing parent dirs are created first, reusing the normal dir-creation path so the dirs get the client's metadata and concurrent syncs stay consistent:

| path | client | mirror (engine copy) | snapshot (pipeline input) |
|------|--------|----------------------|---------------------------|
| `foo/` | ignored | created on demand, so `bar.txt` can be written | present, but only as `bar.txt`'s parent dir |
| `foo/bar.txt` | re-included | written | synced ✓ |
| `foo/ignored.txt` | ignored | never written | absent ✓ |


> [!NOTE]
> Current implementation keeps the dir itself out of the cache key: the pattern `foo/` declares it ignored, and only `bar.txt` was re-included. **_I am unsure about that_**


## Test

To run the regression test:

```go
go test ./engine/filesync -run '^TestSyncReincludedFileUnderIgnoredParent$' -count=1
```