### PR TITLE
fix(workspace): explain missing Git repository instead of "workspace not loaded"

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -247,6 +247,11 @@ type daggerClient struct {
 	// Cached workspace result from ensureWorkspaceLoaded.
 	workspace *core.Workspace
 
+	// noWorkspaceErr explains why detection found no workspace (e.g. no Git
+	// repository in cwd or any parent). Surfaced by CurrentWorkspace so callers
+	// get an actionable error instead of a bare "workspace not loaded".
+	noWorkspaceErr error
+
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
 	modulesMu           sync.Mutex

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -840,6 +840,49 @@ func TestDetectAndLoadWorkspaceDoesNotInferModuleFromCWDWithoutWorkspace(t *test
 	require.Empty(t, client.pendingModules)
 }
 
+func TestDetectAndLoadWorkspaceReportsMissingGitRepository(t *testing.T) {
+	t.Parallel()
+
+	// No .git anywhere: detection succeeds with no workspace, but the reason
+	// must be recorded so CurrentWorkspace can give an actionable error instead
+	// of a bare "workspace not loaded".
+	statFS := core.StatFSFunc(func(_ context.Context, _ string) (string, *core.Stat, error) {
+		return "", nil, os.ErrNotExist
+	})
+	readFile := func(_ context.Context, _ string) ([]byte, error) {
+		return nil, os.ErrNotExist
+	}
+
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID: "test-client",
+	})
+
+	client := &daggerClient{
+		pendingWorkspaceLoad: true,
+		clientMetadata:       &engine.ClientMetadata{LoadWorkspaceModules: true},
+	}
+
+	srv := &Server{}
+	err := srv.detectAndLoadWorkspace(ctx, client,
+		statFS,
+		readFile,
+		"/tmp/nogit",
+		func(ws *workspace.Workspace, relPath string) string {
+			return filepath.Join(ws.Root, relPath)
+		},
+		nil,
+		true,
+	)
+	require.NoError(t, err)
+	require.Nil(t, client.workspace)
+	require.Empty(t, client.pendingModules)
+
+	require.Error(t, client.noWorkspaceErr)
+	require.ErrorIs(t, client.noWorkspaceErr, core.ErrNoCurrentWorkspace)
+	require.Contains(t, client.noWorkspaceErr.Error(), "/tmp/nogit")
+	require.Contains(t, client.noWorkspaceErr.Error(), "git init")
+}
+
 func TestRemoteWorkspaceCwdUsesDetectionStart(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -47,8 +47,16 @@ func (srv *Server) invalidateClientWorkspace(ctx context.Context) error {
 	client.workspaceLoaded = false
 	client.workspaceErr = nil
 	client.workspace = nil
+	client.noWorkspaceErr = nil
 	client.pendingModules = nil
 	return nil
+}
+
+// noGitWorkspaceError describes the missing-Git-repository condition that leaves
+// a local client with no workspace. Wraps ErrNoCurrentWorkspace so semantic
+// checks keep working while the message tells the user how to fix it.
+func noGitWorkspaceError(cwd string) error {
+	return fmt.Errorf("%w: no Git repository found in %q or any parent directory; Dagger uses the Git repository as the workspace boundary — run 'git init' to create one", core.ErrNoCurrentWorkspace, cwd)
 }
 
 // CurrentWorkspace returns the cached workspace for the current client.
@@ -58,6 +66,9 @@ func (srv *Server) CurrentWorkspace(ctx context.Context) (*core.Workspace, error
 		return nil, err
 	}
 	if client.workspace == nil {
+		if client.noWorkspaceErr != nil {
+			return nil, client.noWorkspaceErr
+		}
 		return nil, fmt.Errorf("%w: workspace not loaded", core.ErrNoCurrentWorkspace)
 	}
 	return client.workspace, nil
@@ -183,8 +194,16 @@ func (srv *Server) inheritWorkspaceBinding(ctx context.Context, client *daggerCl
 
 		parent.workspaceMu.Lock()
 		parentWorkspace := parent.workspace
+		parentNoWorkspaceErr := parent.noWorkspaceErr
 		parent.workspaceMu.Unlock()
 		if parentWorkspace == nil {
+			// Carry the nearest parent's reason so a nested client still
+			// explains why no workspace is available (e.g. no Git repository).
+			if parentNoWorkspaceErr != nil {
+				client.workspaceMu.Lock()
+				client.noWorkspaceErr = parentNoWorkspaceErr
+				client.workspaceMu.Unlock()
+			}
 			continue
 		}
 
@@ -687,6 +706,11 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	if ws == nil {
 		client.workspace = nil
 		client.pendingModules = nil
+		// ws is only ever nil for local detection that found no .git root
+		// (DetectInRoot always yields a workspace for remote/declared roots).
+		if isLocal {
+			client.noWorkspaceErr = noGitWorkspaceError(cwd)
+		}
 		return nil
 	}
 	if wsConfig == nil && compatWorkspace == nil {
@@ -704,6 +728,7 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	}
 	coreWS.SetCompatWorkspace(compatWorkspace)
 	client.workspace = coreWS
+	client.noWorkspaceErr = nil
 
 	if !loadModules {
 		return nil


### PR DESCRIPTION
## What

In the 1.0 workspace model the workspace boundary is the enclosing **Git repository**. When a `dagger` command runs outside any Git repo, workspace detection finds nothing and the user hits:

```
Error: ... no current workspace: workspace not loaded
```

…with no hint at the cause. This was reported as a first-time-setup gotcha: the CLI requires a `.git` directory but never says so.

This PR makes the CLI explain the problem and how to fix it. The same command now reports:

```
Error: install sdk: no current workspace: no Git repository found in "/path" or any parent directory; Dagger uses the Git repository as the workspace boundary — run 'git init' to create one
```

The improvement applies to **every** command that needs a workspace (`setup`, `sdk install`, `generate`, `up`, …), since they all bottom out at `CurrentWorkspace`.

## How

- Record a reason on the client when local detection finds no `.git` root (`detectAndLoadWorkspaceWithRootfs`).
- Surface it from `CurrentWorkspace` instead of the bare `workspace not loaded`.
- Propagate it to nested clients that inherit a parent workspace binding; clear it on successful (re)detection and on workspace invalidation.

Detection itself stays non-fatal, so core-only (`dagger core …`) and remote `-m` flows that don't need a workspace are unaffected.

## Test plan

- New unit test `TestDetectAndLoadWorkspaceReportsMissingGitRepository`; existing workspace-detection tests pass.
- Verified end-to-end against a dev engine built from this branch:
  - no `.git`: `dagger sdk install go` and `dagger setup` show the actionable message
  - with `.git`: `dagger sdk install go` works unchanged
  - core-only `dagger core version` in a non-`.git` dir is unaffected

Reported in Discord: https://discord.com/channels/707636530424053791/708371226174685314/1520935495910293657
