### PR TITLE
fix(cli): keep silent SDK-init session out of shared telemetry exporters

### DIFF
--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -292,22 +292,44 @@ func resolveLockMode(paramLockMode, globalLockMode string) (string, error) {
 	return string(mode), nil
 }
 
-func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
-	// Setup telemetry config
-	telemetryCfg := telemetry.Config{
-		Detect:   true,
+// skipSharedTelemetryExporters, when set, makes engineTelemetryConfig leave out
+// the process-wide OTLP exporter singletons (Dagger Cloud + the OTEL_* "Detect"
+// exporters). It is toggled by withEngineSilent for internal plumbing sessions;
+// see engineTelemetryConfig for why.
+var skipSharedTelemetryExporters bool
+
+// engineTelemetryConfig builds the telemetry pipeline for one engine session.
+//
+// Internal plumbing sessions (see skipSharedTelemetryExporters) opt out of the
+// process-wide OTLP exporter singletons — the Dagger Cloud exporters and the
+// OTEL_* "Detect" exporters. Those singletons are sync.Once-cached and get shut
+// down by telemetry.Close(); a pre-command session that wired them up and then
+// tore them down would leave them dead for the real command that runs next in
+// the same process, surfacing "HTTP exporter is shutdown" / "context canceled"
+// telemetry warnings (e.g. the second session opened by `dagger module init`).
+// Such sessions render to a discard frontend and have no reason to export to
+// Cloud, so they simply skip the shared exporters.
+func engineTelemetryConfig(ctx context.Context) telemetry.Config {
+	cfg := telemetry.Config{
+		Detect:   !skipSharedTelemetryExporters,
 		Resource: Resource(ctx),
 
 		LiveTraceExporters:  []sdktrace.SpanExporter{Frontend.SpanExporter()},
 		LiveLogExporters:    []sdklog.Exporter{Frontend.LogExporter()},
 		LiveMetricExporters: []sdkmetric.Exporter{Frontend.MetricExporter()},
 	}
-	if spans, logs, metrics, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
-		telemetryCfg.LiveTraceExporters = append(telemetryCfg.LiveTraceExporters, spans)
-		telemetryCfg.LiveLogExporters = append(telemetryCfg.LiveLogExporters, logs)
-		telemetryCfg.LiveMetricExporters = append(telemetryCfg.LiveMetricExporters, metrics)
+	if !skipSharedTelemetryExporters {
+		if spans, logs, metrics, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
+			cfg.LiveTraceExporters = append(cfg.LiveTraceExporters, spans)
+			cfg.LiveLogExporters = append(cfg.LiveLogExporters, logs)
+			cfg.LiveMetricExporters = append(cfg.LiveMetricExporters, metrics)
+		}
 	}
-	ctx = telemetry.Init(ctx, telemetryCfg)
+	return cfg
+}
+
+func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
+	ctx = telemetry.Init(ctx, engineTelemetryConfig(ctx))
 	// telemetry.Init extracts inherited OTel baggage from the environment.
 	// Re-apply explicit local process settings afterward so a nested Dagger
 	// command's own NO_COLOR/debug request wins over parent baggage.

--- a/internal/cmd/dagger/engine_test.go
+++ b/internal/cmd/dagger/engine_test.go
@@ -1,0 +1,37 @@
+package daggercmd
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/dagger/dagger/dagql/idtui"
+)
+
+// TestEngineTelemetryConfigSkipsSharedExporters guards the fix for the noisy
+// "HTTP exporter is shutdown" / "context canceled" telemetry warnings emitted by
+// the second engine session that `dagger module init` opens. Internal plumbing
+// sessions must not wire up (and later tear down) the process-wide OTLP exporter
+// singletons, otherwise the real command that runs next in the same process
+// re-exports into already-shut-down exporters. See engineTelemetryConfig.
+func TestEngineTelemetryConfigSkipsSharedExporters(t *testing.T) {
+	oldFrontend := Frontend
+	oldSkip := skipSharedTelemetryExporters
+	Frontend = idtui.NewPlain(io.Discard)
+	t.Cleanup(func() {
+		Frontend = oldFrontend
+		skipSharedTelemetryExporters = oldSkip
+	})
+
+	ctx := context.Background()
+
+	skipSharedTelemetryExporters = false
+	if cfg := engineTelemetryConfig(ctx); !cfg.Detect {
+		t.Fatal("expected Detect to be enabled for a normal session")
+	}
+
+	skipSharedTelemetryExporters = true
+	if cfg := engineTelemetryConfig(ctx); cfg.Detect {
+		t.Fatal("expected Detect to be disabled for an internal silent session")
+	}
+}

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -672,11 +672,18 @@ func normalizeWorkspaceGitOrigin(origin string) string {
 func withEngineSilent(ctx context.Context, params client.Params, fn runClientCallback) error {
 	oldFrontend := Frontend
 	oldOpts := opts
+	oldSkip := skipSharedTelemetryExporters
 	Frontend = idtui.NewPlain(io.Discard)
 	opts.Silent = true
+	// This is an internal plumbing session (e.g. the pre-command dynamic SDK-init
+	// registration). Keep it out of the process-wide OTLP exporter singletons so
+	// it doesn't shut them down for the real command that follows in the same
+	// process. See engineTelemetryConfig.
+	skipSharedTelemetryExporters = true
 	defer func() {
 		Frontend = oldFrontend
 		opts = oldOpts
+		skipSharedTelemetryExporters = oldSkip
 	}()
 	return withEngine(ctx, params, fn)
 }


### PR DESCRIPTION
## Problem

On `design/cli-1.0`, `dagger module init <sdk> <name>` (and `dagger api client init`) always end with noisy telemetry warnings:

```
42  : applying changes
43  : ┆ Changeset.export(path: "/root/src/empty"): String!
44  : ┆ ┆ export changeset to host /root/src/empty
44  : ┆ ┆ export changeset to host /root/src/empty DONE [0.0s]
43  : ┆ Changeset.export DONE [0.0s]
42  : applying changes DONE [0.0s]
43  : ┆ Changeset.export(path: "/root/src/empty"): String!
45  : ┆ ┆ downloading /root/src/empty
45  : ┆ ┆ downloading /root/src/empty DONE [0.0s]

WARN - failures detected while emitting telemetry. trace information incomplete
(traces export: Post "http://127.0.0.1:40381/v1/traces": context canceled)


12:16:19 WRN consume error path=/v1/metrics traceID=cb9be0a0c5b588d6d6f1c8ce79abaa39 clientID=lml5w92z4ryzyn4csh1r6gtdq err="re-export metrics: failed to export resource metrics: failed to upload metrics: HTTP exporter is shutdown"
12:16:30 WRN consume error path=/v1/metrics traceID=cb9be0a0c5b588d6d6f1c8ce79abaa39 clientID=lml5w92z4ryzyn4csh1r6gtdq err="re-export metrics: failed to export resource metrics: failed to upload metrics: HTTP exporter is shutdown"
```

## Root cause

`module init` / `api client init` are the only commands that open **two telemetry cycles in one process**:

1. **Pre-command session** — `registerInstalledSDKInitCommands` runs before `rootCmd.Execute` to introspect installed SDKs and build the dynamic subcommands, via `withEngineSilent` (a full `telemetry.Init` → `telemetry.Close()`).
2. **Real session** — the init itself (`withEngine`), a second full `telemetry.Init` / `Close()`.

The process-wide OTLP exporters are `sync.Once`-cached singletons — the Dagger Cloud exporters (`engine/telemetry/cloud.go`) and the `OTEL_*` "Detect" exporters (`otel-go/init.go`). Cycle 1's `telemetry.Close()` shuts them down; cycle 2 reuses the same now-dead instances and re-exports the engine's streamed telemetry into them:

- metrics SSE consumer (`engine/client/client.go`) → `re-export metrics: … HTTP exporter is shutdown`
- the env-configured trace exporter → `traces export: Post ".../v1/traces": context canceled`

Single-cycle commands (`dagger call`, …) never hit this — which is exactly why only `module init` / `client init` are noisy.

## Fix

The pre-command silent session is internal plumbing: it renders to a discard frontend and has no reason to export to Cloud. Mark those sessions so they skip the shared exporter singletons; the real command then initializes them fresh and shuts them down exactly once.

- `internal/cmd/dagger/engine.go` — new `skipSharedTelemetryExporters` flag + `engineTelemetryConfig(ctx)` that gates `Detect` and `ConfiguredCloudExporters` behind it.
- `internal/cmd/dagger/workspace.go` — `withEngineSilent` sets/restores the flag, alongside the existing `Frontend` / `opts` swap.
- `internal/cmd/dagger/engine_test.go` — regression test (verified it goes red without the gating).

### Expected output after the fix

```
42  : applying changes DONE [0.0s]
43  : ┆ Changeset.export(path: "/root/src/empty"): String!
45  : ┆ ┆ downloading /root/src/empty
45  : ┆ ┆ downloading /root/src/empty DONE [0.0s]
```

The trailing `WARN` / `WRN` telemetry block no longer appears.

## Verification

`go build` ✓, `go vet` ✓, the new unit test passes (and fails without the gating). I did **not** run a full end-to-end repro — that needs a dev engine built from this branch + Cloud (or `OTEL_*`) configured + a workspace with an SDK installed to drive the two-cycle path. Confirmation via a real `dagger module init` run on such a setup would be welcome.

## ❓ Question for reviewers

With this change, the internal SDK-introspection session no longer reports to Cloud at all. That's almost certainly desirable — it's invisible plumbing (discard frontend) and would otherwise emit orphan traces unlinked from the command's root span. But it **is** a behavior change, so flagging it explicitly: if internal-session telemetry should instead be preserved in Cloud, that needs a different approach (e.g. sharing a single telemetry lifecycle across both the pre-command and the real session, rather than two `Init`/`Close` cycles).
