### PR TITLE
fix(sdk/java): escape angle brackets in generated javadoc

### DIFF
--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/EnumVisitor.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/EnumVisitor.java
@@ -15,12 +15,13 @@ public class EnumVisitor extends AbstractVisitor {
   TypeSpec generateType(Type type) {
     TypeSpec.Builder classBuilder =
         TypeSpec.enumBuilder(Helpers.formatName(type))
-            .addJavadoc(type.getDescription() != null ? type.getDescription() : "")
+            .addJavadoc(Helpers.escapeJavadoc(type.getDescription()))
             .addModifiers(Modifier.PUBLIC);
 
     for (EnumValue enumValue : type.getEnumValues()) {
       TypeSpec.Builder enumTypeBuilder =
-          TypeSpec.anonymousClassBuilder("").addJavadoc(enumValue.getDescription());
+          TypeSpec.anonymousClassBuilder("")
+              .addJavadoc(Helpers.escapeJavadoc(enumValue.getDescription()));
       if (enumValue.isDeprecated()) {
         enumTypeBuilder.addAnnotation(Deprecated.class);
       }

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Helpers.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Helpers.java
@@ -189,11 +189,17 @@ public class Helpers {
     return builder.build();
   }
 
-  /** Fix using '$' char in javadoc */
+  /**
+   * Escape characters that have a special meaning in javadoc.
+   *
+   * <p>'$' is escaped for JavaPoet's format strings, while '&amp;', '&lt;' and '&gt;' are HTML
+   * entities so that descriptions containing markup-like tokens (e.g. {@code <name>}) don't get
+   * parsed as HTML tags by the javadoc tool.
+   */
   static String escapeJavadoc(String str) {
     if (str == null) {
       return "";
     }
-    return str.replace("$", "$$").replace("&", "&amp;");
+    return str.replace("$", "$$").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
   }
 }

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/InputVisitor.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/InputVisitor.java
@@ -17,7 +17,7 @@ class InputVisitor extends AbstractVisitor {
   TypeSpec generateType(Type type) {
     TypeSpec.Builder classBuilder =
         TypeSpec.classBuilder(Helpers.formatName(type))
-            .addJavadoc(type.getDescription() != null ? type.getDescription() : "")
+            .addJavadoc(Helpers.escapeJavadoc(type.getDescription()))
             .addModifiers(Modifier.PUBLIC)
             .addSuperinterface(ClassName.bestGuess("InputValue"));
 

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/ScalarVisitor.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/ScalarVisitor.java
@@ -16,7 +16,7 @@ class ScalarVisitor extends AbstractVisitor {
   TypeSpec generateType(Type type) {
     TypeSpec.Builder classBuilder =
         TypeSpec.classBuilder(Helpers.formatName(type))
-            .addJavadoc(type.getDescription() != null ? type.getDescription() : "")
+            .addJavadoc(Helpers.escapeJavadoc(type.getDescription()))
             .addModifiers(Modifier.PUBLIC)
             .superclass(
                 ParameterizedTypeName.get(


### PR DESCRIPTION
The Java codegen emitted API descriptions verbatim into javadoc comments. Descriptions containing markup-like tokens such as `<name>` (e.g. on the new Workspace module-install fields) were parsed by the javadoc tool as HTML tags, failing the `release` profile's javadoc generation with `error: unknown tag: name` and breaking `dagger check java-sdk:release-dry-run`.

Escape `<`/`>` (alongside the existing `$`/`&` handling) in `Helpers.escapeJavadoc`, and route the remaining raw `getDescription()` javadoc callers (input objects, enums, scalars) through it so they're protected from the same class of failure.