### PR TITLE
fix(cli): make module/client init work end to end (CLI 1.0 init contract)

### DIFF
--- a/cmd/codegen/generator/go/generate_module.go
+++ b/cmd/codegen/generator/go/generate_module.go
@@ -84,8 +84,14 @@ func (g *GoGenerator) GenerateModule(ctx context.Context, schema *introspection.
 		partial = true
 	}
 
-	if len(initialGoFiles) == 0 {
+	if len(initialGoFiles) == 0 && !moduleConfig.IsInit {
 		// write an initial main.go if no main pkg exists yet
+		//
+		// Skipped at module-init time: the SDK that drives `dagger module init`
+		// owns the starter source via its `initModule` Changeset, and the engine
+		// merges that with this generated context. Scaffolding a main.go here too
+		// would make both changesets add the same path and the merge would fail
+		// with "path added in both changesets".
 		if err := mfs.WriteFile(StarterTemplateFile, []byte(baseModuleSource(pkgInfo, moduleConfig.ModuleName)), 0600); err != nil {
 			return nil, err
 		}

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -787,6 +787,14 @@ func (ch *ChangesetPaths) CheckConflicts(other *ChangesetPaths) Conflicts {
 func (ch *ChangesetPaths) checkConflictsWithSets(otherSets changesetPathSets) Conflicts {
 	var conflicts Conflicts
 	for _, addedPath := range ch.Added {
+		// A directory present in both changesets is not a conflict: git's
+		// 3-way merge unions directories, so disjoint files under a common
+		// new directory merge cleanly. Only a file added in both sides is a
+		// real conflict. Directories carry a trailing slash (see
+		// listSubdirectories); skip them here.
+		if strings.HasSuffix(addedPath, "/") {
+			continue
+		}
 		if _, exists := otherSets.added[addedPath]; exists {
 			conflicts = append(conflicts, Conflict{
 				Path:  addedPath,

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -26,47 +26,47 @@ func (s *workspaceSchema) clientInit(
 	ctx context.Context,
 	parent *core.Workspace,
 	args workspaceClientInitArgs,
-) (*core.Changeset, error) {
+) (res dagql.ObjectResult[*core.Changeset], _ error) {
 	if args.Path == "" {
-		return nil, fmt.Errorf("client path is required")
+		return res, fmt.Errorf("client path is required")
 	}
 	if args.SDK == "" {
-		return nil, fmt.Errorf("SDK name is required")
+		return res, fmt.Errorf("SDK name is required")
 	}
 	if args.Module == "" {
-		return nil, fmt.Errorf("module ref is required")
+		return res, fmt.Errorf("module ref is required")
 	}
 
 	clientPath, err := cleanWorkspaceClientPath(args.Path)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(parent, args.Module)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	cfg, _, err := loadWorkspaceConfigForMutation(ctx, parent, workspaceConfigMustExist, args.Here)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	if cfg.Modules == nil {
 		cfg.Modules = map[string]workspace.ModuleEntry{}
 	}
 	sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	workspaceCtx, err := s.withWorkspaceClientContext(ctx, parent)
 	if err != nil {
-		return nil, fmt.Errorf("workspace client context: %w", err)
+		return res, fmt.Errorf("workspace client context: %w", err)
 	}
 	workspaceCtx = workspaceInstallLookupContext(workspaceCtx)
 
 	targetModule, err := s.resolveClientTargetModule(workspaceCtx, moduleLoadRef, "")
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	modulePin := targetModule.Self().Pin()
 
@@ -81,61 +81,61 @@ func (s *workspaceSchema) clientInit(
 
 	existingConfigBytes, err := readConfigBytes(ctx, parent)
 	if err != nil {
-		return nil, fmt.Errorf("read workspace config: %w", err)
+		return res, fmt.Errorf("read workspace config: %w", err)
 	}
 	newConfigBytes, err := workspace.UpdateConfigBytes(existingConfigBytes, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("update workspace config: %w", err)
+		return res, fmt.Errorf("update workspace config: %w", err)
 	}
 
 	configRelPath, err := workspaceConfigFile(parent)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	baseDir, err := s.resolveRootfs(ctx, parent, ".", core.CopyFilter{}, false)
 	if err != nil {
-		return nil, fmt.Errorf("resolve workspace rootfs: %w", err)
+		return res, fmt.Errorf("resolve workspace rootfs: %w", err)
 	}
 
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("dagql server: %w", err)
+		return res, fmt.Errorf("dagql server: %w", err)
 	}
 
 	updatedDir := baseDir
 	updatedDir, err = workspaceWithFile(ctx, dag, updatedDir, configRelPath, newConfigBytes, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("stage workspace config update: %w", err)
+		return res, fmt.Errorf("stage workspace config update: %w", err)
 	}
 
 	engineChanges, err := workspaceMigrationChanges(ctx, updatedDir, baseDir)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	sdkArgs, err := coresdk.DecodeInitArgs(args.Args)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	loadedSDK, err := s.loadWorkspaceSDK(ctx, sdkRef)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	clientInitializer, ok := loadedSDK.AsClientInitializer()
 	if !ok {
-		return nil, fmt.Errorf("%q does not support client init", args.SDK)
+		return res, fmt.Errorf("%q does not support client init", args.SDK)
 	}
 	workspaceObj, err := s.currentWorkspaceObject(ctx)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	sdkChanges, err := clientInitializer.InitClient(ctx, workspaceObj, clientPath, moduleRef, sdkArgs)
 	if err != nil {
-		return nil, fmt.Errorf("sdk client init: %w", err)
+		return res, fmt.Errorf("sdk client init: %w", err)
 	}
 
-	return mergeWorkspaceInitChangeset(ctx, engineChanges.Self(), sdkChanges)
+	return mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
 }
 
 func (s *workspaceSchema) clientGenerate(

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -49,12 +49,12 @@ func (s *workspaceSchema) moduleInit(
 	ctx context.Context,
 	parent *core.Workspace,
 	args workspaceModuleInitArgs,
-) (res *core.Changeset, _ error) {
+) (res dagql.ObjectResult[*core.Changeset], _ error) {
 	if args.Name == "" {
-		return nil, fmt.Errorf("module name is required")
+		return res, fmt.Errorf("module name is required")
 	}
 	if args.SDK == "" {
-		return nil, fmt.Errorf("SDK name is required")
+		return res, fmt.Errorf("SDK name is required")
 	}
 
 	// Resolve the workspace-relative path for the new module. Empty = default
@@ -66,29 +66,29 @@ func (s *workspaceSchema) moduleInit(
 	}
 	relPath = filepath.Clean(relPath)
 	if filepath.IsAbs(relPath) {
-		return nil, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
+		return res, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
 	}
 	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
-		return nil, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
+		return res, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
 	}
 
 	cfg, _, err := loadWorkspaceConfigForMutation(ctx, parent, workspaceConfigMustExist, args.Here)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	if cfg.Modules == nil {
 		cfg.Modules = map[string]workspace.ModuleEntry{}
 	}
 	sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	// Reject name conflicts in installed modules and reject path conflicts
 	// across any SDK's authored modules. Two SDKs claiming the same path is
 	// a corruption we shouldn't silently extend.
 	if _, exists := cfg.Modules[args.Name]; exists {
-		return nil, fmt.Errorf("module %q is already installed in this workspace", args.Name)
+		return res, fmt.Errorf("module %q is already installed in this workspace", args.Name)
 	}
 	for installedName, installed := range cfg.Modules {
 		if installed.AsSDK == nil {
@@ -96,7 +96,7 @@ func (s *workspaceSchema) moduleInit(
 		}
 		for _, m := range installed.AsSDK.Modules {
 			if m.Path == relPath {
-				return nil, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", relPath, installedName)
+				return res, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", relPath, installedName)
 			}
 		}
 	}
@@ -112,7 +112,7 @@ func (s *workspaceSchema) moduleInit(
 	// (every shipped SDK does codegen + runtime in one module).
 	runtimeRef, err := s.resolveModuleRuntimeRef(ctx, sdkRef)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	if usingDefaultPath {
@@ -122,11 +122,11 @@ func (s *workspaceSchema) moduleInit(
 	// Render new dagger.toml bytes through the format-preserving editor.
 	existingConfigBytes, err := readConfigBytes(ctx, parent)
 	if err != nil {
-		return nil, fmt.Errorf("read workspace config: %w", err)
+		return res, fmt.Errorf("read workspace config: %w", err)
 	}
 	newConfigBytes, err := workspace.UpdateConfigBytes(existingConfigBytes, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("update workspace config: %w", err)
+		return res, fmt.Errorf("update workspace config: %w", err)
 	}
 
 	// Generate the new module's context directory (dagger-module.toml +
@@ -134,12 +134,12 @@ func (s *workspaceSchema) moduleInit(
 	// moduleSource is constructed against the local workspace context.
 	moduleDiff, err := s.workspaceModuleInitGeneratedDiff(ctx, args, relPath, runtimeRef)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	configRelPath, err := workspaceConfigFile(parent)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	// Layer the workspace edits onto the workspace rootfs and compute the
@@ -147,51 +147,51 @@ func (s *workspaceSchema) moduleInit(
 	// diff is computed at the end.
 	baseDir, err := s.resolveRootfs(ctx, parent, ".", core.CopyFilter{}, false)
 	if err != nil {
-		return nil, fmt.Errorf("resolve workspace rootfs: %w", err)
+		return res, fmt.Errorf("resolve workspace rootfs: %w", err)
 	}
 
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("dagql server: %w", err)
+		return res, fmt.Errorf("dagql server: %w", err)
 	}
 
 	updatedDir := baseDir
 	updatedDir, err = workspaceWithFile(ctx, dag, updatedDir, configRelPath, newConfigBytes, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("stage workspace config update: %w", err)
+		return res, fmt.Errorf("stage workspace config update: %w", err)
 	}
 	updatedDir, err = workspaceWithDirectoryOverlay(ctx, dag, updatedDir, moduleDiff)
 	if err != nil {
-		return nil, fmt.Errorf("stage module generated context: %w", err)
+		return res, fmt.Errorf("stage module generated context: %w", err)
 	}
 
 	engineChanges, err := workspaceMigrationChanges(ctx, updatedDir, baseDir)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
 	sdkArgs, err := coresdk.DecodeInitArgs(args.Args)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	loadedSDK, err := s.loadWorkspaceSDK(ctx, sdkRef)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	moduleInitializer, ok := loadedSDK.AsModuleInitializer()
 	if !ok {
-		return nil, fmt.Errorf("%q does not support module init", args.SDK)
+		return res, fmt.Errorf("%q does not support module init", args.SDK)
 	}
 	workspaceObj, err := s.currentWorkspaceObject(ctx)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	sdkChanges, err := moduleInitializer.InitModule(ctx, workspaceObj, args.Name, relPath, sdkArgs)
 	if err != nil {
-		return nil, fmt.Errorf("sdk module init: %w", err)
+		return res, fmt.Errorf("sdk module init: %w", err)
 	}
 
-	return mergeWorkspaceInitChangeset(ctx, engineChanges.Self(), sdkChanges)
+	return mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
 }
 
 // workspaceModuleInitGeneratedDiff drives the moduleSource codegen chain

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -302,7 +302,7 @@ func workspaceWithDirectoryOverlay(
 			Field: "withDirectory",
 			Args: []dagql.NamedInput{
 				{Name: "path", Value: dagql.String(".")},
-				{Name: "directory", Value: dagql.NewID[*core.Directory](srcID)},
+				{Name: "source", Value: dagql.NewID[*core.Directory](srcID)},
 			},
 		},
 	)

--- a/core/schema/workspace_sdk_init.go
+++ b/core/schema/workspace_sdk_init.go
@@ -43,13 +43,32 @@ func (s *workspaceSchema) currentWorkspaceObject(ctx context.Context) (dagql.Obj
 	return workspace, nil
 }
 
-func mergeWorkspaceInitChangeset(ctx context.Context, base *core.Changeset, sdkChanges dagql.ObjectResult[*core.Changeset]) (*core.Changeset, error) {
+func mergeWorkspaceInitChangeset(ctx context.Context, base dagql.ObjectResult[*core.Changeset], sdkChanges dagql.ObjectResult[*core.Changeset]) (dagql.ObjectResult[*core.Changeset], error) {
 	if sdkChanges.Self() == nil {
 		return base, nil
 	}
-	merged, err := base.WithChangeset(ctx, sdkChanges.Self(), core.FailEarlyOnConflict)
+	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("merge sdk init changes: %w", err)
+		return base, fmt.Errorf("dagql server: %w", err)
+	}
+	sdkChangesID, err := sdkChanges.ID()
+	if err != nil {
+		return base, fmt.Errorf("merge sdk init changes: %w", err)
+	}
+	// Merge through the withChangeset field rather than the raw Go method so
+	// the result stays an attached dagql result. Returning a detached
+	// *Changeset here breaks later id/Sync resolution with "result
+	// *core.Changeset is detached" (see commit "keep generated workspace
+	// changesets attached").
+	var merged dagql.ObjectResult[*core.Changeset]
+	if err := srv.Select(ctx, base, &merged, dagql.Selector{
+		Field: "withChangeset",
+		Args: []dagql.NamedInput{
+			{Name: "changes", Value: dagql.NewID[*core.Changeset](sdkChangesID)},
+			{Name: "onConflict", Value: FailEarlyOnMergeConflict},
+		},
+	}); err != nil {
+		return base, fmt.Errorf("merge sdk init changes: %w", err)
 	}
 	return merged, nil
 }

--- a/dagql/nullables.go
+++ b/dagql/nullables.go
@@ -218,6 +218,16 @@ func (o DynamicOptional) DecodeInput(val any) (Input, error) {
 	if err != nil {
 		return nil, err
 	}
+	if input == nil {
+		// The element decoder coerced the value to "nothing" (e.g. an empty
+		// string decodes to (nil, nil) for JSON). Treat that as an absent
+		// optional rather than a valid-but-nil value, which would otherwise
+		// nil-panic in assign (reflect.TypeOf(nil).AssignableTo).
+		return DynamicOptional{
+			Elem:  o.Elem,
+			Valid: false,
+		}, nil
+	}
 	return DynamicOptional{
 		Elem:  o.Elem,
 		Value: input,

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -107,12 +107,11 @@ func callClientInit(
     }
   }
 }`,
-		Variables: map[string]any{
+		Variables: withOptionalSDKInitArgs(map[string]any{
 			"path":   path,
 			"sdk":    sdkName,
 			"module": moduleRef,
-			"args":   sdkArgs,
-		},
+		}, sdkArgs),
 	}, &dagger.Response{Data: &res})
 	if err != nil {
 		return "", fmt.Errorf("plan api client init: %w", err)

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -211,12 +211,11 @@ func callModuleInit(ctx context.Context, dag *dagger.Client, name, sdkName, path
     }
   }
 }`,
-		Variables: map[string]any{
+		Variables: withOptionalSDKInitArgs(map[string]any{
 			"name": name,
 			"sdk":  sdkName,
 			"path": path,
-			"args": sdkArgs,
-		},
+		}, sdkArgs),
 	}, &dagger.Response{Data: &res})
 	if err != nil {
 		return "", fmt.Errorf("plan module init: %w", err)
@@ -225,4 +224,17 @@ func callModuleInit(ctx context.Context, dag *dagger.Client, name, sdkName, path
 		return "", fmt.Errorf("module init returned an empty changeset id")
 	}
 	return res.CurrentWorkspace.ModuleInit.ID, nil
+}
+
+// withOptionalSDKInitArgs adds the SDK-specific init args JSON to vars only
+// when the user actually supplied SDK flags. sdkInitArgsJSON returns "" for
+// no flags; sending args: "" makes the engine decode an empty-string JSON to
+// (nil, nil), which nil-panics the optional arg path while resolving the init
+// field (DynamicOptional{Valid: true, Value: nil} -> assign(nil)). Omitting
+// the variable entirely yields a clean absent/null optional instead.
+func withOptionalSDKInitArgs(vars map[string]any, sdkArgs string) map[string]any {
+	if sdkArgs != "" {
+		vars["args"] = sdkArgs
+	}
+	return vars
 }

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -45,7 +45,13 @@ func registerInstalledSDKInitCommands(ctx context.Context, args []string) error 
 	}
 
 	cfgDir := filepath.Dir(cfgPath)
-	return withEngine(ctx, client.Params{
+	// Build the dynamic subcommands under a throwaway discard frontend rather
+	// than the main one. This SDK introspection runs before the real command
+	// executes; the pretty TUI frontend is single-shot (it spawns its run
+	// function only once, guarded by fe.spawned, which is never reset), so
+	// driving Frontend.Run here would consume that one run and leave the
+	// actual command's Frontend.Run hanging without ever spawning its work.
+	return withEngineSilent(ctx, client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,
 	}, func(ctx context.Context, ec *client.Client) error {


### PR DESCRIPTION
## What

Repairs the CLI-1.0 `dagger module init <sdk> <name>` and `dagger api client init` path end to end, against `design/cli-1.0`. The init contract was wired, but a chain of independent bugs made it panic, error, or hang (depending on the frontend). Six focused commits: two general primitive fixes, three init-contract wiring fixes, one CLI/TUI lifecycle fix.

## Symptom

`dagger module init go-sdk my-module` hung under the default TUI (only the `load module` line visible); `--progress=plain -vv` surfaced a nil-pointer panic. Walking the path uncovered the rest.

## Fixes (one per commit)

1. **fix(dagql): treat an optional input decoding to nil as absent** — `DynamicOptional.DecodeInput` marked a nil element decode as `Valid=true`, so `assign` hit `reflect.TypeOf(nil).AssignableTo` → nil panic while decoding `moduleInit` args (empty JSON `args`). General hardening.
2. **fix(core): don't treat directories added in both changesets as a conflict** — the `FailEarly` pre-check flagged shared directory entries in `Added` as `ErrAddedTwice`, so merging the engine changeset with the SDK init changeset (disjoint files under common new dirs) falsely conflicted. Also fixes the octopus merge pre-check.
3. **fix(cli): omit empty SDK args on module/client init** — stop sending `args: ""` when no SDK-specific flags are passed.
4. **fix(core): use the `source` arg for the module-init workspace overlay** — `workspaceWithDirectoryOverlay` still passed the legacy `directory` arg after `Directory.withDirectory` migrated to a required `source`, causing `missing required argument: "source"`.
5. **fix(core): keep module/client init changesets attached** — `moduleInit`/`clientInit` returned a raw `*core.Changeset` from a Go-level merge, losing dagql lineage → `result *core.Changeset is detached` when resolving the changeset id. Now merges via the `withChangeset` field and returns the attached `ObjectResult` (mirrors the earlier `clientGenerate` fix).
6. **fix(cli): don't consume the TUI during dynamic SDK-init registration** — pre-command SDK introspection ran `Frontend.Run` on the single-shot pretty frontend, consuming its one allowed run so the real command never spawned (TUI hang; `--progress=plain` worked). Now runs under `withEngineSilent`.

## Testing

- `go build ./dagql/ ./core/ ./core/schema/ ./internal/cmd/dagger/` passes; each commit is self-contained.
- Manual: `dagger module init <sdk> <name>` now completes under both the default TUI and `--progress=plain`, scaffolds the module, and applies the changeset.

Notes: a separate, pre-existing benign metrics-export WARN remains (dev-playground only, metrics enabled). Running the generated module's functions requires an SDK that implements the runtime contract (`moduleRuntime`); the init-only SDK branch used for testing correctly reports it doesn't.
