### PR TITLE
docs: replace Algolia with client-side search

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -14,6 +14,14 @@ const docsPath = "./current_docs";
 const baseUrl = process.env.DOCUSAURUS_BASE_URL ?? "/";
 const latestVersion = "0.21.4";
 const versions = require("./versions.json") as string[];
+// Local search only indexes the default version (served at the root). Keep the
+// auto-generated SDK reference and every non-default version out of the index.
+const localSearchExclude = [
+  "/reference/typescript/",
+  ...versions
+    .filter((v) => v !== latestVersion)
+    .map((v) => `${baseUrl}${v}/`),
+];
 const versionLabels: Record<string, string> = {};
 const versionSelectOptions = [
   ...versions.map((version) => ({
@@ -181,6 +189,10 @@ const config: Config = {
     // Parses docs-graphql/schema.graphqls into the model rendered by the
     // API reference components on the type reference pages.
     daggerApiReference,
+    // Builds a client-side search index over the current docs version. Pairs
+    // with the swizzled SearchBar (src/theme/SearchBar) for a local,
+    // command-palette search that needs no external service.
+    ["./plugins/local-search", { exclude: localSearchExclude }],
     [
       "posthog-docusaurus",
       {
@@ -312,11 +324,6 @@ const config: Config = {
           className: "header-searchbar",
         },
       ],
-    },
-    algolia: {
-      apiKey: "bffda1490c07dcce81a26a144115cc02",
-      indexName: "dagger",
-      appId: "XEIYPBWGOI",
     },
     colorMode: {
       defaultMode: "light",

--- a/docs/package.json
+++ b/docs/package.json
@@ -52,6 +52,7 @@
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.5.2",
     "@types/node": "^25.5",
+    "cheerio": "^1.0.0",
     "markdownlint-cli": "^0.48.0"
   },
   "browserslist": {

--- a/docs/plugins/local-search/index.js
+++ b/docs/plugins/local-search/index.js
@@ -1,0 +1,126 @@
+// Local, client-side docs search — no external service.
+//
+// At build time this walks the rendered HTML of the *current* (default) docs
+// version and emits a flat `search_index.json` of section-level entries. The
+// search UI (src/theme/SearchBar) fetches that index lazily on first open and
+// does all matching in the browser, so every keystroke is an in-memory lookup
+// with zero network round-trips.
+//
+// Modeled on the pure-client-side search in github.com/vito/dang.
+
+const fs = require("fs");
+const path = require("path");
+const cheerio = require("cheerio");
+
+// Cap per-section body text so the index stays small and fast to ship. This is
+// plenty for matching and for building a centered snippet.
+const MAX_TEXT = 2000;
+
+// Title-case a URL path segment: "type-system" -> "Type System".
+function humanize(segment) {
+  return segment
+    .split("-")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+// Build a breadcrumb-ish label from a route's parent path, e.g.
+// "/extending/type-system/" -> "Extending › Type System".
+function crumbFromRoute(rel) {
+  const parts = rel.replace(/^\/|\/$/g, "").split("/").filter(Boolean);
+  parts.pop(); // drop the page's own segment
+  return parts.map(humanize).join(" › ");
+}
+
+function collapse(text) {
+  return (text || "").replace(/\s+/g, " ").trim();
+}
+
+module.exports = function localSearchPlugin(context, options) {
+  const indexFileName = (options && options.indexFileName) || "search_index.json";
+  const baseUrl = context.baseUrl || "/";
+  // Routes whose path contains any of these are kept out of the index. The
+  // auto-generated per-SDK reference is excluded so it doesn't dominate search.
+  const exclude = (options && options.exclude) || ["/reference/typescript/"];
+
+  return {
+    name: "local-search",
+
+    async postBuild({ outDir, routesPaths }) {
+      const nextPrefix = baseUrl + "next/";
+      const entries = [];
+
+      for (const route of routesPaths) {
+        if (!route.startsWith(baseUrl)) continue;
+        // Only index the current/default version (served at the root). The
+        // unreleased "next" docs and old versions are intentionally excluded.
+        if (route.startsWith(nextPrefix)) continue;
+        if (exclude.some((frag) => route.includes(frag))) continue;
+
+        const rel = "/" + route.slice(baseUrl.length); // normalize to "/foo/"
+        const htmlFile = path.join(outDir, route.slice(baseUrl.length), "index.html");
+        if (!fs.existsSync(htmlFile)) continue;
+
+        const $ = cheerio.load(fs.readFileSync(htmlFile, "utf8"));
+        const article = $("article");
+        const root = article.find(".theme-doc-markdown").first();
+        // Skip non-doc pages (no rendered markdown container).
+        if (!root.length) continue;
+
+        const pageTitle = collapse(
+          root.find("h1").first().text() || $("title").first().text().split("|")[0],
+        );
+        if (!pageTitle) continue;
+
+        // Split the page into sections at each h2/h3 so results land on the
+        // right anchor. Text before the first heading becomes the page entry.
+        const sections = [];
+        let cur = { id: null, title: pageTitle, parts: [] };
+        root.children().each((_, el) => {
+          const tag = (el.tagName || "").toLowerCase();
+          if (tag === "h2" || tag === "h3") {
+            sections.push(cur);
+            const h = $(el);
+            const id = h.attr("id") || null;
+            const title = collapse(h.clone().find(".hash-link").remove().end().text());
+            cur = { id, title: title || pageTitle, parts: [] };
+          } else {
+            const txt = $(el).text();
+            if (txt) cur.parts.push(txt);
+          }
+        });
+        sections.push(cur);
+
+        const pageCrumb = crumbFromRoute(rel);
+        for (const s of sections) {
+          const text = collapse(s.parts.join(" ")).slice(0, MAX_TEXT);
+          if (!s.id) {
+            // Page-level entry; skip an empty intro when the page has sections.
+            if (!text && sections.length > 1) continue;
+            entries.push({
+              title: pageTitle,
+              crumb: pageCrumb,
+              location: route,
+              text,
+            });
+          } else {
+            if (!text && !s.title) continue;
+            entries.push({
+              title: s.title,
+              crumb: pageTitle,
+              location: route + "#" + s.id,
+              text,
+            });
+          }
+        }
+      }
+
+      fs.writeFileSync(
+        path.join(outDir, indexFileName),
+        JSON.stringify(entries),
+      );
+      console.log(`[local-search] indexed ${entries.length} sections -> ${indexFileName}`);
+    },
+  };
+};

--- a/docs/plugins/local-search/index.js
+++ b/docs/plugins/local-search/index.js
@@ -53,10 +53,11 @@ module.exports = function localSearchPlugin(context, options) {
 
       for (const route of routesPaths) {
         if (!route.startsWith(baseUrl)) continue;
-        // Only index the current/default version (served at the root). The
-        // unreleased "next" docs and old versions are intentionally excluded.
-        if (route.startsWith(nextPrefix)) continue;
+        // Index the default version (served at the root) and the unreleased
+        // "next" version, tagging each entry so the UI can scope results to
+        // whichever version the reader is on. Old versions stay out (excluded).
         if (exclude.some((frag) => route.includes(frag))) continue;
+        const version = route.startsWith(nextPrefix) ? "next" : "";
 
         const rel = "/" + route.slice(baseUrl.length); // normalize to "/foo/"
         const htmlFile = path.join(outDir, route.slice(baseUrl.length), "index.html");
@@ -92,13 +93,15 @@ module.exports = function localSearchPlugin(context, options) {
         });
         sections.push(cur);
 
-        const pageCrumb = crumbFromRoute(rel);
+        // Drop the version segment from next-version crumbs ("Next › …").
+        const pageCrumb = crumbFromRoute(version ? rel.replace(/^\/next/, "") : rel);
         for (const s of sections) {
           const text = collapse(s.parts.join(" ")).slice(0, MAX_TEXT);
           if (!s.id) {
             // Page-level entry; skip an empty intro when the page has sections.
             if (!text && sections.length > 1) continue;
             entries.push({
+              version,
               title: pageTitle,
               crumb: pageCrumb,
               location: route,
@@ -107,6 +110,7 @@ module.exports = function localSearchPlugin(context, options) {
           } else {
             if (!text && !s.title) continue;
             entries.push({
+              version,
               title: s.title,
               crumb: pageTitle,
               location: route + "#" + s.id,
@@ -116,11 +120,19 @@ module.exports = function localSearchPlugin(context, options) {
         }
       }
 
+      const byVersion = entries.reduce((acc, e) => {
+        const k = e.version || "default";
+        acc[k] = (acc[k] || 0) + 1;
+        return acc;
+      }, {});
       fs.writeFileSync(
         path.join(outDir, indexFileName),
         JSON.stringify(entries),
       );
-      console.log(`[local-search] indexed ${entries.length} sections -> ${indexFileName}`);
+      console.log(
+        `[local-search] indexed ${entries.length} sections ` +
+          `(${JSON.stringify(byVersion)}) -> ${indexFileName}`,
+      );
     },
   };
 };

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -1050,80 +1050,12 @@ html[data-theme="dark"] .language-shell > div:nth-child(1) {
   padding-bottom: 0 !important;
 }
 
-// DocSearch button styling to match background color in both themes
-html[data-theme="light"] .DocSearch.DocSearch-Button {
-  background-color: var(--color-white) !important;
-  border: none !important;
-  box-shadow: none !important;
-  border-radius: 8px !important; /* Match Dagger Cloud button radius */
-  height: 36px !important; /* Match navbar links height */
-  padding: 0 0.75rem !important; /* Adjusted padding for consistent height */
-
-  &:hover {
-    background-color: var(--color-backgroundSecondary) !important;
-  }
-}
-
-html[data-theme="dark"] .DocSearch.DocSearch-Button {
-  background-color: var(--color-gray-900) !important;
-  border: none !important;
-  border-radius: 8px !important; /* Match Dagger Cloud button radius */
-  height: 36px !important; /* Match navbar links height */
-  padding: 0 0.75rem !important; /* Adjusted padding for consistent height */
-
-  &:hover {
-    background-color: var(--color-gray-800) !important;
-  }
-
-  @include mobile {
-    background-color: var(--color-purple-800) !important; /* Match announcement bar color in dark mode */
-  }
-}
-
 /* Dark mode toggle button consistent height */
 .navbar__item--right .react-toggle,
 .navbar__item--right .navbar__toggle {
   height: 36px !important;
   display: flex !important;
   align-items: center !important;
-}
-
-// Use mobile-style search (magnifying glass only) on tablet screens
-@include tablet {
-  .DocSearch-Button {
-    width: 48px !important;
-    min-width: 48px !important;
-    padding: 0 !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-
-    .DocSearch-Button-Container {
-      justify-content: center !important;
-      align-items: center !important;
-      display: flex !important;
-    }
-
-    .DocSearch-Search-Icon {
-      width: 20px !important;
-      height: 20px !important;
-      margin: 0 !important;
-    }
-
-    .DocSearch-Button-Placeholder,
-    .DocSearch-Button-Keys {
-      display: none !important;
-    }
-  }
-
-  // Apply mobile hover effect for dark theme on tablet
-  html[data-theme="dark"] .DocSearch.DocSearch-Button {
-    background-color: var(--color-purple-800) !important;
-
-    &:hover {
-      background-color: var(--color-purple-700) !important;
-    }
-  }
 }
 
 @include desktop {
@@ -1136,27 +1068,6 @@ html[data-theme="dark"] .DocSearch.DocSearch-Button {
     margin-top: 0.75rem;
     min-width: 0;
     width: 100%;
-
-    .DocSearch.DocSearch-Button {
-      flex-grow: 1 !important;
-      max-width: 100% !important;
-      min-width: 0 !important;
-      justify-content: space-between !important;
-      padding: 0 0.75rem !important;
-      width: auto !important;
-    }
-
-    .DocSearch-Button-Container {
-      min-width: 0 !important;
-    }
-
-    .DocSearch-Button-Placeholder {
-      display: inline !important;
-    }
-
-    .DocSearch-Button-Keys {
-      display: flex !important;
-    }
   }
 }
 

--- a/docs/src/theme/SearchBar/index.tsx
+++ b/docs/src/theme/SearchBar/index.tsx
@@ -1,0 +1,327 @@
+// Pure client-side docs search, modeled on github.com/vito/dang.
+//
+// A command-palette overlay (Cmd/Ctrl+K, or click the navbar button) searches
+// a small JSON index — generated at build time by plugins/local-search — fully
+// in the browser. The index is fetched lazily on first open, so it costs
+// nothing on initial page load, and every keystroke is an in-memory lookup.
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {createPortal} from "react-dom";
+import {useHistory} from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import useIsBrowser from "@docusaurus/useIsBrowser";
+
+import styles from "./styles.module.css";
+
+type Entry = {
+  title: string;
+  crumb: string;
+  location: string;
+  text: string;
+  haystack: string;
+};
+
+type Scored = {entry: Entry; score: number; terms: string[]};
+
+const MAX_RESULTS = 30;
+
+// Fetch-once cache, shared across mounts so reopening is instant.
+let cachedEntries: Entry[] | null = null;
+let inflight: Promise<Entry[]> | null = null;
+
+function loadIndex(url: string): Promise<Entry[]> {
+  if (cachedEntries) return Promise.resolve(cachedEntries);
+  if (inflight) return inflight;
+  inflight = fetch(url)
+    .then((r) => {
+      if (!r.ok) throw new Error("failed to load search index");
+      return r.json();
+    })
+    .then((data: Omit<Entry, "haystack">[]) => {
+      cachedEntries = data.map((e) => ({
+        ...e,
+        haystack: (`${e.title || ""} ${e.text || ""}`).toLowerCase(),
+      }));
+      return cachedEntries;
+    })
+    .catch((err) => {
+      inflight = null; // allow retry on next open
+      throw err;
+    });
+  return inflight;
+}
+
+function search(query: string, entries: Entry[]): Scored[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (!terms.length) return [];
+  const scored: Scored[] = [];
+  for (const entry of entries) {
+    let ok = true;
+    let score = 0;
+    const title = entry.title.toLowerCase();
+    for (const term of terms) {
+      if (entry.haystack.indexOf(term) === -1) {
+        ok = false;
+        break;
+      }
+      const ti = title.indexOf(term);
+      if (ti === 0) score += 12;
+      else if (ti > 0) score += 6;
+      else score += 1;
+    }
+    if (ok) scored.push({entry, score, terms});
+  }
+  scored.sort(
+    (a, b) => b.score - a.score || a.entry.title.length - b.entry.title.length,
+  );
+  return scored.slice(0, MAX_RESULTS);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"]/g,
+    (c) => ({"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;"})[c]!,
+  );
+}
+
+// Wrap every term occurrence in an already-escaped string with <mark>.
+function highlight(escaped: string, terms: string[]): string {
+  let out = escaped;
+  for (const term of terms) {
+    const re = new RegExp(
+      `(${term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+      "ig",
+    );
+    out = out.replace(re, "\u0000$1\u0001");
+  }
+  return out.split("\u0000").join("<mark>").split("\u0001").join("</mark>");
+}
+
+// A snippet centered on the first matching term.
+function snippet(text: string, terms: string[]): string {
+  const lower = text.toLowerCase();
+  let at = -1;
+  for (const term of terms) {
+    const idx = lower.indexOf(term);
+    if (idx !== -1 && (at === -1 || idx < at)) at = idx;
+  }
+  if (at === -1) return text.slice(0, 140);
+  const start = Math.max(0, at - 50);
+  const end = Math.min(text.length, at + 110);
+  return (
+    (start > 0 ? "…" : "") +
+    text.slice(start, end) +
+    (end < text.length ? "…" : "")
+  );
+}
+
+export default function SearchBar(): JSX.Element {
+  const history = useHistory();
+  const indexUrl = useBaseUrl("/search_index.json");
+  const isBrowser = useIsBrowser();
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [entries, setEntries] = useState<Entry[] | null>(cachedEntries);
+  const [error, setError] = useState(false);
+  const [active, setActive] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLUListElement>(null);
+
+  const isMac =
+    isBrowser && /Mac|iPhone|iPad/.test(navigator.platform || "");
+
+  const results = useMemo(
+    () => (entries && query ? search(query, entries) : []),
+    [entries, query],
+  );
+
+  // Load index + focus input whenever the palette opens.
+  useEffect(() => {
+    if (!open) return;
+    setError(false);
+    loadIndex(indexUrl).then(setEntries).catch(() => setError(true));
+    const id = window.requestAnimationFrame(() => inputRef.current?.focus());
+    return () => window.cancelAnimationFrame(id);
+  }, [open, indexUrl]);
+
+  // Reset the highlighted row when the result set changes.
+  useEffect(() => setActive(0), [results]);
+
+  // Global Cmd/Ctrl+K to toggle, Escape to close.
+  useEffect(() => {
+    function onKey(ev: KeyboardEvent) {
+      if ((ev.ctrlKey || ev.metaKey) && (ev.key === "k" || ev.key === "K")) {
+        ev.preventDefault();
+        setOpen((o) => !o);
+      } else if (ev.key === "Escape") {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  const move = useCallback(
+    (delta: number) => {
+      setActive((a) => {
+        if (!results.length) return 0;
+        const next = (a + delta + results.length) % results.length;
+        const el = resultsRef.current?.children[next] as HTMLElement | undefined;
+        el?.scrollIntoView({block: "nearest"});
+        return next;
+      });
+    },
+    [results.length],
+  );
+
+  const go = useCallback(
+    (idx: number) => {
+      const hit = results[idx];
+      if (!hit) return;
+      setOpen(false);
+      history.push(hit.entry.location);
+    },
+    [results, history],
+  );
+
+  const onInputKeyDown = useCallback(
+    (ev: React.KeyboardEvent) => {
+      if (ev.key === "ArrowDown") {
+        ev.preventDefault();
+        move(1);
+      } else if (ev.key === "ArrowUp") {
+        ev.preventDefault();
+        move(-1);
+      } else if (ev.key === "Enter") {
+        ev.preventDefault();
+        go(active);
+      } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        setOpen(false);
+      }
+    },
+    [move, go, active],
+  );
+
+  const trigger = (
+    <button
+      type="button"
+      className={styles.trigger}
+      aria-label="Search docs"
+      onClick={() => setOpen(true)}
+    >
+      <svg width="15" height="15" viewBox="0 0 20 20" aria-hidden="true">
+        <path
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          d="M8.5 3a5.5 5.5 0 1 0 3.5 9.74l4.13 4.13M8.5 3a5.5 5.5 0 0 1 4.3 8.93"
+        />
+      </svg>
+      <span className={styles.triggerLabel}>Search</span>
+      <span className={styles.kbd}>{isMac ? "⌘K" : "Ctrl K"}</span>
+    </button>
+  );
+
+  const overlay =
+    open && isBrowser
+      ? createPortal(
+          <div
+            className={styles.overlay}
+            onMouseDown={(ev) => {
+              if (ev.target === ev.currentTarget) setOpen(false);
+            }}
+          >
+            <div
+              className={styles.box}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Search docs"
+            >
+              <input
+                ref={inputRef}
+                className={styles.input}
+                type="text"
+                placeholder="Search the docs…"
+                autoComplete="off"
+                spellCheck={false}
+                aria-label="Search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={onInputKeyDown}
+              />
+              <ul className={styles.results} ref={resultsRef}>
+                {error ? (
+                  <li className={styles.message}>
+                    Couldn’t load the search index.
+                  </li>
+                ) : !query ? null : !results.length ? (
+                  <li className={styles.message}>
+                    No results for “{query}”
+                  </li>
+                ) : (
+                  results.map((r, i) => (
+                    <li
+                      key={r.entry.location}
+                      className={i === active ? styles.active : undefined}
+                    >
+                      <a
+                        href={r.entry.location}
+                        onMouseEnter={() => setActive(i)}
+                        onClick={(ev) => {
+                          ev.preventDefault();
+                          go(i);
+                        }}
+                      >
+                        {r.entry.crumb ? (
+                          <span className={styles.crumb}>{r.entry.crumb}</span>
+                        ) : null}
+                        <span
+                          className={styles.title}
+                          // eslint-disable-next-line react/no-danger
+                          dangerouslySetInnerHTML={{
+                            __html: highlight(
+                              escapeHtml(r.entry.title),
+                              r.terms,
+                            ),
+                          }}
+                        />
+                        {r.entry.text ? (
+                          <span
+                            className={styles.snippet}
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                              __html: highlight(
+                                escapeHtml(snippet(r.entry.text, r.terms)),
+                                r.terms,
+                              ),
+                            }}
+                          />
+                        ) : null}
+                      </a>
+                    </li>
+                  ))
+                )}
+              </ul>
+            </div>
+          </div>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <>
+      {trigger}
+      {overlay}
+    </>
+  );
+}

--- a/docs/src/theme/SearchBar/index.tsx
+++ b/docs/src/theme/SearchBar/index.tsx
@@ -13,13 +13,14 @@ import React, {
   useState,
 } from "react";
 import {createPortal} from "react-dom";
-import {useHistory} from "@docusaurus/router";
+import {useHistory, useLocation} from "@docusaurus/router";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 
 import styles from "./styles.module.css";
 
 type Entry = {
+  version: string; // "" for the default version, "next" for the unreleased docs
   title: string;
   crumb: string;
   location: string;
@@ -126,6 +127,15 @@ export default function SearchBar(): JSX.Element {
   const indexUrl = useBaseUrl("/search_index.json");
   const isBrowser = useIsBrowser();
 
+  // Scope results to the version the reader is currently on: "next" under the
+  // unreleased docs, otherwise the default version served at the root.
+  const {pathname} = useLocation();
+  const nextBase = useBaseUrl("/next/");
+  const vkey =
+    pathname === nextBase.slice(0, -1) || pathname.startsWith(nextBase)
+      ? "next"
+      : "";
+
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [entries, setEntries] = useState<Entry[] | null>(cachedEntries);
@@ -139,8 +149,14 @@ export default function SearchBar(): JSX.Element {
     isBrowser && /Mac|iPhone|iPad/.test(navigator.platform || "");
 
   const results = useMemo(
-    () => (entries && query ? search(query, entries) : []),
-    [entries, query],
+    () =>
+      entries && query
+        ? search(
+            query,
+            entries.filter((e) => (e.version || "") === vkey),
+          )
+        : [],
+    [entries, query, vkey],
   );
 
   // Load index + focus input whenever the palette opens.

--- a/docs/src/theme/SearchBar/index.tsx
+++ b/docs/src/theme/SearchBar/index.tsx
@@ -129,7 +129,8 @@ export default function SearchBar(): JSX.Element {
 
   // Scope results to the version the reader is currently on: "next" under the
   // unreleased docs, otherwise the default version served at the root.
-  const {pathname} = useLocation();
+  const location = useLocation();
+  const {pathname} = location;
   const nextBase = useBaseUrl("/next/");
   const vkey =
     pathname === nextBase.slice(0, -1) || pathname.startsWith(nextBase)
@@ -170,6 +171,12 @@ export default function SearchBar(): JSX.Element {
 
   // Reset the highlighted row when the result set changes.
   useEffect(() => setActive(0), [results]);
+
+  // Dismiss the palette on navigation, so picking a result closes it (covers
+  // SPA hash jumps where the click handler's state update might not flush).
+  useEffect(() => {
+    setOpen(false);
+  }, [location.pathname, location.hash]);
 
   // Global Cmd/Ctrl+K to toggle, Escape to close.
   useEffect(() => {

--- a/docs/src/theme/SearchBar/index.tsx
+++ b/docs/src/theme/SearchBar/index.tsx
@@ -178,6 +178,14 @@ export default function SearchBar(): JSX.Element {
     setOpen(false);
   }, [location.pathname, location.hash]);
 
+  // Clear the query when the palette closes, so it opens fresh next time.
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setActive(0);
+    }
+  }, [open]);
+
   // Global Cmd/Ctrl+K to toggle, Escape to close.
   useEffect(() => {
     function onKey(ev: KeyboardEvent) {

--- a/docs/src/theme/SearchBar/styles.module.css
+++ b/docs/src/theme/SearchBar/styles.module.css
@@ -49,9 +49,11 @@
   }
 }
 
-/* Full-width trigger when rendered inside the desktop sidebar. */
+/* Full-width, surface-colored trigger when rendered inside the desktop sidebar
+   (white in light mode) so it reads as a search input. */
 :global(.docs-sidebar-search) .trigger {
   width: 100%;
+  background: var(--ifm-background-surface-color);
 }
 
 :global(.docs-sidebar-search) .kbd {

--- a/docs/src/theme/SearchBar/styles.module.css
+++ b/docs/src/theme/SearchBar/styles.module.css
@@ -1,0 +1,171 @@
+/* Command-palette search, modeled on github.com/vito/dang, themed with the
+   site's Infima variables so it tracks light/dark automatically. */
+
+/* ---- navbar trigger ---------------------------------------------------- */
+
+.trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-content-secondary);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.trigger:hover {
+  color: var(--ifm-color-content);
+  border-color: var(--ifm-color-primary);
+}
+
+.triggerLabel {
+  margin-right: 0.25rem;
+}
+
+.kbd {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.7rem;
+  color: var(--ifm-color-content-secondary);
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 5px;
+  padding: 0.1rem 0.35rem;
+}
+
+@media (max-width: 996px) {
+  .triggerLabel,
+  .kbd {
+    display: none;
+  }
+
+  .trigger {
+    gap: 0;
+    padding: 0.4rem;
+  }
+}
+
+/* Full-width trigger when rendered inside the desktop sidebar. */
+:global(.docs-sidebar-search) .trigger {
+  width: 100%;
+}
+
+:global(.docs-sidebar-search) .kbd {
+  margin-left: auto;
+}
+
+/* ---- overlay ----------------------------------------------------------- */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--ifm-z-index-overlay, 400);
+  background: rgba(13, 12, 27, 0.55);
+  padding: 10vh 1rem 1rem;
+  overflow: hidden;
+  animation: fade 0.12s ease-out;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+}
+
+.box {
+  display: flex;
+  flex-direction: column;
+  max-width: 640px;
+  max-height: 70vh;
+  margin: 0 auto;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 16px 48px rgba(13, 12, 27, 0.4);
+}
+
+.input {
+  width: 100%;
+  padding: 0.95rem 1.1rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  color: var(--ifm-font-color-base);
+  font: inherit;
+  font-size: 1rem;
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--ifm-color-content-secondary);
+}
+
+/* ---- results ----------------------------------------------------------- */
+
+.results {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  overflow-y: auto;
+}
+
+.results li {
+  margin: 0;
+}
+
+.results a {
+  display: block;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+}
+
+.results a:hover,
+.active a {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.crumb {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.15rem;
+}
+
+.title {
+  display: block;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+.snippet {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: 0.15rem;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--ifm-color-content-secondary);
+}
+
+.results mark {
+  background: transparent;
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  padding: 0;
+}
+
+.message {
+  padding: 1.25rem;
+  text-align: center;
+  color: var(--ifm-color-content-secondary);
+  font-size: 0.85rem;
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4282,6 +4282,23 @@ cheerio@1.0.0-rc.12:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
+cheerio@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.2.0.tgz#f23b777c49021ead7475dcf3390d3535a7f896d6"
+  integrity sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    encoding-sniffer "^0.2.1"
+    htmlparser2 "^10.1.0"
+    parse5 "^7.3.0"
+    parse5-htmlparser2-tree-adapter "^7.1.0"
+    parse5-parser-stream "^7.1.2"
+    undici "^7.19.0"
+    whatwg-mimetype "^4.0.0"
+
 chevrotain-allstar@~0.3.0:
   version "0.3.1"
   resolved "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz"
@@ -5339,7 +5356,7 @@ domutils@^2.5.2, domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
-domutils@^3.0.1:
+domutils@^3.0.1, domutils@^3.2.2:
   version "3.2.2"
   resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
@@ -5432,6 +5449,14 @@ encodeurl@~2.0.0:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
+encoding-sniffer@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz#396ec97ac22ce5a037ba44af1992ac9d46a7b819"
+  integrity sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==
+  dependencies:
+    iconv-lite "^0.6.3"
+    whatwg-encoding "^3.1.1"
+
 enhanced-resolve@^5.17.2:
   version "5.18.2"
   resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz"
@@ -5454,6 +5479,11 @@ entities@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
   integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -6302,6 +6332,16 @@ html-webpack-plugin@^5.6.0:
     pretty-error "^4.0.0"
     tapable "^2.0.0"
 
+htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
 htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz"
@@ -6403,7 +6443,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.6:
+iconv-lite@0.6, iconv-lite@0.6.3, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -8354,7 +8394,7 @@ parse-numeric-range@^1.3.0:
   resolved "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz"
   integrity sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==
 
-parse5-htmlparser2-tree-adapter@^7.0.0:
+parse5-htmlparser2-tree-adapter@^7.0.0, parse5-htmlparser2-tree-adapter@^7.1.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz"
   integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
@@ -8362,7 +8402,14 @@ parse5-htmlparser2-tree-adapter@^7.0.0:
     domhandler "^5.0.3"
     parse5 "^7.0.0"
 
-parse5@^7.0.0:
+parse5-parser-stream@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz#d7c20eadc37968d272e2c02660fff92dd27e60e1"
+  integrity sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==
+  dependencies:
+    parse5 "^7.0.0"
+
+parse5@^7.0.0, parse5@^7.3.0:
   version "7.3.0"
   resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz"
   integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
@@ -10505,6 +10552,11 @@ undici-types@~7.18.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
+undici@^7.19.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz"
@@ -10991,6 +11043,18 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Why

Algolia DocSearch round-trips to a hosted API on every keystroke and lazy-loads its modal, so search reads as laggy. For a docs set this small it isn't worth an external service, a crawler config that lives in someone's Algolia dashboard, or the cross-version noise the hosted index surfaces.

## What

A pure client-side search, modeled on the one in [vito/dang](https://github.com/vito/dang):

- **`plugins/local-search`** — a build-time plugin that walks the rendered HTML of the **default** and **next** versions and emits a compact, section-level `search_index.json` (~1.5 MB raw, ~300 KB gzipped), fetched lazily on first open so it costs nothing on initial page load. Each entry is tagged with its version; old archived versions and the auto-generated SDK reference are left out.
- **`src/theme/SearchBar`** — a swizzled command palette (Cmd/Ctrl+K, or click the navbar / sidebar search button). It loads the index once and does all matching, ranking, snippeting, and highlighting in the browser, so every keystroke is an in-memory lookup with no network round-trip. Results are **scoped to whichever version you're viewing** (`next` under `/next/`, otherwise the default). Arrow keys + Enter navigate client-side, Esc closes.
- Removed the `algolia` themeConfig — which also unloads `@docusaurus/theme-search-algolia`, since the classic preset only includes it when configured — along with the now-dead `.DocSearch-*` styles.

## Notes

- Built locally; the index comes out to 1,920 sections (930 default + 990 next) / 1.47 MB.
- The index is generated at `postBuild`, so search runs on production builds — use the Netlify deploy preview to try the UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
