### PR TITLE
test(e2e/helm): fail fast with engine diagnostics on connect timeout

### DIFF
--- a/e2e/helm/helm_test.go
+++ b/e2e/helm/helm_test.go
@@ -162,7 +162,7 @@ func TestInstallK3S(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		ok := t.Run(test.name, func(t *testing.T) {
 			args := []string{
 				"helm", "install", "--wait", "--create-namespace", "--namespace=dagger",
 				"--set=engine.image.ref=" + testEngineImage,
@@ -180,6 +180,13 @@ func TestInstallK3S(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+		if !ok {
+			// All cases deploy the same engine image; if the first one never
+			// becomes reachable the rest will hang the same way. Stop early so we
+			// fail fast with diagnostics instead of burning the whole package
+			// timeout (which previously produced a 10m hang with no output).
+			break
+		}
 	}
 }
 
@@ -238,7 +245,7 @@ func runInstallAssertions(ctx context.Context, engineName string, engineKind str
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", fmt.Sprintf("kube-pod://%s?namespace=dagger", podName)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v0.16.0-000000000000")
 	if err := testDaggerQuery(ctx, "dagger query", byKubePod); err != nil {
-		return err
+		return fmt.Errorf("kube-pod query to engine %q failed: %w\n%s", engineName, err, dumpEngineDiagnostics(ctx, kubectl, engineName))
 	}
 
 	if port != 0 {
@@ -246,14 +253,24 @@ func runInstallAssertions(ctx context.Context, engineName string, engineKind str
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://localhost:4000").
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v0.16.0-000000000000")
 		if err := testDaggerQuery(ctx, fmt.Sprintf("kubectl port-forward --namespace=dagger pods/%s 4000:%d & dagger query", podName, port), byTCP); err != nil {
-			return err
+			return fmt.Errorf("tcp port-forward query to engine %q failed: %w\n%s", engineName, err, dumpEngineDiagnostics(ctx, kubectl, engineName))
 		}
 	}
 
 	return nil
 }
 
+// daggerQueryTimeout bounds how long we wait for the freshly-installed engine to
+// answer a query. The dagger client's "connecting to engine" phase retries
+// silently with no output, so without this bound a non-serving engine hangs
+// until the Go test package timeout (10m) with zero diagnostics. Keep it well
+// under that budget so we still have time to collect engine logs on failure.
+const daggerQueryTimeout = 4 * time.Minute
+
 func testDaggerQuery(ctx context.Context, command string, kubectl *dagger.Container) error {
+	ctx, cancel := context.WithTimeout(ctx, daggerQueryTimeout)
+	defer cancel()
+
 	stdout, err := kubectl.WithExec([]string{"sh", "-c", command}, dagger.ContainerWithExecOpts{
 		Stdin: `{
 				container {
@@ -264,10 +281,40 @@ func testDaggerQuery(ctx context.Context, command string, kubectl *dagger.Contai
 			}`,
 	}).Stdout(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("engine did not answer a query within %s (connection never became ready): %w", daggerQueryTimeout, err)
 	}
 	if !strings.Contains(stdout, "Linux") {
 		return fmt.Errorf("expected to be a Linux container, got: %s", stdout)
 	}
 	return nil
+}
+
+// dumpEngineDiagnostics best-effort collects Kubernetes state for the engine pod
+// so a failed connection produces actionable output (pod status, engine logs,
+// events) instead of an opaque timeout. It never fails the test itself.
+func dumpEngineDiagnostics(ctx context.Context, kubectl *dagger.Container, engineName string) string {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	selector := "name=" + engineName
+	script := strings.Join([]string{
+		"set +e",
+		`echo "=== pods (all namespaces) ==="`,
+		"kubectl get pods -A -o wide 2>&1",
+		`echo "=== describe engine pod ==="`,
+		"kubectl describe pod -l " + selector + " -n dagger 2>&1",
+		`echo "=== engine logs (current) ==="`,
+		"kubectl logs -l " + selector + " -n dagger --all-containers --tail=200 2>&1",
+		`echo "=== engine logs (previous, if any) ==="`,
+		"kubectl logs -l " + selector + " -n dagger --all-containers --previous --tail=200 2>&1",
+		`echo "=== recent events ==="`,
+		"kubectl get events -n dagger --sort-by=.lastTimestamp 2>&1",
+		"exit 0",
+	}, "\n")
+
+	out, err := kubectl.WithExec([]string{"sh", "-c", script}).Stdout(ctx)
+	if err != nil {
+		return fmt.Sprintf("engine diagnostics for %q (collection error: %v):\n%s", engineName, err, out)
+	}
+	return fmt.Sprintf("engine diagnostics for %q:\n%s", engineName, out)
 }


### PR DESCRIPTION
## Why

`golang:test-all` has been failing on `TestInstallK3S` (e2e/helm) with a silent ~10‑minute hang and no diagnostics — most visibly on #13347 (trace `f9aeb308ccde23d62a3f013bc78776df`), but the root issue is on `main`, not that PR.

The test deploys the published `registry.dagger.io/engine:main` into k3s, then connects to it with `dagger query` over `kube-pod://`. The client's "connecting to engine" phase (`Client.Wait` → buildkit `Info()`) retries every second for a hard 10‑minute deadline **with zero output**. When the engine pod never becomes serviceable, the test just hangs until the Go package timeout fires (`FAIL e2e/helm 600.114s`) — telling us nothing about why.

## Confirmed root cause

This PR's own CI run (`golang:test-all`, trace `9b05af6a9c30ab9190496fd44a572f63`) failed in **4m22s instead of hanging 10m**, and the new diagnostics show exactly why:

```
dagger-dagger-helm-engine-wxwk7   0/1   ImagePullBackOff
Failed to pull image "registry.dagger.io/engine:main": failed to resolve reference:
  unexpected status from HEAD request to
  https://registry.dagger.io/v2/engine/manifests/main: 500 Internal Server Error
```

The engine pod never starts because the k3s node can't pull `engine:main` — `registry.dagger.io` returned **HTTP 500** for the manifest. The engine API therefore never comes up, and the connect hangs. (The image pulls fine from elsewhere; HEAD/GET/by-digest all return 200 from a dev box, so this is a transient/environmental registry-reachability failure from CI, not a code or version-skew issue.) This is **infrastructure**, not the PR under test.

## What this PR changes

This is the de‑flake / diagnostics layer. It does **not** change behaviour when the engine comes up normally.

- **Bound the connect.** Each `dagger query` gets a 4‑minute timeout (well under the 10‑minute package budget) so a non‑serving engine errors instead of hanging.
- **Dump engine diagnostics on failure.** On a failed connect we collect the engine pod's Kubernetes state — `get pods -o wide`, `describe pod`, current + previous logs, and recent events — into the test error. This is what turned an opaque 10‑minute hang into the one‑line `ImagePullBackOff … 500` diagnosis above. Previously diagnostics were only emitted for the k3s **node**-readiness step, never for the engine connect.
- **Fail fast.** Stop after the first failing chart variant instead of repeating the same hang for all four.

## Follow‑up

The underlying `registry.dagger.io` 500 on `engine:main` pulls is an infra/registry issue to escalate. A separate hardening option is to remove the e2e test's dependency on a live public‑registry pull (e.g. load the engine image into the k3s node directly) so a flaky/unreachable registry can't fail this contract test. Kept separate from #13347 so that workspace PR isn't blocked on this.
