### PR TITLE
fix(cli): inspect SDKs without serving deps during init registration

### DIFF
--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -9,6 +9,8 @@ package core
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -326,6 +328,86 @@ func (WorkspaceModulesSuite) TestWorkspaceManagedModuleBehavior(ctx context.Cont
 		require.NoError(t, err)
 		require.Equal(t, "hello from configured workspace", strings.TrimSpace(out))
 	})
+}
+
+// TestWorkspaceMultiSDKSharedDependency verifies that two SDKs installed in the
+// same workspace can each depend on a different source for a module of the same
+// name.
+//
+// `dagger module init` registers init commands for every installed SDK by
+// inspecting each one. Inspecting an SDK only needs that SDK's own init
+// contract, so it must not serve the SDK's dependencies into the session's
+// shared module namespace. Otherwise two SDKs that share a transitive
+// dependency name at different sources/pins (e.g. each pinning
+// sdk-sdk/polyfill to a different commit) collide during registration with
+// "module polyfill ... already exists with different source".
+func (WorkspaceModulesSuite) TestWorkspaceMultiSDKSharedDependency(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+
+	// Two distinct dependency modules that share the module name "polyfill".
+	// Their on-disk sources differ, so the engine registers them as different
+	// modules under the same name.
+	writeGoModuleSource(t, filepath.Join(workdir, "poly-a"), "polyfill", "Polyfill")
+	writeGoModuleSource(t, filepath.Join(workdir, "poly-b"), "polyfill", "Polyfill")
+
+	// Two SDKs, each depending on a different "polyfill".
+	writeGoModuleSource(t, filepath.Join(workdir, "alpha"), "alpha", "Alpha",
+		goModuleDep{name: "polyfill", source: "../poly-a"})
+	writeGoModuleSource(t, filepath.Join(workdir, "beta"), "beta", "Beta",
+		goModuleDep{name: "polyfill", source: "../poly-b"})
+
+	writeWorkspaceConfigFile(t, workdir, `[modules.alpha]
+source = "alpha"
+[modules.alpha.as-sdk]
+
+[modules.beta]
+source = "beta"
+[modules.beta.as-sdk]
+`)
+
+	// `dagger module init` with no subcommand prints help, but only after
+	// registering init commands for every installed SDK — the step that used to
+	// fail with the cross-SDK dependency conflict.
+	out, err := hostDaggerExecRaw(ctx, t, workdir, "module", "init")
+	require.NoError(t, err, string(out))
+	require.NotContains(t, string(out), "already exists with different source")
+	require.Contains(t, string(out), "Initialize a new module")
+}
+
+// goModuleDep is a dependency entry for writeGoModuleSource's dagger.json.
+type goModuleDep struct {
+	name   string
+	source string
+}
+
+// writeGoModuleSource writes a minimal Go-SDK module (dagger.json + main.go) at
+// dir, named module with main object obj, declaring the given dependencies.
+func writeGoModuleSource(t *testctx.T, dir, module, obj string, deps ...goModuleDep) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	cfg := map[string]any{
+		"name":          module,
+		"engineVersion": "latest",
+		"sdk":           map[string]any{"source": "go"},
+	}
+	if len(deps) > 0 {
+		entries := make([]map[string]string, 0, len(deps))
+		for _, d := range deps {
+			entries = append(entries, map[string]string{"name": d.name, "source": d.source})
+		}
+		cfg["dependencies"] = entries
+	}
+	cfgBytes, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dagger.json"), cfgBytes, 0o644))
+
+	main := fmt.Sprintf(
+		"package main\n\ntype %s struct{}\n\nfunc (m *%s) Hello() string {\n\treturn \"hello\"\n}\n",
+		obj, obj,
+	)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(main), 0o644))
 }
 
 func readInstalledWorkspaceConfig(t *testctx.T, workdir string) *workspacecfg.Config {

--- a/internal/cmd/dagger/module_inspect.go
+++ b/internal/cmd/dagger/module_inspect.go
@@ -50,6 +50,21 @@ func initializeWorkspace(ctx context.Context, dag *dagger.Client, opts ...loadTy
 	return def, nil
 }
 
+// initModuleOpts configures how initializeModule serves the module before
+// inspecting it.
+type initModuleOpts struct {
+	// entrypoint promotes the module's main-object methods onto the Query root.
+	entrypoint bool
+	// skipDependencies serves only the module itself, without also serving its
+	// dependencies onto the Query root. This matters when several independent
+	// modules are inspected within a single session (e.g. registering init
+	// commands for every installed SDK): serving their dependencies pulls
+	// transitively-shared modules into one shared namespace, where the same
+	// dependency name resolved to different sources/pins collides. Inspecting a
+	// module's own contract never needs its dependency constructors.
+	skipDependencies bool
+}
+
 // initializeModule loads the module at the given source ref
 //
 // Returns an error if the module is not found or invalid.
@@ -58,7 +73,7 @@ func initializeModule(
 	dag *dagger.Client,
 	modRef string,
 	modSrc *dagger.ModuleSource,
-	opts ...dagger.ModuleServeOpts,
+	opts ...initModuleOpts,
 ) (rdef *moduleDef, rerr error) {
 	ctx, span := Tracer().Start(ctx, "load module: "+modRef)
 	defer telemetry.EndWithCause(span, &rerr)
@@ -77,8 +92,11 @@ func initializeModule(
 	serveCtx, serveSpan := Tracer().Start(ctx, "initializing module", telemetry.Encapsulate())
 	serveOpts := dagger.ModuleServeOpts{IncludeDependencies: true}
 	for _, o := range opts {
-		if o.Entrypoint {
+		if o.entrypoint {
 			serveOpts.Entrypoint = true
+		}
+		if o.skipDependencies {
+			serveOpts.IncludeDependencies = false
 		}
 	}
 	err = modSrc.AsModule().Serve(serveCtx, serveOpts)

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -312,7 +312,12 @@ func inspectSDKInitFunction(
 	}
 
 	modSrc := dag.ModuleSource(sdkRef)
-	mod, err := initializeModule(ctx, dag, sdkRef, modSrc)
+	// Inspect the SDK's own init contract only. Serving its dependencies would
+	// pull them into the session's shared module namespace, so two installed
+	// SDKs that share a transitive dependency at different sources/pins (e.g.
+	// each SDK pinning sdk-sdk/polyfill to a different commit) would collide
+	// during registration.
+	mod, err := initializeModule(ctx, dag, sdkRef, modSrc, initModuleOpts{skipDependencies: true})
 	if err != nil {
 		return nil, fmt.Errorf("inspect sdk %q: %w", sdkRef, err)
 	}

--- a/internal/cmd/dagger/shell.go
+++ b/internal/cmd/dagger/shell.go
@@ -221,7 +221,7 @@ func (h *shellCallHandler) Initialize(ctx context.Context) error {
 	var cfg *configuredModule
 
 	if !h.noModule {
-		def, cfg, err = h.maybeLoadModule(ctx, h.moduleURL, dagger.ModuleServeOpts{Entrypoint: true})
+		def, cfg, err = h.maybeLoadModule(ctx, h.moduleURL, initModuleOpts{entrypoint: true})
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/dagger/shell_fs.go
+++ b/internal/cmd/dagger/shell_fs.go
@@ -58,7 +58,7 @@ func (h *shellCallHandler) ChangeDir(ctx context.Context, path string) error {
 
 	var subpath string
 
-	def, cfg, err := h.maybeLoadModule(ctx, path, dagger.ModuleServeOpts{Entrypoint: true})
+	def, cfg, err := h.maybeLoadModule(ctx, path, initModuleOpts{entrypoint: true})
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (src gitSourceContext) File(dag *dagger.Client, subpath string) *dagger.Fil
 	return src.context(dag).File(subpath)
 }
 
-func (h *shellCallHandler) maybeLoadModule(ctx context.Context, path string, opts ...dagger.ModuleServeOpts) (*moduleDef, *configuredModule, error) {
+func (h *shellCallHandler) maybeLoadModule(ctx context.Context, path string, opts ...initModuleOpts) (*moduleDef, *configuredModule, error) {
 	cfg, err := h.parseModRef(ctx, path)
 	if err != nil {
 		return nil, cfg, fmt.Errorf("find module %q: %w", path, err)


### PR DESCRIPTION
## Problem

On `design/cli-1.0`, installing two SDKs that each depend on a different version of the same module breaks `dagger module init` / `dagger api client init`:

```
✘ load module: github.com/dagger/python-sdk@prepare-cli-1.0-init-contract ERROR
✘ initializing module ERROR
! error serving dependency polyfill: module polyfill (source: https://github.com/dagger/sdk-sdk/polyfill@main | pin: 09da957...) already exists
  with different source github.com/dagger/sdk-sdk/polyfill@main (pin: d1532df...)
```

(reported [in Discord](https://discord.com/channels/707636530424053791/1003718839739105300/1517136423277297756))

## Root cause

`dagger module init` / `dagger api client init` register a dynamic subcommand per installed SDK at startup (`registerInstalledSDKInitCommands`). Registration inspects **every** `as-sdk` module within a **single** engine session (`registerSDKInitCommandsFromConfigForKind` → `inspectSDKInitFunction` → `initializeModule`).

`initializeModule` served each SDK with `IncludeDependencies: true`, which serves the SDK's transitive dependencies onto the session's shared `Query` root. When two SDKs share a transitive dependency **name** at different sources/pins, the second serve fails the engine's `serveModule` identity check (`isSameModuleReference`) with `... already exists with different source`. This blocks **all** init operations in such a workspace.

## Fix

Inspecting an SDK's `initModule`/`initClient` contract only needs the SDK module's own type definitions — not its dependency constructors on the `Query` root. Added `initModuleOpts{skipDependencies}` to `initializeModule` and pass `skipDependencies: true` from `inspectSDKInitFunction`. Shell module loading still serves dependencies as before (it relies on the default).

The **legitimate** single-graph conflict (a generated client baked to one pin vs the workspace resolving another commit) still errors — `TestMissmatchDependencyVersion` is intentionally left intact.

## Test

`WorkspaceModulesSuite/TestWorkspaceMultiSDKSharedDependency`: a workspace with two SDKs that each depend on a different-sourced module named `polyfill`, then runs `dagger module init`. It **fails without the fix** with the exact `already exists with different source` error and **passes with it**. Verified against this PR's base (`design/cli-1.0` + this commit).
