### PR TITLE
Load workspace modules on demand for generate/check/up

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -304,6 +304,117 @@ func (m *Consumer) SyncGenerators(ctx context.Context, workspace *dagger.Workspa
 	require.NotContains(t, out, "result *core.Changeset is detached")
 }
 
+// TestWorkspaceGenerateNarrowsToRequestedModule locks in that
+// `dagger generate <module>` only loads the named generator's module. The
+// workspace generators resolver loads modules on demand from its include
+// argument, so an unrelated broken/stale workspace module is never loaded just
+// to enumerate generators and cannot block regenerating a healthy module --
+// including the case where running generate is itself the fix for the broken
+// module.
+//
+// See also TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrokenModules
+// in workspace_test.go, which covers the root-field demand path for raw
+// queries.
+func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating only the healthy module succeeds", func(ctx context.Context, t *testctx.T) {
+		// generate -y is multi-request (list, then run+apply); the later
+		// requests must keep recognizing the already-loaded module instead of
+		// falling back to loading everything.
+		out, err := base.
+			With(daggerExec("generate", "good", "-y", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "no changes to apply")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("generating across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCheckNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate or run a
+// healthy module's checks, so it cannot block checking that module.
+func (GeneratorsSuite) TestWorkspaceCheckNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("check", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("running only the healthy module's checks succeeds", func(ctx context.Context, t *testctx.T) {
+		// --no-generate runs only annotated checks; generate-as-checks are
+		// excluded because the healthy module's generator legitimately reports
+		// pending output (covered by the generate narrowing test), which is
+		// unrelated to whether the broken module was loaded.
+		out, err := base.
+			With(daggerExec("check", "good", "--no-generate", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("checking across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceUpNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger up`: an unrelated
+// broken/stale workspace module must not be loaded just to enumerate a healthy
+// module's services. `dagger up` starts services and blocks, so the assertions
+// use list mode (-l), which still loads workspace modules to enumerate services
+// and thus exercises the same narrowing.
+func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("listing only the healthy module skips the broken one", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("up", "-l", "good")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing across all modules still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("up", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "good"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken/.dagger/modules/good/main.dang
@@ -1,0 +1,26 @@
+type Good {
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+
+  """
+  A trivial check. Used to prove the module loaded for `dagger check`.
+  """
+  pub verify: Void @check {
+    null
+  }
+
+  """
+  A trivial service. Used to prove the module loaded for `dagger up`.
+  """
+  @up
+  pub web: Service! {
+    container
+      .from("nginx:alpine")
+      .withExposedPort(80)
+      .asService
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken/dagger.toml
@@ -1,0 +1,5 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/core/query.go
+++ b/core/query.go
@@ -87,6 +87,11 @@ type Server interface {
 	// The cached workspace result from ensureWorkspaceLoaded.
 	CurrentWorkspace(context.Context) (*Workspace, error)
 
+	// Load pending workspace modules on demand; include narrows to the modules
+	// its patterns name ("module" or "module:item"), empty or unrecognized
+	// loads all.
+	EnsureWorkspaceModules(ctx context.Context, include []string) error
+
 	// A snapshot of the current workspace lockfile for ambient live locking.
 	// Returns ok=false when lock-backed workspace access is unavailable.
 	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -53,6 +53,10 @@ func (s *currentTypeDefsTestServer) CurrentWorkspace(context.Context) (*core.Wor
 	return nil, nil
 }
 
+func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
 func (s *currentTypeDefsTestServer) CurrentServedDeps(context.Context) (*core.SchemaBuilder, error) {
 	return s.deps, nil
 }

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1266,6 +1266,9 @@ func (s *workspaceSchema) checks(
 		noGenerate = true
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1375,6 +1378,9 @@ func (s *workspaceSchema) generators(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1493,6 +1499,9 @@ func (s *workspaceSchema) services(
 		return nil, err
 	}
 
+	if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil {
+		return nil, err
+	}
 	mods, err := currentWorkspacePrimaryModules(ctx)
 	if err != nil {
 		return nil, err
@@ -1645,6 +1654,17 @@ func matchWorkspaceIncludePath(
 		}
 	}
 	return false, nil
+}
+
+// ensureWorkspaceIncludeModulesLoaded loads the workspace modules the include
+// patterns demand (all when they don't narrow). Selector fields validate
+// against the core schema, so loading can wait until resolution.
+func ensureWorkspaceIncludeModulesLoaded(ctx context.Context, include []string) error {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	return query.Server.EnsureWorkspaceModules(ctx, include)
 }
 
 func currentWorkspacePrimaryModules(ctx context.Context) ([]dagql.ObjectResult[*core.Module], error) {

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -56,6 +56,10 @@ func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*M
 	return nil
 }
 
+func (ms *mockServer) EnsureWorkspaceModules(context.Context, []string) error {
+	return nil
+}
+
 func (ms *mockServer) CurrentModule(_ context.Context) (dagql.ObjectResult[*Module], error) {
 	var zero dagql.ObjectResult[*Module]
 	if ms.moduleSource == nil {

--- a/dagql/request_peek.go
+++ b/dagql/request_peek.go
@@ -18,7 +18,9 @@ type peekGraphQLRequest struct {
 }
 
 // PeekRootFields returns the top-level field names selected by a GraphQL-over-HTTP
-// request while preserving the request body for the real server.
+// request while preserving the request body for the real server. The operation
+// to inspect is chosen by the request's operation name (or the sole operation
+// when the document has just one).
 func PeekRootFields(r *http.Request) (bool, []string, error) {
 	query, operationName, ok, err := peekGraphQLRequestBody(r)
 	if err != nil || !ok {

--- a/dagql/request_peek_test.go
+++ b/dagql/request_peek_test.go
@@ -62,3 +62,17 @@ func TestPeekRootFieldsRejectsBatch(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, fields)
 }
+
+func TestPeekRootFieldsRecoversSingleOperation(t *testing.T) {
+	t.Parallel()
+
+	// operationName omitted from the envelope: the sole operation is used.
+	body := `{"query":"query Introspect { currentTypeDefs { name } }"}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	ok, fields, err := dagql.PeekRootFields(req)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"currentTypeDefs"}, fields)
+}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -250,10 +250,20 @@ type daggerClient struct {
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
 	modulesMu           sync.Mutex
-	modulesLoaded       bool
-	modulesErr          error
-	singleQueryMu       sync.Mutex
-	singleQueryServed   bool
+	extraModulesLoaded  bool
+	extraModulesErr     error
+	// load failures by moduleProgressName; failed modules stay pending to keep
+	// reporting their error
+	failedModules map[string]error
+	// whether an entrypoint module has been served (extras outrank ambient)
+	entrypointServed bool
+	// resolved identities already served, for cross-batch deduplication
+	servedModuleKeys map[string]struct{}
+	// served workspace module names, so demand filters recognize them without
+	// reloading
+	servedWorkspaceModuleNames map[string]struct{}
+	singleQueryMu              sync.Mutex
+	singleQueryServed          bool
 
 	// NOTE: do not use this field directly as it may not be open
 	// after the client has shutdown; use TelemetryDB() instead
@@ -1099,7 +1109,7 @@ func (srv *Server) getOrInitClient(
 		}
 		// ExtraModules may arrive on a later request (e.g. /init) after the
 		// session attachable request already created the client without them.
-		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.modulesLoaded {
+		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.extraModulesLoaded {
 			client.clientMetadata.ExtraModules = opts.ExtraModules
 			client.pendingExtraModules = opts.ExtraModules
 		}
@@ -1582,26 +1592,18 @@ func (srv *Server) serveQuery(w http.ResponseWriter, r *http.Request, client *da
 		return gqlErr(err, http.StatusBadRequest)
 	}
 
-	peekRootFieldsOK, peekRootFields, err := peekSingleQueryRootFields(r, client.clientMetadata)
-	if err != nil {
-		return gqlErr(fmt.Errorf("peeking single-query root fields: %w", err), http.StatusBadRequest)
-	}
-
 	// Load workspace modules and extra modules (e.g. from -m flag). These are
 	// deferred from initializeDaggerClient because they need the client's
 	// session attachables, which only become available after the session
 	// attachables handshake completes (after init locks are released).
 	wsCtx, wsOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.workspaceLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureWorkspaceLoaded(wsCtx, client)
+	err := srv.ensureWorkspaceLoaded(wsCtx, client)
 	wsOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading workspace: %w", err), http.StatusInternalServerError)
 	}
-	if peekRootFieldsOK {
-		client.narrowPendingWorkspaceModulesForSingleQuery(peekRootFields)
-	}
 	modCtx, modOp := wcprof.BeginOp(ctx, wcprof.OpKindSessionPhase, "session.modulesLoad", wcprof.OpOpts{ClientID: client.clientID})
-	err = srv.ensureModulesLoaded(modCtx, client)
+	err = srv.ensureRequestModulesLoaded(modCtx, client, r)
 	modOp.EndErr(err)
 	if err != nil {
 		return gqlErr(fmt.Errorf("loading modules: %w", err), http.StatusInternalServerError)
@@ -1648,11 +1650,26 @@ func (client *daggerClient) claimSingleQueryRequest() error {
 	return nil
 }
 
-func peekSingleQueryRootFields(r *http.Request, clientMD *engine.ClientMetadata) (bool, []string, error) {
-	if clientMD == nil || !clientMD.SingleQuery || !clientMD.LoadWorkspaceModules || clientMD.SkipWorkspaceModules {
-		return false, nil, nil
+// ensureRequestModulesLoaded loads the modules this request demands, read from
+// the request's root fields: fields naming pending modules demand those, and
+// full-schema or unrecognized fields demand everything. The rest stay pending.
+func (srv *Server) ensureRequestModulesLoaded(ctx context.Context, client *daggerClient, r *http.Request) error {
+	var filter func([]pendingModule) []pendingModule
+	if client.hasPendingWorkspaceModules() {
+		if ok, rootFields, err := dagql.PeekRootFields(r); err == nil && ok {
+			filter = func(mods []pendingModule) []pendingModule {
+				// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+				return filterPendingWorkspaceModulesForRootFields(mods, client.servedWorkspaceModuleNames, rootFields)
+			}
+		}
 	}
-	return dagql.PeekRootFields(r)
+	return srv.ensureModulesLoaded(ctx, client, filter)
+}
+
+func (client *daggerClient) hasPendingWorkspaceModules() bool {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+	return len(client.pendingModules) > 0
 }
 
 func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *daggerClient) (rerr error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -423,14 +423,14 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 	t.Run("constructor match loads only matching module", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"foo"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"foo"})
 		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("unknown root field with multiple entrypoints loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"doThing"})
 		require.Equal(t, mods, filtered)
 	})
 
@@ -438,36 +438,189 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		oneEntrypoint := []pendingModule{mods[0], mods[1]}
-		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, []string{"doThing"})
 		require.Equal(t, []pendingModule{mods[1]}, filtered)
 	})
 
 	t.Run("introspection loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"__schema"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"__schema"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("current typedefs loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentTypeDefs"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentTypeDefs"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("current module loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"currentModule"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentModule"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("core-only query loads none", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, []string{"container", "version"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"container", "version"})
 		require.Empty(t, filtered)
+	})
+
+	t.Run("current workspace loads none (resolvers load on demand)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentWorkspace"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("already-served root field loads none", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served field combined with pending field loads only pending", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod", "foo"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("env loads all (resolver snapshots served deps)", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"env"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("unrecognized loadFromID field loads all", func(t *testing.T) {
+		t.Parallel()
+
+		// The type name in load<Type>FromID needn't embed the module name, so
+		// only a full load can guarantee the field exists.
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"loadSomethingFromID"})
+		require.Equal(t, mods, filtered)
+	})
+}
+
+func TestFilterPendingWorkspaceModulesBySelectorInclude(t *testing.T) {
+	t.Parallel()
+
+	mods := []pendingModule{
+		{Kind: moduleLoadKindAmbient, Name: "go-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "rust-sdk"},
+		{Kind: moduleLoadKindAmbient, Name: "php-sdk"},
+	}
+
+	t.Run("module:generator selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("module:item works for checks and services too", func(t *testing.T) {
+		t.Parallel()
+
+		// The module-name resolution is identical across generate/check/up: the
+		// segment before ':' is the module name regardless of the item kind.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"rust-sdk:lint", "php-sdk:web"})
+		require.Equal(t, []pendingModule{mods[1], mods[2]}, filtered)
+	})
+
+	t.Run("bare module name selects only that module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("multiple patterns select each named module", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-sdk", "php-sdk:api"})
+		require.Equal(t, []pendingModule{mods[0], mods[2]}, filtered)
+	})
+
+	t.Run("bare token not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// e.g. an item served by the entrypoint module.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("module:item not matching a module selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"typo-sdk:generate"})
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("empty include selects all", func(t *testing.T) {
+		t.Parallel()
+
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, nil)
+		require.Equal(t, mods, filtered)
+	})
+
+	t.Run("already-served module is recognized and selects nothing", func(t *testing.T) {
+		t.Parallel()
+
+		// A re-evaluated selector (e.g. loading a GeneratorGroup from its ID
+		// on a later request) names a module that already loaded; it must not
+		// fall back to loading everything.
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("served and pending patterns select only the pending module", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"dang-sdk": {}}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, served, []string{"dang-sdk:generate", "go-sdk"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("camelCase pattern selects the kebab-case module", func(t *testing.T) {
+		t.Parallel()
+
+		// Name matching is kebab-normalized on both sides, like the include
+		// matchers the selector resolvers use (ModTreePath.Glob/CliCase).
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"goSdk:generate"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
+	})
+
+	t.Run("kebab-case pattern selects the camelCase module", func(t *testing.T) {
+		t.Parallel()
+
+		// The CLI presents module commands in kebab-case, so a module declared
+		// as "myMod" (or "mod1", which kebab-cases to "mod-1") is targeted by
+		// its kebab-case name.
+		camelMods := []pendingModule{
+			{Kind: moduleLoadKindAmbient, Name: "myMod"},
+			{Kind: moduleLoadKindAmbient, Name: "mod1"},
+			{Kind: moduleLoadKindAmbient, Name: "other"},
+		}
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(camelMods, nil, []string{"my-mod", "mod-1:generate"})
+		require.Equal(t, []pendingModule{camelMods[0], camelMods[1]}, filtered)
+	})
+
+	t.Run("glob pattern selects all", func(t *testing.T) {
+		t.Parallel()
+
+		// Glob metacharacters survive normalization and never equal a module
+		// name, so glob patterns conservatively load everything.
+		filtered := filterPendingWorkspaceModulesBySelectorInclude(mods, nil, []string{"go-*"})
+		require.Equal(t, mods, filtered)
 	})
 }
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -890,33 +890,144 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 	return tree, gitRef, nil
 }
 
-// ensureModulesLoaded loads all pending modules (from workspace discovery,
-// compat parsing, and -m flags). Called from serveQuery after
-// ensureWorkspaceLoaded. Uses a mutex+flag instead of sync.Once so that
-// transient failures (e.g. session not yet registered) can be retried.
-func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient) error {
-	if len(client.pendingModules) == 0 && len(client.pendingExtraModules) == 0 {
-		return nil
-	}
-
+// ensureModulesLoaded loads pending modules (workspace, compat, and -m) on
+// demand. filter picks which pending workspace modules this request needs (nil
+// = all); the rest stay pending for a later request or resolver. Loading is
+// additive, so narrowing is deferral, not exclusion. Mutex+flags (not
+// sync.Once) keep transient failures retriable.
+func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule) error {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
 
-	if client.modulesLoaded {
-		return client.modulesErr
+	if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
+		return err
+	}
+
+	if len(client.pendingModules) == 0 {
+		return nil
+	}
+
+	demand := client.pendingModules
+	if filter != nil {
+		demand = filter(client.pendingModules)
+	}
+	// Multiple ambient entrypoint declarations may dedupe to one module; load
+	// everything so the existing conflict detection still runs.
+	if len(demand) > 0 && len(pendingWorkspaceEntrypointIndexes(client.pendingModules)) > 1 {
+		demand = client.pendingModules
+	}
+	if len(demand) == 0 {
+		return nil
+	}
+
+	// A failed module stays pending; surface its recorded error rather than
+	// reloading it.
+	for _, mod := range demand {
+		if err, ok := client.failedModules[moduleProgressName(mod)]; ok {
+			return err
+		}
 	}
 
 	// Wait for the client's session attachables to be available.
-	// Don't mark as loaded on failure — allow retry on next request.
+	// Transient failure — allow retry on next request.
 	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
 		return fmt.Errorf("waiting for client session attachables: %w", err)
 	}
 
-	loads := gatherModuleLoadRequests(client.pendingModules, client.pendingExtraModules)
+	loads := gatherModuleLoadRequests(demand, nil)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			loadErr := moduleLoadErr(load, resolveErrs[i])
+			client.recordFailedModule(load.mod, loadErr)
+			if firstErr == nil {
+				firstErr = loadErr
+			}
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := client.arbitrateAmbientEntrypoints(loads, resolvedLoads); err != nil {
+		return err
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return err
+	}
+	client.markEntrypointServed(resolvedLoads)
+	client.removePendingModules(demand)
+	return nil
+}
+
+// ensureExtraModulesLoadedLocked loads -m modules. They are explicitly
+// requested, so they load eagerly with sticky failures (unlike on-demand
+// workspace modules). client.modulesMu must be held.
+func (srv *Server) ensureExtraModulesLoadedLocked(ctx context.Context, client *daggerClient) error {
+	if client.extraModulesLoaded {
+		return client.extraModulesErr
+	}
+	if len(client.pendingExtraModules) == 0 {
+		return nil
+	}
+
+	// Wait for the client's session attachables to be available.
+	// Transient failure — allow retry on next request.
+	if _, err := client.getClientCaller(ctx, client.clientID); err != nil {
+		return fmt.Errorf("waiting for client session attachables: %w", err)
+	}
+
+	stick := func(err error) error {
+		client.extraModulesErr = err
+		client.extraModulesLoaded = true
+		return err
+	}
+
+	loads := gatherModuleLoadRequests(nil, client.pendingExtraModules)
+	resolvedLoads, resolveErrs, err := srv.resolveModuleLoadBatch(ctx, client, loads)
+	if err != nil {
+		return stick(err)
+	}
+	for i, load := range loads {
+		if resolveErrs[i] != nil {
+			return stick(moduleLoadErr(load, resolveErrs[i]))
+		}
+	}
+
+	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
+	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	if err := srv.serveResolvedModuleLoadsLocked(client, loads, resolvedLoads); err != nil {
+		return stick(err)
+	}
+	client.markEntrypointServed(resolvedLoads)
+
+	client.extraModulesLoaded = true
+	return nil
+}
+
+// resolveModuleLoadBatch resolves a batch of module loads in parallel,
+// collecting per-load errors in deterministic order.
+func (srv *Server) resolveModuleLoadBatch(
+	ctx context.Context,
+	client *daggerClient,
+	loads []moduleLoadRequest,
+) ([]resolvedModuleLoad, []error, error) {
 	resolvedLoads := make([]resolvedModuleLoad, len(loads))
 	resolveErrs := make([]error, len(loads))
 
-	// Load modules in parallel, then apply to client state in deterministic order.
 	jobs := parallel.New().
 		WithContextualTracer(true).
 		WithLimit(moduleLoadParallelism(len(loads)))
@@ -934,57 +1045,189 @@ func (srv *Server) ensureModulesLoaded(ctx context.Context, client *daggerClient
 		})
 	}
 	if err := jobs.Run(ctx); err != nil {
-		client.modulesErr = fmt.Errorf("resolving modules: %w", err)
-		client.modulesLoaded = true
-		return client.modulesErr
+		return nil, nil, fmt.Errorf("resolving modules: %w", err)
 	}
+	return resolvedLoads, resolveErrs, nil
+}
 
-	for i, load := range loads {
-		if resolveErrs[i] != nil {
-			client.modulesErr = moduleLoadErr(load, resolveErrs[i])
-			client.modulesLoaded = true
-			return client.modulesErr
+// arbitrateAmbientEntrypoints picks whether this ambient batch's entrypoint
+// candidate wins: only when none is served yet (extras outrank ambient).
+// Multiple candidates in one batch are a workspace configuration error.
+func (client *daggerClient) arbitrateAmbientEntrypoints(loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+	var candidates []int
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			candidates = append(candidates, i)
 		}
 	}
-
-	loads, resolvedLoads = dedupeResolvedModuleLoads(loads, resolvedLoads)
-	if err := arbitrateResolvedModuleLoads(loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if len(candidates) > 1 {
+		return entrypointConflictError(moduleLoadKindAmbient, candidates, loads)
 	}
-
-	client.stateMu.Lock()
-	defer client.stateMu.Unlock()
-	if err := srv.serveAllResolvedModuleLoads(client, loads, resolvedLoads); err != nil {
-		client.modulesErr = err
-		client.modulesLoaded = true
-		return client.modulesErr
+	if client.entrypointServed {
+		for _, i := range candidates {
+			resolved[i].primaryEntrypoint = false
+		}
 	}
-
-	client.modulesLoaded = true
 	return nil
 }
 
-func (client *daggerClient) narrowPendingWorkspaceModulesForSingleQuery(rootFields []string) {
-	client.modulesMu.Lock()
-	defer client.modulesMu.Unlock()
-
-	if client.modulesLoaded || len(client.pendingModules) == 0 {
-		return
+// markEntrypointServed flags that an entrypoint (primary or blueprint) was
+// served, so later ambient candidates are demoted. client.modulesMu must be held.
+func (client *daggerClient) markEntrypointServed(resolved []resolvedModuleLoad) {
+	for i := range resolved {
+		if resolved[i].primaryEntrypoint {
+			client.entrypointServed = true
+			return
+		}
+		for _, related := range resolved[i].related {
+			if related.entrypoint {
+				client.entrypointServed = true
+				return
+			}
+		}
 	}
-	client.pendingModules = filterPendingWorkspaceModulesForRootFields(client.pendingModules, rootFields)
 }
 
-func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields []string) []pendingModule {
+func (client *daggerClient) recordFailedModule(mod pendingModule, err error) {
+	// Cancellation/deadline is the request's fault, not the module's; keep it
+	// retriable.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	if client.failedModules == nil {
+		client.failedModules = make(map[string]error)
+	}
+	client.failedModules[moduleProgressName(mod)] = err
+}
+
+// removePendingModules drops served modules from the pending set and records
+// their names so demand filters still recognize them. Failed modules stay
+// pending to keep reporting their error. client.modulesMu must be held.
+func (client *daggerClient) removePendingModules(served []pendingModule) {
+	names := make(map[string]struct{}, len(served))
+	for _, mod := range served {
+		names[moduleProgressName(mod)] = struct{}{}
+	}
+	remaining := client.pendingModules[:0]
+	for _, mod := range client.pendingModules {
+		if _, ok := names[moduleProgressName(mod)]; ok {
+			if client.servedWorkspaceModuleNames == nil {
+				client.servedWorkspaceModuleNames = make(map[string]struct{})
+			}
+			client.servedWorkspaceModuleNames[moduleProgressName(mod)] = struct{}{}
+			continue
+		}
+		remaining = append(remaining, mod)
+	}
+	client.pendingModules = remaining
+}
+
+// EnsureWorkspaceModules loads the pending workspace modules a selector
+// resolver (checks/generators/services) demands. Those fields validate against
+// the core schema, so loading waits until resolution where include is native.
+func (srv *Server) EnsureWorkspaceModules(ctx context.Context, include []string) error {
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return srv.ensureModulesLoaded(ctx, client, func(mods []pendingModule) []pendingModule {
+		// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
+		return filterPendingWorkspaceModulesBySelectorInclude(mods, client.servedWorkspaceModuleNames, include)
+	})
+}
+
+// canonicalWorkspaceModuleName kebab-normalizes a name or pattern segment for
+// comparison, matching the include matchers (ModTreePath.Glob/CliCase) and CLI
+// command names: "myMod", "my-mod", "MyMod" are the same module. Glob
+// metacharacters survive, so a glob never equals a module name.
+func canonicalWorkspaceModuleName(name string) string {
+	return strcase.ToKebab(name)
+}
+
+// pendingModuleCliName is the canonical name an include pattern matches against.
+func pendingModuleCliName(mod pendingModule) string {
+	if mod.Name != "" {
+		return canonicalWorkspaceModuleName(mod.Name)
+	}
+	return canonicalWorkspaceModuleName(moduleProgressName(mod))
+}
+
+// knownWorkspaceModuleNames is the canonical-name set of all pending and
+// already-served workspace modules.
+func knownWorkspaceModuleNames(mods []pendingModule, served map[string]struct{}) map[string]struct{} {
+	known := make(map[string]struct{}, len(mods)+len(served))
+	for _, mod := range mods {
+		known[pendingModuleCliName(mod)] = struct{}{}
+	}
+	for name := range served {
+		known[canonicalWorkspaceModuleName(name)] = struct{}{}
+	}
+	return known
+}
+
+// resolveIncludePatternModules maps each pattern's leading segment (before ':')
+// to a known module name. It returns the demanded names and whether any pattern
+// matched nothing known; the caller decides the fallback.
+func resolveIncludePatternModules(mods []pendingModule, served map[string]struct{}, include []string) (wanted map[string]struct{}, unknown bool) {
+	known := knownWorkspaceModuleNames(mods, served)
+	wanted = make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		modName, _, _ := strings.Cut(pattern, ":")
+		modName = canonicalWorkspaceModuleName(modName)
+		if _, ok := known[modName]; !ok {
+			unknown = true
+			continue
+		}
+		wanted[modName] = struct{}{}
+	}
+	return wanted, unknown
+}
+
+// filterPendingWorkspaceModulesBySelectorInclude selects the modules named by
+// `dagger generate`/`check`/`up` patterns ("module" or "module:item"). A
+// pattern naming no known module (an entrypoint-proxied item, or a typo)
+// selects all, so the usual error surfaces. served modules are recognized but
+// contribute nothing to load.
+func filterPendingWorkspaceModulesBySelectorInclude(mods []pendingModule, served map[string]struct{}, include []string) []pendingModule {
+	if len(mods) == 0 || len(include) == 0 {
+		return mods
+	}
+
+	wanted, unknown := resolveIncludePatternModules(mods, served, include)
+	if unknown {
+		return mods
+	}
+
+	// Already-served wanted modules contribute nothing; result may be empty.
+	filtered := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if _, ok := wanted[pendingModuleCliName(mod)]; ok {
+			filtered = append(filtered, mod)
+		}
+	}
+	return filtered
+}
+
+// filterPendingWorkspaceModulesForRootFields selects the pending modules a
+// request's root fields reference. served modules are recognized without
+// loading.
+func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods
+	}
+
+	servedFields := make(map[string]struct{}, len(served))
+	for name := range served {
+		servedFields[strcase.ToLowerCamel(name)] = struct{}{}
 	}
 
 	selected := make([]bool, len(mods))
 	unknownRootField := false
 	for _, field := range rootFields {
 		if isCoreRootField(field) {
+			continue
+		}
+		if _, ok := servedFields[field]; ok {
 			continue
 		}
 		matched := false
@@ -995,6 +1238,11 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, rootFields
 			}
 		}
 		if !matched {
+			// load<Type>FromID can reference a module type without naming the
+			// module, so load everything to be safe.
+			if strings.HasPrefix(field, "load") && strings.HasSuffix(field, "FromID") {
+				return mods
+			}
 			unknownRootField = true
 		}
 	}
@@ -1031,8 +1279,12 @@ func rootFieldsRequireFullWorkspaceSchema(fields []string) bool {
 			"__workspaceModule",
 			"currentEnv",
 			"currentModule",
+			// currentTypeDefs returns the full served schema (bare `dagger
+			// functions`, the in-engine MCP/LLM tool builder), so it needs
+			// every workspace module.
 			"currentTypeDefs",
-			"currentWorkspace":
+			// env's resolver snapshots the served deps, so it needs every module
+			"env":
 			return true
 		}
 	}
@@ -1087,10 +1339,14 @@ func isCoreRootField(field string) bool {
 		"currentEnv",
 		"currentFunctionCall",
 		"currentModule",
+		// currentWorkspace's selector resolvers load on demand from their
+		// include argument, so the root field demands nothing here
+		"currentWorkspace",
 		"defaultPlatform",
 		"directory",
 		"engine",
-		"env",
+		// NOTE: "env" is intentionally absent — it needs the full workspace
+		// (see rootFieldsRequireFullWorkspaceSchema)
 		"envFile",
 		"error",
 		"file",
@@ -1177,8 +1433,10 @@ func (srv *Server) resolveModuleLoad(
 	return resolved, nil
 }
 
-// serveAllResolvedModuleLoads serves all resolved primary modules and their
-// related modules (blueprints, toolchains-of-toolchains).
+// serveResolvedModuleLoadsLocked serves resolved primary modules and their
+// related modules (blueprints, toolchains-of-toolchains), skipping any whose
+// identity an earlier batch already served. client.stateMu and client.modulesMu
+// must be held.
 //
 // Transitive dependencies are only served for the entrypoint module — the one
 // the user is interacting with via `dagger call` or `dagger shell`. This is
@@ -1186,9 +1444,13 @@ func (srv *Server) resolveModuleLoad(
 // (e.g. a Mallard backing a Duck). Toolchain deps are NOT served globally;
 // each module's deps are available in its own internal schema (mod.Deps) for
 // type resolution during function calls.
-func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+func (srv *Server) serveResolvedModuleLoadsLocked(client *daggerClient, loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
 	for i := range loads {
 		load := resolved[i]
+		key := resolvedModuleLoadIdentity(load.primary)
+		if _, ok := client.servedModuleKeys[key]; ok {
+			continue
+		}
 		for _, related := range load.related {
 			if err := srv.serveModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: related.entrypoint}); err != nil {
 				return fmt.Errorf("error serving related module %s: %w", related.mod.Self().Name(), err)
@@ -1208,6 +1470,10 @@ func (srv *Server) serveAllResolvedModuleLoads(client *daggerClient, loads []mod
 				}
 			}
 		}
+		if client.servedModuleKeys == nil {
+			client.servedModuleKeys = make(map[string]struct{})
+		}
+		client.servedModuleKeys[key] = struct{}{}
 	}
 
 	return nil

--- a/hack/designs/demand-driven-module-loading.md
+++ b/hack/designs/demand-driven-module-loading.md
@@ -1,0 +1,196 @@
+# Demand-Driven Workspace Module Loading
+
+Scope: `dagger generate` / `check` / `up` and raw execution queries.
+`dagger call` / `functions` are explicitly out of scope — see
+[Out of scope](#out-of-scope-dagger-call--functions).
+
+## Table of Contents
+
+- [Problem](#problem)
+- [Solution](#solution)
+- [Why this is safe without SingleQuery](#why-this-is-safe-without-singlequery)
+- [Core concept](#core-concept)
+- [What each command gains](#what-each-command-gains)
+- [Out of scope: `dagger call` / `functions`](#out-of-scope-dagger-call--functions)
+- [Implementation](#implementation)
+- [Edge cases](#edge-cases)
+
+## Problem
+
+1. **One-shot loading** — the first schema-needing request loads *every*
+   workspace module (`ensureModulesLoaded`, sticky `modulesLoaded` flag in
+   `engine/server/session_workspaces.go`). `dagger generate good` pays for
+   every module in the workspace.
+2. **Fragility** — one broken module fails the whole load, for every request in
+   the session. For `dagger generate` this includes the very module you were
+   trying to fix by running generate.
+3. **Narrowing is SingleQuery-only** — `narrowPendingWorkspaceModulesForSingleQuery`
+   drops pending modules based on root fields, which is only safe under the
+   single-request promise. `generate` / `check` / `up` are structurally
+   multi-request and cannot use it.
+
+## Solution
+
+Make workspace module loading **additive and demand-driven** instead of
+one-shot. Each request loads only the modules it can possibly touch; the rest
+stay *pending* and load when a later request demands them. The dagql schema is
+already rebuilt from the served set per request, so the session schema grows
+monotonically — narrowing becomes **deferral, not exclusion**, safe for open
+multi-request sessions, and the root-field demand generalizes from
+`SingleQuery` to every client.
+
+The demand source is the natural one for each query shape:
+
+- **`currentWorkspace { checks | generators | services(include: …) }`**
+  validates against the core schema (all those fields return core types), so
+  loading moves *into the resolvers* via a new `Query.Server.EnsureWorkspaceModules`
+  hook — they receive `include` natively, no request peeking or variable
+  resolution. The CLI already sends `include` as the command's functional
+  argument, so `dagger generate | check | up <module>` narrows with **zero CLI
+  and zero API change**.
+- **Root fields** naming a pending module (raw `dagger query '{ good { … } }'`,
+  shell) load just that module; the existing entrypoint fallback is preserved;
+  full-schema fields (`__schema`, `currentTypeDefs`, `env`, …) and anything
+  unrecognized conservatively load everything.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as dagger CLI
+    participant H as serveQuery<br/>(session.go)
+    participant L as ensureModulesLoaded<br/>(session_workspaces.go)
+    participant R as generators resolver<br/>(workspace.go)
+
+    Note over CLI: dagger generate good<br/>(workspace = {good, bad-broken})
+    CLI->>H: query { currentWorkspace { generators(include:["good"]) { … } } }
+    H->>H: ensureWorkspaceLoaded (discover, gather pending = {good, bad})
+    H->>L: ensureRequestModulesLoaded — peek root fields
+    Note over L: root field is currentWorkspace (core)<br/>→ demand = ∅, nothing loads
+    H->>R: resolve generators(include:["good"])
+    R->>L: EnsureWorkspaceModules(["good"])
+    Note over L: include names "good" → demand = {good}<br/>bad stays pending, never loaded
+    L-->>R: good served
+    R-->>CLI: good's generators (bad cannot block this)
+```
+
+## Why this is safe without SingleQuery
+
+The schema is already rebuilt per request from whatever is served
+(`client.servedMods.Schema(ctx)`), and `serveModule` is per-module, idempotent,
+and conflict-checked. So the session schema is allowed to *grow* between
+requests today — module SDKs and `Module.serve` rely on this.
+
+With one-shot loading, narrowing is a bet that no later request needs the
+dropped modules — only SingleQuery can keep that promise. With additive loading
+there is no bet: a later request that references a not-yet-loaded module
+triggers its load before validation. The schema is monotonically increasing and
+every request sees at least what it demands.
+
+## Core concept
+
+Demand-driven loading has two entry points, depending on whether the request
+can even *validate* without the modules:
+
+**1. Resolution-time loading — the `currentWorkspace` selector API.** Every
+`Workspace` field returns core types (`GeneratorGroup`, `CheckGroup`,
+`ServiceGroup`, …): a `currentWorkspace { generators(include: ["good"]) }`
+request validates against the core schema with zero modules loaded. So these
+need **no request peeking** — the `generators` / `checks` / `services` resolvers
+already receive `include` as a native typed argument, and they enumerate modules
+through `currentWorkspacePrimaryModules` → `CurrentServedDeps(ctx)`, which reads
+whatever is served *at resolution time*. The resolvers gain one load hook at
+entry:
+
+```go
+// top of checks/generators/services resolvers:
+if err := ensureWorkspaceIncludeModulesLoaded(ctx, include); err != nil { … }
+// existing enumeration picks up the freshly served modules.
+```
+
+`EnsureWorkspaceModules` matches the patterns against pending module *names*
+(known from config without loading): a pattern whose first segment names a
+module demands just that module; a bare token that is not a module name (an
+entrypoint-proxied item) or an unmatched pattern falls back to loading
+everything; empty `include` loads all. Names are kebab-normalized on both sides,
+matching the include matchers (`ModTreePath.Glob` / `CliCase`) and the CLI
+command names.
+
+**2. Pre-request loading — module root fields.** For execution queries like
+`{ good { verify } }` the *schema itself* depends on the module, so loading must
+happen before validation. `serveQuery` keeps a generalized root-field peek
+(`dagql.PeekRootFields`, already parsed today) for this path, only while pending
+modules remain.
+
+| Request shape | Mechanism | Demand |
+|---|---|---|
+| `currentWorkspace { generators \| checks \| services(include: […]) }` | resolver | modules matching the patterns |
+| `currentWorkspace { … }` bare (`dagger generate` no args) | resolver | all pending |
+| Root field matches a pending module name | peek | that module |
+| Root field unknown (entrypoint-proxied item) | peek | entrypoint module (existing fallback) |
+| `currentTypeDefs`, `__schema`, `env`, `currentModule` | peek | all pending |
+| Unparseable body, non-query operation, anything unrecognized | peek | all pending (conservative) |
+
+`currentWorkspace` is a core root field: its selector resolvers are the demand
+source, so the root-field peek loads nothing for it.
+
+## What each command gains
+
+Engine-only. Zero CLI changes, zero API changes:
+
+| Command | Today (main) | This change |
+|---|---|---|
+| `dagger generate good` | loads all | loads `good` — the CLI **already sends** `generators(include: ["good"])`; the resolver narrows from it |
+| `dagger check good` / `dagger up good` | loads all | loads `good` (same: `include` is already in the query) |
+| `dagger query '{ good { verify } }'` | narrowed only with `--single-query` | narrowed for every client, root-field demand |
+| `dagger call good verify`, bare `dagger functions`, `shell`, `mcp` | loads all | loads all (unchanged — see below) |
+
+A broken or stale sibling module can no longer block a scoped `generate` /
+`check` / `up`, including the case where running `generate` is itself the fix.
+
+## Out of scope: `dagger call` / `functions`
+
+`call` / `functions <module>` build their command tree from a
+`currentTypeDefs(returnAllTypes: true)` introspection, which genuinely carries
+no module signal — it asks for the whole served schema. Narrowing it requires
+getting the target module into the request (a new typedefs path or argument plus
+a CLI change), which is a larger, separately reviewable change with its own
+trade-offs; it is intentionally **not** part of this work.
+
+This change does not regress `call` / `functions`: `currentTypeDefs` stays on
+the full-schema list, so they load everything exactly as on `main`. The
+additive engine underneath is the foundation a later `call`-narrowing change
+can build on.
+
+## Implementation
+
+1. `engine/server/session.go` — `ensureRequestModulesLoaded` peeks every request
+   while pending modules exist (skipped once drained, and for clients with
+   `LoadWorkspaceModules=false`); replaces the SingleQuery-only narrowing call.
+2. `engine/server/session_workspaces.go` — `ensureModulesLoaded(ctx, client,
+   filter)`: per-module load state, additive serving via the existing
+   `serveModule`, per-module (non-sticky) ambient errors, extras kept eager with
+   sticky errors, precomputed entrypoint arbitration. Adds the
+   `EnsureWorkspaceModules` implementation and the selector/root-field demand
+   filters (kebab-normalized name matching, served-module recognition).
+3. `core/schema/workspace.go` + `core/query.go` — add the
+   `Query.Server.EnsureWorkspaceModules(ctx, include)` hook (implemented by the
+   engine, precedent: `CurrentWorkspace`) and call it at the top of the
+   `checks` / `generators` / `services` resolvers. `currentWorkspace` drops off
+   `rootFieldsRequireFullWorkspaceSchema`.
+
+## Edge cases
+
+- **Extra (`-m`) modules** keep loading eagerly with sticky errors — they were
+  explicitly requested.
+- **Ambient failures are per-module and non-sticky**: a broken module only fails
+  the requests that demand it, and stays pending so a later demand reports its
+  load error. Full listings (`dagger generate -l`, bare `dagger functions`) still
+  load everything and surface it.
+- **Cancellation / deadline** is never recorded as a module failure, so an
+  interrupted load stays retryable by later demands in the session.
+- **Entrypoint arbitration** is split across batches: extras outrank ambient
+  candidates; multiple ambient entrypoint declarations load together so the
+  existing conflict detection still runs.
+- **Re-evaluated selectors** (e.g. loading a `GeneratorGroup` from its ID on a
+  later request) name an already-served module; served names are tracked so the
+  demand filter recognizes them instead of falling back to loading everything.


### PR DESCRIPTION
## Problem

Workspace module loading is one-shot: the first schema-needing request loads **every** configured module, so `dagger generate|check|up <module>` pays for all its siblings, and a single broken or stale module blocks operating on any other module — for `generate`, including the very module you were trying to fix. The existing narrowing (peek root fields → drop pending modules) is restricted to `SingleQuery` clients, because dropped modules can't come back in a later request, and `generate`/`check`/`up` are structurally multi-request.

## Fix

Make loading **additive and demand-driven**: each request loads only the modules it can possibly touch; the rest stay *pending* and load when a later request demands them. The dagql schema is already rebuilt from the served set per request, so the session schema grows monotonically — narrowing becomes deferral rather than exclusion, safe for open multi-request sessions, and the root-field demand generalizes from `SingleQuery` to every client.

The demand source is the natural one for each query shape:

- **`currentWorkspace { checks|generators|services(include: …) }`** validates against the core schema (all those fields return core types), so loading moves *into the resolvers* via a new `Query.Server.EnsureWorkspaceModules` hook — they receive `include` natively, no request peeking. Since the CLI already sends `include` as the command's functional argument, `dagger generate|check|up <module>` narrows with **zero CLI and zero API change**.
- **Root fields** naming a pending module (raw `dagger query`, shell) load just that module (existing entrypoint fallback preserved); full-schema fields (`__schema`, `currentTypeDefs`, `env`, …) and anything unrecognized conservatively load everything.

```mermaid
sequenceDiagram
    autonumber
    participant CLI as dagger CLI
    participant H as serveQuery
    participant L as ensureModulesLoaded
    participant R as generators resolver

    Note over CLI: dagger generate good<br/>(workspace = {good, bad-broken})
    CLI->>H: query { currentWorkspace { generators(include:["good"]) { … } } }
    H->>H: ensureWorkspaceLoaded (pending = {good, bad})
    H->>L: peek root fields → currentWorkspace is core → demand = ∅
    H->>R: resolve generators(include:["good"])
    R->>L: EnsureWorkspaceModules(["good"])
    Note over L: include names "good" → load {good}<br/>bad stays pending, never loaded
    R-->>CLI: good's generators (bad cannot block this)
```

Other behavior:

- Extra (`-m`) modules keep loading eagerly with sticky errors (explicitly requested).
- Ambient module failures are per-module and non-sticky: a broken module only fails requests that demand it, and stays pending so later demands report its load error. Full listings (`dagger generate -l`, bare `dagger functions`) still load everything and surface it.
- Cancellation/deadline is never recorded as a module failure, so an interrupted load stays retryable.
- Entrypoint arbitration is split across batches: extras outrank ambient candidates; multiple ambient entrypoint declarations load together to preserve the existing conflict detection.

Design doc: `hack/designs/demand-driven-module-loading.md`.

## Scope — `dagger call` / `functions` are intentionally out

This is the fourth PR on this topic. It deliberately covers **only `generate` / `check` / `up`** (and raw execution queries), which the engine narrows for free from the `include` they already send.

`dagger call|functions <module>` are **not** addressed here. They build their command tree from a `currentTypeDefs(returnAllTypes: true)` introspection that carries no module signal; narrowing it requires getting the target into the request (a new typedefs path/argument plus a CLI change) — a larger, separately reviewable change with its own trade-offs. This PR does not regress them: `currentTypeDefs` stays on the full-schema list, so `call`/`functions` load everything exactly as on `main`. The additive engine here is the foundation a later `call`-narrowing change builds on.

Relationship to the prior PRs (all same author):

- **#13406** — original, bundles the foundation + `generate`/`check`/`up` + a `currentTypeDefs(include:)` argument for `call`/`functions` + SDK regen.
- **#13539** — `call` narrowing via a peeked operation name. Superseded.
- **#13543** — `call` narrowing via a `WorkspaceModule.typeDefs` field. Open.

This PR extracts the engine-only foundation + selector narrowing common to all three, with no SDK regen, no `schema.graphqls` change, and no `cmd/dagger` change.

## Tests

`TestGenerators/TestWorkspace{Generate,Check,Up}NarrowsToRequestedModule`: a broken sibling no longer blocks a scoped `generate`/`check`/`up` of a healthy module, while full listings still load every module and surface the broken one. Verified against a from-source dev engine.
