### PR TITLE
chore(cli): drop run/r aliases for api exec

### DIFF
--- a/future/cli-1.0.md
+++ b/future/cli-1.0.md
@@ -702,7 +702,7 @@ Status legend: ✅ shipped on this branch | 🟡 partially shipped | ⬜ designe
 - ✅ **`dagger api call`** — moved from `dagger function call`.
 - ✅ **`dagger api functions`** — moved + renamed from `dagger function list`.
 - ✅ **`dagger api query`** — unchanged.
-- ✅ **`dagger api exec`** — moved from top-level `dagger exec` (with `run` / `r` aliases preserved under the new path). Short description sharpened to "Run a command with a connected Dagger API session". Top-level `dagger exec` is gone.
+- ✅ **`dagger api exec`** — moved from top-level `dagger exec`. Short description sharpened to "Run a command with a connected Dagger API session". Top-level `dagger exec` is gone.
 - ✅ **`dagger api client init` / `dagger api client list`** — replaces the old hidden `dagger client` group. Client entries live in `[[modules.<sdk>.as-sdk.clients]]`; `dagger generate` regenerates them. **Current shape: `dagger api client init <sdk> <path> <module> [SDK-SPECIFIC FLAGS]`.** `<sdk>` is the workspace install name created by `dagger sdk install`; installed SDKs are registered as `init` child commands only when the SDK exposes `initClient`. The CLI introspects extra `initClient` args as typed flags; `--sdk`, `--module`, and `--option` are gone.
 
 ### Shipped — `dagger sdk`

--- a/internal/cmd/dagger/run.go
+++ b/internal/cmd/dagger/run.go
@@ -28,9 +28,8 @@ import (
 )
 
 var apiExecCmd = &cobra.Command{
-	Use:     "exec [options] <command>...",
-	Aliases: []string{"run", "r"},
-	Short:   "Run a command with a connected Dagger API session (DAGGER_SESSION_PORT/TOKEN injected)",
+	Use:   "exec [options] <command>...",
+	Short: "Run a command with a connected Dagger API session (DAGGER_SESSION_PORT/TOKEN injected)",
 	Long: strings.ReplaceAll(
 		`Run an external command with a live Dagger API session attached.
 
@@ -60,9 +59,8 @@ dagger api exec python main.py
 	Args:         cobra.MinimumNArgs(1),
 	SilenceUsage: true,
 	Annotations: map[string]string{
-		hiddenAliasesAnnotation: "run,r",
-		printTraceLinkKey:       "true",
-		showFinalProgressKey:    "true",
+		printTraceLinkKey:    "true",
+		showFinalProgressKey: "true",
 	},
 }
 


### PR DESCRIPTION
The `dagger api run` and `dagger api r` aliases for `dagger api exec` do not read well — there is no meaningful "api run" or "api r" command.

This removes:
- the `run` / `r` aliases (and the hidden-aliases annotation that hid them) from `apiExecCmd` in the CLI
- the mention of those aliases from the `future/cli-1.0.md` design doc

The separate top-level `dagger run` hidden alias is left untouched.