### PR TITLE
fix(engine): guard session client maps during GC

### DIFF
--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -906,13 +906,34 @@ func (srv *Server) gcClientDBs() {
 func (srv *Server) activeClientIDs() map[string]bool {
 	keep := map[string]bool{}
 
+	// Snapshot the sessions under daggerSessionsMu, then drop it before taking
+	// per-session locks: clients is written by getOrInitClient under clientMu
+	// (so must be read under clientMu), and removeDaggerSession takes
+	// daggerSessionsMu while holding stateMu, so holding daggerSessionsMu while
+	// acquiring stateMu here would risk a lock-order inversion.
 	srv.daggerSessionsMu.RLock()
+	sessions := make([]*daggerSession, 0, len(srv.daggerSessions))
 	for _, sess := range srv.daggerSessions {
+		sessions = append(sessions, sess)
+	}
+	srv.daggerSessionsMu.RUnlock()
+
+	for _, sess := range sessions {
+		sess.stateMu.RLock()
+		// clients is only populated once a session is initialized, and a
+		// removed session's client DBs are already being torn down, so only
+		// initialized sessions contribute IDs worth keeping.
+		if sess.state != sessionStateInitialized {
+			sess.stateMu.RUnlock()
+			continue
+		}
+		sess.clientMu.RLock()
 		for id := range sess.clients {
 			keep[id] = true
 		}
+		sess.clientMu.RUnlock()
+		sess.stateMu.RUnlock()
 	}
-	srv.daggerSessionsMu.RUnlock()
 
 	return keep
 }

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -690,12 +690,27 @@ func (srv *Server) EngineName() string {
 }
 
 func (srv *Server) Clients() []string {
+	// Snapshot under daggerSessionsMu, then read mainClientCallerID under
+	// stateMu (it is set during initialization). Releasing daggerSessionsMu
+	// before taking stateMu avoids inverting removeDaggerSession's
+	// stateMu->daggerSessionsMu lock order; skip sessions that aren't
+	// initialized yet.
 	srv.daggerSessionsMu.RLock()
-	defer srv.daggerSessionsMu.RUnlock()
+	sessions := make([]*daggerSession, 0, len(srv.daggerSessions))
+	for _, sess := range srv.daggerSessions {
+		sessions = append(sessions, sess)
+	}
+	srv.daggerSessionsMu.RUnlock()
 
 	clients := map[string]struct{}{}
-	for _, sess := range srv.daggerSessions {
+	for _, sess := range sessions {
+		sess.stateMu.RLock()
+		if sess.state != sessionStateInitialized {
+			sess.stateMu.RUnlock()
+			continue
+		}
 		clients[sess.mainClientCallerID] = struct{}{}
+		sess.stateMu.RUnlock()
 	}
 
 	return slices.Collect(maps.Keys(clients))

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -441,7 +441,17 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 		}
 	}
 
+	// clients may be mutated under clientMu alone (e.g. getOrInitClient's
+	// failure cleanup deletes entries without holding stateMu), so snapshot
+	// under clientMu rather than iterating the live map below.
+	sess.clientMu.RLock()
+	clients := make([]*daggerClient, 0, len(sess.clients))
 	for _, client := range sess.clients {
+		clients = append(clients, client)
+	}
+	sess.clientMu.RUnlock()
+
+	for _, client := range clients {
 		releaseGroup.Go(func() error {
 			var errs error
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -768,8 +768,8 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 		return nil, fmt.Errorf("missing client ID")
 	}
 	srv.daggerSessionsMu.RLock()
-	defer srv.daggerSessionsMu.RUnlock()
 	sess, ok := srv.daggerSessions[sessID]
+	srv.daggerSessionsMu.RUnlock()
 	if !ok {
 		// This error can happen due to per-LLB-vertex deduplication in the buildkit solver,
 		// where for instance the first client cancels and closes its session while others
@@ -777,6 +777,24 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 		// the still connected client metadata.
 		err := flightcontrol.RetryableError{Err: fmt.Errorf("session %q not found", sessID)}
 		return nil, err
+	}
+
+	// The session pointer is published before initializeDaggerSession populates
+	// its fields, so gate on state under stateMu before reading them. stateMu is
+	// taken only after releasing daggerSessionsMu to avoid inverting
+	// removeDaggerSession's stateMu->daggerSessionsMu lock order.
+	sess.stateMu.RLock()
+	defer sess.stateMu.RUnlock()
+	switch sess.state {
+	case sessionStateInitialized:
+		// continue
+	case sessionStateRemoved:
+		err := flightcontrol.RetryableError{Err: fmt.Errorf("session %q not found", sessID)}
+		return nil, err
+	case sessionStateUninitialized:
+		return nil, fmt.Errorf("session %q not initialized", sessID)
+	default:
+		return nil, fmt.Errorf("session %q has unknown state %q", sessID, sess.state)
 	}
 
 	sess.clientMu.RLock()
@@ -831,10 +849,19 @@ func (srv *Server) getOrInitClient(
 		return nil, nil, errServerShuttingDown
 	}
 	sess, sessionExists := srv.daggerSessions[sessionID]
+	stateMuLocked := false
 	if !sessionExists {
 		sess = &daggerSession{
 			state: sessionStateUninitialized,
 		}
+		// Lock stateMu before publishing the session below so a concurrent
+		// clientFromIDs that looks it up blocks until initialization finishes
+		// instead of observing uninitialized fields. The session is still
+		// unreachable by other goroutines here, so this never blocks and can't
+		// invert removeDaggerSession's stateMu->daggerSessionsMu order even
+		// though we currently hold daggerSessionsMu.
+		sess.stateMu.Lock()
+		stateMuLocked = true
 		srv.daggerSessions[sessionID] = sess
 
 		failureCleanups.Add("delete session ID", func() error {
@@ -846,7 +873,9 @@ func (srv *Server) getOrInitClient(
 	}
 	srv.daggerSessionsMu.Unlock()
 
-	sess.stateMu.Lock()
+	if !stateMuLocked {
+		sess.stateMu.Lock()
+	}
 	defer sess.stateMu.Unlock()
 	switch sess.state {
 	case sessionStateUninitialized:

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -994,11 +994,37 @@ func (srv *Server) getOrInitClient(
 	client.activeCount++
 
 	return client, func() error {
-		client.stateMu.Lock()
-		defer client.stateMu.Unlock()
-		client.activeCount--
+		if clientID != sess.mainClientCallerID {
+			client.stateMu.Lock()
+			client.activeCount--
+			activeCount := client.activeCount
+			client.stateMu.Unlock()
 
-		if client.activeCount > 0 {
+			if activeCount > 0 {
+				return nil
+			}
+
+			slog := slog.With(
+				"sessionID", sess.sessionID,
+				"clientID", client.clientID,
+			)
+			slog.Info("all client connections closed")
+			return nil
+		}
+
+		sess.stateMu.Lock()
+		defer sess.stateMu.Unlock()
+
+		// Keep the lock order consistent with getOrInitClient (session before
+		// client). If cleanup took client.stateMu first, a new request could
+		// hold stateMu while waiting on client.stateMu, while cleanup waited
+		// on stateMu.
+		client.stateMu.Lock()
+		client.activeCount--
+		activeCount := client.activeCount
+		client.stateMu.Unlock()
+
+		if activeCount > 0 {
 			return nil
 		}
 
@@ -1008,13 +1034,6 @@ func (srv *Server) getOrInitClient(
 		)
 		slog.Info("all client connections closed")
 
-		// if the main client caller has no more active calls, cleanup the whole session
-		if clientID != sess.mainClientCallerID {
-			return nil
-		}
-
-		sess.stateMu.Lock()
-		defer sess.stateMu.Unlock()
 		switch sess.state {
 		case sessionStateInitialized:
 			return srv.removeDaggerSession(ctx, sess)

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -83,6 +83,73 @@ func TestActiveClientIDsConcurrentSessionClientMutation(t *testing.T) {
 	}
 }
 
+func TestClientFromIDsConcurrentSessionInitialization(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: clientFromIDs must read sess.state/sess.clients under
+	// stateMu while another goroutine reassigns those fields during session
+	// initialization. Without the stateMu gate this is a data race (caught
+	// here under -race).
+	sess := &daggerSession{
+		state: sessionStateUninitialized,
+	}
+	srv := &Server{
+		daggerSessions: map[string]*daggerSession{
+			"session-a": sess,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	started := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(started)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			_, _ = srv.clientFromIDs("session-a", "client-a")
+		}
+	}()
+	<-started
+
+	for i := 0; i < 1000; i++ {
+		sess.stateMu.Lock()
+		sess.clients = map[string]*daggerClient{
+			"client-a": {clientID: "client-a"},
+		}
+		sess.state = sessionStateInitialized
+		sess.state = sessionStateUninitialized
+		sess.clients = nil
+		sess.stateMu.Unlock()
+	}
+
+	client := &daggerClient{clientID: "client-a"}
+	sess.stateMu.Lock()
+	sess.clientMu.Lock()
+	sess.clients = map[string]*daggerClient{
+		client.clientID: client,
+	}
+	sess.clientMu.Unlock()
+	sess.state = sessionStateInitialized
+	sess.stateMu.Unlock()
+
+	got, err := srv.clientFromIDs("session-a", client.clientID)
+	require.NoError(t, err)
+	require.Same(t, client, got)
+}
+
 func TestPendingLegacyModule(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/dagger/dagger/core"
@@ -29,6 +30,57 @@ func (caller *fakeSessionCaller) Supports(string) bool {
 
 func (caller *fakeSessionCaller) Conn() *grpc.ClientConn {
 	return caller.conn
+}
+
+func TestActiveClientIDsConcurrentSessionClientMutation(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: activeClientIDs must read sess.clients under clientMu.
+	// Without the lock, ranging the map while another goroutine writes it is a
+	// fatal "concurrent map iteration and map write" (caught here under -race).
+	sess := &daggerSession{
+		state: sessionStateInitialized,
+		clients: map[string]*daggerClient{
+			"client-a": {clientID: "client-a"},
+		},
+	}
+	srv := &Server{
+		daggerSessions: map[string]*daggerSession{
+			"session-a": sess,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	started := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(started)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			sess.clientMu.Lock()
+			sess.clients["transient"] = &daggerClient{clientID: "transient"}
+			delete(sess.clients, "transient")
+			sess.clientMu.Unlock()
+		}
+	}()
+	<-started
+
+	for i := 0; i < 1000; i++ {
+		require.True(t, srv.activeClientIDs()["client-a"])
+	}
 }
 
 func TestPendingLegacyModule(t *testing.T) {


### PR DESCRIPTION
## Problem

The engine could crash with a fatal Go runtime panic, triggered from background client-DB garbage collection:

```text
fatal error: concurrent map iteration and map write

goroutine 73 [running]:
internal/runtime/maps.fatal(...)
internal/runtime/maps.(*Iter).Next(...)
github.com/dagger/dagger/engine/server.(*Server).activeClientIDs(...)
      /app/engine/server/server.go:911
github.com/dagger/dagger/engine/server.(*Server).gcClientDBs(...)
      /app/engine/server/server.go:900
created by github.com/dagger/dagger/engine/server.NewServer
```

`gcClientDBs` runs `activeClientIDs` on a background ticker. `activeClientIDs` iterated each session's `sess.clients` map while holding only `daggerSessionsMu`, but `getOrInitClient` writes that map under `sess.clientMu`. So GC could race client (and nested-client) initialization and hit the fatal concurrent map iteration/write.

## Follow-up problems

While fixing the above, a related init-window race surfaced: a new session is published into `srv.daggerSessions` *before* `initializeDaggerSession` populates fields such as `clients` and `mainClientCallerID` under `stateMu`. Readers like `clientFromIDs` and `Clients()` could find the session pointer and read those fields while holding only `daggerSessionsMu` or `clientMu`, racing initialization.

A review also caught a lock-order inversion in main-client cleanup: `getOrInitClient` takes the session lock before the client lock, while the cleanup closure took the client lock before trying to remove the session. An overlapping cleanup and new request for the same main client could therefore block each other.

## Fix

GC / map iteration:

- `activeClientIDs` snapshots the sessions under `daggerSessionsMu` and releases it *before* taking any per-session lock — this avoids a lock-order inversion against `removeDaggerSession`, which holds `stateMu` then takes `daggerSessionsMu` — then reads each initialized session's client map under `stateMu` + `clientMu`.
- `removeDaggerSession` snapshots `sess.clients` under `clientMu` before spawning teardown goroutines.

Init-window race:

- For newly created sessions, `getOrInitClient` locks `stateMu` before publishing the session pointer into `srv.daggerSessions`, so concurrent readers block until initialization completes instead of observing partially initialized fields. This is safe because the session is still unreachable by other goroutines at that point, so the lock never blocks.
- `clientFromIDs` snapshots the session under `daggerSessionsMu`, releases it, gates on session state under `stateMu`, then reads `clients` under `clientMu`.
- `Clients()` similarly snapshots the sessions, then reads `mainClientCallerID` under `stateMu` for initialized sessions only.

Cleanup lock ordering:

- Main-client cleanup now takes `stateMu` before `client.stateMu`, matching `getOrInitClient`, and releases `client.stateMu` before session removal.
- Non-main cleanup only needs `client.stateMu` to decrement its active count, so it avoids taking the session lock.

## Testing

- Added race regression coverage for `activeClientIDs` racing concurrent session-client mutation.
- Added race regression coverage for `clientFromIDs` racing concurrent session initialization.
- `go test ./engine/server`
- `go test -race ./engine/server`