### PR TITLE
feat: add check-generated workspace setting

### DIFF
--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -338,6 +338,49 @@ check.skip = ["failing-check", "failing-container"]
 	require.NotContains(t, out, "hello-with-checks:failing-container")
 }
 
+func (ChecksSuite) TestWorkspaceCheckGeneratedSetting(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := checksTestEnv(t, c)
+	require.NoError(t, err)
+
+	// check-generated = false skips generate-as-checks by default.
+	base := modGen.WithNewFile("dagger.toml", `check-generated = false
+
+[modules.hello-with-generate-checks]
+source = "hello-with-generate-checks"
+`)
+
+	t.Run("list excludes generators by default", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerExec("check", "-l")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "hello-with-generate-checks:passing-check")
+		require.NotContains(t, out, "empty-generate")
+		require.NotContains(t, out, "non-empty-generate")
+	})
+
+	t.Run("run passes by default despite stale generator", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerExec("--progress=report", "check")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Regexp(t, `passing-check.*OK`, out)
+		require.NotContains(t, out, "non-empty-generate")
+	})
+
+	t.Run("--generate flag overrides the config", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerExec("check", "-l", "--generate")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Regexp(t, `empty-generate\s+generate\s+`, out)
+		require.Regexp(t, `non-empty-generate\s+generate\s+`, out)
+		require.NotContains(t, out, "passing-check")
+	})
+
+	t.Run("--no-generate flag matches the config default", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerExec("check", "-l", "--no-generate")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "hello-with-generate-checks:passing-check")
+		require.NotContains(t, out, "empty-generate")
+	})
+}
+
 func (ChecksSuite) TestWorkspaceCheckSkipRemote(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	remoteRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().

--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -554,6 +554,7 @@ func (WorkspaceSuite) TestWorkspaceConfigurationLifecycle(ctx context.Context, t
 		configContents, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
 		require.NoError(t, err)
 		require.Contains(t, string(configContents), "[modules]")
+		require.Contains(t, string(configContents), "check-generated = true")
 	})
 
 	t.Run("workspace config detects the nearest config", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1256,17 +1256,24 @@ func (s *workspaceSchema) checks(
 
 	noGenerate := args.NoGenerate.GetOr(false).Bool()
 	onlyGenerate := args.OnlyGenerate.GetOr(false).Bool()
+
+	cfg, err := workspaceConfigWithCompatFallback(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	// Apply the workspace default only when no generate flag was passed.
+	if !args.NoGenerate.Valid && !args.OnlyGenerate.Valid && cfg.CheckGenerated != nil && !*cfg.CheckGenerated {
+		noGenerate = true
+	}
+
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	ignoreChecks, err := workspaceConfigSkipPatterns(ctx, parent, func(e workspace.ModuleEntry) []string {
+	ignoreChecks := workspaceConfigSkipPatternsFromConfig(cfg, func(e workspace.ModuleEntry) []string {
 		return e.Check.Skip
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	var allChecks []*core.Check
 	for _, mod := range mods {
@@ -1702,14 +1709,22 @@ func workspaceConfigSkipPatterns(
 	if err != nil {
 		return nil, err
 	}
+	return workspaceConfigSkipPatternsFromConfig(cfg, getter), nil
+}
 
+// workspaceConfigSkipPatternsFromConfig derives per-module skip patterns from an
+// already-loaded workspace config.
+func workspaceConfigSkipPatternsFromConfig(
+	cfg *workspace.Config,
+	getter func(workspace.ModuleEntry) []string,
+) map[string][]string {
 	result := make(map[string][]string)
 	for name, entry := range cfg.Modules {
 		if patterns := getter(entry); len(patterns) > 0 {
 			result[name] = patterns
 		}
 	}
-	return result, nil
+	return result
 }
 
 // filterNodesByExclude removes items whose nodes match any of the exclude

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -19,6 +19,10 @@ const initialWorkspaceConfig = `# Dagger workspace configuration
 # Example:
 #   dagger mod install github.com/dagger/dagger/modules/wolfi
 
+# Run generators as part of 'dagger check' and fail when generated files are
+# stale. Set to false to skip them by default (like 'dagger check --no-generate').
+check-generated = true
+
 [modules]
 `
 
@@ -113,7 +117,14 @@ func loadWorkspaceConfigForMutation(
 		return nil, false, fmt.Errorf("initialize workspace: %w", err)
 	}
 
-	return &workspace.Config{Modules: map[string]workspace.ModuleEntry{}}, true, nil
+	// Keep this consistent with initialWorkspaceConfig: the freshly written file
+	// already carries `check-generated = true`, so the returned config must too,
+	// otherwise the next write would prune it as a removed key.
+	checkGenerated := true
+	return &workspace.Config{
+		Modules:        map[string]workspace.ModuleEntry{},
+		CheckGenerated: &checkGenerated,
+	}, true, nil
 }
 
 func ensureWorkspaceInitialized(ctx context.Context, bk *engineutil.Client, ws *core.Workspace, here bool) error {

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -17,8 +17,12 @@ type Config struct {
 	Modules            map[string]ModuleEntry `json:"modules,omitempty" toml:"modules"`
 	Ignore             []string               `json:"ignore,omitempty" toml:"ignore"`
 	DefaultsFromDotEnv bool                   `json:"defaults_from_dotenv,omitempty" toml:"defaults_from_dotenv,omitempty"`
-	Env                map[string]EnvOverlay  `json:"env,omitempty" toml:"env"`
-	Ports              map[string]PortMapping `json:"ports,omitempty" toml:"ports,omitempty"`
+	// CheckGenerated controls whether `dagger check` runs generate-as-checks,
+	// which fail when generated files are stale. Defaults to true; set false to
+	// skip them (like --no-generate). CLI flags override it.
+	CheckGenerated *bool                  `json:"check-generated,omitempty" toml:"check-generated,omitempty"`
+	Env            map[string]EnvOverlay  `json:"env,omitempty" toml:"env"`
+	Ports          map[string]PortMapping `json:"ports,omitempty" toml:"ports,omitempty"`
 }
 
 // PortMapping declares a host port that forwards to a workspace service.
@@ -289,6 +293,10 @@ func SerializeConfig(cfg *Config) []byte {
 		b.WriteString("defaults_from_dotenv = true\n\n")
 	}
 
+	if cfg.CheckGenerated != nil {
+		fmt.Fprintf(&b, "check-generated = %t\n\n", *cfg.CheckGenerated)
+	}
+
 	wroteModules := writeModuleEntries(&b, cfg.Modules)
 	if wroteModules && (len(cfg.Env) > 0 || len(cfg.Ports) > 0) {
 		b.WriteString("\n")
@@ -309,6 +317,10 @@ func cloneConfig(cfg *Config) *Config {
 	cloned := &Config{
 		Ignore:             append([]string(nil), cfg.Ignore...),
 		DefaultsFromDotEnv: cfg.DefaultsFromDotEnv,
+	}
+	if cfg.CheckGenerated != nil {
+		checkGenerated := *cfg.CheckGenerated
+		cloned.CheckGenerated = &checkGenerated
 	}
 	if len(cfg.Modules) > 0 {
 		cloned.Modules = make(map[string]ModuleEntry, len(cfg.Modules))
@@ -604,6 +616,9 @@ func ReadConfigValue(data []byte, key string) (string, error) {
 func readMissingConfigDefault(tree *toml.Tree, parts []string) (string, bool) {
 	if len(parts) == 1 && parts[0] == "defaults_from_dotenv" {
 		return "false", true
+	}
+	if len(parts) == 1 && parts[0] == "check-generated" {
+		return "true", true
 	}
 	if len(parts) == 3 && parts[0] == "modules" && (parts[2] == "entrypoint" || parts[2] == "legacy-default-path") {
 		if tree.GetPath(parts[:2]) != nil {
@@ -923,6 +938,16 @@ func setConfigValue(cfg *Config, parts []string, value any) error { //nolint:goc
 		}
 		cfg.DefaultsFromDotEnv = boolValue
 		return nil
+	case "check-generated":
+		if len(parts) != 1 {
+			return fmt.Errorf("invalid key %q; check-generated does not have sub-keys", strings.Join(parts, "."))
+		}
+		boolValue, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("check-generated must be a boolean")
+		}
+		cfg.CheckGenerated = &boolValue
+		return nil
 	case "modules":
 		if len(parts) < 3 {
 			return fmt.Errorf("cannot set %q directly; specify a field like %s.settings", strings.Join(parts, "."), strings.Join(parts, "."))
@@ -1127,7 +1152,8 @@ func preferredExampleFieldName(t reflect.Type) string {
 func parseValueString(parts []string, rawValue string) any {
 	leaf := parts[len(parts)-1]
 
-	if leaf == "entrypoint" || leaf == "legacy-default-path" || (len(parts) == 1 && parts[0] == "defaults_from_dotenv") {
+	if leaf == "entrypoint" || leaf == "legacy-default-path" ||
+		(len(parts) == 1 && (parts[0] == "defaults_from_dotenv" || parts[0] == "check-generated")) {
 		return rawValue == "true"
 	}
 

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -105,6 +105,9 @@ func configDocumentMap(cfg *Config) map[string]any {
 	if cfg.DefaultsFromDotEnv {
 		values["defaults_from_dotenv"] = true
 	}
+	if cfg.CheckGenerated != nil {
+		values["check-generated"] = *cfg.CheckGenerated
+	}
 	if len(cfg.Modules) > 0 {
 		modules := make(map[string]any, len(cfg.Modules))
 		for name, entry := range cfg.Modules {

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -122,6 +122,87 @@ greeting = "hola"
 `, string(out))
 }
 
+func TestWorkspaceCheckGeneratedSetting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset leaves CheckGenerated nil", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte(`[modules.greeter]
+source = "modules/greeter"
+`))
+		require.NoError(t, err)
+		require.Nil(t, cfg.CheckGenerated)
+	})
+
+	t.Run("parses explicit booleans", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte("check-generated = false\n"))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.CheckGenerated)
+		require.False(t, *cfg.CheckGenerated)
+
+		cfg, err = ParseConfig([]byte("check-generated = true\n"))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.CheckGenerated)
+		require.True(t, *cfg.CheckGenerated)
+	})
+
+	t.Run("serializes when set", func(t *testing.T) {
+		t.Parallel()
+
+		falsy := false
+		out := SerializeConfig(&Config{CheckGenerated: &falsy})
+		require.Equal(t, "check-generated = false\n\n", string(out))
+
+		truthy := true
+		out = SerializeConfig(&Config{CheckGenerated: &truthy})
+		require.Equal(t, "check-generated = true\n\n", string(out))
+
+		out = SerializeConfig(&Config{})
+		require.NotContains(t, string(out), "check-generated")
+	})
+
+	t.Run("read default is true when unset", func(t *testing.T) {
+		t.Parallel()
+
+		value, err := ReadConfigValue([]byte(""), "check-generated")
+		require.NoError(t, err)
+		require.Equal(t, "true", value)
+	})
+
+	t.Run("write and read round-trip", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := WriteConfigValue(nil, "check-generated", "false")
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(data)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.CheckGenerated)
+		require.False(t, *cfg.CheckGenerated)
+
+		value, err := ReadConfigValue(data, "check-generated")
+		require.NoError(t, err)
+		require.Equal(t, "false", value)
+
+		data, err = WriteConfigValue(data, "check-generated", "true")
+		require.NoError(t, err)
+		cfg, err = ParseConfig(data)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.CheckGenerated)
+		require.True(t, *cfg.CheckGenerated)
+	})
+
+	t.Run("rejects sub-keys", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := WriteConfigValue(nil, "check-generated.skip", "foo")
+		require.Error(t, err)
+	})
+}
+
 func TestSerializeConfigQuotesDynamicPathSegments(t *testing.T) {
 	t.Parallel()
 

--- a/docs/current_docs/adopting/workspace-setup.mdx
+++ b/docs/current_docs/adopting/workspace-setup.mdx
@@ -59,6 +59,16 @@ dagger ws settings eslint packageManager yarn
 
 Settings are stored in `dagger.toml` alongside each module, so they're shared with everyone who uses the workspace.
 
+## Control generated-file checks
+
+By default, `dagger check` also runs generators as checks and fails when generated files are stale. That's useful in CI, but during day-to-day development you may not want a check run to fail just because generated files are out of date. New workspaces are created with this default in `dagger.toml`:
+
+```toml
+check-generated = true
+```
+
+Set it to `false` to make `dagger check` skip generate-as-checks by default (the same as passing `--no-generate`). The command-line flags always override the setting: `dagger check --generate` runs only the generators, and `dagger check --no-generate` skips them.
+
 ## Migrate an existing project
 
 If your project already uses a legacy `dagger.json`, convert it to the workspace format:

--- a/docs/static/reference/dagger-workspace.schema.json
+++ b/docs/static/reference/dagger-workspace.schema.json
@@ -20,6 +20,10 @@
         "defaults_from_dotenv": {
           "type": "boolean"
         },
+        "check-generated": {
+          "type": "boolean",
+          "description": "CheckGenerated controls whether `dagger check` runs generate-as-checks, which fail when generated files are stale. Defaults to true; set false to skip them (like --no-generate). CLI flags override it."
+        },
         "env": {
           "additionalProperties": {
             "$ref": "#/$defs/EnvOverlay"


### PR DESCRIPTION
## What

Adds a workspace-level `check-generated` setting in `dagger.toml` that controls whether `dagger check` runs generate-as-checks.

```toml
check-generated = true
```

- Defaults to `true` (generate-as-checks run, failing when generated files are stale) and is written into newly created workspaces' `dagger.toml`.
- Set to `false` to make `dagger check` skip generate-as-checks by default — equivalent to passing `--no-generate` — so a check run no longer fails just because generated files are out of date.
- The command-line flags always override the setting: `dagger check --generate` runs only the generators, and `dagger check --no-generate` skips them.

The setting is applied at the **workspace level** (not per-module).

## Why

`dagger check` verifies that generated files are current, which is useful in CI but often undesirable during day-to-day development, where users had to remember to pass `--no-generate`. This lets a project make "don't fail on stale generated files" the default for `dagger check`, while CI can still opt back in with `--generate`.

Fixes #13535

## Implementation notes

- New `CheckGenerated *bool` field on `workspace.Config` (pointer so an absent key keeps the `true` default for existing workspaces).
- New workspaces are seeded with `check-generated = true`: it's added to the init template and to the in-memory config returned for the first write, so the two stay consistent and the key isn't pruned on the next `dagger.toml` write.
- The `checks` resolver consults the setting only when neither `--generate` nor `--no-generate` was passed on the command line. Explicit-flag detection relies on the Go SDK omitting zero-value boolean args (so an absent flag is genuinely absent from the GraphQL request, observable via `dagql.Optional.Valid`).
- `dagger.toml` JSON schema regenerated; docs updated.

## Test plan

- `core/workspace` unit tests for parse / serialize / read / write / default round-trips of `check-generated`.
- `core/integration`:
  - `TestChecks/TestWorkspaceCheckGeneratedSetting`: `check-generated = false` skips generators by default, the default run passes despite a stale generator, `--generate` overrides the config, `--no-generate` is consistent with it.
  - `TestWorkspace/TestWorkspaceConfigurationLifecycle`: a newly initialized workspace's `dagger.toml` contains `check-generated = true`.

All pass locally.
