### PR TITLE
feat(cli): add hidden `functions` root alias for `api functions`

### DIFF
--- a/future/cli-1.0.md
+++ b/future/cli-1.0.md
@@ -746,6 +746,7 @@ Status legend: ✅ shipped on this branch | 🟡 partially shipped | ⬜ designe
 ### Shipped — hidden aliases
 
 - ✅ **`dagger call`** — hidden alias to `dagger api call`.
+- ✅ **`dagger functions`** — hidden alias to `dagger api functions`.
 - ✅ **`dagger run`** — hidden alias to `dagger api exec`.
 - ✅ **`dagger shell`** — hidden, reachable.
 

--- a/internal/cmd/dagger/call.go
+++ b/internal/cmd/dagger/call.go
@@ -59,6 +59,10 @@ var apiCallCmd = &FuncCommand{
 
 var apiFunctionsCmd = newFunctionListCmd("functions [options] [function]...", false)
 
+// functionsAliasCmd is a hidden root-level alias for `dagger api functions`,
+// mirroring how callModCmd aliases `dagger api call`.
+var functionsAliasCmd = newFunctionListCmd("functions [options] [function]...", true)
+
 func newFunctionListCmd(use string, hidden bool) *cobra.Command {
 	return &cobra.Command{
 		Use:   use,

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -204,6 +204,7 @@ func init() {
 		sdkCmd,
 		callCoreCmd.Command(),
 		callModCmd.Command(),
+		functionsAliasCmd,
 		sessionAliasCmd,
 		shellCmd,
 		mcpCmd,

--- a/internal/cmd/dagger/module.go
+++ b/internal/cmd/dagger/module.go
@@ -58,6 +58,7 @@ func init() {
 	moduleAddFlags(callModCmd.Command(), callModCmd.Command().PersistentFlags(), true)
 
 	moduleAddFlags(apiFunctionsCmd, apiFunctionsCmd.PersistentFlags(), false)
+	moduleAddFlags(functionsAliasCmd, functionsAliasCmd.PersistentFlags(), false)
 	moduleAddFlags(apiListenCmd, apiListenCmd.PersistentFlags(), true)
 	moduleAddFlags(listenCmd, listenCmd.PersistentFlags(), true)
 	moduleAddFlags(apiQueryCmd, apiQueryCmd.PersistentFlags(), true)


### PR DESCRIPTION
## What

Adds a hidden `dagger functions` root-level alias for `dagger api functions`, so the subcommand stays reachable from the root for backward compatibility without appearing in help output.

`dagger call` already exists as a hidden root alias of `dagger api call` (`callModCmd`), so this PR adds the symmetric, previously-missing `functions` alias. Both subcommands are now reachable from the root and hidden from help.

## Changes

- `internal/cmd/dagger/call.go` — add `functionsAliasCmd` via the existing `newFunctionListCmd(..., true)` factory (hidden), mirroring the visible `apiFunctionsCmd`.
- `internal/cmd/dagger/main.go` — register `functionsAliasCmd` in `rootCmd`.
- `internal/cmd/dagger/module.go` — wire module flags for `functionsAliasCmd`, matching `apiFunctionsCmd`.

## Notes

- The alias is hidden: it does not show up in `dagger --help` and is excluded from the generated CLI reference (cobradocs skips non-available commands), so no docs regeneration is needed.

## Test plan

- `go build ./...` and command-tree unit tests pass.
- Built the `dagger` binary and confirmed `dagger functions --help` works while `functions` stays absent from `dagger --help`.