### PR TITLE
fix(sdk/php): exclude vendor/ from generated changeset

### DIFF
--- a/sdk/php/runtime/main.go
+++ b/sdk/php/runtime/main.go
@@ -48,8 +48,15 @@ func (m *PhpSdk) Codegen(
 	if err != nil {
 		return nil, err
 	}
+	subPath, err := modSource.SourceSubpath(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not load module source path: %w", err)
+	}
+	// vendor/ is reinstalled by ModuleRuntime on every run, so keep it out of
+	// the generated changeset. Leaving it in makes the workspace diff-stat walk
+	// thousands of dependency files, which exhausts the engine's OS threads.
 	return dag.
-		GeneratedCode(ctr.Directory(ModSourcePath)).
+		GeneratedCode(ctr.Directory(ModSourcePath).WithoutDirectory(filepath.Join(subPath, "vendor"))).
 		WithVCSGeneratedPaths([]string{
 			GenPath + "/**",
 			"entrypoint.php",


### PR DESCRIPTION
The PHP runtime's Codegen returned the module directory including the composer vendor/ tree (hundreds of packages, thousands of files). The workspace generate flow diff-stats that changeset with one OS thread per file, which exhausts the engine's thread limit and crashes it with "fatal error: thread exhaustion".

vendor/ is reinstalled by ModuleRuntime on every run and is already marked VCS-ignored, so it has no business in the generated changeset. Drop it from the Codegen output, mirroring how the Python SDK excludes its .venv.