### PR TITLE
Load workspace modules on demand (dumb client, peeked operation name)

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -304,6 +304,217 @@ func (m *Consumer) SyncGenerators(ctx context.Context, workspace *dagger.Workspa
 	require.NotContains(t, out, "result *core.Changeset is detached")
 }
 
+// TestWorkspaceGenerateNarrowsToRequestedModule locks in that
+// `dagger generate <module>` only loads the named generator's module. The
+// workspace generators resolver loads modules on demand from its include
+// argument, so an unrelated broken/stale workspace module is never loaded just
+// to enumerate generators and cannot block regenerating a healthy module --
+// including the case where running generate is itself the fix for the broken
+// module.
+//
+// See also TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrokenModules
+// in workspace_test.go, which covers the root-field demand path for raw
+// queries.
+func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating only the healthy module succeeds", func(ctx context.Context, t *testctx.T) {
+		// generate -y is multi-request (list, then run+apply); the later
+		// requests must keep recognizing the already-loaded module instead of
+		// falling back to loading everything.
+		out, err := base.
+			With(daggerExec("generate", "good", "-y", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "no changes to apply")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCheckNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate or run a
+// healthy module's checks, so it cannot block checking that module.
+func (GeneratorsSuite) TestWorkspaceCheckNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("check", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("running only the healthy module's checks succeeds", func(ctx context.Context, t *testctx.T) {
+		// --no-generate runs only annotated checks; generate-as-checks are
+		// excluded because the healthy module's generator legitimately reports
+		// pending output (covered by the generate narrowing test), which is
+		// unrelated to whether the broken module was loaded.
+		out, err := base.
+			With(daggerExec("check", "good", "--no-generate", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("checking across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceUpNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger up`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate a healthy
+// module's services. `dagger up` starts services and blocks, so the assertions
+// use list mode (-l), which still loads workspace modules to enumerate services
+// and thus exercises the same narrowing.
+func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("up", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("up", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger call`: targeting a
+// healthy module's function must not load every workspace module just to build
+// the command tree. The CLI names its typedefs introspection operation after
+// the leading positional token, and the engine peeks that to load only the
+// targeted module on demand, so an unrelated broken/stale module cannot block
+// the call.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("calling a healthy module's function skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good", "verify", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing the healthy module's functions skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsByCliNameAndEntrypoint covers the two demand shapes
+// TestWorkspaceCallNarrowsToRequestedModule cannot see with its single-word
+// module names:
+//
+//   - the CLI targets modules by their kebab-case command name, so a module
+//     declared as "goodMod" is called as `dagger call good-mod ...` and the
+//     engine must normalize both sides the same way to narrow loading;
+//   - with a workspace entrypoint configured, the first argument may be one of
+//     the entrypoint's root-proxied functions rather than a module name, in
+//     which case the entrypoint module must load — and suffice — to resolve
+//     the call.
+//
+// In both cases the broken sibling module must stay unloaded.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsByCliNameAndEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "call-narrowing")
+
+	t.Run("kebab-case module target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good-mod", "ping", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "pong from goodMod")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("entrypoint function target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "greet", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello from entrypoint")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case functions listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good-mod", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case generate listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		// The selector resolvers (generate/check/up) match include patterns
+		// kebab-normalized; on-demand loading must normalize the same way.
+		out, err := base.
+			With(daggerExec("generate", "-l", "good-mod")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "entry"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
@@ -1,0 +1,9 @@
+type Entry {
+  """
+  A trivial entrypoint function, proxied onto the Query root. Used to prove
+  the entrypoint module loaded when it is the first `dagger call` argument.
+  """
+  pub greet: String! {
+    "hello from entrypoint"
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "goodMod"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
@@ -1,0 +1,17 @@
+type GoodMod {
+  """
+  A trivial function. Used to prove the module loaded when targeted by its
+  kebab-case CLI command name (good-mod).
+  """
+  pub ping: String! {
+    "pong from goodMod"
+  }
+
+  """
+  Regenerate by writing a marker file. Used to prove the kebab-case name also
+  narrows the generate/check/up selector path.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from goodMod").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/dagger.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/dagger.toml
@@ -1,0 +1,9 @@
+[modules.goodMod]
+source = ".dagger/modules/goodMod"
+
+[modules.entry]
+source = ".dagger/modules/entry"
+entrypoint = true
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "good"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,0 +1,27 @@
+type Good {
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+
+  """
+  A trivial check. Used to prove the module loaded for `dagger check` and
+  `dagger call`.
+  """
+  pub verify: Void @check {
+    null
+  }
+
+  """
+  A trivial service. Used to prove the module loaded for `dagger up`.
+  """
+  @up
+  pub web: Service! {
+    container
+      .from("nginx:alpine")
+      .withExposedPort(80)
+      .asService
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken/dagger.toml
@@ -1,0 +1,5 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/query.go
+++ b/core/query.go
@@ -87,6 +87,11 @@ type Server interface {
 	// The cached workspace result from ensureWorkspaceLoaded.
 	CurrentWorkspace(context.Context) (*Workspace, error)
 
+	// Load pending workspace modules on demand; include narrows to the modules
+	// its patterns name ("module" or "module:item"), empty or unrecognized
+	// loads all.
+	EnsureWorkspaceModules(ctx context.Context, include []string) error
+
 	// A snapshot of the current workspace lockfile for ambient live locking.
 	// Returns ok=false when lock-backed workspace access is unavailable.
 	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -53,6 +53,10 @@ func (s *currentTypeDefsTestServer) CurrentWorkspace(context.Context) (*core.Wor
 	return nil, nil
 }
 
+func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
 func (s *currentTypeDefsTestServer) CurrentServedDeps(context.Context) (*core.SchemaBuilder, error) {
 	return s.deps, nil
 }

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1266,6 +1266,9 @@ func (s *workspaceSchema) checks(
 		noGenerate = true
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1375,6 +1378,9 @@ func (s *workspaceSchema) generators(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1493,6 +1499,9 @@ func (s *workspaceSchema) services(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1645,6 +1654,17 @@ func matchWorkspaceIncludePath(
 		}
 	}
 	return false, nil
+}
+
+// ensureWorkspaceIncludeModulesLoaded loads the workspace modules the include
+// patterns demand (all when they don't narrow). Selector fields validate
+// against the core schema, so loading can wait until resolution.
+func ensureWorkspaceIncludeModulesLoaded(ctx context.Context, include []string) error {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	return query.Server.EnsureWorkspaceModules(ctx, include)
 }
 
 func currentWorkspacePrimaryModules(ctx context.Context) ([]dagql.ObjectResult[*core.Module], error) {

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -56,6 +56,10 @@ func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*M
 	return nil
 }
 
+func (ms *mockServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
 func (ms *mockServer) CurrentModule(_ context.Context) (dagql.ObjectResult[*Module], error) {
 	var zero dagql.ObjectResult[*Module]
 	if ms.moduleSource == nil {

--- a/dagql/request_peek.go
+++ b/dagql/request_peek.go
@@ -20,26 +20,71 @@ type peekGraphQLRequest struct {
 // PeekRootFields returns the top-level field names selected by a GraphQL-over-HTTP
 // request while preserving the request body for the real server.
 func PeekRootFields(r *http.Request) (bool, []string, error) {
+	ok, _, fields, err := PeekRootFieldsAndOperation(r)
+	return ok, fields, err
+}
+
+// PeekRootFieldsAndOperation is PeekRootFields plus the request's operation
+// name (recovered from the document when the envelope omits it).
+func PeekRootFieldsAndOperation(r *http.Request) (bool, string, []string, error) {
 	query, operationName, ok, err := peekGraphQLRequestBody(r)
 	if err != nil || !ok {
-		return ok, nil, err
+		return ok, operationName, nil, err
 	}
 
 	doc, err := parser.ParseQuery(&ast.Source{Input: query})
 	if err != nil {
-		return false, nil, err
+		return false, operationName, nil, err
 	}
 
 	op, ok := peekOperation(doc, operationName)
 	if !ok || op.Operation != ast.Query {
-		return false, nil, nil
+		return false, operationName, nil, nil
+	}
+	if operationName == "" {
+		operationName = op.Name
 	}
 
 	fields, ok := collectRootFields(op.SelectionSet, doc.Fragments)
 	if !ok {
-		return false, nil, nil
+		return false, operationName, nil, nil
 	}
-	return true, fields, nil
+	return true, operationName, fields, nil
+}
+
+// moduleScopeOperationPrefix marks an operation name that carries a single
+// workspace-module load scope for the server to peek (see the design doc). The
+// prefix is otherwise ignored, so the same query works against engines that
+// don't peek it.
+const moduleScopeOperationPrefix = "DaggerModuleScope_"
+
+// ModuleScopeOperationName encodes a module load scope into a GraphQL operation
+// name. Non-identifier characters (e.g. the '-' in a kebab-case command name)
+// become '_'; the server kebab-normalizes the decoded token, so "good-mod" and
+// "goodMod" still match.
+func ModuleScopeOperationName(scope string) string {
+	return moduleScopeOperationPrefix + sanitizeGraphQLName(scope)
+}
+
+// ModuleScopeFromOperationName returns the module load scope encoded into an
+// operation name, if any.
+func ModuleScopeFromOperationName(operationName string) (string, bool) {
+	scope, ok := strings.CutPrefix(operationName, moduleScopeOperationPrefix)
+	if !ok || scope == "" {
+		return "", false
+	}
+	return scope, true
+}
+
+func sanitizeGraphQLName(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
 }
 
 func peekGraphQLRequestBody(r *http.Request) (string, string, bool, error) {

--- a/dagql/request_peek_test.go
+++ b/dagql/request_peek_test.go
@@ -62,3 +62,53 @@ func TestPeekRootFieldsRejectsBatch(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, fields)
 }
+
+func TestPeekRootFieldsAndOperationRecoversNameFromDocument(t *testing.T) {
+	t.Parallel()
+
+	// operationName omitted from the envelope -- recovered from the document.
+	body := `{"query":"query DaggerModuleScope_good { currentTypeDefs { name } }"}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, operationName, fields, err := dagql.PeekRootFieldsAndOperation(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "DaggerModuleScope_good", operationName)
+	require.Equal(t, []string{"currentTypeDefs"}, fields)
+
+	scope, scoped := dagql.ModuleScopeFromOperationName(operationName)
+	require.True(t, scoped)
+	require.Equal(t, "good", scope)
+}
+
+func TestModuleScopeOperationNameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		scope  string
+		opName string
+	}{
+		{"good", "DaggerModuleScope_good"},
+		// kebab-case command names become identifier-safe; the server
+		// kebab-normalizes the decoded token, so the original still matches.
+		{"good-mod", "DaggerModuleScope_good_mod"},
+		{"greet", "DaggerModuleScope_greet"},
+	} {
+		opName := dagql.ModuleScopeOperationName(tc.scope)
+		require.Equal(t, tc.opName, opName)
+
+		decoded, ok := dagql.ModuleScopeFromOperationName(opName)
+		require.True(t, ok)
+		require.Equal(t, dagql.ModuleScopeOperationName(decoded), opName)
+	}
+}
+
+func TestModuleScopeFromOperationNameIgnoresUnscoped(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"", "TypeDefs", "Picked", "DaggerModuleScope_"} {
+		_, ok := dagql.ModuleScopeFromOperationName(name)
+		require.False(t, ok, name)
+	}
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -214,10 +214,20 @@ type daggerClient struct {
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
 	modulesMu           sync.Mutex
-	modulesLoaded       bool
-	modulesErr          error
-	singleQueryMu       sync.Mutex
-	singleQueryServed   bool
+	extraModulesLoaded  bool
+	extraModulesErr     error
+	// load failures by moduleProgressName; failed modules stay pending to keep
+	// reporting their error
+	failedModules map[string]error
+	// whether an entrypoint module has been served (extras outrank ambient)
+	entrypointServed bool
+	// resolved identities already served, for cross-batch deduplication
+	servedModuleKeys map[string]struct{}
+	// served workspace module names, so demand filters recognize them without
+	// reloading
+	servedWorkspaceModuleNames map[string]struct{}
+	singleQueryMu              sync.Mutex
+	singleQueryServed          bool
 
 	// NOTE: do not use this field directly as it may not be open
 	// after the client has shutdown; use TelemetryDB() instead
@@ -992,7 +1002,7 @@ func (srv *Server) getOrInitClient(
 		}
 		// ExtraModules may arrive on a later request (e.g. /init) after the
 		// session attachable request already created the client without them.
-		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.modulesLoaded {
+		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.extraModulesLoaded {
 			client.clientMetadata.ExtraModules = opts.ExtraModules
 			client.pendingExtraModules = opts.ExtraModules
 		}
@@ -1466,26 +1476,18 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 		return gqlErr(err, http.StatusBadRequest)
 	}
 
-	peekRootFieldsOK, peekRootFields, err := peekSingleQueryRootFields(r, client.clientMetadata)
-	if err != nil {
-		return gqlErr(fmt.Errorf("peeking single-query root fields: %w", err), http.StatusBadRequest)
-	}
-
 	// Load workspace modules and extra modules (e.g. from -m flag). These are
 	// deferred from initializeDaggerClient because they need the client's
 	// session attachables, which only become available after the session
 	// attachables handshake completes (after init locks are released).
 	wsCtx, wsOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.workspaceLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureWorkspaceLoaded(wsCtx, client)
+	err := srv.ensureWorkspaceLoaded(wsCtx, client)
 	wsOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading workspace: %w", err), http.StatusInternalServerError)
 	}
-	if peekRootFieldsOK {
-		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
-	}
 	modCtx, modOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.modulesLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureModulesLoaded(modCtx, client)
+	err = srv.ensureRequestModulesLoaded(modCtx, client, r)
 	modOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1532,11 +1534,37 @@ func (client *daggerClient) claimSingleQueryRequest() error {
 	return nil
 }
 
-func peekSingleQueryRootFields(r *http.Request, clientMD *engine.ClientMetadata) (bool, []string, error) {
-	if clientMD == nil || !clientMD.SingleQuery || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
-		return false, nil, nil
+// ensureRequestModulesLoaded loads the modules this request demands, read from
+// the request: a module-scoped operation name (a targeted call/functions
+// introspection) demands that module plus the entrypoint; otherwise root fields
+// naming pending modules demand those, and full-schema or unrecognized fields
+// demand everything. The rest stay pending.
+func (srv *Server) ensureRequestModulesLoaded(ctx context.Context, client *daggerClient, r *http.Request) error {
+	var filter func([]pendingModule) []pendingModule
+	if client.hasPendingWorkspaceModules() {
+		if ok, operationName, rootFields, err := dagql.PeekRootFieldsAndOperation(r); err == nil && ok {
+			if scope, scoped := dagql.ModuleScopeFromOperationName(operationName); scoped {
+				include := []string{scope}
+				filter = func(mods []pendingModule) []pendingModule {
+					// runs under client.modulesMu, which also guards
+					// servedWorkspaceModuleNames and entrypointServed
+					return filterPendingWorkspaceModulesForTypeDefsTarget(mods, client.servedWorkspaceModuleNames, client.entrypointServed, include)
+				}
+			} else {
+				filter = func(mods []pendingModule) []pendingModule {
+					// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+					return filterPendingWorkspaceModulesForRootFields(mods, client.servedWorkspaceModuleNames, rootFields)
+				}
+			}
+		}
 	}
-	return dagql.PeekRootFields(r)
+	return srv.ensureModulesLoaded(ctx, client, filter)
+}
+
+func (client *daggerClient) hasPendingWorkspaceModules() bool {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+	return len(client.pendingModules) > 0
 }
 
 func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *daggerClient) (rerr error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -222,14 +222,14 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 	t.Run("constructor match loads only matching module", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"foo"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"foo"})
 		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("unknown root field with multiple entrypoints loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"doThing"})
 		require.Equal(t, mods, filtered)
 	})
 
@@ -237,36 +237,277 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		oneEntrypoint := []pendingModule{mods[0], mods[1]}
-		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, []string{"doThing"})
 		require.Equal(t, []pendingModule{mods[1]}, filtered)
 	})
 
 	t.Run("introspection loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"__schema"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"__schema"})
 		require.Equal(t, mods, filtered)
 	})
 
-	t.Run("current typedefs loads all", func(t *testing.T) {
+	t.Run("current typedefs loads all (targeted introspection narrows via operation-name scope)", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentTypeDefs"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentTypeDefs"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("current module loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentModule"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentModule"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("core-only query loads none", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"container", "version"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"container", "version"})
 		require.Empty(t, filtered)
+	})
+
+	t.Run("current workspace loads none (resolvers load on demand)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentWorkspace"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("already-served root field loads none", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served field combined with pending field loads only pending", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod", "foo"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("env loads all (resolver snapshots served deps)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"env"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("unrecognized loadFromID field loads all", func(t *testing.T) {
+		t.Parallel()
+
+		// The type name in load<Type>FromID needn't embed the module name, so
+		// only a full load can guarantee the field exists.
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"loadSomethingFromID"})
+		require.Equal(t, mods, filtered)
+	})
+}
+
+func TestFilterPendingWorkspaceModulesBySelectorInclude(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "go-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "rust-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "php-sdk"},
+	}
+
+	t.Run("module:generator selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("module:item works for checks and services too", func(t *testing.T) {
+		t.Parallel()
+
+		// The module-name resolution is identical across generate/check/up: the
+		// segment before ':' is the module name regardless of the item kind.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"rust-sdk:lint", "php-sdk:web"})
+		require.Equal(t, []pendingModule{mods[1], mods[2]}, filtered)
+	})
+
+	t.Run("bare module name selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("multiple patterns select each named module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk", "php-sdk:api"})
+		require.Equal(t, []pendingModule{mods[0], mods[2]}, filtered)
+	})
+
+	t.Run("bare token not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// e.g. an item served by the entrypoint module.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("module:item not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"typo-sdk:generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("empty include selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, nil)
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("already-served module is recognized and selects nothing", func(t *testing.T) {
+		t.Parallel()
+
+		// A re-evaluated selector (e.g. loading a GeneratorGroup from its ID
+		// on a later request) names a module that already loaded; it must not
+		// fall back to loading everything.
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served and pending patterns select only the pending module", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk:generate", "go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("camelCase pattern selects the kebab-case module", func(t *testing.T) {
+		t.Parallel()
+
+		// Name matching is kebab-normalized on both sides, like the include
+		// matchers the selector resolvers use (ModTreePath.Glob/CliCase).
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"goSdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("kebab-case pattern selects the camelCase module", func(t *testing.T) {
+		t.Parallel()
+
+		// The CLI presents module commands in kebab-case, so a module declared
+		// as "myMod" (or "mod1", which kebab-cases to "mod-1") is targeted by
+		// its kebab-case name.
+		camelMods := []pendingModule{
+			{Kind: moduleLoadKindAmbient, Name: "myMod"},
+			{Kind: moduleLoadKindAmbient, Name: "mod1"},
+			{Kind: moduleLoadKindAmbient, Name: "other"},
+		}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(camelMods, nil, []string{"my-mod", "mod-1:generate"})
+		require.Equal(t, []pendingModule{camelMods[0], camelMods[1]}, filtered)
+	})
+
+	t.Run("glob pattern selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// Glob metacharacters survive normalization and never equal a module
+		// name, so glob patterns conservatively load everything.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-*"})
+		require.Equal(t, mods, filtered)
+	})
+}
+
+func TestFilterPendingWorkspaceModulesForTypeDefsTarget(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "goodMod"},
+		{Kind: moduleLoadKindAmbient, Name: "other"},
+	}
+	withEntrypoint := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "goodMod"},
+		{Kind: moduleLoadKindAmbient, Name: "other"},
+		{Kind: moduleLoadKindAmbient, Name: "entry", Entrypoint: true},
+	}
+
+	t.Run("module target selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, false, []string{"goodMod"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("kebab-case target selects the camelCase module", func(t *testing.T) {
+		t.Parallel()
+
+		// `dagger call good-mod ...`: the CLI command name for module
+		// "goodMod" is its kebab-case form.
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, false, []string{"good-mod"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("unknown target without entrypoint selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, false, []string{"nope"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("module target also selects the pending entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		// The entrypoint's functions live on the Query root next to module
+		// constructors, so a targeted command tree always needs it.
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, []string{"good-mod"})
+		require.Equal(t, []pendingModule{withEntrypoint[0], withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("unknown target with pending entrypoint selects only the entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		// `dagger call container-echo ...` where container-echo is an
+		// entrypoint function: only the entrypoint module can resolve it.
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, []string{"container-echo"})
+		require.Equal(t, []pendingModule{withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("unknown target with served entrypoint selects nothing", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(mods, nil, true, []string{"container-echo"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served module target selects only the entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		// goodMod already loaded on an earlier request: the target is
+		// recognized (no fall back to loading everything) and only the
+		// pending entrypoint still needs to load.
+		served := map[string]struct{}{"goodMod": {}}
+		stillPending := []pendingModule{withEntrypoint[1], withEntrypoint[2]}
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(stillPending, served, false, []string{"good-mod"})
+		require.Equal(t, []pendingModule{withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("entrypoint target selects it once", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, []string{"entry"})
+		require.Equal(t, []pendingModule{withEntrypoint[2]}, filtered)
+	})
+
+	t.Run("empty include selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForTypeDefsTarget(withEntrypoint, nil, false, nil)
+		require.Equal(t, withEntrypoint, filtered)
 	})
 }
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -890,33 +890,144 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 	return tree, gitRef, nil
 }
 
-// ensureModulesLoaded loads all pending modules (from workspace discovery,
-// compat parsing, and -m flags). Called from serveQuery after
-// ensureWorkspaceLoaded. Uses a mutex+flag instead of sync.Once so that
-// transient failures (e.g. session not yet registered) can be retried.
-func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient) error {
-	if len(client.pendingModules) == 0 && len(client.pendingExtraModules) == 0 {
-		return nil
-	}
-
+// ensureModulesLoaded loads pending modules (workspace, compat, and -m) on
+// demand. filter picks which pending workspace modules this request needs (nil
+// = all); the rest stay pending for a later request or resolver. Loading is
+// additive, so narrowing is deferral, not exclusion. Mutex+flags (not
+// sync.Once) keep transient failures retriable.
+func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule) error {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
 
-	if client.modulesLoaded {
-		return client.modulesErr
+	if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
+		return err
+	}
+
+	if len(client.pendingModules) == 0 {
+		return nil
+	}
+
+	demand := client.pendingModules
+	if filter != nil {
+		demand = filter(client.pendingModules)
+	}
+	// Multiple ambient entrypoint declarations may dedupe to one module; load
+	// everything so the existing conflict detection still runs.
+	if len(demand) > 0 && len(pendingWorkspaceEntrypointIndexes(client.pendingModules)) > 1 {
+		demand = client.pendingModules
+	}
+	if len(demand) == 0 {
+		return nil
+	}
+
+	// A failed module stays pending; surface its recorded error rather than
+	// reloading it.
+	for _, mod := range demand {
+		if err, ok := client.failedModules[moduleProgressName(mod)]; ok {
+			return err
+		}
 	}
 
 	// Wait for the client's session attachables to be available.
-	// Don't mark as loaded on failure — allow retry on next request.
+	// Transient failure — allow retry on next request.
 	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
 		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
-	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules)
+	loads := gatherModuleLoadRequests(demand, nil)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			loadErr := moduleLoadErr(load, resolveErrs[i])
+			client.recordFailedModule(load.mod, loadErr)
+			if firstErr == nil {
+				firstErr = loadErr
+			}
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := client.arbitrateAmbientEntrypoints(loads, resolvedLoads); err != nil {
+		return err
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return err
+	}
+	client.markEntrypointServed(resolvedLoads)
+	client.removePendingModules(demand)
+	return nil
+}
+
+// ensureExtraModulesLoadedLocked loads -m modules. They are explicitly
+// requested, so they load eagerly with sticky failures (unlike on-demand
+// workspace modules). client.modulesMu must be held.
+func (srv *Server) ensureExtraModulesLoadedLocked(ctx context.Context, client *daggerClient) error {
+	if client.extraModulesLoaded {
+		return client.extraModulesErr
+	}
+	if len(client.pendingExtraModules) == 0 {
+		return nil
+	}
+
+	// Wait for the client's session attachables to be available.
+	// Transient failure — allow retry on next request.
+	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		return fmt.Errorf("waiting for client session attachables: %w", err)
+	}
+
+	stick := func(err error) error {
+		client.extraModulesErr = err
+		client.extraModulesLoaded = true
+		return err
+	}
+
+	loads := gatherModuleLoadRequests(nil, client.pendingExtraModules)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return stick(err)
+	}
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			return stick(moduleLoadErr(load, resolveErrs[i]))
+		}
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+	client.markEntrypointServed(resolvedLoads)
+
+	client.extraModulesLoaded = true
+	return nil
+}
+
+// resolveModuleLoadBatch resolves a batch of module loads in parallel,
+// collecting per-load errors in deterministic order.
+func (srv *Server) resolveModuleLoadBatch(
+	ctx context.Context,
+	client *daggerClient,
+	loads []moduleLoadRequest,
+) ([]resolvedModuleLoad, []error, error) {
 	resolvedLoads := make([]resolvedModuleLoad, len(loads))
 	resolveErrs := make([]error, len(loads))
 
-	// Load modules in parallel, then apply to client state in deterministic order.
 	jobs := parallel.New().
 		WithContextualTracer(true).
 		WithLimit(moduleLoadParallelism(len(loads)))
@@ -934,57 +1045,225 @@ func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient
 		})
 	}
 	if err := jobs.Run(ctx); err != nil {
-		client.modulesErr = fmt.Errorf("resolving modules: %w", err)
-		client.modulesLoaded = true
-		return client.modulesErr
+		return nil, nil, fmt.Errorf("resolving modules: %w", err)
 	}
+	return resolvedLoads, resolveErrs, nil
+}
 
-	for i, load := range loads {
-		if resolveErrs[i] != nil {
-			client.modulesErr = moduleLoadErr(load, resolveErrs[i])
-			client.modulesLoaded = true
-			return client.modulesErr
+// arbitrateAmbientEntrypoints picks whether this ambient batch's entrypoint
+// candidate wins: only when none is served yet (extras outrank ambient).
+// Multiple candidates in one batch are a workspace configuration error.
+func (client *daggerClient) arbitrateAmbientEntrypoints(loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+	var candidates []int
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			candidates = append(candidates, i)
 		}
 	}
-
-	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
-	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if len(candidates) > 1 {
+		return entrypointConflictError(moduleLoadKindAmbient, candidates, loads)
 	}
-
-	client.stateMu.Lock()
-	defer client.stateMu.Unlock()
-	if err := srv.serveAllResolvedModuleLoads(client, loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if client.entrypointServed {
+		for _, i := range candidates {
+			resolved[i].primaryEntrypoint = false
+		}
 	}
-
-	client.modulesLoaded = true
 	return nil
 }
 
-func (client *daggerClient) narrowPendingWorkspaceModulesForSingleQuery(rootFields []string) {
-	client.modulesMu.Lock()
-	defer client.modulesMu.Unlock()
-
-	if client.modulesLoaded || len(client.pendingModules) == 0 {
-		return
+// markEntrypointServed flags that an entrypoint (primary or blueprint) was
+// served, so later ambient candidates are demoted. client.modulesMu must be held.
+func (client *daggerClient) markEntrypointServed(resolved []resolvedModuleLoad) {
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			client.entrypointServed = true
+			return
+		}
+		for _, related := range resolved[i].related {
+			if related.entrypoint {
+				client.entrypointServed = true
+				return
+			}
+		}
 	}
-	client.pendingModules = filterPendingWorkspaceModulesForRootFields(client.pendingModules, rootFields)
 }
 
-func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields []string) []pendingModule {
+func (client *daggerClient) recordFailedModule(mod pendingModule, err error) {
+	// Cancellation/deadline is the request's fault, not the module's; keep it
+	// retriable.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	if client.failedModules == nil {
+		client.failedModules = make(map[string]error)
+	}
+	client.failedModules[moduleProgressName(mod)] = err
+}
+
+// removePendingModules drops served modules from the pending set and records
+// their names so demand filters still recognize them. Failed modules stay
+// pending to keep reporting their error. client.modulesMu must be held.
+func (client *daggerClient) removePendingModules(served []pendingModule) {
+	names := make(map[string]struct{}, len(served))
+	for _, mod := range served {
+		names[moduleProgressName(mod)] = struct{}{}
+	}
+	remaining := client.pendingModules[:0]
+	for _, mod := range client.pendingModules {
+		if _, ok := names[moduleProgressName(mod)]; ok {
+			if client.servedWorkspaceModuleNames == nil {
+				client.servedWorkspaceModuleNames = make(map[string]struct{})
+			}
+			client.servedWorkspaceModuleNames[moduleProgressName(mod)] = struct{}{}
+			continue
+		}
+		remaining = append(remaining, mod)
+	}
+	client.pendingModules = remaining
+}
+
+// EnsureWorkspaceModules loads the pending workspace modules a selector
+// resolver (checks/generators/services) demands. Those fields validate against
+// the core schema, so loading waits until resolution where include is native.
+func (srv *Server) EnsureWorkspaceModules(ctx context.Context, include []string) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return srv.ensureModulesLoaded(ctx, client, func(mods []pendingModule) []pendingModule {
+		// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+		return filterPendingWorkspaceModulesBySelectorInclude(mods, client.servedWorkspaceModuleNames, include)
+	})
+}
+
+// canonicalWorkspaceModuleName kebab-normalizes a name or pattern segment for
+// comparison, matching the include matchers (ModTreePath.Glob/CliCase) and CLI
+// command names: "myMod", "my-mod", "MyMod" are the same module. Glob
+// metacharacters survive, so a glob never equals a module name.
+func canonicalWorkspaceModuleName(name string) string {
+	return strcase.ToKebab(name)
+}
+
+// pendingModuleCliName is the canonical name an include pattern matches against.
+func pendingModuleCliName(mod pendingModule) string {
+	if mod.Name != "" {
+		return canonicalWorkspaceModuleName(mod.Name)
+	}
+	return canonicalWorkspaceModuleName(moduleProgressName(mod))
+}
+
+// knownWorkspaceModuleNames is the canonical-name set of all pending and
+// already-served workspace modules.
+func knownWorkspaceModuleNames(mods []pendingModule, served map[string]struct{}) map[string]struct{} {
+	known := make(map[string]struct{}, len(mods)+len(served))
+	for _, mod := range mods {
+		known[pendingModuleCliName(mod)] = struct{}{}
+	}
+	for name := range served {
+		known[canonicalWorkspaceModuleName(name)] = struct{}{}
+	}
+	return known
+}
+
+// resolveIncludePatternModules maps each pattern's leading segment (before ':')
+// to a known module name. It returns the demanded names and whether any pattern
+// matched nothing known; the caller decides the fallback.
+func resolveIncludePatternModules(mods []pendingModule, served map[string]struct{}, include []string) (wanted map[string]struct{}, unknown bool) {
+	known := knownWorkspaceModuleNames(mods, served)
+	wanted = make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		modName, _, _ := strings.Cut(pattern, ":")
+		modName = canonicalWorkspaceModuleName(modName)
+		if _, ok := known[modName]; !ok {
+			unknown = true
+			continue
+		}
+		wanted[modName] = struct{}{}
+	}
+	return wanted, unknown
+}
+
+// filterPendingWorkspaceModulesBySelectorInclude selects the modules named by
+// `dagger generate`/`check`/`up` patterns ("module" or "module:item"). A
+// pattern naming no known module (an entrypoint-proxied item, or a typo)
+// selects all, so the usual error surfaces. served modules are recognized but
+// contribute nothing to load.
+func filterPendingWorkspaceModulesBySelectorInclude(mods []pendingModule, served map[string]struct{}, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	wanted, unknown := resolveIncludePatternModules(mods, served, include)
+	if unknown {
+		return mods
+	}
+
+	// Already-served wanted modules contribute nothing; result may be empty.
+	filtered := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if _, ok := wanted[pendingModuleCliName(mod)]; ok {
+			filtered = append(filtered, mod)
+		}
+	}
+	return filtered
+}
+
+// filterPendingWorkspaceModulesForTypeDefsTarget selects the modules a targeted
+// typedefs introspection demands: those the patterns name, plus any pending
+// entrypoint (the target may be one of its root-proxied functions). A pattern
+// naming nothing known selects only the entrypoint when one exists (pending or
+// served), else all so the unknown-command error surfaces.
+func filterPendingWorkspaceModulesForTypeDefsTarget(mods []pendingModule, served map[string]struct{}, entrypointServed bool, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	wanted, unknown := resolveIncludePatternModules(mods, served, include)
+
+	entrypoints := pendingWorkspaceEntrypointIndexes(mods)
+	if unknown && !entrypointServed && len(entrypoints) == 0 {
+		return mods
+	}
+
+	selected := make([]bool, len(mods))
+	for i, mod := range mods {
+		if _, ok := wanted[pendingModuleCliName(mod)]; ok {
+			selected[i] = true
+		}
+	}
+	for _, i := range entrypoints {
+		selected[i] = true
+	}
+
+	filtered := make([]pendingModule, 0, len(mods))
+	for i, mod := range mods {
+		if selected[i] {
+			filtered = append(filtered, mod)
+		}
+	}
+	return filtered
+}
+
+// filterPendingWorkspaceModulesForRootFields selects the pending modules a
+// request's root fields reference. served modules are recognized without
+// loading.
+func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods
+	}
+
+	servedFields := make(map[string]struct{}, len(served))
+	for name := range served {
+		servedFields[strcase.ToLowerCamel(name)] = struct{}{}
 	}
 
 	selected := make([]bool, len(mods))
 	unknownRootField := false
 	for _, field := range rootFields {
 		if isCoreRootField(field) {
+			continue
+		}
+		if _, ok := servedFields[field]; ok {
 			continue
 		}
 		matched := false
@@ -995,6 +1274,11 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields
 			}
 		}
 		if !matched {
+			// load<Type>FromID can reference a module type without naming the
+			// module, so load everything to be safe.
+			if strings.HasPrefix(field, "load") && strings.HasSuffix(field, "FromID") {
+				return mods
+			}
 			unknownRootField = true
 		}
 	}
@@ -1031,8 +1315,11 @@ func rootFieldsRequireFullWorkspaceSchema(fields []string) bool {
 			"__workspaceModule",
 			"currentEnv",
 			"currentModule",
+			// currentTypeDefs loads everything; a targeted introspection instead
+			// narrows via the peeked operation-name scope (ensureRequestModulesLoaded).
 			"currentTypeDefs",
-			"currentWorkspace":
+			// env's resolver snapshots the served deps, so it needs every module
+			"env":
 			return true
 		}
 	}
@@ -1087,10 +1374,14 @@ func isCoreRootField(field string) bool {
 		"currentEnv",
 		"currentFunctionCall",
 		"currentModule",
+		// currentWorkspace's selector resolvers load on demand from their
+		// include argument, so the root field demands nothing here
+		"currentWorkspace",
 		"defaultPlatform",
 		"directory",
 		"engine",
-		"env",
+		// NOTE: "env" is intentionally absent — it needs the full workspace
+		// (see rootFieldsRequireFullWorkspaceSchema)
 		"envFile",
 		"error",
 		"file",
@@ -1177,8 +1468,10 @@ func (srv *Server) resolveModuleLoad(
 	return resolved, nil
 }
 
-// serveAllResolvedModuleLoads serves all resolved primary modules and their
-// related modules (blueprints, toolchains-of-toolchains).
+// serveResolvedModuleLoadsLocked serves resolved primary modules and their
+// related modules (blueprints, toolchains-of-toolchains), skipping any whose
+// identity an earlier batch already served. client.stateMu and client.modulesMu
+// must be held.
 //
 // Transitive dependencies are only served for the entrypoint module — the one
 // the user is interacting with via `dagger call` or `dagger shell`. This is
@@ -1186,9 +1479,13 @@ func (srv *Server) resolveModuleLoad(
 // (e.g. a Mallard backing a Duck). Toolchain deps are NOT served globally;
 // each module's deps are available in its own internal schema (mod.Deps) for
 // type resolution during function calls.
-func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+func (srv *Server) serveResolvedModuleLoadsLocked(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
 	for i := range loads {
 		load := resolved[i]
+		key := resolvedModuleLoadIdentity(load.primary)
+		if _, ok := client.servedModuleKeys[key]; ok {
+			continue
+		}
 		for _, related := range load.related {
 			if err := srv.serveModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: related.entrypoint}); err != nil {
 				return fmt.Errorf("error serving related module %s: %w", related.mod.Self().Name(), err)
@@ -1208,6 +1505,10 @@ func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []mod
 				}
 			}
 		}
+		if client.servedModuleKeys == nil {
+			client.servedModuleKeys = make(map[string]struct{})
+		}
+		client.servedModuleKeys[key] = struct{}{}
 	}
 
 	return nil

--- a/hack/designs/dumb-cli-single-query-peek-module-loading.md
+++ b/hack/designs/dumb-cli-single-query-peek-module-loading.md
@@ -1,0 +1,294 @@
+# Demand-Driven Workspace Module Loading — Dumb-Client Variant
+
+*Alternative to [#13406](https://github.com/dagger/dagger/pull/13406)
+(`module-loading`, "Load workspace modules on demand"), which is itself an
+alternative to [#13380](https://github.com/dagger/dagger/pull/13380).*
+
+## Table of Contents
+
+- [Problem](#problem)
+- [Shared foundation: additive demand-driven loading](#shared-foundation-additive-demand-driven-loading)
+- [The one hard case: `dagger call` / `functions`](#the-one-hard-case-dagger-call--functions)
+- [This design: peek the operation name](#this-design-peek-the-operation-name)
+- [What each command does](#what-each-command-does)
+- [Sequence comparison](#sequence-comparison)
+- [Comparison with #13406](#comparison-with-13406)
+- [Implementation](#implementation)
+- [Edge cases](#edge-cases)
+
+## Problem
+
+Workspace module loading is one-shot: the first schema-needing request loads
+*every* configured module (`ensureModulesLoaded`, a sticky `modulesLoaded` flag
+in `engine/server/session_workspaces.go`). So `dagger generate|check|up|call|
+functions <module>` pays for all its siblings, and a single broken or stale
+module blocks operating on *any* module — for `generate`, including the very
+module you were running generate to fix. The pre-existing narrowing
+(`narrowPendingWorkspaceModulesForSingleQuery`) is restricted to `SingleQuery`
+clients, because once a pending module is *dropped* it can't come back in a
+later request.
+
+## Shared foundation: additive demand-driven loading
+
+This variant keeps #13406's engine foundation verbatim, because that part is
+already a "dumb client" — it requires no CLI change at all. Loading becomes
+**additive and demand-driven**: each request loads only the modules it can
+possibly touch, and the rest stay *pending*, loading when a later request
+demands them. The dagql schema is rebuilt from the served set per request, so
+the session schema grows monotonically — **narrowing is deferral, not
+exclusion**, which is what makes it safe for open multi-request sessions and
+generalizes the demand signal from `SingleQuery` to every client.
+
+The demand source is the natural one for each query shape:
+
+- **Root fields** naming a pending module load just that module (the existing
+  entrypoint fallback is preserved); full-schema fields (`__schema`, `env`, …)
+  and anything unrecognized conservatively load everything.
+- **`currentWorkspace { checks|generators|services(include: …) }`** validates
+  against the core schema, so loading moves *into* those resolvers via a
+  `Query.Server.EnsureWorkspaceModules` hook — they receive `include` as a
+  native typed argument, no request peeking. Since the CLI already sends
+  `include` as the command's functional argument, `dagger generate|check|up
+  <module>` narrows with **zero CLI change**.
+
+A failed module stays pending and only fails the requests that demand it; full
+listings still load everything and surface it. Extra (`-m`) modules keep loading
+eagerly with sticky errors — they were explicitly requested.
+
+## The one hard case: `dagger call` / `functions`
+
+`call`/`functions <module>` build their command tree from a
+`currentTypeDefs(returnAllTypes: true, hideCore: true)` introspection
+(`internal/cmd/dagger/typedefs.graphql`). That request validates against the
+core schema and **names no module** — there is no functional argument to read,
+unlike the selector commands. The narrowing signal has to enter the request
+somehow.
+
+PR #13406 answers this client-side (its "phase 2"): it adds a public
+`currentTypeDefs(include:)` argument and teaches the CLI to derive a
+scope-bearing query document, send it only when a target exists, and fall back
+to the plain document when the engine reports the argument as unknown. That is
+correct, but it is a lot of client intelligence plus a permanent public API
+surface: a base-schema-allowlist gate, a version gate, a `PerClientInput` cache
+fix (loading now happens *inside* the cached resolver), and a regeneration of
+the argument into every SDK's generated client.
+
+## This design: peek the operation name
+
+Keep the CLI dumb. The signal it must convey is one token — *which module*. Put
+that token where every GraphQL request already carries free-form, server-ignored
+text: the **operation name**.
+
+When `dagger call`/`functions` targets a module, the CLI names its introspection
+operation `DaggerModuleScope_<module>` (and sets the matching `operationName` in
+the request envelope). The engine already parses the operation name in its
+per-request peek (`dagql.PeekRootFields` reads it today); the peek now also
+returns it, decodes the scope, and loads just that module (plus the workspace
+entrypoint) **before the request runs** — exactly the same
+`filterPendingWorkspaceModulesForTypeDefsTarget` demand rule #13406 uses, fed
+from the peek instead of a resolver argument.
+
+Consequences, all in the dumb-client direction:
+
+- **No public API change.** `currentTypeDefs` is untouched — no `include`
+  argument, no SDK regeneration, no version gate, no base-schema allowlist
+  entry.
+- **No `PerClientInput`.** Loading happens *before* the resolver (in
+  `serveQuery`, as on `main`), so the schema digest at `currentTypeDefs` call
+  time reflects the workspace's served modules and stays workspace-unique.
+  `CurrentSchemaInput` alone is correct; the resolver-time cache-collision
+  hazard #13406 had to defend against never arises.
+- **No fallback branch.** The same query is sent to every engine: an operation
+  name is always valid GraphQL, so an engine that doesn't peek it simply ignores
+  it and loads every module — the pre-narrowing behavior. The CLI does not need
+  to know the engine's version.
+- **The CLI change is ~one statement per call site** plus a string rename of the
+  embedded operation. No conditional documents, no error sniffing.
+
+Kebab-case command names (`dagger call good-mod`, module `goodMod`) survive
+because GraphQL names allow only `[_0-9A-Za-z]`: the `-` is sanitized to `_` in
+the operation name, and the engine kebab-normalizes the decoded token the same
+way it normalizes module names (`canonicalWorkspaceModuleName` →
+`strcase.ToKebab`), so both sides resolve to `good-mod`.
+
+## What each command does
+
+| Command | Today (`main`) | This design |
+|---|---|---|
+| `dagger generate good` / `check good:*` / `up good` | loads all | loads `good` — resolver reads the `include` it already receives; **no CLI change** |
+| `dagger query '{ good { verify } }'` | narrowed only with `--single-query` | narrowed for every client, root-field demand |
+| `dagger call good verify` | loads all | loads `good` — operation `DaggerModuleScope_good`, peeked; execution `{ good { verify } }` then narrows by root field |
+| `dagger call good-mod ping` | loads all | loads `goodMod` — `-`→`_` sanitized, engine kebab-matches |
+| `dagger call greet` (entrypoint fn) | loads all | loads the entrypoint module alone (scope names no module → entrypoint demand) |
+| bare `dagger functions` / `shell` / `mcp` | loads all | loads all (correct: they need everything) |
+
+## Sequence comparison
+
+All three diagrams trace the same scenario — `dagger call MODULE fn` in a
+workspace of `{ MODULE, sibling-A, sibling-BROKEN }` where `sibling-BROKEN` has
+broken source — since that is where the approaches diverge.
+(`generate`/`check`/`up` narrow identically in #13406 and this design, through
+the selector resolvers' `include` argument, with no CLI change.)
+
+The participants are the engine HTTP handler (`session.go`), the module loader,
+the dagql schema, the `currentTypeDefs` resolver, and the dagql result cache.
+The last two matter because *when* a module loads decides the resolver's cache
+key: load it before the request and the schema digest already identifies the
+workspace; load it inside the resolver and it does not.
+
+### `main` — one-shot, load everything
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI
+    participant H as Engine HTTP handler<br/>(session.go)
+    participant L as Module loader
+    participant S as dagql schema
+    participant R as currentTypeDefs resolver
+    participant C as dagql result cache
+
+    Note over CLI: dagger call MODULE fn --arg ...
+    CLI->>H: query { currentTypeDefs { ... } }<br/>PLAIN doc, no include
+    Note right of CLI: multi-request session →<br/>SingleQuery peek/narrowing does NOT apply
+
+    H->>H: ensureWorkspaceLoaded() (discover)
+    H->>L: ensureModulesLoaded() — ALL pending
+    L-->>H: MODULE ok, sibling-A ok, sibling-BROKEN FAILS
+    Note over H,L: one broken sibling fails the whole request
+
+    H->>S: build schema = core + MODULE + sibling-A + sibling-BROKEN
+    H->>R: resolve currentTypeDefs
+    R->>C: key = CurrentSchemaInput = digest(served schema)
+    Note over C: served schema already contains workspace modules<br/>→ key differs per workspace for free (no client ID needed)
+    R-->>CLI: typedefs (everything served)
+    Note over CLI: build command tree → send actual call (2nd request)
+```
+
+### #13406 — demand-driven, signal in a public argument
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI
+    participant H as Engine HTTP handler<br/>(session.go)
+    participant S as dagql schema
+    participant R as currentTypeDefs resolver
+    participant C as dagql result cache
+    participant L as Module loader
+
+    Note over CLI: dagger call MODULE fn --arg ...<br/>extract leading positional token → "MODULE"
+    CLI->>H: query { currentTypeDefs(include: ["MODULE"]) { ... } }<br/>old engine rejects arg → fall back to PLAIN doc (load-all)
+
+    H->>H: ensureWorkspaceLoaded() (discover)
+    Note over H: ambient modules NOT loaded here (only -m extras)
+    H->>S: build schema = core only
+    Note over S: currentTypeDefs is a core field →<br/>query validates with no modules loaded
+
+    H->>R: resolve currentTypeDefs(include: ["MODULE"])
+    R->>C: key = CurrentSchemaInput(core only) + PerClientInput(client ID)
+    Note over C: schema digest is core-only → identical across workspaces<br/>PerClientInput (client ID) is what prevents an A/B collision
+    R->>L: EnsureWorkspaceModulesForTypeDefs(["MODULE"])
+    L-->>R: MODULE ok (+ entrypoint module if configured)
+    Note over L: sibling-A, sibling-BROKEN stay PENDING (never evaluated)
+    R-->>CLI: typedefs for MODULE
+    Note over CLI: build command tree → send actual call (2nd request)
+```
+
+Loading inside the resolver has a cost: the schema digest at `currentTypeDefs`
+call time is core-only, so it no longer distinguishes workspaces, and
+`PerClientInput` (client ID) must be mixed into the cache key to avoid two
+workspaces sharing one entry. The CLI also owns the `include` document and its
+old-engine fallback, and the new argument ships in every SDK's generated client.
+
+### #13539 — demand-driven, signal peeked from the operation name
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI
+    participant H as Engine HTTP handler<br/>(session.go)
+    participant L as Module loader
+    participant S as dagql schema
+    participant R as currentTypeDefs resolver
+    participant C as dagql result cache
+
+    Note over CLI: dagger call MODULE fn --arg ...<br/>extract leading positional token → "MODULE"
+    CLI->>H: query DaggerModuleScope_MODULE { currentTypeDefs { ... } }<br/>SAME doc for every engine (no include arg, no fallback)
+
+    H->>H: ensureWorkspaceLoaded() (discover)
+    H->>H: ensureRequestModulesLoaded() — peek operation name → scope "MODULE"
+    H->>L: load only MODULE (+ entrypoint module if configured), pre-request
+    L-->>H: MODULE ok
+    Note over L: sibling-A, sibling-BROKEN stay PENDING (never evaluated)
+    Note over H,L: a broken sibling can't fail this request
+
+    H->>S: build schema = core + MODULE
+    Note over S: MODULE served before the request runs
+
+    H->>R: resolve currentTypeDefs (UNCHANGED — no include arg)
+    R->>C: key = CurrentSchemaInput = digest(served schema)
+    Note over C: served schema already contains MODULE<br/>→ key differs per workspace for free (no PerClientInput needed)
+    R-->>CLI: typedefs for MODULE
+    Note over CLI: build command tree → send actual call (2nd request)
+```
+
+Because the module loads *before* the request runs, the schema already contains
+it at `currentTypeDefs` call time, so `CurrentSchemaInput` is workspace-unique
+for free — exactly as on `main`, and the resolver is left untouched. No
+`PerClientInput`, no public argument, no old-engine fallback. The follow-up call
+request (`{ MODULE { fn } }`) then narrows by root field, and `sibling-BROKEN`
+is never evaluated.
+
+## Comparison with #13406
+
+| | #13406 | This design |
+|---|---|---|
+| Engine foundation (additive loading, selector resolvers, root-field peek) | yes | **identical, reused** |
+| `call`/`functions` signal | new public `currentTypeDefs(include:)` arg | operation name, peeked |
+| CLI logic for `call`/`functions` | derive scoped document, conditional send, unknown-arg fallback | name the operation after the target |
+| Public API change | `currentTypeDefs(include:)` (+ allowlist + version gate) | none |
+| `PerClientInput` cache fix | required (resolver-time loading) | not needed (pre-request loading) |
+| SDK regeneration | all SDKs + runtimes | none |
+| Old-engine compatibility | fallback branch in the CLI | same query works everywhere, no branch |
+
+The two are not in conflict about the engine model — they share it. They differ
+only in where the `call`/`functions` target enters the request: a typed public
+argument the client constructs, versus an operation name the server peeks.
+
+## Implementation
+
+1. `dagql/request_peek.go` — `PeekRootFieldsAndOperation` (operation name +
+   root fields, name recovered from the document when the envelope omits it);
+   `ModuleScopeOperationName` / `ModuleScopeFromOperationName` codec.
+2. `engine/server/session.go` — `ensureRequestModulesLoaded` peeks the operation
+   name; a `DaggerModuleScope_<module>` operation narrows via
+   `filterPendingWorkspaceModulesForTypeDefsTarget`, otherwise root-field demand
+   applies.
+3. `engine/server/session_workspaces.go` — `currentTypeDefs` returns to the
+   load-everything default (`rootFieldsRequireFullWorkspaceSchema`), since the
+   scope now overrides it via the peek; the `EnsureWorkspaceModulesForTypeDefs`
+   resolver hook is dropped (the selector hook `EnsureWorkspaceModules` stays).
+4. `internal/cmd/dagger` — `call`/`functions` pass the leading positional token
+   as `loadTypeDefsOpts.Scope`; `loadTypeDefs` renames the introspection
+   operation and sets `operationName`. `currentTypeDefs` and every SDK client
+   are unchanged.
+
+## Edge cases
+
+- **Bare `functions` / `shell`** send no scope, so the operation name carries no
+  prefix and `currentTypeDefs` falls under the load-everything default — they
+  correctly see every module (and surface a broken one).
+- **Operation-name drift**: if `typedefs.graphql`'s `query TypeDefs(` header
+  changes, the rename silently no-ops and the CLI loads everything (safe
+  degradation); a unit test pins the coupling.
+- **Entrypoint execution** (`dagger call greet`): the introspection loads the
+  entrypoint; the follow-up `{ greet }` execution finds it already served, and
+  with no pending entrypoint left an unrecognized root field demands nothing, so
+  the broken sibling stays unloaded.
+- **Cache identity**: pre-request loading keeps the `currentTypeDefs` schema
+  digest workspace-specific, so `CurrentSchemaInput` keys results correctly
+  across concurrent sessions in different workspaces.
+- **Aliases/variables**: the peek uses field and operation *names*, never
+  aliases; operation names cannot be GraphQL variables, so there is nothing to
+  resolve.

--- a/internal/cmd/dagger/call.go
+++ b/internal/cmd/dagger/call.go
@@ -98,7 +98,7 @@ func runFunctionList(cmd *cobra.Command, args []string) error {
 			mod, err = initializeCore(ctx, engineClient.Dagger())
 		} else {
 			// -m modules are loaded at engine connect time as extra modules.
-			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true})
+			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true, Scope: workspaceModuleScope(args)})
 		}
 		if err != nil {
 			return err

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -323,7 +323,7 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		mod, err = initializeCore(ctx, fc.c.Dagger())
 	} else {
 		// -m modules are loaded at engine connect time as extra modules.
-		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true})
+		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true, Scope: workspaceModuleScope(a)})
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/dagger/module_inspect.go
+++ b/internal/cmd/dagger/module_inspect.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/dagui"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/iancoleman/strcase"
@@ -156,6 +157,17 @@ var loadModConfQuery string
 //go:embed typedefs.graphql
 var loadTypeDefsQuery string
 
+// typeDefsOperationName is the operation name in typedefs.graphql; a targeted
+// introspection renames it to carry a module scope the engine peeks.
+const typeDefsOperationName = "TypeDefs"
+
+// workspaceModuleScope returns the leading positional token -- the only token
+// that can name a workspace module. The engine peeks it to scope the typedefs
+// introspection; an empty result (uncertain or no token) loads every module.
+func workspaceModuleScope(args []string) string {
+	return functionName(args)
+}
+
 func inspectModule(ctx context.Context, dag *dagger.Client, source *dagger.ModuleSource) (rdef *moduleDef, rerr error) {
 	ctx, span := Tracer().Start(ctx, "inspecting module metadata", telemetry.Encapsulate())
 	defer telemetry.EndWithCause(span, &rerr)
@@ -260,6 +272,11 @@ type loadTypeDefsOpts struct {
 	// HideCore strips core API functions from the Query type, leaving
 	// only module-sourced functions (constructors, entrypoint proxies).
 	HideCore bool
+
+	// Scope, when set, names the workspace module the introspection targets. It
+	// rides in the operation name; the engine peeks it to load only that module
+	// (and the entrypoint), so a broken sibling can't block building the tree.
+	Scope string
 }
 
 // loadTypeDefs loads the objects defined by the given module in an easier to use data structure.
@@ -276,9 +293,23 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client, opts .
 		TypeDefs []*modTypeDef
 	}
 
+	query := loadTypeDefsQuery
+	var opName string
+	if o.Scope != "" {
+		// Name the operation after the target so the engine peeks it; an engine
+		// that doesn't ignores it and loads everything, as before. If the header
+		// drifted and the rename didn't apply, fall through to the plain query.
+		scopedOp := dagql.ModuleScopeOperationName(o.Scope)
+		if scoped := strings.Replace(query, "query "+typeDefsOperationName+"(", "query "+scopedOp+"(", 1); scoped != query {
+			query = scoped
+			opName = scopedOp
+		}
+	}
+
 	err := dag.Do(ctx, &dagger.Request{
-		Query:     loadTypeDefsQuery,
+		Query:     query,
 		Variables: map[string]any{"hideCore": o.HideCore},
+		OpName:    opName,
 	}, &dagger.Response{
 		Data: &res,
 	})

--- a/internal/cmd/dagger/module_inspect_test.go
+++ b/internal/cmd/dagger/module_inspect_test.go
@@ -1,0 +1,61 @@
+package daggercmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/dagql"
+)
+
+func TestWorkspaceModuleScope(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "first positional token is the scope",
+			args: []string{"my-mod", "container-echo", "--string-arg", "hi"},
+			want: "my-mod",
+		},
+		{
+			name: "self-contained flags are skipped",
+			args: []string{"--json=true", "my-mod", "fn"},
+			want: "my-mod",
+		},
+		{
+			name: "ambiguous flag sends no scope",
+			args: []string{"-o", "out.txt", "my-mod", "fn"},
+			want: "",
+		},
+		{
+			name: "no args sends no scope",
+			args: nil,
+			want: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, workspaceModuleScope(test.args))
+		})
+	}
+}
+
+// TestTypeDefsOperationRenameCoupling guards the coupling between
+// typedefs.graphql's "query TypeDefs(" header and the rename in loadTypeDefs:
+// if it drifts, scoping silently stops applying.
+func TestTypeDefsOperationRenameCoupling(t *testing.T) {
+	header := "query " + typeDefsOperationName + "("
+	require.Contains(t, loadTypeDefsQuery, header,
+		"typedefs.graphql operation header drifted from %q", header)
+
+	scopedOp := dagql.ModuleScopeOperationName("good-mod")
+	scoped := strings.Replace(loadTypeDefsQuery, header, "query "+scopedOp+"(", 1)
+	require.NotEqual(t, loadTypeDefsQuery, scoped, "scoped rename did not apply")
+	require.Contains(t, scoped, "query "+scopedOp+"(")
+
+	decoded, ok := dagql.ModuleScopeFromOperationName(scopedOp)
+	require.True(t, ok)
+	require.Equal(t, "good_mod", decoded) // '-' sanitized to '_'; engine kebab-normalizes
+}


### PR DESCRIPTION
## Summary

Alternative to #13406. Same goal — load workspace modules **on demand** instead of all-at-once, so an unrelated broken or stale module can't block operating on another one — but with **no API change**.

The CLI stays dumb. The intelligence is in the engine; the client just **renames its introspection query** so the engine can peek the target.

- `generate` / `check` / `up` already narrow through their `include` argument — engine-only, zero CLI change.
- `dagger call` / `functions` are the only hard case: their `currentTypeDefs` introspection names no module. Instead of adding a public `currentTypeDefs(include:)` argument (the #13406 approach, which needs a version gate, a cache-key fix, an SDK regen, and a CLI fallback for old engines), **the CLI names the operation `DaggerModuleScope_<module>` and the engine peeks the operation name.** Same query, same arguments — only the operation name changes.

### Why this is nice

- **No API change** — `currentTypeDefs` is untouched: no new argument, no SDK regeneration, no version gate, no `PerClientInput`.
- **Backward compatible** — an operation name is free-form GraphQL. The *same query* works against any engine: an old engine that doesn't peek it simply ignores the name and loads everything (today's behavior). No fallback branch, no engine-version detection.
- Loading happens **before** the request runs, so the schema already contains the module at `currentTypeDefs` time and its cache key stays workspace-unique for free (the property `main` has and #13406 had to restore with `PerClientInput`).

The whole client delta is two call sites plus naming the operation.

Reuses #13406's integration tests as the spec.

## How it works — `dagger call MODULE fn` with `{ MODULE, sibling-A, sibling-BROKEN }`

### `main` — one-shot, load everything (a broken sibling blocks the call)

```mermaid
sequenceDiagram
    autonumber
    participant CLI
    participant H as Engine HTTP handler<br/>(session.go)
    participant L as Module loader
    participant S as dagql schema
    participant R as currentTypeDefs resolver
    participant C as dagql result cache

    Note over CLI: dagger call MODULE fn --arg ...
    CLI->>H: query { currentTypeDefs { ... } }<br/>PLAIN doc, no include
    Note right of CLI: multi-request session →<br/>SingleQuery peek/narrowing does NOT apply

    H->>H: ensureWorkspaceLoaded() (discover)
    H->>L: ensureModulesLoaded() — ALL pending
    L-->>H: MODULE ok, sibling-A ok, sibling-BROKEN FAILS
    Note over H,L: one broken sibling fails the whole request

    H->>S: build schema = core + MODULE + sibling-A + sibling-BROKEN
    H->>R: resolve currentTypeDefs
    R->>C: key = CurrentSchemaInput = digest(served schema)
    Note over C: served schema already contains workspace modules<br/>→ key differs per workspace for free (no client ID needed)
    R-->>CLI: typedefs (everything served)
    Note over CLI: build command tree → send actual call (2nd request)
```

### #13406 — narrow via a new public `include` argument

```mermaid
sequenceDiagram
    autonumber
    participant CLI
    participant H as Engine HTTP handler<br/>(session.go)
    participant S as dagql schema
    participant R as currentTypeDefs resolver
    participant C as dagql result cache
    participant L as Module loader

    Note over CLI: dagger call MODULE fn --arg ...<br/>extract leading positional token → "MODULE"
    CLI->>H: query { currentTypeDefs(include: ["MODULE"]) { ... } }<br/>old engine rejects arg → fall back to PLAIN doc (load-all)

    H->>H: ensureWorkspaceLoaded() (discover)
    Note over H: ambient modules NOT loaded here (only -m extras)
    H->>S: build schema = core only
    Note over S: currentTypeDefs is a core field →<br/>query validates with no modules loaded

    H->>R: resolve currentTypeDefs(include: ["MODULE"])
    R->>C: key = CurrentSchemaInput(core only) + PerClientInput(client ID)
    Note over C: schema digest is core-only → identical across workspaces<br/>PerClientInput (client ID) is what prevents an A/B collision
    R->>L: EnsureWorkspaceModulesForTypeDefs(["MODULE"])
    L-->>R: MODULE ok (+ entrypoint module if configured)
    Note over L: sibling-A, sibling-BROKEN stay PENDING (never evaluated)
    R-->>CLI: typedefs for MODULE
    Note over CLI: build command tree → send actual call (2nd request)
```

### This PR — narrow via the peeked operation name (no API change)

```mermaid
sequenceDiagram
    autonumber
    participant CLI
    participant H as Engine HTTP handler<br/>(session.go)
    participant L as Module loader
    participant S as dagql schema
    participant R as currentTypeDefs resolver
    participant C as dagql result cache

    Note over CLI: dagger call MODULE fn --arg ...<br/>extract leading positional token → "MODULE"
    CLI->>H: query DaggerModuleScope_MODULE { currentTypeDefs { ... } }<br/>SAME doc for every engine (no include arg, no fallback)

    H->>H: ensureWorkspaceLoaded() (discover)
    H->>H: ensureRequestModulesLoaded() — peek operation name → scope "MODULE"
    H->>L: load only MODULE (+ entrypoint module if configured), pre-request
    L-->>H: MODULE ok
    Note over L: sibling-A, sibling-BROKEN stay PENDING (never evaluated)
    Note over H,L: a broken sibling can't fail this request

    H->>S: build schema = core + MODULE
    Note over S: MODULE served before the request runs

    H->>R: resolve currentTypeDefs (UNCHANGED — no include arg)
    R->>C: key = CurrentSchemaInput = digest(served schema)
    Note over C: served schema already contains MODULE<br/>→ key differs per workspace for free (no PerClientInput needed)
    R-->>CLI: typedefs for MODULE
    Note over CLI: build command tree → send actual call (2nd request)
```

## Design doc

`hack/designs/dumb-cli-single-query-peek-module-loading.md`
