### PR TITLE
test(cli-1.0): fix test-base suites and gate unreleased APIs

### DIFF
--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -249,7 +249,7 @@ func (ClientSuite) TestSendsLabelsInTelemetry(ctx context.Context, t *testctx.T)
 		WithExec([]string{"git", "init"}). // init a git repo to test git labels
 		WithExec([]string{"git", "add", "."}).
 		WithExec([]string{"git", "commit", "-m", "init test repo"}).
-		WithExec([]string{"dagger", "run", "go", "run", "./core/integration/testdata/basic-container/"}).
+		WithExec([]string{"dagger", "api", "run", "go", "run", "./core/integration/testdata/basic-container/"}).
 		Stderr(ctx)
 	require.NoError(t, err)
 

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -193,7 +193,8 @@ func (GeneratorsSuite) TestGeneratorsInstalledInWorkspace(ctx context.Context, t
 			require.NoError(t, err)
 			modGen = modGen.
 				WithWorkdir("app").
-				With(daggerExec("workspace", "init")).
+				// Workspace creation is implicit on first install; the
+				// `dagger workspace init` verb was removed in CLI 1.0.
 				With(daggerExec("install", "../"+tc.path))
 
 			t.Run("list", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/workspace_test.go
+++ b/core/integration/workspace_test.go
@@ -41,7 +41,11 @@ func workspaceBase(t testing.TB, c *dagger.Client) *dagger.Container {
 // `dagger workspace init`: a dagger.toml inside the git root.
 func nativeWorkspaceBase(t testing.TB, c *dagger.Client) *dagger.Container {
 	t.Helper()
-	return workspaceBase(t, c).With(daggerExec("workspace", "init"))
+	// The `dagger workspace init` verb was removed in CLI 1.0 (workspace
+	// creation is implicit on first install). Seed the workspace config
+	// directly so this helper still yields a native workspace with config
+	// present, matching what `workspace init` used to write.
+	return workspaceBase(t, c).WithNewFile("dagger.toml", "[modules]\n")
 }
 
 func workspaceFixture(t testing.TB, c *dagger.Client, fixture string) *dagger.Container {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -212,6 +212,7 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 			Doc(`The generated files and directories made on top of the module source's context directory.`),
 
 		dagql.NodeFunc("updatedConfigDirectory", s.moduleSourceUpdatedConfigDirectory).
+			View(AfterVersion("v1.0.0-0")).
 			Doc(`The module's dagger.json with any in-memory edits from with* APIs applied, as a diff relative to the source's context directory.`,
 				`Unlike generatedContextDirectory, this does not run codegen and does not validate the engine version against the running engine, so it can be used to declare an engine requirement newer than the running engine. Loading or serving such a module still fails at moduleSource.asModule.`),
 

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -127,6 +127,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
 		dagql.Func("clientInit", s.clientInit).
+			View(AfterVersion("v1.0.0-0")).
 			DoNotCache("Plans workspace changes against live host filesystem").
 			Doc("Plan the workspace changes for initializing a generated API client: generated client files at `path` plus a [[modules.<sdk-name>.as-sdk.clients]] entry in dagger.toml. Returns the resulting Changeset for the caller to preview and apply.").
 			Args(
@@ -136,6 +137,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
 		dagql.Func("clientGenerate", s.clientGenerate).
+			View(AfterVersion("v1.0.0-0")).
 			DoNotCache("Regenerates workspace client files against live host filesystem").
 			Doc("Regenerate all generated API clients registered in workspace config and return the resulting Changeset."),
 		dagql.Func("configRead", s.configRead).

--- a/internal/cmd/dagger/cloud_test.go
+++ b/internal/cmd/dagger/cloud_test.go
@@ -44,7 +44,7 @@ func daggerCloudWithEnv(t *testing.T, env []string, args []string, testCommandFn
 
 func TestCloudEngineUnauth(t *testing.T) {
 	env := []string{}
-	args := []string{"--cloud", "functions"}
+	args := []string{"--cloud", "api", "functions"}
 	daggerCloudWithEnv(t, env, args, func(t *testing.T, err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
 		require.Error(t, err, fmt.Sprintf(
 			"expected '%s dagger %s' to return an error, but instead: %s",
@@ -64,7 +64,7 @@ func TestCloudEngineWithCloudToken(t *testing.T) {
 	}
 
 	env := []string{"DAGGER_CLOUD_TOKEN=" + daggerCloudToken}
-	args := []string{"--cloud", "--load-module", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "functions"}
+	args := []string{"--cloud", "--load-module", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "api", "functions"}
 
 	daggerCloudWithEnv(t, env, args, func(t *testing.T, err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
 		require.NoError(t, err, fmt.Sprintf(
@@ -86,7 +86,7 @@ func TestCloudEngineEnvWithCloudToken(t *testing.T) {
 	}
 
 	env := []string{"DAGGER_CLOUD_TOKEN=" + daggerCloudToken, "DAGGER_CLOUD_ENGINE=true"}
-	args := []string{"--load-module", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "functions"}
+	args := []string{"--load-module", "github.com/gerhard/daggerverse/sysi@sysi/v0.1.0", "api", "functions"}
 
 	daggerCloudWithEnv(t, env, args, func(t *testing.T, err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
 		require.NoError(t, err, fmt.Sprintf(


### PR DESCRIPTION
Follow-up on the CLI 1.0 work (base: `design/cli-1.0`) to get `test-split:test-base` green again. Two commits:

### `fix(core/schema)`: gate unreleased workspace and module-source APIs
The base schema allowlist (`TestBaseSchemaAllowlist`) freezes the public API surface visible to the oldest supported module view. Three APIs added after the allowlist was last refreshed leaked into that view because they lacked a version gate:

- `Workspace.clientInit` / `Workspace.clientGenerate` (cmd/dagger workspace API client commands)
- `ModuleSource.updatedConfigDirectory` (module authoring group)

They're now gated behind `View(AfterVersion("v1.0.0-0"))`, matching their already-gated siblings (`init`, `install`, `moduleInit`, …). They stay visible at the latest view (so SDK/reference codegen is unchanged) and are hidden from the base view, which is what old pinned module runtimes must see to avoid drift.

### `test`: update test-base suites for CLI 1.0 command changes
Several `test-split:test-base` suites still drove CLI verbs that were renamed or removed during the CLI 1.0 rework:

- `TestCloudEngineUnauth` (and the token-gated cloud cases): `dagger functions` moved under `dagger api functions`.
- `TestClient` / `TestSendsLabelsInTelemetry`: `dagger run` moved under `dagger api run`.
- `TestGenerators` / `TestGeneratorsInstalledInWorkspace`: `dagger workspace init` was removed (workspace creation is implicit on first install), so drop the init step and let the following `install` create `dagger.toml`.
- `TestLockfile` workspace subtests: the shared `nativeWorkspaceBase` helper used the removed `dagger workspace init`; seed `dagger.toml` directly so it still yields a native workspace with config present.