### PR TITLE
test(workspace): cover SDK-managed generate from nested cwd

### DIFF
--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -252,6 +252,42 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 	})
 }
 
+// TestWorkspaceModuleGenerate covers generation for modules registered in a
+// workspace.
+func (WorkspaceModulesSuite) TestWorkspaceModuleGenerate(ctx context.Context, t *testctx.T) {
+	setupSDKManagedGoModule := func(ctx context.Context, t *testctx.T) (string, string) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "go")
+		require.NoError(t, err)
+
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+		require.NoError(t, err)
+
+		moduleDir := filepath.Join(workdir, ".dagger", "modules", "myapp")
+		require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.go"), []byte(`package main
+
+type Myapp struct{}
+`), 0o644))
+
+		return workdir, moduleDir
+	}
+
+	workdir, moduleDir := setupSDKManagedGoModule(ctx, t)
+	cwd := filepath.Join(workdir, ".dagger")
+
+	out, err := hostDaggerExecRaw(ctx, t, cwd, "--silent", "generate", "-y")
+	require.NoError(t, err, "%s: %s", ".dagger", string(out))
+
+	_, err = os.Stat(filepath.Join(moduleDir, "internal", "dagger", "dagger.gen.go"))
+	require.NoError(t, err)
+
+	nestedGeneratedClient := filepath.Join(cwd, ".dagger", "modules", "myapp", "internal", "dagger", "dagger.gen.go")
+	_, err = os.Stat(nestedGeneratedClient)
+	require.True(t, os.IsNotExist(err), "expected generate from .dagger to write at workspace root, not %s", nestedGeneratedClient)
+}
+
 // TestWorkspaceModuleMutation should cover updates and config-level conflicts
 // around configured modules.
 func (WorkspaceModulesSuite) TestWorkspaceModuleMutation(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
### Context

`dagger generate` could break for SDK-managed modules when it was run from a nested workspace directory.

The repro is:

```sh
dagger sdk install go
dagger module init go myapp
cd .dagger
dagger generate
```

The SDK-managed module path is stored as a workspace-relative path, for example `.dagger/modules/myapp`. The bug was that SDK helpers passed that path to `moduleSource` as if it were relative to the current working directory. From `.dagger`, that became `.dagger/.dagger/modules/myapp`, and generate failed while computing/applying the changeset.

### What This PR Does

This adds the engine-side regression test for the full user flow.

The test creates a workspace, installs the Go SDK, initializes an SDK-managed Go module, and runs `dagger generate` from `.dagger`. It checks that the generated Go client lands under the real workspace module path, not under a nested `.dagger/.dagger/...` path.

This intentionally uses the Go SDK because it gives the test a concrete generated client file to assert on. Dang is lighter, but its current codegen path is no-op, so it would mostly prove that `generate` succeeds rather than proving where generated files were exported.

The SDK fixes have merged, so this PR now only carries the regression test.

### Reference SDK PRs

- dagger/go-sdk#6
- dagger/python-sdk#7
- dagger/typescript-sdk#7
- dagger/dang-sdk#5
- dagger/sdk-sdk#9
