### PR TITLE
ci: forward Docker config to SDK dev engines

### DIFF
--- a/.env.gha
+++ b/.env.gha
@@ -5,3 +5,6 @@
 # It is provided by our CI compute provider (namespace) to bypass Docker Hub rate limiting
 #engineDev_clientDockerConfig=file://~/.docker/config.json
 engineDev_clientDockerConfig=file:///home/runner/.docker/config.json
+pythonSdk_clientDockerConfig=file:///home/runner/.docker/config.json
+phpSdk_clientDockerConfig=file:///home/runner/.docker/config.json
+rustSdk_clientDockerConfig=file:///home/runner/.docker/config.json

--- a/toolchains/all-sdks/internal/dagger/php-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/php-sdk-dev.gen.go
@@ -69,7 +69,7 @@ func (r *PhpSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *PhpSDKDev {
 }
 
 // Regenerate the PHP SDK API
-func (r *PhpSDKDev) API() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:140:1)
+func (r *PhpSDKDev) API() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:147:1)
 	q := r.query.Select("api")
 
 	return &Changeset{
@@ -77,7 +77,7 @@ func (r *PhpSDKDev) API() *Changeset { // php-sdk-dev (../../../../toolchains/ph
 	}
 }
 
-func (r *PhpSDKDev) BaseContainer() *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:53:1)
+func (r *PhpSDKDev) BaseContainer() *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:58:1)
 	q := r.query.Select("baseContainer")
 
 	return &Container{
@@ -86,7 +86,7 @@ func (r *PhpSDKDev) BaseContainer() *Container { // php-sdk-dev (../../../../too
 }
 
 // Bump the PHP SDK's Engine dependency
-func (r *PhpSDKDev) Bump(version string) *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:265:1)
+func (r *PhpSDKDev) Bump(version string) *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:272:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -95,7 +95,7 @@ func (r *PhpSDKDev) Bump(version string) *Changeset { // php-sdk-dev (../../../.
 	}
 }
 
-func (r *PhpSDKDev) Changes() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:151:1)
+func (r *PhpSDKDev) Changes() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:158:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -108,12 +108,12 @@ type PhpSDKDevDevContainerOpts struct {
 	//
 	// Run composer install before returning the container
 	//
-	RunInstall bool // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:81:2)
+	RunInstall bool // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:88:2)
 }
 
 // Returns the PHP SDK workspace mounted in a dev container,
 // and working directory set to the SDK source
-func (r *PhpSDKDev) DevContainer(opts ...PhpSDKDevDevContainerOpts) *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:78:1)
+func (r *PhpSDKDev) DevContainer(opts ...PhpSDKDevDevContainerOpts) *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:85:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -128,7 +128,7 @@ func (r *PhpSDKDev) DevContainer(opts ...PhpSDKDevDevContainerOpts) *Container {
 }
 
 // DoctumConfig returns the doctum configuration file
-func (r *PhpSDKDev) DoctumConfig() *File { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:104:1)
+func (r *PhpSDKDev) DoctumConfig() *File { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:111:1)
 	q := r.query.Select("doctumConfig")
 
 	return &File{
@@ -186,7 +186,7 @@ func (r *PhpSDKDev) UnmarshalJSON(bs []byte) error {
 }
 
 // Lint the PHP code with PHP CodeSniffer (https://github.com/squizlabs/PHP_CodeSniffer)
-func (r *PhpSDKDev) PhpCodeSniffer(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:110:1)
+func (r *PhpSDKDev) PhpCodeSniffer(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:117:1)
 	if r.phpCodeSniffer != nil {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (r *PhpSDKDev) PhpCodeSniffer(ctx context.Context) error { // php-sdk-dev (
 }
 
 // Analyze the PHP code with PHPStan (https://phpstan.org)
-func (r *PhpSDKDev) PhpStan(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:120:1)
+func (r *PhpSDKDev) PhpStan(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:127:1)
 	if r.phpStan != nil {
 		return nil
 	}
@@ -210,16 +210,16 @@ type PhpSDKDevReleaseOpts struct {
 	//
 	// The source git repository to release
 	//
-	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:240:2)
+	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:247:2)
 
 	// Default: "https://github.com/dagger/dagger-php-sdk.git"
-	Dest string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:247:2)
+	Dest string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:254:2)
 
-	GithubToken *Secret // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:249:2)
+	GithubToken *Secret // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:256:2)
 }
 
 // Publish the PHP SDK
-func (r *PhpSDKDev) Release(ctx context.Context, sourceTag string, opts ...PhpSDKDevReleaseOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:235:1)
+func (r *PhpSDKDev) Release(ctx context.Context, sourceTag string, opts ...PhpSDKDevReleaseOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:242:1)
 	if r.release != nil {
 		return nil
 	}
@@ -248,23 +248,23 @@ type PhpSDKDevReleaseDryRunOpts struct {
 	//
 	// Source git repository to fake-release
 	//
-	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:208:2)
+	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:215:2)
 	//
 	// Source git tag to fake-release
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:211:2)
+	SourceTag string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:218:2)
 	//
 	// Target git remote to fake-release *to*
 	//
 	//
 	// Default: "https://github.com/dagger/dagger-php-sdk.git"
-	DestRemote string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:214:2)
+	DestRemote string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:221:2)
 }
 
 // Test the publishing process
-func (r *PhpSDKDev) ReleaseDryRun(ctx context.Context, opts ...PhpSDKDevReleaseDryRunOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:204:1)
+func (r *PhpSDKDev) ReleaseDryRun(ctx context.Context, opts ...PhpSDKDevReleaseDryRunOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:211:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -288,7 +288,7 @@ func (r *PhpSDKDev) ReleaseDryRun(ctx context.Context, opts ...PhpSDKDevReleaseD
 }
 
 // Source returns the source directory for the PHP SDK
-func (r *PhpSDKDev) Source() *Directory { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:99:1)
+func (r *PhpSDKDev) Source() *Directory { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:106:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -297,7 +297,7 @@ func (r *PhpSDKDev) Source() *Directory { // php-sdk-dev (../../../../toolchains
 }
 
 // Test the PHP SDK with PHPUnit (https://phpunit.de/)
-func (r *PhpSDKDev) Test(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:131:1)
+func (r *PhpSDKDev) Test(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:138:1)
 	if r.test != nil {
 		return nil
 	}
@@ -307,7 +307,7 @@ func (r *PhpSDKDev) Test(ctx context.Context) error { // php-sdk-dev (../../../.
 }
 
 // Get v1.2.3 from sdk/php/v1.2.3
-func (r *PhpSDKDev) VersionFromTag(ctx context.Context, tag string) (string, error) { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:229:1)
+func (r *PhpSDKDev) VersionFromTag(ctx context.Context, tag string) (string, error) { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:236:1)
 	if r.versionFromTag != nil {
 		return *r.versionFromTag, nil
 	}
@@ -320,7 +320,7 @@ func (r *PhpSDKDev) VersionFromTag(ctx context.Context, tag string) (string, err
 	return response, q.Execute(ctx)
 }
 
-func (r *PhpSDKDev) WithGeneratedClient() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:155:1)
+func (r *PhpSDKDev) WithGeneratedClient() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:162:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &PhpSDKDev{
@@ -331,7 +331,7 @@ func (r *PhpSDKDev) WithGeneratedClient() *PhpSDKDev { // php-sdk-dev (../../../
 // Generate reference docs from the generated client
 // NOTE: it's the caller's responsibility to ensure the generated client is up-to-date
 // (see WithGeneratedClient)
-func (r *PhpSDKDev) WithGeneratedDocs() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:175:1)
+func (r *PhpSDKDev) WithGeneratedDocs() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:182:1)
 	q := r.query.Select("withGeneratedDocs")
 
 	return &PhpSDKDev{
@@ -352,23 +352,27 @@ type PhpSDKDevOpts struct {
 	//
 	// A directory with all the files needed to develop the SDK
 	//
-	WorkspaceDir *Directory // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:37:2)
+	WorkspaceDir *Directory // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:38:2)
 	//
 	// The path of the SDK source in the workspace
 	//
 	//
 	// Default: "sdk/php"
-	SourcePath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:40:2)
+	SourcePath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:41:2)
 	//
 	// The path of the doctum config in the workspace
 	//
 	//
 	// Default: "docs/doctum-config.php"
-	DoctumConfigPath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:43:2)
+	DoctumConfigPath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:44:2)
+	//
+	// A docker config file with credentials to install on clients.
+	//
+	ClientDockerConfig *Secret // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:47:2)
 }
 
 // Develop the Dagger PHP SDK (experimental)
-func (r *Query) PhpSDKDev(opts ...PhpSDKDevOpts) *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:33:1)
+func (r *Query) PhpSDKDev(opts ...PhpSDKDevOpts) *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:34:1)
 	q := r.query.Select("phpSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspaceDir` optional argument
@@ -382,6 +386,10 @@ func (r *Query) PhpSDKDev(opts ...PhpSDKDevOpts) *PhpSDKDev { // php-sdk-dev (..
 		// `doctumConfigPath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoctumConfigPath) {
 			q = q.Arg("doctumConfigPath", opts[i].DoctumConfigPath)
+		}
+		// `clientDockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientDockerConfig) {
+			q = q.Arg("clientDockerConfig", opts[i].ClientDockerConfig)
 		}
 	}
 

--- a/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/python-sdk-dev.gen.go
@@ -140,11 +140,11 @@ type PythonSDKDevBuildOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:288:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:293:2)
 }
 
 // Build the Python SDK client library package for distribution
-func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:285:1)
+func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:290:1)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -159,7 +159,7 @@ func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // pyth
 }
 
 // Bump the Python SDK's Engine dependency
-func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:273:1)
+func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:278:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -169,7 +169,7 @@ func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../.
 }
 
 // Regenerate the core Python client library
-func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:176:1)
+func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:181:1)
 	q := r.query.Select("clientLibrary")
 
 	return &Changeset{
@@ -187,7 +187,7 @@ func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../.
 }
 
 // Preview the reference documentation
-func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:326:1)
+func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:331:1)
 	q := r.query.Select("docs")
 
 	return &PythonSDKDevDocs{
@@ -200,11 +200,11 @@ type PythonSDKDevFormatOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:105:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:110:2)
 }
 
 // Format source files
-func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:102:1)
+func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:107:1)
 	q := r.query.Select("format")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -272,11 +272,11 @@ type PythonSDKDevLintOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:93:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:98:2)
 }
 
 // Check for linting errors
-func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:90:1)
+func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:95:1)
 	q := r.query.Select("lint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -292,11 +292,11 @@ func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python
 
 // PythonSDKDevLintDocsSnippetsOpts contains options for PythonSDKDev.LintDocsSnippets
 type PythonSDKDevLintDocsSnippetsOpts struct {
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:82:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:87:2)
 }
 
 // Lint the Python snippets in the documentation
-func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:74:1)
+func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:79:1)
 	q := r.query.Select("lintDocsSnippets")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -315,10 +315,10 @@ type PythonSDKDevProvisionOpts struct {
 	//
 	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
 	//
-	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:338:2)
+	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:343:2)
 }
 
-func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:332:1)
+func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:337:1)
 	assertNotNil("cliBin", cliBin)
 	q := r.query.Select("provision")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -341,15 +341,15 @@ type PythonSDKDevPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:302:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:307:2)
 	//
 	// The URL of the upload endpoint (empty means PyPI)
 	//
-	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:305:2)
+	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:2)
 }
 
 // Publish Python SDK client library to PyPI
-func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:297:1)
+func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:302:1)
 	assertNotNil("token", token)
 	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -370,7 +370,7 @@ func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *
 }
 
 // Test suite for python 3.10
-func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:135:1)
+func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:140:1)
 	q := r.query.Select("python310")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -379,7 +379,7 @@ func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.11
-func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:143:1)
+func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:148:1)
 	q := r.query.Select("python311")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -388,7 +388,7 @@ func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.12
-func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:151:1)
+func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:156:1)
 	q := r.query.Select("python312")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -397,7 +397,7 @@ func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.13
-func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:159:1)
+func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:164:1)
 	q := r.query.Select("python313")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -406,7 +406,7 @@ func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.14
-func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:167:1)
+func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:172:1)
 	q := r.query.Select("python314")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -416,17 +416,17 @@ func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python
 
 // PythonSDKDevReleaseOpts contains options for PythonSDKDev.Release
 type PythonSDKDevReleaseOpts struct {
-	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:241:2)
+	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:246:2)
 
-	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:244:2)
+	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:249:2)
 
-	PypiURL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:247:2)
+	PypiURL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:252:2)
 
-	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:250:2)
+	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:255:2)
 }
 
 // Release the Python SDK
-func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:234:1)
+func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:239:1)
 	if r.release != nil {
 		return nil
 	}
@@ -455,7 +455,7 @@ func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...Py
 }
 
 // Test the publishing process
-func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:222:1)
+func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:227:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -493,11 +493,11 @@ type PythonSDKDevTestPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:320:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:325:2)
 }
 
 // Test the publishing of the Python SDK client library to TestPyPI
-func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:315:1)
+func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:320:1)
 	assertNotNil("token", token)
 	q := r.query.Select("testPublish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -515,7 +515,7 @@ func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublis
 
 // Run the type checker (mypy)
 // FIXME: this is not included as an automated check. Should it?
-func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:117:1)
+func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:122:1)
 	if r.typecheck != nil {
 		return nil
 	}
@@ -525,7 +525,7 @@ func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev 
 }
 
 // Mount a directory on the base container
-func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:126:1)
+func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:131:1)
 	assertNotNil("source", source)
 	q := r.query.Select("withDirectory")
 	q = q.Arg("source", source)
@@ -766,6 +766,10 @@ type PythonSDKDevOpts struct {
 
 	// Default: "sdk/python"
 	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:48:2)
+	//
+	// A docker config file with credentials to install on clients.
+	//
+	ClientDockerConfig *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:51:2)
 }
 
 // A toolchain to develop the Dagger Python SDK
@@ -779,6 +783,10 @@ func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python
 		// `sourcePath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SourcePath) {
 			q = q.Arg("sourcePath", opts[i].SourcePath)
+		}
+		// `clientDockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientDockerConfig) {
+			q = q.Arg("clientDockerConfig", opts[i].ClientDockerConfig)
 		}
 	}
 

--- a/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/all-sdks/internal/dagger/rust-sdk-dev.gen.go
@@ -54,6 +54,10 @@ type RustSDKDevOpts struct {
 	//
 	// Default: "sdk/rust"
 	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:45:2)
+	//
+	// A docker config file with credentials to install on clients.
+	//
+	ClientDockerConfig *Secret // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:48:2)
 }
 
 // Develop the Dagger Rust SDK (experimental)
@@ -67,6 +71,10 @@ func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev
 		// `sourcePath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SourcePath) {
 			q = q.Arg("sourcePath", opts[i].SourcePath)
+		}
+		// `clientDockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientDockerConfig) {
+			q = q.Arg("clientDockerConfig", opts[i].ClientDockerConfig)
 		}
 	}
 
@@ -102,7 +110,7 @@ func (r *RustSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *RustSDKDev {
 }
 
 // Regenerate the Rust SDK API client.
-func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:152:1)
+func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:157:1)
 	q := r.query.Select("apiclient")
 
 	return &Changeset{
@@ -119,7 +127,7 @@ func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../t
 }
 
 // Bump the Rust SDK's engine dependency version.
-func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:295:1)
+func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:300:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -129,7 +137,7 @@ func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../..
 }
 
 // Run cargo check on the Rust SDK
-func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:131:1)
+func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:136:1)
 	if r.cargoCheck != nil {
 		return nil
 	}
@@ -139,7 +147,7 @@ func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (..
 }
 
 // Run cargo fmt on the Rust SDK
-func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:121:1)
+func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:126:1)
 	if r.cargoFmt != nil {
 		return nil
 	}
@@ -148,7 +156,7 @@ func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../.
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:156:1)
+func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:161:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -162,12 +170,12 @@ type RustSDKDevDevContainerOpts struct {
 	// Install workspace dependencies and any tools required
 	// to develop the Rust SDK.
 	//
-	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:75:2)
+	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:80:2)
 }
 
 // Return the Rust SDK workspace mounted in a dev container,
 // and working directory set to the SDK source.
-func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:71:1)
+func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:76:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -235,11 +243,11 @@ type RustSDKDevReleaseOpts struct {
 	//
 	// Cargo registry index URL to publish to instead of crates.io.
 	//
-	CargoRegistryIndex string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:258:2)
+	CargoRegistryIndex string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:263:2)
 }
 
 // Release the Rust SDK
-func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret, opts ...RustSDKDevReleaseOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:248:1)
+func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret, opts ...RustSDKDevReleaseOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:253:1)
 	assertNotNil("cargoRegistryToken", cargoRegistryToken)
 	if r.release != nil {
 		return nil
@@ -264,11 +272,11 @@ type RustSDKDevReleaseDryRunOpts struct {
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:185:2)
+	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:190:2)
 }
 
 // Test the publishing process
-func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:180:1)
+func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:185:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -284,7 +292,7 @@ func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleas
 }
 
 // Source returns the source directory for the Rust SDK.
-func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:115:1)
+func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:120:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -293,7 +301,7 @@ func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchai
 }
 
 // Test the Rust SDK
-func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:141:1)
+func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:146:1)
 	if r.test != nil {
 		return nil
 	}
@@ -302,7 +310,7 @@ func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../..
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:160:1)
+func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:165:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &RustSDKDev{

--- a/toolchains/php-sdk-dev/dagger.gen.go
+++ b/toolchains/php-sdk-dev/dagger.gen.go
@@ -61,24 +61,27 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 
 func (r PhpSdkDev) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		OriginalWorkspace *dagger.Directory
-		Workspace         *dagger.Directory
-		DoctumConfigPath  string
-		SourcePath        string
+		OriginalWorkspace  *dagger.Directory
+		Workspace          *dagger.Directory
+		DoctumConfigPath   string
+		SourcePath         string
+		ClientDockerConfig *dagger.Secret
 	}
 	concrete.OriginalWorkspace = r.OriginalWorkspace
 	concrete.Workspace = r.Workspace
 	concrete.DoctumConfigPath = r.DoctumConfigPath
 	concrete.SourcePath = r.SourcePath
+	concrete.ClientDockerConfig = r.ClientDockerConfig
 	return json.Marshal(&concrete)
 }
 
 func (r *PhpSdkDev) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		OriginalWorkspace *dagger.Directory
-		Workspace         *dagger.Directory
-		DoctumConfigPath  string
-		SourcePath        string
+		OriginalWorkspace  *dagger.Directory
+		Workspace          *dagger.Directory
+		DoctumConfigPath   string
+		SourcePath         string
+		ClientDockerConfig *dagger.Secret
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
@@ -88,6 +91,7 @@ func (r *PhpSdkDev) UnmarshalJSON(bs []byte) error {
 	r.Workspace = concrete.Workspace
 	r.DoctumConfigPath = concrete.DoctumConfigPath
 	r.SourcePath = concrete.SourcePath
+	r.ClientDockerConfig = concrete.ClientDockerConfig
 	return nil
 }
 
@@ -412,7 +416,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg doctumConfigPath", err))
 				}
 			}
-			return New(workspaceDir, sourcePath, doctumConfigPath), nil
+			var clientDockerConfig *dagger.Secret
+			if inputArgs["clientDockerConfig"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientDockerConfig"]), &clientDockerConfig)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientDockerConfig", err))
+				}
+			}
+			return New(workspaceDir, sourcePath, doctumConfigPath, clientDockerConfig), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/toolchains/php-sdk-dev/main.go
+++ b/toolchains/php-sdk-dev/main.go
@@ -23,10 +23,11 @@ const (
 )
 
 type PhpSdkDev struct {
-	OriginalWorkspace *dagger.Directory // +private
-	Workspace         *dagger.Directory // +private
-	DoctumConfigPath  string            // +private
-	SourcePath        string            // +private
+	OriginalWorkspace  *dagger.Directory // +private
+	Workspace          *dagger.Directory // +private
+	DoctumConfigPath   string            // +private
+	SourcePath         string            // +private
+	ClientDockerConfig *dagger.Secret    // +private
 }
 
 // Develop the Dagger PHP SDK (experimental)
@@ -41,12 +42,16 @@ func New(
 	// The path of the doctum config in the workspace
 	// +default="docs/doctum-config.php"
 	doctumConfigPath string,
+	// A docker config file with credentials to install on clients.
+	// +optional
+	clientDockerConfig *dagger.Secret,
 ) *PhpSdkDev {
 	return &PhpSdkDev{
-		Workspace:         workspaceDir,
-		OriginalWorkspace: workspaceDir,
-		SourcePath:        sourcePath,
-		DoctumConfigPath:  doctumConfigPath,
+		Workspace:          workspaceDir,
+		OriginalWorkspace:  workspaceDir,
+		SourcePath:         sourcePath,
+		DoctumConfigPath:   doctumConfigPath,
+		ClientDockerConfig: clientDockerConfig,
 	}
 }
 
@@ -69,7 +74,9 @@ func (t PhpSdkDev) BaseContainer() *dagger.Container {
 		WithEnvVariable("COMPOSER_ALLOW_SUPERUSER", "1").
 		WithWorkdir("/src").
 		With(func(c *dagger.Container) *dagger.Container {
-			return dag.DaggerEngine().InstallClient(c)
+			return dag.DaggerEngine(dagger.DaggerEngineOpts{
+				ClientDockerConfig: t.ClientDockerConfig,
+			}).InstallClient(c)
 		})
 }
 

--- a/toolchains/python-sdk-dev/dagger.gen.go
+++ b/toolchains/python-sdk-dev/dagger.gen.go
@@ -559,7 +559,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg sourcePath", err))
 				}
 			}
-			return New(workspaceDir, sourcePath), nil
+			var clientDockerConfig *dagger.Secret
+			if inputArgs["clientDockerConfig"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientDockerConfig"]), &clientDockerConfig)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientDockerConfig", err))
+				}
+			}
+			return New(workspaceDir, sourcePath, clientDockerConfig), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/toolchains/python-sdk-dev/main.go
+++ b/toolchains/python-sdk-dev/main.go
@@ -46,9 +46,14 @@ func New(
 
 	// +default="sdk/python"
 	sourcePath string,
+	// A docker config file with credentials to install on clients.
+	// +optional
+	clientDockerConfig *dagger.Secret,
 ) *PythonSdkDev {
 	return &PythonSdkDev{
-		DevContainer: dag.DaggerEngine().InstallClient(
+		DevContainer: dag.DaggerEngine(dagger.DaggerEngineOpts{
+			ClientDockerConfig: clientDockerConfig,
+		}).InstallClient(
 			dag.Wolfi().
 				Container(dagger.WolfiContainerOpts{Packages: []string{"libgcc"}}).
 				WithEnvVariable("PYTHONUNBUFFERED", "1").

--- a/toolchains/release/internal/dagger/php-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/php-sdk-dev.gen.go
@@ -69,7 +69,7 @@ func (r *PhpSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *PhpSDKDev {
 }
 
 // Regenerate the PHP SDK API
-func (r *PhpSDKDev) API() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:140:1)
+func (r *PhpSDKDev) API() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:147:1)
 	q := r.query.Select("api")
 
 	return &Changeset{
@@ -77,7 +77,7 @@ func (r *PhpSDKDev) API() *Changeset { // php-sdk-dev (../../../../toolchains/ph
 	}
 }
 
-func (r *PhpSDKDev) BaseContainer() *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:53:1)
+func (r *PhpSDKDev) BaseContainer() *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:58:1)
 	q := r.query.Select("baseContainer")
 
 	return &Container{
@@ -86,7 +86,7 @@ func (r *PhpSDKDev) BaseContainer() *Container { // php-sdk-dev (../../../../too
 }
 
 // Bump the PHP SDK's Engine dependency
-func (r *PhpSDKDev) Bump(version string) *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:265:1)
+func (r *PhpSDKDev) Bump(version string) *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:272:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -95,7 +95,7 @@ func (r *PhpSDKDev) Bump(version string) *Changeset { // php-sdk-dev (../../../.
 	}
 }
 
-func (r *PhpSDKDev) Changes() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:151:1)
+func (r *PhpSDKDev) Changes() *Changeset { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:158:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -108,12 +108,12 @@ type PhpSDKDevDevContainerOpts struct {
 	//
 	// Run composer install before returning the container
 	//
-	RunInstall bool // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:81:2)
+	RunInstall bool // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:88:2)
 }
 
 // Returns the PHP SDK workspace mounted in a dev container,
 // and working directory set to the SDK source
-func (r *PhpSDKDev) DevContainer(opts ...PhpSDKDevDevContainerOpts) *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:78:1)
+func (r *PhpSDKDev) DevContainer(opts ...PhpSDKDevDevContainerOpts) *Container { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:85:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -128,7 +128,7 @@ func (r *PhpSDKDev) DevContainer(opts ...PhpSDKDevDevContainerOpts) *Container {
 }
 
 // DoctumConfig returns the doctum configuration file
-func (r *PhpSDKDev) DoctumConfig() *File { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:104:1)
+func (r *PhpSDKDev) DoctumConfig() *File { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:111:1)
 	q := r.query.Select("doctumConfig")
 
 	return &File{
@@ -186,7 +186,7 @@ func (r *PhpSDKDev) UnmarshalJSON(bs []byte) error {
 }
 
 // Lint the PHP code with PHP CodeSniffer (https://github.com/squizlabs/PHP_CodeSniffer)
-func (r *PhpSDKDev) PhpCodeSniffer(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:110:1)
+func (r *PhpSDKDev) PhpCodeSniffer(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:117:1)
 	if r.phpCodeSniffer != nil {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (r *PhpSDKDev) PhpCodeSniffer(ctx context.Context) error { // php-sdk-dev (
 }
 
 // Analyze the PHP code with PHPStan (https://phpstan.org)
-func (r *PhpSDKDev) PhpStan(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:120:1)
+func (r *PhpSDKDev) PhpStan(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:127:1)
 	if r.phpStan != nil {
 		return nil
 	}
@@ -210,16 +210,16 @@ type PhpSDKDevReleaseOpts struct {
 	//
 	// The source git repository to release
 	//
-	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:240:2)
+	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:247:2)
 
 	// Default: "https://github.com/dagger/dagger-php-sdk.git"
-	Dest string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:247:2)
+	Dest string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:254:2)
 
-	GithubToken *Secret // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:249:2)
+	GithubToken *Secret // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:256:2)
 }
 
 // Publish the PHP SDK
-func (r *PhpSDKDev) Release(ctx context.Context, sourceTag string, opts ...PhpSDKDevReleaseOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:235:1)
+func (r *PhpSDKDev) Release(ctx context.Context, sourceTag string, opts ...PhpSDKDevReleaseOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:242:1)
 	if r.release != nil {
 		return nil
 	}
@@ -248,23 +248,23 @@ type PhpSDKDevReleaseDryRunOpts struct {
 	//
 	// Source git repository to fake-release
 	//
-	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:208:2)
+	SourceRepo *GitRepository // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:215:2)
 	//
 	// Source git tag to fake-release
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:211:2)
+	SourceTag string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:218:2)
 	//
 	// Target git remote to fake-release *to*
 	//
 	//
 	// Default: "https://github.com/dagger/dagger-php-sdk.git"
-	DestRemote string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:214:2)
+	DestRemote string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:221:2)
 }
 
 // Test the publishing process
-func (r *PhpSDKDev) ReleaseDryRun(ctx context.Context, opts ...PhpSDKDevReleaseDryRunOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:204:1)
+func (r *PhpSDKDev) ReleaseDryRun(ctx context.Context, opts ...PhpSDKDevReleaseDryRunOpts) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:211:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -288,7 +288,7 @@ func (r *PhpSDKDev) ReleaseDryRun(ctx context.Context, opts ...PhpSDKDevReleaseD
 }
 
 // Source returns the source directory for the PHP SDK
-func (r *PhpSDKDev) Source() *Directory { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:99:1)
+func (r *PhpSDKDev) Source() *Directory { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:106:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -297,7 +297,7 @@ func (r *PhpSDKDev) Source() *Directory { // php-sdk-dev (../../../../toolchains
 }
 
 // Test the PHP SDK with PHPUnit (https://phpunit.de/)
-func (r *PhpSDKDev) Test(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:131:1)
+func (r *PhpSDKDev) Test(ctx context.Context) error { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:138:1)
 	if r.test != nil {
 		return nil
 	}
@@ -307,7 +307,7 @@ func (r *PhpSDKDev) Test(ctx context.Context) error { // php-sdk-dev (../../../.
 }
 
 // Get v1.2.3 from sdk/php/v1.2.3
-func (r *PhpSDKDev) VersionFromTag(ctx context.Context, tag string) (string, error) { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:229:1)
+func (r *PhpSDKDev) VersionFromTag(ctx context.Context, tag string) (string, error) { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:236:1)
 	if r.versionFromTag != nil {
 		return *r.versionFromTag, nil
 	}
@@ -320,7 +320,7 @@ func (r *PhpSDKDev) VersionFromTag(ctx context.Context, tag string) (string, err
 	return response, q.Execute(ctx)
 }
 
-func (r *PhpSDKDev) WithGeneratedClient() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:155:1)
+func (r *PhpSDKDev) WithGeneratedClient() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:162:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &PhpSDKDev{
@@ -331,7 +331,7 @@ func (r *PhpSDKDev) WithGeneratedClient() *PhpSDKDev { // php-sdk-dev (../../../
 // Generate reference docs from the generated client
 // NOTE: it's the caller's responsibility to ensure the generated client is up-to-date
 // (see WithGeneratedClient)
-func (r *PhpSDKDev) WithGeneratedDocs() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:175:1)
+func (r *PhpSDKDev) WithGeneratedDocs() *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:182:1)
 	q := r.query.Select("withGeneratedDocs")
 
 	return &PhpSDKDev{
@@ -352,23 +352,27 @@ type PhpSDKDevOpts struct {
 	//
 	// A directory with all the files needed to develop the SDK
 	//
-	WorkspaceDir *Directory // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:37:2)
+	WorkspaceDir *Directory // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:38:2)
 	//
 	// The path of the SDK source in the workspace
 	//
 	//
 	// Default: "sdk/php"
-	SourcePath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:40:2)
+	SourcePath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:41:2)
 	//
 	// The path of the doctum config in the workspace
 	//
 	//
 	// Default: "docs/doctum-config.php"
-	DoctumConfigPath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:43:2)
+	DoctumConfigPath string // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:44:2)
+	//
+	// A docker config file with credentials to install on clients.
+	//
+	ClientDockerConfig *Secret // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:47:2)
 }
 
 // Develop the Dagger PHP SDK (experimental)
-func (r *Query) PhpSDKDev(opts ...PhpSDKDevOpts) *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:33:1)
+func (r *Query) PhpSDKDev(opts ...PhpSDKDevOpts) *PhpSDKDev { // php-sdk-dev (../../../../toolchains/php-sdk-dev/main.go:34:1)
 	q := r.query.Select("phpSdkDev")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspaceDir` optional argument
@@ -382,6 +386,10 @@ func (r *Query) PhpSDKDev(opts ...PhpSDKDevOpts) *PhpSDKDev { // php-sdk-dev (..
 		// `doctumConfigPath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DoctumConfigPath) {
 			q = q.Arg("doctumConfigPath", opts[i].DoctumConfigPath)
+		}
+		// `clientDockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientDockerConfig) {
+			q = q.Arg("clientDockerConfig", opts[i].ClientDockerConfig)
 		}
 	}
 

--- a/toolchains/release/internal/dagger/python-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/python-sdk-dev.gen.go
@@ -140,11 +140,11 @@ type PythonSDKDevBuildOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:288:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:293:2)
 }
 
 // Build the Python SDK client library package for distribution
-func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:285:1)
+func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:290:1)
 	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -159,7 +159,7 @@ func (r *PythonSDKDev) Build(opts ...PythonSDKDevBuildOpts) *Container { // pyth
 }
 
 // Bump the Python SDK's Engine dependency
-func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:273:1)
+func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:278:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -169,7 +169,7 @@ func (r *PythonSDKDev) Bump(version string) *Changeset { // python-sdk-dev (../.
 }
 
 // Regenerate the core Python client library
-func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:176:1)
+func (r *PythonSDKDev) ClientLibrary() *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:181:1)
 	q := r.query.Select("clientLibrary")
 
 	return &Changeset{
@@ -187,7 +187,7 @@ func (r *PythonSDKDev) DevContainer() *Container { // python-sdk-dev (../../../.
 }
 
 // Preview the reference documentation
-func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:326:1)
+func (r *PythonSDKDev) Docs() *PythonSDKDevDocs { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:331:1)
 	q := r.query.Select("docs")
 
 	return &PythonSDKDevDocs{
@@ -200,11 +200,11 @@ type PythonSDKDevFormatOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:105:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:110:2)
 }
 
 // Format source files
-func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:102:1)
+func (r *PythonSDKDev) Format(opts ...PythonSDKDevFormatOpts) *Changeset { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:107:1)
 	q := r.query.Select("format")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -272,11 +272,11 @@ type PythonSDKDevLintOpts struct {
 	//
 	// List of files or directories to check
 	//
-	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:93:2)
+	Paths []string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:98:2)
 }
 
 // Check for linting errors
-func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:90:1)
+func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:95:1)
 	q := r.query.Select("lint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `paths` optional argument
@@ -292,11 +292,11 @@ func (r *PythonSDKDev) Lint(opts ...PythonSDKDevLintOpts) *Container { // python
 
 // PythonSDKDevLintDocsSnippetsOpts contains options for PythonSDKDev.LintDocsSnippets
 type PythonSDKDevLintDocsSnippetsOpts struct {
-	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:82:2)
+	Workspace *Directory // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:87:2)
 }
 
 // Lint the Python snippets in the documentation
-func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:74:1)
+func (r *PythonSDKDev) LintDocsSnippets(opts ...PythonSDKDevLintDocsSnippetsOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:79:1)
 	q := r.query.Select("lintDocsSnippets")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `workspace` optional argument
@@ -315,10 +315,10 @@ type PythonSDKDevProvisionOpts struct {
 	//
 	// _EXPERIMENTAL_DAGGER_RUNNER_HOST value
 	//
-	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:338:2)
+	RunnerHost string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:343:2)
 }
 
-func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:332:1)
+func (r *PythonSDKDev) Provision(cliBin *File, opts ...PythonSDKDevProvisionOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:337:1)
 	assertNotNil("cliBin", cliBin)
 	q := r.query.Select("provision")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -341,15 +341,15 @@ type PythonSDKDevPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:302:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:307:2)
 	//
 	// The URL of the upload endpoint (empty means PyPI)
 	//
-	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:305:2)
+	URL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:310:2)
 }
 
 // Publish Python SDK client library to PyPI
-func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:297:1)
+func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:302:1)
 	assertNotNil("token", token)
 	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -370,7 +370,7 @@ func (r *PythonSDKDev) Publish(token *Secret, opts ...PythonSDKDevPublishOpts) *
 }
 
 // Test suite for python 3.10
-func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:135:1)
+func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:140:1)
 	q := r.query.Select("python310")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -379,7 +379,7 @@ func (r *PythonSDKDev) Python310() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.11
-func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:143:1)
+func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:148:1)
 	q := r.query.Select("python311")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -388,7 +388,7 @@ func (r *PythonSDKDev) Python311() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.12
-func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:151:1)
+func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:156:1)
 	q := r.query.Select("python312")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -397,7 +397,7 @@ func (r *PythonSDKDev) Python312() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.13
-func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:159:1)
+func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:164:1)
 	q := r.query.Select("python313")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -406,7 +406,7 @@ func (r *PythonSDKDev) Python313() *PythonSDKDevTestForPythonVersion { // python
 }
 
 // Test suite for python 3.14
-func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:167:1)
+func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:172:1)
 	q := r.query.Select("python314")
 
 	return &PythonSDKDevTestForPythonVersion{
@@ -416,17 +416,17 @@ func (r *PythonSDKDev) Python314() *PythonSDKDevTestForPythonVersion { // python
 
 // PythonSDKDevReleaseOpts contains options for PythonSDKDev.Release
 type PythonSDKDevReleaseOpts struct {
-	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:241:2)
+	DryRun bool // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:246:2)
 
-	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:244:2)
+	PypiRepo string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:249:2)
 
-	PypiURL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:247:2)
+	PypiURL string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:252:2)
 
-	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:250:2)
+	PypiToken *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:255:2)
 }
 
 // Release the Python SDK
-func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:234:1)
+func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...PythonSDKDevReleaseOpts) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:239:1)
 	if r.release != nil {
 		return nil
 	}
@@ -455,7 +455,7 @@ func (r *PythonSDKDev) Release(ctx context.Context, sourceTag string, opts ...Py
 }
 
 // Test the publishing process
-func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:222:1)
+func (r *PythonSDKDev) ReleaseDryRun(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:227:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -493,11 +493,11 @@ type PythonSDKDevTestPublishOpts struct {
 	//
 	//
 	// Default: "0.0.0"
-	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:320:2)
+	Version string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:325:2)
 }
 
 // Test the publishing of the Python SDK client library to TestPyPI
-func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:315:1)
+func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublishOpts) *Container { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:320:1)
 	assertNotNil("token", token)
 	q := r.query.Select("testPublish")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -515,7 +515,7 @@ func (r *PythonSDKDev) TestPublish(token *Secret, opts ...PythonSDKDevTestPublis
 
 // Run the type checker (mypy)
 // FIXME: this is not included as an automated check. Should it?
-func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:117:1)
+func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:122:1)
 	if r.typecheck != nil {
 		return nil
 	}
@@ -525,7 +525,7 @@ func (r *PythonSDKDev) Typecheck(ctx context.Context) error { // python-sdk-dev 
 }
 
 // Mount a directory on the base container
-func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:126:1)
+func (r *PythonSDKDev) WithDirectory(source *Directory) *PythonSDKDev { // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:131:1)
 	assertNotNil("source", source)
 	q := r.query.Select("withDirectory")
 	q = q.Arg("source", source)
@@ -766,6 +766,10 @@ type PythonSDKDevOpts struct {
 
 	// Default: "sdk/python"
 	SourcePath string // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:48:2)
+	//
+	// A docker config file with credentials to install on clients.
+	//
+	ClientDockerConfig *Secret // python-sdk-dev (../../../../toolchains/python-sdk-dev/main.go:51:2)
 }
 
 // A toolchain to develop the Dagger Python SDK
@@ -779,6 +783,10 @@ func (r *Query) PythonSDKDev(opts ...PythonSDKDevOpts) *PythonSDKDev { // python
 		// `sourcePath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SourcePath) {
 			q = q.Arg("sourcePath", opts[i].SourcePath)
+		}
+		// `clientDockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientDockerConfig) {
+			q = q.Arg("clientDockerConfig", opts[i].ClientDockerConfig)
 		}
 	}
 

--- a/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
+++ b/toolchains/release/internal/dagger/rust-sdk-dev.gen.go
@@ -54,6 +54,10 @@ type RustSDKDevOpts struct {
 	//
 	// Default: "sdk/rust"
 	SourcePath string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:45:2)
+	//
+	// A docker config file with credentials to install on clients.
+	//
+	ClientDockerConfig *Secret // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:48:2)
 }
 
 // Develop the Dagger Rust SDK (experimental)
@@ -67,6 +71,10 @@ func (r *Query) RustSDKDev(opts ...RustSDKDevOpts) *RustSDKDev { // rust-sdk-dev
 		// `sourcePath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SourcePath) {
 			q = q.Arg("sourcePath", opts[i].SourcePath)
+		}
+		// `clientDockerConfig` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ClientDockerConfig) {
+			q = q.Arg("clientDockerConfig", opts[i].ClientDockerConfig)
 		}
 	}
 
@@ -102,7 +110,7 @@ func (r *RustSDKDev) WithGraphQLQuery(q *querybuilder.Selection) *RustSDKDev {
 }
 
 // Regenerate the Rust SDK API client.
-func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:152:1)
+func (r *RustSDKDev) Apiclient() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:157:1)
 	q := r.query.Select("apiclient")
 
 	return &Changeset{
@@ -119,7 +127,7 @@ func (r *RustSDKDev) BaseContainer() *Container { // rust-sdk-dev (../../../../t
 }
 
 // Bump the Rust SDK's engine dependency version.
-func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:295:1)
+func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:300:1)
 	q := r.query.Select("bump")
 	q = q.Arg("version", version)
 
@@ -129,7 +137,7 @@ func (r *RustSDKDev) Bump(version string) *Changeset { // rust-sdk-dev (../../..
 }
 
 // Run cargo check on the Rust SDK
-func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:131:1)
+func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:136:1)
 	if r.cargoCheck != nil {
 		return nil
 	}
@@ -139,7 +147,7 @@ func (r *RustSDKDev) CargoCheck(ctx context.Context) error { // rust-sdk-dev (..
 }
 
 // Run cargo fmt on the Rust SDK
-func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:121:1)
+func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:126:1)
 	if r.cargoFmt != nil {
 		return nil
 	}
@@ -148,7 +156,7 @@ func (r *RustSDKDev) CargoFmt(ctx context.Context) error { // rust-sdk-dev (../.
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:156:1)
+func (r *RustSDKDev) Changes() *Changeset { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:161:1)
 	q := r.query.Select("changes")
 
 	return &Changeset{
@@ -162,12 +170,12 @@ type RustSDKDevDevContainerOpts struct {
 	// Install workspace dependencies and any tools required
 	// to develop the Rust SDK.
 	//
-	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:75:2)
+	RunInstall bool // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:80:2)
 }
 
 // Return the Rust SDK workspace mounted in a dev container,
 // and working directory set to the SDK source.
-func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:71:1)
+func (r *RustSDKDev) DevContainer(opts ...RustSDKDevDevContainerOpts) *Container { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:76:1)
 	q := r.query.Select("devContainer")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `runInstall` optional argument
@@ -235,11 +243,11 @@ type RustSDKDevReleaseOpts struct {
 	//
 	// Cargo registry index URL to publish to instead of crates.io.
 	//
-	CargoRegistryIndex string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:258:2)
+	CargoRegistryIndex string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:263:2)
 }
 
 // Release the Rust SDK
-func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret, opts ...RustSDKDevReleaseOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:248:1)
+func (r *RustSDKDev) Release(ctx context.Context, sourceTag string, cargoRegistryToken *Secret, opts ...RustSDKDevReleaseOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:253:1)
 	assertNotNil("cargoRegistryToken", cargoRegistryToken)
 	if r.release != nil {
 		return nil
@@ -264,11 +272,11 @@ type RustSDKDevReleaseDryRunOpts struct {
 	//
 	//
 	// Default: "HEAD"
-	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:185:2)
+	SourceTag string // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:190:2)
 }
 
 // Test the publishing process
-func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:180:1)
+func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleaseDryRunOpts) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:185:1)
 	if r.releaseDryRun != nil {
 		return nil
 	}
@@ -284,7 +292,7 @@ func (r *RustSDKDev) ReleaseDryRun(ctx context.Context, opts ...RustSDKDevReleas
 }
 
 // Source returns the source directory for the Rust SDK.
-func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:115:1)
+func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:120:1)
 	q := r.query.Select("source")
 
 	return &Directory{
@@ -293,7 +301,7 @@ func (r *RustSDKDev) Source() *Directory { // rust-sdk-dev (../../../../toolchai
 }
 
 // Test the Rust SDK
-func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:141:1)
+func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:146:1)
 	if r.test != nil {
 		return nil
 	}
@@ -302,7 +310,7 @@ func (r *RustSDKDev) Test(ctx context.Context) error { // rust-sdk-dev (../../..
 	return q.Execute(ctx)
 }
 
-func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:160:1)
+func (r *RustSDKDev) WithGeneratedClient() *RustSDKDev { // rust-sdk-dev (../../../../toolchains/rust-sdk-dev/main.go:165:1)
 	q := r.query.Select("withGeneratedClient")
 
 	return &RustSDKDev{

--- a/toolchains/rust-sdk-dev/dagger.gen.go
+++ b/toolchains/rust-sdk-dev/dagger.gen.go
@@ -349,7 +349,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg sourcePath", err))
 				}
 			}
-			return New(workspace, sourcePath), nil
+			var clientDockerConfig *dagger.Secret
+			if inputArgs["clientDockerConfig"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["clientDockerConfig"]), &clientDockerConfig)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg clientDockerConfig", err))
+				}
+			}
+			return New(workspace, sourcePath, clientDockerConfig), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/toolchains/rust-sdk-dev/main.go
+++ b/toolchains/rust-sdk-dev/main.go
@@ -43,6 +43,9 @@ func New(
 	// The path of the SDK source in the workspace
 	// +default="sdk/rust"
 	sourcePath string,
+	// A docker config file with credentials to install on clients.
+	// +optional
+	clientDockerConfig *dagger.Secret,
 ) *RustSdkDev {
 	rustSrc := workspace.Directory("/", dagger.WorkspaceDirectoryOpts{
 		Exclude: []string{"*", "!sdk/rust/crates", "!sdk/rust/Cargo.lock", "!sdk/rust/Cargo.toml"},
@@ -55,7 +58,9 @@ func New(
 		WithWorkdir("/src").
 		// FIXME: not all functions need a full engine build (eg. bump). Do this lazily as needed
 		With(func(c *dagger.Container) *dagger.Container {
-			return dag.DaggerEngine().InstallClient(c)
+			return dag.DaggerEngine(dagger.DaggerEngineOpts{
+				ClientDockerConfig: clientDockerConfig,
+			}).InstallClient(c)
 		})
 
 	return &RustSdkDev{


### PR DESCRIPTION
## Problem

SDK checks, such as `python-sdk:python-313:slow`, run their tests against a nested dev engine reached via `_EXPERIMENTAL_DAGGER_RUNNER_HOST`, not the outer CI engine. Docker Hub credentials from the outer CI session do not cross that engine boundary, so unless the test client container has a Docker config mounted, the dev engine resolves images like `alpine:3.20.2` anonymously and can hit Docker Hub `429 Too Many Requests`.

The pre-split monolith mounted the runner's Docker config into SDK test clients with `withDockerCfg` to avoid rate limiting in CI. When CI was split into per-toolchain modules, `engine-dev` kept the replacement `clientDockerConfig` hook, but the SDK toolchains never passed anything to it.

## Fix

- Add an optional `clientDockerConfig` input to the Python, PHP, and Rust SDK dev modules, forwarded to `DaggerEngine.InstallClient`.
- Add `.env.gha` defaults so CI provides the same runner Docker config already used by `engine-dev`.
- Regenerate the affected module stubs and reverse bindings.

Scope: this is only the credential-forwarding wiring. It does not change the engine resolver or address request volume.

## Validation

- `go test ./...` in `toolchains/python-sdk-dev`, `toolchains/php-sdk-dev`, `toolchains/rust-sdk-dev`, `toolchains/all-sdks`, and `toolchains/release`
- `dagger call python-sdk --help`, `dagger call php-sdk --help`, and `dagger call rust-sdk --help` show `--client-docker-config`
- `git diff --check HEAD~1 HEAD`