### PR TITLE
test(core/integration): drop removed `dagger workspace init`

### DIFF
--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -155,11 +155,11 @@ func (ModuleSuite) TestGeneratePrivateGitDependency(ctx context.Context, t *test
 		return out, runErr
 	}
 
-	// Initialize a workspace with the go-sdk generator installed.
+	// Initialize a workspace with the go-sdk generator installed. Workspace
+	// creation is implicit on first install (it creates dagger.toml at the
+	// workspace root), so there is no separate `workspace init` step.
 	require.NoError(t, exec.Command("git", "-C", workDir, "init").Run())
-	out, err := run("workspace", "init")
-	require.NoError(t, err, string(out))
-	out, err = run("install", "github.com/dagger/go-sdk")
+	out, err := run("install", "github.com/dagger/go-sdk")
 	require.NoError(t, err, string(out))
 
 	// A Go SDK module (discovered by go-sdk's generate-all) that declares the


### PR DESCRIPTION
CLI 1.0 phase 3 (1b53092cb) removed the `dagger workspace init` command: workspace creation is now implicit on first `dagger install` (which creates dagger.toml at the workspace root). Several integration tests still drove the old verb and failed with:

  Error: unknown command "init" for "dagger workspace"

- module_private_deps_test.go (TestModule/TestGeneratePrivateGitDependency, the test-split:test-modules failure): drop the explicit init step and let the following `dagger install` create the workspace.
- generators_test.go (TestGeneratorsInstalledInWorkspace): same, the subsequent `dagger install` creates the workspace.
- workspace_selection_test.go (TestWorkspaceSelectionCommandPolicy): the CurrentWorkspace.init mutation the CLI verb fronted still exists, so exercise the local-only -W policy through the `{currentWorkspace{init}}` query instead of the dropped command. The two skipped binding-propagation cases drop the redundant init (dagger.toml is written explicitly after).