### PR TITLE
chore(version): use Git API for tag lookup

### DIFF
--- a/toolchains/cli-dev/internal/dagger/version.gen.go
+++ b/toolchains/cli-dev/internal/dagger/version.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:58:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -19,7 +19,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:58:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:58:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,7 +47,7 @@ type VersionOpts struct {
 	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:25:2)
+	GitParent *Directory // version (../../../../version/main.go:24:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -55,18 +55,18 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:35:2)
+	Inputs *Directory // version (../../../../version/main.go:34:2)
 	//
 	// File containing the next release version (e.g. .changes/.next)
 	//
-	NextVersionFile *File // version (../../../../version/main.go:40:2)
+	NextVersionFile *File // version (../../../../version/main.go:39:2)
 }
 
 // Shared logic for managing Dagger versions
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:18:1)
+// Dev builds use semver-compatible prereleases:
+// v<major>.<minor>.<patch>-dev-<commit-or-digest>
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -88,7 +88,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:58:6)
+type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -105,7 +105,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:201:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -117,7 +117,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:182:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:177:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -129,7 +129,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:61:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -187,7 +187,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:156:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:275:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:240:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:72:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:71:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/engine-dev/internal/dagger/version.gen.go
+++ b/toolchains/engine-dev/internal/dagger/version.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:58:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -19,7 +19,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:58:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:58:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,7 +47,7 @@ type VersionOpts struct {
 	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:25:2)
+	GitParent *Directory // version (../../../../version/main.go:24:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -55,18 +55,18 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:35:2)
+	Inputs *Directory // version (../../../../version/main.go:34:2)
 	//
 	// File containing the next release version (e.g. .changes/.next)
 	//
-	NextVersionFile *File // version (../../../../version/main.go:40:2)
+	NextVersionFile *File // version (../../../../version/main.go:39:2)
 }
 
 // Shared logic for managing Dagger versions
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:18:1)
+// Dev builds use semver-compatible prereleases:
+// v<major>.<minor>.<patch>-dev-<commit-or-digest>
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -88,7 +88,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:58:6)
+type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -105,7 +105,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:201:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -117,7 +117,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:182:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:177:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -129,7 +129,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:61:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -187,7 +187,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:156:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:275:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:240:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:72:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:71:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/toolchains/release/internal/dagger/version.gen.go
+++ b/toolchains/release/internal/dagger/version.gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Retrieve the binding value, as type Version
-func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:58:6)
+func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("asVersion")
 
 	return &Version{
@@ -19,7 +19,7 @@ func (r *Binding) AsVersion() *Version { // version (../../../../version/main.go
 }
 
 // Create or update a binding of type Version in the environment
-func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:58:6)
+func (r *Env) WithVersionInput(name string, value *Version, description string) *Env { // version (../../../../version/main.go:57:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withVersionInput")
 	q = q.Arg("name", name)
@@ -32,7 +32,7 @@ func (r *Env) WithVersionInput(name string, value *Version, description string) 
 }
 
 // Declare a desired Version output to be assigned in the environment
-func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:58:6)
+func (r *Env) WithVersionOutput(name string, description string) *Env { // version (../../../../version/main.go:57:6)
 	q := r.query.Select("withVersionOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -47,7 +47,7 @@ type VersionOpts struct {
 	//
 	// A git repository containing the source code of the artifact to be versioned.
 	//
-	GitParent *Directory // version (../../../../version/main.go:25:2)
+	GitParent *Directory // version (../../../../version/main.go:24:2)
 	//
 	// A directory containing all the inputs of the artifact to be versioned.
 	// An input is any file that changes the artifact if it changes.
@@ -55,18 +55,18 @@ type VersionOpts struct {
 	// - To avoid false positives, only include actual inputs
 	// - To avoid false negatives, include *all* inputs
 	//
-	Inputs *Directory // version (../../../../version/main.go:35:2)
+	Inputs *Directory // version (../../../../version/main.go:34:2)
 	//
 	// File containing the next release version (e.g. .changes/.next)
 	//
-	NextVersionFile *File // version (../../../../version/main.go:40:2)
+	NextVersionFile *File // version (../../../../version/main.go:39:2)
 }
 
 // Shared logic for managing Dagger versions
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
-func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:18:1)
+// Dev builds use semver-compatible prereleases:
+// v<major>.<minor>.<patch>-dev-<commit-or-digest>
+func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../version/main.go:17:1)
 	q := r.query.Select("version")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `gitParent` optional argument
@@ -88,7 +88,7 @@ func (r *Query) Version(opts ...VersionOpts) *Version { // version (../../../../
 	}
 }
 
-type Version struct { // version (../../../../version/main.go:58:6)
+type Version struct { // version (../../../../version/main.go:57:6)
 	query *querybuilder.Selection
 
 	currentTag         *string
@@ -105,7 +105,7 @@ func (r *Version) WithGraphQLQuery(q *querybuilder.Selection) *Version {
 	}
 }
 
-func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:204:1)
+func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:201:1)
 	if r.currentTag != nil {
 		return *r.currentTag, nil
 	}
@@ -117,7 +117,7 @@ func (r *Version) CurrentTag(ctx context.Context) (string, error) { // version (
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:182:1)
+func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../../../version/main.go:177:1)
 	if r.dirty != nil {
 		return *r.dirty, nil
 	}
@@ -129,7 +129,7 @@ func (r *Version) Dirty(ctx context.Context) (bool, error) { // version (../../.
 	return response, q.Execute(ctx)
 }
 
-func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:61:2)
+func (r *Version) GitDir() *Directory { // version (../../../../version/main.go:60:2)
 	q := r.query.Select("gitDir")
 
 	return &Directory{
@@ -187,7 +187,7 @@ func (r *Version) UnmarshalJSON(bs []byte) error {
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
-func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:156:1)
+func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (../../../../version/main.go:151:1)
 	if r.imageTag != nil {
 		return *r.imageTag, nil
 	}
@@ -200,7 +200,7 @@ func (r *Version) ImageTag(ctx context.Context) (string, error) { // version (..
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next
-func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:275:1)
+func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // version (../../../../version/main.go:240:1)
 	if r.nextReleaseVersion != nil {
 		return *r.nextReleaseVersion, nil
 	}
@@ -213,7 +213,7 @@ func (r *Version) NextReleaseVersion(ctx context.Context) (string, error) { // v
 }
 
 // Generate a version string from the current context
-func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:72:1)
+func (r *Version) Version(ctx context.Context) (string, error) { // version (../../../../version/main.go:71:1)
 	if r.version != nil {
 		return *r.version, nil
 	}

--- a/version/main.go
+++ b/version/main.go
@@ -1,14 +1,13 @@
 // Shared logic for managing Dagger versions
 //
-// In general, it attempts to follow go's psedudoversioning:
-// https://go.dev/doc/modules/version-numbers
+// Dev builds use semver-compatible prereleases:
+// v<major>.<minor>.<patch>-dev-<commit-or-digest>
 package main
 
 import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/dagger/dagger/version/internal/dagger"
 	"golang.org/x/mod/semver"
@@ -81,7 +80,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 
 	if dirty {
 		// this is a dirty version - git state is dirty
-		// (v<major>.<minor>.<patch>-<timestamp>-dev-<inputdigest>)
+		// (v<major>.<minor>.<patch>-dev-<inputdigest>)
 		next, err := v.NextReleaseVersion(ctx)
 		if err != nil {
 			return "", err
@@ -94,7 +93,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("invalid digest: %s", rawDigest)
 		}
-		return fmt.Sprintf("%s-%s-dev-%s", next, pseudoversionTimestamp(time.Now()), digest[:12]), nil
+		return fmt.Sprintf("%s-dev-%s", next, digest[:12]), nil
 	}
 
 	if tag, err := v.CurrentTag(ctx); err != nil {
@@ -106,7 +105,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 	}
 
 	// this is a clean, untagged version - git state is clean, but no tag
-	// (v<major>.<minor>.<patch>-<timestamp>-dev-<commit>)
+	// (v<major>.<minor>.<patch>-dev-<commit>)
 	next, err := v.NextReleaseVersion(ctx)
 	if err != nil {
 		return "", err
@@ -116,11 +115,7 @@ func (v Version) Version(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	commitDate, err := refTimestamp(ctx, head)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s-%s-dev-%s", next, pseudoversionTimestamp(commitDate), commit[:12]), nil
+	return fmt.Sprintf("%s-dev-%s", next, commit[:12]), nil
 }
 
 func (v Version) fallbackVersion(ctx context.Context) (string, error) {
@@ -148,7 +143,7 @@ func (v Version) fallbackVersion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("invalid digest: %s", rawDigest)
 	}
 
-	return fmt.Sprintf("%s-%s-dev-%s", next, pseudoversionTimestamp(time.Now()), digest[:12]), nil
+	return fmt.Sprintf("%s-dev-%s", next, digest[:12]), nil
 }
 
 // Return the tag to use when auto-downloading the engine image from the CLI
@@ -184,7 +179,9 @@ func (v Version) Dirty(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	committed := v.Git.Head().Tree()
+	committed := v.Git.Head().Tree(dagger.GitRefTreeOpts{
+		IncludeTags: true,
+	})
 
 	// Overlay local inputs onto committed tree, then diff.
 	// This detects additions and modifications but not deletions.
@@ -210,65 +207,33 @@ func (v Version) CurrentTag(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tags, err := v.tagsAtCommit(ctx, commit)
+	return v.semverTagAtCommit(ctx, commit)
+}
+
+func (v Version) semverTagAtCommit(ctx context.Context, commit string) (string, error) {
+	repo := v.Git.Head().Tree(dagger.GitRefTreeOpts{
+		IncludeTags: true,
+	}).AsGit()
+	tags, err := repo.Tags(ctx, dagger.GitRepositoryTagsOpts{
+		Patterns: []string{"v*"},
+	})
 	if err != nil {
 		return "", err
 	}
+
 	for _, tag := range tags {
-		if semver.IsValid(tag) {
+		if !semver.IsValid(tag) {
+			continue
+		}
+		tagCommit, err := repo.Tag(tag).Commit(ctx)
+		if err != nil {
+			return "", fmt.Errorf("resolve tag %q: %w", tag, err)
+		}
+		if tagCommit == commit {
 			return tag, nil
 		}
 	}
 	return "", nil
-}
-
-func (v Version) tagsAtCommit(ctx context.Context, commit string) ([]string, error) {
-	// NOTE: this uses the git dir directly rather than the git repo
-	// since there's no dagger API to do this operation
-	out, err := dag.Container().
-		From("alpine/git:latest").
-		WithWorkdir("/src").
-		WithMountedDirectory(".git", v.GitDir).
-		WithExec([]string{"git", "config", "--add", "url.https://github.com/.insteadOf", "git@github.com:"}).
-		WithExec([]string{"git", "config", "--add", "url.https://github.com/.insteadOf", "ssh://git@github.com/"}).
-		// Remote tags are mutable, so avoid reusing a stale pre-tag fetch layer.
-		WithEnvVariable("DAGGER_VERSION_CACHE_BUSTER", time.Now().UTC().Format(time.RFC3339Nano)).
-		WithExec([]string{"git", "fetch", "--tags"}).
-		WithExec([]string{"git", "tag", "-l", "--points-at=" + commit}).
-		Stdout(ctx)
-	if err != nil {
-		return nil, err
-	}
-	out = strings.TrimSpace(out)
-	if out == "" {
-		return nil, nil
-	}
-	return strings.Split(out, "\n"), nil
-}
-
-func refTimestamp(ctx context.Context, head *dagger.GitRef) (time.Time, error) {
-	checkout := head.Tree()
-	status, err := dag.Container().
-		From("alpine/git:latest").
-		WithWorkdir("/src").
-		WithMountedDirectory(".", checkout).
-		WithExec([]string{"git", "log", "-1", "--format=%cI"}).
-		Stdout(ctx)
-	if err != nil {
-		return time.Time{}, err
-	}
-	status = strings.TrimSpace(status)
-	t, err := time.Parse(time.RFC3339, status)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return t, nil
-}
-
-func pseudoversionTimestamp(t time.Time) string {
-	// go time formatting is bizarre - this translates to "yyyymmddhhmmss"
-	// inspired from: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.22.0:module/pseudo.go
-	return t.UTC().Format("20060102150405")
 }
 
 // NextReleaseVersion returns the next release version from .changes/.next


### PR DESCRIPTION
Replace the alpine/git tag fetch with the GitRepository API and hydrate tags via includeTags when the version module needs to detect a release tag.

Drop timestamps from dev versions and use vX.Y.Z-dev-<commit-or-digest> instead. The timestamp had some value, but not enough to justify materializing a checkout just to run alpine/git for git log; the commit or input digest is enough for the version module's current uses.

This reduces cold wait time for `version` from about 1 minute to about 5 seconds. Follow-up work on workspaces should reduce it close to zero by avoiding unnecessary materialized worktrees.

Alternative to #13313 which was also trying, among other things, to reduce the wait time.