### PR TITLE
bump dang

### DIFF
--- a/core/integration/testdata/modules/dang/test-enum/main.dang
+++ b/core/integration/testdata/modules/dang/test-enum/main.dang
@@ -20,7 +20,7 @@ type TestEnum {
   Returns the status value
   """
   pub getStatus(status: Status!): String! {
-    toJSON(status)
+    JSON.encode(status)
   }
 
   """

--- a/core/integration/testdata/modules/dang/test-map-field/main.dang
+++ b/core/integration/testdata/modules/dang/test-map-field/main.dang
@@ -15,10 +15,10 @@ type TestMapField {
   }
 
   envJson: String! {
-    toJSON(env)
+    JSON.encode(env)
   }
 
   nestedJson: String! {
-    toJSON(config.environment)
+    JSON.encode(config.environment)
   }
 }

--- a/core/integration/testdata/modules/dang/test-scalar/main.dang
+++ b/core/integration/testdata/modules/dang/test-scalar/main.dang
@@ -9,13 +9,13 @@ type TestScalar {
   Returns the timestamp value as a string
   """
   pub getTimestamp(ts: Timestamp!): String! {
-    toJSON(ts)
+    JSON.encode(ts)
   }
 
   """
   Returns the URL value as a string
   """
   pub getURL(url: URL!): String! {
-    toJSON(url)
+    JSON.encode(url)
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/dang v1.0.1
-	github.com/vito/dang/v2 v2.0.3-0.20260616005952-fd0fc4f72aa1
+	github.com/vito/dang/v2 v2.0.3-0.20260617050800-a59661e1b2bb
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/dang v1.0.1
-	github.com/vito/dang/v2 v2.1.0
+	github.com/vito/dang/v2 v2.1.1
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/dang v1.0.1
-	github.com/vito/dang/v2 v2.0.3-0.20260617050800-a59661e1b2bb
+	github.com/vito/dang/v2 v2.1.0
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
 github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
-github.com/vito/dang/v2 v2.1.0 h1:zLFARPqRQ/MEppNR3TzNZAKlhcITofqb5EF6O/yT5HY=
-github.com/vito/dang/v2 v2.1.0/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
+github.com/vito/dang/v2 v2.1.1 h1:HUv9BMYlCUlS9XX5NvVJbo+zWg5yrZFfOFn2CiNj2gc=
+github.com/vito/dang/v2 v2.1.1/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
 github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
-github.com/vito/dang/v2 v2.0.3-0.20260616005952-fd0fc4f72aa1 h1:eVUAkPE+L1+kZFvo0qnnrTukEhWivQEhK7fRJSrHMgQ=
-github.com/vito/dang/v2 v2.0.3-0.20260616005952-fd0fc4f72aa1/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
+github.com/vito/dang/v2 v2.0.3-0.20260617050800-a59661e1b2bb h1:SMWJGj/0nfuD2aIxjfBfTKXyq1lTbqou6Gs8A6KIv6U=
+github.com/vito/dang/v2 v2.0.3-0.20260617050800-a59661e1b2bb/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
 github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
-github.com/vito/dang/v2 v2.0.3-0.20260617050800-a59661e1b2bb h1:SMWJGj/0nfuD2aIxjfBfTKXyq1lTbqou6Gs8A6KIv6U=
-github.com/vito/dang/v2 v2.0.3-0.20260617050800-a59661e1b2bb/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
+github.com/vito/dang/v2 v2.1.0 h1:zLFARPqRQ/MEppNR3TzNZAKlhcITofqb5EF6O/yT5HY=
+github.com/vito/dang/v2 v2.1.0/go.mod h1:xfMZLktE16YvCWaPJvSc9aTe0acCli4EcKnJw5Zw3Ek=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=


### PR DESCRIPTION
Bumps `github.com/vito/dang/v2` to `a59661e1b2bb`.

## What's new in Dang

### Codecs: JSON / YAML / TOML are now first-class

- The top-level `toJSON` / `fromJSON` / `fromYAML` functions are replaced by `JSON.encode` / `JSON.decode`, `YAML.encode` / `YAML.decode`, and `TOML.encode` / `TOML.decode`. All three formats now behave identically.
- Dang ships `JSON`, `YAML`, and `TOML` as builtin codec scalars installed in the prelude, so `:: JSON` resolves in type position with no import. A same-named schema- or user-declared scalar (e.g. Dagger's `scalar JSON`) merges with the builtin and gets the same codec grafted on, instead of colliding.
- Scalar API attachment is generalized beyond codecs into a builtin-scalar registry, so members can be stapled onto any same-named scalar (owned, user-declared, or schema-imported).

### Codec field directives

- Per-format field directives for the JSON/YAML/TOML codecs: `@JSON.field(name:, omitNull:, omitEmpty:)` renames a field's serialized key and can drop it when null/empty, and `@JSON.ignore` excludes it entirely. The same directives exist for `YAML` and `TOML`, scoped per format so a rename in one never leaks into another.
- `omitEmpty` drops a field when its value is empty the way Go's `encoding/json` `omitempty` does (null, `""`, `0`, `false`, or an empty list/map); `omitNull` stays the narrower option that only drops null.
- Renamed fields round-trip through decode, and directives are validated at inference time: non-literal/malformed names, `omitNull` on a non-null field, `omitNull` + `omitEmpty` together, `ignore` + `field` together, and two fields colliding on one key are all compile errors with source locations.

### String methods

- `toBase64` / `fromBase64` for String -> String base64 conversion (`fromBase64` reports a source-located error on invalid input).
- `truncate` for strings (thanks @sagikazarmark).

### Misc

- `FindDaggerModule` now also looks for `dagger.toml`.
- TOML encode/decode errors (top-level non-table, null-in-list) are now reported in Dang terms.
- Treesitter parses qualified directive applications; playground grammar wasm regenerated.
- stdlib reference docs gain a table of contents and JSON/YAML/TOML coverage.

Full range: https://github.com/vito/dang/compare/fd0fc4f72aa1...a59661e1b2bb
