### PR TITLE
test: opt contextual workspace modules into v1 API

### DIFF
--- a/core/integration/contextual_workspace_test.go
+++ b/core/integration/contextual_workspace_test.go
@@ -66,6 +66,7 @@ func (ContextualWorkspaceSuite) TestContextualWorkspaceSelection(ctx context.Con
 
 		ctr := legacyWorkspaceBase(t, c, `{
   "name": "myapp",
+  "engineVersion": "v1.0.0",
   "sdk": {"source": "dang"},
   "source": "ci"
 }`, func(ctr *dagger.Container) *dagger.Container {
@@ -122,6 +123,7 @@ type Myapp {
 
 		ctr := legacyWorkspaceBase(t, c, `{
   "name": "standalone",
+  "engineVersion": "v1.0.0",
   "sdk": {"source": "dang"}
 }`, func(ctr *dagger.Container) *dagger.Container {
 			return ctr.WithNewFile("main.dang", `

--- a/core/integration/testdata/workspaces/contextual/paths-full/app/.dagger/modules/paths/dagger.json
+++ b/core/integration/testdata/workspaces/contextual/paths-full/app/.dagger/modules/paths/dagger.json
@@ -1,1 +1,1 @@
-{"name":"paths","engineVersion":"v0.21.5","sdk":{"source":"dang"}}
+{"name":"paths","engineVersion":"v1.0.0","sdk":{"source":"dang"}}

--- a/core/integration/testdata/workspaces/contextual/paths-shape/app/.dagger/modules/paths/dagger.json
+++ b/core/integration/testdata/workspaces/contextual/paths-shape/app/.dagger/modules/paths/dagger.json
@@ -1,1 +1,1 @@
-{"name":"paths","engineVersion":"v0.21.5","sdk":{"source":"dang"}}
+{"name":"paths","engineVersion":"v1.0.0","sdk":{"source":"dang"}}

--- a/toolchains/release/internal/dagger/docs-dev.gen.go
+++ b/toolchains/release/internal/dagger/docs-dev.gen.go
@@ -34,7 +34,7 @@ func (r *DocsDev) WithGraphQLQuery(q *querybuilder.Selection) *DocsDev {
 }
 
 // Bump the Go SDK's Engine dependency
-func (r *DocsDev) Bump(engineVersion string) *Changeset { // docs-dev (../../../../toolchains/docs-dev/main.go:128:1)
+func (r *DocsDev) Bump(engineVersion string) *Changeset { // docs-dev (../../../../toolchains/docs-dev/main.go:131:1)
 	q := r.query.Select("bump")
 	q = q.Arg("engineVersion", engineVersion)
 
@@ -54,7 +54,7 @@ func (r *DocsDev) Check(ctx context.Context) error { // docs-dev (../../../../to
 }
 
 // Deploys a current build of the docs.
-func (r *DocsDev) Deploy(ctx context.Context, message string, netlifyToken *Secret) (string, error) { // docs-dev (../../../../toolchains/docs-dev/main.go:143:1)
+func (r *DocsDev) Deploy(ctx context.Context, message string, netlifyToken *Secret) (string, error) { // docs-dev (../../../../toolchains/docs-dev/main.go:146:1)
 	assertNotNil("netlifyToken", netlifyToken)
 	if r.deploy != nil {
 		return *r.deploy, nil
@@ -120,13 +120,13 @@ func (r *DocsDev) UnmarshalJSON(bs []byte) error {
 
 // DocsDevPublishOpts contains options for DocsDev.Publish
 type DocsDevPublishOpts struct {
-	Deployment string // docs-dev (../../../../toolchains/docs-dev/main.go:176:2)
+	Deployment string // docs-dev (../../../../toolchains/docs-dev/main.go:179:2)
 
-	APIURL string // docs-dev (../../../../toolchains/docs-dev/main.go:178:2)
+	APIURL string // docs-dev (../../../../toolchains/docs-dev/main.go:181:2)
 }
 
 // Publish a previous deployment to production - defaults to the latest deployment on the main branch.
-func (r *DocsDev) Publish(ctx context.Context, netlifyToken *Secret, opts ...DocsDevPublishOpts) error { // docs-dev (../../../../toolchains/docs-dev/main.go:172:1)
+func (r *DocsDev) Publish(ctx context.Context, netlifyToken *Secret, opts ...DocsDevPublishOpts) error { // docs-dev (../../../../toolchains/docs-dev/main.go:175:1)
 	assertNotNil("netlifyToken", netlifyToken)
 	if r.publish != nil {
 		return nil


### PR DESCRIPTION
## Summary
- Bump contextual workspace Dang test modules that use `Workspace.cwd` to `engineVersion = "v1.0.0"`.
- Update both checked-in fixtures and inline legacy-workspace snippets.

## Why
`c54a8fd` correctly hides `Workspace.cwd` from older module API views. These tests were still pinned to older views while exercising the newer workspace API, so module initialization failed with `field "cwd" not found in Dagger.Workspace`.

## Validation
- `dagger --progress=plain call engine-dev test --pkg ./core/integration --run='TestContextualWorkspace'`
