### PR TITLE
add gcr mirror to dev engine

### DIFF
--- a/toolchains/engine-dev/config.go
+++ b/toolchains/engine-dev/config.go
@@ -82,9 +82,19 @@ func generateEntrypoint() (*dagger.File, error) {
 
 func generateConfig(logLevel string) (*dagger.File, error) {
 	cfg := struct {
-		LogLevel string `json:"logLevel,omitempty"`
+		LogLevel   string `json:"logLevel,omitempty"`
+		Registries map[string]struct {
+			Mirrors []string `json:"mirrors"`
+		} `json:"registries"`
 	}{
 		LogLevel: logLevel,
+		Registries: map[string]struct {
+			Mirrors []string `json:"mirrors"`
+		}{
+			"docker.io": {
+				Mirrors: []string{"mirror.gcr.io"},
+			},
+		},
 	}
 
 	res, err := json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
hardcode this in the config to avoid being rate-limited by docker.io this is pretty stable and we have been using it for native-ci for a while so it's safe to hardcode it here.