### PR TITLE
core: per-step cgroup resource limits for withExec and asService

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -111,6 +111,10 @@ type Container struct {
 	// DefaultArgs have been explicitly set by the user
 	DefaultArgs bool
 
+	// DefaultExecResources are cgroup resource constraints applied to subsequent
+	// execs unless overridden per-exec via ContainerExecOpts.Resources.
+	DefaultExecResources *ContainerExecResources `json:"defaultExecResources,omitempty"`
+
 	Lazy Lazy[*Container]
 }
 
@@ -530,8 +534,9 @@ type persistedContainerPayload struct {
 	DefaultTerminalCmd DefaultTerminalCmdOpts              `json:"defaultTerminalCmd"`
 	SystemEnvNames     []string                            `json:"systemEnvNames,omitempty"`
 	VolatileEnv        []string                            `json:"volatileEnv,omitempty"`
-	DefaultArgs        bool                                `json:"defaultArgs,omitempty"`
-	LazyJSON           json.RawMessage                     `json:"lazyJSON,omitempty"`
+	DefaultArgs          bool                                `json:"defaultArgs,omitempty"`
+	DefaultExecResources *ContainerExecResources             `json:"defaultExecResources,omitempty"`
+	LazyJSON             json.RawMessage                     `json:"lazyJSON,omitempty"`
 }
 
 const (
@@ -1035,6 +1040,7 @@ func materializeContainerStateFromParent(ctx context.Context, dst *Container, pa
 	dst.DefaultTerminalCmd = parent.Self().DefaultTerminalCmd
 	dst.SystemEnvNames = slices.Clone(parent.Self().SystemEnvNames)
 	dst.DefaultArgs = parent.Self().DefaultArgs
+	dst.DefaultExecResources = parent.Self().DefaultExecResources
 	return nil
 }
 
@@ -1470,10 +1476,11 @@ func (container *Container) EncodePersistedObject(ctx context.Context, cache dag
 		ImageRef:           container.ImageRef,
 		Ports:              slices.Clone(container.Ports),
 		Services:           services,
-		DefaultTerminalCmd: container.DefaultTerminalCmd,
-		SystemEnvNames:     slices.Clone(container.SystemEnvNames),
-		VolatileEnv:        slices.Clone(container.VolatileEnv),
-		DefaultArgs:        container.DefaultArgs,
+		DefaultTerminalCmd:   container.DefaultTerminalCmd,
+		SystemEnvNames:       slices.Clone(container.SystemEnvNames),
+		VolatileEnv:          slices.Clone(container.VolatileEnv),
+		DefaultArgs:          container.DefaultArgs,
+		DefaultExecResources: container.DefaultExecResources,
 	}
 	if container.Lazy != nil {
 		lazyJSON, err := container.Lazy.EncodePersisted(ctx, cache)
@@ -1709,10 +1716,11 @@ func (*Container) DecodePersistedObject(ctx context.Context, dag *dagql.Server, 
 		ImageRef:           persisted.ImageRef,
 		Ports:              slices.Clone(persisted.Ports),
 		Services:           services,
-		DefaultTerminalCmd: persisted.DefaultTerminalCmd,
-		SystemEnvNames:     slices.Clone(persisted.SystemEnvNames),
-		VolatileEnv:        slices.Clone(persisted.VolatileEnv),
-		DefaultArgs:        persisted.DefaultArgs,
+		DefaultTerminalCmd:   persisted.DefaultTerminalCmd,
+		SystemEnvNames:       slices.Clone(persisted.SystemEnvNames),
+		VolatileEnv:          slices.Clone(persisted.VolatileEnv),
+		DefaultArgs:          persisted.DefaultArgs,
+		DefaultExecResources: persisted.DefaultExecResources,
 	}
 	if persisted.Form != persistedContainerFormLazy {
 		return container, nil

--- a/core/container.go
+++ b/core/container.go
@@ -6734,6 +6734,10 @@ type ContainerAsServiceArgs struct {
 	// Skip the init process injected into containers by default so that the
 	// user's process is PID 1
 	NoInit bool `default:"false"`
+
+	// Resource constraints for the service container (cgroup limits).
+	// If nil, inherits the container's DefaultExecResources if set.
+	Resources *ContainerExecResources `default:"null"`
 }
 
 func (container *Container) AsService(ctx context.Context, containerRes dagql.ObjectResult[*Container], args ContainerAsServiceArgs) (*Service, error) {
@@ -6769,6 +6773,7 @@ func (container *Container) AsService(ctx context.Context, containerRes dagql.Ob
 		ExperimentalPrivilegedNesting: args.ExperimentalPrivilegedNesting,
 		InsecureRootCapabilities:      args.InsecureRootCapabilities,
 		NoInit:                        args.NoInit,
+		Resources:                     args.Resources,
 	}, nil
 }
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -103,12 +103,12 @@ type ContainerExecResources struct {
 	MemorySoftBytes int64 `default:"0"`
 
 	// CPU limit in fractional cores, e.g. 1.5 (cgroup cpu.max quota/period).
-	// Translated to quota=int64(Cpus*1e5), period=100000.
-	Cpus float64 `default:"0"`
+	// Translated to quota=int64(CPUs*1e5), period=100000.
+	CPUs float64 `default:"0"`
 
 	// Relative CPU weight under contention (cgroup cpu.weight, range 1-10000).
 	// Does not cap CPU; only affects sharing when the engine is saturated.
-	CpuShares int64 `default:"0"`
+	CPUShares int64 `default:"0"`
 
 	// Maximum number of processes/threads (cgroup pids.max).
 	Pids int64 `default:"0"`

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -383,6 +383,16 @@ func (container *Container) metaSpec(ctx context.Context, opts ContainerExecOpts
 		metaSpec.ValidExitCodes = opts.Expect.ReturnCodes()
 	}
 
+	if opts.Resources != nil {
+		rm := resourcesIntoMeta(opts.Resources)
+		metaSpec.MemoryBytes = rm.MemoryBytes
+		metaSpec.MemorySoftBytes = rm.MemorySoftBytes
+		metaSpec.CPUQuota = rm.CPUQuota
+		metaSpec.CPUPeriod = rm.CPUPeriod
+		metaSpec.CPUShares = rm.CPUShares
+		metaSpec.PidsLimit = rm.PidsLimit
+	}
+
 	return &metaSpec, nil
 }
 
@@ -397,6 +407,26 @@ func execNetMode(opts ContainerExecOpts) (pb.NetMode, error) {
 		return pb.NetMode_HOST, nil
 	}
 	return pb.NetMode_UNSET, nil
+}
+
+// resourcesIntoMeta converts ContainerExecResources fields into executor.Meta
+// cgroup resource fields. A nil r is a no-op (returns zero Meta).
+func resourcesIntoMeta(r *ContainerExecResources) executor.Meta {
+	if r == nil {
+		return executor.Meta{}
+	}
+	m := executor.Meta{
+		MemoryBytes:     r.MemoryBytes,
+		MemorySoftBytes: r.MemorySoftBytes,
+		CPUShares:       r.CPUShares,
+		PidsLimit:       r.Pids,
+	}
+	if r.CPUs > 0 {
+		const period = 100000
+		m.CPUQuota = int64(r.CPUs * period)
+		m.CPUPeriod = period
+	}
+	return m
 }
 
 type serviceBindingExitError struct {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -383,8 +383,9 @@ func (container *Container) metaSpec(ctx context.Context, opts ContainerExecOpts
 		metaSpec.ValidExitCodes = opts.Expect.ReturnCodes()
 	}
 
-	if opts.Resources != nil {
-		rm := resourcesIntoMeta(opts.Resources)
+	effective := mergeExecResources(container.DefaultExecResources, opts.Resources)
+	if effective != nil {
+		rm := resourcesIntoMeta(effective)
 		metaSpec.MemoryBytes = rm.MemoryBytes
 		metaSpec.MemorySoftBytes = rm.MemorySoftBytes
 		metaSpec.CPUQuota = rm.CPUQuota
@@ -427,6 +428,38 @@ func resourcesIntoMeta(r *ContainerExecResources) executor.Meta {
 		m.CPUPeriod = period
 	}
 	return m
+}
+
+// mergeExecResources merges per-exec resources on top of container defaults.
+// Per-exec non-zero fields override the corresponding default. Returns nil if
+// both inputs are nil.
+func mergeExecResources(defaults, perExec *ContainerExecResources) *ContainerExecResources {
+	if defaults == nil && perExec == nil {
+		return nil
+	}
+	merged := ContainerExecResources{}
+	if defaults != nil {
+		merged = *defaults
+	}
+	if perExec == nil {
+		return &merged
+	}
+	if perExec.MemoryBytes != 0 {
+		merged.MemoryBytes = perExec.MemoryBytes
+	}
+	if perExec.MemorySoftBytes != 0 {
+		merged.MemorySoftBytes = perExec.MemorySoftBytes
+	}
+	if perExec.CPUs != 0 {
+		merged.CPUs = perExec.CPUs
+	}
+	if perExec.CPUShares != 0 {
+		merged.CPUShares = perExec.CPUShares
+	}
+	if perExec.Pids != 0 {
+		merged.Pids = perExec.Pids
+	}
+	return &merged
 }
 
 type serviceBindingExitError struct {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -85,6 +85,33 @@ type ContainerExecOpts struct {
 	// Skip the init process injected into containers by default so that the
 	// user's process is PID 1
 	NoInit bool `default:"false"`
+
+	// Resource constraints applied to this exec via cgroups.
+	// All fields are optional; nil means no limit (current behaviour).
+	Resources *ContainerExecResources `default:"null"`
+}
+
+// ContainerExecResources defines cgroup resource constraints for a single exec.
+// All fields are optional; zero/nil means no limit (current behaviour).
+type ContainerExecResources struct {
+	// Hard memory limit in bytes (cgroup memory.max).
+	// The process is OOM-killed if it exceeds this.
+	MemoryBytes int64 `default:"0"`
+
+	// Soft memory limit in bytes (cgroup memory.high).
+	// The kernel throttles the process under pressure rather than killing it.
+	MemorySoftBytes int64 `default:"0"`
+
+	// CPU limit in fractional cores, e.g. 1.5 (cgroup cpu.max quota/period).
+	// Translated to quota=int64(Cpus*1e5), period=100000.
+	Cpus float64 `default:"0"`
+
+	// Relative CPU weight under contention (cgroup cpu.weight, range 1-10000).
+	// Does not cap CPU; only affects sharing when the engine is saturated.
+	CpuShares int64 `default:"0"`
+
+	// Maximum number of processes/threads (cgroup pids.max).
+	Pids int64 `default:"0"`
 }
 
 type ContainerExecState struct {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -96,22 +96,30 @@ type ContainerExecOpts struct {
 type ContainerExecResources struct {
 	// Hard memory limit in bytes (cgroup memory.max).
 	// The process is OOM-killed if it exceeds this.
-	MemoryBytes int64 `default:"0"`
+	MemoryBytes int64 `default:"0" doc:"Hard memory limit in bytes (cgroup memory.max). The process is OOM-killed if it exceeds this."`
 
 	// Soft memory limit in bytes (cgroup memory.high).
 	// The kernel throttles the process under pressure rather than killing it.
-	MemorySoftBytes int64 `default:"0"`
+	MemorySoftBytes int64 `default:"0" doc:"Soft memory limit in bytes (cgroup memory.high). The kernel throttles the process under pressure rather than killing it."`
 
 	// CPU limit in fractional cores, e.g. 1.5 (cgroup cpu.max quota/period).
 	// Translated to quota=int64(CPUs*1e5), period=100000.
-	CPUs float64 `default:"0"`
+	CPUs float64 `default:"0" doc:"CPU limit in fractional cores (cgroup cpu.max quota/period). E.g. 1.5 for one-and-a-half cores."`
 
 	// Relative CPU weight under contention (cgroup cpu.weight, range 1-10000).
 	// Does not cap CPU; only affects sharing when the engine is saturated.
-	CPUShares int64 `default:"0"`
+	CPUShares int64 `default:"0" doc:"Relative CPU weight under contention (cgroup cpu.weight, range 1-10000). Does not cap CPU; only affects scheduling priority."`
 
 	// Maximum number of processes/threads (cgroup pids.max).
-	Pids int64 `default:"0"`
+	Pids int64 `default:"0" doc:"Maximum number of processes/threads allowed (cgroup pids.max)."`
+}
+
+func (ContainerExecResources) TypeName() string {
+	return "ContainerExecResources"
+}
+
+func (ContainerExecResources) TypeDescription() string {
+	return "Cgroup resource constraints for a container exec. All fields are optional; zero means no limit."
 }
 
 type ContainerExecState struct {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -98,17 +98,19 @@ type ContainerExecResources struct {
 	// The process is OOM-killed if it exceeds this.
 	MemoryBytes int64 `default:"0" doc:"Hard memory limit in bytes (cgroup memory.max). The process is OOM-killed if it exceeds this."`
 
-	// Soft memory limit in bytes (cgroup memory.high).
-	// The kernel throttles the process under pressure rather than killing it.
-	MemorySoftBytes int64 `default:"0" doc:"Soft memory limit in bytes (cgroup memory.high). The kernel throttles the process under pressure rather than killing it."`
+	// Soft memory limit in bytes (OCI memory reservation / cgroup memory.low on v2,
+	// soft_limit_in_bytes on v1). The kernel reclaims from this process first under
+	// memory pressure; it is not a hard cap and does not trigger OOM-kill.
+	MemorySoftBytes int64 `default:"0" doc:"Soft memory reservation in bytes (OCI memory.reservation). The kernel reclaims from this process first under memory pressure; no hard cap."`
 
 	// CPU limit in fractional cores, e.g. 1.5 (cgroup cpu.max quota/period).
 	// Translated to quota=int64(CPUs*1e5), period=100000.
 	CPUs float64 `default:"0" doc:"CPU limit in fractional cores (cgroup cpu.max quota/period). E.g. 1.5 for one-and-a-half cores."`
 
-	// Relative CPU weight under contention (cgroup cpu.weight, range 1-10000).
+	// Relative CPU scheduling weight (OCI cpu.shares / cgroup v1 cpu.shares scale,
+	// 2-262144; runc converts to cgroup v2 cpu.weight on v2 hosts).
 	// Does not cap CPU; only affects sharing when the engine is saturated.
-	CPUShares int64 `default:"0" doc:"Relative CPU weight under contention (cgroup cpu.weight, range 1-10000). Does not cap CPU; only affects scheduling priority."`
+	CPUShares int64 `default:"0" doc:"Relative CPU scheduling weight (OCI cpu.shares, 2-262144). Does not cap CPU; only affects priority under contention."`
 
 	// Maximum number of processes/threads (cgroup pids.max).
 	Pids int64 `default:"0" doc:"Maximum number of processes/threads allowed (cgroup pids.max)."`

--- a/core/container_exec_test.go
+++ b/core/container_exec_test.go
@@ -41,3 +41,10 @@ func TestExecNetModeConflict(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot set both noNetwork and hostNetwork")
 }
+
+func TestExecResourcesNilIsNoop(t *testing.T) {
+	t.Parallel()
+	// Resources nil → no change to opts, backward compat
+	opts := ContainerExecOpts{}
+	require.Nil(t, opts.Resources)
+}

--- a/core/container_exec_test.go
+++ b/core/container_exec_test.go
@@ -61,6 +61,41 @@ func TestResourcesIntoMeta(t *testing.T) {
 	})
 }
 
+func TestMergeExecResources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil default and nil per-exec returns nil", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, mergeExecResources(nil, nil))
+	})
+
+	t.Run("nil per-exec returns copy of default", func(t *testing.T) {
+		t.Parallel()
+		def := &ContainerExecResources{MemoryBytes: 1 * 1024 * 1024 * 1024, Pids: 512}
+		result := mergeExecResources(def, nil)
+		require.NotNil(t, result)
+		require.Equal(t, def.MemoryBytes, result.MemoryBytes)
+		require.Equal(t, def.Pids, result.Pids)
+		require.Zero(t, result.CPUs)
+	})
+
+	t.Run("per-exec non-zero overrides default", func(t *testing.T) {
+		t.Parallel()
+		def := &ContainerExecResources{MemoryBytes: 1 * 1024 * 1024 * 1024, Pids: 512}
+		perExec := &ContainerExecResources{MemoryBytes: 2 * 1024 * 1024 * 1024}
+		result := mergeExecResources(def, perExec)
+		require.Equal(t, int64(2*1024*1024*1024), result.MemoryBytes)
+		require.Equal(t, int64(512), result.Pids) // inherited from default
+	})
+
+	t.Run("nil default with per-exec returns per-exec", func(t *testing.T) {
+		t.Parallel()
+		perExec := &ContainerExecResources{CPUs: 2.0}
+		result := mergeExecResources(nil, perExec)
+		require.Equal(t, float64(2.0), result.CPUs)
+	})
+}
+
 func TestExecNetModeDefault(t *testing.T) {
 	t.Parallel()
 

--- a/core/container_exec_test.go
+++ b/core/container_exec_test.go
@@ -41,10 +41,3 @@ func TestExecNetModeConflict(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot set both noNetwork and hostNetwork")
 }
-
-func TestExecResourcesNilIsNoop(t *testing.T) {
-	t.Parallel()
-	// Resources nil → no change to opts, backward compat
-	opts := ContainerExecOpts{}
-	require.Nil(t, opts.Resources)
-}

--- a/core/container_exec_test.go
+++ b/core/container_exec_test.go
@@ -7,6 +7,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResourcesIntoMeta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns zero meta", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(nil)
+		require.Zero(t, m.MemoryBytes)
+		require.Zero(t, m.MemorySoftBytes)
+		require.Zero(t, m.CPUQuota)
+		require.Zero(t, m.CPUPeriod)
+		require.Zero(t, m.CPUShares)
+		require.Zero(t, m.PidsLimit)
+	})
+
+	t.Run("memory bytes", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(&ContainerExecResources{MemoryBytes: 512 * 1024 * 1024})
+		require.Equal(t, int64(512*1024*1024), m.MemoryBytes)
+		require.Zero(t, m.MemorySoftBytes)
+	})
+
+	t.Run("memory soft", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(&ContainerExecResources{MemorySoftBytes: 256 * 1024 * 1024})
+		require.Equal(t, int64(256*1024*1024), m.MemorySoftBytes)
+	})
+
+	t.Run("CPUs 1.5 translates to quota 150000 period 100000", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(&ContainerExecResources{CPUs: 1.5})
+		require.Equal(t, int64(150000), m.CPUQuota)
+		require.Equal(t, uint64(100000), m.CPUPeriod)
+	})
+
+	t.Run("CPUs 0 leaves quota and period zero", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(&ContainerExecResources{MemoryBytes: 1024})
+		require.Zero(t, m.CPUQuota)
+		require.Zero(t, m.CPUPeriod)
+	})
+
+	t.Run("CPUShares", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(&ContainerExecResources{CPUShares: 512})
+		require.Equal(t, int64(512), m.CPUShares)
+	})
+
+	t.Run("pids", func(t *testing.T) {
+		t.Parallel()
+		m := resourcesIntoMeta(&ContainerExecResources{Pids: 256})
+		require.Equal(t, int64(256), m.PidsLimit)
+	})
+}
+
 func TestExecNetModeDefault(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -931,6 +931,15 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				absolutely necessary and only with trusted commands.`),
 			),
 
+		dagql.NodeFunc("withDefaultExecResources", s.withDefaultExecResources).
+			IsPersistable().
+			View(AllVersion).
+			Doc(`Set default cgroup resource constraints applied to subsequent execs.`,
+				`Per-exec resources set via withExec override these field-by-field.`).
+			Args(
+				dagql.Arg("resources").Doc(`Default resource constraints for subsequent execs.`),
+			),
+
 		dagql.NodeFunc("experimentalWithGPU", s.withGPU).
 			Doc(`EXPERIMENTAL API! Subject to change/removal at any time.`,
 				`Configures the provided list of devices to be accessible to this container.`,
@@ -4409,4 +4418,17 @@ func (s *containerSchema) terminalLegacy(
 
 func (s *containerSchema) terminalLegacyWebsocketEndpoint(ctx context.Context, parent *core.TerminalLegacy, args struct{}) (string, error) {
 	return "", nil
+}
+
+type containerDefaultExecResourcesArgs struct {
+	Resources core.ContainerExecResources
+}
+
+func (s *containerSchema) withDefaultExecResources(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerDefaultExecResourcesArgs) (*core.Container, error) {
+	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	ctr.DefaultExecResources = &args.Resources
+	return ctr, nil
 }

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -77,6 +77,7 @@ func (s *querySchema) Install(srv *dagql.Server) {
 	dagql.MustInputSpec(PipelineLabel{}).Install(srv)
 	dagql.MustInputSpec(core.PortForward{}).Install(srv)
 	dagql.MustInputSpec(core.BuildArg{}).Install(srv)
+	dagql.MustInputSpec(core.ContainerExecResources{}).Install(srv)
 
 	dagql.Fields[core.EnvVariable]{}.Install(srv)
 

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -359,7 +359,7 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.ObjectResult[
 			"memoryBytes":     r.MemoryBytes,
 			"memorySoftBytes": r.MemorySoftBytes,
 			"cpus":            r.CPUs,
-			"cpuShares":       r.CPUShares,
+			"cpushares":       r.CPUShares,
 			"pids":            r.Pids,
 		})
 		if err != nil {

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -47,6 +47,9 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 					`This should only be used if the user requires that their exec process be the
 					pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
 				),
+				dagql.Arg("resources").Doc(
+					`Cgroup resource constraints for the service container.`,
+					`If unset, inherits the container's default exec resources if configured.`),
 			),
 
 		dagql.NodeFunc("up", s.containerUpLegacy).
@@ -90,6 +93,9 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 					`This should only be used if the user requires that their exec process be the
 					pid 1 process in the container. Otherwise it may result in unexpected behavior.`,
 				),
+				dagql.Arg("resources").Doc(
+					`Cgroup resource constraints for the service container.`,
+					`If unset, inherits the container's default exec resources if configured.`),
 			),
 	}.Install(srv)
 
@@ -345,6 +351,23 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.ObjectResult[
 		inputs = append(inputs, dagql.NamedInput{
 			Name:  "noInit",
 			Value: dagql.Boolean(true),
+		})
+	}
+	if args.Resources != nil {
+		r := args.Resources
+		resInput, err := (dagql.InputObject[core.ContainerExecResources]{}).Decoder().DecodeInput(map[string]any{
+			"memoryBytes":     r.MemoryBytes,
+			"memorySoftBytes": r.MemorySoftBytes,
+			"cpus":            r.CPUs,
+			"cpuShares":       r.CPUShares,
+			"pids":            r.Pids,
+		})
+		if err != nil {
+			return res, fmt.Errorf("encode resources: %w", err)
+		}
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "resources",
+			Value: resInput.(dagql.Input),
 		})
 	}
 

--- a/core/service.go
+++ b/core/service.go
@@ -56,6 +56,7 @@ type Service struct {
 	ExperimentalPrivilegedNesting bool
 	InsecureRootCapabilities      bool
 	NoInit                        bool
+	Resources                     *ContainerExecResources
 	ExecMD                        *engineutil.ExecutionMetadata
 	ModuleContext                 dagql.ObjectResult[*Module]
 	ExecMeta                      *executor.Meta
@@ -712,6 +713,7 @@ func (svc *Service) startContainer(
 			ExperimentalPrivilegedNesting: svc.ExperimentalPrivilegedNesting,
 			InsecureRootCapabilities:      svc.InsecureRootCapabilities,
 			NoInit:                        svc.NoInit,
+			Resources:                     svc.Resources,
 		}, false)
 		if err != nil {
 			return err

--- a/internal/buildkit/executor/executor.go
+++ b/internal/buildkit/executor/executor.go
@@ -27,6 +27,14 @@ type Meta struct {
 	ValidExitCodes []int
 
 	RemoveMountStubsRecursive bool
+
+	// Cgroup resource limits. Zero value means no limit.
+	MemoryBytes     int64  // cgroup memory.max (hard limit, bytes)
+	MemorySoftBytes int64  // cgroup memory.high (soft limit, bytes)
+	CPUQuota        int64  // cgroup cpu.max quota (microseconds per period)
+	CPUPeriod       uint64 // cgroup cpu.max period (microseconds); 0 → default 100000
+	CPUShares       int64  // cgroup cpu.weight (relative weight, 1-10000)
+	PidsLimit       int64  // cgroup pids.max
 }
 
 type MountableRef interface {

--- a/internal/buildkit/executor/oci/spec.go
+++ b/internal/buildkit/executor/oci/spec.go
@@ -110,6 +110,10 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		return nil, nil, err
 	}
 
+	if resourceOpts := generateResourceOpts(meta); len(resourceOpts) > 0 {
+		opts = append(opts, resourceOpts...)
+	}
+
 	hostname := defaultHostname
 	if meta.Hostname != "" {
 		hostname = meta.Hostname

--- a/internal/buildkit/executor/oci/spec_darwin.go
+++ b/internal/buildkit/executor/oci/spec_darwin.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/continuity/fs"
+	"github.com/dagger/dagger/internal/buildkit/executor"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -38,6 +39,11 @@ func generateRlimitOpts(ulimits []*pb.Ulimit) ([]oci.SpecOpts, error) {
 		return nil, nil
 	}
 	return nil, errors.New("no support for POSIXRlimit on Darwin")
+}
+
+// generateResourceOpts is a no-op on Darwin; cgroup resource limits are Linux-only.
+func generateResourceOpts(_ executor.Meta) []oci.SpecOpts {
+	return nil
 }
 
 // tracing is not implemented on Darwin

--- a/internal/buildkit/executor/oci/spec_freebsd.go
+++ b/internal/buildkit/executor/oci/spec_freebsd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/continuity/fs"
+	"github.com/dagger/dagger/internal/buildkit/executor"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/docker/docker/pkg/idtools"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -46,6 +47,11 @@ func generateRlimitOpts(ulimits []*pb.Ulimit) ([]oci.SpecOpts, error) {
 		return nil, nil
 	}
 	return nil, errors.New("no support for POSIXRlimit on FreeBSD")
+}
+
+// generateResourceOpts is a no-op on FreeBSD; cgroup resource limits are Linux-only.
+func generateResourceOpts(_ executor.Meta) []oci.SpecOpts {
+	return nil
 }
 
 // tracing is not implemented on FreeBSD

--- a/internal/buildkit/executor/oci/spec_linux.go
+++ b/internal/buildkit/executor/oci/spec_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	cdseccomp "github.com/containerd/containerd/v2/pkg/seccomp"
 	"github.com/containerd/continuity/fs"
+	"github.com/dagger/dagger/internal/buildkit/executor"
 	"github.com/dagger/dagger/internal/buildkit/snapshot"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/dagger/dagger/internal/buildkit/util/entitlements/security"
@@ -140,6 +141,67 @@ func generateRlimitOpts(ulimits []*pb.Ulimit) ([]oci.SpecOpts, error) {
 			return nil
 		},
 	}, nil
+}
+
+// generateResourceOpts returns oci.SpecOpts that populate spec.Linux.Resources
+// from the cgroup limit fields in meta. Returns nil when all limit fields are
+// zero — preserving current unlimited behaviour.
+func generateResourceOpts(meta executor.Meta) []oci.SpecOpts {
+	if meta.MemoryBytes == 0 && meta.MemorySoftBytes == 0 &&
+		meta.CPUQuota == 0 && meta.CPUShares == 0 && meta.PidsLimit == 0 {
+		return nil
+	}
+
+	return []oci.SpecOpts{func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		if s.Linux == nil {
+			s.Linux = &specs.Linux{}
+		}
+		if s.Linux.Resources == nil {
+			s.Linux.Resources = &specs.LinuxResources{}
+		}
+
+		if meta.MemoryBytes != 0 || meta.MemorySoftBytes != 0 {
+			if s.Linux.Resources.Memory == nil {
+				s.Linux.Resources.Memory = &specs.LinuxMemory{}
+			}
+			if meta.MemoryBytes != 0 {
+				v := meta.MemoryBytes
+				s.Linux.Resources.Memory.Limit = &v
+			}
+			if meta.MemorySoftBytes != 0 {
+				v := meta.MemorySoftBytes
+				s.Linux.Resources.Memory.Reservation = &v
+			}
+		}
+
+		if meta.CPUQuota != 0 || meta.CPUShares != 0 {
+			if s.Linux.Resources.CPU == nil {
+				s.Linux.Resources.CPU = &specs.LinuxCPU{}
+			}
+			if meta.CPUQuota != 0 {
+				period := meta.CPUPeriod
+				if period == 0 {
+					period = 100000
+				}
+				s.Linux.Resources.CPU.Quota = &meta.CPUQuota
+				s.Linux.Resources.CPU.Period = &period
+			}
+			if meta.CPUShares != 0 {
+				shares := uint64(meta.CPUShares)
+				s.Linux.Resources.CPU.Shares = &shares
+			}
+		}
+
+		if meta.PidsLimit != 0 {
+			if s.Linux.Resources.Pids == nil {
+				s.Linux.Resources.Pids = &specs.LinuxPids{}
+			}
+			v := meta.PidsLimit
+			s.Linux.Resources.Pids.Limit = &v
+		}
+
+		return nil
+	}}
 }
 
 // withDefaultProfile sets the default seccomp profile to the spec.

--- a/internal/buildkit/executor/oci/spec_linux.go
+++ b/internal/buildkit/executor/oci/spec_linux.go
@@ -183,7 +183,8 @@ func generateResourceOpts(meta executor.Meta) []oci.SpecOpts {
 				if period == 0 {
 					period = 100000
 				}
-				s.Linux.Resources.CPU.Quota = &meta.CPUQuota
+				quota := meta.CPUQuota
+				s.Linux.Resources.CPU.Quota = &quota
 				s.Linux.Resources.CPU.Period = &period
 			}
 			if meta.CPUShares != 0 {

--- a/internal/buildkit/executor/oci/spec_resources_test.go
+++ b/internal/buildkit/executor/oci/spec_resources_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package oci
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/internal/buildkit/executor"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+)
+
+func minimalSpec() *specs.Spec {
+	return &specs.Spec{
+		Linux: &specs.Linux{},
+	}
+}
+
+func TestGenerateResourceOptsZeroIsNoop(t *testing.T) {
+	t.Parallel()
+	opts := generateResourceOpts(executor.Meta{})
+	require.Nil(t, opts)
+}
+
+func TestGenerateResourceOptsMemoryLimit(t *testing.T) {
+	t.Parallel()
+	opts := generateResourceOpts(executor.Meta{MemoryBytes: 512 * 1024 * 1024})
+	require.Len(t, opts, 1)
+
+	s := minimalSpec()
+	require.NoError(t, opts[0](context.Background(), nil, nil, s))
+	require.NotNil(t, s.Linux.Resources.Memory.Limit)
+	require.Equal(t, int64(512*1024*1024), *s.Linux.Resources.Memory.Limit)
+	require.Nil(t, s.Linux.Resources.Memory.Reservation)
+}
+
+func TestGenerateResourceOptsMemorySoft(t *testing.T) {
+	t.Parallel()
+	opts := generateResourceOpts(executor.Meta{MemorySoftBytes: 256 * 1024 * 1024})
+	require.Len(t, opts, 1)
+
+	s := minimalSpec()
+	require.NoError(t, opts[0](context.Background(), nil, nil, s))
+	require.Nil(t, s.Linux.Resources.Memory.Limit)
+	require.NotNil(t, s.Linux.Resources.Memory.Reservation)
+	require.Equal(t, int64(256*1024*1024), *s.Linux.Resources.Memory.Reservation)
+}
+
+func TestGenerateResourceOptsCPUQuota(t *testing.T) {
+	t.Parallel()
+	opts := generateResourceOpts(executor.Meta{CPUQuota: 150000, CPUPeriod: 100000})
+	require.Len(t, opts, 1)
+
+	s := minimalSpec()
+	require.NoError(t, opts[0](context.Background(), nil, nil, s))
+	require.NotNil(t, s.Linux.Resources.CPU.Quota)
+	require.Equal(t, int64(150000), *s.Linux.Resources.CPU.Quota)
+	require.NotNil(t, s.Linux.Resources.CPU.Period)
+	require.Equal(t, uint64(100000), *s.Linux.Resources.CPU.Period)
+}
+
+func TestGenerateResourceOptsCPUQuotaDefaultPeriod(t *testing.T) {
+	t.Parallel()
+	// CPUPeriod == 0 should default to 100000
+	opts := generateResourceOpts(executor.Meta{CPUQuota: 150000})
+	require.Len(t, opts, 1)
+
+	s := minimalSpec()
+	require.NoError(t, opts[0](context.Background(), nil, nil, s))
+	require.Equal(t, uint64(100000), *s.Linux.Resources.CPU.Period)
+}
+
+func TestGenerateResourceOptsCPUShares(t *testing.T) {
+	t.Parallel()
+	opts := generateResourceOpts(executor.Meta{CPUShares: 512})
+	require.Len(t, opts, 1)
+
+	s := minimalSpec()
+	require.NoError(t, opts[0](context.Background(), nil, nil, s))
+	require.NotNil(t, s.Linux.Resources.CPU.Shares)
+	require.Equal(t, uint64(512), *s.Linux.Resources.CPU.Shares)
+}
+
+func TestGenerateResourceOptsPids(t *testing.T) {
+	t.Parallel()
+	opts := generateResourceOpts(executor.Meta{PidsLimit: 256})
+	require.Len(t, opts, 1)
+
+	s := minimalSpec()
+	require.NoError(t, opts[0](context.Background(), nil, nil, s))
+	require.NotNil(t, s.Linux.Resources.Pids.Limit)
+	require.Equal(t, int64(256), *s.Linux.Resources.Pids.Limit)
+}

--- a/internal/buildkit/executor/oci/spec_windows.go
+++ b/internal/buildkit/executor/oci/spec_windows.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/continuity/fs"
+	"github.com/dagger/dagger/internal/buildkit/executor"
 	"github.com/dagger/dagger/internal/buildkit/solver/pb"
 	"github.com/docker/docker/pkg/idtools"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -85,6 +86,11 @@ func generateRlimitOpts(ulimits []*pb.Ulimit) ([]oci.SpecOpts, error) {
 		return nil, nil
 	}
 	return nil, errors.New("no support for POSIXRlimit on Windows")
+}
+
+// generateResourceOpts is a no-op on Windows; cgroup resource limits are Linux-only.
+func generateResourceOpts(_ executor.Meta) []oci.SpecOpts {
+	return nil
 }
 
 func getTracingSocketMount(socket string) *specs.Mount {


### PR DESCRIPTION
## Summary

- Adds a `ContainerExecResources` input type exposing cgroup memory, CPU, and pids limits per exec
- Extends `withExec` with a `resources` argument and `Container` with `withDefaultExecResources` for container-level defaults (overridable per call, persisted across container ops)
- Extends `asService` with a `resources` argument so long-running services get the same limits
- Threads values end-to-end: `ContainerExecOpts → executor.Meta → oci.GenerateSpec → spec.Linux.Resources → runc`

## Changes

- `core/container_exec.go` — `ContainerExecResources` type, `resourcesIntoMeta`, `mergeExecResources` (field-by-field override), wired into `metaSpec`
- `internal/buildkit/executor/executor.go` — 6 new cgroup resource fields on `Meta` (MemoryBytes, MemorySoftBytes, CPUQuota, CPUPeriod, CPUShares, PidsLimit)
- `internal/buildkit/executor/oci/spec_linux.go` — `generateResourceOpts` populates `spec.Linux.Resources`; platform stubs on darwin/freebsd/windows (no-op)
- `core/container.go` — `DefaultExecResources` field, persisted payload, encode/decode, clone
- `core/schema/container.go` — `withDefaultExecResources` resolver (`IsPersistable`, `AllVersion`)
- `core/schema/service.go` — `resources` arg on `asService`; `containerUp` resources forwarding
- `core/schema/query.go` — `ContainerExecResources` registered as dagql input type

## Motivation

1. **Hard resource ceilings per step.** A single `withExec` (compiler, test suite, node build) can OOM-kill the engine or its neighbours. No way currently to say "this step gets at most 2 GiB / 1.5 CPUs."
2. **Runtime self-sizing.** JVM, Node, Go read cgroup limits to size heaps, GC, and `GOMAXPROCS`. With no limit set they assume the whole host and over-allocate.
3. **Primitive was unused.** Dagger already generates an OCI spec for every exec and never populated `Linux.Resources` — this fills it in.

The per-exec cgroups are a subtree of the engine's own cgroup, so any outer Docker `--memory`/`--cpus` cap remains the kernel-enforced aggregate ceiling. No changes to BuildKit LLB proto required.

## Test Plan

- [ ] Unit tests: `TestResourcesIntoMeta` (7 subtests), `TestMergeExecResources` (4 subtests) in `core/container_exec_test.go`
- [ ] Unit tests: `TestGenerateResourceOpts*` (7 subtests, `//go:build linux`) in `internal/buildkit/executor/oci/spec_resources_test.go`
- [ ] `GOOS=linux go build ./core/ ./internal/buildkit/executor/...` — clean
- [ ] End-to-end: `container.from("alpine").withDefaultExecResources({memoryBytes: 536870912}).withExec(["cat", "/sys/fs/cgroup/memory.max"])` should print `536870912` on a cgroup-v2 Linux host

## Risk

- **Low.** Zero-value fields are omitted (no change to existing behaviour). Linux-only code path is guarded by build tags and platform stubs. No BuildKit proto changes.
- The `runtime.NumCPU()` capacity bug (engine reports host CPU count, ignoring Docker `--cpus` quota) is documented and out of scope — it affects Phase 2 scheduling, not Phase 1 limits.

## Related

- Design proposal: https://github.com/dagger/dagger/discussions/13390 (Phase 1)
- Phase 2 proposal (resource-aware scheduling / admission control): https://github.com/dagger/dagger/discussions/13391