### PR TITLE
fix(setup): install module SDKs correctly when migrating

### DIFF
--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -686,7 +686,7 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, configOut, `[modules.go-sdk]`)
+		require.Contains(t, configOut, `[modules.dagger-go-sdk]`)
 		require.Contains(t, configOut, `source = "github.com/dagger/go-sdk"`)
 
 		reportOut, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -180,7 +180,7 @@ type Myapp {
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, configOut, `[modules.go-sdk]`)
+		require.Contains(t, configOut, `[modules.dagger-go-sdk]`)
 		require.Contains(t, configOut, `source = "github.com/dagger/go-sdk"`)
 
 		reportOut, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)
@@ -704,9 +704,9 @@ type Videostitch struct{}
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, configOut, `[modules.go-sdk]`)
+		require.Contains(t, configOut, `[modules.dagger-go-sdk]`)
 		require.Contains(t, configOut, `source = "github.com/dagger/go-sdk"`)
-		require.Contains(t, configOut, `[modules.typescript-sdk]`)
+		require.Contains(t, configOut, `[modules.dagger-typescript-sdk]`)
 		require.Contains(t, configOut, `source = "github.com/dagger/typescript-sdk"`)
 
 		reportOut, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -256,7 +256,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.Contains(t, cfg.Modules, "myapp")
-		goSDK := cfg.Modules["go-sdk"]
+		goSDK := cfg.Modules["dagger-go-sdk"]
 		require.NotNil(t, goSDK.AsSDK)
 		require.Equal(t, []workspacecfg.SDKManagedModule{{Path: ".dagger/modules/myapp"}}, goSDK.AsSDK.Modules)
 
@@ -265,7 +265,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 
 		cfg = readInstalledWorkspaceConfig(t, workdir)
 		require.NotContains(t, cfg.Modules, "myapp")
-		goSDK = cfg.Modules["go-sdk"]
+		goSDK = cfg.Modules["dagger-go-sdk"]
 		require.NotNil(t, goSDK.AsSDK)
 		require.Empty(t, goSDK.AsSDK.Modules)
 

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -305,7 +305,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Equal(t, root, plans[0].ProjectRoot)
 		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["go-sdk"].Source)
+		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
 		require.Equal(t, []string{
 			"modules/video requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m modules/video ...`.",
 		}, plans[0].Warnings)
@@ -327,7 +327,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Equal(t, root, plans[0].ProjectRoot)
 		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["go-sdk"].Source)
+		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
 		require.Equal(t, []string{
 			"Root module requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m . ...`.",
 		}, plans[0].Warnings)
@@ -352,7 +352,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Empty(t, plans)
 		cfg, err := workspace.ParseConfig(migrated.WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["go-sdk"].Source)
+		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
 		require.Equal(t, []string{
 			"services/api/modules/video requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m services/api/modules/video ...`.",
 		}, workspaceMigrationWarnings(migrated))
@@ -392,7 +392,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
 		require.NoError(t, err)
 		require.Len(t, cfg.Modules, 1)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["go-sdk"].Source)
+		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
 	})
 
 	t.Run("parent SDK module name conflicts get a stable alternate name", func(t *testing.T) {
@@ -402,7 +402,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 }`)
 		migrated := &workspace.MigrationPlan{
 			ProjectRoot: filepath.Join(root, "services", "api"),
-			WorkspaceConfigData: []byte(`[modules.go-sdk]
+			WorkspaceConfigData: []byte(`[modules.dagger-go-sdk]
 source = "github.com/acme/custom-go-sdk"
 `),
 		}
@@ -411,8 +411,8 @@ source = "github.com/acme/custom-go-sdk"
 		require.NoError(t, err)
 		cfg, err := workspace.ParseConfig(migrated.WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/acme/custom-go-sdk", cfg.Modules["go-sdk"].Source)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["go-sdk-runtime"].Source)
+		require.Equal(t, "github.com/acme/custom-go-sdk", cfg.Modules["dagger-go-sdk"].Source)
+		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk-runtime"].Source)
 	})
 }
 

--- a/core/sdk/consts.go
+++ b/core/sdk/consts.go
@@ -1,5 +1,7 @@
 package sdk
 
+import "github.com/dagger/dagger/core/sdk/sdkmeta"
+
 const (
 	RuntimeWorkdirPath = "/scratch"
 )
@@ -7,26 +9,14 @@ const (
 type sdk string
 
 const (
-	sdkGo         sdk = "go"
-	sdkDang       sdk = "dang"
-	sdkPython     sdk = "python"
-	sdkTypescript sdk = "typescript"
-	sdkPHP        sdk = "php"
-	sdkElixir     sdk = "elixir"
-	sdkJava       sdk = "java"
+	sdkGo         sdk = sdkmeta.Go
+	sdkDang       sdk = sdkmeta.Dang
+	sdkPython     sdk = sdkmeta.Python
+	sdkTypescript sdk = sdkmeta.Typescript
+	sdkPHP        sdk = sdkmeta.PHP
+	sdkElixir     sdk = sdkmeta.Elixir
+	sdkJava       sdk = sdkmeta.Java
 )
-
-// this list is to format the invalid sdk msg
-// and keeping that in sync with builtinSDK func
-var validInbuiltSDKs = []sdk{
-	sdkGo,
-	sdkDang,
-	sdkPython,
-	sdkTypescript,
-	sdkPHP,
-	sdkElixir,
-	sdkJava,
-}
 
 // The list of functions that may be implemented by a SDK module.
 var sdkFunctions = []string{

--- a/core/sdk/loader.go
+++ b/core/sdk/loader.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/sdk/sdkmeta"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/distconsts"
@@ -71,7 +72,7 @@ func (l *Loader) SDKForModule(
 	fmt.Fprintln(stdio.Stderr, "-", extErr)
 	fmt.Fprintln(stdio.Stderr)
 	fmt.Fprintln(stdio.Stderr, "The available SDKs are:")
-	for _, sdk := range validInbuiltSDKs {
+	for _, sdk := range sdkmeta.Builtins {
 		fmt.Fprintln(stdio.Stderr, "-", sdk)
 	}
 	fmt.Fprintln(stdio.Stderr, "- any git module ref, e.g. github.com/dagger/dagger/sdk/elixir@main")
@@ -231,7 +232,7 @@ func parseSDKName(sdkName string) (sdk, string, error) {
 
 	// this validation may seem redundant, but it helps keep the list of
 	// builtin sdk between invalidSDKError message and builtinSDK function in sync.
-	if !slices.Contains(validInbuiltSDKs, sdk(sdkNameParsed)) {
+	if !sdkmeta.IsBuiltin(sdkNameParsed) {
 		return "", "", errUnknownBuiltinSDK
 	}
 
@@ -260,5 +261,5 @@ func parseSDKName(sdkName string) (sdk, string, error) {
 // modules that can be loaded from a path or ref.
 func IsBuiltinSDKName(source string) bool {
 	name, _, _ := strings.Cut(source, "@")
-	return slices.Contains(validInbuiltSDKs, sdk(name))
+	return sdkmeta.IsBuiltin(name)
 }

--- a/core/sdk/loader_test.go
+++ b/core/sdk/loader_test.go
@@ -123,37 +123,37 @@ func TestWorkspaceModuleForRuntime(t *testing.T) {
 		{
 			name:    "go",
 			runtime: "go",
-			want:    WorkspaceModule{Name: "go-sdk", Source: "github.com/dagger/go-sdk"},
+			want:    WorkspaceModule{Name: "dagger-go-sdk", Source: "github.com/dagger/go-sdk"},
 			wantOK:  true,
 		},
 		{
 			name:    "typescript",
 			runtime: "typescript",
-			want:    WorkspaceModule{Name: "typescript-sdk", Source: "github.com/dagger/typescript-sdk"},
+			want:    WorkspaceModule{Name: "dagger-typescript-sdk", Source: "github.com/dagger/typescript-sdk"},
 			wantOK:  true,
 		},
 		{
 			name:    "python",
 			runtime: "python",
-			want:    WorkspaceModule{Name: "python-sdk", Source: "github.com/dagger/python-sdk"},
+			want:    WorkspaceModule{Name: "dagger-python-sdk", Source: "github.com/dagger/python-sdk"},
 			wantOK:  true,
 		},
 		{
 			name:    "java defaults to engine tag",
 			runtime: "java",
-			want:    WorkspaceModule{Name: "java-sdk", Source: "github.com/dagger/dagger/sdk/java@v0.12.6"},
+			want:    WorkspaceModule{Name: "dagger-java-sdk", Source: "github.com/dagger/dagger/sdk/java@v0.12.6"},
 			wantOK:  true,
 		},
 		{
 			name:    "php keeps explicit suffix",
 			runtime: "php@main",
-			want:    WorkspaceModule{Name: "php-sdk", Source: "github.com/dagger/dagger/sdk/php@main"},
+			want:    WorkspaceModule{Name: "dagger-php-sdk", Source: "github.com/dagger/dagger/sdk/php@main"},
 			wantOK:  true,
 		},
 		{
 			name:    "dang",
 			runtime: "dang",
-			want:    WorkspaceModule{Name: "dang-sdk", Source: "github.com/dagger/dang-sdk"},
+			want:    WorkspaceModule{Name: "dagger-dang-sdk", Source: "github.com/dagger/dang-sdk"},
 			wantOK:  true,
 		},
 		{

--- a/core/sdk/sdkmeta/sdkmeta.go
+++ b/core/sdk/sdkmeta/sdkmeta.go
@@ -19,6 +19,11 @@ const (
 // Builtins lists every SDK runtime short name bundled in the engine.
 var Builtins = []string{Go, Dang, Python, Typescript, PHP, Elixir, Java}
 
+// InstallNamePrefix is prepended to the workspace install name of a known SDK
+// (e.g. "go" -> "dagger-go-sdk") to reduce the chance of colliding with an
+// unrelated module. The SDK's source ref and as-sdk name are unaffected.
+const InstallNamePrefix = "dagger-"
+
 // IsBuiltin reports whether name (without any "@version" suffix) is a builtin
 // SDK runtime short name.
 func IsBuiltin(name string) bool {

--- a/core/sdk/sdkmeta/sdkmeta.go
+++ b/core/sdk/sdkmeta/sdkmeta.go
@@ -1,0 +1,26 @@
+// Package sdkmeta holds metadata about the SDK runtimes bundled in the engine.
+// It carries no dependencies so both core/sdk and core/workspace can share the
+// canonical builtin SDK list without an import cycle.
+package sdkmeta
+
+import "slices"
+
+// Builtin SDK runtime short names bundled in the engine.
+const (
+	Go         = "go"
+	Dang       = "dang"
+	Python     = "python"
+	Typescript = "typescript"
+	PHP        = "php"
+	Elixir     = "elixir"
+	Java       = "java"
+)
+
+// Builtins lists every SDK runtime short name bundled in the engine.
+var Builtins = []string{Go, Dang, Python, Typescript, PHP, Elixir, Java}
+
+// IsBuiltin reports whether name (without any "@version" suffix) is a builtin
+// SDK runtime short name.
+func IsBuiltin(name string) bool {
+	return slices.Contains(Builtins, name)
+}

--- a/core/sdk/utils.go
+++ b/core/sdk/utils.go
@@ -3,9 +3,9 @@ package sdk
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/sdk/sdkmeta"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/util/hashutil"
@@ -13,7 +13,7 @@ import (
 
 // Return true if the given module is a builtin SDK.
 func IsModuleSDKBuiltin(module string) bool {
-	return slices.Contains(validInbuiltSDKs, sdk(module))
+	return sdkmeta.IsBuiltin(module)
 }
 
 func scopeSourceForSDKOperation(

--- a/core/sdk/workspace_module.go
+++ b/core/sdk/workspace_module.go
@@ -1,6 +1,10 @@
 package sdk
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/dagger/dagger/core/sdk/sdkmeta"
+)
 
 // WorkspaceModule describes the SDK module a workspace should install for a
 // child module runtime.
@@ -22,6 +26,12 @@ func WorkspaceModuleForRuntime(runtime string) (WorkspaceModule, bool, error) {
 	}
 
 	mod, ok := workspaceModuleForBuiltinSDK(sdkName, suffix)
+	if ok {
+		// Prefix the install name to match `dagger sdk install` (e.g.
+		// "go-sdk" -> "dagger-go-sdk"), reducing collisions with unrelated
+		// modules. Source and runtime resolution are unaffected.
+		mod.Name = sdkmeta.InstallNamePrefix + mod.Name
+	}
 	return mod, ok, nil
 }
 

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/core/sdk/sdkmeta"
 )
 
 // ConventionalSDKShortName returns the workspace-side short name to use for
@@ -23,6 +24,35 @@ func ConventionalSDKShortName(sdkRef string) string {
 		ref = ref[i+1:]
 	}
 	return ref
+}
+
+// migrationSDKInstallName returns the workspace module install name to record
+// for a legacy SDK ref. A builtin runtime short name (e.g. "go", "php@v1") is
+// keyed by a "dagger-"-prefixed canonical basename ("dagger-go-sdk",
+// "dagger-php-sdk"), matching `dagger sdk install`, so the SDK install cannot
+// collide with an unrelated module legitimately named "go". External refs and
+// custom/local SDK names keep their existing basename.
+func migrationSDKInstallName(sdkRef string) string {
+	name := ConventionalSDKShortName(sdkRef)
+	if sdkmeta.IsBuiltin(name) {
+		return sdkmeta.InstallNamePrefix + name + "-sdk"
+	}
+	return name
+}
+
+// uniqueModuleName returns base if free, otherwise base with a numeric suffix,
+// so a migrated SDK install never silently overwrites an unrelated module that
+// happens to share its name.
+func uniqueModuleName(modules map[string]ModuleEntry, base string) string {
+	if _, taken := modules[base]; !taken {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if _, taken := modules[candidate]; !taken {
+			return candidate
+		}
+	}
 }
 
 // IsLocalRef performs a fast heuristic check to determine whether a module
@@ -104,8 +134,17 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 	// [modules.<sdk>.as-sdk.*]. This is the file-format catch-up for the
 	// runtime/SDK split.
 	if hasSDK {
-		sdkName := ConventionalSDKShortName(cfg.SDK.Source)
+		sdkName := migrationSDKInstallName(cfg.SDK.Source)
+		sdkIsBuiltin := sdkmeta.IsBuiltin(ConventionalSDKShortName(cfg.SDK.Source))
 		entry, exists := wsCfg.Modules[sdkName]
+		// A builtin SDK's legacy source (e.g. "go") is a runtime name, not a
+		// module source, so an existing same-named module is never the same
+		// install. For external/custom SDKs the source is a real ref/path, so
+		// reuse the entry only when it matches; otherwise don't clobber it.
+		if exists && (sdkIsBuiltin || entry.Source != cfg.SDK.Source) {
+			sdkName = uniqueModuleName(wsCfg.Modules, sdkName)
+			exists = false
+		}
 		if !exists {
 			entry = ModuleEntry{Source: cfg.SDK.Source}
 		}

--- a/core/workspace/migrate_test.go
+++ b/core/workspace/migrate_test.go
@@ -175,8 +175,10 @@ func TestPlanMigrationWritesMainModuleFirst(t *testing.T) {
 }
 
 // TestPlanMigrationWritesAsSDK verifies that the legacy `sdk` field on
-// dagger.json is surfaced as a workspace module installed as an SDK, with
-// the migrated module recorded under [[modules.<name>.as-sdk.modules]].
+// dagger.json is surfaced as a workspace module installed as an SDK, keyed by
+// a "dagger-"-prefixed canonical basename (go -> dagger-go-sdk) so it cannot
+// collide with an unrelated module named "go", with the migrated module
+// recorded under [[modules.<name>.as-sdk.modules]].
 func TestPlanMigrationWritesAsSDK(t *testing.T) {
 	t.Parallel()
 
@@ -190,10 +192,86 @@ func TestPlanMigrationWritesAsSDK(t *testing.T) {
 }`)
 
 	configData := string(plan.WorkspaceConfigData)
-	require.Contains(t, configData, "[modules.go]")
+	require.Contains(t, configData, "[modules.dagger-go-sdk]")
 	require.Contains(t, configData, `source = "go"`)
-	require.Contains(t, configData, "[[modules.go.as-sdk.modules]]")
+	require.Contains(t, configData, "[[modules.dagger-go-sdk.as-sdk.modules]]")
 	require.Contains(t, configData, `path = ".dagger/modules/myapp"`)
+}
+
+func TestMigrationSDKInstallName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"go", "dagger-go-sdk"},         // builtin short name -> prefixed basename
+		{"php", "dagger-php-sdk"},       // builtin short name -> prefixed basename
+		{"php@v0.18", "dagger-php-sdk"}, // versioned builtin
+		{"go-sdk", "go-sdk"},            // already a basename, not a builtin runtime
+		{"coolsdk", "coolsdk"},          // custom/local SDK kept as-is
+		{"github.com/dagger/go-sdk@v1.2.3", "go-sdk"},
+		{"github.com/acme/custom", "custom"},
+	} {
+		require.Equal(t, tc.want, migrationSDKInstallName(tc.in), "input %q", tc.in)
+	}
+}
+
+// TestPlanMigrationKeepsUnrelatedModuleNamedLikeSDK verifies the migrated SDK
+// install does not clobber an unrelated module that already carries the SDK's
+// prefixed install name; it is recorded under a distinct name instead.
+func TestPlanMigrationKeepsUnrelatedModuleNamedLikeSDK(t *testing.T) {
+	t.Parallel()
+
+	plan := testMigrationPlan(t, "repo", `{
+  "name": "myapp",
+  "sdk": {"source": "go"},
+  "source": "src",
+  "toolchains": [
+    {"name": "dagger-go-sdk", "source": "github.com/acme/go-sdk"}
+  ]
+}`)
+
+	cfg, err := ParseConfig(plan.WorkspaceConfigData)
+	require.NoError(t, err)
+
+	unrelated, ok := cfg.Modules["dagger-go-sdk"]
+	require.True(t, ok)
+	require.Equal(t, "github.com/acme/go-sdk", unrelated.Source)
+	require.Nil(t, unrelated.AsSDK, "unrelated module must not be marked as an SDK")
+
+	sdk, ok := cfg.Modules["dagger-go-sdk-2"]
+	require.True(t, ok)
+	require.Equal(t, "go", sdk.Source)
+	require.NotNil(t, sdk.AsSDK)
+}
+
+// TestPlanMigrationKeepsModuleSharingBuiltinSDKSource covers the subtle case
+// where an unrelated module shares both the SDK's prefixed install name and its
+// bare source string ("go"): the string means a runtime in SDK context but a
+// local path in module context, so it must not be treated as the same install.
+func TestPlanMigrationKeepsModuleSharingBuiltinSDKSource(t *testing.T) {
+	t.Parallel()
+
+	plan := testMigrationPlan(t, "repo", `{
+  "name": "myapp",
+  "sdk": {"source": "go"},
+  "source": "src",
+  "toolchains": [
+    {"name": "dagger-go-sdk", "source": "go"}
+  ]
+}`)
+
+	cfg, err := ParseConfig(plan.WorkspaceConfigData)
+	require.NoError(t, err)
+
+	unrelated, ok := cfg.Modules["dagger-go-sdk"]
+	require.True(t, ok)
+	require.Nil(t, unrelated.AsSDK, "unrelated module must not be marked as an SDK")
+
+	sdk, ok := cfg.Modules["dagger-go-sdk-2"]
+	require.True(t, ok)
+	require.NotNil(t, sdk.AsSDK)
 }
 
 // TestPlanMigrationExternalSDKShortName verifies the SDK short name is

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1835,7 +1835,7 @@ SDKs are workspace modules whose role is to scaffold/codegen other things:
 new Dagger modules (`dagger module init`) or typed clients against the
 Dagger API (`dagger api client init`). An install becomes an SDK when
 added through this group — `dagger sdk install go` installs
-[modules.go-sdk] with [modules.go-sdk.as-sdk] name = "go" so
+[modules.dagger-go-sdk] with [modules.dagger-go-sdk.as-sdk] name = "go" so
 `dagger module init go` / `dagger api client init go`
 dispatch through that SDK.
 
@@ -1919,9 +1919,9 @@ Install an SDK into the current workspace and mark it with the
 
 Alias resolution: `dagger sdk install go` resolves "go" via the
 embedded sdks.json registry to github.com/dagger/go-sdk. The workspace
-install name is the canonical ref basename (`go-sdk`), and the
-user-facing name is persisted as [modules.go-sdk.as-sdk] name = "go".
-Direct refs work too:
+install name is the canonical ref basename prefixed with "dagger-"
+(`dagger-go-sdk`), and the user-facing name is persisted as
+[modules.dagger-go-sdk.as-sdk] name = "go". Direct refs work too:
 `dagger sdk install github.com/foo/sdk` is installed as
 [modules.sdk] by basename.
 
@@ -1942,7 +1942,7 @@ dagger sdk install go
 
 ```
       --here          Write to the workspace config directory at the workspace cwd
-  -n, --name string   Override the workspace install name (defaults to the registry repo basename, or the basename of a direct ref)
+  -n, --name string   Override the workspace install name (defaults to the registry repo basename prefixed with "dagger-", or the basename of a direct ref)
 ```
 
 ### Options inherited from parent commands

--- a/e2e/helm/helm_test.go
+++ b/e2e/helm/helm_test.go
@@ -11,6 +11,7 @@
 //go:test:include ../../core/modules
 //go:test:include ../../core/openrouter
 //go:test:include ../../core/prompts
+//go:test:include ../../core/sdk/sdkmeta
 //go:test:include ../../core/workspace
 //go:test:include ../../dagql
 //go:test:include ../../engine

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/core/sdk/sdkmeta"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/spf13/cobra"
 )
@@ -62,8 +63,9 @@ func sdkResolve(input string) (string, error) {
 
 // sdkResolveInstall maps an SDK install value to:
 //   - the canonical full ref that should flow downstream to the engine; and
-//   - the registry repo basename to use as the workspace install name when the
-//     user did not pass --name; and
+//   - the workspace install name to use when the user did not pass --name: the
+//     registry repo basename with a "dagger-" prefix (e.g. "dagger-go-sdk"),
+//     reducing the chance of colliding with an unrelated module; and
 //   - the registry's canonical user-facing name to persist as as-sdk.name.
 //
 // Full refs return an empty install name so Workspace.install keeps its normal
@@ -99,7 +101,7 @@ func sdkResolveInstall(input string) (ref string, installName string, asSDKName 
 	case 0:
 		return "", "", "", fmt.Errorf("SDK %q not found in registry; try `dagger sdk search %s` or pass a full ref (e.g., github.com/dagger/go-sdk)", input, input)
 	case 1:
-		return matches[0].Repo, sdkRegistryRepoBase(matches[0].Repo), matches[0].Name, nil
+		return matches[0].Repo, sdkmeta.InstallNamePrefix + sdkRegistryRepoBase(matches[0].Repo), matches[0].Name, nil
 	default:
 		names := make([]string, 0, len(matches))
 		for _, m := range matches {

--- a/internal/cmd/dagger/module_init_test.go
+++ b/internal/cmd/dagger/module_init_test.go
@@ -4,8 +4,38 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPlanMigratedSDKFixups(t *testing.T) {
+	cfg := &workspace.Config{
+		Modules: map[string]workspace.ModuleEntry{
+			// builtin SDK recorded by migration (keyed by prefixed name, bare
+			// source): resolve the bare source to its real ref + name
+			"dagger-php-sdk": {Source: "php", AsSDK: &workspace.ModuleAsSDK{}},
+			"dagger-go-sdk":  {Source: "go", AsSDK: &workspace.ModuleAsSDK{}},
+			// versioned builtin source: resolve, preserving the @version
+			"dagger-java-sdk": {Source: "java@v0.18", AsSDK: &workspace.ModuleAsSDK{}},
+			// already a full ref: leave untouched
+			"custom-sdk": {Source: "github.com/dagger/go-sdk@v1.2.3", AsSDK: &workspace.ModuleAsSDK{}},
+			// not an SDK install: ignore even with a bare source
+			"plain": {Source: "mymod"},
+			// local path SDK: leave untouched
+			"local": {Source: "./sdks/local", AsSDK: &workspace.ModuleAsSDK{}},
+			// bare name absent from the registry: leave untouched
+			"mystery": {Source: "mystery", AsSDK: &workspace.ModuleAsSDK{}},
+		},
+	}
+
+	require.Equal(t, []migratedSDKFixup{
+		{ModuleName: "dagger-go-sdk", Ref: "github.com/dagger/go-sdk", SDKName: "go"},
+		{ModuleName: "dagger-java-sdk", Ref: "github.com/dagger/java-sdk@v0.18", SDKName: "java"},
+		{ModuleName: "dagger-php-sdk", Ref: "github.com/dagger/php-sdk", SDKName: "php"},
+	}, planMigratedSDKFixups(cfg))
+
+	require.Nil(t, planMigratedSDKFixups(nil))
+}
 
 func TestSDKResolve(t *testing.T) {
 	for _, tt := range []struct {
@@ -91,28 +121,28 @@ func TestSDKResolveInstall(t *testing.T) {
 			name:            "registry name resolves repo, install name, and sdk alias",
 			input:           "go",
 			wantRef:         "github.com/dagger/go-sdk",
-			wantInstallName: "go-sdk",
+			wantInstallName: "dagger-go-sdk",
 			wantAsSDKName:   "go",
 		},
 		{
 			name:            "registry alias resolves repo, install name, and canonical sdk alias",
 			input:           "golang",
 			wantRef:         "github.com/dagger/go-sdk",
-			wantInstallName: "go-sdk",
+			wantInstallName: "dagger-go-sdk",
 			wantAsSDKName:   "go",
 		},
 		{
 			name:            "repo basename compatibility fallback resolves repo, install name, and sdk alias",
 			input:           "go-sdk",
 			wantRef:         "github.com/dagger/go-sdk",
-			wantInstallName: "go-sdk",
+			wantInstallName: "dagger-go-sdk",
 			wantAsSDKName:   "go",
 		},
 		{
 			name:            "dang resolves repo, install name, and sdk alias",
 			input:           "dang",
 			wantRef:         "github.com/dagger/dang-sdk",
-			wantInstallName: "dang-sdk",
+			wantInstallName: "dagger-dang-sdk",
 			wantAsSDKName:   "dang",
 		},
 		{

--- a/internal/cmd/dagger/sdk.go
+++ b/internal/cmd/dagger/sdk.go
@@ -36,7 +36,7 @@ SDKs are workspace modules whose role is to scaffold/codegen other things:
 new Dagger modules (` + "`dagger module init`" + `) or typed clients against the
 Dagger API (` + "`dagger api client init`" + `). An install becomes an SDK when
 added through this group — ` + "`dagger sdk install go`" + ` installs
-[modules.go-sdk] with [modules.go-sdk.as-sdk] name = "go" so
+[modules.dagger-go-sdk] with [modules.dagger-go-sdk.as-sdk] name = "go" so
 ` + "`dagger module init go`" + ` / ` + "`dagger api client init go`" + `
 dispatch through that SDK.`,
 }
@@ -57,9 +57,9 @@ var sdkInstallCmd = &cobra.Command{
 
 Alias resolution: ` + "`dagger sdk install go`" + ` resolves "go" via the
 embedded sdks.json registry to github.com/dagger/go-sdk. The workspace
-install name is the canonical ref basename (` + "`go-sdk`" + `), and the
-user-facing name is persisted as [modules.go-sdk.as-sdk] name = "go".
-Direct refs work too:
+install name is the canonical ref basename prefixed with "dagger-"
+(` + "`dagger-go-sdk`" + `), and the user-facing name is persisted as
+[modules.dagger-go-sdk.as-sdk] name = "go". Direct refs work too:
 ` + "`dagger sdk install github.com/foo/sdk`" + ` is installed as
 [modules.sdk] by basename.
 
@@ -131,7 +131,7 @@ Requires the SDK to implement the initClient capability.`,
 }
 
 func init() {
-	sdkInstallCmd.Flags().StringVarP(&sdkInstallName, "name", "n", "", "Override the workspace install name (defaults to the registry repo basename, or the basename of a direct ref)")
+	sdkInstallCmd.Flags().StringVarP(&sdkInstallName, "name", "n", "", "Override the workspace install name (defaults to the registry repo basename prefixed with \"dagger-\", or the basename of a direct ref)")
 	sdkInstallCmd.Flags().BoolVar(&sdkInstallHere, "here", false, "Write to the workspace config directory at the workspace cwd")
 
 	sdkUninstallCmd.Flags().BoolVar(&sdkUninstallForce, "force", false, "Remove even if modules or clients are authored under this SDK")
@@ -429,6 +429,51 @@ func printSDKInitOptions(out io.Writer, sdkName string, kind sdkInitKind, args [
 		}
 	}
 	return w.Flush()
+}
+
+// migratedSDKFixup describes a workspace SDK install that migration recorded by
+// bare SDK short name and that must be resolved to its real ref and canonical
+// name through the sdks.json registry.
+type migratedSDKFixup struct {
+	ModuleName string
+	Ref        string
+	SDKName    string
+}
+
+// planMigratedSDKFixups finds [modules.<name>.as-sdk] installs whose source is a
+// bare SDK short name — how `dagger setup` migration records a legacy `sdk`
+// field (e.g. "php") — and resolves each through sdks.json to its real ref and
+// canonical name. A bare source is treated as a local path by the authoring
+// commands (`dagger module init <sdk>`), so it must be rewritten to a loadable
+// ref. Entries whose source is already a path/ref, or a bare name absent from
+// the registry, are left untouched.
+func planMigratedSDKFixups(cfg *workspace.Config) []migratedSDKFixup {
+	if cfg == nil {
+		return nil
+	}
+	var fixups []migratedSDKFixup
+	for name, entry := range cfg.Modules {
+		if entry.AsSDK == nil {
+			continue
+		}
+		// A migrated builtin SDK is recorded by bare short name, optionally with
+		// an "@version" the engine accepts (e.g. "php", "php@v0.18"). A full ref
+		// or a local path always contains a slash and is left untouched.
+		if entry.Source == "" || strings.Contains(entry.Source, "/") {
+			continue
+		}
+		base, version, _ := strings.Cut(entry.Source, "@")
+		ref, _, sdkName, err := sdkResolveInstall(base)
+		if err != nil {
+			continue
+		}
+		if version != "" {
+			ref += "@" + version
+		}
+		fixups = append(fixups, migratedSDKFixup{ModuleName: name, Ref: ref, SDKName: sdkName})
+	}
+	sort.Slice(fixups, func(i, j int) bool { return fixups[i].ModuleName < fixups[j].ModuleName })
+	return fixups
 }
 
 func readLocalWorkspaceConfig() (*workspace.Config, string, error) {

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -14,6 +14,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/charmbracelet/huh"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
@@ -64,8 +65,9 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 		// confirm form). The migrate write lands here; the session is closed
 		// before the install session opens so the workspace lock is released.
 		var (
-			recs    []recommendation
-			install bool
+			recs     []recommendation
+			install  bool
+			migrated bool
 		)
 		if err := func() error {
 			sess, closeSess, err := connect(ctx)
@@ -74,7 +76,8 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			}
 			defer closeSess()
 			dag := sess.Dagger()
-			if err := setupStepMigrate(ctx, cmd, dag); err != nil {
+			migrated, err = setupStepMigrate(ctx, cmd, dag)
+			if err != nil {
 				return fmt.Errorf("step 2 (migrate): %w", err)
 			}
 			recs, install, err = planRecommend(ctx, cmd, dag)
@@ -86,16 +89,28 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		// Session 2: install in a fresh session, which re-detects the workspace
-		// migrated in session 1 as native.
-		if install && len(recs) > 0 {
+		// Session 2: a fresh session re-detects the workspace migrated in
+		// session 1 as native. Resolve any SDK that migration recorded by short
+		// name to its real ref (sdks.json), then install accepted recommendations.
+		needInstall := install && len(recs) > 0
+		if migrated || needInstall {
 			sess, closeSess, err := connect(ctx)
 			if err != nil {
 				return err
 			}
 			defer closeSess()
-			if err := installRecommended(ctx, cmd, sess.Dagger(), recs); err != nil {
-				return fmt.Errorf("step 3 (install): %w", err)
+			dag := sess.Dagger()
+			// Only a migration writes SDK installs by short name, so scope the
+			// resolution to that case — never rewrite an already-native config.
+			if migrated {
+				if err := setupResolveMigratedSDKs(ctx, cmd, dag); err != nil {
+					return fmt.Errorf("step 2 (resolve SDKs): %w", err)
+				}
+			}
+			if needInstall {
+				if err := installRecommended(ctx, cmd, dag, recs); err != nil {
+					return fmt.Errorf("step 3 (install): %w", err)
+				}
 			}
 		}
 
@@ -131,7 +146,9 @@ func setupStepLogin(cmd *cobra.Command) error {
 
 // --- Step 2: Migrate ---
 
-func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) error {
+// setupStepMigrate reports whether a migration was needed (and thus a fresh
+// session should resolve SDKs migration may have recorded by short name).
+func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (bool, error) {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "\nStep 2: Workspace migration")
 
@@ -141,27 +158,60 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 
 	changesID, err := changes.ID(ctx)
 	if err != nil {
-		return fmt.Errorf("compute migration: %w", err)
+		return false, fmt.Errorf("compute migration: %w", err)
 	}
 	changes = dagger.Ref[*dagger.Changeset](dag, changesID)
 
 	isEmpty, err := changes.IsEmpty(ctx)
 	if err != nil {
-		return fmt.Errorf("check migration: %w", err)
+		return false, fmt.Errorf("check migration: %w", err)
 	}
 	if isEmpty {
 		fmt.Fprintln(out, "  No migration needed.")
-		return nil
+		return false, nil
 	}
 
 	exportPath, err := currentWorkspaceExportPath(ctx, ws)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// handleChangesetResponseAt owns the apply prompt via a huh form when
 	// autoApply is false — we don't run our own confirm() here, otherwise
 	// the user would face two prompts back-to-back for the same action.
-	return handleChangesetResponseAt(ctx, dag, changes, autoApply, exportPath)
+	if err := handleChangesetResponseAt(ctx, dag, changes, autoApply, exportPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// setupResolveMigratedSDKs rewrites SDK installs that migration recorded by bare
+// short name (e.g. `php`) to their real ref and canonical name from sdks.json,
+// so the SDK is loadable for authoring (`dagger module init <sdk>`) instead of
+// being treated as a local path. Runs in a post-migration session where the
+// workspace is native; a no-op when nothing was recorded by short name (and
+// when the user declined migration, leaving the legacy config in place).
+func setupResolveMigratedSDKs(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) error {
+	ws := dag.CurrentWorkspace()
+	raw, err := ws.ConfigRead(ctx)
+	if err != nil {
+		return err
+	}
+	cfg, err := workspace.ParseConfig([]byte(raw))
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	for _, fix := range planMigratedSDKFixups(cfg) {
+		if _, err := ws.ConfigWrite(ctx, "modules."+fix.ModuleName+".source", fix.Ref); err != nil {
+			return fmt.Errorf("set %s SDK source: %w", fix.SDKName, err)
+		}
+		if _, err := ws.ConfigWrite(ctx, "modules."+fix.ModuleName+".as-sdk.name", fix.SDKName); err != nil {
+			return fmt.Errorf("set %s SDK name: %w", fix.SDKName, err)
+		}
+		fmt.Fprintf(out, "  Resolved SDK %q to %s\n", fix.SDKName, fix.Ref)
+	}
+	return nil
 }
 
 // --- Step 3: Recommend modules ---


### PR DESCRIPTION
Two commits, about installing/migrating module SDKs correctly during `dagger sdk install` and `dagger setup`.

### `refactor(sdk): extract builtin SDK list into core/sdk/sdkmeta`
The set of SDK runtime short names bundled in the engine was hard-coded as `validInbuiltSDKs` in `core/sdk`. `core/workspace` needs the same list but cannot import `core/sdk` (import cycle), so the list is moved into a new dependency-free leaf package, `core/sdk/sdkmeta`, consumed by both. This package also holds the shared `dagger-` install-name prefix described below.

### `fix(setup): install module SDKs correctly when migrating`
When a legacy `dagger.json` declares its SDK by short name (e.g. `php`), migration recorded the workspace SDK install keyed by that bare runtime name, with a bare source and no as-sdk name. Two problems:

- The bare key (e.g. `go`) collides with an unrelated module legitimately named `go`: the SDK block reuses that entry and stamps an as-sdk marker on it.
- The authoring commands treat a bare source as a local path (`IsLocalRef`), so `dagger module init <sdk>` fails to load the SDK.

After migrating, `dagger setup` resolves each short-name SDK install through the embedded `sdks.json` registry to its real ref and canonical name (e.g. `php` → `github.com/dagger/php-sdk`, name `php`) and records them, so the SDK is loadable for authoring. A builtin version suffix (e.g. `php@v0.18`) is preserved.

### The `dagger-` install-name prefix
Installing an SDK adds a workspace module entry to `dagger.toml`, and that entry's name must not clobber — or be clobbered by — an unrelated module, toolchain, or SDK the user already has. Because SDK repos are conventionally named `<lang>-sdk` (e.g. `go-sdk`), a bare install name like `go-sdk` is plausible enough to collide with something the user authored.

To minimize that, every **known/built-in** SDK install name is now prefixed with `dagger-`, applied consistently across every path that installs one:

- `dagger sdk install go` → module `dagger-go-sdk`
- `dagger setup` migration of a legacy `sdk` field → `dagger-go-sdk`
- the runtime module installed for plain / sdk-only modules during migration → `dagger-go-sdk`

Only the workspace install **name** changes. The SDK's source ref (`github.com/dagger/go-sdk`) and its user-facing `as-sdk` name (`go`) are unchanged, so `dagger module init go` still works. External / custom full-ref SDKs are left untouched (they aren't built-in, so they keep their existing basename). If a `dagger-`-prefixed name is somehow still taken, installation falls back to a distinct, non-colliding name rather than overwriting the existing entry.

Example migrated `dagger.toml`:

```toml
[modules.dagger-go-sdk]
source = "github.com/dagger/go-sdk"

[modules.dagger-go-sdk.as-sdk]
name = "go"
```
