### PR TITLE
docs: remove generated TypeScript SDK reference

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -10,7 +10,6 @@
 versioned_docs/version-zenith/developer/typescript/reference/*
 versioned_docs/version-zenith/reference/typescript/*
 current_docs/sdk/nodejs/reference/*
-current_docs/reference/typescript/*
 static/guides.json
 
 # Misc

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -189,35 +189,6 @@ const config: Config = {
         enableInDevelopment: true, // Enable tracking in development
       },
     ],
-    [
-      "docusaurus-plugin-typedoc",
-      {
-        id: "current-generation",
-        plugin: ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
-        entryPoints: [
-          "../sdk/typescript/src/connect.ts",
-          "../sdk/typescript/src/api/client.gen.ts",
-          "../sdk/typescript/src/common/errors/index.ts",
-        ],
-        tsconfig: "../sdk/typescript/tsconfig.json",
-        out: "current_docs/reference/typescript/",
-        excludeProtected: true,
-        exclude: "../sdk/typescript/node_modules/**",
-        skipErrorChecking: true,
-        disableSources: true,
-        sanitizeComments: true,
-        frontmatterGlobals: {
-          displayed_sidebar: "current",
-          sidebar_label: "TypeScript SDK Reference",
-          title: "TypeScript SDK Reference",
-        },
-        textContentMappings: {
-          "title.indexPage": "TypeScript SDK Reference",
-          "footer.text": "",
-        },
-        requiredToBeDocumented: ["Class"],
-      },
-    ],
   ],
   themes: ["@docusaurus/theme-mermaid"],
   themeConfig: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,6 @@
     "clsx": "^2.1.1",
     "docusaurus-plugin-image-zoom": "^3.0.1",
     "docusaurus-plugin-sass": "^0.2.6",
-    "docusaurus-plugin-typedoc": "^1.4.2",
     "graphql": "^16",
     "posthog-docusaurus": "^2.0.5",
     "posthog-js": "^1.364.7",
@@ -41,9 +40,6 @@
     "react-dom": "^19.2.4",
     "remark-code-import": "^1.2.0",
     "sass": "^1.99.0",
-    "typedoc": "^0.28.18",
-    "typedoc-plugin-frontmatter": "^1.3.1",
-    "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "^6.0.2",
     "unist-util-visit": "^5.1.0"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2032,17 +2032,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@gerrit0/mini-shiki@^3.23.0":
-  version "3.23.0"
-  resolved "https://registry.yarnpkg.com/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz#d9414f3080b88303b18f3a311846e37e424d800c"
-  integrity sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==
-  dependencies:
-    "@shikijs/engine-oniguruma" "^3.23.0"
-    "@shikijs/langs" "^3.23.0"
-    "@shikijs/themes" "^3.23.0"
-    "@shikijs/types" "^3.23.0"
-    "@shikijs/vscode-textmate" "^10.0.2"
-
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz"
@@ -2660,41 +2649,6 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz#3cfdafeed01078e116bd4f191b684c8b484de425"
   integrity sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==
-
-"@shikijs/engine-oniguruma@^3.23.0":
-  version "3.23.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz#789421048d66ac1b33613169d6d18b9cc6e340ed"
-  integrity sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==
-  dependencies:
-    "@shikijs/types" "3.23.0"
-    "@shikijs/vscode-textmate" "^10.0.2"
-
-"@shikijs/langs@^3.23.0":
-  version "3.23.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-3.23.0.tgz#00959d8b16c7f671221ae79b3ad8cde7e6a5c112"
-  integrity sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==
-  dependencies:
-    "@shikijs/types" "3.23.0"
-
-"@shikijs/themes@^3.23.0":
-  version "3.23.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-3.23.0.tgz#fd96ca5ad52639057995bc2093682884e1846f27"
-  integrity sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==
-  dependencies:
-    "@shikijs/types" "3.23.0"
-
-"@shikijs/types@3.23.0", "@shikijs/types@^3.23.0":
-  version "3.23.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-3.23.0.tgz#d441571a058641926018ae3de99866f39e5bbdf2"
-  integrity sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==
-  dependencies:
-    "@shikijs/vscode-textmate" "^10.0.2"
-    "@types/hast" "^3.0.4"
-
-"@shikijs/vscode-textmate@^10.0.2":
-  version "10.0.2"
-  resolved "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz"
-  integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
 
 "@sideway/address@^4.1.5":
   version "4.1.5"
@@ -3345,7 +3299,7 @@
   resolved "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz"
   integrity sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==
 
-"@types/hast@^3.0.0", "@types/hast@^3.0.4":
+"@types/hast@^3.0.0":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz"
   integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
@@ -4067,13 +4021,6 @@ brace-expansion@^5.0.2:
   version "5.0.4"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz"
   integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
-  dependencies:
-    balanced-match "^4.0.2"
-
-brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -5271,13 +5218,6 @@ docusaurus-plugin-sass@^0.2.6:
   integrity sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==
   dependencies:
     sass-loader "^16.0.2"
-
-docusaurus-plugin-typedoc@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-1.4.2.tgz"
-  integrity sha512-1qerRejLSYxEWdyVPLDMMeKFPLA/37yZAsdwJy9ThHFQR78+v3b5spSbk67VHGLr2mAn4FVHu0aGJ6p7iWotSg==
-  dependencies:
-    typedoc-docusaurus-theme "^1.4.0"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -7105,17 +7045,12 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lunr@^2.3.9:
-  version "2.3.9"
-  resolved "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz"
-  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
-
 markdown-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz"
   integrity sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==
 
-markdown-it@^14.1.1, markdown-it@~14.1.1:
+markdown-it@~14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.1.tgz#856f90b66fc39ae70affd25c1b18b581d7deee1f"
   integrity sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==
@@ -8013,13 +7948,6 @@ minimatch@3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^10.2.5:
-  version "10.2.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
-  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
-  dependencies:
-    brace-expansion "^5.0.5"
 
 minimatch@~10.2.4:
   version "10.2.4"
@@ -10457,34 +10385,6 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedoc-docusaurus-theme@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/typedoc-docusaurus-theme/-/typedoc-docusaurus-theme-1.4.0.tgz"
-  integrity sha512-L8etzGUfGv1nxcdzw/s/0MUgfiIetTMttdqCY2ZpTnK26pDB8GsBi+9hHwl8cgDrMz+FF+mIyPKNDKhqDeGvTA==
-
-typedoc-plugin-frontmatter@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/typedoc-plugin-frontmatter/-/typedoc-plugin-frontmatter-1.3.1.tgz"
-  integrity sha512-wXKnhpiOuG3lY9GGKiKcXNrhKbPYm/jA5wbzGE/kKdwlSu8++ZbEuKA0K2dvIna3F+5EQrv+3AeObHkS1QP7JA==
-  dependencies:
-    yaml "^2.8.1"
-
-typedoc-plugin-markdown@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz#57c29b0aeec2eba41e995670591de63bcf645b80"
-  integrity sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==
-
-typedoc@^0.28.18:
-  version "0.28.19"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.28.19.tgz#0940c6b98eafae27cba71e57855d593f88a80649"
-  integrity sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==
-  dependencies:
-    "@gerrit0/mini-shiki" "^3.23.0"
-    lunr "^2.3.9"
-    markdown-it "^14.1.1"
-    minimatch "^10.2.5"
-    yaml "^2.8.3"
-
 typescript@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
@@ -11072,16 +10972,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yaml@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz"
-  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
-
-yaml@^2.8.3:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
-  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yocto-queue@^1.0.0:
   version "1.2.1"


### PR DESCRIPTION
The `docusaurus-plugin-typedoc` plugin baked an auto-generated TypeScript SDK API reference into the Docusaurus site, where its pages were indexed alongside the hand-written docs and competed with them for search priority. Now that the docs have a first-class API reference, this drops the plugin and its `typedoc` dependencies so the reference is no longer generated for the current docs.

## What changed
- Removed the `docusaurus-plugin-typedoc` plugin block from `docusaurus.config.ts`.
- Dropped `docusaurus-plugin-typedoc`, `typedoc`, `typedoc-plugin-markdown`, and `typedoc-plugin-frontmatter` from `package.json` and regenerated `yarn.lock`.
- Removed the now-unused `current_docs/reference/typescript/*` entry from `.gitignore`.

## Scope notes
- Only TypeScript was baked into Docusaurus. The PHP (doctum) reference is a standalone static HTML site under `static/reference/php`, and the Python reference is hosted externally on ReadTheDocs — neither is a Docusaurus page competing for search priority, so both are left as-is.
- Released versions are unaffected: the 0.21.4 TypeScript reference is committed under `versioned_docs/` and the `/reference/typescript/...` redirect is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
