### PR TITLE
version: rewrite ssh github remotes for tag fetch

### DIFF
--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:274:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:275:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:274:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:275:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:274:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:275:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}

--- a/version/main.go
+++ b/version/main.go
@@ -229,7 +229,8 @@ func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, err
 		From("alpine/git:latest").
 		WithWorkdir("/src").
 		WithMountedDirectory(".git", v.GitDir).
-		WithExec([]string{"git", "config", "url.https://github.com/.insteadOf", "git@github.com:"}).
+		WithExec([]string{"git", "config", "--add", "url.https://github.com/.insteadOf", "git@github.com:"}).
+		WithExec([]string{"git", "config", "--add", "url.https://github.com/.insteadOf", "ssh://git@github.com/"}).
 		// Remote tags are mutable, so avoid reusing a stale pre-tag fetch layer.
 		WithEnvVariable("DAGGER_VERSION_CACHE_BUSTER", time.Now().UTC().Format(time.RFC3339Nano)).
 		WithExec([]string{"git", "fetch", "--tags"}).


### PR DESCRIPTION
## Summary
- `version.tagsAtCommit` rewrites `git@github.com:` (scp-style) remotes to HTTPS so containerized tag fetches work without SSH creds. This extends it to also rewrite `ssh://git@github.com/`-style remotes, using `git config --add` so both rewrite rules coexist.

## Test plan
- [ ] Tag fetch succeeds in the version container for repos with an `ssh://git@github.com/...` origin
- [x] `version` module builds; consumer bindings regenerated (line-ref comment bump only)