### PR TITLE
feat: Service.publish for host exposed ports

### DIFF
--- a/.changes/unreleased/Added-20260620-000305.yaml
+++ b/.changes/unreleased/Added-20260620-000305.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: |
+  Add `Service.publish` so trusted modules can publish service ports on the host from inside a function.
+time: 2026-06-20T00:03:05Z
+custom:
+  Author: dagger-codex[bot]

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -2076,12 +2076,13 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		var nestedClientMetadata *engine.ClientMetadata
 		if opts.ExperimentalPrivilegedNesting {
 			nestedClientMetadata = &engine.ClientMetadata{
-				ClientID:              identity.NewID(),
-				ClientVersion:         engine.Version,
-				SessionID:             clientMetadata.SessionID,
-				AllowedLLMModules:     slices.Clone(clientMetadata.AllowedLLMModules),
-				LockMode:              clientMetadata.LockMode,
-				UseRecipeIDsByDefault: execMD != nil && execMD.UseRecipeIDsByDefault,
+				ClientID:               identity.NewID(),
+				ClientVersion:          engine.Version,
+				SessionID:              clientMetadata.SessionID,
+				AllowedLLMModules:      slices.Clone(clientMetadata.AllowedLLMModules),
+				AllowedHostPortModules: slices.Clone(clientMetadata.AllowedHostPortModules),
+				LockMode:               clientMetadata.LockMode,
+				UseRecipeIDsByDefault:  execMD != nil && execMD.UseRecipeIDsByDefault,
 			}
 		}
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/identity"
 	resolverconfig "github.com/dagger/dagger/internal/buildkit/util/resolver/config"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -1696,6 +1697,89 @@ func (ServiceSuite) TestHostToContainer(ctx context.Context, t *testctx.T) {
 
 		_, err := c.Host().Tunnel(srv).ID(ctx)
 		require.Error(t, err)
+	})
+}
+
+func (ServiceSuite) TestPublishFromModule(ctx context.Context, t *testctx.T) {
+	modDir := t.TempDir()
+	copyTestdataFixture(ctx, t, modDir, "modules", "go", "service-publish")
+
+	t.Run("denied without opt-in", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		require.NoError(t, c.ModuleSource(modDir).AsModule().Serve(ctx))
+
+		_, err := testutil.QueryWithClient[struct {
+			Test struct {
+				PublishEndpoint string
+			}
+		}](c, t, `{test{publishEndpoint}}`, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "not allowed to publish host ports")
+		require.ErrorContains(t, err, "--allow-host-ports=local")
+	})
+
+	t.Run("allowed local module publishes random host port", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t, dagger.WithAllowedHostPorts("local"))
+		require.NoError(t, c.ModuleSource(modDir).AsModule().Serve(ctx))
+
+		res, err := testutil.QueryWithClient[struct {
+			Test struct {
+				PublishEndpoint string
+			}
+		}](c, t, `{test{publishEndpoint}}`, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Test.PublishEndpoint)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			resp, err := http.Get(res.Test.PublishEndpoint)
+			require.NoError(c, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(c, err)
+			require.Equal(c, http.StatusOK, resp.StatusCode)
+			require.Equal(c, "published from module", string(body))
+		}, time.Minute, time.Second)
+	})
+
+	t.Run("published service handle can start and stop", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t, dagger.WithAllowedHostPorts("local"))
+		require.NoError(t, c.ModuleSource(modDir).AsModule().Serve(ctx))
+
+		res, err := testutil.QueryWithClient[struct {
+			Test struct {
+				PublishStartStop string
+			}
+		}](c, t, `{test{publishStartStop}}`, nil)
+		require.NoError(t, err)
+		require.Equal(t, "ok", res.Test.PublishStartStop)
+	})
+
+	t.Run("fixed port collision fails", func(ctx context.Context, t *testctx.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+
+		_, portStr, err := net.SplitHostPort(listener.Addr().String())
+		require.NoError(t, err)
+		port, err := strconv.Atoi(portStr)
+		require.NoError(t, err)
+
+		c := connect(ctx, t, dagger.WithAllowedHostPorts("local"))
+		require.NoError(t, c.ModuleSource(modDir).AsModule().Serve(ctx))
+
+		_, err = testutil.QueryWithClient[struct {
+			Test struct {
+				PublishFixed string
+			}
+		}](c, t, `query PublishFixed($frontend: Int!){test{publishFixed(frontend:$frontend)}}`, &testutil.QueryOptions{
+			Operation: "PublishFixed",
+			Variables: map[string]any{
+				"frontend": port,
+			},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, strconv.Itoa(port))
 	})
 }
 

--- a/core/integration/testdata/modules/go/service-publish/dagger.json
+++ b/core/integration/testdata/modules/go/service-publish/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "engineVersion": "v1.0.0-0",
+  "sdk": {
+    "source": "go"
+  }
+}

--- a/core/integration/testdata/modules/go/service-publish/main.go
+++ b/core/integration/testdata/modules/go/service-publish/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+
+	"dagger/test/internal/dagger"
+)
+
+type Test struct{}
+
+func (*Test) PublishEndpoint(ctx context.Context) (string, error) {
+	return publish(ctx, 0, true)
+}
+
+func (*Test) PublishFixed(ctx context.Context, frontend int) (string, error) {
+	return publish(ctx, frontend, false)
+}
+
+func (*Test) PublishStartStop(ctx context.Context) (string, error) {
+	svc := publishService(0, true)
+	started, err := svc.Start(ctx)
+	if err != nil {
+		return "", err
+	}
+	if _, err := started.Stop(ctx, dagger.ServiceStopOpts{Kill: true}); err != nil {
+		return "", err
+	}
+	return "ok", nil
+}
+
+func publish(ctx context.Context, frontend int, random bool) (string, error) {
+	svc := publishService(frontend, random)
+
+	return svc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "http"})
+}
+
+func publishService(frontend int, random bool) *dagger.Service {
+	return dag.Container().
+		From("python").
+		WithMountedDirectory(
+			"/srv/www",
+			dag.Directory().WithNewFile("index.html", "published from module"),
+		).
+		WithWorkdir("/srv/www").
+		WithExposedPort(8000).
+		WithDefaultArgs([]string{"python", "-m", "http.server", "8000"}).
+		AsService().
+		Publish(dagger.ServicePublishOpts{
+			Ports: []dagger.PortForward{{
+				Backend:  8000,
+				Frontend: frontend,
+			}},
+			Random: random,
+		})
+}

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -2,12 +2,16 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/internal/buildkit/identity"
 )
 
 type serviceSchema struct{}
@@ -128,6 +132,17 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 		dagql.NodeFunc("up", s.up).
 			DoNotCache("Starts a host tunnel, possibly with ports that change each time it's started.").
 			Doc(`Creates a tunnel that forwards traffic from the caller's network to this service.`).
+			Args(
+				dagql.Arg("ports").Doc(`List of frontend/backend port mappings to forward.`,
+					`Frontend is the port accepting traffic on the host, backend is the service port.`),
+				dagql.Arg("random").Doc(`Bind each tunnel port to a random port on the host.`),
+			),
+
+		dagql.NodeFunc("publish", s.publish).
+			View(AfterVersion("v1.0.0-0")).
+			DoNotCache("Starts a host tunnel, possibly with ports that change each time it's started.").
+			Doc(`Start this service and publish its ports on the main client's host.`,
+				`Nested module calls require explicit host-port permission.`).
 			Args(
 				dagql.Arg("ports").Doc(`List of frontend/backend port mappings to forward.`,
 					`Frontend is the port accepting traffic on the host, backend is the service port.`),
@@ -454,7 +469,11 @@ func (s *serviceSchema) start(ctx context.Context, parent dagql.ObjectResult[*co
 	if err != nil {
 		return res, err
 	}
-	if _, err := svcs.StartResult(ctx, parent, parent.Self().TunnelUpstream.Self() != nil); err != nil {
+	runtimeCtx, err := parent.Self().RuntimeContext(ctx)
+	if err != nil {
+		return res, err
+	}
+	if _, err := svcs.StartResult(runtimeCtx, parent, parent.Self().TunnelUpstream.Self() != nil); err != nil {
 		return res, err
 	}
 
@@ -525,21 +544,23 @@ type UpArgs struct {
 
 const InstrumentationLibrary = "dagger.io/engine.schema"
 
-func (s *serviceSchema) up(ctx context.Context, svc dagql.ObjectResult[*core.Service], args UpArgs) (res dagql.Nullable[core.Void], _ error) {
-	void := dagql.Null[core.Void]()
-
+func (s *serviceSchema) hostTunnel(
+	ctx context.Context,
+	svc dagql.ObjectResult[*core.Service],
+	args UpArgs,
+) (dagql.ObjectResult[*core.Service], error) {
+	var hostSvc dagql.ObjectResult[*core.Service]
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return res, fmt.Errorf("failed to get Dagger server: %w", err)
+		return hostSvc, fmt.Errorf("failed to get Dagger server: %w", err)
 	}
 	svcID, err := svc.ID()
 	if err != nil {
-		return res, fmt.Errorf("service ID: %w", err)
+		return hostSvc, fmt.Errorf("service ID: %w", err)
 	}
 
 	useNative := !args.Random && len(args.Ports) == 0
 
-	var hostSvc dagql.Result[*core.Service]
 	err = srv.Select(ctx, srv.Root(), &hostSvc,
 		dagql.Selector{
 			Field: "host",
@@ -554,7 +575,17 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.ObjectResult[*core.Ser
 		},
 	)
 	if err != nil {
-		return res, fmt.Errorf("failed to select host service: %w", err)
+		return hostSvc, fmt.Errorf("failed to select host service: %w", err)
+	}
+	return hostSvc, nil
+}
+
+func (s *serviceSchema) up(ctx context.Context, svc dagql.ObjectResult[*core.Service], args UpArgs) (res dagql.Nullable[core.Void], _ error) {
+	void := dagql.Null[core.Void]()
+
+	hostSvc, err := s.hostTunnel(ctx, svc, args)
+	if err != nil {
+		return res, err
 	}
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
@@ -573,6 +604,111 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.ObjectResult[*core.Ser
 		return res, fmt.Errorf("failed to start host service: %w", err)
 	}
 
+	logTunnelStarted(ctx, runningSvc)
+
+	// wait for the request to be canceled
+	<-ctx.Done()
+
+	return void, nil
+}
+
+func (s *serviceSchema) publish(ctx context.Context, svc dagql.ObjectResult[*core.Service], args UpArgs) (dagql.ObjectResult[*core.Service], error) {
+	var res dagql.ObjectResult[*core.Service]
+	if err := s.allowHostPortPublish(ctx); err != nil {
+		return res, err
+	}
+
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return res, err
+	}
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return res, err
+	}
+	mainClientMetadata, err := query.MainClientCallerMetadata(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to get main client metadata: %w", err)
+	}
+	hostSvc, err := s.hostTunnel(ctx, svc, args)
+	if err != nil {
+		return res, err
+	}
+	publishedSvc := hostSvc.Self().Clone()
+	publishedSvc.TunnelUpstreamClientID = clientMetadata.ClientID
+	publishedSvc.TunnelListenClientID = mainClientMetadata.ClientID
+
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to get Dagger server: %w", err)
+	}
+	res, err = newPublishedServiceResult(ctx, srv, publishedSvc)
+	if err != nil {
+		return res, err
+	}
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to get Dagger cache: %w", err)
+	}
+	if clientMetadata.SessionID == "" {
+		return res, fmt.Errorf("failed to attach published service: empty session ID")
+	}
+	attachedAny, err := cache.AttachResult(ctx, clientMetadata.SessionID, srv, res)
+	if err != nil {
+		return res, fmt.Errorf("failed to attach published service: %w", err)
+	}
+	attached, ok := attachedAny.(dagql.ObjectResult[*core.Service])
+	if !ok {
+		return res, fmt.Errorf("failed to attach published service: expected %T, got %T", res, attachedAny)
+	}
+	res = attached
+	publishedSvc = res.Self()
+
+	svcs, err := query.Services(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to get host services: %w", err)
+	}
+	hostSvcDig, err := res.ContentPreferredDigest(ctx)
+	if err != nil {
+		return res, fmt.Errorf("host service digest: %w", err)
+	}
+	runtimeCtx, err := publishedSvc.RuntimeContext(ctx)
+	if err != nil {
+		return res, err
+	}
+	runningSvc, err := svcs.Start(runtimeCtx, hostSvcDig, publishedSvc, true)
+	if err != nil {
+		return res, fmt.Errorf("failed to publish host service: %w", err)
+	}
+
+	logTunnelStarted(ctx, runningSvc)
+	return res, nil
+}
+
+func newPublishedServiceResult(
+	ctx context.Context,
+	srv *dagql.Server,
+	svc *core.Service,
+) (dagql.ObjectResult[*core.Service], error) {
+	var res dagql.ObjectResult[*core.Service]
+	publishCall := (&dagql.CallRequest{ResultCall: dagql.CurrentCall(ctx)}).Clone().ResultCall
+	if publishCall == nil {
+		return res, fmt.Errorf("current call is nil")
+	}
+	// publish allocates listener state on a specific host client. Give the
+	// returned handle a unique recipe identity so attaching it cannot reuse a
+	// cached tunnel with stale session/client ownership or a previous random port.
+	publishCall.ImplicitInputs = append(publishCall.ImplicitInputs, &dagql.ResultCallArg{
+		Name: "service.publish.id",
+		Value: &dagql.ResultCallLiteral{
+			Kind:        dagql.ResultCallLiteralKindString,
+			StringValue: identity.NewID(),
+		},
+	})
+	return dagql.NewObjectResultForCall(svc, srv, publishCall)
+}
+
+func logTunnelStarted(ctx context.Context, runningSvc *core.RunningService) {
 	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	for _, port := range runningSvc.Ports {
@@ -588,9 +724,68 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.ObjectResult[*core.Ser
 			"description", *port.Description,
 		)
 	}
+}
 
-	// wait for the request to be canceled
-	<-ctx.Done()
+func (s *serviceSchema) allowHostPortPublish(ctx context.Context) error {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	mainClientMetadata, err := query.MainClientCallerMetadata(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get main client metadata: %w", err)
+	}
+	if clientMetadata.ClientID == mainClientMetadata.ClientID {
+		return nil
+	}
 
-	return void, nil
+	mod, err := query.CurrentModule(ctx)
+	if err != nil {
+		if errors.Is(err, core.ErrNoCurrentModule) {
+			return fmt.Errorf("nested clients must be executing a module to publish host ports")
+		}
+		return fmt.Errorf("failed to determine module for host port permission: %w", err)
+	}
+	if !mod.Self().ContextSource.Valid || mod.Self().ContextSource.Value.Self() == nil {
+		return fmt.Errorf("module %q has no context source for host port permission", mod.Self().NameField)
+	}
+	src := mod.Self().ContextSource.Value.Self()
+	if hostPortModuleAllowed(mainClientMetadata.AllowedHostPortModules, src) {
+		return nil
+	}
+	return fmt.Errorf("module %q is not allowed to publish host ports; pass --allow-host-ports=%s to allow", mod.Self().NameField, hostPortAllowHint(src))
+}
+
+func hostPortModuleAllowed(allowed []string, src *core.ModuleSource) bool {
+	for _, entry := range allowed {
+		switch strings.TrimSpace(entry) {
+		case "all":
+			return true
+		case "local":
+			if src.Kind == core.ModuleSourceKindLocal || src.Kind == core.ModuleSourceKindDir {
+				return true
+			}
+		default:
+			if src.Kind == core.ModuleSourceKindGit && src.Git != nil && strings.TrimSpace(entry) == src.Git.Symbolic {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hostPortAllowHint(src *core.ModuleSource) string {
+	switch src.Kind {
+	case core.ModuleSourceKindLocal, core.ModuleSourceKindDir:
+		return "local"
+	case core.ModuleSourceKindGit:
+		if src.Git != nil && src.Git.Symbolic != "" {
+			return src.Git.Symbolic
+		}
+	}
+	return "all"
 }

--- a/core/schema/service_test.go
+++ b/core/schema/service_test.go
@@ -1,0 +1,93 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostPortModuleAllowed(t *testing.T) {
+	t.Parallel()
+
+	localSrc := &core.ModuleSource{
+		Kind: core.ModuleSourceKindLocal,
+	}
+	dirSrc := &core.ModuleSource{
+		Kind: core.ModuleSourceKindDir,
+	}
+	gitSrc := &core.ModuleSource{
+		Kind: core.ModuleSourceKindGit,
+		Git: &core.GitModuleSource{
+			Symbolic: "github.com/acme/trusted/subdir",
+		},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		allowed []string
+		src     *core.ModuleSource
+		want    bool
+	}{
+		{
+			name:    "local allowed",
+			allowed: []string{"local"},
+			src:     localSrc,
+			want:    true,
+		},
+		{
+			name:    "directory source allowed as local",
+			allowed: []string{"local"},
+			src:     dirSrc,
+			want:    true,
+		},
+		{
+			name:    "local denied without local or all",
+			allowed: []string{"github.com/acme/trusted/subdir"},
+			src:     localSrc,
+			want:    false,
+		},
+		{
+			name:    "git allowed by exact symbolic ref",
+			allowed: []string{"github.com/acme/trusted/subdir"},
+			src:     gitSrc,
+			want:    true,
+		},
+		{
+			name:    "git denied by different ref",
+			allowed: []string{"github.com/acme/other"},
+			src:     gitSrc,
+			want:    false,
+		},
+		{
+			name:    "git denied by local",
+			allowed: []string{"local"},
+			src:     gitSrc,
+			want:    false,
+		},
+		{
+			name:    "all allows local",
+			allowed: []string{"all"},
+			src:     localSrc,
+			want:    true,
+		},
+		{
+			name:    "all allows git",
+			allowed: []string{"all"},
+			src:     gitSrc,
+			want:    true,
+		},
+		{
+			name:    "trim spaces",
+			allowed: []string{" github.com/acme/trusted/subdir "},
+			src:     gitSrc,
+			want:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, hostPortModuleAllowed(tc.allowed, tc.src))
+		})
+	}
+}

--- a/core/sdk/dang/shared/shared.go
+++ b/core/sdk/dang/shared/shared.go
@@ -103,13 +103,14 @@ func NewNestedClientMetadata(ctx context.Context) (*engine.ClientMetadata, *engi
 	}
 
 	nestedClientMetadata := &engine.ClientMetadata{
-		ClientID:          identity.NewID(),
-		ClientSecretToken: identity.NewID(),
-		SessionID:         clientMetadata.SessionID,
-		ClientStableID:    identity.NewID(),
-		ClientVersion:     engine.Version,
-		AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
-		LockMode:          clientMetadata.LockMode,
+		ClientID:               identity.NewID(),
+		ClientSecretToken:      identity.NewID(),
+		SessionID:              clientMetadata.SessionID,
+		ClientStableID:         identity.NewID(),
+		ClientVersion:          engine.Version,
+		AllowedLLMModules:      slices.Clone(clientMetadata.AllowedLLMModules),
+		AllowedHostPortModules: slices.Clone(clientMetadata.AllowedHostPortModules),
+		LockMode:               clientMetadata.LockMode,
 	}
 
 	return clientMetadata, nestedClientMetadata, nil

--- a/core/service.go
+++ b/core/service.go
@@ -64,6 +64,10 @@ type Service struct {
 	TunnelUpstream dagql.ObjectResult[*Service]
 	// TunnelPorts configures the port forwarding rules for the tunnel.
 	TunnelPorts []PortForward
+	// TunnelUpstreamClientID is the client that owns the upstream service.
+	TunnelUpstreamClientID string
+	// TunnelListenClientID is the client whose host should bind the tunnel ports.
+	TunnelListenClientID string
 
 	// The sockets on the host to reverse tunnel
 	HostSockets []*Socket
@@ -96,6 +100,8 @@ type persistedServicePayload struct {
 	ExecMeta                      *executor.Meta                `json:"execMeta,omitempty"`
 	TunnelUpstreamResultID        uint64                        `json:"tunnelUpstreamResultID,omitempty"`
 	TunnelPorts                   []PortForward                 `json:"tunnelPorts,omitempty"`
+	TunnelUpstreamClientID        string                        `json:"tunnelUpstreamClientID,omitempty"`
+	TunnelListenClientID          string                        `json:"tunnelListenClientID,omitempty"`
 	HostSockets                   []persistedServiceHostSocket  `json:"hostSockets,omitempty"`
 }
 
@@ -127,6 +133,8 @@ func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.Persi
 		ExecMD:                        svc.ExecMD,
 		ExecMeta:                      svc.ExecMeta,
 		TunnelPorts:                   slices.Clone(svc.TunnelPorts),
+		TunnelUpstreamClientID:        svc.TunnelUpstreamClientID,
+		TunnelListenClientID:          svc.TunnelListenClientID,
 		HostSockets:                   make([]persistedServiceHostSocket, 0, len(svc.HostSockets)),
 	}
 	var err error
@@ -206,6 +214,8 @@ func (*Service) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ 
 		ExecMeta:                      persisted.ExecMeta,
 		TunnelUpstream:                tunnelUpstream,
 		TunnelPorts:                   slices.Clone(persisted.TunnelPorts),
+		TunnelUpstreamClientID:        persisted.TunnelUpstreamClientID,
+		TunnelListenClientID:          persisted.TunnelListenClientID,
 		HostSockets:                   hostSockets,
 	}, nil
 }
@@ -299,6 +309,34 @@ func (svc *Service) Clone() *Service {
 	return &cp
 }
 
+func contextWithServiceClientID(ctx context.Context, clientID string) (context.Context, error) {
+	if clientID == "" {
+		return ctx, nil
+	}
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	clientMetadata, err := query.SpecificClientMetadata(ctx, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("service client %q: %w", clientID, err)
+	}
+	return engine.ContextWithClientMetadata(ctx, clientMetadata), nil
+}
+
+// RuntimeContext returns the client context that owns this service's running
+// key. Tunnel services published to the host are keyed by their listener owner.
+func (svc *Service) RuntimeContext(ctx context.Context) (context.Context, error) {
+	if svc.TunnelUpstream.Self() != nil && svc.TunnelListenClientID != "" {
+		return contextWithServiceClientID(ctx, svc.TunnelListenClientID)
+	}
+	return ctx, nil
+}
+
+func (svc *Service) tunnelUpstreamContext(ctx context.Context) (context.Context, error) {
+	return contextWithServiceClientID(ctx, svc.TunnelUpstreamClientID)
+}
+
 func (svc *Service) Evaluate(ctx context.Context) error {
 	return nil
 }
@@ -329,7 +367,11 @@ func (svc *Service) Hostname(ctx context.Context, dig digest.Digest) (string, er
 		if err != nil {
 			return "", err
 		}
-		upstream, err := svcs.Get(ctx, dig, true)
+		runtimeCtx, err := svc.RuntimeContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		upstream, err := svcs.Get(runtimeCtx, dig, true)
 		if err != nil {
 			return "", err
 		}
@@ -358,7 +400,11 @@ func (svc *Service) Ports(ctx context.Context, dig digest.Digest) ([]Port, error
 		if err != nil {
 			return nil, err
 		}
-		running, err := svcs.Get(ctx, dig, svc.TunnelUpstream.Self() != nil)
+		runtimeCtx, err := svc.RuntimeContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		running, err := svcs.Get(runtimeCtx, dig, svc.TunnelUpstream.Self() != nil)
 		if err != nil {
 			return nil, err
 		}
@@ -398,7 +444,11 @@ func (svc *Service) Endpoint(ctx context.Context, dig digest.Digest, port int, s
 		if err != nil {
 			return "", err
 		}
-		tunnel, err := svcs.Get(ctx, dig, true)
+		runtimeCtx, err := svc.RuntimeContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		tunnel, err := svcs.Get(runtimeCtx, dig, true)
 		if err != nil {
 			return "", err
 		}
@@ -446,7 +496,11 @@ func (svc *Service) Stop(ctx context.Context, dig digest.Digest, kill bool) erro
 	if err != nil {
 		return err
 	}
-	return svcs.Stop(ctx, dig, kill, svc.TunnelUpstream.Self() != nil)
+	runtimeCtx, err := svc.RuntimeContext(ctx)
+	if err != nil {
+		return err
+	}
+	return svcs.Stop(runtimeCtx, dig, kill, svc.TunnelUpstream.Self() != nil)
 }
 
 type ServiceIO struct {
@@ -811,11 +865,12 @@ func (svc *Service) startContainer(
 	var nestedClientMetadata *engine.ClientMetadata
 	if svc.ExperimentalPrivilegedNesting {
 		nestedClientMetadata = &engine.ClientMetadata{
-			ClientID:          identity.NewID(),
-			ClientVersion:     engine.Version,
-			SessionID:         clientMetadata.SessionID,
-			AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
-			LockMode:          clientMetadata.LockMode,
+			ClientID:               identity.NewID(),
+			ClientVersion:          engine.Version,
+			SessionID:              clientMetadata.SessionID,
+			AllowedLLMModules:      slices.Clone(clientMetadata.AllowedLLMModules),
+			AllowedHostPortModules: slices.Clone(clientMetadata.AllowedHostPortModules),
+			LockMode:               clientMetadata.LockMode,
 		}
 	}
 
@@ -1169,7 +1224,15 @@ func (svc *Service) startTunnel(ctx context.Context, running *RunningService, _ 
 	if err != nil {
 		return err
 	}
-	svcCtx = engine.ContextWithClientMetadata(svcCtx, clientMetadata)
+	defaultCtx := engine.ContextWithClientMetadata(svcCtx, clientMetadata)
+	upstreamCtx, err := svc.tunnelUpstreamContext(defaultCtx)
+	if err != nil {
+		return err
+	}
+	listenCtx, err := svc.RuntimeContext(defaultCtx)
+	if err != nil {
+		return err
+	}
 
 	query, err := CurrentQuery(ctx)
 	if err != nil {
@@ -1179,12 +1242,12 @@ func (svc *Service) startTunnel(ctx context.Context, running *RunningService, _ 
 	if err != nil {
 		return fmt.Errorf("failed to get services: %w", err)
 	}
-	bk, err := query.Engine(ctx)
+	bk, err := query.Engine(listenCtx)
 	if err != nil {
 		return fmt.Errorf("failed to get engine client: %w", err)
 	}
 
-	upstream, err := svcs.StartResult(svcCtx, svc.TunnelUpstream, svc.TunnelUpstream.Self().TunnelUpstream.Self() != nil)
+	upstream, err := svcs.StartResult(upstreamCtx, svc.TunnelUpstream, svc.TunnelUpstream.Self().TunnelUpstream.Self() != nil)
 	if err != nil {
 		return fmt.Errorf("start upstream: %w", err)
 	}
@@ -1204,7 +1267,7 @@ func (svc *Service) startTunnel(ctx context.Context, running *RunningService, _ 
 			frontend = 0 // allow OS to choose
 		}
 		res, closeListener, err := bk.ListenHostToContainer(
-			svcCtx,
+			listenCtx,
 			fmt.Sprintf("%s:%d", bindHost, frontend),
 			forward.Protocol.Network(),
 			fmt.Sprintf("%s:%d", upstream.Host, forward.Backend),
@@ -1239,7 +1302,7 @@ func (svc *Service) startTunnel(ctx context.Context, running *RunningService, _ 
 	shutdown := func(cause error) error {
 		shutdownOnce.Do(func() {
 			stop(cause)
-			svcs.Detach(svcCtx, upstream)
+			svcs.Detach(upstreamCtx, upstream)
 			var errs []error
 			for _, closeListener := range closers {
 				errs = append(errs, closeListener())

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -15,6 +15,7 @@ dagger [options] [subcommand | file...]
 ### Options
 
 ```
+      --allow-host-ports strings     List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes
       --allow-llm strings            List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -c, --command string               Execute a dagger shell command
@@ -150,12 +151,13 @@ dagger api call [options] [function]...
 ### Options
 
 ```
-      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-runtime        load module runtime eagerly
-  -j, --json                 Present result as JSON
-  -m, --load-module string   Use a one-off module (local path or git ref)
-  -M, --no-load-module       Don't load any module for this command
-  -o, --output string        Save the result to a local file or directory
+      --allow-host-ports strings   List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes
+      --allow-llm strings          List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --eager-runtime              load module runtime eagerly
+  -j, --json                       Present result as JSON
+  -m, --load-module string         Use a one-off module (local path or git ref)
+  -M, --no-load-module             Don't load any module for this command
+  -o, --output string              Save the result to a local file or directory
 ```
 
 ### Options inherited from parent commands
@@ -399,9 +401,10 @@ dagger api functions [options] [function]...
 ### Options
 
 ```
-      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-runtime        load module runtime eagerly
-  -m, --load-module string   Use a one-off module (local path or git ref)
+      --allow-host-ports strings   List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes
+      --allow-llm strings          List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --eager-runtime              load module runtime eagerly
+  -m, --load-module string         Use a one-off module (local path or git ref)
 ```
 
 ### Options inherited from parent commands
@@ -466,13 +469,14 @@ EOF
 ### Options
 
 ```
-      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --doc string           Read query from file (defaults to reading from stdin)
-      --eager-runtime        load module runtime eagerly
-  -m, --load-module string   Use a one-off module (local path or git ref)
-  -M, --no-load-module       Don't load any module for this command
-      --var strings          List of query variables, in key=value format
-      --var-json string      Query variables in JSON format (overrides --var)
+      --allow-host-ports strings   List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes
+      --allow-llm strings          List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --doc string                 Read query from file (defaults to reading from stdin)
+      --eager-runtime              load module runtime eagerly
+  -m, --load-module string         Use a one-off module (local path or git ref)
+  -M, --no-load-module             Don't load any module for this command
+      --var strings                List of query variables, in key=value format
+      --var-json string            Query variables in JSON format (overrides --var)
 ```
 
 ### Options inherited from parent commands
@@ -522,17 +526,18 @@ dagger check [options] [pattern...]
 ### Options
 
 ```
-      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-      --eager-runtime        load module runtime eagerly
-      --failfast             Cancel remaining checks on first failure
-      --generate             Only run generate-as-checks, skip annotated check functions
-  -l, --list                 List available checks
-  -m, --load-module string   Use a one-off module (local path or git ref)
-      --no-generate          Only run annotated check functions, skip generate-as-checks
-      --no-past              Disable past Cloud Checks lookup
-      --past                 Only replay past Cloud Checks results
-      --run                  Run checks even when past Cloud Checks results are replayed
-      --skip stringArray     Skip checks matching the specified patterns
+      --allow-host-ports strings   List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes
+      --allow-llm strings          List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+      --eager-runtime              load module runtime eagerly
+      --failfast                   Cancel remaining checks on first failure
+      --generate                   Only run generate-as-checks, skip annotated check functions
+  -l, --list                       List available checks
+  -m, --load-module string         Use a one-off module (local path or git ref)
+      --no-generate                Only run annotated check functions, skip generate-as-checks
+      --no-past                    Disable past Cloud Checks lookup
+      --past                       Only replay past Cloud Checks results
+      --run                        Run checks even when past Cloud Checks results are replayed
+      --skip stringArray           Skip checks matching the specified patterns
 ```
 
 ### Options inherited from parent commands

--- a/docs/current_docs/using-dagger/services.mdx
+++ b/docs/current_docs/using-dagger/services.mdx
@@ -46,6 +46,68 @@ dagger up web
 curl http://localhost:80
 ```
 
+`dagger up` is intended for interactive use from the CLI. It starts the
+selected services, publishes their ports on your host, and blocks until you stop
+it with Ctrl+C.
+
+Functions can publish service ports too, but this is an explicit trust grant
+because it opens ports on the host running the Dagger session. Use
+`Service.publish()` when trusted module code needs to start a host-published
+tunnel and manage its lifecycle from inside a function.
+
+```typescript
+import { dag, func, object, NetworkProtocol } from "@dagger.io/dagger"
+
+@object()
+export class App {
+  @func()
+  async endpoint(): Promise<string> {
+    const service = dag
+      .container()
+      .from("nginx")
+      .withExposedPort(80)
+      .asService()
+
+    const tunnel = await service
+      .publish({
+        ports: [{ frontend: 8080, backend: 80, protocol: NetworkProtocol.Tcp }],
+      })
+      .start()
+
+    try {
+      return await tunnel.endpoint({ scheme: "http" })
+    } finally {
+      await tunnel.stop({ kill: true })
+    }
+  }
+}
+```
+
+Set `random: true` to bind each published port to a random available host port,
+then read the selected port with `endpoint()` or `ports()`.
+
+The service returned by `publish()` is the tunnel handle. Use that handle for
+`endpoint()`, `ports()`, and `stop()`. If another container needs to connect to
+the service inside Dagger, bind the original service instead of the published
+tunnel handle.
+
+When a nested module calls `publish()`, the main client must allow it:
+
+```shell
+# Allow local modules to publish host ports
+dagger call --allow-host-ports=local endpoint
+
+# Allow one Git module by symbolic module ref
+dagger call -m github.com/example/tools --allow-host-ports=github.com/example/tools endpoint
+
+# Environment variable equivalent
+DAGGER_ALLOW_HOST_PORTS=local dagger call endpoint
+```
+
+Use `--allow-host-ports=all` only for trusted sessions. Main-client direct calls
+are allowed; nested module calls require `local`, an exact Git module ref, or
+`all`.
+
 ## Host-to-container networking
 
 Containers running in Dagger can also connect to services on your host machine. This is useful for testing against a locally running database or API.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5585,6 +5585,23 @@ type Service implements Node & Syncer {
   ports: [Port!]!
 
   """
+  Start this service and publish its ports on the main client's host.
+
+  Nested module calls require explicit host-port permission.
+  """
+  publish(
+    """
+    List of frontend/backend port mappings to forward.
+
+    Frontend is the port accepting traffic on the host, backend is the service port.
+    """
+    ports: [PortForward!] = []
+
+    """Bind each tunnel port to a random port on the host."""
+    random: Boolean = false
+  ): Service!
+
+  """
   Start the service and wait for its health checks to succeed.
 
   Services bound to a Container do not need to be manually started.

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -113,7 +113,8 @@ type Params struct {
 
 	WithTerminal terminal.WithTerminalFunc
 
-	AllowedLLMModules []string
+	AllowedLLMModules      []string
+	AllowedHostPortModules []string
 
 	PromptHandler prompt.PromptHandler
 
@@ -1157,7 +1158,7 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Host:   "dagger",
 			Path:   r.URL.Path,
 		},
-		Header: r.Header,
+		Header: c.AppendHTTPRequestHeaders(r.Header),
 		Body:   r.Body,
 	}
 	proxyReq = proxyReq.WithContext(ctx)
@@ -1443,6 +1444,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		InteractiveCommand:             c.InteractiveCommand,
 		SSHAuthSocketPath:              sshAuthSock,
 		AllowedLLMModules:              c.AllowedLLMModules,
+		AllowedHostPortModules:         c.AllowedHostPortModules,
 		EagerRuntime:                   c.EagerRuntime,
 		SingleQuery:                    c.SingleQuery,
 		SuppressCompatWorkspaceWarning: c.SuppressCompatWorkspaceWarning,

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -97,6 +97,9 @@ type ClientMetadata struct {
 	// Modules permitted to access LLM APIs or "all" to bypass restrictions for any loaded module.
 	AllowedLLMModules []string `json:"allowed_llm_modules"`
 
+	// Modules permitted to publish ports on the main client's host, or "local"/"all" to allow broader scopes.
+	AllowedHostPortModules []string `json:"allowed_host_port_modules"`
+
 	// Disable lazy loading on module runtime.
 	EagerRuntime bool `json:"eager_runtime"`
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1067,6 +1067,9 @@ func (srv *Server) getOrInitClient(
 		if client.clientMetadata.AllowedLLMModules == nil {
 			client.clientMetadata.AllowedLLMModules = opts.AllowedLLMModules
 		}
+		if client.clientMetadata.AllowedHostPortModules == nil {
+			client.clientMetadata.AllowedHostPortModules = opts.AllowedHostPortModules
+		}
 		if opts.LoadWorkspaceModules {
 			client.clientMetadata.LoadWorkspaceModules = true
 		}
@@ -1258,6 +1261,7 @@ func (srv *Server) ServeHTTPToNestedClient(
 func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.ClientMetadata) *engine.ClientMetadata {
 	clientMetadata := *nestedClientMetadata
 	clientMetadata.AllowedLLMModules = slices.Clone(nestedClientMetadata.AllowedLLMModules)
+	clientMetadata.AllowedHostPortModules = slices.Clone(nestedClientMetadata.AllowedHostPortModules)
 	if clientMetadata.ClientVersion == "" {
 		clientMetadata.ClientVersion = engine.Version
 	}

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1251,8 +1251,9 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			Labels: map[string]string{
 				"ignored": "true",
 			},
-			SSHAuthSocketPath: "/tmp/ssh.sock",
-			AllowedLLMModules: []string{"parent"},
+			SSHAuthSocketPath:      "/tmp/ssh.sock",
+			AllowedLLMModules:      []string{"parent"},
+			AllowedHostPortModules: []string{"local"},
 			ExtraModules: []engine.ExtraModule{{
 				Ref: "github.com/dagger/base-extra",
 			}},
@@ -1280,6 +1281,7 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 		require.Empty(t, md.Labels)
 		require.Equal(t, "/tmp/ssh.sock", md.SSHAuthSocketPath)
 		require.Equal(t, []string{"parent"}, md.AllowedLLMModules)
+		require.Equal(t, []string{"local"}, md.AllowedHostPortModules)
 		require.Equal(t, string(workspace.LockModeFrozen), md.LockMode)
 		require.Empty(t, md.ExtraModules)
 		require.False(t, md.LoadWorkspaceModules)
@@ -1290,6 +1292,8 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 
 		base.AllowedLLMModules[0] = "mutated"
 		require.Equal(t, []string{"parent"}, md.AllowedLLMModules)
+		base.AllowedHostPortModules[0] = "mutated"
+		require.Equal(t, []string{"local"}, md.AllowedHostPortModules)
 	})
 
 	t.Run("overlays request-scoped forwarded metadata", func(t *testing.T) {
@@ -1307,8 +1311,9 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			Labels: map[string]string{
 				"forwarded": "ignored",
 			},
-			SSHAuthSocketPath: "/tmp/forwarded-ssh.sock",
-			AllowedLLMModules: []string{"child"},
+			SSHAuthSocketPath:      "/tmp/forwarded-ssh.sock",
+			AllowedLLMModules:      []string{"child"},
+			AllowedHostPortModules: []string{"all"},
 			ExtraModules: []engine.ExtraModule{{
 				Ref:        "github.com/dagger/mod",
 				Entrypoint: true,
@@ -1333,6 +1338,7 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 
 		require.Equal(t, "v-test", md.ClientVersion)
 		require.Equal(t, []string{"child"}, md.AllowedLLMModules)
+		require.Equal(t, []string{"local"}, md.AllowedHostPortModules)
 		require.Equal(t, string(workspace.LockModeLive), md.LockMode)
 		require.True(t, md.LoadWorkspaceModules)
 		require.True(t, md.EagerRuntime)
@@ -1350,14 +1356,16 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 		t.Parallel()
 
 		forwarded := engine.ClientMetadata{
-			ClientVersion:     "v-test",
-			AllowedLLMModules: []string{"child"},
+			ClientVersion:          "v-test",
+			AllowedLLMModules:      []string{"child"},
+			AllowedHostPortModules: []string{"all"},
 		}
 
 		md := nestedClientMetadataForRequest(forwarded.AppendToHTTPHeaders(http.Header{}), baseMetadata())
 
 		require.Equal(t, "v-test", md.ClientVersion)
 		require.Equal(t, []string{"child"}, md.AllowedLLMModules)
+		require.Equal(t, []string{"local"}, md.AllowedHostPortModules)
 		require.Equal(t, string(workspace.LockModeFrozen), md.LockMode)
 		require.Nil(t, md.WorkspaceEnv)
 		require.True(t, md.UseRecipeIDsByDefault)

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -159,6 +159,9 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 	}
 
 	params.AllowedLLMModules = allowedLLMModules
+	if len(params.AllowedHostPortModules) == 0 {
+		params.AllowedHostPortModules = allowedHostPortModules
+	}
 
 	params.Profile = profileFlag
 

--- a/internal/cmd/dagger/module.go
+++ b/internal/cmd/dagger/module.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	moduleURL         string
-	moduleNoURL       bool
-	allowedLLMModules []string
+	moduleURL              string
+	moduleNoURL            bool
+	allowedLLMModules      []string
+	allowedHostPortModules []string
 
 	installName   string
 	workspaceHere bool
@@ -49,8 +50,17 @@ func moduleAddFlags(cmd *cobra.Command, flags *pflag.FlagSet, optional bool) {
 	}
 	flags.StringSliceVar(&allowedLLMModules, "allow-llm", defaultAllowLLM, "List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session")
 
+	flags.StringSliceVar(&allowedHostPortModules, "allow-host-ports", defaultAllowedHostPortModules(), "List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes")
+
 	// Add the eager module loading flag to disable lazy load on runtime.
 	flags.BoolVar(&eagerRuntime, "eager-runtime", false, "load module runtime eagerly")
+}
+
+func defaultAllowedHostPortModules() []string {
+	if allowHostPortsEnv := os.Getenv("DAGGER_ALLOW_HOST_PORTS"); allowHostPortsEnv != "" {
+		return strings.Split(allowHostPortsEnv, ",")
+	}
+	return nil
 }
 
 func init() {

--- a/internal/cmd/dagger/session.go
+++ b/internal/cmd/dagger/session.go
@@ -26,6 +26,7 @@ var (
 	sessionLoadWorkspaceModules bool
 	sessionSkipWorkspaceModules bool
 	sessionWorkspace            string
+	sessionAllowedHostPorts     []string
 )
 
 func sessionCmd() *cobra.Command {
@@ -53,6 +54,7 @@ func newSessionCmd(hidden bool) *cobra.Command {
 	cmd.Flags().StringVarP(&sessionWorkspace, "workspace", "W", "", "select the workspace to load")
 	cmd.Flags().BoolVar(&sessionLoadWorkspaceModules, "load-workspace-modules", false, "load workspace modules")
 	cmd.Flags().BoolVar(&sessionSkipWorkspaceModules, "skip-workspace-modules", false, "skip loading workspace modules")
+	cmd.Flags().StringSliceVar(&sessionAllowedHostPorts, "allow-host-ports", defaultAllowedHostPortModules(), "List of local/Git modules allowed to publish ports on the host, or 'local'/'all' to allow broader scopes")
 	return cmd
 }
 
@@ -146,9 +148,10 @@ func sessionClientParams(secretToken string) (client.Params, error) {
 	}
 
 	params := client.Params{
-		SecretToken:          secretToken,
-		Version:              sessionVersion,
-		LoadWorkspaceModules: sessionLoadWorkspaceModules,
+		SecretToken:            secretToken,
+		Version:                sessionVersion,
+		LoadWorkspaceModules:   sessionLoadWorkspaceModules,
+		AllowedHostPortModules: sessionAllowedHostPorts,
 	}
 	if sessionWorkspace != "" {
 		params.Workspace = &sessionWorkspace

--- a/internal/cmd/dagger/session_test.go
+++ b/internal/cmd/dagger/session_test.go
@@ -16,6 +16,13 @@ func TestSessionCmdWorkspaceFlag(t *testing.T) {
 	require.Equal(t, "W", flag.Shorthand)
 }
 
+func TestSessionCmdAllowHostPortsFlag(t *testing.T) {
+	cmd := sessionCmd()
+
+	flag := cmd.Flags().Lookup("allow-host-ports")
+	require.NotNil(t, flag)
+}
+
 // TestSessionClientParamsWorkspace verifies that the session command forwards
 // its explicit workspace selection into engine client params.
 func TestSessionClientParamsWorkspace(t *testing.T) {
@@ -24,18 +31,21 @@ func TestSessionClientParamsWorkspace(t *testing.T) {
 	oldVersion := sessionVersion
 	oldLoad := sessionLoadWorkspaceModules
 	oldSkip := sessionSkipWorkspaceModules
+	oldAllowedHostPorts := sessionAllowedHostPorts
 	t.Cleanup(func() {
 		sessionWorkspace = oldWorkspace
 		workspaceRef = oldGlobalWorkspace
 		sessionVersion = oldVersion
 		sessionLoadWorkspaceModules = oldLoad
 		sessionSkipWorkspaceModules = oldSkip
+		sessionAllowedHostPorts = oldAllowedHostPorts
 	})
 
 	sessionWorkspace = "github.com/acme/ws"
 	workspaceRef = ""
 	sessionVersion = "v1.2.3"
 	sessionLoadWorkspaceModules = true
+	sessionAllowedHostPorts = []string{"local", "github.com/acme/mod@v1.2.3"}
 
 	params, err := sessionClientParams("secret")
 	require.NoError(t, err)
@@ -45,6 +55,7 @@ func TestSessionClientParamsWorkspace(t *testing.T) {
 	require.True(t, params.LoadWorkspaceModules)
 	require.NotNil(t, params.Workspace)
 	require.Equal(t, "github.com/acme/ws", *params.Workspace)
+	require.Equal(t, []string{"local", "github.com/acme/mod@v1.2.3"}, params.AllowedHostPortModules)
 }
 
 func TestSessionClientParamsGlobalWorkspace(t *testing.T) {
@@ -53,12 +64,14 @@ func TestSessionClientParamsGlobalWorkspace(t *testing.T) {
 	oldVersion := sessionVersion
 	oldLoad := sessionLoadWorkspaceModules
 	oldSkip := sessionSkipWorkspaceModules
+	oldAllowedHostPorts := sessionAllowedHostPorts
 	t.Cleanup(func() {
 		sessionWorkspace = oldWorkspace
 		workspaceRef = oldGlobalWorkspace
 		sessionVersion = oldVersion
 		sessionLoadWorkspaceModules = oldLoad
 		sessionSkipWorkspaceModules = oldSkip
+		sessionAllowedHostPorts = oldAllowedHostPorts
 	})
 
 	sessionWorkspace = ""
@@ -66,6 +79,7 @@ func TestSessionClientParamsGlobalWorkspace(t *testing.T) {
 	sessionVersion = ""
 	sessionLoadWorkspaceModules = false
 	sessionSkipWorkspaceModules = false
+	sessionAllowedHostPorts = nil
 
 	params, err := sessionClientParams("secret")
 	require.NoError(t, err)
@@ -79,17 +93,20 @@ func TestSessionClientParamsRejectConflictingWorkspaceModuleFlags(t *testing.T) 
 	oldGlobalWorkspace := workspaceRef
 	oldLoad := sessionLoadWorkspaceModules
 	oldSkip := sessionSkipWorkspaceModules
+	oldAllowedHostPorts := sessionAllowedHostPorts
 	t.Cleanup(func() {
 		sessionWorkspace = oldWorkspace
 		workspaceRef = oldGlobalWorkspace
 		sessionLoadWorkspaceModules = oldLoad
 		sessionSkipWorkspaceModules = oldSkip
+		sessionAllowedHostPorts = oldAllowedHostPorts
 	})
 
 	sessionWorkspace = ""
 	workspaceRef = ""
 	sessionLoadWorkspaceModules = true
 	sessionSkipWorkspaceModules = true
+	sessionAllowedHostPorts = nil
 
 	_, err := sessionClientParams("secret")
 	require.ErrorContains(t, err, "mutually exclusive")

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -63,6 +63,16 @@ func WithLoadWorkspaceModules() ClientOpt {
 	})
 }
 
+// WithAllowedHostPorts allows trusted modules to publish ports on the host.
+//
+// Use "local" to allow local modules, "all" to allow any module, or an exact
+// Git module ref such as "github.com/acme/mod/subdir".
+func WithAllowedHostPorts(modules ...string) ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.AllowedHostPortModules = append(cfg.AllowedHostPortModules, modules...)
+	})
+}
+
 // WithConn sets the engine connection explicitly
 func WithConn(conn engineconn.EngineConn) ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {

--- a/sdk/go/engineconn/engineconn.go
+++ b/sdk/go/engineconn/engineconn.go
@@ -19,16 +19,17 @@ type EngineConn interface {
 }
 
 type Config struct {
-	Workdir              string
-	Workspace            string
-	LogOutput            io.Writer
-	RunnerHost           string
-	Conn                 EngineConn
-	VersionOverride      string
-	Verbosity            int
-	ExtraEnv             []string
-	LoadWorkspaceModules bool
-	SkipWorkspaceModules bool
+	Workdir                string
+	Workspace              string
+	LogOutput              io.Writer
+	RunnerHost             string
+	Conn                   EngineConn
+	VersionOverride        string
+	Verbosity              int
+	ExtraEnv               []string
+	AllowedHostPortModules []string
+	LoadWorkspaceModules   bool
+	SkipWorkspaceModules   bool
 }
 
 type ConnectParams struct {
@@ -50,14 +51,15 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 		return nil, err
 	}
 	cfg = &Config{
-		Workdir:              cfg.Workdir,
-		Workspace:            cfg.Workspace,
-		LogOutput:            cfg.LogOutput,
-		RunnerHost:           cfg.RunnerHost,
-		VersionOverride:      cfg.VersionOverride,
-		Verbosity:            cfg.Verbosity,
-		ExtraEnv:             cfg.ExtraEnv,
-		LoadWorkspaceModules: loadWorkspaceModules,
+		Workdir:                cfg.Workdir,
+		Workspace:              cfg.Workspace,
+		LogOutput:              cfg.LogOutput,
+		RunnerHost:             cfg.RunnerHost,
+		VersionOverride:        cfg.VersionOverride,
+		Verbosity:              cfg.Verbosity,
+		ExtraEnv:               cfg.ExtraEnv,
+		AllowedHostPortModules: cfg.AllowedHostPortModules,
+		LoadWorkspaceModules:   loadWorkspaceModules,
 	}
 
 	// Try DAGGER_SESSION_PORT next
@@ -74,6 +76,9 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 		}
 		if cfg.LoadWorkspaceModules {
 			return nil, fmt.Errorf("cannot configure workspace module loading for existing session")
+		}
+		if len(cfg.AllowedHostPortModules) > 0 {
+			return nil, fmt.Errorf("cannot configure host port module allowlist for existing session")
 		}
 		return conn, nil
 	}

--- a/sdk/go/engineconn/session.go
+++ b/sdk/go/engineconn/session.go
@@ -92,6 +92,9 @@ func cliSessionArgs(cfg *Config) []string {
 	if cfg.LoadWorkspaceModules {
 		args = append(args, "--load-workspace-modules")
 	}
+	for _, module := range cfg.AllowedHostPortModules {
+		args = append(args, "--allow-host-ports", module)
+	}
 
 	if cfg.Verbosity > 0 {
 		args = append(args, "-"+strings.Repeat("v", cfg.Verbosity))

--- a/sdk/go/engineconn/session_test.go
+++ b/sdk/go/engineconn/session_test.go
@@ -31,6 +31,18 @@ func TestCLISessionArgsIncludeLoadWorkspaceModules(t *testing.T) {
 	require.NotContains(t, args, "--skip-workspace-modules")
 }
 
+func TestCLISessionArgsIncludeAllowedHostPorts(t *testing.T) {
+	t.Parallel()
+
+	args := cliSessionArgs(&Config{
+		AllowedHostPortModules: []string{"local", "github.com/acme/mod@v1.2.3"},
+	})
+
+	require.Contains(t, args, "--allow-host-ports")
+	require.Contains(t, args, "local")
+	require.Contains(t, args, "github.com/acme/mod@v1.2.3")
+}
+
 // TestGetRejectsWorkspaceForExistingSession verifies that an existing session's
 // workspace binding cannot be overridden by client config.
 func TestGetRejectsWorkspaceForExistingSession(t *testing.T) {
@@ -51,4 +63,14 @@ func TestGetRejectsWorkspaceModuleLoadingForExistingSession(t *testing.T) {
 		LoadWorkspaceModules: true,
 	})
 	require.ErrorContains(t, err, "cannot configure workspace module loading for existing session")
+}
+
+func TestGetRejectsAllowedHostPortsForExistingSession(t *testing.T) {
+	t.Setenv("DAGGER_SESSION_PORT", "1234")
+	t.Setenv("DAGGER_SESSION_TOKEN", "secret")
+
+	_, err := Get(context.Background(), &Config{
+		AllowedHostPortModules: []string{"local"},
+	})
+	require.ErrorContains(t, err, "cannot configure host port module allowlist for existing session")
 }


### PR DESCRIPTION
Adds `Service.publish` to allow tunneling ports to the host from trusted services started by trusted functions. This is based on top of and used in conjunction with https://github.com/dagger/dagger/pull/13526 to allow a function to start a service, pass it a directory, and get changes back while the service is accessible to the host. Particularly useful/necessary for attaching to codex in a service container started by a function.

This may not necessarily be the best approach here. I did this by driving codex out of need for my own use case of human-in-the-loop interaction with codex server running in dagger. The trust model is based on the llm trust model stuff, and seems workable to me but maybe something like this needs to be part of a larger more comprehensive way of trusting functions/services to work with the host.