### PR TITLE
feat(cli): contextual next-step hints for authoring commands

### DIFF
--- a/core/integration/command_hints_test.go
+++ b/core/integration/command_hints_test.go
@@ -1,0 +1,69 @@
+package core
+
+// These tests cover the contextual next-step hints the CLI prints on the
+// success path of the authoring commands: `dagger setup` (empty workspace),
+// `dagger sdk install` (per SDK capability), and `dagger api client init`.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+type CommandHintsSuite struct{}
+
+func TestCommandHints(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(CommandHintsSuite{})
+}
+
+// TestEmptySetupHint verifies that `dagger setup` on a greenfield workspace
+// (nothing to migrate, no config) prints the get-started hint, writes no
+// dagger.toml, and that --silent suppresses the hint.
+func (CommandHintsSuite) TestEmptySetupHint(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+
+	out, err := hostDaggerExecRaw(ctx, t, workdir, "setup", "--auto-apply")
+	require.NoError(t, err, "%s", string(out))
+
+	got := string(out)
+	require.Contains(t, got, "nothing to migrate")
+	require.Contains(t, got, "dagger install <module>")
+	require.Contains(t, got, "dagger sdk install <sdk>")
+	require.Contains(t, got, "dagger module init <sdk> <name>")
+
+	_, statErr := os.Stat(filepath.Join(workdir, "dagger.toml"))
+	require.True(t, os.IsNotExist(statErr), "setup should not create dagger.toml on an empty workspace")
+
+	silentOut, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "setup", "--auto-apply")
+	require.NoError(t, err, "%s", string(silentOut))
+	require.NotContains(t, string(silentOut), "To get started")
+}
+
+// TestSDKInstallAndClientInitHints verifies that `dagger sdk install go` prints
+// a hint for each capability the go SDK has (it authors both modules and
+// clients), and that `dagger api client init` points the user at
+// `dagger generate` once the client is scaffolded.
+func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+
+	installOut, err := hostDaggerExecRaw(ctx, t, workdir, "sdk", "install", "go")
+	require.NoError(t, err, "%s", string(installOut))
+
+	got := string(installOut)
+	require.Contains(t, got, "This SDK can")
+	require.Contains(t, got, "dagger module init go")
+	require.Contains(t, got, "dagger api client init go")
+
+	_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+	require.NoError(t, err)
+
+	clientOut, err := hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "api", "client", "init", "go", "./myclient", ".dagger/modules/myapp")
+	require.NoError(t, err, "%s", string(clientOut))
+	require.Contains(t, string(clientOut), "dagger generate")
+}

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -81,9 +81,25 @@ func runAPIClientInitWithSDK(cmd *cobra.Command, sdkName, clientPath, moduleRef 
 			return err
 		}
 
-		return handleChangesetResponseAt(ctx, dag, changesetID, autoApply, exportPath)
+		applied, err := handleChangesetResponseAt(ctx, dag, changesetID, autoApply, exportPath)
+		if err != nil {
+			return err
+		}
+		if applied && !silent {
+			fmt.Fprint(cmd.OutOrStdout(), clientInitGenerateHint)
+		}
+		return nil
 	})
 }
+
+// clientInitGenerateHint points the user at the generate step: `api client
+// init` records and scaffolds the client, but its bindings are produced by
+// `dagger generate`.
+const clientInitGenerateHint = `
+  Client scaffolded. Generate its bindings with:
+
+      dagger generate
+`
 
 func callClientInit(
 	ctx context.Context,

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -919,29 +919,33 @@ func toChangeset(dag *dagger.Client, item any) (*dagger.Changeset, error) {
 	}
 }
 
-func handleChangesetResponse(ctx context.Context, dag *dagger.Client, response any, autoApply bool) (rerr error) {
-	return handleChangesetResponseAt(ctx, dag, response, autoApply, ".")
+func handleChangesetResponse(ctx context.Context, dag *dagger.Client, response any, autoApply bool) error {
+	_, err := handleChangesetResponseAt(ctx, dag, response, autoApply, ".")
+	return err
 }
 
-func handleChangesetResponseAt(ctx context.Context, dag *dagger.Client, response any, autoApply bool, exportPath string) (rerr error) {
+// handleChangesetResponseAt reports whether it actually applied the changeset,
+// so callers can print follow-up guidance only when files were written (not on
+// a no-op or a declined preview).
+func handleChangesetResponseAt(ctx context.Context, dag *dagger.Client, response any, autoApply bool, exportPath string) (applied bool, rerr error) {
 	changeset, err := toChangeset(dag, response)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if changeset == nil {
 		slog.Info("no changes to apply")
-		return nil
+		return false, nil
 	}
 
 	analyzeCtx, analyzeSpan := Tracer().Start(ctx, "analyzing changes")
 	entries, err := idtui.PreviewPatch(analyzeCtx, dag, changeset)
 	telemetry.EndWithCause(analyzeSpan, &err)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(entries) == 0 {
 		slog.Info("no changes to apply")
-		return nil
+		return false, nil
 	}
 
 	summaryWidth := min(getViewWidth(), 80)
@@ -963,19 +967,19 @@ func handleChangesetResponseAt(ctx context.Context, dag *dagger.Client, response
 			),
 		)
 		if err := Frontend.HandleForm(ctx, form); err != nil {
-			return err
+			return false, err
 		}
 		if !confirm {
-			return nil
+			return false, nil
 		}
 	}
 
 	ctx, span := Tracer().Start(ctx, "applying changes")
 	defer telemetry.EndWithCause(span, &rerr)
 	if _, err := changeset.Export(ctx, exportPath); err != nil {
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 // startInteractivePromptMode starts the interactive shell with the returned LLM assigned as $agent

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -185,7 +185,8 @@ func runModuleInitWithSDK(cmd *cobra.Command, sdkName, name string) error {
 			return err
 		}
 
-		return handleChangesetResponseAt(ctx, dag, changesetID, autoApply, exportPath)
+		_, err = handleChangesetResponseAt(ctx, dag, changesetID, autoApply, exportPath)
+		return err
 	})
 }
 

--- a/internal/cmd/dagger/sdk.go
+++ b/internal/cmd/dagger/sdk.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/slog"
+	telemetry "github.com/dagger/otel-go"
 	"github.com/spf13/cobra"
 )
 
@@ -189,7 +190,13 @@ func runSDKInstall(cmd *cobra.Command, args []string) error {
 // `dagger module init` and `dagger api client init`. A probe error other than
 // "capability absent" is returned, so callers can skip guidance rather than
 // wrongly imply the SDK does nothing.
-func sdkAuthoringCapabilities(ctx context.Context, dag *dagger.Client, sdkRef string) (module, client bool, _ error) {
+func sdkAuthoringCapabilities(ctx context.Context, dag *dagger.Client, sdkRef string) (module, client bool, rerr error) {
+	// Probing reloads the SDK module (serve + type defs); keep that plumbing out
+	// of the command's progress output — otherwise the install appears to reload
+	// the module after it already finished.
+	ctx, span := Tracer().Start(ctx, "inspect SDK capabilities", telemetry.Internal(), telemetry.Encapsulate())
+	defer telemetry.EndWithCause(span, &rerr)
+
 	_, errModule := inspectSDKInitFunction(ctx, dag, sdkRef, sdkInitKindModule)
 	if errModule != nil && !errors.Is(errModule, errSDKInitFunctionNotFound) {
 		return false, false, errModule

--- a/internal/cmd/dagger/sdk.go
+++ b/internal/cmd/dagger/sdk.go
@@ -14,6 +14,7 @@ import (
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine/client"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/spf13/cobra"
 )
 
@@ -163,13 +164,84 @@ func runSDKInstall(cmd *cobra.Command, args []string) error {
 	if name == "" {
 		name = defaultName
 	}
+	// The name the authoring commands dispatch on: the as-sdk alias if the
+	// registry set one, otherwise the install name.
+	hintName := asSDKName
+	if hintName == "" {
+		hintName = name
+	}
 
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,
 	}, func(ctx context.Context, ec *client.Client) error {
-		return callSDKInstall(ctx, ec.Dagger(), cmd.OutOrStdout(), canonicalRef, name, asSDKName, sdkInstallHere)
+		dag := ec.Dagger()
+		if err := callSDKInstall(ctx, dag, cmd.OutOrStdout(), canonicalRef, name, asSDKName, sdkInstallHere); err != nil {
+			return err
+		}
+		printSDKInstallCapabilityHints(ctx, dag, cmd, hintName, canonicalRef)
+		return nil
 	})
+}
+
+// sdkAuthoringCapabilities reports whether the SDK at sdkRef can author modules
+// (initModule) and/or clients (initClient) — the capabilities that gate
+// `dagger module init` and `dagger api client init`. A probe error other than
+// "capability absent" is returned, so callers can skip guidance rather than
+// wrongly imply the SDK does nothing.
+func sdkAuthoringCapabilities(ctx context.Context, dag *dagger.Client, sdkRef string) (module, client bool, _ error) {
+	_, errModule := inspectSDKInitFunction(ctx, dag, sdkRef, sdkInitKindModule)
+	if errModule != nil && !errors.Is(errModule, errSDKInitFunctionNotFound) {
+		return false, false, errModule
+	}
+	_, errClient := inspectSDKInitFunction(ctx, dag, sdkRef, sdkInitKindClient)
+	if errClient != nil && !errors.Is(errClient, errSDKInitFunctionNotFound) {
+		return false, false, errClient
+	}
+	return errModule == nil, errClient == nil, nil
+}
+
+// sdkInstallNoCapabilityWarning is shown when a just-installed SDK can author
+// neither modules nor clients: that's not a usable SDK, so it likely isn't one
+// (or targets an incompatible engine version).
+const sdkInstallNoCapabilityWarning = `
+  ⚠ %q was installed as an SDK, but it can neither create modules nor
+    initialize clients (no initModule or initClient). This usually means the
+    ref isn't an SDK, or it targets an incompatible engine version.
+
+    If that's not what you wanted, remove it:
+        dagger sdk uninstall %[1]s
+`
+
+// printSDKInstallCapabilityHints prints, after a successful install, one hint
+// per authoring capability the SDK has. An SDK that authors neither modules nor
+// clients is warned about (to stderr, and not suppressed by --silent) rather
+// than hinted at. Best-effort: a probe failure is logged and skipped, never
+// fatal — the install already succeeded.
+func printSDKInstallCapabilityHints(ctx context.Context, dag *dagger.Client, cmd *cobra.Command, sdkName, sdkRef string) {
+	canModule, canClient, err := sdkAuthoringCapabilities(ctx, dag, sdkRef)
+	if err != nil {
+		slog.Debug("inspect SDK capabilities for install hint", "sdk", sdkName, "err", err)
+		return
+	}
+
+	if !canModule && !canClient {
+		fmt.Fprintf(cmd.ErrOrStderr(), sdkInstallNoCapabilityWarning, sdkName)
+		return
+	}
+
+	if silent {
+		return
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "\n  Installed SDK %q. This SDK can:\n", sdkName)
+	if canModule {
+		fmt.Fprintf(out, "\n    • Create a new module:\n        dagger module init %s <name>\n", sdkName)
+	}
+	if canClient {
+		fmt.Fprintf(out, "\n    • Initialize a generated API client:\n        dagger api client init %s <path> <module>\n", sdkName)
+	}
 }
 
 // callSDKInstall invokes Workspace.install with asSdk=true via raw GraphQL.

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -146,6 +146,23 @@ func setupStepLogin(cmd *cobra.Command) error {
 
 // --- Step 2: Migrate ---
 
+// emptyWorkspaceSetupHint is printed when `dagger setup` has nothing to migrate
+// and no workspace config exists yet: the greenfield case, where the useful
+// thing is to show how to get started rather than write an empty dagger.toml.
+const emptyWorkspaceSetupHint = `  No workspace loaded here yet — nothing to migrate.
+
+  To get started:
+
+    • Install a published module as a dependency:
+        dagger install <module>
+
+    • Install an SDK to author your own:
+        dagger sdk install <sdk>        (e.g. dagger sdk install go)
+
+    • Create a new module (after installing an SDK):
+        dagger module init <sdk> <name>
+`
+
 // setupStepMigrate reports whether a migration was needed (and thus a fresh
 // session should resolve SDKs migration may have recorded by short name).
 func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (bool, error) {
@@ -167,6 +184,18 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 		return false, fmt.Errorf("check migration: %w", err)
 	}
 	if isEmpty {
+		configFile, err := ws.ConfigFile(ctx)
+		if err != nil {
+			return false, fmt.Errorf("check workspace config: %w", err)
+		}
+		if configFile == "" {
+			// Nothing to migrate and no workspace config yet — don't seed an empty
+			// dagger.toml; guide the user to get started instead.
+			if !silent {
+				fmt.Fprint(out, emptyWorkspaceSetupHint)
+			}
+			return false, nil
+		}
 		fmt.Fprintln(out, "  No migration needed.")
 		return false, nil
 	}
@@ -178,7 +207,7 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 	// handleChangesetResponseAt owns the apply prompt via a huh form when
 	// autoApply is false — we don't run our own confirm() here, otherwise
 	// the user would face two prompts back-to-back for the same action.
-	if err := handleChangesetResponseAt(ctx, dag, changes, autoApply, exportPath); err != nil {
+	if _, err := handleChangesetResponseAt(ctx, dag, changes, autoApply, exportPath); err != nil {
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
## What

Print a short, contextual next-step hint on the **success path** of the three authoring commands, so users discover what to do next instead of being left at a silent prompt.

| Command | Trigger | Hint |
|---|---|---|
| `dagger setup` | nothing to migrate **and** no workspace config yet | install a module / install an SDK / create a module |
| `dagger sdk install <sdk>` | install succeeds | one hint per capability the SDK has (`module init` / `api client init`) |
| `dagger api client init …` | changeset applied | `dagger generate` |

## Details

- **Empty `setup`** (`setup.go`): in the greenfield case (nothing to migrate, no `dagger.toml`), guide the user to get started rather than seeding an empty config.
- **`sdk install`** (`sdk.go`): inspect the installed SDK's authoring capabilities (`initModule` / `initClient`) by reusing the existing `inspectSDKInitFunction` — the same probe that registers the dynamic `module init` / `api client init` subcommands — so **no new API surface** is needed. One hint per capability present. An SDK that authors *neither* modules nor clients is **warned** about on stderr, since that usually means the ref isn't an SDK (or targets an incompatible engine version).
- **`api client init`** (`client.go` + `functions.go`): `handleChangesetResponseAt` now reports whether it actually applied, so the hint fires only on the apply path (never on a declined preview or a no-op).

Hints go to stdout and are suppressed by `--silent`; the sdk-install "not a usable SDK" warning goes to stderr and is not suppressed.

> The design note (`hack/designs/command-hints.md`) is tracked **separately** and is not part of this PR — it will land / be discussed on its own.

## Relationship to #13556

#13556 has since merged. This PR's empty-`setup` hint is self-contained and consistent with it (it broadens the get-started guidance to the three authoring paths); no reconcile is needed.

## Testing

`core/integration/command_hints_test.go` (`CommandHintsSuite`), run against a dev engine:

- empty `setup` prints the hint, writes no `dagger.toml`, and is suppressed by `--silent`;
- `sdk install go` prints a hint for each capability (the go SDK authors both modules and clients);
- `api client init` points at `dagger generate` after scaffolding.

```
ok  github.com/dagger/dagger/core/integration  18.387s
```
