### PR TITLE
Load workspace modules on demand (per-module typedefs)

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -304,6 +304,217 @@ func (m *Consumer) SyncGenerators(ctx context.Context, workspace *dagger.Workspa
 	require.NotContains(t, out, "result *core.Changeset is detached")
 }
 
+// TestWorkspaceGenerateNarrowsToRequestedModule locks in that
+// `dagger generate <module>` only loads the named generator's module. The
+// workspace generators resolver loads modules on demand from its include
+// argument, so an unrelated broken/stale workspace module is never loaded just
+// to enumerate generators and cannot block regenerating a healthy module --
+// including the case where running generate is itself the fix for the broken
+// module.
+//
+// See also TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrokenModules
+// in workspace_test.go, which covers the root-field demand path for raw
+// queries.
+func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating only the healthy module succeeds", func(ctx context.Context, t *testctx.T) {
+		// generate -y is multi-request (list, then run+apply); the later
+		// requests must keep recognizing the already-loaded module instead of
+		// falling back to loading everything.
+		out, err := base.
+			With(daggerExec("generate", "good", "-y", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "no changes to apply")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCheckNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate or run a
+// healthy module's checks, so it cannot block checking that module.
+func (GeneratorsSuite) TestWorkspaceCheckNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("check", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("running only the healthy module's checks succeeds", func(ctx context.Context, t *testctx.T) {
+		// --no-generate runs only annotated checks; generate-as-checks are
+		// excluded because the healthy module's generator legitimately reports
+		// pending output (covered by the generate narrowing test), which is
+		// unrelated to whether the broken module was loaded.
+		out, err := base.
+			With(daggerExec("check", "good", "--no-generate", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("checking across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceUpNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger up`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate a healthy
+// module's services. `dagger up` starts services and blocks, so the assertions
+// use list mode (-l), which still loads workspace modules to enumerate services
+// and thus exercises the same narrowing.
+func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("up", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("up", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger call`: targeting a
+// healthy module's function must not load every workspace module just to build
+// the command tree. The CLI resolves the leading positional token to an
+// installed module and fetches only that module's typedefs via
+// currentWorkspace.moduleList.typeDefs, so an unrelated broken/stale module
+// cannot block the call.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("calling a healthy module's function skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good", "verify", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing the healthy module's functions skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsByCliNameAndEntrypoint covers the two demand shapes
+// TestWorkspaceCallNarrowsToRequestedModule cannot see with its single-word
+// module names:
+//
+//   - the CLI targets modules by their kebab-case command name, so a module
+//     declared as "goodMod" is called as `dagger call good-mod ...` and the
+//     engine must normalize both sides the same way to narrow loading;
+//   - with a workspace entrypoint configured, the first argument may be one of
+//     the entrypoint's root-proxied functions rather than a module name, in
+//     which case the entrypoint module must load — and suffice — to resolve
+//     the call.
+//
+// In both cases the broken sibling module must stay unloaded.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsByCliNameAndEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "call-narrowing")
+
+	t.Run("kebab-case module target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "good-mod", "ping", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "pong from goodMod")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("entrypoint function target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("call", "greet", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello from entrypoint")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case functions listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("functions", "good-mod", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case generate listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		// The selector resolvers (generate/check/up) match include patterns
+		// kebab-normalized; on-demand loading must normalize the same way.
+		out, err := base.
+			With(daggerExec("generate", "-l", "good-mod")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "entry"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
@@ -1,0 +1,9 @@
+type Entry {
+  """
+  A trivial entrypoint function, proxied onto the Query root. Used to prove
+  the entrypoint module loaded when it is the first `dagger call` argument.
+  """
+  pub greet: String! {
+    "hello from entrypoint"
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "goodMod"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
@@ -1,0 +1,17 @@
+type GoodMod {
+  """
+  A trivial function. Used to prove the module loaded when targeted by its
+  kebab-case CLI command name (good-mod).
+  """
+  pub ping: String! {
+    "pong from goodMod"
+  }
+
+  """
+  Regenerate by writing a marker file. Used to prove the kebab-case name also
+  narrows the generate/check/up selector path.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from goodMod").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/dagger.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/dagger.toml
@@ -1,0 +1,9 @@
+[modules.goodMod]
+source = ".dagger/modules/goodMod"
+
+[modules.entry]
+source = ".dagger/modules/entry"
+entrypoint = true
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "good"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,0 +1,27 @@
+type Good {
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+
+  """
+  A trivial check. Used to prove the module loaded for `dagger check` and
+  `dagger call`.
+  """
+  pub verify: Void @check {
+    null
+  }
+
+  """
+  A trivial service. Used to prove the module loaded for `dagger up`.
+  """
+  @up
+  pub web: Service! {
+    container
+      .from("nginx:alpine")
+      .withExposedPort(80)
+      .asService
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken/dagger.toml
@@ -1,0 +1,5 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/query.go
+++ b/core/query.go
@@ -87,6 +87,11 @@ type Server interface {
 	// The cached workspace result from ensureWorkspaceLoaded.
 	CurrentWorkspace(context.Context) (*Workspace, error)
 
+	// Load pending workspace modules on demand; include narrows to the modules
+	// its patterns name ("module" or "module:item"), empty or unrecognized
+	// loads all.
+	EnsureWorkspaceModules(ctx context.Context, include []string) error
+
 	// A snapshot of the current workspace lockfile for ambient live locking.
 	// Returns ok=false when lock-backed workspace access is unavailable.
 	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -2117,6 +2117,13 @@ func (s *moduleSchema) currentTypeDefs(ctx context.Context, self *core.Query, ar
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current module: %w", err)
 	}
+	return typeDefsFromServedDeps(ctx, deps, args.ReturnAllTypes, args.HideCore.GetOr(dagql.NewBoolean(false)).Bool())
+}
+
+// typeDefsFromServedDeps builds the typedef list for a served dependency set,
+// swapping in the live Query typedef and applying the hideCore / returnAllTypes
+// shaping. Shared by Query.currentTypeDefs and WorkspaceModule.typeDefs.
+func typeDefsFromServedDeps(ctx context.Context, deps *core.SchemaBuilder, returnAllTypes, hideCore bool) (dagql.ObjectResultArray[*core.TypeDef], error) {
 	dag, err := deps.Schema(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current schema: %w", err)
@@ -2149,13 +2156,13 @@ func (s *moduleSchema) currentTypeDefs(ctx context.Context, self *core.Query, ar
 		typeDefs = append(typeDefs, queryTypeDef)
 	}
 
-	if args.HideCore.GetOr(dagql.NewBoolean(false)).Bool() {
+	if hideCore {
 		typeDefs, err = stripCoreQueryFunctions(ctx, dag, typeDefs)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if !args.ReturnAllTypes {
+	if !returnAllTypes {
 		return typeDefs, nil
 	}
 	return expandTypeDefClosure(ctx, dag, typeDefs)

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -53,6 +53,10 @@ func (s *currentTypeDefsTestServer) CurrentWorkspace(context.Context) (*core.Wor
 	return nil, nil
 }
 
+func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
 func (s *currentTypeDefsTestServer) CurrentServedDeps(context.Context) (*core.SchemaBuilder, error) {
 	return s.deps, nil
 }

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1266,6 +1266,9 @@ func (s *workspaceSchema) checks(
 		noGenerate = true
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1375,6 +1378,9 @@ func (s *workspaceSchema) generators(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1493,6 +1499,9 @@ func (s *workspaceSchema) services(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1645,6 +1654,17 @@ func matchWorkspaceIncludePath(
 		}
 	}
 	return false, nil
+}
+
+// ensureWorkspaceIncludeModulesLoaded loads the workspace modules the include
+// patterns demand (all when they don't narrow). Selector fields validate
+// against the core schema, so loading can wait until resolution.
+func ensureWorkspaceIncludeModulesLoaded(ctx context.Context, include []string) error {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	return query.Server.EnsureWorkspaceModules(ctx, include)
 }
 
 func currentWorkspacePrimaryModules(ctx context.Context) ([]dagql.ObjectResult[*core.Module], error) {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -267,6 +267,13 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 		dagql.NodeFunc("settings", s.moduleSettings).
 			DoNotCache("Reads live config and module metadata from the workspace").
 			Doc("List constructor-backed settings for this module."),
+		dagql.NodeFunc("typeDefs", s.moduleTypeDefs).
+			DoNotCache("Loads the module on demand and reads live config from the workspace").
+			Doc("Type definitions for this module, loading only this module on demand.").
+			Args(
+				dagql.Arg("returnAllTypes").Doc("Return the full referenced typedef closure instead of only top-level served typedefs."),
+				dagql.Arg("hideCore").Doc("Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.)."),
+			),
 	}.Install(srv)
 	dagql.Fields[*core.WorkspaceModuleSetting]{}.Install(srv)
 	dagql.Fields[*core.WorkspaceMigration]{}.Install(srv)

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -176,6 +176,57 @@ func (s *workspaceSchema) moduleSettings(
 	return settings, nil
 }
 
+type workspaceModuleTypeDefsArgs struct {
+	ReturnAllTypes bool `default:"false"`
+	HideCore       dagql.Optional[dagql.Boolean]
+}
+
+func (s *workspaceSchema) moduleTypeDefs(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.WorkspaceModule],
+	args workspaceModuleTypeDefsArgs,
+) (dagql.ObjectResultArray[*core.TypeDef], error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// moduleList creates WorkspaceModule results from Workspace.__workspaceModule,
+	// so the DagQL receiver is the workspace that owns this module entry.
+	receiver, err := parent.Receiver(ctx, srv)
+	if err != nil {
+		return nil, err
+	}
+	ws, ok := receiver.(dagql.ObjectResult[*core.Workspace])
+	if !ok {
+		return nil, fmt.Errorf("workspace module %q has unexpected receiver %T", parent.Self().Name, receiver)
+	}
+	if err := unsupportedSyntheticWorkspaceFeature(ws.Self(), "module typedefs"); err != nil {
+		return nil, err
+	}
+
+	ctx, err = s.withWorkspaceClientContext(ctx, ws.Self())
+	if err != nil {
+		return nil, err
+	}
+
+	// Load only this module on demand; siblings stay pending, so a broken sibling
+	// can't fail introspecting this one.
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, []string{parent.Self().Name}); err != nil {
+		return nil, err
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	deps, err := query.CurrentServedDeps(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("current served deps: %w", err)
+	}
+	return typeDefsFromServedDeps(ctx, deps, args.ReturnAllTypes, args.HideCore.GetOr(dagql.NewBoolean(false)).Bool())
+}
+
 func workspaceSettingsModuleRef(
 	ws *core.Workspace,
 	configDir string,

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -56,6 +56,10 @@ func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*M
 	return nil
 }
 
+func (ms *mockServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
 func (ms *mockServer) CurrentModule(_ context.Context) (dagql.ObjectResult[*Module], error) {
 	var zero dagql.ObjectResult[*Module]
 	if ms.moduleSource == nil {

--- a/dagql/request_peek.go
+++ b/dagql/request_peek.go
@@ -18,7 +18,9 @@ type peekGraphQLRequest struct {
 }
 
 // PeekRootFields returns the top-level field names selected by a GraphQL-over-HTTP
-// request while preserving the request body for the real server.
+// request while preserving the request body for the real server. The operation
+// to inspect is chosen by the request's operation name (or the sole operation
+// when the document has just one).
 func PeekRootFields(r *http.Request) (bool, []string, error) {
 	query, operationName, ok, err := peekGraphQLRequestBody(r)
 	if err != nil || !ok {

--- a/dagql/request_peek_test.go
+++ b/dagql/request_peek_test.go
@@ -62,3 +62,17 @@ func TestPeekRootFieldsRejectsBatch(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, fields)
 }
+
+func TestPeekRootFieldsRecoversSingleOperation(t *testing.T) {
+	t.Parallel()
+
+	// operationName omitted from the envelope: the sole operation is used.
+	body := `{"query":"query Introspect { currentTypeDefs { name } }"}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, fields, err := dagql.PeekRootFields(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"currentTypeDefs"}, fields)
+}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6407,6 +6407,20 @@ type WorkspaceModule implements Node {
 
   """The module source path."""
   source: String!
+
+  """Type definitions for this module, loading only this module on demand."""
+  typeDefs(
+    """
+    Return the full referenced typedef closure instead of only top-level served typedefs.
+    """
+    returnAllTypes: Boolean = false
+
+    """
+    Strip core API functions from the Query type, leaving only module-sourced
+    functions (constructors, entrypoint proxies, etc.).
+    """
+    hideCore: Boolean
+  ): [TypeDef!]!
 }
 
 """A constructor-backed module setting."""

--- a/docs/static/reference/php/Dagger/WorkspaceModule.html
+++ b/docs/static/reference/php/Dagger/WorkspaceModule.html
@@ -191,6 +191,16 @@
                                             <p><p>The module source path.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    array
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_typeDefs">typeDefs</a>(bool|null $returnAllTypes = false, bool|null $hideCore = null)
+        
+                                            <p><p>Type definitions for this module, loading only this module on demand.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
             </div>
 
 
@@ -435,6 +445,53 @@
                     <table class="table table-condensed">
         <tr>
             <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_typeDefs">
+        <div class="location">at line 64</div>
+        <code>                    array
+    <strong>typeDefs</strong>(bool|null $returnAllTypes = false, bool|null $hideCore = null)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Type definitions for this module, loading only this module on demand.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>bool|null</td>
+                <td>$returnAllTypes</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$hideCore</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>array</td>
             <td></td>
         </tr>
     </table>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1488,7 +1488,9 @@
                     <dd><p>An interactive terminal that clients can connect to.</p></dd><dt><a href="Dagger/TerminalId.html"><abbr title="Dagger\TerminalId">TerminalId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>A unique identifier for an object.</p></dd><dt><a href="Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
                     <dd><p>A definition of a parameter or return type in a Module.</p></dd><dt><a href="Dagger/TypeDefId.html"><abbr title="Dagger\TypeDefId">TypeDefId</abbr></a> &mdash; <em>Class in namespace <a href="Dagger.html">Dagger</a></em></dt>
-                    <dd><p>A unique identifier for an object.</p></dd>        </dl><h2 id="letterU">U</h2>
+                    <dd><p>A unique identifier for an object.</p></dd><dt><a href="Dagger/WorkspaceModule.html#method_typeDefs">
+<abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr>::typeDefs</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a></em></dt>
+                    <dd><p>Type definitions for this module, loading only this module on demand.</p></dd>        </dl><h2 id="letterU">U</h2>
         <dl id="indexU"><dt><a href="Dagger/Container.html#method_up">
 <abbr title="Dagger\Container">Container</abbr>::up</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></dd><dt><a href="Dagger/Container.html#method_user">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -6942,6 +6942,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\WorkspaceModule::typeDefs",
+			"p": "Dagger/WorkspaceModule.html#method_typeDefs",
+			"d": "<p>Type definitions for this module, loading only this module on demand.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\WorkspaceModuleSetting::description",
 			"p": "Dagger/WorkspaceModuleSetting.html#method_description",
 			"d": "<p>The constructor argument description.</p>"

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -214,10 +214,20 @@ type daggerClient struct {
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
 	modulesMu           sync.Mutex
-	modulesLoaded       bool
-	modulesErr          error
-	singleQueryMu       sync.Mutex
-	singleQueryServed   bool
+	extraModulesLoaded  bool
+	extraModulesErr     error
+	// load failures by moduleProgressName; failed modules stay pending to keep
+	// reporting their error
+	failedModules map[string]error
+	// whether an entrypoint module has been served (extras outrank ambient)
+	entrypointServed bool
+	// resolved identities already served, for cross-batch deduplication
+	servedModuleKeys map[string]struct{}
+	// served workspace module names, so demand filters recognize them without
+	// reloading
+	servedWorkspaceModuleNames map[string]struct{}
+	singleQueryMu              sync.Mutex
+	singleQueryServed          bool
 
 	// NOTE: do not use this field directly as it may not be open
 	// after the client has shutdown; use TelemetryDB() instead
@@ -992,7 +1002,7 @@ func (srv *Server) getOrInitClient(
 		}
 		// ExtraModules may arrive on a later request (e.g. /init) after the
 		// session attachable request already created the client without them.
-		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.modulesLoaded {
+		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.extraModulesLoaded {
 			client.clientMetadata.ExtraModules = opts.ExtraModules
 			client.pendingExtraModules = opts.ExtraModules
 		}
@@ -1466,26 +1476,18 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 		return gqlErr(err, http.StatusBadRequest)
 	}
 
-	peekRootFieldsOK, peekRootFields, err := peekSingleQueryRootFields(r, client.clientMetadata)
-	if err != nil {
-		return gqlErr(fmt.Errorf("peeking single-query root fields: %w", err), http.StatusBadRequest)
-	}
-
 	// Load workspace modules and extra modules (e.g. from -m flag). These are
 	// deferred from initializeDaggerClient because they need the client's
 	// session attachables, which only become available after the session
 	// attachables handshake completes (after init locks are released).
 	wsCtx, wsOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.workspaceLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureWorkspaceLoaded(wsCtx, client)
+	err := srv.ensureWorkspaceLoaded(wsCtx, client)
 	wsOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading workspace: %w", err), http.StatusInternalServerError)
 	}
-	if peekRootFieldsOK {
-		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
-	}
 	modCtx, modOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.modulesLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureModulesLoaded(modCtx, client)
+	err = srv.ensureRequestModulesLoaded(modCtx, client, r)
 	modOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1532,11 +1534,26 @@ func (client *daggerClient) claimSingleQueryRequest() error {
 	return nil
 }
 
-func peekSingleQueryRootFields(r *http.Request, clientMD *engine.ClientMetadata) (bool, []string, error) {
-	if clientMD == nil || !clientMD.SingleQuery || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
-		return false, nil, nil
+// ensureRequestModulesLoaded loads the modules this request demands, read from
+// the request's root fields: fields naming pending modules demand those, and
+// full-schema or unrecognized fields demand everything. The rest stay pending.
+func (srv *Server) ensureRequestModulesLoaded(ctx context.Context, client *daggerClient, r *http.Request) error {
+	var filter func([]pendingModule) []pendingModule
+	if client.hasPendingWorkspaceModules() {
+		if ok, rootFields, err := dagql.PeekRootFields(r); err == nil && ok {
+			filter = func(mods []pendingModule) []pendingModule {
+				// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+				return filterPendingWorkspaceModulesForRootFields(mods, client.servedWorkspaceModuleNames, rootFields)
+			}
+		}
 	}
-	return dagql.PeekRootFields(r)
+	return srv.ensureModulesLoaded(ctx, client, filter)
+}
+
+func (client *daggerClient) hasPendingWorkspaceModules() bool {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+	return len(client.pendingModules) > 0
 }
 
 func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *daggerClient) (rerr error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -222,14 +222,14 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 	t.Run("constructor match loads only matching module", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"foo"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"foo"})
 		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("unknown root field with multiple entrypoints loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"doThing"})
 		require.Equal(t, mods, filtered)
 	})
 
@@ -237,36 +237,189 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		oneEntrypoint := []pendingModule{mods[0], mods[1]}
-		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, []string{"doThing"})
 		require.Equal(t, []pendingModule{mods[1]}, filtered)
 	})
 
 	t.Run("introspection loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"__schema"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"__schema"})
 		require.Equal(t, mods, filtered)
 	})
 
-	t.Run("current typedefs loads all", func(t *testing.T) {
+	t.Run("current typedefs loads all (targeted introspection narrows via operation-name scope)", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentTypeDefs"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentTypeDefs"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("current module loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentModule"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentModule"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("core-only query loads none", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"container", "version"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"container", "version"})
 		require.Empty(t, filtered)
+	})
+
+	t.Run("current workspace loads none (resolvers load on demand)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentWorkspace"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("already-served root field loads none", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served field combined with pending field loads only pending", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod", "foo"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("env loads all (resolver snapshots served deps)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"env"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("unrecognized loadFromID field loads all", func(t *testing.T) {
+		t.Parallel()
+
+		// The type name in load<Type>FromID needn't embed the module name, so
+		// only a full load can guarantee the field exists.
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"loadSomethingFromID"})
+		require.Equal(t, mods, filtered)
+	})
+}
+
+func TestFilterPendingWorkspaceModulesBySelectorInclude(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "go-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "rust-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "php-sdk"},
+	}
+
+	t.Run("module:generator selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("module:item works for checks and services too", func(t *testing.T) {
+		t.Parallel()
+
+		// The module-name resolution is identical across generate/check/up: the
+		// segment before ':' is the module name regardless of the item kind.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"rust-sdk:lint", "php-sdk:web"})
+		require.Equal(t, []pendingModule{mods[1], mods[2]}, filtered)
+	})
+
+	t.Run("bare module name selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("multiple patterns select each named module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk", "php-sdk:api"})
+		require.Equal(t, []pendingModule{mods[0], mods[2]}, filtered)
+	})
+
+	t.Run("bare token not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// e.g. an item served by the entrypoint module.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("module:item not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"typo-sdk:generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("empty include selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, nil)
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("already-served module is recognized and selects nothing", func(t *testing.T) {
+		t.Parallel()
+
+		// A re-evaluated selector (e.g. loading a GeneratorGroup from its ID
+		// on a later request) names a module that already loaded; it must not
+		// fall back to loading everything.
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served and pending patterns select only the pending module", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk:generate", "go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("camelCase pattern selects the kebab-case module", func(t *testing.T) {
+		t.Parallel()
+
+		// Name matching is kebab-normalized on both sides, like the include
+		// matchers the selector resolvers use (ModTreePath.Glob/CliCase).
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"goSdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("kebab-case pattern selects the camelCase module", func(t *testing.T) {
+		t.Parallel()
+
+		// The CLI presents module commands in kebab-case, so a module declared
+		// as "myMod" (or "mod1", which kebab-cases to "mod-1") is targeted by
+		// its kebab-case name.
+		camelMods := []pendingModule{
+			{Kind: moduleLoadKindAmbient, Name: "myMod"},
+			{Kind: moduleLoadKindAmbient, Name: "mod1"},
+			{Kind: moduleLoadKindAmbient, Name: "other"},
+		}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(camelMods, nil, []string{"my-mod", "mod-1:generate"})
+		require.Equal(t, []pendingModule{camelMods[0], camelMods[1]}, filtered)
+	})
+
+	t.Run("glob pattern selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// Glob metacharacters survive normalization and never equal a module
+		// name, so glob patterns conservatively load everything.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-*"})
+		require.Equal(t, mods, filtered)
 	})
 }
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -890,33 +890,144 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 	return tree, gitRef, nil
 }
 
-// ensureModulesLoaded loads all pending modules (from workspace discovery,
-// compat parsing, and -m flags). Called from serveQuery after
-// ensureWorkspaceLoaded. Uses a mutex+flag instead of sync.Once so that
-// transient failures (e.g. session not yet registered) can be retried.
-func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient) error {
-	if len(client.pendingModules) == 0 && len(client.pendingExtraModules) == 0 {
-		return nil
-	}
-
+// ensureModulesLoaded loads pending modules (workspace, compat, and -m) on
+// demand. filter picks which pending workspace modules this request needs (nil
+// = all); the rest stay pending for a later request or resolver. Loading is
+// additive, so narrowing is deferral, not exclusion. Mutex+flags (not
+// sync.Once) keep transient failures retriable.
+func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule) error {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
 
-	if client.modulesLoaded {
-		return client.modulesErr
+	if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
+		return err
+	}
+
+	if len(client.pendingModules) == 0 {
+		return nil
+	}
+
+	demand := client.pendingModules
+	if filter != nil {
+		demand = filter(client.pendingModules)
+	}
+	// Multiple ambient entrypoint declarations may dedupe to one module; load
+	// everything so the existing conflict detection still runs.
+	if len(demand) > 0 && len(pendingWorkspaceEntrypointIndexes(client.pendingModules)) > 1 {
+		demand = client.pendingModules
+	}
+	if len(demand) == 0 {
+		return nil
+	}
+
+	// A failed module stays pending; surface its recorded error rather than
+	// reloading it.
+	for _, mod := range demand {
+		if err, ok := client.failedModules[moduleProgressName(mod)]; ok {
+			return err
+		}
 	}
 
 	// Wait for the client's session attachables to be available.
-	// Don't mark as loaded on failure — allow retry on next request.
+	// Transient failure — allow retry on next request.
 	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
 		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
-	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules)
+	loads := gatherModuleLoadRequests(demand, nil)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			loadErr := moduleLoadErr(load, resolveErrs[i])
+			client.recordFailedModule(load.mod, loadErr)
+			if firstErr == nil {
+				firstErr = loadErr
+			}
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := client.arbitrateAmbientEntrypoints(loads, resolvedLoads); err != nil {
+		return err
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return err
+	}
+	client.markEntrypointServed(resolvedLoads)
+	client.removePendingModules(demand)
+	return nil
+}
+
+// ensureExtraModulesLoadedLocked loads -m modules. They are explicitly
+// requested, so they load eagerly with sticky failures (unlike on-demand
+// workspace modules). client.modulesMu must be held.
+func (srv *Server) ensureExtraModulesLoadedLocked(ctx context.Context, client *daggerClient) error {
+	if client.extraModulesLoaded {
+		return client.extraModulesErr
+	}
+	if len(client.pendingExtraModules) == 0 {
+		return nil
+	}
+
+	// Wait for the client's session attachables to be available.
+	// Transient failure — allow retry on next request.
+	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		return fmt.Errorf("waiting for client session attachables: %w", err)
+	}
+
+	stick := func(err error) error {
+		client.extraModulesErr = err
+		client.extraModulesLoaded = true
+		return err
+	}
+
+	loads := gatherModuleLoadRequests(nil, client.pendingExtraModules)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return stick(err)
+	}
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			return stick(moduleLoadErr(load, resolveErrs[i]))
+		}
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+	client.markEntrypointServed(resolvedLoads)
+
+	client.extraModulesLoaded = true
+	return nil
+}
+
+// resolveModuleLoadBatch resolves a batch of module loads in parallel,
+// collecting per-load errors in deterministic order.
+func (srv *Server) resolveModuleLoadBatch(
+	ctx context.Context,
+	client *daggerClient,
+	loads []moduleLoadRequest,
+) ([]resolvedModuleLoad, []error, error) {
 	resolvedLoads := make([]resolvedModuleLoad, len(loads))
 	resolveErrs := make([]error, len(loads))
 
-	// Load modules in parallel, then apply to client state in deterministic order.
 	jobs := parallel.New().
 		WithContextualTracer(true).
 		WithLimit(moduleLoadParallelism(len(loads)))
@@ -934,57 +1045,189 @@ func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient
 		})
 	}
 	if err := jobs.Run(ctx); err != nil {
-		client.modulesErr = fmt.Errorf("resolving modules: %w", err)
-		client.modulesLoaded = true
-		return client.modulesErr
+		return nil, nil, fmt.Errorf("resolving modules: %w", err)
 	}
+	return resolvedLoads, resolveErrs, nil
+}
 
-	for i, load := range loads {
-		if resolveErrs[i] != nil {
-			client.modulesErr = moduleLoadErr(load, resolveErrs[i])
-			client.modulesLoaded = true
-			return client.modulesErr
+// arbitrateAmbientEntrypoints picks whether this ambient batch's entrypoint
+// candidate wins: only when none is served yet (extras outrank ambient).
+// Multiple candidates in one batch are a workspace configuration error.
+func (client *daggerClient) arbitrateAmbientEntrypoints(loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+	var candidates []int
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			candidates = append(candidates, i)
 		}
 	}
-
-	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
-	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if len(candidates) > 1 {
+		return entrypointConflictError(moduleLoadKindAmbient, candidates, loads)
 	}
-
-	client.stateMu.Lock()
-	defer client.stateMu.Unlock()
-	if err := srv.serveAllResolvedModuleLoads(client, loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if client.entrypointServed {
+		for _, i := range candidates {
+			resolved[i].primaryEntrypoint = false
+		}
 	}
-
-	client.modulesLoaded = true
 	return nil
 }
 
-func (client *daggerClient) narrowPendingWorkspaceModulesForSingleQuery(rootFields []string) {
-	client.modulesMu.Lock()
-	defer client.modulesMu.Unlock()
-
-	if client.modulesLoaded || len(client.pendingModules) == 0 {
-		return
+// markEntrypointServed flags that an entrypoint (primary or blueprint) was
+// served, so later ambient candidates are demoted. client.modulesMu must be held.
+func (client *daggerClient) markEntrypointServed(resolved []resolvedModuleLoad) {
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			client.entrypointServed = true
+			return
+		}
+		for _, related := range resolved[i].related {
+			if related.entrypoint {
+				client.entrypointServed = true
+				return
+			}
+		}
 	}
-	client.pendingModules = filterPendingWorkspaceModulesForRootFields(client.pendingModules, rootFields)
 }
 
-func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields []string) []pendingModule {
+func (client *daggerClient) recordFailedModule(mod pendingModule, err error) {
+	// Cancellation/deadline is the request's fault, not the module's; keep it
+	// retriable.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	if client.failedModules == nil {
+		client.failedModules = make(map[string]error)
+	}
+	client.failedModules[moduleProgressName(mod)] = err
+}
+
+// removePendingModules drops served modules from the pending set and records
+// their names so demand filters still recognize them. Failed modules stay
+// pending to keep reporting their error. client.modulesMu must be held.
+func (client *daggerClient) removePendingModules(served []pendingModule) {
+	names := make(map[string]struct{}, len(served))
+	for _, mod := range served {
+		names[moduleProgressName(mod)] = struct{}{}
+	}
+	remaining := client.pendingModules[:0]
+	for _, mod := range client.pendingModules {
+		if _, ok := names[moduleProgressName(mod)]; ok {
+			if client.servedWorkspaceModuleNames == nil {
+				client.servedWorkspaceModuleNames = make(map[string]struct{})
+			}
+			client.servedWorkspaceModuleNames[moduleProgressName(mod)] = struct{}{}
+			continue
+		}
+		remaining = append(remaining, mod)
+	}
+	client.pendingModules = remaining
+}
+
+// EnsureWorkspaceModules loads the pending workspace modules a selector
+// resolver (checks/generators/services) demands. Those fields validate against
+// the core schema, so loading waits until resolution where include is native.
+func (srv *Server) EnsureWorkspaceModules(ctx context.Context, include []string) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return srv.ensureModulesLoaded(ctx, client, func(mods []pendingModule) []pendingModule {
+		// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+		return filterPendingWorkspaceModulesBySelectorInclude(mods, client.servedWorkspaceModuleNames, include)
+	})
+}
+
+// canonicalWorkspaceModuleName kebab-normalizes a name or pattern segment for
+// comparison, matching the include matchers (ModTreePath.Glob/CliCase) and CLI
+// command names: "myMod", "my-mod", "MyMod" are the same module. Glob
+// metacharacters survive, so a glob never equals a module name.
+func canonicalWorkspaceModuleName(name string) string {
+	return strcase.ToKebab(name)
+}
+
+// pendingModuleCliName is the canonical name an include pattern matches against.
+func pendingModuleCliName(mod pendingModule) string {
+	if mod.Name != "" {
+		return canonicalWorkspaceModuleName(mod.Name)
+	}
+	return canonicalWorkspaceModuleName(moduleProgressName(mod))
+}
+
+// knownWorkspaceModuleNames is the canonical-name set of all pending and
+// already-served workspace modules.
+func knownWorkspaceModuleNames(mods []pendingModule, served map[string]struct{}) map[string]struct{} {
+	known := make(map[string]struct{}, len(mods)+len(served))
+	for _, mod := range mods {
+		known[pendingModuleCliName(mod)] = struct{}{}
+	}
+	for name := range served {
+		known[canonicalWorkspaceModuleName(name)] = struct{}{}
+	}
+	return known
+}
+
+// resolveIncludePatternModules maps each pattern's leading segment (before ':')
+// to a known module name. It returns the demanded names and whether any pattern
+// matched nothing known; the caller decides the fallback.
+func resolveIncludePatternModules(mods []pendingModule, served map[string]struct{}, include []string) (wanted map[string]struct{}, unknown bool) {
+	known := knownWorkspaceModuleNames(mods, served)
+	wanted = make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		modName, _, _ := strings.Cut(pattern, ":")
+		modName = canonicalWorkspaceModuleName(modName)
+		if _, ok := known[modName]; !ok {
+			unknown = true
+			continue
+		}
+		wanted[modName] = struct{}{}
+	}
+	return wanted, unknown
+}
+
+// filterPendingWorkspaceModulesBySelectorInclude selects the modules named by
+// `dagger generate`/`check`/`up` patterns ("module" or "module:item"). A
+// pattern naming no known module (an entrypoint-proxied item, or a typo)
+// selects all, so the usual error surfaces. served modules are recognized but
+// contribute nothing to load.
+func filterPendingWorkspaceModulesBySelectorInclude(mods []pendingModule, served map[string]struct{}, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	wanted, unknown := resolveIncludePatternModules(mods, served, include)
+	if unknown {
+		return mods
+	}
+
+	// Already-served wanted modules contribute nothing; result may be empty.
+	filtered := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if _, ok := wanted[pendingModuleCliName(mod)]; ok {
+			filtered = append(filtered, mod)
+		}
+	}
+	return filtered
+}
+
+// filterPendingWorkspaceModulesForRootFields selects the pending modules a
+// request's root fields reference. served modules are recognized without
+// loading.
+func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods
+	}
+
+	servedFields := make(map[string]struct{}, len(served))
+	for name := range served {
+		servedFields[strcase.ToLowerCamel(name)] = struct{}{}
 	}
 
 	selected := make([]bool, len(mods))
 	unknownRootField := false
 	for _, field := range rootFields {
 		if isCoreRootField(field) {
+			continue
+		}
+		if _, ok := servedFields[field]; ok {
 			continue
 		}
 		matched := false
@@ -995,6 +1238,11 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields
 			}
 		}
 		if !matched {
+			// load<Type>FromID can reference a module type without naming the
+			// module, so load everything to be safe.
+			if strings.HasPrefix(field, "load") && strings.HasSuffix(field, "FromID") {
+				return mods
+			}
 			unknownRootField = true
 		}
 	}
@@ -1031,8 +1279,11 @@ func rootFieldsRequireFullWorkspaceSchema(fields []string) bool {
 			"__workspaceModule",
 			"currentEnv",
 			"currentModule",
+			// currentTypeDefs loads everything; a targeted introspection instead
+			// narrows via the peeked operation-name scope (ensureRequestModulesLoaded).
 			"currentTypeDefs",
-			"currentWorkspace":
+			// env's resolver snapshots the served deps, so it needs every module
+			"env":
 			return true
 		}
 	}
@@ -1087,10 +1338,14 @@ func isCoreRootField(field string) bool {
 		"currentEnv",
 		"currentFunctionCall",
 		"currentModule",
+		// currentWorkspace's selector resolvers load on demand from their
+		// include argument, so the root field demands nothing here
+		"currentWorkspace",
 		"defaultPlatform",
 		"directory",
 		"engine",
-		"env",
+		// NOTE: "env" is intentionally absent — it needs the full workspace
+		// (see rootFieldsRequireFullWorkspaceSchema)
 		"envFile",
 		"error",
 		"file",
@@ -1177,8 +1432,10 @@ func (srv *Server) resolveModuleLoad(
 	return resolved, nil
 }
 
-// serveAllResolvedModuleLoads serves all resolved primary modules and their
-// related modules (blueprints, toolchains-of-toolchains).
+// serveResolvedModuleLoadsLocked serves resolved primary modules and their
+// related modules (blueprints, toolchains-of-toolchains), skipping any whose
+// identity an earlier batch already served. client.stateMu and client.modulesMu
+// must be held.
 //
 // Transitive dependencies are only served for the entrypoint module — the one
 // the user is interacting with via `dagger call` or `dagger shell`. This is
@@ -1186,9 +1443,13 @@ func (srv *Server) resolveModuleLoad(
 // (e.g. a Mallard backing a Duck). Toolchain deps are NOT served globally;
 // each module's deps are available in its own internal schema (mod.Deps) for
 // type resolution during function calls.
-func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+func (srv *Server) serveResolvedModuleLoadsLocked(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
 	for i := range loads {
 		load := resolved[i]
+		key := resolvedModuleLoadIdentity(load.primary)
+		if _, ok := client.servedModuleKeys[key]; ok {
+			continue
+		}
 		for _, related := range load.related {
 			if err := srv.serveModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: related.entrypoint}); err != nil {
 				return fmt.Errorf("error serving related module %s: %w", related.mod.Self().Name(), err)
@@ -1208,6 +1469,10 @@ func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []mod
 				}
 			}
 		}
+		if client.servedModuleKeys == nil {
+			client.servedModuleKeys = make(map[string]struct{})
+		}
+		client.servedModuleKeys[key] = struct{}{}
 	}
 
 	return nil

--- a/hack/designs/per-module-typedefs.md
+++ b/hack/designs/per-module-typedefs.md
@@ -1,0 +1,199 @@
+# Lazy workspace module loading: names first, types on demand
+
+*Stop loading every workspace module to operate on one: `dagger call`/`functions`
+discovers module names without loading anything, then fetches only the targeted
+module's typedefs — instead of the load-all `currentTypeDefs`.*
+
+## Table of Contents
+
+- [Problem](#problem)
+- [Solution](#solution)
+- [Core Concept](#core-concept)
+- [Flow](#flow)
+- [CLI](#cli)
+- [Edge cases](#edge-cases)
+- [Version gating and caching](#version-gating-and-caching)
+- [Status](#status)
+
+## Problem
+
+1. **One-shot load-all** — `dagger call|functions <module>` builds its command
+   tree from `currentTypeDefs(returnAllTypes: true)` (`core/schema/module.go:2110`),
+   which serves *every* workspace module. Running one module pays for all its
+   siblings.
+2. **Fragility** — one broken or stale sibling fails the whole introspection for
+   every request in the session, including the module you ran `dagger generate`
+   to fix.
+3. **The target isn't in the query** — `currentTypeDefs` names no module, so the
+   engine cannot scope the load from the request. The CLI knows the target (the
+   leading argv token), but the introspection it sends has no place to carry it.
+
+## Solution
+
+Don't fetch the typed universe up front. The workspace already exposes module
+**names** without loading anything (`currentWorkspace.moduleList`,
+`core/schema/workspace.go:210`); add a sibling that returns a **single module's
+typedefs while loading only that module**. `dagger call backend test` reads the
+names (free), picks `backend` from argv, then asks for `backend`'s types alone —
+the engine reads the target straight from the query as a normal argument.
+`currentTypeDefs` stays as-is
+for its other consumer, the in-engine MCP/LLM tool builder (`core/mcp.go:505`),
+and for bare `dagger functions`.
+
+## Core Concept
+
+A `typeDefs` field on `WorkspaceModule`, beside the existing `settings`:
+
+```graphql
+type WorkspaceModule {
+  name: String!
+  entrypoint: Boolean!
+  source: String!
+
+  "Per-module constructor arguments (existing)."
+  settings: [WorkspaceModuleSetting!]!
+
+  """
+  Type definitions for this module alone. Loads only this module (plus the
+  workspace entrypoint) and its dependency closure, leaving sibling modules
+  pending. Mirrors Query.currentTypeDefs, scoped to one workspace module.
+  """
+  typeDefs(
+    "Return the full referenced typedef closure, not only top-level served typedefs."
+    returnAllTypes: Boolean = false
+    "Strip core API functions from the Query type."
+    hideCore: Boolean
+  ): [TypeDef!]!
+}
+```
+
+`WorkspaceModule` comes from `currentWorkspace.moduleList`, which reads workspace
+config and serves nothing (`core/schema/workspace_module.go:17`, `DoNotCache`).
+The existing `settings` field already demonstrates per-module scoped introspection
+(constructor args, `workspace_module.go:94`); `typeDefs` extends that pattern to
+the full type closure.
+
+The resolver is a scoped load followed by the existing `currentTypeDefs` body:
+
+```go
+func (s *workspaceSchema) moduleTypeDefs(
+    ctx context.Context, mod dagql.Instance[*core.WorkspaceModule], args typeDefsArgs,
+) ([]*core.TypeDef, error) {
+    // additive demand load: serve this module (+ the entrypoint, as the
+    // typedefs-target rule does), leaving siblings pending.
+    if err := mod.Self().Query.EnsureWorkspaceModules(ctx, []string{mod.Self().Name}); err != nil {
+        return nil, err
+    }
+    // identical closure computation to Query.currentTypeDefs, now over the
+    // scoped served set (CurrentServedDeps -> deps.TypeDefs -> expand/strip).
+    return s.currentTypeDefs(ctx, currentTypeDefsArgs{
+        ReturnAllTypes: args.ReturnAllTypes,
+        HideCore:       args.HideCore,
+    })
+}
+```
+
+`EnsureWorkspaceModules(include)` (`core/query.go:90`) is the additive demand hook
+already used by the `generators|checks|services(include:)` resolvers. Here it
+loads `backend` (+ the entrypoint), leaving `frontend`/`docs` pending — a broken
+`frontend` can't fail `dagger call backend`.
+
+## Flow
+
+The "pick" comes from argv, so step 1 (names) is for completion, good errors, and
+installed-module-vs-entrypoint disambiguation:
+
+```mermaid
+flowchart TD
+    A["leading argv token, e.g. backend"] --> B{"token in moduleList names?"}
+    B -->|"yes"| C["target = that module"]
+    B -->|"no"| D["target = entrypoint module"]
+    C --> E["moduleList(module: token).typeDefs"]
+    D --> F["load entrypoint, find token among proxied functions"]
+    E --> G["build command tree from scoped typedefs"]
+    F --> G
+    G --> H["walk argv, marshal flags, build execution query"]
+```
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant CLI as dagger CLI
+    participant ENG as Engine
+
+    U->>CLI: dagger call backend test --race
+    CLI->>ENG: connect session
+    Note over ENG: no modules loaded yet
+
+    Note over CLI,ENG: step 1 — names, no module load (exists)
+    CLI->>ENG: currentWorkspace.moduleList (name, entrypoint)
+    ENG-->>CLI: backend, frontend, docs plus entrypoint ci
+
+    Note over CLI: pick from argv — backend is an installed name
+
+    Note over CLI,ENG: step 3 — types for the picked module only (new)
+    CLI->>ENG: moduleList(module: backend).typeDefs(returnAllTypes: true)
+    Note over ENG: load backend plus ci only, frontend and docs stay pending
+    ENG-->>CLI: Query plus backend closure
+
+    Note over CLI: build tree, walk argv, marshal flags
+    CLI->>ENG: execution backend.test(race: true)
+    ENG-->>CLI: result
+    CLI-->>U: result
+```
+
+## CLI
+
+`dagger call backend test --race` issues:
+
+```graphql
+# step 1 — names, no module load (already exists)
+{ currentWorkspace { moduleList { name entrypoint } } }
+# -> [backend, frontend, docs], entrypoint = ci
+
+# step 3 — types for the picked module only (new field)
+{ currentWorkspace { moduleList(module: "backend") {
+    typeDefs(returnAllTypes: true, hideCore: true) { ...TypeDefParts }
+} } }
+# engine loads backend (+ ci) only; frontend/docs stay pending
+```
+
+The leading-token extraction already exists (`functionName`,
+`internal/cmd/dagger/function_name.go`). The CLI builds `moduleDef` from the
+returned `[TypeDef]` exactly as today — the shape is identical to
+`currentTypeDefs`, so the `module_inspect.go` walker is unchanged.
+
+```bash
+dagger call backend test --race    # loads backend (+ ci) only
+dagger call deploy                  # 'deploy' not in moduleList -> entrypoint fn -> load ci
+dagger functions                    # no token -> currentTypeDefs (load all) fallback
+```
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Entrypoint-proxied function (`dagger call deploy`) | token not in `moduleList` names → load the entrypoint (its `entrypoint` flag is in `moduleList`) and find the proxied fn there |
+| Cross-module chaining (`dagger call backend test report`) | covered by `backend`'s `returnAllTypes` closure — a function can only return types its own module depends on |
+| Name collision (token is both an installed module and an entrypoint fn) | installed module wins; document the precedence |
+| Bare `dagger functions` / `shell` / `mcp` | no token → `currentTypeDefs` load-all (listing everything inherently loads everything) |
+| Old engine without the field | CLI falls back to `currentTypeDefs`; `moduleList` already exists so step 1 stays valid |
+
+## Version gating and caching
+
+- Gate the field with `View(AfterVersion("v1.0.0-0"))`, matching `moduleList` and
+  the rest of the v1 workspace API (`core/schema/workspace.go`). The return type
+  `[TypeDef!]!` already exists, so there is no new type surface to gate — but
+  still run `TestBaseSchemaAllowlist` (see `internal-docs/version-gating.md`).
+- `DoNotCache`, like `moduleList` (it reads live host config and loads on demand).
+  Because the load happens in a non-cached resolver, there is no
+  `CurrentSchemaInput` collision, so **no `PerClientInput`** is needed.
+
+## Status
+
+Proposal. Engine: one new `WorkspaceModule.typeDefs` field reusing
+`currentTypeDefs`' closure logic after a scoped `EnsureWorkspaceModules` load.
+CLI: `call`/`functions` phase-1 switches from `currentTypeDefs` to
+`moduleList(module:) { typeDefs }` when it has a target, with `currentTypeDefs`
+as the no-token / old-engine fallback. `currentTypeDefs` itself is unchanged.

--- a/internal/cmd/dagger/call.go
+++ b/internal/cmd/dagger/call.go
@@ -98,7 +98,7 @@ func runFunctionList(cmd *cobra.Command, args []string) error {
 			mod, err = initializeCore(ctx, engineClient.Dagger())
 		} else {
 			// -m modules are loaded at engine connect time as extra modules.
-			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true})
+			mod, err = initializeWorkspace(ctx, engineClient.Dagger(), loadTypeDefsOpts{HideCore: true, Module: functionName(args)})
 		}
 		if err != nil {
 			return err

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -323,7 +323,7 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		mod, err = initializeCore(ctx, fc.c.Dagger())
 	} else {
 		// -m modules are loaded at engine connect time as extra modules.
-		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true})
+		mod, err = initializeWorkspace(ctx, fc.c.Dagger(), loadTypeDefsOpts{HideCore: true, Module: functionName(a)})
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/dagger/module_inspect.go
+++ b/internal/cmd/dagger/module_inspect.go
@@ -260,6 +260,92 @@ type loadTypeDefsOpts struct {
 	// HideCore strips core API functions from the Query type, leaving
 	// only module-sourced functions (constructors, entrypoint proxies).
 	HideCore bool
+	// Module is the leading CLI token (e.g. "good" in `dagger call good fn`).
+	// When it names an installed workspace module, typedefs are scoped to that
+	// module so only it loads; otherwise the full schema loads.
+	Module string
+}
+
+// queryTypeDefs fetches the typedefs the command tree is built from. When the
+// leading token names an installed workspace module, it scopes the introspection
+// to that module (loading only it) via currentWorkspace.moduleList.typeDefs;
+// otherwise it falls back to the load-all currentTypeDefs.
+func (m *moduleDef) queryTypeDefs(ctx context.Context, dag *dagger.Client, o loadTypeDefsOpts) ([]*modTypeDef, error) {
+	if o.Module != "" {
+		name, ok, err := resolveInstalledWorkspaceModule(ctx, dag, o.Module)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			var res struct {
+				CurrentWorkspace struct {
+					ModuleList []struct {
+						TypeDefs []*modTypeDef
+					}
+				}
+			}
+			if err := dag.Do(ctx, &dagger.Request{
+				Query:     loadTypeDefsQuery,
+				OpName:    "ModuleTypeDefs",
+				Variables: map[string]any{"module": name, "hideCore": o.HideCore},
+			}, &dagger.Response{Data: &res}); err != nil {
+				return nil, fmt.Errorf("query module typedefs: %w", err)
+			}
+			if len(res.CurrentWorkspace.ModuleList) == 0 {
+				return nil, fmt.Errorf("workspace module %q returned no type definitions", name)
+			}
+			return res.CurrentWorkspace.ModuleList[0].TypeDefs, nil
+		}
+	}
+
+	var res struct {
+		TypeDefs []*modTypeDef
+	}
+	if err := dag.Do(ctx, &dagger.Request{
+		Query:     loadTypeDefsQuery,
+		OpName:    "TypeDefs",
+		Variables: map[string]any{"hideCore": o.HideCore},
+	}, &dagger.Response{Data: &res}); err != nil {
+		return nil, fmt.Errorf("query module objects: %w", err)
+	}
+	return res.TypeDefs, nil
+}
+
+// resolveInstalledWorkspaceModule maps a CLI token to the raw config name of the
+// workspace module to scope typedefs introspection to: the module the token
+// names (kebab-insensitive), or the workspace entrypoint when the token is one
+// of its root-proxied functions. Returns ok=false only when nothing matches and
+// there is no entrypoint, so the caller loads the full schema.
+func resolveInstalledWorkspaceModule(ctx context.Context, dag *dagger.Client, token string) (string, bool, error) {
+	var res struct {
+		CurrentWorkspace struct {
+			ModuleList []struct {
+				Name       string
+				Entrypoint bool
+			}
+		}
+	}
+	if err := dag.Do(ctx, &dagger.Request{
+		Query: `query { currentWorkspace { moduleList { name entrypoint } } }`,
+	}, &dagger.Response{Data: &res}); err != nil {
+		return "", false, fmt.Errorf("list workspace modules: %w", err)
+	}
+	want := strcase.ToKebab(token)
+	entrypoint := ""
+	for _, mod := range res.CurrentWorkspace.ModuleList {
+		if strcase.ToKebab(mod.Name) == want {
+			return mod.Name, true, nil
+		}
+		if mod.Entrypoint {
+			entrypoint = mod.Name
+		}
+	}
+	// The token may be one of the entrypoint's root-proxied functions; loading
+	// the entrypoint module resolves it without loading the siblings.
+	if entrypoint != "" {
+		return entrypoint, true, nil
+	}
+	return "", false, nil
 }
 
 // loadTypeDefs loads the objects defined by the given module in an easier to use data structure.
@@ -272,18 +358,9 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client, opts .
 		o = opts[0]
 	}
 
-	var res struct {
-		TypeDefs []*modTypeDef
-	}
-
-	err := dag.Do(ctx, &dagger.Request{
-		Query:     loadTypeDefsQuery,
-		Variables: map[string]any{"hideCore": o.HideCore},
-	}, &dagger.Response{
-		Data: &res,
-	})
+	typeDefs, err := m.queryTypeDefs(ctx, dag, o)
 	if err != nil {
-		return fmt.Errorf("query module objects: %w", err)
+		return err
 	}
 
 	m.MainObject = nil
@@ -291,9 +368,9 @@ func (m *moduleDef) loadTypeDefs(ctx context.Context, dag *dagger.Client, opts .
 	m.Interfaces = nil
 	m.Enums = nil
 	m.Inputs = nil
-	m.typeDefsByName = make(map[string]*modTypeDef, len(res.TypeDefs))
+	m.typeDefsByName = make(map[string]*modTypeDef, len(typeDefs))
 
-	for _, typeDef := range res.TypeDefs {
+	for _, typeDef := range typeDefs {
 		if typeDef == nil {
 			return fmt.Errorf("currentTypeDefs returned nil TypeDef")
 		}

--- a/internal/cmd/dagger/typedefs.graphql
+++ b/internal/cmd/dagger/typedefs.graphql
@@ -30,56 +30,70 @@ fragment FieldParts on FieldTypeDef {
   }
 }
 
+fragment TypeDefParts on TypeDef {
+	name
+	kind
+	optional
+	asObject {
+		name
+		description
+		sourceModuleName
+		constructor {
+			...FunctionParts
+		}
+		functions {
+			...FunctionParts
+		}
+		fields {
+			...FieldParts
+		}
+	}
+	asScalar {
+		name
+		description
+		sourceModuleName
+	}
+	asEnum {
+		name
+		description
+		sourceModuleName
+		members {
+			name
+			description
+		}
+	}
+	asInterface {
+		name
+		description
+		sourceModuleName
+		functions {
+			...FunctionParts
+		}
+	}
+	asInput {
+		name
+		fields {
+			...FieldParts
+		}
+	}
+	asList {
+		elementTypeDef {
+			...TypeDefRefParts
+		}
+	}
+}
+
 query TypeDefs($hideCore: Boolean) {
 	typeDefs: currentTypeDefs(returnAllTypes: true, hideCore: $hideCore) {
-		name
-		kind
-		optional
-		asObject {
-			name
-			description
-			sourceModuleName
-			constructor {
-				...FunctionParts
-			}
-			functions {
-				...FunctionParts
-			}
-			fields {
-				...FieldParts
-			}
-		}
-		asScalar {
-			name
-			description
-			sourceModuleName
-		}
-		asEnum {
-			name
-			description
-			sourceModuleName
-			members {
-				name
-				description
-			}
-		}
-		asInterface {
-			name
-			description
-			sourceModuleName
-			functions {
-				...FunctionParts
-			}
-		}
-		asInput {
-			name
-			fields {
-				...FieldParts
-			}
-		}
-		asList {
-			elementTypeDef {
-				...TypeDefRefParts
+		...TypeDefParts
+	}
+}
+
+query ModuleTypeDefs($module: String!, $hideCore: Boolean) {
+	currentWorkspace {
+		moduleList(module: $module) {
+			typeDefs(returnAllTypes: true, hideCore: $hideCore) {
+				...TypeDefParts
 			}
 		}
 	}

--- a/sdk/elixir/lib/dagger/gen/workspace_module.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace_module.ex
@@ -81,6 +81,34 @@ defmodule Dagger.WorkspaceModule do
 
     Client.execute(workspace_module.client, query_builder)
   end
+
+  @doc """
+  Type definitions for this module, loading only this module on demand.
+  """
+  @spec type_defs(t(), [{:return_all_types, boolean() | nil}, {:hide_core, boolean() | nil}]) ::
+          {:ok, [Dagger.TypeDef.t()]} | {:error, term()}
+  def type_defs(%__MODULE__{} = workspace_module, optional_args \\ []) do
+    query_builder =
+      workspace_module.query_builder
+      |> QB.select("typeDefs")
+      |> QB.maybe_put_arg("returnAllTypes", optional_args[:return_all_types])
+      |> QB.maybe_put_arg("hideCore", optional_args[:hide_core])
+      |> QB.select("id")
+
+    with {:ok, items} <- Client.execute(workspace_module.client, query_builder) do
+      {:ok,
+       for %{"id" => id} <- items do
+         %Dagger.TypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("TypeDef"),
+           client: workspace_module.client
+         }
+       end}
+    end
+  end
 end
 
 defimpl Jason.Encoder, for: Dagger.WorkspaceModule do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -17004,6 +17004,57 @@ func (r *WorkspaceModule) Source(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
+// WorkspaceModuleTypeDefsOpts contains options for WorkspaceModule.TypeDefs
+type WorkspaceModuleTypeDefsOpts struct {
+	// Return the full referenced typedef closure instead of only top-level served typedefs.
+	ReturnAllTypes bool
+	// Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
+	HideCore bool
+}
+
+// Type definitions for this module, loading only this module on demand.
+func (r *WorkspaceModule) TypeDefs(ctx context.Context, opts ...WorkspaceModuleTypeDefsOpts) ([]TypeDef, error) {
+	q := r.query.Select("typeDefs")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `returnAllTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ReturnAllTypes) {
+			q = q.Arg("returnAllTypes", opts[i].ReturnAllTypes)
+		}
+		// `hideCore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].HideCore) {
+			q = q.Arg("hideCore", opts[i].HideCore)
+		}
+	}
+
+	q = q.Select("id")
+
+	type typeDefs struct {
+		Id ID
+	}
+
+	convert := func(fields []typeDefs) []TypeDef {
+		out := []TypeDef{}
+
+		for i := range fields {
+			val := TypeDef{id: &fields[i].Id}
+			val.query = selectNode(q.Root(), fields[i].Id, "TypeDef")
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []typeDefs
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
 // AsNode returns this WorkspaceModule as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *WorkspaceModule) AsNode() Node {

--- a/sdk/php/generated/WorkspaceModule.php
+++ b/sdk/php/generated/WorkspaceModule.php
@@ -57,4 +57,19 @@ class WorkspaceModule extends Client\AbstractObject implements Client\IdAble, No
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('source');
         return (string)$this->queryLeaf($leafQueryBuilder, 'source');
     }
+
+    /**
+     * Type definitions for this module, loading only this module on demand.
+     */
+    public function typeDefs(?bool $returnAllTypes = false, ?bool $hideCore = null): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('typeDefs');
+        if (null !== $returnAllTypes) {
+        $leafQueryBuilder->setArgument('returnAllTypes', $returnAllTypes);
+        }
+        if (null !== $hideCore) {
+        $leafQueryBuilder->setArgument('hideCore', $hideCore);
+        }
+        return (array)$this->queryLeaf($leafQueryBuilder, 'typeDefs');
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -16613,6 +16613,30 @@ class WorkspaceModule(Type):
         _ctx = self._select("source", _args)
         return await _ctx.execute(str)
 
+    async def type_defs(
+        self,
+        *,
+        return_all_types: bool | None = False,
+        hide_core: bool | None = None,
+    ) -> list[TypeDef]:
+        """Type definitions for this module, loading only this module on demand.
+
+        Parameters
+        ----------
+        return_all_types:
+            Return the full referenced typedef closure instead of only top-
+            level served typedefs.
+        hide_core:
+            Strip core API functions from the Query type, leaving only module-
+            sourced functions (constructors, entrypoint proxies, etc.).
+        """
+        _args = [
+            Arg("returnAllTypes", return_all_types, False),
+            Arg("hideCore", hide_core, None),
+        ]
+        _ctx = self._select("typeDefs", _args)
+        return await _ctx.execute_object_list(TypeDef)
+
 
 @typecheck
 class WorkspaceModuleSetting(Type):

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -17041,6 +17041,15 @@ pub struct WorkspaceModule {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
+#[derive(Builder, Debug, PartialEq)]
+pub struct WorkspaceModuleTypeDefsOpts {
+    /// Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
+    #[builder(setter(into, strip_option), default)]
+    pub hide_core: Option<bool>,
+    /// Return the full referenced typedef closure instead of only top-level served typedefs.
+    #[builder(setter(into, strip_option), default)]
+    pub return_all_types: Option<bool>,
+}
 impl IntoID<Id> for WorkspaceModule {
     fn into_id(
         self,
@@ -17101,6 +17110,57 @@ impl WorkspaceModule {
     pub async fn source(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("source");
         query.execute(self.graphql_client.clone()).await
+    }
+    /// Type definitions for this module, loading only this module on demand.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn type_defs(&self) -> Result<Vec<TypeDef>, DaggerError> {
+        let query = self.selection.select("typeDefs");
+        let query = query.select("id");
+        let ids: Vec<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(ids
+            .into_iter()
+            .map(|id| TypeDef {
+                proc: self.proc.clone(),
+                selection: crate::querybuilder::query()
+                    .select("node")
+                    .arg("id", &id.0)
+                    .inline_fragment("TypeDef"),
+                graphql_client: self.graphql_client.clone(),
+            })
+            .collect())
+    }
+    /// Type definitions for this module, loading only this module on demand.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn type_defs_opts(
+        &self,
+        opts: WorkspaceModuleTypeDefsOpts,
+    ) -> Result<Vec<TypeDef>, DaggerError> {
+        let mut query = self.selection.select("typeDefs");
+        if let Some(return_all_types) = opts.return_all_types {
+            query = query.arg("returnAllTypes", return_all_types);
+        }
+        if let Some(hide_core) = opts.hide_core {
+            query = query.arg("hideCore", hide_core);
+        }
+        let query = query.select("id");
+        let ids: Vec<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(ids
+            .into_iter()
+            .map(|id| TypeDef {
+                proc: self.proc.clone(),
+                selection: crate::querybuilder::query()
+                    .select("node")
+                    .arg("id", &id.0)
+                    .inline_fragment("TypeDef"),
+                graphql_client: self.graphql_client.clone(),
+            })
+            .collect())
     }
 }
 impl Node for WorkspaceModule {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2890,6 +2890,18 @@ export type WorkspaceWithNewFileOpts = {
   permissions?: number
 }
 
+export type WorkspaceModuleTypeDefsOpts = {
+  /**
+   * Return the full referenced typedef closure instead of only top-level served typedefs.
+   */
+  returnAllTypes?: boolean
+
+  /**
+   * Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
+   */
+  hideCore?: boolean
+}
+
 export type __DirectiveArgsOpts = {
   includeDeprecated?: boolean
 }
@@ -15646,6 +15658,25 @@ export class WorkspaceModule extends BaseClient {
     const response: Awaited<string> = await ctx.execute()
 
     return response
+  }
+
+  /**
+   * Type definitions for this module, loading only this module on demand.
+   * @param opts.returnAllTypes Return the full referenced typedef closure instead of only top-level served typedefs.
+   * @param opts.hideCore Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).
+   */
+  typeDefs = async (opts?: WorkspaceModuleTypeDefsOpts): Promise<TypeDef[]> => {
+    type typeDefs = {
+      id: ID
+    }
+
+    const ctx = this._ctx.select("typeDefs", { ...opts }).select("id")
+
+    const response: Awaited<typeDefs[]> = await ctx.execute()
+
+    return response.map(
+      (r) => new TypeDef(ctx.copy().selectNode(r.id, "TypeDef")),
+    )
   }
 }
 


### PR DESCRIPTION
## Problem

`dagger call|functions <module>` builds its command tree from `currentTypeDefs(returnAllTypes: true)`, which serves **every** workspace module. Running one module pays for all its siblings, and a single broken or stale sibling blocks operating on *any* module — including the one you ran `dagger generate` to fix.

## Solution

Discover module names without loading anything, then fetch only the targeted module's typedefs:

- **`WorkspaceModule.typeDefs(returnAllTypes, hideCore)`** (new engine field): loads only the named workspace module on demand via `EnsureWorkspaceModules`, then builds its typedefs through the closure logic shared with `currentTypeDefs`. Siblings stay pending, so a broken one can't block the call.
- **CLI**: `dagger call|functions` resolve the leading token to an installed module (`currentWorkspace.moduleList`, kebab-mapped to the config name) and request only that module's typedefs via `moduleList(module:).typeDefs`. An unmatched token falls back to the workspace entrypoint module; bare / no-token falls back to load-all `currentTypeDefs`.

`currentTypeDefs` itself is unchanged — still used by the in-engine MCP/LLM tool builder and by bare `dagger functions`.

## Flow

```mermaid
sequenceDiagram
    autonumber
    actor U as User
    participant CLI as dagger CLI
    participant ENG as Engine

    U->>CLI: dagger call backend test
    CLI->>ENG: connect session
    Note over ENG: no modules loaded yet
    CLI->>ENG: currentWorkspace.moduleList (names, no load)
    ENG-->>CLI: backend, frontend, docs (+ entrypoint flag)
    Note over CLI: backend is an installed module
    CLI->>ENG: moduleList(module: backend).typeDefs
    Note over ENG: load backend only — siblings stay pending
    ENG-->>CLI: Query + backend typedefs
    CLI->>ENG: execution backend.test
    ENG-->>CLI: result
```

## Tests

`TestGenerators/TestWorkspace*Narrows` (generate / check / up / call): a broken sibling no longer blocks a scoped `dagger call`; kebab-case and entrypoint targets are covered; bare `dagger functions` still loads everything (and surfaces the broken module).

Design notes: `hack/designs/per-module-typedefs.md`.

---

Builds on the additive demand-loading foundation from #13406 (included here). Supersedes #13539, which carried the target in an encoded operation name; here it enters the query as a normal argument.

