### PR TITLE
feat(workspace): don't write check-generated to dagger.toml by default

### DIFF
--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -554,7 +554,9 @@ func (WorkspaceSuite) TestWorkspaceConfigurationLifecycle(ctx context.Context, t
 		configContents, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
 		require.NoError(t, err)
 		require.Contains(t, string(configContents), "[modules]")
-		require.Contains(t, string(configContents), "check-generated = true")
+		// check-generated is not written by default; an absent setting already
+		// behaves as check-generated = true.
+		require.NotContains(t, string(configContents), "check-generated")
 	})
 
 	t.Run("workspace config detects the nearest config", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -19,10 +19,6 @@ const initialWorkspaceConfig = `# Dagger workspace configuration
 # Example:
 #   dagger mod install github.com/dagger/dagger/modules/wolfi
 
-# Run generators as part of 'dagger check' and fail when generated files are
-# stale. Set to false to skip them by default (like 'dagger check --no-generate').
-check-generated = true
-
 [modules]
 `
 
@@ -117,13 +113,8 @@ func loadWorkspaceConfigForMutation(
 		return nil, false, fmt.Errorf("initialize workspace: %w", err)
 	}
 
-	// Keep this consistent with initialWorkspaceConfig: the freshly written file
-	// already carries `check-generated = true`, so the returned config must too,
-	// otherwise the next write would prune it as a removed key.
-	checkGenerated := true
 	return &workspace.Config{
-		Modules:        map[string]workspace.ModuleEntry{},
-		CheckGenerated: &checkGenerated,
+		Modules: map[string]workspace.ModuleEntry{},
 	}, true, nil
 }
 

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -23,6 +23,22 @@ func TestWorkspacePrivateSourceFieldsAreNotGraphQLFields(t *testing.T) {
 	}
 }
 
+// TestInitialWorkspaceConfigOmitsCheckGenerated verifies the default dagger.toml
+// (written by dagger install / workspace init) does not set check-generated: the
+// engine never writes it by default, and an absent setting already behaves as
+// check-generated = true.
+func TestInitialWorkspaceConfigOmitsCheckGenerated(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, initialWorkspaceConfig, "# Dagger workspace configuration")
+	require.Contains(t, initialWorkspaceConfig, "[modules]")
+	require.NotContains(t, initialWorkspaceConfig, "check-generated")
+
+	cfg, err := workspace.ParseConfig([]byte(initialWorkspaceConfig))
+	require.NoError(t, err)
+	require.Nil(t, cfg.CheckGenerated)
+}
+
 func TestMatchWorkspaceInclude(t *testing.T) {
 	ctx := context.Background()
 	node := modTreeNode("go", "lint")


### PR DESCRIPTION
The engine was writing `check-generated = true` (with its comment) into `dagger.toml` by default — on `dagger install`, `dagger sdk install`, `dagger workspace init`, and `dagger setup`'s migration. But an **absent** `check-generated` already behaves as `true` (the only consumer skips generate-as-checks solely when it's explicitly `false`), so writing it by default is redundant clutter. The engine should never add it on its own — only an explicit user setting should.

This PR stops writing `check-generated` by default: removed it from `initialWorkspaceConfig` (the default template seeded by install / sdk install / workspace init) and from the config returned by `loadWorkspaceConfigForMutation`. The migrate path no longer writes it either. Explicit user values still round-trip untouched.

### Behavior

An absent `check-generated` is unchanged — it still behaves as `check-generated = true`. This PR only stops the engine from materializing that default on disk.

### Tests

- Unit: the default template omits `check-generated` and parses to `CheckGenerated == nil`.
- Integration: `init` no longer writes `check-generated` into the created `dagger.toml`.
