### PR TITLE
fix(workspace): remove SDK-managed modules on `dagger uninstall`

### DIFF
--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -239,6 +239,40 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 		require.NotContains(t, readInstalledWorkspaceConfig(t, workdir).Modules, "dep")
 	})
 
+	t.Run("uninstall removes an SDK-managed default-path module", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "go")
+		require.NoError(t, err)
+
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+		require.NoError(t, err)
+
+		moduleDir := filepath.Join(workdir, ".dagger", "modules", "myapp")
+		info, err := os.Stat(moduleDir)
+		require.NoError(t, err)
+		require.True(t, info.IsDir())
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Contains(t, cfg.Modules, "myapp")
+		goSDK := cfg.Modules["go-sdk"]
+		require.NotNil(t, goSDK.AsSDK)
+		require.Equal(t, []workspacecfg.SDKManagedModule{{Path: ".dagger/modules/myapp"}}, goSDK.AsSDK.Modules)
+
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "myapp")
+		require.NoError(t, err)
+
+		cfg = readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Modules, "myapp")
+		goSDK = cfg.Modules["go-sdk"]
+		require.NotNil(t, goSDK.AsSDK)
+		require.Empty(t, goSDK.AsSDK.Modules)
+
+		_, err = os.Stat(moduleDir)
+		require.True(t, os.IsNotExist(err), "expected %s to be removed, got %v", moduleDir, err)
+	})
+
 	t.Run("uninstalling an unknown module errors", func(ctx context.Context, t *testctx.T) {
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)

--- a/core/schema/workspace_uninstall.go
+++ b/core/schema/workspace_uninstall.go
@@ -3,8 +3,12 @@ package schema
 import (
 	"context"
 	"fmt"
+	"path"
+	"path/filepath"
+	"slices"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 )
 
@@ -30,13 +34,25 @@ func (s *workspaceSchema) uninstall(
 		return "", err
 	}
 
-	if _, ok := cfg.Modules[args.Name]; !ok {
+	entry, ok := cfg.Modules[args.Name]
+	if !ok {
 		return "", fmt.Errorf("module %q is not installed in the workspace", args.Name)
 	}
+
+	configDir, err := workspaceConfigDirectory(parent)
+	if err != nil {
+		return "", err
+	}
+	managedModulePath, removeManagedModuleDir := removeSDKManagedModuleReference(cfg, configDir, entry)
 
 	delete(cfg.Modules, args.Name)
 	if err := writeWorkspaceConfig(ctx, parent, cfg); err != nil {
 		return "", err
+	}
+	if removeManagedModuleDir {
+		if err := s.removeWorkspaceDirectoryFromHost(ctx, parent, managedModulePath); err != nil {
+			return "", err
+		}
 	}
 
 	cfgPath, err := configHostPath(parent)
@@ -45,4 +61,70 @@ func (s *workspaceSchema) uninstall(
 	}
 
 	return dagql.String(fmt.Sprintf("Uninstalled module %q from %s", args.Name, cfgPath)), nil
+}
+
+// removeSDKManagedModuleReference removes the installed module's source path
+// from any [[modules.<sdk>.as-sdk.modules]] list. It returns a host-removal
+// path only when the matched source is workspace-relative and safe to delete.
+func removeSDKManagedModuleReference(cfg *workspace.Config, configDir string, entry workspace.ModuleEntry) (string, bool) {
+	if cfg == nil || entry.AsSDK != nil || !workspace.IsLocalRef(entry.Source, entry.Pin) {
+		return "", false
+	}
+
+	resolvedSource := workspace.ResolveModuleEntrySource(configDir, entry.Source)
+	sourcePath := filepath.ToSlash(resolvedSource)
+	removed := false
+	for moduleName, sdkEntry := range cfg.Modules {
+		if sdkEntry.AsSDK == nil || len(sdkEntry.AsSDK.Modules) == 0 {
+			continue
+		}
+
+		sdkEntry.AsSDK.Modules = slices.DeleteFunc(sdkEntry.AsSDK.Modules, func(mod workspace.SDKManagedModule) bool {
+			if filepath.ToSlash(filepath.Clean(mod.Path)) == sourcePath {
+				removed = true
+				return true
+			}
+			return false
+		})
+		cfg.Modules[moduleName] = sdkEntry
+	}
+	if !removed {
+		return "", false
+	}
+
+	// Local installed modules can point outside the workspace (for example,
+	// "../dep"). Clean up the TOML reference above, but only delete authored
+	// SDK module directories that resolve inside the workspace.
+	if filepath.IsAbs(resolvedSource) {
+		return "", false
+	}
+	deletePath, err := resolveWorkspacePath(sourcePath, ".")
+	if err != nil || deletePath == "." {
+		return "", false
+	}
+	return deletePath, true
+}
+
+// removeWorkspaceDirectoryFromHost applies the same Directory.withoutDirectory
+// diff/export path used by other workspace filesystem mutations.
+func (s *workspaceSchema) removeWorkspaceDirectoryFromHost(ctx context.Context, parent *core.Workspace, dir string) error {
+	baseDir, err := s.resolveRootfs(ctx, parent, ".", core.CopyFilter{}, false)
+	if err != nil {
+		return fmt.Errorf("resolve workspace rootfs: %w", err)
+	}
+	updatedDir, err := workspaceMigrationSelectDirectory(ctx, baseDir, "withoutDirectory", []dagql.NamedInput{
+		{Name: "path", Value: dagql.String(path.Clean(filepath.ToSlash(dir)))},
+	})
+	if err != nil {
+		return fmt.Errorf("stage workspace directory removal %q: %w", dir, err)
+	}
+
+	changes, err := workspaceMigrationChanges(ctx, updatedDir, baseDir)
+	if err != nil {
+		return err
+	}
+	if changes.Self() == nil {
+		return nil
+	}
+	return changes.Self().Export(ctx, parent.HostPath())
 }


### PR DESCRIPTION
### Problem

`dagger module init go myapp` creates a module that is owned by the installed Go SDK. That means it writes three pieces of workspace state:

- the normal installed module entry: `[modules.myapp]`
- the SDK ownership entry: `[[modules.go-sdk.as-sdk.modules]]`
- the authored module directory: `.dagger/modules/myapp`

Before this change, `dagger uninstall myapp` only removed the first one.

So after uninstall, `dagger.toml` no longer had `modules.myapp`, but it still said the Go SDK managed `.dagger/modules/myapp`, and that directory was still present on disk.

### Solution

Uninstall now cleans up the SDK-managed module state that the engine owns.

When the uninstalled module source matches an entry under `[[modules.<sdk>.as-sdk.modules]]`, we now remove that SDK-managed entry from the parsed workspace config before writing `dagger.toml`.

If that matched module path is a workspace-owned path, we also remove the module directory from the host workspace using the existing `Directory.withoutDirectory` changeset/export path.

The disk deletion is intentionally narrower than the TOML cleanup. Local module sources can point outside the workspace, for example with `dagger install ../dep`, and uninstall should not delete those directories. This fix only removes files for the SDK-authored module case created by `dagger module init`, where the module path is workspace-relative.

### How to test

Added a regression test for the full CLI flow:

```sh
dagger sdk install go
dagger module init go myapp
dagger uninstall myapp
```

The test checks that:

- `modules.myapp` is gone
- `modules.go-sdk.as-sdk.modules` is empty
- `.dagger/modules/myapp` was removed from disk

Ran:

```sh
dagger call engine-dev test --pkg ./core/integration --run '^TestWorkspaceModules/TestWorkspaceModuleUninstall/uninstall_removes_an_SDK-managed_default-path_module$' --test-verbose
```
