### PR TITLE
fix(auth): forward Go auth to typedef generation

### DIFF
--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -739,7 +739,7 @@ func (GitSuite) TestGitTagsSSH(ctx context.Context, t *testctx.T) {
 			SSHAuthSocket: c.Host().UnixSocket(sockPath),
 		}).Tags(ctx)
 		require.NoError(t, err)
-		require.ElementsMatch(t, []string{"cool-sdk/v0.1", "v0.1.1"}, tags)
+		require.Subset(t, tags, []string{"cool-sdk/v0.1", "v0.1.1"})
 	})
 
 	t.Run("without SSH auth", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -203,4 +203,64 @@ func (ModuleSuite) TestPrivateDeps(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "ubercool", howCoolIsDagger)
 	})
+
+	t.Run("golang transitive existing go.mod", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		sockPath, cleanup := setupPrivateRepoSSHAgent(t)
+		defer cleanup()
+
+		socket := c.Host().UnixSocket(sockPath)
+
+		const (
+			privateDep        = "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git/privatewrapper"
+			privateDepVersion = "v0.0.1"
+		)
+
+		modGen := goGitBase(t, c).
+			WithExec([]string{"apk", "add", "openssh", "openssl"}).
+			WithUnixSocket("/sock/unix-socket", socket).
+			WithEnvVariable("SSH_AUTH_SOCK", "/sock/unix-socket").
+			WithNewFile("/root/.gitconfig", `
+[url "ssh://git@gitlab.com/"]
+	insteadOf = https://gitlab.com/
+`).
+			WithEnvVariable("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no").
+			WithNewFile("/work/dagger.toml", `[modules.foo]
+source = ".dagger/modules/foo"
+entrypoint = true
+`).
+			WithNewFile("/work/.dagger/modules/foo/dagger.json", `{
+  "name": "foo",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go",
+    "config": {
+      "goprivate": "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git"
+    }
+  }
+}`).
+			WithNewFile("/work/.dagger/modules/foo/go.mod", fmt.Sprintf(`module dagger/foo
+
+go 1.21.3
+
+require %s %s
+`, privateDep, privateDepVersion)).
+			WithNewFile("/work/.dagger/modules/foo/main.go", fmt.Sprintf(`package main
+
+import "%s/pkg/coolwrapper"
+
+type Foo struct{}
+
+func (m *Foo) HowCoolIsDagger() string {
+	return coolwrapper.HowCoolIsThat()
+}
+`, privateDep)).
+			WithWorkdir("/work")
+
+		howCoolIsDagger, err := modGen.
+			With(daggerExec("call", "how-cool-is-dagger")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "private-transitive-go-dep:ubercool", howCoolIsDagger)
+	})
 }

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -325,8 +325,8 @@ func (sdk *goSDK) ModuleTypes(
 		}
 		execMD.CallDigest = callDigest
 	}
-	err = dag.Select(ctx, ctr, &ctr,
-		dagql.Selector{
+	selectors := []dagql.Selector{
+		{
 			Field: "withMountedFile",
 			Args: []dagql.NamedInput{
 				{
@@ -339,7 +339,7 @@ func (sdk *goSDK) ModuleTypes(
 				},
 			},
 		},
-		dagql.Selector{
+		{
 			Field: "withMountedDirectory",
 			Args: []dagql.NamedInput{
 				{
@@ -352,7 +352,7 @@ func (sdk *goSDK) ModuleTypes(
 				},
 			},
 		},
-		dagql.Selector{
+		{
 			Field: "withoutFile",
 			Args: []dagql.NamedInput{
 				{
@@ -361,7 +361,7 @@ func (sdk *goSDK) ModuleTypes(
 				},
 			},
 		},
-		dagql.Selector{
+		{
 			Field: "withoutDirectory",
 			Args: []dagql.NamedInput{
 				{
@@ -370,7 +370,7 @@ func (sdk *goSDK) ModuleTypes(
 				},
 			},
 		},
-		dagql.Selector{
+		{
 			Field: "withWorkdir",
 			Args: []dagql.NamedInput{
 				{
@@ -379,6 +379,15 @@ func (sdk *goSDK) ModuleTypes(
 				},
 			},
 		},
+	}
+
+	dependencySelectors, cleanupDependencySelectors, err := sdk.moduleDependencyConfigSelectors(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to configure go module type deps generation container: %w", err)
+	}
+	selectors = append(selectors, dependencySelectors...)
+
+	selectors = append(selectors,
 		dagql.Selector{
 			Field: "withExec",
 			Args: []dagql.NamedInput{
@@ -409,6 +418,9 @@ func (sdk *goSDK) ModuleTypes(
 			},
 		},
 	)
+	selectors = append(selectors, cleanupDependencySelectors...)
+
+	err = dag.Select(ctx, ctr, &ctr, selectors...)
 	if err != nil {
 		return inst, fmt.Errorf("failed to run go module type defs generation: %w", err)
 	}
@@ -662,49 +674,11 @@ func (sdk *goSDK) baseWithCodegen(
 		},
 	}
 
-	var config goSDKConfig
-	var mapstructureMetadata mapstructure.Metadata
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		Metadata: &mapstructureMetadata,
-		Result:   &config,
-	})
+	dependencySelectors, cleanupDependencySelectors, err := sdk.moduleDependencyConfigSelectors(ctx)
 	if err != nil {
 		return ctr, err
 	}
-
-	err = decoder.Decode(sdk.rawConfig)
-	if err != nil {
-		return ctr, err
-	}
-
-	if len(mapstructureMetadata.Unused) > 0 {
-		return ctr, fmt.Errorf("unknown sdk config keys found %v", mapstructureMetadata.Unused)
-	}
-
-	configSelectors := getSDKConfigSelectors(ctx, config)
-	selectors = append(selectors, configSelectors...)
-
-	// fetch gitconfig selectors
-	bk, err := sdk.root.Engine(ctx)
-	if err != nil {
-		return ctr, err
-	}
-
-	gitConfigSelectors, err := gitConfigSelectors(ctx, bk)
-	if err != nil {
-		return ctr, err
-	}
-	selectors = append(selectors, gitConfigSelectors...)
-
-	// TODO(rajatjindal): verify with Erik as to why this
-	// cause failures if we also mount this in Runtime.
-	// Issue we run into is that when we try to run sdk checks
-	// using .dagger, it fails trying to find the socket
-	setSSHAuthSelectors, unsetSSHAuthSelectors, err := sdk.getUnixSocketSelector(ctx)
-	if err != nil {
-		return ctr, err
-	}
-	selectors = append(selectors, setSSHAuthSelectors...)
+	selectors = append(selectors, dependencySelectors...)
 
 	// now that we are done with gitconfig and injecting env
 	// variables, we can run the codegen command.
@@ -725,13 +699,58 @@ func (sdk *goSDK) baseWithCodegen(
 		},
 	)
 
-	selectors = append(selectors, unsetSSHAuthSelectors...)
+	selectors = append(selectors, cleanupDependencySelectors...)
 
 	if err := dag.Select(ctx, ctr, &ctr, selectors...); err != nil {
 		return ctr, fmt.Errorf("failed to mount introspection json file into go module sdk container codegen: %w", err)
 	}
 
 	return ctr, nil
+}
+
+func (sdk *goSDK) moduleDependencyConfigSelectors(ctx context.Context) ([]dagql.Selector, []dagql.Selector, error) {
+	var config goSDKConfig
+	var mapstructureMetadata mapstructure.Metadata
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Metadata: &mapstructureMetadata,
+		Result:   &config,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := decoder.Decode(sdk.rawConfig); err != nil {
+		return nil, nil, err
+	}
+
+	if len(mapstructureMetadata.Unused) > 0 {
+		return nil, nil, fmt.Errorf("unknown sdk config keys found %v", mapstructureMetadata.Unused)
+	}
+
+	selectors := getSDKConfigSelectors(ctx, config)
+
+	bk, err := sdk.root.Engine(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gitConfigSelectors, err := gitConfigSelectors(ctx, bk)
+	if err != nil {
+		return nil, nil, err
+	}
+	selectors = append(selectors, gitConfigSelectors...)
+
+	// TODO(rajatjindal): verify with Erik as to why this
+	// cause failures if we also mount this in Runtime.
+	// Issue we run into is that when we try to run sdk checks
+	// using .dagger, it fails trying to find the socket
+	setSSHAuthSelectors, unsetSSHAuthSelectors, err := sdk.getUnixSocketSelector(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	selectors = append(selectors, setSSHAuthSelectors...)
+
+	return selectors, unsetSSHAuthSelectors, nil
 }
 
 func (sdk *goSDK) base(ctx context.Context) (dagql.ObjectResult[*core.Container], error) {


### PR DESCRIPTION
## Summary

Fixes #13056.

Go SDK module loading could fail before invoking the requested function when the module's existing `go.mod` included a private transitive Go dependency.

The failure happened during `codegen generate-typedefs`: after the Go SDK library pinning change, typedef generation runs Go module resolution to pin `dagger.io/dagger` and `github.com/dagger/querybuilder`. That resolution also loads the user's existing `go.mod` graph, but `ModuleTypes` was not applying the same auth/dependency setup as normal Go SDK codegen.

This PR applies the Go SDK dependency configuration to typedef generation too:

- SDK config selectors, including `GOPRIVATE`
- forwarded Git config
- forwarded `SSH_AUTH_SOCK`
- cleanup selectors after codegen runs

`baseWithCodegen` keeps its existing `withoutDefaultArgs` behavior. `ModuleTypes` intentionally does not add it, because it did not use it before and the bug only requires forwarding dependency/auth configuration.

## Test Coverage

Adds an integration test for a Go SDK module with:
- an existing `go.mod`
- a direct private Go module dependency
- a private transitive Go module dependency

The fixture lives in `grouville/daggerverse-private` and is accessed with a read-only GitHub deploy key scoped to that repo.

## Validation

```sh
dagger call engine-dev test \
  --pkg ./core/integration \
  --run '^TestModule/TestPrivateDeps/golang transitive existing go\.mod$' \
  --test-verbose
```

Trace:
https://dagger.cloud/dagger/traces/4b38ec36b3f981d060f8a57956859ee1