### PR TITLE
fix(cli-1.0): pass workspace & migration suites via dagger setup

### DIFF
--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -155,11 +155,11 @@ func (ModuleSuite) TestGeneratePrivateGitDependency(ctx context.Context, t *test
 		return out, runErr
 	}
 
-	// Initialize a workspace with the go-sdk generator installed.
+	// Initialize a workspace with the go-sdk generator installed. Workspace
+	// creation is implicit on first install (it creates dagger.toml at the
+	// workspace root), so there is no separate `workspace init` step.
 	require.NoError(t, exec.Command("git", "-C", workDir, "init").Run())
-	out, err := run("workspace", "init")
-	require.NoError(t, err, string(out))
-	out, err = run("install", "github.com/dagger/go-sdk")
+	out, err := run("install", "github.com/dagger/go-sdk")
 	require.NoError(t, err, string(out))
 
 	// A Go SDK module (discovered by go-sdk's generate-all) that declares the

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -36,6 +36,21 @@ func TestWorkspaceCompat(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(WorkspaceCompatSuite{})
 }
 
+// migrateViaSetupSkip explains why the migration-driving compat tests below
+// cannot pass yet. `dagger migrate` was removed and folded into `dagger setup`
+// (its migrate step), but setup does not reproduce the removed command's
+// behavior: it calls Workspace.migrate without force, so a module whose
+// settings hints can't be generated (e.g. a `dang`-source compat module that
+// doesn't resolve as a local path) aborts the migrate with "use --force to
+// migrate anyway"; the post-migrate install step still sees the legacy
+// dagger.json ("run dagger setup first"); and the migration warnings/summaries
+// now land in .dagger/migration-report.md rather than stdout. These tests
+// assert on a clean `setup --auto-apply` plus the migrated runtime, so they
+// cannot pass as-is. To re-enable: either restore that behavior in setup's
+// migrate step (force + stdout feedback + fresh install session), or rewrite
+// the assertions to read .dagger/migration-report.md + the on-disk dagger.toml.
+const migrateViaSetupSkip = "TODO(migrate-via-setup): migration now runs through `dagger setup`, which does not yet reproduce the removed `dagger migrate` behavior (no --force for unloadable settings hints, post-migrate install sees legacy dagger.json, warnings moved to .dagger/migration-report.md); see migrateViaSetupSkip comment"
+
 func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
@@ -629,6 +644,7 @@ func (WorkspaceCompatSuite) TestGenericAsModuleIgnoresLegacyWorkspaceFields(ctx 
 // TestCompatMigration should cover the explicit handoff from compat runtime to
 // workspace migration.
 func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.T) {
+	t.Skip(migrateViaSetupSkip)
 	t.Run("migrate converts a compat workspace into workspace config plus modules", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		ctr := legacyCompatDangSource(t, c, "hello from migrated compat").
@@ -731,6 +747,7 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 // ignoreServices), which translate into [modules.<name>] check.skip /
 // generate.skip / up.skip in the workspace config.
 func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.Context, t *testctx.T) {
+	t.Skip(migrateViaSetupSkip)
 	c := connect(ctx, t)
 
 	modGen, err := generatorsTestEnv(t, c)
@@ -783,6 +800,7 @@ func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.C
 // migration of toolchains[].portMappings, which translates into top-level
 // [ports.<host>] entries with backendService/backendPort.
 func (WorkspaceCompatSuite) TestCompatMigrationPortMappings(ctx context.Context, t *testctx.T) {
+	t.Skip(migrateViaSetupSkip)
 	c := connect(ctx, t)
 
 	modGen, err := upTestEnv(t, c)
@@ -873,6 +891,7 @@ func (WorkspaceCompatSuite) TestCompatUpSkipsAndPortMappingsBeforeMigration(ctx 
 // new design: compat mode and migrated workspace mode expose the same runtime
 // behavior for the same legacy project.
 func (WorkspaceCompatSuite) TestCompatAndMigratedWorkspaceMatch(ctx context.Context, t *testctx.T) {
+	t.Skip(migrateViaSetupSkip)
 	c := connect(ctx, t)
 	base := legacyWorkspaceBase(t, c, `{
   "name": "myapp",

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -36,20 +36,27 @@ func TestWorkspaceCompat(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(WorkspaceCompatSuite{})
 }
 
-// migrateViaSetupSkip explains why the migration-driving compat tests below
-// cannot pass yet. `dagger migrate` was removed and folded into `dagger setup`
-// (its migrate step), but setup does not reproduce the removed command's
-// behavior: it calls Workspace.migrate without force, so a module whose
-// settings hints can't be generated (e.g. a `dang`-source compat module that
-// doesn't resolve as a local path) aborts the migrate with "use --force to
-// migrate anyway"; the post-migrate install step still sees the legacy
-// dagger.json ("run dagger setup first"); and the migration warnings/summaries
-// now land in .dagger/migration-report.md rather than stdout. These tests
-// assert on a clean `setup --auto-apply` plus the migrated runtime, so they
-// cannot pass as-is. To re-enable: either restore that behavior in setup's
-// migrate step (force + stdout feedback + fresh install session), or rewrite
-// the assertions to read .dagger/migration-report.md + the on-disk dagger.toml.
-const migrateViaSetupSkip = "TODO(migrate-via-setup): migration now runs through `dagger setup`, which does not yet reproduce the removed `dagger migrate` behavior (no --force for unloadable settings hints, post-migrate install sees legacy dagger.json, warnings moved to .dagger/migration-report.md); see migrateViaSetupSkip comment"
+// `dagger migrate` was removed and folded into `dagger setup` (its migrate
+// step). The compat→workspace assertions below now read the on-disk
+// .dagger/migration-report.md + dagger.toml that the migrate changeset writes,
+// which works for the cases where `setup` completes. Two `setup` behaviors are
+// still missing and block the remaining migration-driving suites:
+//
+//   - migrateForceSkip: setup calls Workspace.migrate without --force, so a
+//     compat module whose SDK source can't be loaded as a local path (e.g.
+//     `dang`) aborts step 2 ("could not load modules to generate settings
+//     hints ... use --force to migrate anyway") before anything is written.
+//   - migrateRecommendInstallSkip: setup's step-3 recommended-module install
+//     runs against the just-migrated workspace and fails with "workspace is
+//     using legacy dagger.json config; run dagger setup first".
+//
+// Un-skip each suite once setup forces through unloadable hints / guards the
+// recommend-install after migrating (or once the migration stops emitting a
+// `dang`-source module entry that can't be introspected).
+const (
+	migrateForceSkip            = "TODO(migrate-via-setup): `dagger setup` migrates without --force, so a `dang`-source compat module aborts step 2 with \"... use --force to migrate anyway\"; see migrateForceSkip comment"
+	migrateRecommendInstallSkip = "TODO(migrate-via-setup): `dagger setup` step-3 recommended-module install fails against the just-migrated workspace with \"workspace is using legacy dagger.json config; run dagger setup first\"; see migrateRecommendInstallSkip comment"
+)
 
 func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
@@ -644,8 +651,8 @@ func (WorkspaceCompatSuite) TestGenericAsModuleIgnoresLegacyWorkspaceFields(ctx 
 // TestCompatMigration should cover the explicit handoff from compat runtime to
 // workspace migration.
 func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateViaSetupSkip)
 	t.Run("migrate converts a compat workspace into workspace config plus modules", func(ctx context.Context, t *testctx.T) {
+		t.Skip(migrateForceSkip)
 		c := connect(ctx, t)
 		ctr := legacyCompatDangSource(t, c, "hello from migrated compat").
 			With(compatDaggerExec("setup", "--auto-apply"))
@@ -682,9 +689,11 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 		ctr := legacySDKOnlyGoSource(t, c, "hello from sdk-only root").
 			With(compatDaggerExec("setup", "--auto-apply"))
 
+		// `dagger setup` runs migration through a changeset and records its
+		// follow-up warnings in .dagger/migration-report.md rather than on
+		// stdout, so assert on the on-disk report below instead of the output.
 		out, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, out)
-		require.Contains(t, out, "Warning: Root module requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m . ...`.")
 
 		_, err = ctr.WithExec([]string{"test", "-f", "dagger.json"}).Sync(ctx)
 		require.NoError(t, err, "sdk-only dagger.json should remain in place")
@@ -729,9 +738,11 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 }`, legacyDangModule("toolchain", "toolchain", "Toolchain", "hello from toolchain")).
 			With(compatDaggerExec("setup", "--auto-apply"))
 
+		// The "N old setting(s) need review" summary now lives in the on-disk
+		// migration report (and as per-gap sections) rather than on stdout, so
+		// assert on .dagger/migration-report.md instead of the command output.
 		output, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, output)
-		require.Contains(t, output, "Warning: 2 old setting(s) need review; see .dagger/migration-report.md")
 
 		report, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -747,7 +758,7 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 // ignoreServices), which translate into [modules.<name>] check.skip /
 // generate.skip / up.skip in the workspace config.
 func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateViaSetupSkip)
+	t.Skip(migrateRecommendInstallSkip)
 	c := connect(ctx, t)
 
 	modGen, err := generatorsTestEnv(t, c)
@@ -800,7 +811,7 @@ func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.C
 // migration of toolchains[].portMappings, which translates into top-level
 // [ports.<host>] entries with backendService/backendPort.
 func (WorkspaceCompatSuite) TestCompatMigrationPortMappings(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateViaSetupSkip)
+	t.Skip(migrateRecommendInstallSkip)
 	c := connect(ctx, t)
 
 	modGen, err := upTestEnv(t, c)
@@ -891,7 +902,7 @@ func (WorkspaceCompatSuite) TestCompatUpSkipsAndPortMappingsBeforeMigration(ctx 
 // new design: compat mode and migrated workspace mode expose the same runtime
 // behavior for the same legacy project.
 func (WorkspaceCompatSuite) TestCompatAndMigratedWorkspaceMatch(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateViaSetupSkip)
+	t.Skip(migrateForceSkip)
 	c := connect(ctx, t)
 	base := legacyWorkspaceBase(t, c, `{
   "name": "myapp",

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -37,19 +37,10 @@ func TestWorkspaceCompat(t *testing.T) {
 }
 
 // `dagger migrate` was removed and folded into `dagger setup` (its migrate
-// step). The compat→workspace assertions below now read the on-disk
-// .dagger/migration-report.md + dagger.toml that the migrate changeset writes.
-// The migrate step no longer aborts when a compat module's SDK source can't be
-// loaded to generate settings hints (e.g. `dang`): those hint failures are
-// recorded as migration-report warnings instead, so the dang-source suites now
-// run. One `setup` behavior is still missing and blocks the remaining suites:
-//
-//   - migrateRecommendInstallSkip: setup's step-3 recommended-module install
-//     runs against the just-migrated workspace and fails with "workspace is
-//     using legacy dagger.json config; run dagger setup first".
-//
-// Un-skip each suite once setup guards the recommend-install after migrating.
-const migrateRecommendInstallSkip = "TODO(migrate-via-setup): `dagger setup` step-3 recommended-module install fails against the just-migrated workspace with \"workspace is using legacy dagger.json config; run dagger setup first\"; see migrateRecommendInstallSkip comment"
+// step). The compat→workspace assertions below read the on-disk
+// .dagger/migration-report.md + dagger.toml that the migrate changeset writes,
+// then exercise the migrated workspace through `dagger setup --auto-apply`
+// (migrate + recommended-module install).
 
 func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
@@ -750,7 +741,6 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 // ignoreServices), which translate into [modules.<name>] check.skip /
 // generate.skip / up.skip in the workspace config.
 func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateRecommendInstallSkip)
 	c := connect(ctx, t)
 
 	modGen, err := generatorsTestEnv(t, c)
@@ -803,7 +793,6 @@ func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.C
 // migration of toolchains[].portMappings, which translates into top-level
 // [ports.<host>] entries with backendService/backendPort.
 func (WorkspaceCompatSuite) TestCompatMigrationPortMappings(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateRecommendInstallSkip)
 	c := connect(ctx, t)
 
 	modGen, err := upTestEnv(t, c)

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -38,25 +38,18 @@ func TestWorkspaceCompat(t *testing.T) {
 
 // `dagger migrate` was removed and folded into `dagger setup` (its migrate
 // step). The compat→workspace assertions below now read the on-disk
-// .dagger/migration-report.md + dagger.toml that the migrate changeset writes,
-// which works for the cases where `setup` completes. Two `setup` behaviors are
-// still missing and block the remaining migration-driving suites:
+// .dagger/migration-report.md + dagger.toml that the migrate changeset writes.
+// The migrate step no longer aborts when a compat module's SDK source can't be
+// loaded to generate settings hints (e.g. `dang`): those hint failures are
+// recorded as migration-report warnings instead, so the dang-source suites now
+// run. One `setup` behavior is still missing and blocks the remaining suites:
 //
-//   - migrateForceSkip: setup calls Workspace.migrate without --force, so a
-//     compat module whose SDK source can't be loaded as a local path (e.g.
-//     `dang`) aborts step 2 ("could not load modules to generate settings
-//     hints ... use --force to migrate anyway") before anything is written.
 //   - migrateRecommendInstallSkip: setup's step-3 recommended-module install
 //     runs against the just-migrated workspace and fails with "workspace is
 //     using legacy dagger.json config; run dagger setup first".
 //
-// Un-skip each suite once setup forces through unloadable hints / guards the
-// recommend-install after migrating (or once the migration stops emitting a
-// `dang`-source module entry that can't be introspected).
-const (
-	migrateForceSkip            = "TODO(migrate-via-setup): `dagger setup` migrates without --force, so a `dang`-source compat module aborts step 2 with \"... use --force to migrate anyway\"; see migrateForceSkip comment"
-	migrateRecommendInstallSkip = "TODO(migrate-via-setup): `dagger setup` step-3 recommended-module install fails against the just-migrated workspace with \"workspace is using legacy dagger.json config; run dagger setup first\"; see migrateRecommendInstallSkip comment"
-)
+// Un-skip each suite once setup guards the recommend-install after migrating.
+const migrateRecommendInstallSkip = "TODO(migrate-via-setup): `dagger setup` step-3 recommended-module install fails against the just-migrated workspace with \"workspace is using legacy dagger.json config; run dagger setup first\"; see migrateRecommendInstallSkip comment"
 
 func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
@@ -652,7 +645,6 @@ func (WorkspaceCompatSuite) TestGenericAsModuleIgnoresLegacyWorkspaceFields(ctx 
 // workspace migration.
 func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.T) {
 	t.Run("migrate converts a compat workspace into workspace config plus modules", func(ctx context.Context, t *testctx.T) {
-		t.Skip(migrateForceSkip)
 		c := connect(ctx, t)
 		ctr := legacyCompatDangSource(t, c, "hello from migrated compat").
 			With(compatDaggerExec("setup", "--auto-apply"))
@@ -902,7 +894,6 @@ func (WorkspaceCompatSuite) TestCompatUpSkipsAndPortMappingsBeforeMigration(ctx 
 // new design: compat mode and migrated workspace mode expose the same runtime
 // behavior for the same legacy project.
 func (WorkspaceCompatSuite) TestCompatAndMigratedWorkspaceMatch(ctx context.Context, t *testctx.T) {
-	t.Skip(migrateForceSkip)
 	c := connect(ctx, t)
 	base := legacyWorkspaceBase(t, c, `{
   "name": "myapp",

--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -1,8 +1,15 @@
 package core
 
 // These tests cover current workspace config in `dagger.toml`. They verify
-// reads, writes, command aliases, workspace boundaries, and how
-// `[modules.<name>.settings]` affects loaded modules.
+// reads, writes, workspace boundaries, and how `[modules.<name>.settings]`
+// affects loaded modules.
+//
+// The CLI 1.0 redesign moved raw config to `dagger workspace config` (the
+// top-level `dagger config` alias was dropped) and removed the explicit
+// `dagger workspace init` command — workspace creation is now implicit on the
+// first `dagger install` (covered in workspace_modules_test.go's "install
+// initializes empty workspace"). The old TestConfigAlias and
+// TestWorkspaceInitCommand tests were dropped accordingly.
 //
 // See also:
 // - workspace_env_management_test.go: config while an environment is selected.
@@ -240,24 +247,6 @@ service = "tcp://www:80"
 	})
 }
 
-func (WorkspaceSuite) TestConfigAlias(ctx context.Context, t *testctx.T) {
-	workdir := newWorkspaceConfigWorkdir(ctx, t, `[modules.greeter]
-source = "modules/greeter"
-entrypoint = true
-`)
-
-	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.greeter.source")
-	require.NoError(t, err)
-	require.Equal(t, "modules/greeter", strings.TrimSpace(string(out)))
-
-	_, err = hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.greeter.entrypoint", "false")
-	require.NoError(t, err)
-
-	out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.entrypoint")
-	require.NoError(t, err)
-	require.Equal(t, "false", strings.TrimSpace(string(out)))
-}
-
 func (WorkspaceSuite) TestWorkspaceConfigReadWithoutNativeConfig(ctx context.Context, t *testctx.T) {
 	t.Run("full read is empty", func(ctx context.Context, t *testctx.T) {
 		workdir := t.TempDir()
@@ -274,7 +263,7 @@ func (WorkspaceSuite) TestWorkspaceConfigReadWithoutNativeConfig(ctx context.Con
 		require.NoError(t, os.WriteFile(filepath.Join(workdir, workspace.ModuleConfigFileName), []byte(`name = "app"
 `), 0o644))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "config")
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config")
 		require.NoError(t, err)
 		require.Empty(t, string(out))
 	})
@@ -316,85 +305,6 @@ func (WorkspaceSuite) TestCurrentWorkspaceConfigBoundary(ctx context.Context, t 
 			"configFile": %q
 		}
 	}`, filepath.Join("app", workspace.ConfigFileName)), string(out))
-}
-
-func (WorkspaceSuite) TestWorkspaceInitCommand(ctx context.Context, t *testctx.T) {
-	t.Run("creates config at the workspace root by default", func(ctx context.Context, t *testctx.T) {
-		workdir := t.TempDir()
-		nestedDir := filepath.Join(workdir, "app", "sub")
-
-		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
-		require.NoError(t, os.WriteFile(
-			filepath.Join(nestedDir, "query.graphql"),
-			[]byte(currentWorkspaceConfigQuery),
-			0o644,
-		))
-		initGitRepo(ctx, t, workdir)
-
-		out, err := hostDaggerExecRaw(ctx, t, nestedDir, "--silent", "workspace", "init")
-		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("Created workspace config in %s", workdir), strings.TrimSpace(string(out)))
-
-		configHostPath := filepath.Join(workdir, workspace.ConfigFileName)
-		configContents, err := os.ReadFile(configHostPath)
-		require.NoError(t, err)
-		require.Contains(t, string(configContents), "[modules]")
-
-		out, err = hostDaggerExec(ctx, t, nestedDir, "--silent", "query", "--doc", "query.graphql")
-		require.NoError(t, err)
-		require.JSONEq(t, fmt.Sprintf(`{
-			"currentWorkspace": {
-				"cwd": "/app/sub",
-				"configFile": %q
-			}
-		}`, workspace.ConfigFileName), string(out))
-	})
-
-	t.Run("creates config at the workspace cwd with --here", func(ctx context.Context, t *testctx.T) {
-		workdir := t.TempDir()
-		nestedDir := filepath.Join(workdir, "app", "sub")
-
-		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
-		require.NoError(t, os.WriteFile(
-			filepath.Join(nestedDir, "query.graphql"),
-			[]byte(currentWorkspaceConfigQuery),
-			0o644,
-		))
-		initGitRepo(ctx, t, workdir)
-
-		out, err := hostDaggerExecRaw(ctx, t, nestedDir, "--silent", "workspace", "init", "--here")
-		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("Created workspace config in %s", nestedDir), strings.TrimSpace(string(out)))
-
-		configHostPath := filepath.Join(nestedDir, workspace.ConfigFileName)
-		configContents, err := os.ReadFile(configHostPath)
-		require.NoError(t, err)
-		require.Contains(t, string(configContents), "[modules]")
-
-		out, err = hostDaggerExec(ctx, t, nestedDir, "--silent", "query", "--doc", "query.graphql")
-		require.NoError(t, err)
-		require.JSONEq(t, fmt.Sprintf(`{
-			"currentWorkspace": {
-				"cwd": "/app/sub",
-				"configFile": %q
-			}
-		}`, filepath.Join("app", "sub", workspace.ConfigFileName)), string(out))
-	})
-
-	t.Run("rejects reinitialization", func(ctx context.Context, t *testctx.T) {
-		workdir := t.TempDir()
-		nestedDir := filepath.Join(workdir, "app")
-
-		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
-		initGitRepo(ctx, t, workdir)
-
-		_, err := hostDaggerExec(ctx, t, nestedDir, "--silent", "workspace", "init")
-		require.NoError(t, err)
-
-		_, err = hostDaggerExec(ctx, t, nestedDir, "--silent", "workspace", "init")
-		require.Error(t, err)
-		requireErrOut(t, err, fmt.Sprintf("workspace config already exists at %s", workdir))
-	})
 }
 
 func (WorkspaceSuite) TestWorkspaceModuleSettingsPolicy(ctx context.Context, t *testctx.T) {

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -33,7 +33,6 @@ func TestWorkspaceMigration(t *testing.T) {
 // preview via the workspace `migrate` API (non-mutating) and apply via
 // `dagger setup --auto-apply`.
 func (WorkspaceMigrationSuite) TestWorkspaceMigratePreviewAndApply(ctx context.Context, t *testctx.T) {
-	t.Skip("TODO(migrate-via-setup): `dagger migrate` was removed and folded into `dagger setup` (its migrate step), but setup does NOT reproduce migrate's stdout user feedback: the per-module 'requires explicit loading' warnings, the 'prepare migration diff' / 'install module:' / 'move module:' apply summary, and 'No migration needed.' now go to .dagger/migration-report.md (or nowhere) rather than stdout, and some applies exit non-zero through setup. These tests assert that stdout, so they cannot pass via `setup --auto-apply` as-is. To re-enable: either (a) restore that stdout feedback in setup's migrate step, or (b) rewrite each assertion below to read .dagger/migration-report.md + the on-disk dagger.toml instead of setup stdout. Migration behavior itself is still covered by workspace_compat_test.go.")
 	t.Run("preview reports changes without applying them", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
@@ -123,7 +122,6 @@ type Myapp {
 // TestWorkspaceMigrateOutcomes should cover the main result classes of a
 // migration.
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateOutcomes(ctx context.Context, t *testctx.T) {
-	t.Skip("TODO(migrate-via-setup): `dagger migrate` was removed and folded into `dagger setup` (its migrate step), but setup does NOT reproduce migrate's stdout user feedback: the per-module 'requires explicit loading' warnings, the 'prepare migration diff' / 'install module:' / 'move module:' apply summary, and 'No migration needed.' now go to .dagger/migration-report.md (or nowhere) rather than stdout, and some applies exit non-zero through setup. These tests assert that stdout, so they cannot pass via `setup --auto-apply` as-is. To re-enable: either (a) restore that stdout feedback in setup's migrate step, or (b) rewrite each assertion below to read .dagger/migration-report.md + the on-disk dagger.toml instead of setup stdout. Migration behavior itself is still covered by workspace_compat_test.go.")
 	t.Run("non-local source stays in place behind moved config", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
@@ -168,7 +166,8 @@ type Myapp {
 
 		out, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, out)
-		require.Contains(t, out, "Warning: Root module requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m . ...`.")
+		// The "requires explicit loading" warning is recorded in the on-disk
+		// migration report (asserted below), not printed to setup stdout.
 
 		_, err = ctr.WithExec([]string{"test", "-f", "main.go"}).Sync(ctx)
 		require.NoError(t, err, "source file should remain at root")
@@ -409,7 +408,6 @@ type Myapp {
 // TestWorkspaceMigrateUserFeedback should cover the user-facing output of
 // explicit migration.
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateUserFeedback(ctx context.Context, t *testctx.T) {
-	t.Skip("TODO(migrate-via-setup): `dagger migrate` was removed and folded into `dagger setup` (its migrate step), but setup does NOT reproduce migrate's stdout user feedback: the per-module 'requires explicit loading' warnings, the 'prepare migration diff' / 'install module:' / 'move module:' apply summary, and 'No migration needed.' now go to .dagger/migration-report.md (or nowhere) rather than stdout, and some applies exit non-zero through setup. These tests assert that stdout, so they cannot pass via `setup --auto-apply` as-is. To re-enable: either (a) restore that stdout feedback in setup's migrate step, or (b) rewrite each assertion below to read .dagger/migration-report.md + the on-disk dagger.toml instead of setup stdout. Migration behavior itself is still covered by workspace_compat_test.go.")
 	withFreshMigrationProgress := func(ctr *dagger.Container) *dagger.Container {
 		workdir := "/work-" + identity.NewID()
 		return ctr.
@@ -534,10 +532,17 @@ type Toolchain {
 		require.Contains(t, output, "workspace configuration: dagger.toml")
 		require.Contains(t, output, "install module: ./toolchain")
 		require.Contains(t, output, "migration report: .dagger/migration-report.md")
-		require.Contains(t, output, "Warning: 2 old setting(s) need review; see .dagger/migration-report.md")
 		require.NotContains(t, output, "If you apply this migration, review .dagger/migration-report.md.")
-		require.Equal(t, 1, strings.Count(output, "Warning: 2 old setting(s) need review; see .dagger/migration-report.md"))
 		require.NotContains(t, output, "Migrated to workspace format")
+
+		// The "N old setting(s) need review" summary and per-gap details land in
+		// the on-disk migration report rather than setup stdout.
+		report, err := migrate.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, report, "# Migration Report")
+		require.Contains(t, report, "`toolchain` needs a manual check")
+		require.Contains(t, report, `constructor arg "src" has 'ignore' and 'defaultPath', which workspace settings do not support`)
+		require.Contains(t, report, `function setting "build.tag" is not supported in workspace config`)
 	})
 
 	t.Run("dot dagger source does not warn about skipped cleanup", func(ctx context.Context, t *testctx.T) {
@@ -566,7 +571,6 @@ type Myapp {
 // TestWorkspaceMigrateScope should lock down what the migration actually uses
 // as input.
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateScope(ctx context.Context, t *testctx.T) {
-	t.Skip("TODO(migrate-via-setup): `dagger migrate` was removed and folded into `dagger setup` (its migrate step), but setup does NOT reproduce migrate's stdout user feedback: the per-module 'requires explicit loading' warnings, the 'prepare migration diff' / 'install module:' / 'move module:' apply summary, and 'No migration needed.' now go to .dagger/migration-report.md (or nowhere) rather than stdout, and some applies exit non-zero through setup. These tests assert that stdout, so they cannot pass via `setup --auto-apply` as-is. To re-enable: either (a) restore that stdout feedback in setup's migrate step, or (b) rewrite each assertion below to read .dagger/migration-report.md + the on-disk dagger.toml instead of setup stdout. Migration behavior itself is still covered by workspace_compat_test.go.")
 	c := connect(ctx, t)
 
 	t.Run("migrates selected nested config without touching outer config", func(ctx context.Context, t *testctx.T) {
@@ -674,8 +678,8 @@ type Videostitch struct{}
 
 		output, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, output)
-		require.Contains(t, output, "Warning: .dagger/modules/videostitch requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m .dagger/modules/videostitch ...`.")
-		require.Contains(t, output, "Warning: .dagger/modules/clipper requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m .dagger/modules/clipper ...`.")
+		// The per-module "requires explicit loading" warnings are recorded in the
+		// on-disk migration report (asserted below), not printed to setup stdout.
 
 		_, err = ctr.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
 		require.NoError(t, err, "root parent workspace config should be created")
@@ -715,7 +719,6 @@ type Videostitch struct{}
 }
 
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateSafety(ctx context.Context, t *testctx.T) {
-	t.Skip("TODO(migrate-via-setup): `dagger migrate` was removed and folded into `dagger setup` (its migrate step), but setup does NOT reproduce migrate's stdout user feedback: the per-module 'requires explicit loading' warnings, the 'prepare migration diff' / 'install module:' / 'move module:' apply summary, and 'No migration needed.' now go to .dagger/migration-report.md (or nowhere) rather than stdout, and some applies exit non-zero through setup. These tests assert that stdout, so they cannot pass via `setup --auto-apply` as-is. To re-enable: either (a) restore that stdout feedback in setup's migrate step, or (b) rewrite each assertion below to read .dagger/migration-report.md + the on-disk dagger.toml instead of setup stdout. Migration behavior itself is still covered by workspace_compat_test.go.")
 	t.Run("rerunning migrate after apply is a no-op", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -178,11 +178,12 @@ entrypoint = true
 
 		require.NoError(t, os.MkdirAll(emptyDir, 0o755))
 		initGitRepo(ctx, t, workdir)
+		// `dagger workspace init` was removed in CLI 1.0; seed an empty native
+		// workspace config directly so the failed install has something to
+		// (not) corrupt.
+		writeWorkspaceConfigFile(t, workdir, "[modules]\n")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "workspace", "init")
-		require.NoError(t, err)
-
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./empty")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./empty")
 		require.Error(t, err)
 		requireErrOut(t, err, `ref "./empty" does not point to an initialized module`)
 
@@ -239,11 +240,11 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 	t.Run("uninstalling an unknown module errors", func(ctx context.Context, t *testctx.T) {
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
+		// `dagger workspace init` was removed in CLI 1.0; seed an empty native
+		// workspace config directly so uninstall has a workspace to look in.
+		writeWorkspaceConfigFile(t, workdir, "[modules]\n")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "workspace", "init")
-		require.NoError(t, err)
-
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "ghost")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "ghost")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "ghost" is not installed in the workspace`)
 	})

--- a/core/integration/workspace_selection_test.go
+++ b/core/integration/workspace_selection_test.go
@@ -320,10 +320,14 @@ func (WorkspaceSelectionSuite) TestWorkspaceSelectionCommandPolicy(ctx context.C
 
 	t.Run("local-only workspace mutations accept a local selected workspace", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
+		// `dagger workspace init` was removed in CLI 1.0; a raw `workspace
+		// config` write (which creates dagger.toml when missing) is the modern
+		// local-only mutation that materializes a workspace config at the
+		// selected workspace's cwd.
 		ctr := workspaceBase(t, c).
 			WithExec([]string{"mkdir", "-p", "/work/caller", "/work/selected"}).
 			WithWorkdir("/work/caller").
-			With(workspaceSelectionDaggerExec("-W", "../selected", "workspace", "init", "--here"))
+			With(workspaceSelectionDaggerExec("-W", "../selected", "workspace", "config", "modules.example.source", "github.com/acme/example", "--here"))
 
 		_, err := ctr.WithExec([]string{"test", "-f", "/work/selected/dagger.toml"}).Sync(ctx)
 		require.NoError(t, err)
@@ -802,7 +806,6 @@ func (WorkspaceSelectionSuite) TestDeclaredWorkspaceBindingPropagation(ctx conte
 			WithExec([]string{"mkdir", "-p", "/work/caller", "/work/selected"}).
 			With(workspaceSelectionEnvWorkspace("/work/ambient", "ambient-base", "ambient-ci")).
 			WithWorkdir("/work/selected").
-			With(workspaceSelectionDaggerExec("workspace", "init", "--here")).
 			With(withModuleFixture(t, c, "/work/selected/.dagger/modules/nester", "go/workspace-selection-nester")).
 			WithNewFile("/work/selected/dagger.toml", `[modules.nester]
 source = ".dagger/modules/nester"
@@ -829,7 +832,6 @@ greeting = "selected-ci"
 			WithExec([]string{"mkdir", "-p", "/work/caller", "/work/selected"}).
 			With(workspaceSelectionEnvWorkspace("/work/ambient", "ambient-base", "ambient-ci")).
 			WithWorkdir("/work/selected").
-			With(workspaceSelectionDaggerExec("workspace", "init", "--here")).
 			With(withModuleFixture(t, c, "/work/selected/.dagger/modules/nester", "go/workspace-selection-nester")).
 			WithNewFile("/work/selected/dagger.toml", `[modules.nester]
 source = ".dagger/modules/nester"

--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -305,7 +305,7 @@ region = "us-west-2"
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.aws.settings.region")
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 
@@ -351,15 +351,15 @@ source = "modules/vitest"
 		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke, regression")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.vitest.settings.failFast")
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.failFast")
 		require.NoError(t, err)
 		require.Equal(t, "true", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.vitest.settings.retries")
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.retries")
 		require.NoError(t, err)
 		require.Equal(t, "3", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.vitest.settings.tags")
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.tags")
 		require.NoError(t, err)
 		require.Equal(t, "[smoke, regression]", strings.TrimSpace(string(out)))
 	})
@@ -407,13 +407,13 @@ region = "us-east-1"
 
 		settingsBase, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
 		require.NoError(t, err)
-		configBase, err := hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.aws.settings.region")
+		configBase, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(string(configBase)), strings.TrimSpace(string(settingsBase)))
 
 		settingsEnv, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
 		require.NoError(t, err)
-		configEnv, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "config", "modules.aws.settings.region")
+		configEnv, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(string(configEnv)), strings.TrimSpace(string(settingsEnv)))
 	})
@@ -430,7 +430,7 @@ region = "us-west-2"
 		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "eu-central-1")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "config", "modules.aws.settings.region")
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -15,8 +15,10 @@ import (
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/util/hashutil"
 	"github.com/moby/patternmatcher/ignorefile"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -1316,6 +1318,15 @@ func (s *directorySchema) changesetExport(ctx context.Context, parent dagql.Obje
 	if err != nil {
 		return "", err
 	}
+	// Applying a changeset that writes workspace config (e.g. a `dagger setup`
+	// migration creating dagger.toml / removing the legacy dagger.json) leaves
+	// the caller's per-client workspace detection stale. Drop it so the next
+	// access re-detects — best effort, never fail an already-applied export.
+	if changesetTouchesWorkspaceConfig(ctx, parent.Self()) {
+		if invErr := core.InvalidateCurrentWorkspace(ctx); invErr != nil {
+			slog.Warn("could not invalidate workspace after changeset export", "error", invErr)
+		}
+	}
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return "", err
@@ -1329,6 +1340,28 @@ func (s *directorySchema) changesetExport(ctx context.Context, parent dagql.Obje
 		return "", err
 	}
 	return dagql.String(stat.Path), err
+}
+
+// changesetTouchesWorkspaceConfig reports whether an exported changeset adds,
+// modifies, or removes a workspace config file (dagger.toml / legacy
+// dagger.json). Used to decide whether the caller's cached workspace detection
+// must be invalidated. Best effort: a path-computation error is treated as "no
+// touch" rather than failing the export.
+func changesetTouchesWorkspaceConfig(ctx context.Context, ch *core.Changeset) bool {
+	paths, err := ch.ComputePaths(ctx)
+	if err != nil {
+		slog.Warn("could not compute changeset paths for workspace invalidation", "error", err)
+		return false
+	}
+	for _, group := range [][]string{paths.Added, paths.Modified, paths.Removed} {
+		for _, p := range group {
+			switch path.Base(p) {
+			case workspace.ConfigFileName, workspace.LegacyModuleConfigFileName:
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s *directorySchema) changesetEmpty(ctx context.Context, parent dagql.ObjectResult[*core.Changeset], args struct{}) (dagql.Boolean, error) {

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -18,11 +18,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type workspaceMigrateArgs struct {
-	// Proceed even if modules cannot be loaded to generate settings hints.
-	Force bool `default:"false"`
-}
-
 type workspaceMigrationProgressContextKey struct{}
 
 type workspaceMigrationPlanBundle struct {
@@ -48,7 +43,7 @@ func (plans workspaceMigrationPlanBundle) empty() bool {
 func (s *workspaceSchema) migrate(
 	ctx context.Context,
 	ws *core.Workspace,
-	args workspaceMigrateArgs,
+	args struct{},
 ) (migration *core.WorkspaceMigration, rerr error) {
 	if ws.HostPath() == "" {
 		return nil, fmt.Errorf("workspace migration is local-only")
@@ -97,7 +92,7 @@ func (s *workspaceSchema) migrate(
 			continue
 		}
 
-		plan, err := s.prepareWorkspaceMigrationPlan(ctx, ws, args, compatWorkspace)
+		plan, err := s.prepareWorkspaceMigrationPlan(ctx, ws, compatWorkspace)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +142,6 @@ func (s *workspaceSchema) migrate(
 func (s *workspaceSchema) prepareWorkspaceMigrationPlan(
 	ctx context.Context,
 	ws *core.Workspace,
-	args workspaceMigrateArgs,
 	compatWorkspace *workspace.CompatWorkspace,
 ) (*workspace.MigrationPlan, error) {
 	plan, err := workspace.PlanMigration(compatWorkspace)
@@ -170,9 +164,12 @@ func (s *workspaceSchema) prepareWorkspaceMigrationPlan(
 	}
 	hints, hintWarnings := s.collectWorkspaceSettingsHintsFromConfig(ctx, ws, cfg, plannedConfigDir, plan.ProjectRoot, updatedDir)
 	if len(hintWarnings) > 0 {
-		if !args.Force {
-			return nil, fmt.Errorf("could not load modules to generate settings hints: %s; use --force to migrate anyway", strings.Join(hintWarnings, "; "))
-		}
+		// Settings hints are pure enrichment (pre-filled [modules.<m>.settings.*]
+		// defaults). When a module can't be loaded to introspect them — e.g. an
+		// SDK source that doesn't resolve as a local path — record the failure as
+		// a migration-report warning instead of aborting. The mechanical
+		// sdk->runtime migration is still valid; the user can fill in settings
+		// later with `dagger settings`.
 		appendWorkspaceMigrationNonGapWarnings(plan, hintWarnings)
 	}
 	if len(hints) > 0 {

--- a/core/sdk/loader.go
+++ b/core/sdk/loader.go
@@ -252,3 +252,13 @@ func parseSDKName(sdkName string) (sdk, string, error) {
 
 	return sdk(sdkNameParsed), sdkSuffix, nil
 }
+
+// IsBuiltinSDKName reports whether source names a built-in SDK/runtime bundled
+// in the engine (e.g. "go", "python", "dang"), optionally with an "@version"
+// suffix — as opposed to an external module ref or local path. Such names are
+// resolved in-engine when a module's runtime loads; they are not standalone
+// modules that can be loaded from a path or ref.
+func IsBuiltinSDKName(source string) bool {
+	name, _, _ := strings.Cut(source, "@")
+	return slices.Contains(validInbuiltSDKs, sdk(name))
+}

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -11,6 +11,31 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
+// workspaceInvalidator drops the cached per-client workspace detection so the
+// next access re-detects from the host. Set by engine/server (which owns the
+// per-client cache); nil in contexts without a server, where invalidation is a
+// no-op.
+var workspaceInvalidator func(context.Context) error
+
+// SetWorkspaceInvalidator registers the hook used to drop the current client's
+// cached workspace detection. Mirrors SetModuleSourceSDKLoader.
+func SetWorkspaceInvalidator(fn func(context.Context) error) {
+	workspaceInvalidator = fn
+}
+
+// InvalidateCurrentWorkspace drops the calling client's cached workspace
+// detection so the next access re-detects it from the host. Used after writing
+// workspace config files to the host (e.g. applying a migration changeset),
+// since the per-client cache would otherwise keep serving the pre-write view
+// for the lifetime of the client — which, under nested execution, spans more
+// than one session.
+func InvalidateCurrentWorkspace(ctx context.Context) error {
+	if workspaceInvalidator == nil {
+		return nil
+	}
+	return workspaceInvalidator(ctx)
+}
+
 // Workspace represents a detected workspace in the dagql schema.
 type Workspace struct {
 	// rootfs is the pre-fetched root filesystem for remote workspaces.

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -170,22 +170,22 @@ func configRequiresQuotedPathSegments(cfg *Config) bool {
 		return false
 	}
 	for moduleName, module := range cfg.Modules {
-		if !isBareConfigPathSegment(moduleName) || configMapRequiresQuotedPathSegments(module.Settings) {
+		if pathSegmentUnsafeForDocumentUpdate(moduleName) || configMapRequiresQuotedPathSegments(module.Settings) {
 			return true
 		}
 	}
 	for envName, env := range cfg.Env {
-		if !isBareConfigPathSegment(envName) {
+		if pathSegmentUnsafeForDocumentUpdate(envName) {
 			return true
 		}
 		for moduleName, module := range env.Modules {
-			if !isBareConfigPathSegment(moduleName) || configMapRequiresQuotedPathSegments(module.Settings) {
+			if pathSegmentUnsafeForDocumentUpdate(moduleName) || configMapRequiresQuotedPathSegments(module.Settings) {
 				return true
 			}
 		}
 	}
 	for host := range cfg.Ports {
-		if !isBareConfigPathSegment(host) {
+		if pathSegmentUnsafeForDocumentUpdate(host) {
 			return true
 		}
 	}
@@ -194,11 +194,34 @@ func configRequiresQuotedPathSegments(cfg *Config) bool {
 
 func configMapRequiresQuotedPathSegments(values map[string]any) bool {
 	for key := range values {
-		if !isBareConfigPathSegment(key) {
+		if pathSegmentUnsafeForDocumentUpdate(key) {
 			return true
 		}
 	}
 	return false
+}
+
+// pathSegmentUnsafeForDocumentUpdate reports whether segment cannot be used as a
+// dotted-path segment when updating an existing config document in place (via
+// neontoml's doc.Set/Delete/ApplyMap). Beyond non-bare characters, an all-digit
+// segment — e.g. a port host like "3000" — is unsafe because the dotted-path
+// parser reads it as a number ("invalid float"). Configs containing such a
+// segment fall back to a full re-serialization, which still writes the segment
+// unquoted as a TOML section header (e.g. [ports.3000]).
+func pathSegmentUnsafeForDocumentUpdate(segment string) bool {
+	return !isBareConfigPathSegment(segment) || isAllDigitConfigPathSegment(segment)
+}
+
+func isAllDigitConfigPathSegment(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	for i := 0; i < len(segment); i++ {
+		if segment[i] < '0' || segment[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func deleteRemovedManagedConfigPaths(doc *neontoml.Document, existingValues, desiredValues map[string]any) error {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6094,7 +6094,7 @@ type Workspace implements Node {
 
   The returned plan has an empty changeset and no steps when no migration is needed.
   """
-  migrate(force: Boolean = false): WorkspaceMigration!
+  migrate: WorkspaceMigration!
 
   """
   Plan the workspace changes for initializing a new module: dagger-module.toml +

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -346,7 +346,7 @@
                     <a href="../Dagger/WorkspaceMigration.html"><abbr title="Dagger\WorkspaceMigration">WorkspaceMigration</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_migrate">migrate</a>(bool|null $force = false)
+                    <a href="#method_migrate">migrate</a>()
         
                                             <p><p>Plan the explicit migration needed for the current workspace.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1355,7 +1355,7 @@
                     <h3 id="method_migrate">
         <div class="location">at line 302</div>
         <code>                    <a href="../Dagger/WorkspaceMigration.html"><abbr title="Dagger\WorkspaceMigration">WorkspaceMigration</abbr></a>
-    <strong>migrate</strong>(bool|null $force = false)
+    <strong>migrate</strong>()
         </code>
     </h3>
     <div class="details">    
@@ -1366,16 +1366,6 @@
                             <p><p>Plan the explicit migration needed for the current workspace.</p></p>                <p><p>The returned plan has an empty changeset and no steps when no migration is needed.</p></p>        
         </div>
         <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td>bool|null</td>
-                <td>$force</td>
-                <td></td>
-            </tr>
-            </table>
-
             
                             <h4>Return Value</h4>
 
@@ -1395,7 +1385,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleInit">
-        <div class="location">at line 314</div>
+        <div class="location">at line 311</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>moduleInit</strong>(string $name, string|null $sdk = &#039;&#039;, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], bool|null $here = false, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null)
         </code>
@@ -1467,7 +1457,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleList">
-        <div class="location">at line 349</div>
+        <div class="location">at line 346</div>
         <code>                    array
     <strong>moduleList</strong>(string|null $module = &#039;&#039;)
         </code>
@@ -1509,7 +1499,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 361</div>
+        <div class="location">at line 358</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1551,7 +1541,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_uninstall">
-        <div class="location">at line 373</div>
+        <div class="location">at line 370</div>
         <code>                    string
     <strong>uninstall</strong>(string $name, bool|null $here = false)
         </code>
@@ -1598,7 +1588,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_update">
-        <div class="location">at line 388</div>
+        <div class="location">at line 385</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>update</strong>()
         </code>

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins/diff/walking"
 	"github.com/containerd/go-runc"
 	"github.com/containerd/platforms"
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/schema"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/config"
@@ -199,6 +200,11 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		locker: locker.New(),
 	}
 	srv.shutdownCtx, srv.shutdownCancel = context.WithCancelCause(context.Background())
+
+	// Let core (e.g. changeset export) drop this server's per-client workspace
+	// cache after workspace config is written to the host. One engine = one
+	// Server, so a process-global hook is sufficient.
+	core.SetWorkspaceInvalidator(srv.invalidateClientWorkspace)
 
 	// start the global namespace worker pool, which is used for running Go funcs
 	// in container namespaces dynamically

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/schema"
+	coresdk "github.com/dagger/dagger/core/sdk"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
@@ -464,6 +465,14 @@ func workspaceConfigPendingModules(
 	pending := make([]pendingModule, 0, len(names))
 	for _, name := range names {
 		entry := cfg.Modules[name]
+		// A built-in SDK install entry (e.g. dang/go written by migration) has a
+		// bare runtime name as its source, not a loadable module ref. It exists
+		// only to carry the [modules.<sdk>.as-sdk] authoring metadata; the runtime
+		// itself resolves in-engine when a consuming module loads. Skip it here so
+		// the loader doesn't try to resolve the bare name as a local path.
+		if entry.AsSDK != nil && coresdk.IsBuiltinSDKName(entry.Source) {
+			continue
+		}
 		mod := pendingModule{
 			Kind:               moduleLoadKindAmbient,
 			Ref:                entry.Source,

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -27,6 +27,30 @@ import (
 	"github.com/dagger/dagger/util/parallel"
 )
 
+// invalidateClientWorkspace drops the calling client's cached workspace
+// detection so the next ensureWorkspaceLoaded re-detects it from the host.
+//
+// Registered as core.SetWorkspaceInvalidator and triggered after a changeset
+// export writes workspace config files (e.g. a `dagger setup` migration that
+// creates dagger.toml / removes the legacy dagger.json). The per-client cache
+// would otherwise serve the pre-migration view for the client's whole lifetime;
+// under nested execution that lifetime spans multiple sessions in one process
+// (the client ID is pinned by DAGGER_SESSION_CLIENT_ID), so the post-migrate
+// recommended-module install would still see the legacy dagger.json and fail.
+func (srv *Server) invalidateClientWorkspace(ctx context.Context) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	client.workspaceMu.Lock()
+	defer client.workspaceMu.Unlock()
+	client.workspaceLoaded = false
+	client.workspaceErr = nil
+	client.workspace = nil
+	client.pendingModules = nil
+	return nil
+}
+
 // CurrentWorkspace returns the cached workspace for the current client.
 func (srv *Server) CurrentWorkspace(ctx context.Context) (*core.Workspace, error) {
 	client, err := srv.clientFromContext(ctx)

--- a/migrate-settings-hints-tracking.md
+++ b/migrate-settings-hints-tracking.md
@@ -144,3 +144,21 @@ Verification so far:
 - `go test ./core/workspace` passes locally.
 - Linux compile-only checks pass with `GOCACHE=/tmp/go-build-dagger-workspace GOOS=linux GOARCH=amd64 go test -c ./core/schema -o /tmp/schema.test`, plus the same command for `./core/integration` and `./cmd/dagger`.
 - A focused Dagger-run integration attempt reached the new subtest but failed before exercising migration because the nested test CLI rejected `--skip-workspace-modules`; that looks like a local toolchain/version mismatch in the test harness.
+
+## Update (2026-06-17)
+
+The "fail by default / `--force` to override" behavior described above has been
+removed. Rationale (per `future/cli-1.0.md`): `dagger migrate` and its `--force`
+flag are gone — migration now runs only through `dagger setup`, which the CLI-1.0
+design keeps free of migrate-specific knobs. Settings hints are pure enrichment
+(pre-filled `[modules.<m>.settings.*]` defaults) and the runtime/SDK split means
+a module that can't be introspected is still a valid, executable migration.
+
+- `core/schema/workspace_migrate.go` no longer aborts when hint introspection
+  fails. Hint failures are always recorded as migration-report warnings via
+  `appendWorkspaceMigrationNonGapWarnings`; the mechanical `sdk`→`runtime`
+  migration still completes.
+- The `force` argument was dropped from `Workspace.migrate` (and the generated
+  Go/TypeScript/Rust clients).
+- This un-blocks the `dang`-source compat suites that were skipped with
+  `migrateForceSkip` (`TestCompatMigration` / `TestCompatAndMigratedWorkspaceMatch`).

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -341,12 +341,10 @@ defmodule Dagger.Workspace do
 
   The returned plan has an empty changeset and no steps when no migration is needed.
   """
-  @spec migrate(t(), [{:force, boolean() | nil}]) :: Dagger.WorkspaceMigration.t()
-  def migrate(%__MODULE__{} = workspace, optional_args \\ []) do
+  @spec migrate(t()) :: Dagger.WorkspaceMigration.t()
+  def migrate(%__MODULE__{} = workspace) do
     query_builder =
-      workspace.query_builder
-      |> QB.select("migrate")
-      |> QB.maybe_put_arg("force", optional_args[:force])
+      workspace.query_builder |> QB.select("migrate")
 
     %Dagger.WorkspaceMigration{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -15903,22 +15903,11 @@ func (r *Workspace) Install(ctx context.Context, ref string, opts ...WorkspaceIn
 	return response, q.Execute(ctx)
 }
 
-// WorkspaceMigrateOpts contains options for Workspace.Migrate
-type WorkspaceMigrateOpts struct {
-	Force bool
-}
-
 // Plan the explicit migration needed for the current workspace.
 //
 // The returned plan has an empty changeset and no steps when no migration is needed.
-func (r *Workspace) Migrate(opts ...WorkspaceMigrateOpts) *WorkspaceMigration {
+func (r *Workspace) Migrate() *WorkspaceMigration {
 	q := r.query.Select("migrate")
-	for i := len(opts) - 1; i >= 0; i-- {
-		// `force` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Force) {
-			q = q.Arg("force", opts[i].Force)
-		}
-	}
 
 	return &WorkspaceMigration{
 		query: q,

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -299,12 +299,9 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
      *
      * The returned plan has an empty changeset and no steps when no migration is needed.
      */
-    public function migrate(?bool $force = false): WorkspaceMigration
+    public function migrate(): WorkspaceMigration
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('migrate');
-        if (null !== $force) {
-        $innerQueryBuilder->setArgument('force', $force);
-        }
         return new \Dagger\WorkspaceMigration($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15722,15 +15722,13 @@ class Workspace(Type):
         _ctx = self._select("install", _args)
         return await _ctx.execute(str)
 
-    def migrate(self, *, force: bool | None = False) -> "WorkspaceMigration":
+    def migrate(self) -> "WorkspaceMigration":
         """Plan the explicit migration needed for the current workspace.
 
         The returned plan has an empty changeset and no steps when no
         migration is needed.
         """
-        _args = [
-            Arg("force", force, False),
-        ]
+        _args: list[Arg] = []
         _ctx = self._select("migrate", _args)
         return WorkspaceMigration(_ctx)
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -15620,11 +15620,6 @@ pub struct WorkspaceInstallOpts<'a> {
     pub name: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct WorkspaceMigrateOpts {
-    #[builder(setter(into, strip_option), default)]
-    pub force: Option<bool>,
-}
-#[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceModuleInitOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub args: Option<Json>,
@@ -16137,29 +16132,8 @@ impl Workspace {
     }
     /// Plan the explicit migration needed for the current workspace.
     /// The returned plan has an empty changeset and no steps when no migration is needed.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn migrate(&self) -> WorkspaceMigration {
         let query = self.selection.select("migrate");
-        WorkspaceMigration {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
-    /// Plan the explicit migration needed for the current workspace.
-    /// The returned plan has an empty changeset and no steps when no migration is needed.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn migrate_opts(&self, opts: WorkspaceMigrateOpts) -> WorkspaceMigration {
-        let mut query = self.selection.select("migrate");
-        if let Some(force) = opts.force {
-            query = query.arg("force", force);
-        }
         WorkspaceMigration {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2822,10 +2822,6 @@ export type WorkspaceInstallOpts = {
   asSdk?: boolean
 }
 
-export type WorkspaceMigrateOpts = {
-  force?: boolean
-}
-
 export type WorkspaceModuleInitOpts = {
   /**
    * Workspace install name of the SDK to use.
@@ -14853,8 +14849,8 @@ export class Workspace extends BaseClient {
    *
    * The returned plan has an empty changeset and no steps when no migration is needed.
    */
-  migrate = (opts?: WorkspaceMigrateOpts): WorkspaceMigration => {
-    const ctx = this._ctx.select("migrate", { ...opts })
+  migrate = (): WorkspaceMigration => {
+    const ctx = this._ctx.select("migrate")
     return new WorkspaceMigration(ctx)
   }
 


### PR DESCRIPTION
## What

Gets the CLI 1.0 workspace and migration integration suites passing under the new "migrate via `dagger setup`" model, and fixes several engine/config bugs those tests surfaced.

In CLI 1.0:
- `dagger migrate` was folded into `dagger setup` (its migrate step), which records migration warnings/summaries in `.dagger/migration-report.md` rather than on stdout.
- `dagger workspace init` was removed — workspace creation is implicit on first `dagger install`.

Adapting the tests to that model exposed four real bugs in the migrate/workspace path, fixed here.

## Engine / core fixes

- **Migration no longer aborts when settings hints can't be generated** (`core/schema/workspace_migrate.go`). A compat module whose SDK source can't be loaded as a local path (e.g. `dang`) previously aborted the migrate step with "use `--force` to migrate anyway" — but `dagger setup` exposes no `--force`. Settings hints are pure enrichment, so hint-introspection failures are now recorded as migration-report warnings and the mechanical `sdk`→`runtime` migration completes. The now-unreachable `force` argument is dropped from `Workspace.migrate` (clients regenerated).

- **Skip builtin SDK installs when loading workspace modules** (`core/sdk`, `engine/server`). Migrating a `sdk: {source: "dang"}` project writes `[modules.dang] source = "dang"`; the workspace loader treated the bare builtin name as a local module path (`/work/dang`) and failed. Such entries only carry the `[modules.<sdk>.as-sdk]` authoring metadata — the runtime resolves in-engine — so they're skipped during workspace module enumeration.

- **Invalidate the per-client workspace cache after a config-writing export** (`core/workspace.go`, `core/schema/directory.go`, `engine/server`). `dagger setup` migrates and then installs recommended modules in one process; under nested execution both sessions share a client ID (`DAGGER_SESSION_CLIENT_ID`) and therefore one cached workspace detection, so the install kept seeing the pre-migration legacy `dagger.json` ("run dagger setup first"). Applying a changeset that writes `dagger.toml` / `dagger.json` now drops that cache so the next access re-detects.

- **Full-serialize workspace configs with numeric path segments** (`core/workspace/config_document.go`). Updating an existing `dagger.toml` in place uses dotted-path operations; an all-digit segment like a port host (`ports.3000.backendPort`) was parsed as a number and failed. Such configs now fall back to full re-serialization, still emitting `[ports.3000]` unquoted as a section header.

## Test updates

- Track CLI 1.0 workspace command renames; read `.dagger/migration-report.md` + on-disk `dagger.toml` for compat assertions instead of `dagger migrate` stdout.
- Un-skip the `migrate-via-setup` compat and migration suites that the fixes above unblock, and remove the obsolete skip constants. The migration warnings these suites asserted on setup stdout now live in the migration report (by design), so those assertions were converted to read the report.
- Drop the removed `dagger workspace init` from `TestGeneratePrivateGitDependency` — workspace creation is implicit on first `dagger install`.
- `chore: generate` regenerates the PHP/Elixir/Python clients and GraphQL schema docs for the dropped `force` arg.

## Testing

- `TestWorkspaceCompat` + `TestWorkspaceMigration` integration suites: **133 passed, 0 failed** against a dev engine built from this branch.
- `core/workspace` unit tests pass.
- `TestGeneratePrivateGitDependency`: the change is mechanical (drops a call to the removed `workspace init`) and compiles; not run live here, as it exercises private-git dependency auth that needs the CI harness.
