### PR TITLE
fix(envfile): keep non-matching vars as hidden expansion context when…

### DIFF
--- a/core/dotenv/dotenv.go
+++ b/core/dotenv/dotenv.go
@@ -231,7 +231,7 @@ func (g *GraphEvaluator) All() (map[string]string, error) {
 	return result, nil
 }
 
-// Evaluate an array of key=value strings in the dotenv syntax,
+// All evaluates an array of key=value strings in the dotenv syntax,
 // and return a map of evaluated variables
 func All(environ []string, systemLookup func(string) string, noUnset bool) (map[string]string, error) {
 	g, err := NewGraphEvaluator(environ, systemLookup, noUnset)
@@ -239,6 +239,49 @@ func All(environ []string, systemLookup func(string) string, noUnset bool) (map[
 		return nil, err
 	}
 	return g.All()
+}
+
+// AllWithContext evaluates only the variables defined in own, while making the
+// variables in context available for ${...} expansion (they are not returned).
+// context entries are only expanded if referenced by an own value, so an
+// unrelated unbound context entry never triggers an error. When a name is
+// defined in both, the own value wins.
+func AllWithContext(own, context []string, systemLookup func(string) string, noUnset bool) (map[string]string, error) {
+	g, err := NewGraphEvaluator(mergeEnviron(context, own), systemLookup, noUnset)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]string)
+	for name := range AllRaw(own) {
+		value, _, err := g.Lookup(name)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+// LookupWithContext evaluates a single own variable, using context for ${...}
+// expansion. Returns found=false if name is not defined in own.
+func LookupWithContext(own, context []string, name string, systemLookup func(string) string) (string, bool, error) {
+	if _, ok := LookupRaw(own, name); !ok {
+		return "", false, nil
+	}
+	g, err := NewGraphEvaluator(mergeEnviron(context, own), systemLookup, true)
+	if err != nil {
+		return "", false, err
+	}
+	return g.Lookup(name)
+}
+
+// mergeEnviron concatenates environ slices; later entries override earlier ones
+// (as the graph evaluator keys raw entries by name), so own wins over context.
+func mergeEnviron(context, own []string) []string {
+	merged := make([]string, 0, len(context)+len(own))
+	merged = append(merged, context...)
+	merged = append(merged, own...)
+	return merged
 }
 
 // Evaluate an array of key=value strings in the dotenv syntax,

--- a/core/dotenv/dotenv_test.go
+++ b/core/dotenv/dotenv_test.go
@@ -346,6 +346,29 @@ func TestLookup(t *testing.T) {
 	require.Equal(t, "bar-baz", val)
 }
 
+func TestAllWithContext(t *testing.T) {
+	own := []string{
+		`SOURCE=${ROOT_DIR}/pepe`,
+	}
+	context := []string{
+		`ROOT_DIR=../..`,
+		`HELM_SOURCE=${UNDEFINED_THING}`,
+	}
+
+	all, err := AllWithContext(own, context, nil, true)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"SOURCE": "../../pepe"}, all)
+
+	val, ok, err := LookupWithContext(own, context, "SOURCE", nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "../../pepe", val)
+
+	_, ok, err = LookupWithContext(own, context, "ROOT_DIR", nil)
+	require.NoError(t, err)
+	require.False(t, ok, "context-only variable should not be found")
+}
+
 func TestNoSystemLookupWhenLiteral(t *testing.T) {
 	var called bool
 	lookup := func(name string) string {

--- a/core/envfile.go
+++ b/core/envfile.go
@@ -26,10 +26,17 @@ type EnvFile struct {
 	// Variables stored as key-value pairs, preserving order and allowing duplicates
 	Environ []string `json:"variables"`
 	Expand  bool     `json:"expand"`
+	// Context holds variables that are used only for ${...} expansion of the
+	// Environ values. They are not exposed via Variables/Lookup/AsFile. This is
+	// how Namespace preserves non-matching variables (e.g. a shared ROOT_DIR)
+	// that namespaced values still reference but that should not become defaults.
+	Context []string `json:"context,omitempty"`
 }
 
-var _ dagql.PersistedObject = (*EnvFile)(nil)
-var _ dagql.PersistedObjectDecoder = (*EnvFile)(nil)
+var (
+	_ dagql.PersistedObject        = (*EnvFile)(nil)
+	_ dagql.PersistedObjectDecoder = (*EnvFile)(nil)
+)
 
 func (*EnvFile) Type() *ast.Type {
 	return &ast.Type{
@@ -81,7 +88,7 @@ func (ef *EnvFile) WithVariables(variables []EnvVariable) *EnvFile {
 	return ef
 }
 
-// WithVariables adds multiple environment variables to the EnvFile
+// WithEnvFiles adds multiple environment variables to the EnvFile
 func (ef *EnvFile) WithEnvFiles(others ...*EnvFile) *EnvFile {
 	ef = ef.Clone()
 	for _, other := range others {
@@ -91,6 +98,9 @@ func (ef *EnvFile) WithEnvFiles(others ...*EnvFile) *EnvFile {
 		// Last variable assignment wins: other file's variables win over
 		// our own.
 		ef.Environ = append(ef.Environ, other.Environ...)
+		// Carry over hidden expansion context so namespaced values keep
+		// resolving their references after files are merged.
+		ef.Context = append(ef.Context, other.Context...)
 	}
 	return ef
 }
@@ -99,6 +109,7 @@ func (ef *EnvFile) WithEnvFiles(others ...*EnvFile) *EnvFile {
 func (ef *EnvFile) Clone() *EnvFile {
 	cp := *ef
 	cp.Environ = slices.Clone(ef.Environ)
+	cp.Context = slices.Clone(ef.Context)
 	return &cp
 }
 
@@ -139,7 +150,7 @@ func (ef *EnvFile) variables(ctx context.Context, allowUnboundVariables bool) (v
 		// Fallback to using host values for expansion
 		return Host{}.GetEnv(ctx, name)
 	}
-	all, err := dotenv.All(ef.Environ, hostGetEnv, !allowUnboundVariables)
+	all, err := dotenv.AllWithContext(ef.Environ, ef.Context, hostGetEnv, !allowUnboundVariables)
 	if err != nil {
 		return nil, err
 	}
@@ -171,10 +182,17 @@ func (ef *EnvFile) Namespace(ctx context.Context, prefix string) (*EnvFile, erro
 	}
 	result := &EnvFile{
 		Expand: ef.Expand,
+		// Preserve any hidden expansion context already carried by the source.
+		Context: slices.Clone(ef.Context),
 	}
 	for _, variable := range vars {
 		if after, match := cutFlexPrefix(variable.Name, prefix); match {
-			result = result.WithVariable(after, variable.Value)
+			result.add(after, variable.Value)
+		} else {
+			// Keep non-matching variables as hidden expansion context so that
+			// namespaced values referencing them (e.g. SOURCE=${ROOT_DIR}) can
+			// still be expanded later. They are not exposed as defaults.
+			result.Context = append(result.Context, variable.Name+"="+variable.Value)
 		}
 	}
 	return result, nil
@@ -222,7 +240,7 @@ func (ef *EnvFile) Lookup(ctx context.Context, name string, raw bool) (string, b
 		// Fallback to using host values for expansion
 		return Host{}.GetEnv(ctx, name)
 	}
-	return dotenv.Lookup(ef.Environ, name, hostGetEnv)
+	return dotenv.LookupWithContext(ef.Environ, ef.Context, name, hostGetEnv)
 }
 
 func (ef *EnvFile) LookupCaseInsensitive(ctx context.Context, name string) (string, bool, error) {


### PR DESCRIPTION
… namespacing

A namespaced user-default value referencing a shared, non-prefixed variable (e.g. SOURCE=${ROOT_DIR}) failed with "unbound variable" because Namespace dropped the referenced var before expansion. Carry such vars as hidden expansion context: available for ${...} resolution but not exposed as defaults via Variables/Lookup/AsFile.