### PR TITLE
fix(core): split module-init changeset ownership (engine config-only)

### DIFF
--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/dagger/dagger/core"
@@ -202,7 +203,59 @@ func (s *workspaceSchema) moduleInit(
 		return res, fmt.Errorf("sdk module init: %w", err)
 	}
 
+	// Enforce the ownership split: the SDK's initModule must not touch the
+	// engine-owned config files. Catching it here yields a clear, actionable
+	// error instead of a cryptic "added in both changesets" from the merge
+	// below (or, worse, an SDK silently clobbering config the engine wrote).
+	if err := validateSDKInitChangesetOwnership(ctx, args.SDK, sdkChanges, configRelPath, relPath); err != nil {
+		return res, err
+	}
+
 	return mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
+}
+
+// validateSDKInitChangesetOwnership enforces the CLI-1.0 ownership split: the
+// engine owns the workspace config (dagger.toml) and the module config
+// (dagger-module.toml); the SDK's initModule owns every other file in the
+// module directory. An SDK that writes an engine-owned config would otherwise
+// collide in the merge as a cryptic "added in both changesets" — or silently
+// overwrite the config the engine just generated — so reject it up front.
+func validateSDKInitChangesetOwnership(
+	ctx context.Context,
+	sdkName string,
+	sdkChanges dagql.ObjectResult[*core.Changeset],
+	workspaceConfigPath string,
+	modulePath string,
+) error {
+	if sdkChanges.Self() == nil {
+		return nil
+	}
+	paths, err := sdkChanges.Self().ComputePaths(ctx)
+	if err != nil {
+		return fmt.Errorf("inspect sdk init changeset: %w", err)
+	}
+
+	engineOwned := map[string]string{
+		filepath.Clean(workspaceConfigPath):                             "workspace config",
+		filepath.Join(modulePath, workspace.ModuleConfigFileName):       "module config",
+		filepath.Join(modulePath, workspace.LegacyModuleConfigFileName): "module config",
+	}
+
+	var touched []string
+	for _, p := range slices.Concat(paths.Added, paths.Modified) {
+		if label, ok := engineOwned[filepath.Clean(p)]; ok {
+			touched = append(touched, fmt.Sprintf("%s (%s)", filepath.Clean(p), label))
+		}
+	}
+	slices.Sort(touched)
+	touched = slices.Compact(touched)
+	if len(touched) > 0 {
+		return fmt.Errorf(
+			"sdk %q initModule must not modify engine-owned file(s): %s",
+			sdkName, strings.Join(touched, ", "),
+		)
+	}
+	return nil
 }
 
 // workspaceModuleInitConfigDiff builds the new module's config file

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -31,12 +31,18 @@ type workspaceModuleInitArgs struct {
 }
 
 // moduleInit builds the workspace edits required to create a new module
-// owned by this workspace: codegen output (dagger-module.toml plus
-// SDK-generated source) at `path`, the authoring entry under
-// `[[modules.<sdk>.as-sdk.modules]]`, and - when the default path is used -
-// an `[modules.<name>]` install for the new module so it's callable in this
-// workspace. The SDK must already be installed as an SDK; init is dispatch,
-// not install.
+// owned by this workspace: the module config file (dagger-module.toml) at
+// `path`, the authoring entry under `[[modules.<sdk>.as-sdk.modules]]`, and —
+// when the default path is used — an `[modules.<name>]` install for the new
+// module so it's callable in this workspace. The SDK must already be
+// installed as an SDK; init is dispatch, not install.
+//
+// The engine's changeset is deliberately limited to engine-owned config
+// (the workspace dagger.toml and the module's dagger-module.toml). All other
+// files in the new module directory — starter source, the generated client,
+// language scaffolding — come from the SDK's `initModule` Changeset, which is
+// merged in at the end. The two are disjoint by construction, so the merge
+// never conflicts on a shared path.
 //
 // Every change is staged into one Changeset and returned. No filesystem
 // write happens inside this function; the caller previews via
@@ -129,10 +135,15 @@ func (s *workspaceSchema) moduleInit(
 		return res, fmt.Errorf("update workspace config: %w", err)
 	}
 
-	// Generate the new module's context directory (dagger-module.toml +
-	// SDK-emitted source). The diff is workspace-root-relative because the
-	// moduleSource is constructed against the local workspace context.
-	moduleDiff, err := s.workspaceModuleInitGeneratedDiff(ctx, args, relPath, runtimeRef)
+	// Generate the new module's config file (dagger-module.toml) ONLY. The
+	// engine owns the module config; the SDK's initModule (merged in below)
+	// owns every other file in the module directory — starter source, the
+	// generated client, language scaffolding, etc. Emitting just the config
+	// here keeps the engine and SDK changesets disjoint by construction, so
+	// they can never collide on a shared path ("added in both changesets").
+	// The diff is workspace-root-relative because the moduleSource is
+	// constructed against the local workspace context.
+	moduleDiff, err := s.workspaceModuleInitConfigDiff(ctx, args, relPath, runtimeRef)
 	if err != nil {
 		return res, err
 	}
@@ -194,13 +205,18 @@ func (s *workspaceSchema) moduleInit(
 	return mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
 }
 
-// workspaceModuleInitGeneratedDiff drives the moduleSource codegen chain
-// for the new module and returns the resulting context-directory diff,
-// suitable for overlaying onto the workspace rootfs. runtimeRef is what
-// gets recorded as the module's `runtime` field on disk; it may differ
-// from args.SDK when the SDK delegates execution to a separate runtime
-// module (see resolveModuleRuntimeRef).
-func (s *workspaceSchema) workspaceModuleInitGeneratedDiff(
+// workspaceModuleInitConfigDiff builds the new module's config file
+// (dagger-module.toml) and returns it as a context-directory diff suitable
+// for overlaying onto the workspace rootfs. It deliberately does NOT run
+// codegen: per the CLI-1.0 contract the engine owns only the config file
+// (dagger.toml + dagger-module.toml), while the SDK's initModule owns the
+// rest of the module directory. It therefore selects updatedConfigDirectory
+// (config-only) rather than generatedContextDirectory (full codegen pass),
+// so the engine's changeset stays a single file and never overlaps the
+// SDK's. runtimeRef is what gets recorded as the module's `runtime` field on
+// disk; it may differ from args.SDK when the SDK delegates execution to a
+// separate runtime module (see resolveModuleRuntimeRef).
+func (s *workspaceSchema) workspaceModuleInitConfigDiff(
 	ctx context.Context,
 	args workspaceModuleInitArgs,
 	relPath string,
@@ -251,11 +267,17 @@ func (s *workspaceSchema) workspaceModuleInitGeneratedDiff(
 			Field: "withEngineVersion",
 			Args:  []dagql.NamedInput{{Name: "version", Value: dagql.String(modules.EngineVersionLatest)}},
 		},
-		dagql.Selector{Field: "generatedContextDirectory"},
+		// updatedConfigDirectory writes only the module config file and diffs
+		// it against the (empty) source context, so the result is exactly
+		// {<relPath>/dagger-module.toml}. Using generatedContextDirectory here
+		// would instead run a full SDK codegen pass and emit the starter
+		// source + generated client too, which then collides with the SDK's
+		// own initModule output during the merge below.
+		dagql.Selector{Field: "updatedConfigDirectory"},
 	)
 
 	if err := srv.Select(ctx, srv.Root(), &res, selectors...); err != nil {
-		return res, fmt.Errorf("generate module context: %w", err)
+		return res, fmt.Errorf("generate module config: %w", err)
 	}
 	return res, nil
 }


### PR DESCRIPTION
## Problem

`dagger module init <sdk> <name>` merges two changesets — the engine's and the SDK's `initModule` output — and failed with `path added in both changesets` for every SDK whose `initModule` scaffolds files:

```
$ dagger module init typescript-sdk my-ts-mod --template=legacy
! merge sdk init changes: conflict between changesets at path ".dagger/modules/my-ts-mod/package.json": path added in both changesets
  ... src/index.ts, tsconfig.json
$ dagger module init python my-py-mod --template=legacy
! merge sdk init changes: conflict between changesets at path ".dagger/modules/my-py-mod/.gitattributes": path added in both changesets
  ... .gitignore, pyproject.toml, src/<mod>/__init__.py, src/<mod>/main.py
```

**Root cause:** the engine built its changeset via the moduleSource `generatedContextDirectory` field, which runs a *full SDK codegen pass* and emits the module config **plus** all the starter source and managed/generated files. The SDK's own `initModule` emits those same files → collision. #13392 patched the Go codegen to skip `main.go`, but that per-file band-aid doesn't scale to TS/Python's much broader overlap.

## Fix

`future/cli-1.0.md` already specifies the ownership split (engine owns `dagger.toml` + `dagger-module.toml`; the SDK's `initModule` owns the rest — lines 307/309, and line 494: *"engine validates SDK Changesets don't touch engine-owned files"*). The engine already had the right building block: the `updatedConfigDirectory` field, which writes byte-identical config content but skips codegen.

- **`fix(core): emit only the module config in the init changeset`** — the init path now selects `updatedConfigDirectory` instead of `generatedContextDirectory`. The engine changeset becomes exactly `{dagger.toml, <path>/dagger-module.toml}` and the SDK's `initModule` owns everything else, so the two are **disjoint by construction** — no conflict, for every SDK, not just Go. Also drops the now-redundant codegen pass at init (faster).
- **`fix(core): reject SDK init changesets touching engine-owned config`** — implements the line-494 guard: a clear, actionable error if an SDK's `initModule` writes `dagger.toml`/`dagger-module.toml`, instead of a cryptic "added in both" (or a silent clobber).

This generalizes #13392 (the per-file `main.go` skip is now subsumed and can be reverted as a follow-up cleanup).

## Note

Since the engine no longer codegens at init, each SDK's `initModule` must own the complete module (including the generated client) — which is the SDK's job per the design contract (in-repo SDKs don't implement `initModule`; that lives in the external SDK repos, design-doc line 759).

## Test plan

- [x] `go build ./core/... ./cmd/codegen/... ./internal/cmd/dagger/...`, `go vet`, `gofmt` clean
- [x] init-wiring unit tests pass
- [x] manual: `dagger module init typescript-sdk my-ts-mod --template=legacy` and `dagger module init python my-py-mod --template=legacy` now succeed (engine contributes only `dagger-module.toml`)
