### PR TITLE
fix(engine): release stale conns in h2c tunnel bridge

### DIFF
--- a/engine/engineutil/client.go
+++ b/engine/engineutil/client.go
@@ -304,6 +304,18 @@ func (c *Client) ListenHostToContainer(
 				continue
 			}
 
+			if res.GetClose() {
+				// The host side closed its end; release our upstream conn.
+				connsL.Lock()
+				conn, found := conns[connID]
+				delete(conns, connID)
+				connsL.Unlock()
+				if found {
+					conn.Close()
+				}
+				continue
+			}
+
 			connsL.Lock()
 			conn, found := conns[connID]
 			connsL.Unlock()
@@ -331,6 +343,22 @@ func (c *Client) ListenHostToContainer(
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					// Always release the upstream conn and notify the host
+					// when this goroutine exits, otherwise stale conns
+					// accumulate in the map and leak FDs.
+					defer func() {
+						connsL.Lock()
+						delete(conns, connID)
+						connsL.Unlock()
+						conn.Close()
+
+						sendL.Lock()
+						_ = listener.Send(&h2c.ListenRequest{
+							ConnId: connID,
+							Close:  true,
+						})
+						sendL.Unlock()
+					}()
 
 					data := make([]byte, 32*1024)
 					for {
@@ -349,13 +377,6 @@ func (c *Client) ListenHostToContainer(
 							break
 						}
 					}
-
-					sendL.Lock()
-					_ = listener.Send(&h2c.ListenRequest{
-						ConnId: connID,
-						Close:  true,
-					})
-					sendL.Unlock()
 				}()
 			}
 

--- a/engine/session/h2c/h2c.go
+++ b/engine/session/h2c/h2c.go
@@ -94,17 +94,37 @@ func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error 
 			}
 
 			go func() {
+				// Always release the conn when this goroutine exits: close
+				// the underlying conn, drop it from the map, and tell the peer
+				// to close its end too. Without this, conns whose read side
+				// ends (e.g. EOF from the local client) are left open in the
+				// map, leaking FDs until the whole tunnel is torn down and
+				// eventually exhausting the accept loop.
+				defer func() {
+					connsL.Lock()
+					delete(conns, connID)
+					connsL.Unlock()
+					conn.Close()
+
+					sendL.Lock()
+					err := srv.Send(&ListenResponse{
+						ConnId: connID,
+						Close:  true,
+					})
+					sendL.Unlock()
+					if err != nil {
+						slog.Warn("listener send close error", "error", err)
+					}
+				}()
+
 				for {
 					// Read data from the connection
 					data := make([]byte, 1024)
 					n, err := conn.Read(data)
 					if err != nil {
-						if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
-							// conn closed
-							return
+						if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
+							slog.Warn("conn read error", "error", err)
 						}
-
-						slog.Warn("conn read error", "error", err)
 						return
 					}
 
@@ -155,7 +175,11 @@ func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error 
 		conn, ok := conns[connID]
 		connsL.Unlock()
 		if !ok {
-			slog.Warn("listener request for unknown connID", "connID", connID)
+			// A close can race with our own goroutine-side cleanup, so don't
+			// warn when the conn is already gone.
+			if !req.GetClose() {
+				slog.Warn("listener request for unknown connID", "connID", connID)
+			}
 			continue
 		}
 

--- a/engine/session/h2c/h2c_test.go
+++ b/engine/session/h2c/h2c_test.go
@@ -1,0 +1,100 @@
+package h2c
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// fakeListenServer is a minimal in-memory TunnelListener_ListenServer. Only
+// Send/Recv are exercised by Listen; the embedded grpc.ServerStream satisfies
+// the rest of the interface but is never called.
+type fakeListenServer struct {
+	grpc.ServerStream
+	recv chan *ListenRequest
+	sent chan *ListenResponse
+}
+
+func (f *fakeListenServer) Send(resp *ListenResponse) error {
+	f.sent <- resp
+	return nil
+}
+
+func (f *fakeListenServer) Recv() (*ListenRequest, error) {
+	req, ok := <-f.recv
+	if !ok {
+		return nil, io.EOF
+	}
+	return req, nil
+}
+
+// TestListenReleasesConnOnClientClose is a regression test for a connection
+// leak: when the local client closes its end of an accepted conn, the per-conn
+// goroutine used to return without closing the conn, deleting it from the map,
+// or telling the peer. That leaked an FD per connection until the accept loop
+// eventually failed and the tunnel stopped accepting connections.
+func TestListenReleasesConnOnClientClose(t *testing.T) {
+	fake := &fakeListenServer{
+		recv: make(chan *ListenRequest, 8),
+		sent: make(chan *ListenResponse, 8),
+	}
+
+	// Initial request asking the host to listen.
+	fake.recv <- &ListenRequest{Protocol: "tcp", Addr: "127.0.0.1:0"}
+
+	attach := NewTunnelListenerAttachable(context.Background())
+	listenDone := make(chan error, 1)
+	go func() {
+		listenDone <- attach.Listen(fake)
+	}()
+
+	// First response carries the bound address.
+	addr := recvResp(t, fake.sent).GetAddr()
+	require.NotEmpty(t, addr)
+
+	// Connect as a local client, then immediately close (EOF on the read side).
+	client, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+
+	// The accept triggers a connID notification.
+	connID := recvResp(t, fake.sent).GetConnId()
+	require.NotEmpty(t, connID)
+
+	require.NoError(t, client.Close())
+
+	// The fix makes the host propagate a Close for that connID; on the old
+	// code nothing was sent and this times out.
+	gotClose := false
+	for !gotClose {
+		resp := recvResp(t, fake.sent)
+		if resp.GetConnId() == connID && resp.GetClose() {
+			gotClose = true
+		}
+	}
+	require.True(t, gotClose)
+
+	// Shut the listener down cleanly.
+	close(fake.recv)
+	select {
+	case err := <-listenDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Listen did not return")
+	}
+}
+
+func recvResp(t *testing.T, ch <-chan *ListenResponse) *ListenResponse {
+	t.Helper()
+	select {
+	case resp := <-ch:
+		return resp
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for ListenResponse")
+		return nil
+	}
+}


### PR DESCRIPTION
The h2c tunnel bridge stored every accepted connection in a map but never released conns whose read side ended (e.g. EOF when the local client disconnects). The per-conn goroutine returned without closing the conn, removing it from the map, or notifying the peer.

Over time this leaked a file descriptor per connection on both ends of the tunnel, until the accept loop failed with too-many-open-files and the tunnel silently stopped accepting new connections — while the underlying service stayed healthy.

Both ends now close the conn, drop it from the map, and propagate a close to the peer when a connection goes away, and the engine side acts on an inbound close. Includes a regression test on the host side.

Reported on Discord: https://discord.com/channels/707636530424053791/1515418938631000095/1515418940254322919