### PR TITLE
fix(apple): grant all capabilities to engine container

### DIFF
--- a/engine/client/drivers/apple.go
+++ b/engine/client/drivers/apple.go
@@ -51,10 +51,10 @@ func (apple) ImageLoader(ctx context.Context) imageload.Backend {
 	return imageload.Apple{}
 }
 
-func (apple) ContainerRun(ctx context.Context, name string, opts runOpts) error {
-	args := []string{"run", "--name", name, "-d"}
+func (apple) runArgs(name string, opts runOpts) (args []string, envs []string, _ error) {
+	args = []string{"run", "--name", name, "-d"}
 
-	envs := os.Environ()
+	envs = os.Environ()
 
 	for _, volume := range opts.volumes {
 		if !strings.Contains(volume, ":") {
@@ -73,7 +73,15 @@ func (apple) ContainerRun(ctx context.Context, name string, opts runOpts) error 
 		}
 	}
 	for _, port := range opts.ports {
-		return fmt.Errorf("unsupported port argument %q", port)
+		return nil, nil, fmt.Errorf("unsupported port argument %q", port)
+	}
+
+	if opts.privileged {
+		// apple's `container` has no `--privileged` flag; `--cap-add ALL` is the
+		// equivalent. Since `container` 1.0.0 the default capability set no longer
+		// includes CAP_SYS_ADMIN, which the engine needs to bind-mount
+		// /etc/resolv.conf during network setup, so it must be granted explicitly.
+		args = append(args, "--cap-add", "ALL")
 	}
 
 	if opts.cpus != "" {
@@ -91,6 +99,15 @@ func (apple) ContainerRun(ctx context.Context, name string, opts runOpts) error 
 
 	args = append(args, opts.image)
 	args = append(args, opts.args...)
+
+	return args, envs, nil
+}
+
+func (a apple) ContainerRun(ctx context.Context, name string, opts runOpts) error {
+	args, envs, err := a.runArgs(name, opts)
+	if err != nil {
+		return err
+	}
 
 	cmd := exec.CommandContext(ctx, "container", args...)
 	cmd.Env = envs

--- a/engine/client/drivers/apple_test.go
+++ b/engine/client/drivers/apple_test.go
@@ -1,0 +1,33 @@
+package drivers
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppleRunArgsPrivilegedGrantsAllCapabilities(t *testing.T) {
+	// Apple's `container` has no `--privileged` flag; the equivalent is
+	// `--cap-add ALL`. Since `container` 1.0.0 the default capability set no
+	// longer includes CAP_SYS_ADMIN, which the engine needs to bind-mount
+	// /etc/resolv.conf at startup, so this must be passed when privileged.
+	args, _, err := apple{}.runArgs("dagger-engine-test", runOpts{
+		image:      "registry.dagger.io/engine:test",
+		privileged: true,
+	})
+	require.NoError(t, err)
+	idx := slices.Index(args, "--cap-add")
+	require.NotEqual(t, -1, idx, "expected --cap-add in args: %v", args)
+	require.Less(t, idx+1, len(args))
+	require.Equal(t, "ALL", args[idx+1])
+}
+
+func TestAppleRunArgsNotPrivilegedOmitsCapabilities(t *testing.T) {
+	args, _, err := apple{}.runArgs("dagger-engine-test", runOpts{
+		image:      "registry.dagger.io/engine:test",
+		privileged: false,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, args, "--cap-add")
+}


### PR DESCRIPTION
## Problem

Running the Dagger engine through [Apple's `container`](https://github.com/apple/container) CLI **1.0.0** crashes the engine immediately on startup:

```
dagger-engine: install resolv.conf: remount /etc/resolv.conf to upstream alias: operation not permitted
```

This worked on older `container` releases (e.g. `0.4.1-49`) and broke after upgrading to `1.0.0`.

Fixes #13459

## Root cause

`container` 1.0.0 [reduced the default capability set](https://github.com/apple/container/blob/1.0.0/docs/how-to.md) and introduced `--cap-add`/`--cap-drop`. From the 1.0.0 release notes:

> Support `--cap-add` and `--cap-drop` for containers. The default set of capabilities has been reduced, so if you need the old behavior that grants all capabilities, you will need to delete and recreate your containers.

`CAP_SYS_ADMIN` is no longer granted by default. The engine needs it to bind-mount `/etc/resolv.conf` during network setup (`netinst.InstallResolvconf`), one of the very first things it does at startup — hence the immediate `operation not permitted` (EPERM) crash.

The shared provisioning code already sets `runOpts.privileged = true` (the Docker driver maps this to `--privileged`), but the apple driver ignored it and passed no capability flags. With older `container` versions this was harmless because all capabilities were granted by default.

## Fix

Apple's `container` has no `--privileged` flag; `--cap-add ALL` is the documented equivalent (`--cap-drop ALL --cap-add ALL` grants everything). Honor `opts.privileged` in the apple driver by passing `--cap-add ALL`.

Extracted the argument construction into a `runArgs` helper so it can be unit-tested.

## Testing

- Added unit tests asserting `--cap-add ALL` is present when privileged and absent otherwise.
- `go build` / `go vet` / `go test ./engine/client/drivers/` pass.
- Needs a manual confirmation on an Apple Silicon Mac with `container` 1.0.0 (reporter can reproduce).
