### PR TITLE
Add a failure summary to 'dagger trace' for diagnosing failed traces

### DIFF
--- a/dagql/idtui/output.go
+++ b/dagql/idtui/output.go
@@ -24,18 +24,64 @@ func NewOutput(w io.Writer, opts ...termenv.OutputOption) *termenv.Output {
 	}, opts...)...)
 }
 
-// ColorProfile returns Ascii if, and only if, NO_COLOR or similar is set.
-// Otherwise it returns termenv.ANSI, allowing colors to be used.
+// ColorProfile returns Ascii if NO_COLOR (or similar) is set, or if we're being
+// driven by an AI agent. Otherwise it returns termenv.ANSI, allowing colors to
+// be used.
 //
 // Note that color profiles beyond simple ANSI are not used by Progrock. 16
 // colors is all you need. Anything else disrespects the user's color scheme
 // preferences.
 func ColorProfile() termenv.Profile {
-	if termenv.EnvNoColor() {
+	if termenv.EnvNoColor() || RunningInAgent() {
 		return termenv.Ascii
 	} else {
 		return termenv.ANSI
 	}
+}
+
+// agentEnvVars are environment variables whose mere presence indicates the CLI
+// is being driven by an AI coding agent rather than a human at a terminal. The
+// value isn't parsed -- tools don't agree on its format, only on setting the
+// variable. There's no single ratified standard yet, so we check the emerging
+// generic conventions plus the tool-specific variables catalogued by Vercel's
+// @vercel/detect-agent.
+//
+// Deliberately omitted: platform signals that are also set for ordinary human
+// sessions (e.g. Replit's REPL_ID), and Devin's /opt/.devin marker, which is a
+// file rather than an environment variable.
+var agentEnvVars = []string{
+	// Generic, cross-tool conventions.
+	"AI_AGENT",        // Vercel detect-agent standard; set by Claude Code, Cursor, v0, Copilot, ...
+	"AGENT",           // Goose, Amp
+	"PI_CODING_AGENT", // pi
+
+	// Tool-specific.
+	"CLAUDECODE",           // Claude Code
+	"CLAUDE_CODE",          // Claude Code
+	"CURSOR_AGENT",         // Cursor CLI
+	"CURSOR_TRACE_ID",      // Cursor
+	"GEMINI_CLI",           // Gemini CLI
+	"CODEX_SANDBOX",        // OpenAI Codex
+	"CODEX_THREAD_ID",      // OpenAI Codex
+	"ANTIGRAVITY_AGENT",    // Antigravity
+	"AUGMENT_AGENT",        // Augment CLI
+	"OPENCODE_CLIENT",      // OpenCode
+	"COPILOT_MODEL",        // GitHub Copilot CLI
+	"COPILOT_GITHUB_TOKEN", // GitHub Copilot CLI
+	"COPILOT_ALLOW_ALL",    // GitHub Copilot CLI
+}
+
+// RunningInAgent reports whether the CLI is being driven by an AI coding agent
+// (Claude Code, Cursor, Codex, Gemini, Copilot, pi, Goose, Amp, etc.) rather
+// than a human at a terminal. Agents consume the output as text, so escape
+// codes are just noise.
+func RunningInAgent() bool {
+	for _, name := range agentEnvVars {
+		if os.Getenv(name) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 var (

--- a/internal/cloud/analyze.go
+++ b/internal/cloud/analyze.go
@@ -1,0 +1,80 @@
+package cloud
+
+import (
+	"context"
+	"time"
+)
+
+// TraceQuestions holds the high-level answers about a trace, computed server-side
+// in ClickHouse without loading the whole trace. It mirrors the traceQuestions
+// GraphQL type and backs `dagger cloud analyze`.
+type TraceQuestions struct {
+	OverallStatus   *TraceOverallStatus `json:"overallStatus"`
+	FailingCommands []FailingCommand    `json:"failingCommands"`
+	Checks          []TraceCheckStatus  `json:"checks"`
+	FailedTests     []FailedTest        `json:"failedTests"`
+}
+
+type TraceOverallStatus struct {
+	TraceID    string     `json:"traceId"`
+	SpanID     string     `json:"spanId"`
+	Command    string     `json:"command"`
+	StatusCode string     `json:"statusCode"`
+	Outcome    string     `json:"outcome"` // passed | failed | running
+	Error      string     `json:"error"`
+	StartedAt  *time.Time `json:"startedAt"`
+	EndedAt    *time.Time `json:"endedAt"`
+}
+
+type FailingCommand struct {
+	SpanID    string     `json:"spanId"`
+	Command   string     `json:"command"`
+	Error     string     `json:"error"`
+	StartedAt *time.Time `json:"startedAt"`
+}
+
+type TraceCheckStatus struct {
+	Name      string     `json:"name"`
+	SpanID    string     `json:"spanId"`
+	Status    string     `json:"status"` // passed | failed | running | unknown
+	Error     string     `json:"error"`
+	StartedAt *time.Time `json:"startedAt"`
+	EndedAt   *time.Time `json:"endedAt"`
+}
+
+type FailedTest struct {
+	Name          string     `json:"name"`
+	Suite         string     `json:"suite"`
+	DisplayName   string     `json:"displayName"`
+	SpanID        string     `json:"spanId"`
+	FailureStatus string     `json:"failureStatus"`
+	Error         string     `json:"error"`
+	OriginCommand string     `json:"originCommand"`
+	OriginError   string     `json:"originError"`
+	StartedAt     *time.Time `json:"startedAt"`
+}
+
+const traceQuestionsQuery = `
+query Analyze($orgID: ID!, $traceID: ID!) {
+	traceQuestions(id: $traceID, org: $orgID) {
+		overallStatus { traceId spanId command statusCode outcome error startedAt endedAt }
+		failingCommands { spanId command error startedAt }
+		checks { name spanId status error startedAt endedAt }
+		failedTests { name suite displayName spanId failureStatus error originCommand originError startedAt }
+	}
+}
+`
+
+// TraceQuestions fetches the high-level analysis of a trace.
+func (c *Client) TraceQuestions(ctx context.Context, orgID, traceID string) (*TraceQuestions, error) {
+	var out struct {
+		TraceQuestions *TraceQuestions `json:"traceQuestions"`
+	}
+	if err := c.doGraphQL(ctx, "Analyze", traceQuestionsQuery, map[string]any{
+		"orgID":   orgID,
+		"traceID": traceID,
+	}, &out); err != nil {
+		return nil, err
+	}
+	return out.TraceQuestions, nil
+}

--- a/internal/cloud/trace.go
+++ b/internal/cloud/trace.go
@@ -182,12 +182,15 @@ func (c *Client) StreamSpans(
 	})
 }
 
-// StreamLogs streams log messages for a trace from Dagger Cloud's GraphQL API.
+// StreamLogs streams log messages for a span from Dagger Cloud's GraphQL API.
+// When descendants is true, logs from the span's whole subtree are included;
+// when false, only the span's own logs are returned.
 func (c *Client) StreamLogs(
 	ctx context.Context,
 	orgID string,
 	traceID string,
 	spanID string,
+	descendants bool,
 	handler func([]LogMessage),
 ) error {
 	return c.streamGraphQL(ctx, &graphqlRequest{
@@ -197,7 +200,7 @@ func (c *Client) StreamLogs(
 			"orgID":       orgID,
 			"traceID":     traceID,
 			"spanID":      spanID,
-			"descendants": true,
+			"descendants": descendants,
 			"after":       nil,
 		},
 	}, func(data []byte) error {

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -99,7 +99,10 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			fmt.Fprintf(o, "%s %s\n", bold(o, "Command:"), s.Command)
 		}
 		if s.Error != "" {
-			fmt.Fprintf(o, "%s   %s\n", bold(o, "Error:"), oneLine(s.Error))
+			// Values align at column 9 ("Error:" + 3). The real cause is often on
+			// a later line (the first is a generic "exit code N" wrapper), so show
+			// the whole message rather than truncating to the first line.
+			fmt.Fprintf(o, "%s   %s\n", bold(o, "Error:"), errText(s.Error, 9))
 		}
 	} else {
 		fmt.Fprintf(o, "%s  UNKNOWN (no root span found)\n", bold(o, "Status:"))
@@ -118,7 +121,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 		// marker before the command, consistent with checks and tests.
 		fmt.Fprintf(&rootCause, "%s %s\n", marker(o, "failed"), emptyDash(fc.Command))
 		if fc.Error != "" {
-			fmt.Fprintf(&rootCause, "  %s %s\n", bold(o, "error:"), oneLine(fc.Error))
+			fmt.Fprintf(&rootCause, "  %s %s\n", bold(o, "error:"), errText(fc.Error, 9))
 		}
 		fmt.Fprintf(&rootCause, "  %s  %s\n", bold(o, "span:"), fc.SpanID)
 		cli.renderSpanLogs(&rootCause, o, traceID, fc.SpanID, logs[fc.SpanID])
@@ -146,7 +149,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 		}
 		fmt.Fprintf(&checks, "%s %s\n", marker(o, c.Status), bold(o, emptyDash(c.Name)))
 		if c.Error != "" {
-			fmt.Fprintf(&checks, "  %s %s\n", bold(o, "error:"), oneLine(c.Error))
+			fmt.Fprintf(&checks, "  %s %s\n", bold(o, "error:"), errText(c.Error, 9))
 		}
 		if c.Status == "failed" {
 			fmt.Fprintf(&checks, "  %s  %s\n", bold(o, "span:"), c.SpanID)
@@ -180,7 +183,8 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			fmt.Fprintf(&tests, "  %s %s\n", bold(o, "caused by:"), t.OriginCommand)
 		}
 		if msg := firstNonEmptyStr(t.OriginError, t.Error); msg != "" {
-			fmt.Fprintf(&tests, "  %s     %s\n", bold(o, "error:"), oneLine(msg))
+			// Values in this block align at column 13 ("caused by:" + 1).
+			fmt.Fprintf(&tests, "  %s     %s\n", bold(o, "error:"), errText(msg, 13))
 		}
 		fmt.Fprintf(&tests, "  %s      %s\n", bold(o, "span:"), t.SpanID)
 		// Roll up the descendant logs for leaf tests: the real failure usually
@@ -504,12 +508,25 @@ func emptyDash(s string) string {
 	return s
 }
 
-func oneLine(s string) string {
-	s = strings.TrimSpace(s)
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return strings.TrimSpace(s[:i]) + " …"
+// errText formats a possibly multi-line error message for display after a
+// label. The first line follows the label; subsequent non-empty lines are
+// indented to align beneath it (indent columns). Blank lines are dropped so
+// wrapped errors stay compact. We deliberately keep every non-empty line: the
+// real cause is frequently below a generic "exit code N" first line, so
+// collapsing to one line would hide it. Returns "-" for an empty message.
+func errText(msg string, indent int) string {
+	var lines []string
+	for _, ln := range strings.Split(msg, "\n") {
+		ln = strings.TrimRight(ln, " \t")
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		lines = append(lines, ln)
 	}
-	return s
+	if len(lines) == 0 {
+		return "-"
+	}
+	return strings.Join(lines, "\n"+strings.Repeat(" ", indent))
 }
 
 func firstNonEmptyStr(vals ...string) string {

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -11,6 +11,7 @@ import (
 
 	cloudapi "github.com/dagger/dagger/internal/cloud"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -109,6 +110,12 @@ func (cli *CloudCLI) Analyze(cmd *cobra.Command, args []string) error {
 func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, orgID, traceID string, tq *cloudapi.TraceQuestions) {
 	out := cmd.OutOrStdout()
 
+	// Fetch all the failed spans' log tails up front, concurrently: the log
+	// endpoints are slow, and rendering is sequential, so doing them inline would
+	// serialize the wait. Results are keyed by span id and looked up while
+	// rendering. nil when logs are disabled.
+	logs := cli.prefetchLogTails(cmd.Context(), client, orgID, traceID, tq)
+
 	fmt.Fprintf(out, "TRACE %s\n", traceID)
 	if s := tq.OverallStatus; s != nil {
 		fmt.Fprintf(out, "Status:  %s\n", strings.ToUpper(emptyDash(s.Outcome)))
@@ -137,7 +144,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			fmt.Fprintf(out, "  error: %s\n", oneLine(fc.Error))
 		}
 		fmt.Fprintf(out, "  span:  %s\n", fc.SpanID)
-		cli.printSpanLogs(cmd, client, orgID, traceID, fc.SpanID, false)
+		cli.renderSpanLogs(out, traceID, fc.SpanID, logs[fc.SpanID])
 	}
 
 	// Checks.
@@ -159,7 +166,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			}
 			if c.Status == "failed" {
 				fmt.Fprintf(out, "  span:  %s\n", c.SpanID)
-				cli.printSpanLogs(cmd, client, orgID, traceID, c.SpanID, true)
+				cli.renderSpanLogs(out, traceID, c.SpanID, logs[c.SpanID])
 			}
 		}
 	}
@@ -187,7 +194,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			// Only the leaf failures (those with a distinct origin command) have
 			// useful per-test logs; aggregate parent tests just roll up children.
 			if t.OriginCommand != "" {
-				cli.printSpanLogs(cmd, client, orgID, traceID, t.SpanID, true)
+				cli.renderSpanLogs(out, traceID, t.SpanID, logs[t.SpanID])
 			}
 		}
 	}
@@ -195,33 +202,98 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 	fmt.Fprintf(out, "\nFull logs for any span: dagger cloud logs %s <span-id> -o span.log\n", traceID)
 }
 
-// printSpanLogs prints the tail of a span's logs and the command to get the full
-// logs. Bounded by --log-lines and --log-timeout so it never hangs or floods.
-func (cli *CloudCLI) printSpanLogs(cmd *cobra.Command, client *cloudapi.Client, orgID, traceID, spanID string, descendants bool) {
-	out := cmd.OutOrStdout()
-	full := fmt.Sprintf("dagger cloud logs %s %s", traceID, spanID)
+// logTarget is a span whose logs we want to fetch for the analysis.
+type logTarget struct {
+	spanID      string
+	descendants bool
+}
+
+// logResult is the outcome of fetching one span's log tail.
+type logResult struct {
+	tail     *lineTail
+	timedOut bool
+	err      error
+}
+
+// logTargets returns the spans whose logs the analysis displays, in no
+// particular order. Failing commands want their own output (descendants=false:
+// a withExec's stdout/stderr is on the span itself); checks and leaf failed
+// tests want their subtree.
+func logTargets(tq *cloudapi.TraceQuestions) []logTarget {
+	var targets []logTarget
+	for _, fc := range tq.FailingCommands {
+		targets = append(targets, logTarget{fc.SpanID, false})
+	}
+	for _, c := range tq.Checks {
+		if c.Status == "failed" {
+			targets = append(targets, logTarget{c.SpanID, true})
+		}
+	}
+	for _, t := range tq.FailedTests {
+		if t.OriginCommand != "" {
+			targets = append(targets, logTarget{t.SpanID, true})
+		}
+	}
+	return targets
+}
+
+// prefetchLogTails fetches every target span's log tail concurrently. The log
+// endpoints are slow and rendering is sequential, so fetching inline would add
+// up the waits; fetching in parallel makes the total roughly the slowest single
+// span. Returns nil when logs are disabled. Per-span errors are kept in the
+// result so one failure doesn't sink the rest.
+func (cli *CloudCLI) prefetchLogTails(ctx context.Context, client *cloudapi.Client, orgID, traceID string, tq *cloudapi.TraceQuestions) map[string]*logResult {
 	if analyzeNoLogs || analyzeLogLines <= 0 {
+		return nil
+	}
+	targets := logTargets(tq)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	results := make([]*logResult, len(targets))
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(8)
+	for i, tgt := range targets {
+		i, tgt := i, tgt
+		eg.Go(func() error {
+			tail, timedOut, err := cli.tailSpanLogs(ctx, client, orgID, traceID, tgt.spanID, tgt.descendants)
+			results[i] = &logResult{tail: tail, timedOut: timedOut, err: err}
+			return nil
+		})
+	}
+	_ = eg.Wait()
+
+	out := make(map[string]*logResult, len(targets))
+	for i, tgt := range targets {
+		out[tgt.spanID] = results[i]
+	}
+	return out
+}
+
+// renderSpanLogs prints a span's prefetched log tail and the command to get the
+// full logs. A nil result means logs were disabled, so just print the command.
+func (cli *CloudCLI) renderSpanLogs(out io.Writer, traceID, spanID string, res *logResult) {
+	full := fmt.Sprintf("dagger cloud logs %s %s", traceID, spanID)
+	if res == nil {
 		fmt.Fprintf(out, "  logs:  %s\n", full)
 		return
 	}
-
-	tail, timedOut, err := cli.tailSpanLogs(cmd.Context(), client, orgID, traceID, spanID, descendants)
-	if err != nil {
-		fmt.Fprintf(out, "  logs:  (error fetching: %v) %s\n", err, full)
+	if res.err != nil {
+		fmt.Fprintf(out, "  logs:  (error fetching: %v) %s\n", res.err, full)
 		return
 	}
-	if tail.total == 0 {
+	if res.tail == nil || res.tail.total == 0 {
 		fmt.Fprintf(out, "  logs:  (none) — %s\n", full)
 		return
 	}
 
 	suffix := ""
-	if timedOut {
+	if res.timedOut {
 		suffix = ", timed out — partial"
 	}
-	shown := len(tail.lines)
-	fmt.Fprintf(out, "  logs (last %d of %d lines%s; full: %s):\n", shown, tail.total, suffix, full)
-	for _, ln := range tail.lines {
+	fmt.Fprintf(out, "  logs (last %d of %d lines%s; full: %s):\n", len(res.tail.lines), res.tail.total, suffix, full)
+	for _, ln := range res.tail.lines {
 		fmt.Fprintf(out, "    | %s\n", ln)
 	}
 }

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -106,24 +106,28 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 	}
 
 	// What command caused the failure.
-	fmt.Fprintf(o, "\n%s\n", bold(o, "== ROOT CAUSE =="))
+	var rootCause strings.Builder
 	if len(tq.FailingCommands) == 0 {
-		fmt.Fprintln(o, "(nothing failed)")
+		fmt.Fprintln(&rootCause, "(nothing failed)")
 	}
 	for i, fc := range tq.FailingCommands {
+		if i > 0 {
+			fmt.Fprintln(&rootCause)
+		}
 		label := "cause"
 		if i == 0 {
 			label = "root cause"
 		}
-		fmt.Fprintf(o, "\n%s %s\n", bold(o, "["+label+"]"), emptyDash(fc.Command))
+		fmt.Fprintf(&rootCause, "%s %s\n", bold(o, "["+label+"]"), emptyDash(fc.Command))
 		if fc.Error != "" {
-			fmt.Fprintf(o, "  %s %s\n", bold(o, "error:"), oneLine(fc.Error))
+			fmt.Fprintf(&rootCause, "  %s %s\n", bold(o, "error:"), oneLine(fc.Error))
 		}
-		fmt.Fprintf(o, "  %s  %s\n", bold(o, "span:"), fc.SpanID)
-		cli.renderSpanLogs(o, traceID, fc.SpanID, logs[fc.SpanID])
+		fmt.Fprintf(&rootCause, "  %s  %s\n", bold(o, "span:"), fc.SpanID)
+		cli.renderSpanLogs(&rootCause, o, traceID, fc.SpanID, logs[fc.SpanID])
 	}
+	section(o, "ROOT CAUSE", rootCause.String())
 
-	// Checks. Always show the header so "no checks ran" is explicit rather than
+	// Checks. Always show the section so "no checks ran" is explicit rather than
 	// an ambiguous omission.
 	var passed, failed int
 	for _, c := range tq.Checks {
@@ -134,27 +138,34 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			failed++
 		}
 	}
-	fmt.Fprintf(o, "\n%s\n", bold(o, fmt.Sprintf("== CHECKS (%d passed, %d failed, %d total) ==", passed, failed, len(tq.Checks))))
+	var checks strings.Builder
 	if len(tq.Checks) == 0 {
-		fmt.Fprintln(o, "(no checks ran)")
+		fmt.Fprintln(&checks, "(no checks ran)")
 	}
-	for _, c := range tq.Checks {
-		fmt.Fprintf(o, "\n%s %s\n", marker(o, c.Status), bold(o, emptyDash(c.Name)))
+	for i, c := range tq.Checks {
+		if i > 0 {
+			fmt.Fprintln(&checks)
+		}
+		fmt.Fprintf(&checks, "%s %s\n", marker(o, c.Status), bold(o, emptyDash(c.Name)))
 		if c.Error != "" {
-			fmt.Fprintf(o, "  %s %s\n", bold(o, "error:"), oneLine(c.Error))
+			fmt.Fprintf(&checks, "  %s %s\n", bold(o, "error:"), oneLine(c.Error))
 		}
 		if c.Status == "failed" {
-			fmt.Fprintf(o, "  %s  %s\n", bold(o, "span:"), c.SpanID)
-			cli.renderSpanLogs(o, traceID, c.SpanID, logs[c.SpanID])
+			fmt.Fprintf(&checks, "  %s  %s\n", bold(o, "span:"), c.SpanID)
+			cli.renderSpanLogs(&checks, o, traceID, c.SpanID, logs[c.SpanID])
 		}
 	}
+	section(o, fmt.Sprintf("CHECKS (%d passed, %d failed, %d total)", passed, failed, len(tq.Checks)), checks.String())
 
-	// Failed tests. Always show the header for the same reason.
-	fmt.Fprintf(o, "\n%s\n", bold(o, fmt.Sprintf("== FAILED TESTS (%d) ==", len(tq.FailedTests))))
+	// Failed tests. Always show the section for the same reason.
+	var tests strings.Builder
 	if len(tq.FailedTests) == 0 {
-		fmt.Fprintln(o, "(no failed tests)")
+		fmt.Fprintln(&tests, "(no failed tests)")
 	}
-	for _, t := range tq.FailedTests {
+	for i, t := range tq.FailedTests {
+		if i > 0 {
+			fmt.Fprintln(&tests)
+		}
 		name := t.Name
 		if t.Suite != "" && t.Suite != t.Name {
 			// Use an ASCII separator for agents; the test name is a prime grep
@@ -165,27 +176,59 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			}
 			name = t.Suite + sep + t.Name
 		}
-		fmt.Fprintf(o, "\n%s %s\n", marker(o, "failed"), bold(o, emptyDash(name)))
+		fmt.Fprintf(&tests, "%s %s\n", marker(o, "failed"), bold(o, emptyDash(name)))
 		if t.OriginCommand != "" {
-			fmt.Fprintf(o, "  %s %s\n", bold(o, "caused by:"), t.OriginCommand)
+			fmt.Fprintf(&tests, "  %s %s\n", bold(o, "caused by:"), t.OriginCommand)
 		}
 		if msg := firstNonEmptyStr(t.OriginError, t.Error); msg != "" {
-			fmt.Fprintf(o, "  %s     %s\n", bold(o, "error:"), oneLine(msg))
+			fmt.Fprintf(&tests, "  %s     %s\n", bold(o, "error:"), oneLine(msg))
 		}
-		fmt.Fprintf(o, "  %s      %s\n", bold(o, "span:"), t.SpanID)
+		fmt.Fprintf(&tests, "  %s      %s\n", bold(o, "span:"), t.SpanID)
 		// Only the leaf failures (those with a distinct origin command) have
 		// useful per-test logs; aggregate parent tests just roll up children.
 		if t.OriginCommand != "" {
-			cli.renderSpanLogs(o, traceID, t.SpanID, logs[t.SpanID])
+			cli.renderSpanLogs(&tests, o, traceID, t.SpanID, logs[t.SpanID])
 		}
 	}
+	section(o, fmt.Sprintf("FAILED TESTS (%d)", len(tq.FailedTests)), tests.String())
 
 	// This summary is intentionally a flat triage: it drops the call tree that
 	// led to each failure (which function calls, with which arguments, and how
 	// long they took). When that context matters, the full trace renders it.
-	fmt.Fprintf(o, "\n%s\n", bold(o, "== MORE CONTEXT =="))
-	fmt.Fprintf(o, "Full call tree, arguments, and timing:  dagger trace --full %s\n", traceID)
-	fmt.Fprintf(o, "Full logs for any span:                 dagger cloud logs %s <span-id> -o span.log\n", traceID)
+	var more strings.Builder
+	fmt.Fprintf(&more, "Full call tree, arguments, and timing:  dagger trace --full %s\n", traceID)
+	fmt.Fprintf(&more, "Full logs for any span:                 dagger cloud logs %s <span-id> -o span.log\n", traceID)
+	section(o, "MORE CONTEXT", more.String())
+}
+
+// section renders a titled block. For humans the title is a bold, all-caps
+// heading with the body indented two spaces -- the style used elsewhere in the
+// CLI. For agents it's a flat, greppable "== TITLE ==" marker with the body
+// left at the margin. body is pre-rendered and may already contain styling.
+func section(o *termenv.Output, title, body string) {
+	body = strings.TrimRight(body, "\n")
+	if idtui.RunningInAgent() {
+		fmt.Fprintf(o, "\n== %s ==\n", title)
+		if body != "" {
+			fmt.Fprintln(o, body)
+		}
+		return
+	}
+	fmt.Fprintf(o, "\n%s\n", bold(o, title))
+	if body != "" {
+		fmt.Fprintln(o, indentLines(body, "  "))
+	}
+}
+
+// indentLines prefixes every non-empty line of s with prefix.
+func indentLines(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		if ln != "" {
+			lines[i] = prefix + ln
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // logTarget is a span whose logs we want to fetch for the analysis.
@@ -257,19 +300,20 @@ func (cli *CloudCLI) prefetchLogTails(ctx context.Context, client *cloudapi.Clie
 	return out
 }
 
-// renderSpanLogs prints a span's prefetched log tail and the command to get the
-// full logs. A nil result means logs were disabled, so just print the command.
-func (cli *CloudCLI) renderSpanLogs(o *termenv.Output, traceID, spanID string, res *logResult) {
+// renderSpanLogs writes a span's prefetched log tail and the command to get the
+// full logs to w, styling with o. A nil result means logs were disabled, so
+// just print the command.
+func (cli *CloudCLI) renderSpanLogs(w io.Writer, o *termenv.Output, traceID, spanID string, res *logResult) {
 	full := fmt.Sprintf("dagger cloud logs %s %s", traceID, spanID)
 	switch {
 	case res == nil:
-		fmt.Fprintf(o, "  %s  %s\n", bold(o, "logs:"), full)
+		fmt.Fprintf(w, "  %s  %s\n", bold(o, "logs:"), full)
 		return
 	case res.err != nil:
-		fmt.Fprintf(o, "  %s  (error fetching: %v) %s\n", bold(o, "logs:"), res.err, full)
+		fmt.Fprintf(w, "  %s  (error fetching: %v) %s\n", bold(o, "logs:"), res.err, full)
 		return
 	case res.tail == nil || res.tail.total == 0:
-		fmt.Fprintf(o, "  %s  (none) — %s\n", bold(o, "logs:"), full)
+		fmt.Fprintf(w, "  %s  (none) — %s\n", bold(o, "logs:"), full)
 		return
 	}
 
@@ -278,10 +322,10 @@ func (cli *CloudCLI) renderSpanLogs(o *termenv.Output, traceID, spanID string, r
 		suffix = ", timed out — partial"
 	}
 	header := fmt.Sprintf("logs (last %d of %d lines%s; full: %s):", len(res.tail.lines), res.tail.total, suffix, full)
-	fmt.Fprintf(o, "  %s\n", bold(o, header))
+	fmt.Fprintf(w, "  %s\n", bold(o, header))
 	pipe := dim(o, "|")
 	for _, ln := range res.tail.lines {
-		fmt.Fprintf(o, "    %s %s\n", pipe, ln)
+		fmt.Fprintf(w, "    %s %s\n", pipe, ln)
 	}
 }
 

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -114,11 +114,9 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 		if i > 0 {
 			fmt.Fprintln(&rootCause)
 		}
-		label := "cause"
-		if i == 0 {
-			label = "root cause"
-		}
-		fmt.Fprintf(&rootCause, "%s %s\n", bold(o, "["+label+"]"), emptyDash(fc.Command))
+		// The ROOT CAUSE heading already says what this is; just show the status
+		// marker before the command, consistent with checks and tests.
+		fmt.Fprintf(&rootCause, "%s %s\n", marker(o, "failed"), emptyDash(fc.Command))
 		if fc.Error != "" {
 			fmt.Fprintf(&rootCause, "  %s %s\n", bold(o, "error:"), oneLine(fc.Error))
 		}

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -160,6 +160,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 	if len(tq.FailedTests) == 0 {
 		fmt.Fprintln(&tests, "(no failed tests)")
 	}
+	leaves := leafFailedTests(tq.FailedTests)
 	for i, t := range tq.FailedTests {
 		if i > 0 {
 			fmt.Fprintln(&tests)
@@ -182,9 +183,11 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			fmt.Fprintf(&tests, "  %s     %s\n", bold(o, "error:"), oneLine(msg))
 		}
 		fmt.Fprintf(&tests, "  %s      %s\n", bold(o, "span:"), t.SpanID)
-		// Only the leaf failures (those with a distinct origin command) have
-		// useful per-test logs; aggregate parent tests just roll up children.
-		if t.OriginCommand != "" {
+		// Roll up the descendant logs for leaf tests: the real failure usually
+		// lives in a sub-operation the test ran (a withExec, a nested dagger
+		// call), not on the test span itself. Aggregate parent tests are skipped
+		// -- they'd just repeat their children's logs.
+		if leaves[t.SpanID] {
 			cli.renderSpanLogs(&tests, o, traceID, t.SpanID, logs[t.SpanID])
 		}
 	}
@@ -245,7 +248,8 @@ type logResult struct {
 // logTargets returns the spans whose logs the analysis displays, in no
 // particular order. Failing commands want their own output (descendants=false:
 // a withExec's stdout/stderr is on the span itself); checks and leaf failed
-// tests want their subtree.
+// tests want their subtree, so the failure that happened in a sub-operation
+// rolls up.
 func logTargets(tq *cloudapi.TraceQuestions) []logTarget {
 	var targets []logTarget
 	for _, fc := range tq.FailingCommands {
@@ -256,12 +260,37 @@ func logTargets(tq *cloudapi.TraceQuestions) []logTarget {
 			targets = append(targets, logTarget{c.SpanID, true})
 		}
 	}
+	leaves := leafFailedTests(tq.FailedTests)
 	for _, t := range tq.FailedTests {
-		if t.OriginCommand != "" {
+		if leaves[t.SpanID] {
 			targets = append(targets, logTarget{t.SpanID, true})
 		}
 	}
 	return targets
+}
+
+// leafFailedTests returns the span IDs of the failed tests that are leaves: no
+// other failed test is nested beneath them, by "/"-delimited name within the
+// same suite (Go subtests). Only leaves get a descendant log roll-up; an
+// ancestor's subtree would just repeat its children's logs.
+func leafFailedTests(tests []cloudapi.FailedTest) map[string]bool {
+	leaves := make(map[string]bool, len(tests))
+	for _, t := range tests {
+		leaf := true
+		for _, other := range tests {
+			if other.SpanID == t.SpanID {
+				continue
+			}
+			if other.Suite == t.Suite && strings.HasPrefix(other.Name, t.Name+"/") {
+				leaf = false
+				break
+			}
+		}
+		if leaf {
+			leaves[t.SpanID] = true
+		}
+	}
+	return leaves
 }
 
 // prefetchLogTails fetches every target span's log tail concurrently. The log

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -24,39 +24,10 @@ var (
 	logsTimeout     time.Duration
 )
 
-var cloudAnalyzeCmd = newAnalyzeCmd(false)
-var analyzeCmd = newAnalyzeCmd(true)
-
 var cloudLogsCmd = newCloudLogsCmd()
 
 func init() {
-	cloudCmd.AddCommand(cloudAnalyzeCmd, cloudLogsCmd)
-	rootCmd.AddCommand(analyzeCmd)
-}
-
-func newAnalyzeCmd(hidden bool) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "analyze <trace-id>",
-		Short: "Summarize why a Dagger Cloud trace failed (LLM-friendly)",
-		Long: `Summarize a Dagger Cloud trace: overall status, the command(s) that caused
-the failure, check results, and failed tests -- computed server-side without
-loading the whole trace.
-
-For each failed span it also shows the tail of that span's logs and prints the
-exact command to fetch the full logs, which can be redirected to a file and
-grepped:
-
-    dagger cloud logs <trace-id> <span-id> -o span.log`,
-		Args:    cobra.ExactArgs(1),
-		Hidden:  hidden,
-		Aliases: []string{"diagnose"},
-		RunE:    cloudCLI.Analyze,
-	}
-	cmd.Flags().BoolVar(&cloudJSON, "json", false, "Print the analysis as JSON (no logs)")
-	cmd.Flags().IntVar(&analyzeLogLines, "log-lines", 20, "Lines of log tail to show per failed span (0 to disable)")
-	cmd.Flags().BoolVar(&analyzeNoLogs, "no-logs", false, "Don't fetch logs, just the summary")
-	cmd.Flags().DurationVar(&analyzeLogTimeout, "log-timeout", 30*time.Second, "Max time to spend fetching each span's log tail")
-	return cmd
+	cloudCmd.AddCommand(cloudLogsCmd)
 }
 
 func newCloudLogsCmd() *cobra.Command {
@@ -118,7 +89,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 
 	fmt.Fprintf(out, "TRACE %s\n", traceID)
 	if s := tq.OverallStatus; s != nil {
-		fmt.Fprintf(out, "Status:  %s\n", strings.ToUpper(emptyDash(s.Outcome)))
+		fmt.Fprintf(out, "Status:  %s %s\n", checkMark(s.Outcome), strings.ToUpper(emptyDash(s.Outcome)))
 		if s.Command != "" {
 			fmt.Fprintf(out, "Command: %s\n", s.Command)
 		}
@@ -183,7 +154,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 		if t.Suite != "" && t.Suite != t.Name {
 			name = t.Suite + " › " + t.Name
 		}
-		fmt.Fprintf(out, "\n✗ %s", emptyDash(name))
+		fmt.Fprintf(out, "\n✘ %s", emptyDash(name))
 		if t.FailureStatus != "" {
 			fmt.Fprintf(out, "  (%s)", t.FailureStatus)
 		}
@@ -206,7 +177,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 	// led to each failure (which function calls, with which arguments, and how
 	// long they took). When that context matters, the full trace renders it.
 	fmt.Fprintf(out, "\n== MORE CONTEXT ==\n")
-	fmt.Fprintf(out, "Full call tree, arguments, and timing:  dagger trace %s\n", traceID)
+	fmt.Fprintf(out, "Full call tree, arguments, and timing:  dagger trace --full %s\n", traceID)
 	fmt.Fprintf(out, "Full logs for any span:                 dagger cloud logs %s <span-id> -o span.log\n", traceID)
 }
 
@@ -393,9 +364,9 @@ func (cli *CloudCLI) tailSpanLogs(ctx context.Context, client *cloudapi.Client, 
 func checkMark(status string) string {
 	switch status {
 	case "passed":
-		return "✓"
+		return "✔"
 	case "failed":
-		return "✗"
+		return "✘"
 	case "running":
 		return "…"
 	default:

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -94,7 +94,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 
 	fmt.Fprintf(o, "%s %s\n", bold(o, "TRACE"), traceID)
 	if s := tq.OverallStatus; s != nil {
-		fmt.Fprintf(o, "%s  %s %s\n", bold(o, "Status:"), statusMark(o, s.Outcome), statusText(o, s.Outcome, strings.ToUpper(emptyDash(s.Outcome))))
+		fmt.Fprintf(o, "%s  %s\n", bold(o, "Status:"), statusHeadline(o, s.Outcome))
 		if s.Command != "" {
 			fmt.Fprintf(o, "%s %s\n", bold(o, "Command:"), s.Command)
 		}
@@ -139,7 +139,7 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 		fmt.Fprintln(o, "(no checks ran)")
 	}
 	for _, c := range tq.Checks {
-		fmt.Fprintf(o, "\n%s %s\n", statusMark(o, c.Status), bold(o, emptyDash(c.Name)))
+		fmt.Fprintf(o, "\n%s %s\n", marker(o, c.Status), bold(o, emptyDash(c.Name)))
 		if c.Error != "" {
 			fmt.Fprintf(o, "  %s %s\n", bold(o, "error:"), oneLine(c.Error))
 		}
@@ -157,9 +157,15 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 	for _, t := range tq.FailedTests {
 		name := t.Name
 		if t.Suite != "" && t.Suite != t.Name {
-			name = t.Suite + " › " + t.Name
+			// Use an ASCII separator for agents; the test name is a prime grep
+			// target and › is awkward to match.
+			sep := " › "
+			if idtui.RunningInAgent() {
+				sep = " > "
+			}
+			name = t.Suite + sep + t.Name
 		}
-		fmt.Fprintf(o, "\n%s %s\n", statusMark(o, "failed"), bold(o, emptyDash(name)))
+		fmt.Fprintf(o, "\n%s %s\n", marker(o, "failed"), bold(o, emptyDash(name)))
 		if t.OriginCommand != "" {
 			fmt.Fprintf(o, "  %s %s\n", bold(o, "caused by:"), t.OriginCommand)
 		}
@@ -363,10 +369,14 @@ func (cli *CloudCLI) tailSpanLogs(ctx context.Context, client *cloudapi.Client, 
 	return tail, false, err
 }
 
-// statusMark returns the colored glyph for a span/check/test status, matching
-// the vocabulary the report frontend uses (green ✔ / red ✘). The color is
-// stripped automatically when output isn't styled (NO_COLOR, agents, pipes).
-func statusMark(o *termenv.Output, status string) string {
+// marker is the leading status indicator for a check or test line. For humans
+// it's a colored glyph matching the report frontend's vocabulary (green ✔ /
+// red ✘); for agents it's a greppable ASCII token like "[FAILED]", so a single
+// `grep '\[FAILED\]'` surfaces every failure across the summary.
+func marker(o *termenv.Output, status string) string {
+	if idtui.RunningInAgent() {
+		return statusToken(status)
+	}
 	switch status {
 	case "passed":
 		return o.String("✔").Foreground(termenv.ANSIGreen).String()
@@ -379,15 +389,30 @@ func statusMark(o *termenv.Output, status string) string {
 	}
 }
 
-// statusText colors a status word (e.g. FAILED/PASSED) to match its glyph.
-func statusText(o *termenv.Output, status, text string) string {
+// statusToken is the ASCII status tag shown to agents, e.g. "[FAILED]".
+func statusToken(status string) string {
+	w := strings.ToUpper(status)
+	if w == "" {
+		w = "UNKNOWN"
+	}
+	return "[" + w + "]"
+}
+
+// statusHeadline renders the overall outcome on the Status line: a colored
+// glyph plus the uppercased word for humans, or just the ASCII token for agents
+// (which already spells out the outcome, so no separate word is needed).
+func statusHeadline(o *termenv.Output, status string) string {
+	if idtui.RunningInAgent() {
+		return statusToken(status)
+	}
+	word := strings.ToUpper(emptyDash(status))
 	switch status {
 	case "passed":
-		return o.String(text).Foreground(termenv.ANSIGreen).String()
+		return o.String("✔ " + word).Foreground(termenv.ANSIGreen).String()
 	case "failed":
-		return o.String(text).Foreground(termenv.ANSIRed).String()
+		return o.String("✘ " + word).Foreground(termenv.ANSIRed).String()
 	default:
-		return text
+		return marker(o, status) + " " + word
 	}
 }
 

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -147,59 +147,67 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 		cli.renderSpanLogs(out, traceID, fc.SpanID, logs[fc.SpanID])
 	}
 
-	// Checks.
-	if len(tq.Checks) > 0 {
-		var passed, failed int
-		for _, c := range tq.Checks {
-			switch c.Status {
-			case "passed":
-				passed++
-			case "failed":
-				failed++
-			}
+	// Checks. Always show the header so "no checks ran" is explicit rather than
+	// an ambiguous omission.
+	var passed, failed int
+	for _, c := range tq.Checks {
+		switch c.Status {
+		case "passed":
+			passed++
+		case "failed":
+			failed++
 		}
-		fmt.Fprintf(out, "\n== CHECKS (%d passed, %d failed, %d total) ==\n", passed, failed, len(tq.Checks))
-		for _, c := range tq.Checks {
-			fmt.Fprintf(out, "\n%s %s\n", checkMark(c.Status), emptyDash(c.Name))
-			if c.Error != "" {
-				fmt.Fprintf(out, "  error: %s\n", oneLine(c.Error))
-			}
-			if c.Status == "failed" {
-				fmt.Fprintf(out, "  span:  %s\n", c.SpanID)
-				cli.renderSpanLogs(out, traceID, c.SpanID, logs[c.SpanID])
-			}
+	}
+	fmt.Fprintf(out, "\n== CHECKS (%d passed, %d failed, %d total) ==\n", passed, failed, len(tq.Checks))
+	if len(tq.Checks) == 0 {
+		fmt.Fprintln(out, "(no checks ran)")
+	}
+	for _, c := range tq.Checks {
+		fmt.Fprintf(out, "\n%s %s\n", checkMark(c.Status), emptyDash(c.Name))
+		if c.Error != "" {
+			fmt.Fprintf(out, "  error: %s\n", oneLine(c.Error))
+		}
+		if c.Status == "failed" {
+			fmt.Fprintf(out, "  span:  %s\n", c.SpanID)
+			cli.renderSpanLogs(out, traceID, c.SpanID, logs[c.SpanID])
 		}
 	}
 
-	// Failed tests.
-	if len(tq.FailedTests) > 0 {
-		fmt.Fprintf(out, "\n== FAILED TESTS (%d) ==\n", len(tq.FailedTests))
-		for _, t := range tq.FailedTests {
-			name := t.Name
-			if t.Suite != "" && t.Suite != t.Name {
-				name = t.Suite + " › " + t.Name
-			}
-			fmt.Fprintf(out, "\n✗ %s", emptyDash(name))
-			if t.FailureStatus != "" {
-				fmt.Fprintf(out, "  (%s)", t.FailureStatus)
-			}
-			fmt.Fprintln(out)
-			if t.OriginCommand != "" {
-				fmt.Fprintf(out, "  caused by: %s\n", t.OriginCommand)
-			}
-			if msg := firstNonEmptyStr(t.OriginError, t.Error); msg != "" {
-				fmt.Fprintf(out, "  error:     %s\n", oneLine(msg))
-			}
-			fmt.Fprintf(out, "  span:      %s\n", t.SpanID)
-			// Only the leaf failures (those with a distinct origin command) have
-			// useful per-test logs; aggregate parent tests just roll up children.
-			if t.OriginCommand != "" {
-				cli.renderSpanLogs(out, traceID, t.SpanID, logs[t.SpanID])
-			}
+	// Failed tests. Always show the header for the same reason.
+	fmt.Fprintf(out, "\n== FAILED TESTS (%d) ==\n", len(tq.FailedTests))
+	if len(tq.FailedTests) == 0 {
+		fmt.Fprintln(out, "(no failed tests)")
+	}
+	for _, t := range tq.FailedTests {
+		name := t.Name
+		if t.Suite != "" && t.Suite != t.Name {
+			name = t.Suite + " › " + t.Name
+		}
+		fmt.Fprintf(out, "\n✗ %s", emptyDash(name))
+		if t.FailureStatus != "" {
+			fmt.Fprintf(out, "  (%s)", t.FailureStatus)
+		}
+		fmt.Fprintln(out)
+		if t.OriginCommand != "" {
+			fmt.Fprintf(out, "  caused by: %s\n", t.OriginCommand)
+		}
+		if msg := firstNonEmptyStr(t.OriginError, t.Error); msg != "" {
+			fmt.Fprintf(out, "  error:     %s\n", oneLine(msg))
+		}
+		fmt.Fprintf(out, "  span:      %s\n", t.SpanID)
+		// Only the leaf failures (those with a distinct origin command) have
+		// useful per-test logs; aggregate parent tests just roll up children.
+		if t.OriginCommand != "" {
+			cli.renderSpanLogs(out, traceID, t.SpanID, logs[t.SpanID])
 		}
 	}
 
-	fmt.Fprintf(out, "\nFull logs for any span: dagger cloud logs %s <span-id> -o span.log\n", traceID)
+	// This summary is intentionally a flat triage: it drops the call tree that
+	// led to each failure (which function calls, with which arguments, and how
+	// long they took). When that context matters, the full trace renders it.
+	fmt.Fprintf(out, "\n== MORE CONTEXT ==\n")
+	fmt.Fprintf(out, "Full call tree, arguments, and timing:  dagger trace %s\n", traceID)
+	fmt.Fprintf(out, "Full logs for any span:                 dagger cloud logs %s <span-id> -o span.log\n", traceID)
 }
 
 // logTarget is a span whose logs we want to fetch for the analysis.

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -1,0 +1,348 @@
+package daggercmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/spf13/cobra"
+)
+
+var (
+	analyzeLogLines   int
+	analyzeNoLogs     bool
+	analyzeLogTimeout time.Duration
+
+	logsOutput      string
+	logsDescendants bool
+	logsTimeout     time.Duration
+)
+
+var cloudAnalyzeCmd = newAnalyzeCmd(false)
+var analyzeCmd = newAnalyzeCmd(true)
+
+var cloudLogsCmd = newCloudLogsCmd()
+
+func init() {
+	cloudCmd.AddCommand(cloudAnalyzeCmd, cloudLogsCmd)
+	rootCmd.AddCommand(analyzeCmd)
+}
+
+func newAnalyzeCmd(hidden bool) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "analyze <trace-id>",
+		Short: "Summarize why a Dagger Cloud trace failed (LLM-friendly)",
+		Long: `Summarize a Dagger Cloud trace: overall status, the command(s) that caused
+the failure, check results, and failed tests -- computed server-side without
+loading the whole trace.
+
+For each failed span it also shows the tail of that span's logs and prints the
+exact command to fetch the full logs, which can be redirected to a file and
+grepped:
+
+    dagger cloud logs <trace-id> <span-id> -o span.log`,
+		Args:    cobra.ExactArgs(1),
+		Hidden:  hidden,
+		Aliases: []string{"diagnose"},
+		RunE:    cloudCLI.Analyze,
+	}
+	cmd.Flags().BoolVar(&cloudJSON, "json", false, "Print the analysis as JSON (no logs)")
+	cmd.Flags().IntVar(&analyzeLogLines, "log-lines", 20, "Lines of log tail to show per failed span (0 to disable)")
+	cmd.Flags().BoolVar(&analyzeNoLogs, "no-logs", false, "Don't fetch logs, just the summary")
+	cmd.Flags().DurationVar(&analyzeLogTimeout, "log-timeout", 30*time.Second, "Max time to spend fetching each span's log tail")
+	return cmd
+}
+
+func newCloudLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs <trace-id> <span-id>",
+		Short: "Print the full logs for a span in a Dagger Cloud trace",
+		Long: `Stream the full logs for a single span. Use this as a follow-up to
+'dagger cloud analyze' to inspect a failed span in detail. Redirect to a file
+to grep large logs in a controlled way:
+
+    dagger cloud logs <trace-id> <span-id> -o span.log
+    grep -i error span.log`,
+		Args: cobra.ExactArgs(2),
+		RunE: cloudCLI.CloudLogs,
+	}
+	cmd.Flags().StringVarP(&logsOutput, "output", "o", "", "Write logs to a file instead of stdout")
+	cmd.Flags().BoolVar(&logsDescendants, "descendants", true, "Include logs from descendant spans")
+	cmd.Flags().DurationVar(&logsTimeout, "timeout", 2*time.Minute, "Max time to spend streaming logs")
+	return cmd
+}
+
+func (cli *CloudCLI) Analyze(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	traceID := args[0]
+
+	client, cloudAuth, err := cli.cloudClient(ctx)
+	if err != nil {
+		return err
+	}
+	org, err := cli.resolveCloudOrg(ctx, client, cloudAuth)
+	if err != nil {
+		return err
+	}
+
+	tq, err := client.TraceQuestions(ctx, org.ID, traceID)
+	if err != nil {
+		return err
+	}
+	if tq == nil {
+		return fmt.Errorf("trace %q not found (or no data yet)", traceID)
+	}
+
+	if cloudJSON {
+		return writeCloudJSON(cmd, tq)
+	}
+
+	cli.printAnalysis(cmd, client, org.ID, traceID, tq)
+	return nil
+}
+
+func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, orgID, traceID string, tq *cloudapi.TraceQuestions) {
+	out := cmd.OutOrStdout()
+
+	fmt.Fprintf(out, "TRACE %s\n", traceID)
+	if s := tq.OverallStatus; s != nil {
+		fmt.Fprintf(out, "Status:  %s\n", strings.ToUpper(emptyDash(s.Outcome)))
+		if s.Command != "" {
+			fmt.Fprintf(out, "Command: %s\n", s.Command)
+		}
+		if s.Error != "" {
+			fmt.Fprintf(out, "Error:   %s\n", oneLine(s.Error))
+		}
+	} else {
+		fmt.Fprintln(out, "Status:  UNKNOWN (no root span found)")
+	}
+
+	// What command caused the failure.
+	fmt.Fprintf(out, "\n== ROOT CAUSE ==\n")
+	if len(tq.FailingCommands) == 0 {
+		fmt.Fprintln(out, "(nothing failed)")
+	}
+	for i, fc := range tq.FailingCommands {
+		label := "cause"
+		if i == 0 {
+			label = "root cause"
+		}
+		fmt.Fprintf(out, "\n[%s] %s\n", label, emptyDash(fc.Command))
+		if fc.Error != "" {
+			fmt.Fprintf(out, "  error: %s\n", oneLine(fc.Error))
+		}
+		fmt.Fprintf(out, "  span:  %s\n", fc.SpanID)
+		cli.printSpanLogs(cmd, client, orgID, traceID, fc.SpanID, false)
+	}
+
+	// Checks.
+	if len(tq.Checks) > 0 {
+		var passed, failed int
+		for _, c := range tq.Checks {
+			switch c.Status {
+			case "passed":
+				passed++
+			case "failed":
+				failed++
+			}
+		}
+		fmt.Fprintf(out, "\n== CHECKS (%d passed, %d failed, %d total) ==\n", passed, failed, len(tq.Checks))
+		for _, c := range tq.Checks {
+			fmt.Fprintf(out, "\n%s %s\n", checkMark(c.Status), emptyDash(c.Name))
+			if c.Error != "" {
+				fmt.Fprintf(out, "  error: %s\n", oneLine(c.Error))
+			}
+			if c.Status == "failed" {
+				fmt.Fprintf(out, "  span:  %s\n", c.SpanID)
+				cli.printSpanLogs(cmd, client, orgID, traceID, c.SpanID, true)
+			}
+		}
+	}
+
+	// Failed tests.
+	if len(tq.FailedTests) > 0 {
+		fmt.Fprintf(out, "\n== FAILED TESTS (%d) ==\n", len(tq.FailedTests))
+		for _, t := range tq.FailedTests {
+			name := t.Name
+			if t.Suite != "" && t.Suite != t.Name {
+				name = t.Suite + " › " + t.Name
+			}
+			fmt.Fprintf(out, "\n✗ %s", emptyDash(name))
+			if t.FailureStatus != "" {
+				fmt.Fprintf(out, "  (%s)", t.FailureStatus)
+			}
+			fmt.Fprintln(out)
+			if t.OriginCommand != "" {
+				fmt.Fprintf(out, "  caused by: %s\n", t.OriginCommand)
+			}
+			if msg := firstNonEmptyStr(t.OriginError, t.Error); msg != "" {
+				fmt.Fprintf(out, "  error:     %s\n", oneLine(msg))
+			}
+			fmt.Fprintf(out, "  span:      %s\n", t.SpanID)
+			// Only the leaf failures (those with a distinct origin command) have
+			// useful per-test logs; aggregate parent tests just roll up children.
+			if t.OriginCommand != "" {
+				cli.printSpanLogs(cmd, client, orgID, traceID, t.SpanID, true)
+			}
+		}
+	}
+
+	fmt.Fprintf(out, "\nFull logs for any span: dagger cloud logs %s <span-id> -o span.log\n", traceID)
+}
+
+// printSpanLogs prints the tail of a span's logs and the command to get the full
+// logs. Bounded by --log-lines and --log-timeout so it never hangs or floods.
+func (cli *CloudCLI) printSpanLogs(cmd *cobra.Command, client *cloudapi.Client, orgID, traceID, spanID string, descendants bool) {
+	out := cmd.OutOrStdout()
+	full := fmt.Sprintf("dagger cloud logs %s %s", traceID, spanID)
+	if analyzeNoLogs || analyzeLogLines <= 0 {
+		fmt.Fprintf(out, "  logs:  %s\n", full)
+		return
+	}
+
+	tail, timedOut, err := cli.tailSpanLogs(cmd.Context(), client, orgID, traceID, spanID, descendants)
+	if err != nil {
+		fmt.Fprintf(out, "  logs:  (error fetching: %v) %s\n", err, full)
+		return
+	}
+	if tail.total == 0 {
+		fmt.Fprintf(out, "  logs:  (none) — %s\n", full)
+		return
+	}
+
+	suffix := ""
+	if timedOut {
+		suffix = ", timed out — partial"
+	}
+	shown := len(tail.lines)
+	fmt.Fprintf(out, "  logs (last %d of %d lines%s; full: %s):\n", shown, tail.total, suffix, full)
+	for _, ln := range tail.lines {
+		fmt.Fprintf(out, "    | %s\n", ln)
+	}
+}
+
+func (cli *CloudCLI) CloudLogs(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	traceID, spanID := args[0], args[1]
+
+	client, cloudAuth, err := cli.cloudClient(ctx)
+	if err != nil {
+		return err
+	}
+	org, err := cli.resolveCloudOrg(ctx, client, cloudAuth)
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = cmd.OutOrStdout()
+	if logsOutput != "" {
+		f, err := os.Create(logsOutput)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		w = f
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, logsTimeout)
+	defer cancel()
+
+	var n int
+	streamErr := client.StreamLogs(ctx, org.ID, traceID, spanID, logsDescendants, func(msgs []cloudapi.LogMessage) {
+		for _, m := range msgs {
+			n++
+			io.WriteString(w, m.Body)
+			if !strings.HasSuffix(m.Body, "\n") {
+				io.WriteString(w, "\n")
+			}
+		}
+	})
+	// A deadline is an expected way to stop a long stream, not an error.
+	if streamErr != nil && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return streamErr
+	}
+	if logsOutput != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "wrote %d log messages to %s\n", n, logsOutput)
+	}
+	return nil
+}
+
+// lineTail keeps the last n lines streamed to it (a ring buffer), tracking the
+// total seen so the caller can report "last N of M".
+type lineTail struct {
+	n     int
+	lines []string
+	total int
+}
+
+func (t *lineTail) addBody(body string) {
+	body = strings.TrimSuffix(body, "\n")
+	if body == "" {
+		return
+	}
+	for _, ln := range strings.Split(body, "\n") {
+		t.total++
+		t.lines = append(t.lines, ln)
+		if len(t.lines) > t.n {
+			t.lines = t.lines[1:]
+		}
+	}
+}
+
+func (cli *CloudCLI) tailSpanLogs(ctx context.Context, client *cloudapi.Client, orgID, traceID, spanID string, descendants bool) (*lineTail, bool, error) {
+	cctx, cancel := context.WithTimeout(ctx, analyzeLogTimeout)
+	defer cancel()
+
+	tail := &lineTail{n: analyzeLogLines}
+	err := client.StreamLogs(cctx, orgID, traceID, spanID, descendants, func(msgs []cloudapi.LogMessage) {
+		for _, m := range msgs {
+			tail.addBody(m.Body)
+		}
+	})
+	if errors.Is(cctx.Err(), context.DeadlineExceeded) {
+		return tail, true, nil
+	}
+	return tail, false, err
+}
+
+func checkMark(status string) string {
+	switch status {
+	case "passed":
+		return "✓"
+	case "failed":
+		return "✗"
+	case "running":
+		return "…"
+	default:
+		return "?"
+	}
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func oneLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i]) + " …"
+	}
+	return s
+}
+
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/cmd/dagger/analyze_cloud.go
+++ b/internal/cmd/dagger/analyze_cloud.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dagger/dagger/dagql/idtui"
 	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -79,7 +81,10 @@ func (cli *CloudCLI) Analyze(cmd *cobra.Command, args []string) error {
 }
 
 func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, orgID, traceID string, tq *cloudapi.TraceQuestions) {
-	out := cmd.OutOrStdout()
+	// idtui.NewOutput keeps styling consistent with the rest of the CLI: it
+	// colors unless NO_COLOR is set or an AI agent is driving us (see
+	// idtui.ColorProfile), so piped/agent output stays plain automatically.
+	o := idtui.NewOutput(cmd.OutOrStdout())
 
 	// Fetch all the failed spans' log tails up front, concurrently: the log
 	// endpoints are slow, and rendering is sequential, so doing them inline would
@@ -87,35 +92,35 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 	// rendering. nil when logs are disabled.
 	logs := cli.prefetchLogTails(cmd.Context(), client, orgID, traceID, tq)
 
-	fmt.Fprintf(out, "TRACE %s\n", traceID)
+	fmt.Fprintf(o, "%s %s\n", bold(o, "TRACE"), traceID)
 	if s := tq.OverallStatus; s != nil {
-		fmt.Fprintf(out, "Status:  %s %s\n", checkMark(s.Outcome), strings.ToUpper(emptyDash(s.Outcome)))
+		fmt.Fprintf(o, "%s  %s %s\n", bold(o, "Status:"), statusMark(o, s.Outcome), statusText(o, s.Outcome, strings.ToUpper(emptyDash(s.Outcome))))
 		if s.Command != "" {
-			fmt.Fprintf(out, "Command: %s\n", s.Command)
+			fmt.Fprintf(o, "%s %s\n", bold(o, "Command:"), s.Command)
 		}
 		if s.Error != "" {
-			fmt.Fprintf(out, "Error:   %s\n", oneLine(s.Error))
+			fmt.Fprintf(o, "%s   %s\n", bold(o, "Error:"), oneLine(s.Error))
 		}
 	} else {
-		fmt.Fprintln(out, "Status:  UNKNOWN (no root span found)")
+		fmt.Fprintf(o, "%s  UNKNOWN (no root span found)\n", bold(o, "Status:"))
 	}
 
 	// What command caused the failure.
-	fmt.Fprintf(out, "\n== ROOT CAUSE ==\n")
+	fmt.Fprintf(o, "\n%s\n", bold(o, "== ROOT CAUSE =="))
 	if len(tq.FailingCommands) == 0 {
-		fmt.Fprintln(out, "(nothing failed)")
+		fmt.Fprintln(o, "(nothing failed)")
 	}
 	for i, fc := range tq.FailingCommands {
 		label := "cause"
 		if i == 0 {
 			label = "root cause"
 		}
-		fmt.Fprintf(out, "\n[%s] %s\n", label, emptyDash(fc.Command))
+		fmt.Fprintf(o, "\n%s %s\n", bold(o, "["+label+"]"), emptyDash(fc.Command))
 		if fc.Error != "" {
-			fmt.Fprintf(out, "  error: %s\n", oneLine(fc.Error))
+			fmt.Fprintf(o, "  %s %s\n", bold(o, "error:"), oneLine(fc.Error))
 		}
-		fmt.Fprintf(out, "  span:  %s\n", fc.SpanID)
-		cli.renderSpanLogs(out, traceID, fc.SpanID, logs[fc.SpanID])
+		fmt.Fprintf(o, "  %s  %s\n", bold(o, "span:"), fc.SpanID)
+		cli.renderSpanLogs(o, traceID, fc.SpanID, logs[fc.SpanID])
 	}
 
 	// Checks. Always show the header so "no checks ran" is explicit rather than
@@ -129,56 +134,52 @@ func (cli *CloudCLI) printAnalysis(cmd *cobra.Command, client *cloudapi.Client, 
 			failed++
 		}
 	}
-	fmt.Fprintf(out, "\n== CHECKS (%d passed, %d failed, %d total) ==\n", passed, failed, len(tq.Checks))
+	fmt.Fprintf(o, "\n%s\n", bold(o, fmt.Sprintf("== CHECKS (%d passed, %d failed, %d total) ==", passed, failed, len(tq.Checks))))
 	if len(tq.Checks) == 0 {
-		fmt.Fprintln(out, "(no checks ran)")
+		fmt.Fprintln(o, "(no checks ran)")
 	}
 	for _, c := range tq.Checks {
-		fmt.Fprintf(out, "\n%s %s\n", checkMark(c.Status), emptyDash(c.Name))
+		fmt.Fprintf(o, "\n%s %s\n", statusMark(o, c.Status), bold(o, emptyDash(c.Name)))
 		if c.Error != "" {
-			fmt.Fprintf(out, "  error: %s\n", oneLine(c.Error))
+			fmt.Fprintf(o, "  %s %s\n", bold(o, "error:"), oneLine(c.Error))
 		}
 		if c.Status == "failed" {
-			fmt.Fprintf(out, "  span:  %s\n", c.SpanID)
-			cli.renderSpanLogs(out, traceID, c.SpanID, logs[c.SpanID])
+			fmt.Fprintf(o, "  %s  %s\n", bold(o, "span:"), c.SpanID)
+			cli.renderSpanLogs(o, traceID, c.SpanID, logs[c.SpanID])
 		}
 	}
 
 	// Failed tests. Always show the header for the same reason.
-	fmt.Fprintf(out, "\n== FAILED TESTS (%d) ==\n", len(tq.FailedTests))
+	fmt.Fprintf(o, "\n%s\n", bold(o, fmt.Sprintf("== FAILED TESTS (%d) ==", len(tq.FailedTests))))
 	if len(tq.FailedTests) == 0 {
-		fmt.Fprintln(out, "(no failed tests)")
+		fmt.Fprintln(o, "(no failed tests)")
 	}
 	for _, t := range tq.FailedTests {
 		name := t.Name
 		if t.Suite != "" && t.Suite != t.Name {
 			name = t.Suite + " › " + t.Name
 		}
-		fmt.Fprintf(out, "\n✘ %s", emptyDash(name))
-		if t.FailureStatus != "" {
-			fmt.Fprintf(out, "  (%s)", t.FailureStatus)
-		}
-		fmt.Fprintln(out)
+		fmt.Fprintf(o, "\n%s %s\n", statusMark(o, "failed"), bold(o, emptyDash(name)))
 		if t.OriginCommand != "" {
-			fmt.Fprintf(out, "  caused by: %s\n", t.OriginCommand)
+			fmt.Fprintf(o, "  %s %s\n", bold(o, "caused by:"), t.OriginCommand)
 		}
 		if msg := firstNonEmptyStr(t.OriginError, t.Error); msg != "" {
-			fmt.Fprintf(out, "  error:     %s\n", oneLine(msg))
+			fmt.Fprintf(o, "  %s     %s\n", bold(o, "error:"), oneLine(msg))
 		}
-		fmt.Fprintf(out, "  span:      %s\n", t.SpanID)
+		fmt.Fprintf(o, "  %s      %s\n", bold(o, "span:"), t.SpanID)
 		// Only the leaf failures (those with a distinct origin command) have
 		// useful per-test logs; aggregate parent tests just roll up children.
 		if t.OriginCommand != "" {
-			cli.renderSpanLogs(out, traceID, t.SpanID, logs[t.SpanID])
+			cli.renderSpanLogs(o, traceID, t.SpanID, logs[t.SpanID])
 		}
 	}
 
 	// This summary is intentionally a flat triage: it drops the call tree that
 	// led to each failure (which function calls, with which arguments, and how
 	// long they took). When that context matters, the full trace renders it.
-	fmt.Fprintf(out, "\n== MORE CONTEXT ==\n")
-	fmt.Fprintf(out, "Full call tree, arguments, and timing:  dagger trace --full %s\n", traceID)
-	fmt.Fprintf(out, "Full logs for any span:                 dagger cloud logs %s <span-id> -o span.log\n", traceID)
+	fmt.Fprintf(o, "\n%s\n", bold(o, "== MORE CONTEXT =="))
+	fmt.Fprintf(o, "Full call tree, arguments, and timing:  dagger trace --full %s\n", traceID)
+	fmt.Fprintf(o, "Full logs for any span:                 dagger cloud logs %s <span-id> -o span.log\n", traceID)
 }
 
 // logTarget is a span whose logs we want to fetch for the analysis.
@@ -252,18 +253,17 @@ func (cli *CloudCLI) prefetchLogTails(ctx context.Context, client *cloudapi.Clie
 
 // renderSpanLogs prints a span's prefetched log tail and the command to get the
 // full logs. A nil result means logs were disabled, so just print the command.
-func (cli *CloudCLI) renderSpanLogs(out io.Writer, traceID, spanID string, res *logResult) {
+func (cli *CloudCLI) renderSpanLogs(o *termenv.Output, traceID, spanID string, res *logResult) {
 	full := fmt.Sprintf("dagger cloud logs %s %s", traceID, spanID)
-	if res == nil {
-		fmt.Fprintf(out, "  logs:  %s\n", full)
+	switch {
+	case res == nil:
+		fmt.Fprintf(o, "  %s  %s\n", bold(o, "logs:"), full)
 		return
-	}
-	if res.err != nil {
-		fmt.Fprintf(out, "  logs:  (error fetching: %v) %s\n", res.err, full)
+	case res.err != nil:
+		fmt.Fprintf(o, "  %s  (error fetching: %v) %s\n", bold(o, "logs:"), res.err, full)
 		return
-	}
-	if res.tail == nil || res.tail.total == 0 {
-		fmt.Fprintf(out, "  logs:  (none) — %s\n", full)
+	case res.tail == nil || res.tail.total == 0:
+		fmt.Fprintf(o, "  %s  (none) — %s\n", bold(o, "logs:"), full)
 		return
 	}
 
@@ -271,9 +271,11 @@ func (cli *CloudCLI) renderSpanLogs(out io.Writer, traceID, spanID string, res *
 	if res.timedOut {
 		suffix = ", timed out — partial"
 	}
-	fmt.Fprintf(out, "  logs (last %d of %d lines%s; full: %s):\n", len(res.tail.lines), res.tail.total, suffix, full)
+	header := fmt.Sprintf("logs (last %d of %d lines%s; full: %s):", len(res.tail.lines), res.tail.total, suffix, full)
+	fmt.Fprintf(o, "  %s\n", bold(o, header))
+	pipe := dim(o, "|")
 	for _, ln := range res.tail.lines {
-		fmt.Fprintf(out, "    | %s\n", ln)
+		fmt.Fprintf(o, "    %s %s\n", pipe, ln)
 	}
 }
 
@@ -361,17 +363,42 @@ func (cli *CloudCLI) tailSpanLogs(ctx context.Context, client *cloudapi.Client, 
 	return tail, false, err
 }
 
-func checkMark(status string) string {
+// statusMark returns the colored glyph for a span/check/test status, matching
+// the vocabulary the report frontend uses (green ✔ / red ✘). The color is
+// stripped automatically when output isn't styled (NO_COLOR, agents, pipes).
+func statusMark(o *termenv.Output, status string) string {
 	switch status {
 	case "passed":
-		return "✔"
+		return o.String("✔").Foreground(termenv.ANSIGreen).String()
 	case "failed":
-		return "✘"
+		return o.String("✘").Foreground(termenv.ANSIRed).String()
 	case "running":
-		return "…"
+		return o.String("…").Foreground(termenv.ANSIYellow).String()
 	default:
-		return "?"
+		return o.String("?").Foreground(termenv.ANSIBrightBlack).String()
 	}
+}
+
+// statusText colors a status word (e.g. FAILED/PASSED) to match its glyph.
+func statusText(o *termenv.Output, status, text string) string {
+	switch status {
+	case "passed":
+		return o.String(text).Foreground(termenv.ANSIGreen).String()
+	case "failed":
+		return o.String(text).Foreground(termenv.ANSIRed).String()
+	default:
+		return text
+	}
+}
+
+// bold styles headings and labels.
+func bold(o *termenv.Output, s string) string {
+	return o.String(s).Bold().String()
+}
+
+// dim styles de-emphasized decoration, like the log line gutter.
+func dim(o *termenv.Output, s string) string {
+	return o.String(s).Foreground(termenv.ANSIBrightBlack).String()
 }
 
 func emptyDash(s string) string {

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -49,6 +49,8 @@ func TestAnalyzeRender(t *testing.T) {
 		"✓ fmt",
 		"== FAILED TESTS (2) ==",
 		"caused by: go test -c -o ./test ./core/integration",
+		"== MORE CONTEXT ==",
+		"Full call tree, arguments, and timing:  dagger trace a0d14706",
 		"dagger cloud logs a0d14706 <span-id> -o span.log",
 	} {
 		if !bytes.Contains(buf.Bytes(), []byte(want)) {

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -14,10 +14,9 @@ func TestAnalyzeRender(t *testing.T) {
 	analyzeLogLines = 0
 	t.Cleanup(func() { analyzeNoLogs = false; analyzeLogLines = 20 })
 
-	// Force plain output so assertions don't depend on the ambient color/agent
-	// environment (CI has neither NO_COLOR nor an agent var set, so styling
-	// would otherwise emit ANSI codes into the buffer).
-	t.Setenv("NO_COLOR", "1")
+	// Pin agent mode so the test is deterministic regardless of the ambient
+	// environment: agents get plain output (no color) and ASCII status tokens.
+	t.Setenv("AI_AGENT", "test")
 
 	tq := &cloudapi.TraceQuestions{
 		OverallStatus: &cloudapi.TraceOverallStatus{
@@ -46,13 +45,14 @@ func TestAnalyzeRender(t *testing.T) {
 	t.Logf("\n%s", buf.String())
 
 	for _, want := range []string{
-		"Status:  ✘ FAILED",
+		"Status:  [FAILED]",
 		"== ROOT CAUSE ==",
 		"[root cause] otelgotest",
 		"== CHECKS (1 passed, 1 failed, 2 total) ==",
-		"✘ lint",
-		"✔ fmt",
+		"[FAILED] lint",
+		"[PASSED] fmt",
 		"== FAILED TESTS (2) ==",
+		"[FAILED] core/integration > TestContainer",
 		"caused by: go test -c -o ./test ./core/integration",
 		"== MORE CONTEXT ==",
 		"Full call tree, arguments, and timing:  dagger trace --full a0d14706",

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -1,0 +1,58 @@
+package daggercmd
+
+import (
+	"bytes"
+	"testing"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/spf13/cobra"
+)
+
+func TestAnalyzeRender(t *testing.T) {
+	// Render without fetching logs (nil client is safe in this mode).
+	analyzeNoLogs = true
+	analyzeLogLines = 0
+	t.Cleanup(func() { analyzeNoLogs = false; analyzeLogLines = 20 })
+
+	tq := &cloudapi.TraceQuestions{
+		OverallStatus: &cloudapi.TraceOverallStatus{
+			TraceID: "a0d14706", SpanID: "32370f63",
+			Command: "test-split:test-container", Outcome: "failed",
+			Error: "check failed due to an internal error: exit code: 1",
+		},
+		FailingCommands: []cloudapi.FailingCommand{
+			{SpanID: "52311111", Command: "otelgotest -p 8 -timeout=15m ./...", Error: "exit code: 1"},
+		},
+		Checks: []cloudapi.TraceCheckStatus{
+			{Name: "lint", SpanID: "aaaa", Status: "failed", Error: "lint failed"},
+			{Name: "fmt", SpanID: "bbbb", Status: "passed"},
+		},
+		FailedTests: []cloudapi.FailedTest{
+			{Name: "TestContainer", Suite: "core/integration", SpanID: "e4985ed2", FailureStatus: "fail (continuation)"},
+			{Name: "TestContainer/TestSystemGoProxy", Suite: "core/integration", SpanID: "3ce9fe84",
+				FailureStatus: "fail (continuation)", OriginCommand: "go test -c -o ./test ./core/integration", OriginError: "exit code: 1"},
+		},
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cloudCLI.printAnalysis(cmd, nil, "0c8f0f6c", "a0d14706", tq)
+	t.Logf("\n%s", buf.String())
+
+	for _, want := range []string{
+		"Status:  FAILED",
+		"== ROOT CAUSE ==",
+		"[root cause] otelgotest",
+		"== CHECKS (1 passed, 1 failed, 2 total) ==",
+		"✗ lint",
+		"✓ fmt",
+		"== FAILED TESTS (2) ==",
+		"caused by: go test -c -o ./test ./core/integration",
+		"dagger cloud logs a0d14706 <span-id> -o span.log",
+	} {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -22,7 +22,9 @@ func TestAnalyzeRender(t *testing.T) {
 		OverallStatus: &cloudapi.TraceOverallStatus{
 			TraceID: "a0d14706", SpanID: "32370f63",
 			Command: "test-split:test-container", Outcome: "failed",
-			Error: "check failed due to an internal error: exit code: 1",
+			// Multi-line: the first line is a generic wrapper and the real cause
+			// is below it. The summary must show the whole thing, not truncate.
+			Error: "exit code 1\n\nconvert arg ws: node field not found in environment",
 		},
 		FailingCommands: []cloudapi.FailingCommand{
 			{SpanID: "52311111", Command: "otelgotest -p 8 -timeout=15m ./...", Error: "exit code: 1"},
@@ -43,6 +45,17 @@ func TestAnalyzeRender(t *testing.T) {
 	cmd.SetOut(&buf)
 	cloudCLI.printAnalysis(cmd, nil, "0c8f0f6c", "a0d14706", tq)
 	t.Logf("\n%s", buf.String())
+
+	// The real cause lives on a later line of a multi-line error; it must
+	// survive into the output rather than being collapsed to the first line.
+	if !bytes.Contains(buf.Bytes(), []byte("convert arg ws: node field not found in environment")) {
+		t.Errorf("output dropped the multi-line error cause")
+	}
+	// The old behavior truncated to the first line with an ellipsis; make sure
+	// we no longer do that.
+	if bytes.Contains(buf.Bytes(), []byte("exit code 1 …")) {
+		t.Errorf("output truncated the error with an ellipsis")
+	}
 
 	for _, want := range []string{
 		"Status:  [FAILED]",

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -14,6 +14,11 @@ func TestAnalyzeRender(t *testing.T) {
 	analyzeLogLines = 0
 	t.Cleanup(func() { analyzeNoLogs = false; analyzeLogLines = 20 })
 
+	// Force plain output so assertions don't depend on the ambient color/agent
+	// environment (CI has neither NO_COLOR nor an agent var set, so styling
+	// would otherwise emit ANSI codes into the buffer).
+	t.Setenv("NO_COLOR", "1")
+
 	tq := &cloudapi.TraceQuestions{
 		OverallStatus: &cloudapi.TraceOverallStatus{
 			TraceID: "a0d14706", SpanID: "32370f63",

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -47,7 +47,7 @@ func TestAnalyzeRender(t *testing.T) {
 	for _, want := range []string{
 		"Status:  [FAILED]",
 		"== ROOT CAUSE ==",
-		"[root cause] otelgotest",
+		"[FAILED] otelgotest",
 		"== CHECKS (1 passed, 1 failed, 2 total) ==",
 		"[FAILED] lint",
 		"[PASSED] fmt",

--- a/internal/cmd/dagger/analyze_cloud_test.go
+++ b/internal/cmd/dagger/analyze_cloud_test.go
@@ -41,16 +41,16 @@ func TestAnalyzeRender(t *testing.T) {
 	t.Logf("\n%s", buf.String())
 
 	for _, want := range []string{
-		"Status:  FAILED",
+		"Status:  ✘ FAILED",
 		"== ROOT CAUSE ==",
 		"[root cause] otelgotest",
 		"== CHECKS (1 passed, 1 failed, 2 total) ==",
-		"✗ lint",
-		"✓ fmt",
+		"✘ lint",
+		"✔ fmt",
 		"== FAILED TESTS (2) ==",
 		"caused by: go test -c -o ./test ./core/integration",
 		"== MORE CONTEXT ==",
-		"Full call tree, arguments, and timing:  dagger trace a0d14706",
+		"Full call tree, arguments, and timing:  dagger trace --full a0d14706",
 		"dagger cloud logs a0d14706 <span-id> -o span.log",
 	} {
 		if !bytes.Contains(buf.Bytes(), []byte(want)) {

--- a/internal/cmd/dagger/cloud_checks.go
+++ b/internal/cmd/dagger/cloud_checks.go
@@ -862,7 +862,7 @@ func replayCloudChecks(cmd *cobra.Command, client *cloudapi.Client, orgID string
 			for _, logs := range logBatches {
 				logs := logs
 				eg.Go(func() error {
-					return client.StreamLogs(ctx, orgID, logs.OriginalTraceID, logs.RootSpanID, func(messages []cloudapi.LogMessage) {
+					return client.StreamLogs(ctx, orgID, logs.OriginalTraceID, logs.RootSpanID, true, func(messages []cloudapi.LogMessage) {
 						records := cloudapi.LogMessagesToRecords(traceID, messages)
 						if len(records) == 0 {
 							return

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -412,7 +412,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.CountVarP(&quiet, "quiet", "q", "Reduce verbosity (show progress, but clean up at the end)")
 	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
-	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty, dots, logs)")
+	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty, dots, logs, report)")
 	flags.StringVar(&lockMode, "lock", "", "Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
@@ -811,7 +811,7 @@ func Main() {
 		} else if hasTTY {
 			progress = "tty"
 		} else {
-			progress = "plain"
+			progress = "report"
 		}
 	}
 	if silent {

--- a/internal/cmd/dagger/trace.go
+++ b/internal/cmd/dagger/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/engine/slog"
@@ -15,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var traceOrgFlag string
+var traceFull bool
 
 var traceCmd = &cobra.Command{
 	Use:    "trace [trace ID]",
@@ -25,17 +26,39 @@ var traceCmd = &cobra.Command{
 		"experimental":       "true",
 		showFinalProgressKey: "true",
 	},
-	Aliases: []string{"t"},
-	Short:   "View a Dagger trace from Dagger Cloud.",
+	Aliases: []string{"t", "analyze", "diagnose"},
+	Short:   "Diagnose or view a Dagger Cloud trace.",
+	Long: `Summarize why a trace failed: overall status, the command(s) that caused the
+failure, check results, and failed tests, each with the tail of its logs. This
+summary is computed server-side without loading the whole trace, and is the
+default.
+
+Pass --full to instead stream and render the entire trace -- the full call
+tree, arguments, and timing.`,
 	Example: `dagger trace 2f123ba77bf7bd2d4db2f70ed20613e8`,
-	RunE:    Trace,
+	RunE:    traceRun,
 }
 
 func init() {
-	traceCmd.Flags().StringVar(&traceOrgFlag, "org", "", "Dagger Cloud org name (defaults to current org)")
+	traceCmd.Flags().BoolVar(&traceFull, "full", false, "Render the full trace (call tree, arguments, timing) instead of the failure summary")
+	traceCmd.Flags().BoolVar(&cloudJSON, "json", false, "Print the summary as JSON (no logs; ignored with --full)")
+	traceCmd.Flags().IntVar(&analyzeLogLines, "log-lines", 20, "Lines of log tail to show per failed span in the summary (0 to disable)")
+	traceCmd.Flags().BoolVar(&analyzeNoLogs, "no-logs", false, "Skip fetching logs in the summary, just the triage")
+	traceCmd.Flags().DurationVar(&analyzeLogTimeout, "log-timeout", 30*time.Second, "Max time to spend fetching each span's log tail in the summary")
 }
 
-func Trace(cmd *cobra.Command, args []string) error {
+// traceRun shows the server-computed failure summary by default, and the full
+// streamed trace when --full is given. The summary path is the same one the
+// 'cloud analyze' work produced; --full keeps the original render-everything
+// behavior.
+func traceRun(cmd *cobra.Command, args []string) error {
+	if traceFull {
+		return traceFullRender(cmd, args)
+	}
+	return cloudCLI.Analyze(cmd, args)
+}
+
+func traceFullRender(cmd *cobra.Command, args []string) error {
 	traceID := args[0]
 
 	return Frontend.Run(cmd.Context(), opts, func(ctx context.Context) (cleanups.CleanupF, error) {
@@ -127,10 +150,7 @@ func Trace(cmd *cobra.Command, args []string) error {
 }
 
 func resolveOrgID(ctx context.Context, client *cloud.Client, cloudAuth *auth.Cloud) (string, error) {
-	orgName := traceOrgFlag
-	if orgName == "" {
-		orgName = cloudOrgFlag
-	}
+	orgName := cloudOrgFlag
 	if orgName != "" {
 		// Resolve org name to ID via GraphQL
 		org, err := client.OrgByName(ctx, orgName)

--- a/internal/cmd/dagger/trace.go
+++ b/internal/cmd/dagger/trace.go
@@ -100,7 +100,7 @@ func Trace(cmd *cobra.Command, args []string) error {
 						rootSpanHex := span.SpanContext().SpanID().String()
 						logStreamOnce.Do(func() {
 							eg.Go(func() error {
-								return client.StreamLogs(ctx, orgID, traceID, rootSpanHex, func(logs []cloud.LogMessage) {
+								return client.StreamLogs(ctx, orgID, traceID, rootSpanHex, true, func(logs []cloud.LogMessage) {
 									slog.Debug("received logs from cloud", "count", len(logs))
 									records := cloud.LogMessagesToRecords(traceID, logs)
 									if len(records) == 0 {

--- a/internal/cmd/dagger/trace_test.go
+++ b/internal/cmd/dagger/trace_test.go
@@ -39,7 +39,7 @@ func TestTraceUsesGlobalFrontendOpts(t *testing.T) {
 		},
 	}
 
-	err := Trace(&cobra.Command{}, []string{"2f123ba77bf7bd2d4db2f70ed20613e8"})
+	err := traceFullRender(&cobra.Command{}, []string{"2f123ba77bf7bd2d4db2f70ed20613e8"})
 	require.NoError(t, err)
 
 	require.Equal(t, opts, gotOpts)


### PR DESCRIPTION
## What

Turns `dagger trace <trace-id>` into a fast, LLM-friendly **failure summary** for a Dagger Cloud trace, with the original full render moved behind `--full`.

By default it now prints a server-computed triage — overall status, the command(s) that caused the failure, check results, and failed tests — each with the tail of the relevant span's logs and the exact command to fetch the rest:

```
TRACE <id>
Status:  ✘ FAILED
Command: dagger --cloud call provision-preview-db ...

ROOT CAUSE
  ✘ sh -c psql $DB_CONNECTION -c "DELETE FROM scheduler_routes"
    error: exit code: 1
    span:  ebc08c2d410cde20
    logs (last 3 of 3 lines; full: dagger cloud logs <id> ebc08c2d410cde20):
      | ERROR:  relation "scheduler_routes" does not exist

CHECKS (0 passed, 0 failed, 0 total)
  (no checks ran)

FAILED TESTS (0)
  (no failed tests)

MORE CONTEXT
  Full call tree, arguments, and timing:  dagger trace --full <id>
  Full logs for any span:                 dagger cloud logs <id> <span-id> -o span.log
```

The summary is intentionally a flat triage; it hands off to `dagger trace --full <id>` for the full call tree, arguments, and timing, and to `dagger cloud logs <id> <span-id>` for complete per-span logs.

## Why

The goal is to make it easier for both humans and AI coding agents to diagnose a failed trace without scrolling the entire thing. Several pieces support that:

- **AI-agent awareness.** Added `idtui.RunningInAgent()`, which detects the emerging env-var conventions (`AI_AGENT`, `AGENT`, `PI_CODING_AGENT`) plus the tool-specific variables catalogued by Vercel's `detect-agent`, and folded it into `ColorProfile()` alongside `NO_COLOR`. Agents get plain output (color is just noise in their context) and ASCII status tokens like `[FAILED]`/`[PASSED]` instead of `✔`/`✘`, so a single `grep '\[FAILED\]'` surfaces every failure. Humans get colored glyphs and bold all-caps section headings. CI keeps its colors, since it sets none of these vars.
- **Full error messages.** Errors render in full instead of being collapsed to their first line with a trailing `…`. The real cause is frequently below a generic `exit code N` wrapper, and not every failure comes from a command — e.g. an overall-status error whose first line is `exit code 1` and whose second is the actual `convert arg ws: node field not found in environment`.
- **Leaf-test log roll-up.** A failed test often has no error of its own; the real failure lives in a sub-operation it ran. For leaf failed tests the summary rolls up the descendant logs, mirroring what the web UI shows when you open a single test.
- **`report` is the non-TTY default.** Quieter than `plain` and renders a clean call tree, so `dagger trace --full <id>` reads well without spelling out `--progress`.

## Note

The summary relies on Dagger Cloud's `Trace.summary` GraphQL API (companion PR dagger/dagger.io#5099), including the per-test `cause` command. The `--full` path and `cloud logs` work against any trace today; the summary needs that API support deployed. The `trace`/`analyze`/`diagnose` commands remain hidden/experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
