### PR TITLE
fix(dang): resolve @cache args against file scope

### DIFF
--- a/core/integration/module_dang_test.go
+++ b/core/integration/module_dang_test.go
@@ -72,6 +72,16 @@ func (DangSuite) TestDirectives(_ context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		assertEntries(t, out, "keep.log", "keep.txt")
 	})
+
+	t.Run("cache directive with enum argument", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "test-directives").
+			With(daggerCall("with-never-cache")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "never", strings.TrimSpace(out))
+	})
 }
 
 func (DangSuite) TestEnums(_ context.Context, t *testctx.T) {

--- a/core/integration/testdata/modules/dang/test-directives/main.dang
+++ b/core/integration/testdata/modules/dang/test-directives/main.dang
@@ -54,4 +54,15 @@ type TestDirectives {
   ): [String!]! {
     source.entries
   }
+
+  """
+  Test @cache with an argument referencing an imported symbol
+  (FunctionCachePolicy). Imports are file-scoped, so the directive argument
+  must resolve against the declaring file's scope. Regression test for
+  dagger#13440.
+  """
+  @cache(policy: FunctionCachePolicy.Never)
+  pub withNeverCache(): String! {
+    "never"
+  }
 }

--- a/core/sdk/dang/v1/helpers.go
+++ b/core/sdk/dang/v1/helpers.go
@@ -353,11 +353,11 @@ func initDangModule(ctx context.Context, srv *dagql.Server, env dang.ValueScope)
 		}
 		switch val := binding.Value.(type) {
 		case *dang.ConstructorFunction:
-			objDef, err := createObjectTypeDef(ctx, srv, binding.Key, val, env, localTypes)
+			objDef, err := createObjectTypeDef(ctx, srv, binding.Key, val, localTypes)
 			if err != nil {
 				return res, fmt.Errorf("failed to create object %s: %w", binding.Key, err)
 			}
-			fnDef, err := createFunction(ctx, srv, val.ObjectType, binding.Key, val.FnType, env, localTypes)
+			fnDef, err := createFunction(ctx, srv, val.ObjectType, binding.Key, val.FnType, val.Closure, localTypes)
 			if err != nil {
 				return res, fmt.Errorf("failed to create constructor for %s: %w", binding.Key, err)
 			}
@@ -434,7 +434,12 @@ func initDangModule(ctx context.Context, srv *dagql.Server, env dang.ValueScope)
 	return res, nil
 }
 
-func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name string, fn *hm.FunctionType, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.Function], error) {
+// createFunction builds a core.Function for the named slot. directiveScope is the
+// file-local scope used to evaluate directive arguments; it must be the owning
+// type's captured closure (ConstructorFunction.Closure) so that directive args
+// referencing imported symbols (e.g. @cache(policy: FunctionCachePolicy.Never))
+// resolve the same way the type's own source does. See issue #13440.
+func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name string, fn *hm.FunctionType, directiveScope dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.Function], error) {
 	var res dagql.ObjectResult[*core.Function]
 
 	retTypeDef, err := dangTypeToTypeDef(ctx, srv, fn.Ret(false), localTypes)
@@ -463,7 +468,7 @@ func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name
 		})
 	}
 
-	dirSels, err := functionDirectiveSelectors(ctx, env, mod.GetDirectives(name))
+	dirSels, err := functionDirectiveSelectors(ctx, directiveScope, mod.GetDirectives(name))
 	if err != nil {
 		return res, fmt.Errorf("directives for %s: %w", name, err)
 	}
@@ -504,7 +509,7 @@ func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name
 			argArgs = append(argArgs, dagql.NamedInput{Name: "description", Value: dagql.String(doc)})
 		}
 
-		argArgs, err = applyArgDirectives(ctx, env, argArgs, arg.Key, args.Directives)
+		argArgs, err = applyArgDirectives(ctx, directiveScope, argArgs, arg.Key, args.Directives)
 		if err != nil {
 			return res, err
 		}
@@ -666,7 +671,7 @@ func dangValToGo(val dang.Value) (any, error) {
 	}
 }
 
-func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, module *dang.ConstructorFunction, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
+func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, module *dang.ConstructorFunction, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
 	var res dagql.ObjectResult[*core.TypeDef]
 
 	classMod := module.ObjectType
@@ -701,7 +706,7 @@ func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, mo
 		}
 		switch x := slotType.(type) {
 		case *hm.FunctionType:
-			fnDef, err := createFunction(ctx, srv, classMod, bindingName, x, env, localTypes)
+			fnDef, err := createFunction(ctx, srv, classMod, bindingName, x, module.Closure, localTypes)
 			if err != nil {
 				return res, fmt.Errorf("failed to create method %s for %s: %w", bindingName, name, err)
 			}

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -371,11 +371,11 @@ func initDangModule(ctx context.Context, srv *dagql.Server, env dang.ValueScope)
 		}
 		switch val := binding.Value.(type) {
 		case *dang.ConstructorFunction:
-			objDef, err := createObjectTypeDef(ctx, srv, binding.Key, val, env, localTypes)
+			objDef, err := createObjectTypeDef(ctx, srv, binding.Key, val, localTypes)
 			if err != nil {
 				return res, fmt.Errorf("failed to create object %s: %w", binding.Key, err)
 			}
-			fnDef, err := createFunction(ctx, srv, val.ObjectType, binding.Key, val.FnType, env, localTypes)
+			fnDef, err := createFunction(ctx, srv, val.ObjectType, binding.Key, val.FnType, val.Closure, localTypes)
 			if err != nil {
 				return res, fmt.Errorf("failed to create constructor for %s: %w", binding.Key, err)
 			}
@@ -452,7 +452,12 @@ func initDangModule(ctx context.Context, srv *dagql.Server, env dang.ValueScope)
 	return res, nil
 }
 
-func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name string, fn *hm.FunctionType, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.Function], error) {
+// createFunction builds a core.Function for the named slot. directiveScope is the
+// file-local scope used to evaluate directive arguments; it must be the owning
+// type's captured closure (ConstructorFunction.Closure) so that directive args
+// referencing imported symbols (e.g. @cache(policy: FunctionCachePolicy.Never))
+// resolve the same way the type's own source does. See issue #13440.
+func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name string, fn *hm.FunctionType, directiveScope dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.Function], error) {
 	var res dagql.ObjectResult[*core.Function]
 
 	retTypeDef, err := dangTypeToTypeDef(ctx, srv, fn.Ret(false), localTypes)
@@ -481,7 +486,7 @@ func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name
 		})
 	}
 
-	dirSels, err := functionDirectiveSelectors(ctx, env, mod.GetDirectives(name))
+	dirSels, err := functionDirectiveSelectors(ctx, directiveScope, mod.GetDirectives(name))
 	if err != nil {
 		return res, fmt.Errorf("directives for %s: %w", name, err)
 	}
@@ -522,7 +527,7 @@ func createFunction(ctx context.Context, srv *dagql.Server, mod *dang.Type, name
 			argArgs = append(argArgs, dagql.NamedInput{Name: "description", Value: dagql.String(doc)})
 		}
 
-		argArgs, err = applyArgDirectives(ctx, env, argArgs, arg.Key, args.Directives)
+		argArgs, err = applyArgDirectives(ctx, directiveScope, argArgs, arg.Key, args.Directives)
 		if err != nil {
 			return res, err
 		}
@@ -684,7 +689,7 @@ func dangValToGo(val dang.Value) (any, error) {
 	}
 }
 
-func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, module *dang.ConstructorFunction, env dang.ValueScope, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
+func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, module *dang.ConstructorFunction, localTypes dangLocalTypes) (dagql.ObjectResult[*core.TypeDef], error) {
 	var res dagql.ObjectResult[*core.TypeDef]
 
 	classMod := module.ObjectType
@@ -719,7 +724,7 @@ func createObjectTypeDef(ctx context.Context, srv *dagql.Server, name string, mo
 		}
 		switch x := slotType.(type) {
 		case *hm.FunctionType:
-			fnDef, err := createFunction(ctx, srv, classMod, bindingName, x, env, localTypes)
+			fnDef, err := createFunction(ctx, srv, classMod, bindingName, x, module.Closure, localTypes)
 			if err != nil {
 				return res, fmt.Errorf("failed to create method %s for %s: %w", bindingName, name, err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/dang v1.0.1
-	github.com/vito/dang/v2 v2.0.0
+	github.com/vito/dang/v2 v2.0.3-0.20260616005952-fd0fc4f72aa1
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
 github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
-github.com/vito/dang/v2 v2.0.0 h1:izNyWGUHPg5+J2LgqKUKoE/xXTIFoeeLheHIe1M6SEc=
-github.com/vito/dang/v2 v2.0.0/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
+github.com/vito/dang/v2 v2.0.3-0.20260616005952-fd0fc4f72aa1 h1:eVUAkPE+L1+kZFvo0qnnrTukEhWivQEhK7fRJSrHMgQ=
+github.com/vito/dang/v2 v2.0.3-0.20260616005952-fd0fc4f72aa1/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=


### PR DESCRIPTION
## What

Evaluate Dang `@cache` (and other) directive arguments against the owning type's captured closure — the file-local scope — instead of the top-level module scope, and bump `vito/dang/v2` to the matching `file-scope imports` change so the two are consistent.

## Why

In a multi-file Dang module, `import`s are file-scoped: they live in a per-file scope, not the aggregate module scope returned by `RunDir`. Directive arguments, however, were evaluated against that module scope after the fact, so a directive like:

```dang
withExec(args: [String!]!): Container! @cache(policy: FunctionCachePolicy.Never) { ... }
```

failed during module init whenever the declaring type lived in a file other than the first one processed:

```
failed to evaluate @cache argument policy: evaluating receiver: Symbol.Eval: "FunctionCachePolicy" not found in env: module {...}
```

Single-file modules only worked by accident — their imports leaked into the returned module scope.

## How

Each Dang type's `ConstructorFunction` already captures the file-local scope it was declared in as `Closure` — the same scope rehydrated method bodies use at call time (`callDangFunction`). This change routes directive-argument evaluation through that closure, so imported symbols referenced by a directive resolve exactly as they do in the type's own source, regardless of how many files the module spans. Applies to both the v1 and v2 Dang SDK helpers.

## Dependency bump

This also bumps `vito/dang/v2` (`v2.0.0` → pseudo-version at dang `main`, since the fix isn't in a tagged release yet). Only `vito/dang/v2` is bumped; the frozen v1 lineage (modules with `engineVersion < v0.21.5`) keeps its pinned library, retaining only the harmless v1 helpers fix for multi-file v1 modules.

The bump spans `v2.0.0`, `v2.0.1`, `v2.0.2`, and post-`v2.0.2` `main`. The PRs included:

**The change this PR depends on**
- [#135](https://github.com/vito/dang/pull/135) — `lang: file-scope imports in single-file modules`. Imports are now file-scoped in single- **and** multi-file modules alike, instead of single-file modules leaking their imports into the returned module scope. Combined with the helpers change above, directive arguments referencing imported symbols resolve via the declaring file's closure in every case. Ships its own regression test (`TestRunDirImportsFileLocalReachableViaClosure`).

**Language / parser changes** (affect v2-lineage `.dang` authoring)
- [#130](https://github.com/vito/dang/pull/130) — separate block statements with `;` (a newline still works; only a stray comma between statements is now an error)
- [#132](https://github.com/vito/dang/pull/132) — require braces on non-trivial `if` expressions
- [#119](https://github.com/vito/dang/pull/119) — allow any expression as an `if`/`else` branch (drops `ConditionalBody`)
- [#124](https://github.com/vito/dang/pull/124) — widen `case` branches; yield null when no branch matches
- [#108](https://github.com/vito/dang/pull/108) — remove the `for` keyword in favor of a `loop` builtin; error on bare references to block-taking functions
- [#126](https://github.com/vito/dang/pull/126) — allow constructors to define local variables

**Formatting**
- [#122](https://github.com/vito/dang/pull/122) — better dot-block formatting
- [#127](https://github.com/vito/dang/pull/127) — remove empty lines before braces

**Docs, editor highlighting, and tree-sitter tooling** (no language impact)
- [#106](https://github.com/vito/dang/pull/106), [#107](https://github.com/vito/dang/pull/107), [#115](https://github.com/vito/dang/pull/115), [#118](https://github.com/vito/dang/pull/118), [#109](https://github.com/vito/dang/pull/109), [#110](https://github.com/vito/dang/pull/110), [#111](https://github.com/vito/dang/pull/111), [#112](https://github.com/vito/dang/pull/112), [#114](https://github.com/vito/dang/pull/114), [#116](https://github.com/vito/dang/pull/116), [#117](https://github.com/vito/dang/pull/117), [#123](https://github.com/vito/dang/pull/123), [#125](https://github.com/vito/dang/pull/125), [#129](https://github.com/vito/dang/pull/129)

None of the repo's bundled `.dang` modules use the removed `for` keyword, and v2 semantics only apply to modules at `engineVersion >= v0.21.5`; older modules stay on the v1 lineage.

## Tests

The unit-level regression test lives in `vito/dang` (`TestRunDirImportsFileLocalReachableViaClosure`, covering single- and multi-file modules). On the Dagger side, `test-directives` gains a `withNeverCache` function using `@cache(policy: FunctionCachePolicy.Never)` — a directive argument that references an imported symbol. Because the bump stops single-file modules from leaking imports, this case regresses without the helpers fix; verified failing pre-fix and passing post-fix against a dev engine.

Fixes #13440.
