### PR TITLE
test: scrub packet loss from telemetry goldens

### DIFF
--- a/util/scrub/scrub.go
+++ b/util/scrub/scrub.go
@@ -183,6 +183,12 @@ var scrubs = []scrubber{
 		"1048576000 bytes",
 		"XX bytes",
 	},
+	// Packet loss depends on transient network conditions in the test environment.
+	{
+		regexp.MustCompile(` \(\d+(\.\d+)?(e[+-]?\d+)?% dropped\)`),
+		" (5.88% dropped)",
+		"",
+	},
 	// duration quantities
 	{
 		regexp.MustCompile(`\d+(\.\d+)?(µs|ms|s)`),

--- a/util/scrub/scrub_test.go
+++ b/util/scrub/scrub_test.go
@@ -30,3 +30,10 @@ func TestStabilizeDedupesAdjacentPortWarnings(t *testing.T) {
 
 	require.Equal(t, expected, Stabilize(input))
 }
+
+func TestStabilizeRemovesPacketLoss(t *testing.T) {
+	input := "✘ .failEffect: Container! 3.7s ERROR (5.88% dropped)\n"
+	expected := "✘ .failEffect: Container! X.Xs ERROR\n"
+
+	require.Equal(t, expected, Stabilize(input))
+}


### PR DESCRIPTION
## Summary

Normalize transient packet-loss annotations such as `(5.88% dropped)` in the shared telemetry golden scrubber. Add focused coverage for the TypeScript `fail-effect` shape that appeared in CI.

## Why

The failed `test-split:test-telemetry` trace showed `TestTelemetry/TestGolden/typescript-fail-effect` differing only by a packet-loss suffix on `.failEffect`. That suffix comes from ephemeral network metrics in the test environment and does not change the progress-rendering behavior the golden is meant to assert.

## Validation

- `go test ./util/scrub`
- `git diff --check`