### PR TITLE
fix(engine): decouple the connected-clients API from per-session lifecycle locks

### DIFF
--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -696,11 +696,11 @@ func (srv *Server) EngineName() string {
 }
 
 func (srv *Server) Clients() []string {
-	// Snapshot under daggerSessionsMu, then read mainClientCallerID under
-	// stateMu (it is set during initialization). Releasing daggerSessionsMu
-	// before taking stateMu avoids inverting removeDaggerSession's
-	// stateMu->daggerSessionsMu lock order; skip sessions that aren't
-	// initialized yet.
+	// Snapshot the session pointers under daggerSessionsMu, then read each
+	// session's liveness and identity WITHOUT any per-session lock: state is
+	// atomic and mainClientCallerID is immutable (set at construction). This is
+	// what keeps the active-clients API (polled by the cloud keepalive) from ever
+	// blocking on a session that is initializing or tearing down.
 	srv.daggerSessionsMu.RLock()
 	sessions := make([]*daggerSession, 0, len(srv.daggerSessions))
 	for _, sess := range srv.daggerSessions {
@@ -710,13 +710,10 @@ func (srv *Server) Clients() []string {
 
 	clients := map[string]struct{}{}
 	for _, sess := range sessions {
-		sess.stateMu.RLock()
-		if sess.state != sessionStateInitialized {
-			sess.stateMu.RUnlock()
+		if sess.state.Load() != sessionStateInitialized {
 			continue
 		}
 		clients[sess.mainClientCallerID] = struct{}{}
-		sess.stateMu.RUnlock()
 	}
 
 	return slices.Collect(maps.Keys(clients))
@@ -731,8 +728,14 @@ func (srv *Server) GracefulStop(ctx context.Context) error {
 
 	// note this *could* cause a panic in Session if it was still running, so
 	// the server should be shutdown first
+	// snapshot the session pointers into a slice (not an alias of the live map)
+	// so concurrent pointer-conditional deleteSession calls can't race this
+	// iteration.
 	srv.daggerSessionsMu.Lock()
-	daggerSessions := srv.daggerSessions
+	daggerSessions := make([]*daggerSession, 0, len(srv.daggerSessions))
+	for _, s := range srv.daggerSessions {
+		daggerSessions = append(daggerSessions, s)
+	}
 	srv.daggerSessionsMu.Unlock()
 
 	if srv.engineCache != nil {
@@ -741,9 +744,15 @@ func (srv *Server) GracefulStop(ctx context.Context) error {
 	}
 
 	for _, s := range daggerSessions {
-		s.stateMu.Lock()
-		err = errors.Join(err, srv.removeDaggerSession(ctx, s))
-		s.stateMu.Unlock()
+		s.lifecycleMu.Lock()
+		// Wait out any in-flight init (lifecycleMu serializes it), then tear down
+		// only if the session actually initialized; an already-removed tombstone
+		// or a still-uninitialized session has nothing (more) to remove here.
+		if s.state.Load() == sessionStateInitialized {
+			err = errors.Join(err, srv.removeDaggerSession(ctx, s))
+		}
+		s.lifecycleMu.Unlock()
+		srv.deleteSession(s)
 	}
 
 	if srv.engineCache != nil && len(srv.workerGCPolicies) > 0 {
@@ -927,11 +936,10 @@ func (srv *Server) gcClientDBs() {
 func (srv *Server) activeClientIDs() map[string]bool {
 	keep := map[string]bool{}
 
-	// Snapshot the sessions under daggerSessionsMu, then drop it before taking
-	// per-session locks: clients is written by getOrInitClient under clientMu
-	// (so must be read under clientMu), and removeDaggerSession takes
-	// daggerSessionsMu while holding stateMu, so holding daggerSessionsMu while
-	// acquiring stateMu here would risk a lock-order inversion.
+	// Snapshot session pointers under daggerSessionsMu, then per session read
+	// state atomically (lock-free) and the clients map under clientMu. No
+	// per-session lifecycle lock is taken, so the client-DB GC ticker can never
+	// block on a session that is initializing or tearing down.
 	srv.daggerSessionsMu.RLock()
 	sessions := make([]*daggerSession, 0, len(srv.daggerSessions))
 	for _, sess := range srv.daggerSessions {
@@ -940,12 +948,10 @@ func (srv *Server) activeClientIDs() map[string]bool {
 	srv.daggerSessionsMu.RUnlock()
 
 	for _, sess := range sessions {
-		sess.stateMu.RLock()
-		// clients is only populated once a session is initialized, and a
-		// removed session's client DBs are already being torn down, so only
-		// initialized sessions contribute IDs worth keeping.
-		if sess.state != sessionStateInitialized {
-			sess.stateMu.RUnlock()
+		// clients is only populated once a session is initialized, and a removed
+		// session's client DBs are already being torn down, so only initialized
+		// sessions contribute IDs worth keeping.
+		if sess.state.Load() != sessionStateInitialized {
 			continue
 		}
 		sess.clientMu.RLock()
@@ -953,7 +959,6 @@ func (srv *Server) activeClientIDs() map[string]bool {
 			keep[id] = true
 		}
 		sess.clientMu.RUnlock()
-		sess.stateMu.RUnlock()
 	}
 
 	return keep

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -68,8 +69,16 @@ type daggerSession struct {
 	// off.
 	wcprofEnabled bool
 
-	state   daggerSessionState
-	stateMu sync.RWMutex
+	// state is read lock-free by observer paths and written only under
+	// lifecycleMu. The zero value is sessionStateUninitialized.
+	state atomicSessionState
+
+	// lifecycleMu serializes this session's initialization and teardown. It is
+	// held across the (potentially slow, up to ~60s) init and teardown work, but
+	// NO observer path (Clients/activeClientIDs/clientFromIDs) ever acquires it,
+	// so a session stuck initializing or tearing down can never stall the
+	// active-clients API or the client-DB GC.
+	lifecycleMu sync.Mutex
 
 	clients  map[string]*daggerClient // clientID -> client
 	clientMu sync.RWMutex
@@ -130,13 +139,40 @@ type workspaceLockState struct {
 	dirty    bool
 }
 
-type daggerSessionState string
+// daggerSessionState is the lifecycle state of a session. It is intentionally
+// int-backed (rather than string) so it can be stored in an atomic and read by
+// observers without locking; the zero value is sessionStateUninitialized.
+type daggerSessionState int32
 
 const (
-	sessionStateUninitialized daggerSessionState = "uninitialized"
-	sessionStateInitialized   daggerSessionState = "initialized"
-	sessionStateRemoved       daggerSessionState = "removed"
+	sessionStateUninitialized daggerSessionState = iota
+	sessionStateInitialized
+	sessionStateRemoved
 )
+
+func (s daggerSessionState) String() string {
+	switch s {
+	case sessionStateUninitialized:
+		return "uninitialized"
+	case sessionStateInitialized:
+		return "initialized"
+	case sessionStateRemoved:
+		return "removed"
+	default:
+		return fmt.Sprintf("unknown(%d)", int32(s))
+	}
+}
+
+// atomicSessionState wraps the session's lifecycle state so it can be read
+// lock-free by observer paths (Clients/activeClientIDs/clientFromIDs). Writes
+// only ever happen while holding the session's lifecycleMu, which serializes
+// state transitions; the atomic is what makes concurrent lock-free reads safe.
+type atomicSessionState struct {
+	v atomic.Int32
+}
+
+func (a *atomicSessionState) Load() daggerSessionState   { return daggerSessionState(a.v.Load()) }
+func (a *atomicSessionState) Store(s daggerSessionState) { a.v.Store(int32(s)) }
 
 type daggerClient struct {
 	daggerSession  *daggerSession
@@ -319,7 +355,7 @@ func (sess *daggerSession) FlushTelemetry(ctx context.Context) error {
 	return eg.Wait()
 }
 
-// requires that sess.stateMu is held
+// requires that sess.lifecycleMu is held
 func (srv *Server) initializeDaggerSession(
 	clientMetadata *engine.ClientMetadata,
 	sess *daggerSession,
@@ -328,10 +364,10 @@ func (srv *Server) initializeDaggerSession(
 	slog.Info("initializing new session", "session", clientMetadata.SessionID)
 	defer slog.Debug("initialized new session", "session", clientMetadata.SessionID)
 
-	sess.sessionID = clientMetadata.SessionID
-	sess.mainClientCallerID = clientMetadata.ClientID
+	// NOTE: sessionID, mainClientCallerID and the clients map are set at
+	// construction (before the session is published) and are immutable /
+	// clientMu-protected thereafter; they are deliberately not assigned here.
 	sess.wcprofEnabled = clientMetadata.Profile
-	sess.clients = map[string]*daggerClient{}
 	sess.attachables = newSessionAttachableManager()
 	sess.endpoints = map[string]http.Handler{}
 	sess.closingCtx, sess.cancelClosing = context.WithCancelCause(context.Background())
@@ -370,7 +406,10 @@ func (srv *Server) initializeDaggerSession(
 	})
 	failureCleanups.Add("close session analytics", sess.analytics.Close)
 
-	sess.state = sessionStateInitialized
+	// NOTE: state is NOT set to sessionStateInitialized here. getOrInitClient
+	// performs that atomic transition as its last step, after the main client is
+	// initialized and inserted, so observers never see an initialized session
+	// whose fields/clients aren't ready yet.
 	return nil
 }
 
@@ -396,12 +435,27 @@ func (sess *daggerSession) withClosingCancel(ctx context.Context) context.Contex
 	return ctx
 }
 
-// requires that sess.stateMu is held
+// requires that sess.lifecycleMu is held.
+//
+// removeDaggerSession does NOT remove the session from srv.daggerSessions; it
+// leaves it in place as a "removed" tombstone so observers see the removed state
+// and a concurrent same-id getOrInitClient bails out instead of resurrecting the
+// session while its cache is still being released. The caller must call
+// deleteSession (after releasing lifecycleMu) to drop the tombstone once
+// teardown is complete.
 func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession) error {
 	slog := slog.With("session", sess.sessionID)
 
 	slog.Info("removing session; stopping client services and flushing")
 	defer slog.Debug("session removed")
+
+	// Publish the removed state first (atomic) so observers holding a stale
+	// snapshot pointer, and any concurrent same-id getOrInitClient, observe it
+	// immediately and skip/bail instead of using a tearing-down session. The
+	// session is intentionally left in srv.daggerSessions as a tombstone until
+	// the caller drops it via deleteSession after lifecycleMu is released.
+	sess.state.Store(sessionStateRemoved)
+	sess.beginClosing()
 
 	// check if the local cache needs pruning after session is removed, prune if so
 	defer func() {
@@ -410,13 +464,6 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 		}
 		time.AfterFunc(time.Second, srv.throttledGC)
 	}()
-
-	srv.daggerSessionsMu.Lock()
-	delete(srv.daggerSessions, sess.sessionID)
-	srv.daggerSessionsMu.Unlock()
-
-	sess.state = sessionStateRemoved
-	sess.beginClosing()
 
 	var errs error
 
@@ -514,6 +561,18 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	})
 
 	return errs
+}
+
+// deleteSession drops a session from the registry, but only if the map entry is
+// still this exact session pointer. Pointer-conditional deletion ensures a slow
+// teardown can't delete a freshly created same-id session. Call only after the
+// session's teardown is complete and lifecycleMu has been released.
+func (srv *Server) deleteSession(sess *daggerSession) {
+	srv.daggerSessionsMu.Lock()
+	if srv.daggerSessions[sess.sessionID] == sess {
+		delete(srv.daggerSessions, sess.sessionID)
+	}
+	srv.daggerSessionsMu.Unlock()
 }
 
 type ClientInitOpts struct {
@@ -787,13 +846,11 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 		return nil, err
 	}
 
-	// The session pointer is published before initializeDaggerSession populates
-	// its fields, so gate on state under stateMu before reading them. stateMu is
-	// taken only after releasing daggerSessionsMu to avoid inverting
-	// removeDaggerSession's stateMu->daggerSessionsMu lock order.
-	sess.stateMu.RLock()
-	defer sess.stateMu.RUnlock()
-	switch sess.state {
+	// Gate on the session's lifecycle state via a lock-free atomic read (never
+	// lifecycleMu), so this lookup can't block on a session that is initializing
+	// or tearing down. A client is inserted into sess.clients only after it is
+	// fully initialized, so a clientMu read can't observe a half-initialized one.
+	switch st := sess.state.Load(); st {
 	case sessionStateInitialized:
 		// continue
 	case sessionStateRemoved:
@@ -802,14 +859,21 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 	case sessionStateUninitialized:
 		return nil, fmt.Errorf("session %q not initialized", sessID)
 	default:
-		return nil, fmt.Errorf("session %q has unknown state %q", sessID, sess.state)
+		return nil, fmt.Errorf("session %q has unknown state %s", sessID, st)
 	}
 
 	sess.clientMu.RLock()
-	defer sess.clientMu.RUnlock()
 	client, ok := sess.clients[clientID]
+	sess.clientMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("client %q not found", clientID)
+	}
+
+	// Re-check state: if the session flipped to removed while we read the clients
+	// map, treat it as not-found rather than handing back a client whose session
+	// is tearing down. This is a lock-free atomic read, so it never blocks.
+	if sess.state.Load() == sessionStateRemoved {
+		return nil, flightcontrol.RetryableError{Err: fmt.Errorf("session %q not found", sessID)}
 	}
 
 	return client, nil
@@ -841,13 +905,10 @@ func (srv *Server) getOrInitClient(
 		return nil, nil, fmt.Errorf("client secret token is required")
 	}
 
-	// cleanup to do if this method fails
+	// cleanup to do if this method fails; the failure handler that runs these is
+	// installed below, once we hold the session's lifecycleMu (so it can publish
+	// the removed tombstone before unlocking, then drop it only after cleanups).
 	failureCleanups := &cleanups.Cleanups{}
-	defer func() {
-		if rerr != nil {
-			rerr = errors.Join(rerr, failureCleanups.Run())
-		}
-	}()
 
 	// get or initialize the session as a whole
 
@@ -857,35 +918,75 @@ func (srv *Server) getOrInitClient(
 		return nil, nil, errServerShuttingDown
 	}
 	sess, sessionExists := srv.daggerSessions[sessionID]
-	stateMuLocked := false
+	createdSession := false
 	if !sessionExists {
+		// Construct with immutable identity and a non-nil clients map, and lock
+		// the new session's lifecycleMu BEFORE publishing it, so this goroutine
+		// is guaranteed to be the session's initializer: any concurrent caller
+		// that finds the published-but-uninitialized session blocks on
+		// lifecycleMu until initialization completes (or sees the removed
+		// tombstone if init fails). The session is still unreachable here, so this
+		// acquisition never contends and can't invert the lock order even though
+		// we currently hold daggerSessionsMu (the one "unpublished object"
+		// exception to "lifecycleMu and daggerSessionsMu are never nested").
 		sess = &daggerSession{
-			state: sessionStateUninitialized,
+			sessionID:          sessionID,
+			mainClientCallerID: clientID,
+			clients:            map[string]*daggerClient{},
 		}
-		// Lock stateMu before publishing the session below so a concurrent
-		// clientFromIDs that looks it up blocks until initialization finishes
-		// instead of observing uninitialized fields. The session is still
-		// unreachable by other goroutines here, so this never blocks and can't
-		// invert removeDaggerSession's stateMu->daggerSessionsMu order even
-		// though we currently hold daggerSessionsMu.
-		sess.stateMu.Lock()
-		stateMuLocked = true
+		sess.lifecycleMu.Lock()
+		createdSession = true
 		srv.daggerSessions[sessionID] = sess
-
-		failureCleanups.Add("delete session ID", func() error {
-			srv.daggerSessionsMu.Lock()
-			delete(srv.daggerSessions, sessionID)
-			srv.daggerSessionsMu.Unlock()
-			return nil
-		})
 	}
 	srv.daggerSessionsMu.Unlock()
 
-	if !stateMuLocked {
-		sess.stateMu.Lock()
+	if !createdSession {
+		// Fast, lock-free check: if the session is already a removed tombstone,
+		// bail immediately rather than blocking on lifecycleMu for the (possibly
+		// ~60s) teardown. A same-id reconnect then retries and gets a fresh
+		// session once the tombstone is dropped.
+		if sess.state.Load() == sessionStateRemoved {
+			return nil, nil, flightcontrol.RetryableError{Err: fmt.Errorf("session %q removed", sessionID)}
+		}
+		sess.lifecycleMu.Lock()
 	}
-	defer sess.stateMu.Unlock()
-	switch sess.state {
+
+	// We now hold sess.lifecycleMu. The deferred handler below manages the unlock
+	// for both success and failure. On failure of a session WE created it:
+	// publishes the removed tombstone (while still holding lifecycleMu, so a
+	// waiting same-id caller observes removed and bails instead of resurrecting a
+	// half-built session), releases the lock, runs resource cleanups, and only
+	// THEN drops the tombstone from the registry — so no fresh same-id session can
+	// be created while this one's resources are still being released.
+	lifecycleHeld := true
+	unlockLifecycle := func() {
+		if lifecycleHeld {
+			lifecycleHeld = false
+			sess.lifecycleMu.Unlock()
+		}
+	}
+	defer func() {
+		if rerr == nil {
+			unlockLifecycle()
+			return
+		}
+		if createdSession {
+			sess.state.Store(sessionStateRemoved)
+		}
+		unlockLifecycle()
+		rerr = errors.Join(rerr, failureCleanups.Run())
+		// No engineCache.ReleaseSession is needed here: session-scoped cache refs
+		// are only attached (via AttachResult) during nested-client init carrying
+		// Env/Module context, which always targets an already-existing session
+		// (createdSession=false). In current in-tree call paths a created session
+		// is always a main-client session that has attached nothing session-scoped,
+		// so there is nothing to release before dropping the tombstone.
+		if createdSession {
+			srv.deleteSession(sess)
+		}
+	}()
+
+	switch sess.state.Load() {
 	case sessionStateUninitialized:
 		if err := srv.initializeDaggerSession(opts.ClientMetadata, sess, failureCleanups); err != nil {
 			return nil, nil, fmt.Errorf("initialize session: %w", err)
@@ -893,13 +994,20 @@ func (srv *Server) getOrInitClient(
 	case sessionStateInitialized:
 		// nothing to do
 	case sessionStateRemoved:
-		return nil, nil, fmt.Errorf("session %q removed", sess.sessionID)
+		return nil, nil, flightcontrol.RetryableError{Err: fmt.Errorf("session %q removed", sessionID)}
 	}
 
-	// get or initialize the client itself
-
-	sess.clientMu.Lock()
+	// get or initialize the client itself.
+	//
+	// A client is inserted into sess.clients only AFTER it is fully initialized,
+	// so observer paths (clientFromIDs/activeClientIDs) can never see a
+	// half-initialized client. We hold lifecycleMu here, so no other goroutine
+	// can be creating the same client concurrently; a brief clientMu read to find
+	// an existing client is therefore sufficient (no double-checked locking).
+	sess.clientMu.RLock()
 	client, clientExists := sess.clients[clientID]
+	sess.clientMu.RUnlock()
+
 	if !clientExists {
 		client = &daggerClient{
 			state:          clientStateUninitialized,
@@ -910,9 +1018,9 @@ func (srv *Server) getOrInitClient(
 			shutdownCh:     make(chan struct{}),
 			clientMetadata: opts.ClientMetadata,
 		}
-		sess.clients[clientID] = client
 
-		// initialize SQLite DB early so we can subscribe to it immediately
+		// Open the SQLite DB outside clientMu (its busy_timeout is 10s) so a slow
+		// open can never block observers reading the clients map under clientMu.
 		if db, err := srv.clientDBs.Open(ctx, client.clientID); err != nil {
 			slog.Warn("failed to open client DB; continuing without keepalive",
 				"sessionID", sessionID,
@@ -926,20 +1034,14 @@ func (srv *Server) getOrInitClient(
 			})
 		}
 
+		sess.clientMu.RLock()
 		parent, parentExists := sess.clients[opts.CallerClientID]
+		sess.clientMu.RUnlock()
 		if parentExists {
 			client.parents = slices.Clone(parent.parents)
 			client.parents = append(client.parents, parent)
 		}
-
-		failureCleanups.Add("delete client ID", func() error {
-			sess.clientMu.Lock()
-			delete(sess.clients, clientID)
-			sess.clientMu.Unlock()
-			return nil
-		})
 	}
-	sess.clientMu.Unlock()
 
 	client.stateMu.Lock()
 	defer client.stateMu.Unlock()
@@ -948,6 +1050,11 @@ func (srv *Server) getOrInitClient(
 		if err := srv.initializeDaggerClient(ctx, client, opts); err != nil {
 			return nil, nil, fmt.Errorf("initialize client: %w", err)
 		}
+		// Now that the client is fully initialized, publish it into the session.
+		// (We hold lifecycleMu, so this is the only goroutine creating it.)
+		sess.clientMu.Lock()
+		sess.clients[clientID] = client
+		sess.clientMu.Unlock()
 	case clientStateInitialized:
 		// verify token matches existing client
 		if token != client.secretToken {
@@ -1001,6 +1108,13 @@ func (srv *Server) getOrInitClient(
 	// increment the number of active connections from this client
 	client.activeCount++
 
+	// If this call initialized the session, mark it initialized now — as the
+	// LAST step, after the main client has been initialized and inserted — so
+	// observers never see an initialized session whose main client isn't present.
+	if sess.state.Load() == sessionStateUninitialized {
+		sess.state.Store(sessionStateInitialized)
+	}
+
 	return client, func() error {
 		if clientID != sess.mainClientCallerID {
 			client.stateMu.Lock()
@@ -1012,46 +1126,48 @@ func (srv *Server) getOrInitClient(
 				return nil
 			}
 
-			slog := slog.With(
+			slog.With(
 				"sessionID", sess.sessionID,
 				"clientID", client.clientID,
-			)
-			slog.Info("all client connections closed")
+			).Info("all client connections closed")
 			return nil
 		}
 
-		sess.stateMu.Lock()
-		defer sess.stateMu.Unlock()
+		// Main client cleanup. Take lifecycleMu BEFORE client.stateMu (matching
+		// getOrInitClient's order) and hold it across the activeCount zero-check
+		// and the teardown decision, so a concurrent getOrInitClient (which bumps
+		// activeCount under lifecycleMu) cannot slip a new connection in between
+		// the check and removeDaggerSession.
+		sess.lifecycleMu.Lock()
 
-		// Keep the lock order consistent with getOrInitClient (session before
-		// client). If cleanup took client.stateMu first, a new request could
-		// hold stateMu while waiting on client.stateMu, while cleanup waited
-		// on stateMu.
 		client.stateMu.Lock()
 		client.activeCount--
 		activeCount := client.activeCount
 		client.stateMu.Unlock()
 
 		if activeCount > 0 {
+			sess.lifecycleMu.Unlock()
 			return nil
 		}
 
-		slog := slog.With(
+		slog.With(
 			"sessionID", sess.sessionID,
 			"clientID", client.clientID,
-		)
-		slog.Info("all client connections closed")
+		).Info("all client connections closed")
 
-		switch sess.state {
-		case sessionStateInitialized:
-			return srv.removeDaggerSession(ctx, sess)
-		default:
-			// this should never happen unless there's a bug
-			slog.Error("session state being removed not in initialized state",
-				"state", sess.state,
-			)
+		if sess.state.Load() != sessionStateInitialized {
+			// Already removed, or never fully initialized: nothing to tear down.
+			sess.lifecycleMu.Unlock()
 			return nil
 		}
+
+		err := srv.removeDaggerSession(ctx, sess)
+		sess.lifecycleMu.Unlock()
+		// Drop the tombstone now that teardown is complete and lifecycleMu is
+		// released (pointer-conditional, so a fresh same-id session is never
+		// deleted).
+		srv.deleteSession(sess)
+		return err
 	}, nil
 }
 

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -3,11 +3,13 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
@@ -15,6 +17,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -39,11 +42,11 @@ func TestActiveClientIDsConcurrentSessionClientMutation(t *testing.T) {
 	// Without the lock, ranging the map while another goroutine writes it is a
 	// fatal "concurrent map iteration and map write" (caught here under -race).
 	sess := &daggerSession{
-		state: sessionStateInitialized,
 		clients: map[string]*daggerClient{
 			"client-a": {clientID: "client-a"},
 		},
 	}
+	sess.state.Store(sessionStateInitialized)
 	srv := &Server{
 		daggerSessions: map[string]*daggerSession{
 			"session-a": sess,
@@ -86,13 +89,12 @@ func TestActiveClientIDsConcurrentSessionClientMutation(t *testing.T) {
 func TestClientFromIDsConcurrentSessionInitialization(t *testing.T) {
 	t.Parallel()
 
-	// Regression test: clientFromIDs must read sess.state/sess.clients under
-	// stateMu while another goroutine reassigns those fields during session
-	// initialization. Without the stateMu gate this is a data race (caught
+	// Regression test: clientFromIDs must read sess.state (atomically) and
+	// sess.clients (under clientMu) while another goroutine mutates them during
+	// session initialization. Without that discipline this is a data race (caught
 	// here under -race).
-	sess := &daggerSession{
-		state: sessionStateUninitialized,
-	}
+	sess := &daggerSession{}
+	sess.state.Store(sessionStateUninitialized)
 	srv := &Server{
 		daggerSessions: map[string]*daggerSession{
 			"session-a": sess,
@@ -125,29 +127,228 @@ func TestClientFromIDsConcurrentSessionInitialization(t *testing.T) {
 	<-started
 
 	for i := 0; i < 1000; i++ {
-		sess.stateMu.Lock()
+		sess.clientMu.Lock()
 		sess.clients = map[string]*daggerClient{
 			"client-a": {clientID: "client-a"},
 		}
-		sess.state = sessionStateInitialized
-		sess.state = sessionStateUninitialized
+		sess.clientMu.Unlock()
+		sess.state.Store(sessionStateInitialized)
+		sess.state.Store(sessionStateUninitialized)
+		sess.clientMu.Lock()
 		sess.clients = nil
-		sess.stateMu.Unlock()
+		sess.clientMu.Unlock()
 	}
 
 	client := &daggerClient{clientID: "client-a"}
-	sess.stateMu.Lock()
 	sess.clientMu.Lock()
 	sess.clients = map[string]*daggerClient{
 		client.clientID: client,
 	}
 	sess.clientMu.Unlock()
-	sess.state = sessionStateInitialized
-	sess.stateMu.Unlock()
+	sess.state.Store(sessionStateInitialized)
 
 	got, err := srv.clientFromIDs("session-a", client.clientID)
 	require.NoError(t, err)
 	require.Same(t, client, got)
+}
+
+func TestClientsDoesNotBlockWhileSessionLifecycleLocked(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the >15s active-clients stall (Discord: "Session lock might
+	// be causing unwanted session shutdowns"): Clients() must never acquire a
+	// session's lifecycleMu. A session stuck initializing or tearing down holds
+	// lifecycleMu for a long time (teardown has a 60s safeguard), but that must
+	// not stall the active-clients API the cloud keepalive polls.
+	live := &daggerSession{sessionID: "live", mainClientCallerID: "main-live"}
+	live.state.Store(sessionStateInitialized)
+	busy := &daggerSession{sessionID: "busy", mainClientCallerID: "main-busy"}
+	busy.state.Store(sessionStateInitialized)
+	srv := &Server{daggerSessions: map[string]*daggerSession{
+		"live": live,
+		"busy": busy,
+	}}
+
+	// Simulate an in-progress init/teardown holding busy's lifecycleMu.
+	busy.lifecycleMu.Lock()
+	defer busy.lifecycleMu.Unlock()
+
+	done := make(chan []string, 1)
+	go func() { done <- srv.Clients() }()
+
+	select {
+	case clients := <-done:
+		require.ElementsMatch(t, []string{"main-live", "main-busy"}, clients)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Clients() blocked while a session's lifecycleMu was held")
+	}
+}
+
+func TestActiveClientIDsDoesNotBlockWhileSessionLifecycleLocked(t *testing.T) {
+	t.Parallel()
+
+	// activeClientIDs() (the client-DB GC ticker) must also never acquire a
+	// session's lifecycleMu, for the same reason as Clients().
+	live := &daggerSession{
+		sessionID: "live",
+		clients:   map[string]*daggerClient{"c-live": {clientID: "c-live"}},
+	}
+	live.state.Store(sessionStateInitialized)
+	busy := &daggerSession{
+		sessionID: "busy",
+		clients:   map[string]*daggerClient{"c-busy": {clientID: "c-busy"}},
+	}
+	busy.state.Store(sessionStateInitialized)
+	srv := &Server{daggerSessions: map[string]*daggerSession{
+		"live": live,
+		"busy": busy,
+	}}
+
+	busy.lifecycleMu.Lock()
+	defer busy.lifecycleMu.Unlock()
+
+	done := make(chan map[string]bool, 1)
+	go func() { done <- srv.activeClientIDs() }()
+
+	select {
+	case keep := <-done:
+		require.True(t, keep["c-live"], "expected live session's client to be kept")
+		require.True(t, keep["c-busy"], "expected initialized busy session's client to be kept")
+	case <-time.After(10 * time.Second):
+		t.Fatal("activeClientIDs() blocked while a session's lifecycleMu was held")
+	}
+}
+
+func TestGetOrInitClientReturnsFastForRemovedTombstone(t *testing.T) {
+	t.Parallel()
+
+	// A session mid-teardown holds lifecycleMu and is marked removed (a tombstone
+	// left in the registry until cleanup completes). A same-id getOrInitClient
+	// must bail immediately via the lock-free removed pre-check rather than block
+	// on lifecycleMu for the (possibly ~60s) teardown.
+	tombstone := &daggerSession{sessionID: "s", mainClientCallerID: "m"}
+	tombstone.state.Store(sessionStateRemoved)
+	srv := &Server{daggerSessions: map[string]*daggerSession{"s": tombstone}}
+
+	// Hold lifecycleMu to simulate an in-progress teardown.
+	tombstone.lifecycleMu.Lock()
+	defer tombstone.lifecycleMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := srv.getOrInitClient(context.Background(), &ClientInitOpts{
+			ClientMetadata: &engine.ClientMetadata{
+				SessionID:         "s",
+				ClientID:          "m",
+				ClientSecretToken: "token",
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		var retryable flightcontrol.RetryableError
+		require.ErrorAs(t, err, &retryable, "removed tombstone should yield a retryable error")
+	case <-time.After(10 * time.Second):
+		t.Fatal("getOrInitClient blocked on lifecycleMu for a removed tombstone")
+	}
+}
+
+func TestClientFromIDsStateGating(t *testing.T) {
+	t.Parallel()
+
+	// clientFromIDs gates on the session's (atomic) lifecycle state without ever
+	// taking lifecycleMu, and never returns a client whose session isn't usable.
+	client := &daggerClient{clientID: "c"}
+	sess := &daggerSession{
+		sessionID: "s",
+		clients:   map[string]*daggerClient{"c": client},
+	}
+	srv := &Server{daggerSessions: map[string]*daggerSession{"s": sess}}
+
+	// uninitialized: not yet usable.
+	sess.state.Store(sessionStateUninitialized)
+	_, err := srv.clientFromIDs("s", "c")
+	require.ErrorContains(t, err, "not initialized")
+
+	// removed: retryable not-found (session is tearing down).
+	sess.state.Store(sessionStateRemoved)
+	_, err = srv.clientFromIDs("s", "c")
+	var retryable flightcontrol.RetryableError
+	require.ErrorAs(t, err, &retryable)
+
+	// initialized: returns the client.
+	sess.state.Store(sessionStateInitialized)
+	got, err := srv.clientFromIDs("s", "c")
+	require.NoError(t, err)
+	require.Same(t, client, got)
+}
+
+func TestSessionLifecycleObserverConcurrency(t *testing.T) {
+	t.Parallel()
+
+	// Stress the observer paths (Clients/activeClientIDs/clientFromIDs) against
+	// concurrent session churn. The churners exercise the observer-visible state
+	// the way the real lifecycle does — registry writes under daggerSessionsMu,
+	// the clients map under clientMu, the lifecycle state via the atomic, and a
+	// pointer-conditional deleteSession on teardown — but deliberately do NOT take
+	// lifecycleMu, since the whole point of the redesign is that observers don't
+	// depend on it. Run under -race to catch data races; the observers must also
+	// never block (completing while churn runs is the liveness assertion).
+	srv := &Server{daggerSessions: map[string]*daggerSession{}}
+
+	const (
+		churners         = 4
+		cyclesPerChurner = 1000
+	)
+	var wg sync.WaitGroup
+	for i := range churners {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := fmt.Sprintf("s%d", n)
+			for range cyclesPerChurner {
+				sess := &daggerSession{
+					sessionID:          id,
+					mainClientCallerID: "m" + id,
+					clients:            map[string]*daggerClient{},
+				}
+				// publish, then populate clients, then flip to initialized last.
+				srv.daggerSessionsMu.Lock()
+				srv.daggerSessions[id] = sess
+				srv.daggerSessionsMu.Unlock()
+				sess.clientMu.Lock()
+				sess.clients["c"] = &daggerClient{clientID: "c"}
+				sess.clientMu.Unlock()
+				sess.state.Store(sessionStateInitialized)
+
+				// teardown: removed first, then pointer-conditional delete.
+				sess.state.Store(sessionStateRemoved)
+				srv.deleteSession(sess)
+			}
+		}(i)
+	}
+
+	churnDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(churnDone)
+	}()
+
+	// Hammer the observers concurrently until every churner has finished its
+	// fixed workload, so the race window is exercised deterministically rather
+	// than depending on scheduler timing.
+	for {
+		select {
+		case <-churnDone:
+			return
+		default:
+		}
+		_ = srv.Clients()
+		_ = srv.activeClientIDs()
+		_, _ = srv.clientFromIDs("s0", "c")
+	}
 }
 
 func TestPendingLegacyModule(t *testing.T) {


### PR DESCRIPTION
## What was happening

On Dagger Cloud, live engines with actively-connected clients were sometimes being **suspended out from under those clients**, crashing runs mid-execution.

This surfaced via a report in `#engine`. The cloud's "keeper" polls each engine for its list of connected clients — the `engine { clients }` GraphQL field — roughly every couple of seconds and treats the response as a keepalive; the consolidator suspends an engine after ~15s with no successful keepalive. The observed symptom was that, even with clients genuinely connected, the engine would occasionally take **longer than 15s** to answer that poll, the keepalive would lapse, and a perfectly healthy engine would be suspended.

## Root cause

The `engine { clients }` resolver (and the internal client-DB GC ticker) enumerated sessions while taking **each session's `stateMu`**. That lock is held across a session's *entire* initialization, and across its teardown (`removeDaggerSession` — which stops the session's services, releases its dagql cache, drains in-flight work, and flushes/closes telemetry, all under a 60s safeguard).

Because the enumeration acquired `stateMu` per session, a **single** session that happened to be mid-init or mid-teardown would block the connected-clients enumeration for **all** sessions, for as long as that one session's lifecycle work took. Under churn (clients constantly connecting and disconnecting), a poll that coincided with a slow teardown could blow past the 15s keepalive budget. A Go `RWMutex` read lock is also not context-cancellable, so the keeper timing out client-side did not unblock the engine goroutine.

This per-session-lock coupling on the read path was introduced relatively recently (#13474, which fixed a real concurrent-map panic), which is why the symptom was new.

## The fix

Restructure the session/client locking so that the **read-only observer paths never acquire a per-session lifecycle lock**. Listing connected clients becomes a cheap, lock-free read that cannot be blocked by any session's init or teardown.

## Technical details

- **Immutable identity.** A session's `sessionID` and `mainClientCallerID` are now set at construction, before the session is published into the registry, and never mutated — so observers can read them with no per-session lock.
- **Atomic state.** The session lifecycle state (`uninitialized` / `initialized` / `removed`) is an atomic, so liveness can be read lock-free.
- **A pure lifecycle lock.** The per-session lock is renamed `stateMu` → `lifecycleMu` and now serializes *only* initialization and teardown. The three observer paths — `Clients()` (the resolver), `activeClientIDs()` (the GC ticker), and `clientFromIDs()` — read the atomic state plus immutable identity (and, where they need the client map, a brief `clientMu`), and **never** take `lifecycleMu`. A session parked in init or teardown is therefore invisible to stalls.
- **Tombstone teardown.** `removeDaggerSession` now stores `state = removed` *first* (so a concurrent observer or reconnect sees it immediately), keeps the session in the registry as a tombstone while it cleans up, and the registry entry is pointer-conditionally deleted only *after* `lifecycleMu` is released. As a side benefit this closes a latent same-session-ID resurrection race that existed before: the old teardown removed the session from the registry at the *start* of teardown, so a reconnect with the same ID could create a fresh session while the old one was still releasing its session-scoped cache.
- **Supporting coherence changes.** `getOrInitClient` does a lock-free fast-path return for a removed tombstone (so a same-ID reconnect during a slow teardown doesn't block on `lifecycleMu`); the creating goroutine locks `lifecycleMu` before publishing a new session (guaranteeing it is the initializer); a client is inserted into the session only after it is fully initialized (so observers never see a half-built client); the per-client SQLite DB is opened outside `clientMu`; and `GracefulStop` snapshots session pointers into a slice before iterating.

## Tests

Adds `-race` regression coverage:

- the connected-clients API does not stall while a session's lifecycle lock is held;
- the same for the client-DB GC path;
- a same-ID reconnect returns quickly (retryable) while a teardown is in progress, instead of blocking;
- `clientFromIDs` state gating; and
- a lifecycle/observer concurrency stress test.

The existing #13474 concurrent-map and init-window race tests are adapted to the new field types (atomic state, `clientMu`-guarded client map).
