### PR TITLE
test(core/integration): migrate remaining engine tests to CLI 1.0 verbs

### DIFF
--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -244,38 +244,49 @@ func (EngineSuite) TestSetsNameFromEnv(ctx context.Context, t *testctx.T) {
 	require.Equal(t, engineName, strings.TrimSpace(stdout))
 }
 
-func (EngineSuite) TestDaggerRun(ctx context.Context, t *testctx.T) {
+func (EngineSuite) TestDaggerExec(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	devEngine := devEngineContainerAsService(devEngineContainer(c))
+	for _, tc := range []struct {
+		name string
+		cmd  string
+	}{
+		{"exec", "dagger api exec"},
+		{"compat", "dagger run"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.W[*testing.T]) {
+			devEngine := devEngineContainerAsService(devEngineContainer(c))
 
-	clientCtr := engineClientContainer(ctx, t, c, devEngine)
+			clientCtr := engineClientContainer(ctx, t, c, devEngine)
 
-	command := fmt.Sprintf(`
-		export NO_COLOR=1
-		jq -n '{query:"{container{from(address: \"%s\"){file(path: \"/etc/alpine-release\"){contents}}}}"}' | \
-		dagger api exec sh -c 'curl -s \
-			-u $DAGGER_SESSION_TOKEN: \
-			--max-time 30 \
-			-H "content-type:application/json" \
-			-d @- \
-			http://127.0.0.1:$DAGGER_SESSION_PORT/query'`,
-		alpineImage,
-	)
+			command := fmt.Sprintf(`
+				export NO_COLOR=1
+				jq -n '{query:"{container{from(address: \"%s\"){file(path: \"/etc/alpine-release\"){contents}}}}"}' | \
+				%s sh -c 'curl -s \
+					-u $DAGGER_SESSION_TOKEN: \
+					--max-time 30 \
+					-H "content-type:application/json" \
+					-d @- \
+					http://127.0.0.1:$DAGGER_SESSION_PORT/query'`,
+				alpineImage,
+				tc.cmd,
+			)
 
-	clientCtr = clientCtr.
-		WithExec([]string{"apk", "add", "jq", "curl"}).
-		WithExec([]string{"sh", "-c", command})
+			clientCtr = clientCtr.
+				WithExec([]string{"apk", "add", "jq", "curl"}).
+				WithExec([]string{"sh", "-c", command})
 
-	stdout, err := clientCtr.Stdout(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stdout, distconsts.AlpineVersion)
-	require.JSONEq(t, `{"data": {"container": {"from": {"file": {"contents": "`+distconsts.AlpineVersion+`\n"}}}}}`, stdout)
+			stdout, err := clientCtr.Stdout(ctx)
+			require.NoError(t, err)
+			require.Contains(t, stdout, distconsts.AlpineVersion)
+			require.JSONEq(t, `{"data": {"container": {"from": {"file": {"contents": "`+distconsts.AlpineVersion+`\n"}}}}}`, stdout)
 
-	stderr, err := clientCtr.Stderr(ctx)
-	require.NoError(t, err)
-	// verify we got some progress output
-	require.Contains(t, stderr, "Container.from")
+			stderr, err := clientCtr.Stderr(ctx)
+			require.NoError(t, err)
+			// verify we got some progress output
+			require.Contains(t, stderr, "Container.from")
+		})
+	}
 }
 
 func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -1,7 +1,7 @@
 package core
 
 // These tests cover the Dagger engine process and the client/engine contract.
-// They verify signal handling, engine naming, `dagger run`, version
+// They verify signal handling, engine naming, `dagger api exec`, version
 // compatibility, cancellation, Prometheus metrics, DagQL cache cleanup, and
 // client metadata reuse.
 //
@@ -254,7 +254,7 @@ func (EngineSuite) TestDaggerRun(ctx context.Context, t *testctx.T) {
 	command := fmt.Sprintf(`
 		export NO_COLOR=1
 		jq -n '{query:"{container{from(address: \"%s\"){file(path: \"/etc/alpine-release\"){contents}}}}"}' | \
-		dagger run sh -c 'curl -s \
+		dagger api exec sh -c 'curl -s \
 			-u $DAGGER_SESSION_TOKEN: \
 			--max-time 30 \
 			-H "content-type:application/json" \
@@ -923,7 +923,7 @@ class Dep:
 set -eu
 # Load module + dependency schema a few times to exercise cache lifecycle.
 for i in $(seq 1 4); do
-  dagger functions >/dev/null
+  dagger api functions >/dev/null
 done
 			`}).Sync(ctx)
 		return err

--- a/future/cli-1.0.md
+++ b/future/cli-1.0.md
@@ -746,6 +746,7 @@ Status legend: ✅ shipped on this branch | 🟡 partially shipped | ⬜ designe
 ### Shipped — hidden aliases
 
 - ✅ **`dagger call`** — hidden alias to `dagger api call`.
+- ✅ **`dagger run`** — hidden alias to `dagger api exec`.
 - ✅ **`dagger shell`** — hidden, reachable.
 
 ### ⬜ Not yet implemented — handoff to follow-up PRs

--- a/internal/cmd/dagger/api.go
+++ b/internal/cmd/dagger/api.go
@@ -15,5 +15,6 @@ See https://docs.dagger.io/api for the full overview.`,
 }
 
 func init() {
-	apiCmd.AddCommand(apiQueryCmd, apiListenCmd, apiSessionCmd, apiCallCmd.Command(), apiFunctionsCmd, apiClientCmd, runCmd)
+	apiCmd.AddCommand(apiQueryCmd, apiListenCmd, apiSessionCmd, apiCallCmd.Command(), apiFunctionsCmd, apiClientCmd, apiExecCmd)
+	rootCmd.AddCommand(runCmd)
 }

--- a/internal/cmd/dagger/run.go
+++ b/internal/cmd/dagger/run.go
@@ -27,7 +27,7 @@ import (
 	telemetry "github.com/dagger/otel-go"
 )
 
-var runCmd = &cobra.Command{
+var apiExecCmd = &cobra.Command{
 	Use:     "exec [options] <command>...",
 	Aliases: []string{"run", "r"},
 	Short:   "Run a command with a connected Dagger API session (DAGGER_SESSION_PORT/TOKEN injected)",
@@ -66,14 +66,33 @@ dagger api exec python main.py
 	},
 }
 
+var runCmd = &cobra.Command{
+	Use:          "run [options] <command>...",
+	Hidden:       true,
+	RunE:         Run,
+	Args:         cobra.MinimumNArgs(1),
+	SilenceUsage: true,
+	Annotations: map[string]string{
+		printTraceLinkKey:    "true",
+		showFinalProgressKey: "true",
+	},
+}
+
 var waitDelay time.Duration
 var runFocus bool
 var runLoadWorkspaceModules bool
 
 func init() {
 	// don't require -- to disambiguate subcommand flags
+	apiExecCmd.Flags().SetInterspersed(false)
 	runCmd.Flags().SetInterspersed(false)
 
+	apiExecCmd.Flags().DurationVar(
+		&waitDelay,
+		"cleanup-timeout",
+		10*time.Second,
+		"max duration to wait between SIGTERM and SIGKILL on interrupt",
+	)
 	runCmd.Flags().DurationVar(
 		&waitDelay,
 		"cleanup-timeout",
@@ -81,8 +100,14 @@ func init() {
 		"max duration to wait between SIGTERM and SIGKILL on interrupt",
 	)
 
+	apiExecCmd.Flags().BoolVar(&runFocus, "focus", false, "Only show output for focused commands.")
 	runCmd.Flags().BoolVar(&runFocus, "focus", false, "Only show output for focused commands.")
+	apiExecCmd.Flags().BoolVar(&runLoadWorkspaceModules, "load-workspace-modules", false, "load workspace modules")
 	runCmd.Flags().BoolVar(&runLoadWorkspaceModules, "load-workspace-modules", false, "load workspace modules")
+	if err := apiExecCmd.Flags().MarkHidden("load-workspace-modules"); err != nil {
+		fmt.Fprintln(stderr, "Error hiding flag: load-workspace-modules", err)
+		os.Exit(1)
+	}
 	if err := runCmd.Flags().MarkHidden("load-workspace-modules"); err != nil {
 		fmt.Fprintln(stderr, "Error hiding flag: load-workspace-modules", err)
 		os.Exit(1)

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -78,12 +78,16 @@ func TestCosmeticCommandAliases(t *testing.T) {
 	require.True(t, cmd.Hidden)
 	require.Contains(t, cmd.Deprecated, "dagger -m core api call")
 
-	// exec / run moved under `dagger api`; no longer reachable at root.
+	// exec / run moved under `dagger api`; available at root for backward compat
 	cmd, _, err = rootCmd.Find([]string{"api", "exec"})
 	require.NoError(t, err)
-	require.Same(t, runCmd, cmd)
+	require.Same(t, apiExecCmd, cmd)
 
 	cmd, _, err = rootCmd.Find([]string{"api", "run"})
+	require.NoError(t, err)
+	require.Same(t, apiExecCmd, cmd)
+
+	cmd, _, err = rootCmd.Find([]string{"run"})
 	require.NoError(t, err)
 	require.Same(t, runCmd, cmd)
 
@@ -261,7 +265,7 @@ func TestRootHelpShowsImplicitCommandGrouping(t *testing.T) {
 func TestHelpAliasesRespectHiddenAliases(t *testing.T) {
 	require.Contains(t, renderHelp(t, workspaceCmd), "workspace, ws")
 
-	execHelp := renderHelp(t, runCmd)
+	execHelp := renderHelp(t, apiExecCmd)
 	require.NotContains(t, execHelp, "exec, run")
 	require.NotContains(t, execHelp, "exec, r")
 	require.NotContains(t, execHelp, "ALIASES")


### PR DESCRIPTION
PR #13392 reworked the top-level CLI surface, and commit acab805f9 migrated most integration tests to the renamed verbs. Two call sites in the engine suite were missed and still invoked removed top-level commands, so their withExec calls exited 1:

- TestDaggerRun used `dagger run` -> now `dagger api exec`
- TestDagqlCacheEntriesNoLeak used `dagger functions` -> now `dagger api functions`

Update both (and the suite header comment) so they exercise the new commands.