### PR TITLE
core: fix $BUILDPLATFORM resolving to the target platform in dockerBuild (cross-platform cache regression)

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -5166,6 +5166,14 @@ func (container *Container) Build(
 		Config: dockerui.Config{
 			BuildArgs: buildArgMap,
 			Target:    target,
+			// BuildPlatforms must be the engine's native platform, matching what
+			// BuildKit's dockerui frontend does (see dockerui.Client.init). This is
+			// what feeds the predefined BUILDPLATFORM/BUILDOS/BUILDARCH build args. If
+			// left unset, buildPlatformOpt falls back to using the target platform as
+			// the build platform, so BUILDPLATFORM would incorrectly track the target
+			// (emulating $BUILDPLATFORM stages and diverging the cache key per target
+			// platform instead of sharing it across them).
+			BuildPlatforms: []specs.Platform{query.Platform().Spec()},
 		},
 		MainContext:    &mainContext,
 		TargetPlatform: ptr(container.Platform.Spec()),

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -959,6 +959,102 @@ HEALTHCHECK --interval=21s --timeout=4s --start-period=9s --start-interval=2s --
 	})
 }
 
+// TestDockerBuildBuildPlatformArg is a regression repro for the layer-caching regression
+// reported upgrading 0.20.8 -> 0.21.x for Dockerfiles that pin stages to the build platform
+// via `FROM --platform=$BUILDPLATFORM`.
+//
+// The predefined BUILDPLATFORM build arg must resolve to the engine's *native* (build host)
+// platform, independent of the target platform being built. That is what BuildKit's frontend
+// did (and what 0.20.8 relied on): dockerui.Client.init always sets BuildPlatforms to the
+// worker's native platform (see internal/buildkit/frontend/dockerui/config.go).
+//
+// In 0.21.x the dagql-native dockerBuild path (core/container.go Container.Build) constructs
+// dockerfile2llb.ConvertOpt with TargetPlatform set but WITHOUT setting BuildPlatforms, so
+// buildPlatformOpt (internal/buildkit/frontend/dockerfile/dockerfile2llb/platform.go) falls
+// back to using TargetPlatform as the build platform. That makes BUILDPLATFORM ==
+// TARGETPLATFORM, which both emulates stages that should run natively on the host and diverges
+// the cache key per target platform, so the identical $BUILDPLATFORM stages of an amd64 vs
+// arm64 build stop sharing cache.
+func (DockerfileSuite) TestDockerBuildBuildPlatformArg(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	nativePlatform, err := c.DefaultPlatform(ctx)
+	require.NoError(t, err)
+	nativeUname, ok := platformToUname[nativePlatform]
+	require.True(t, ok, "unsupported native platform %q", nativePlatform)
+
+	// a target platform that differs from the engine's native platform
+	targetPlatform := dagger.Platform("linux/arm64")
+	if nativePlatform == targetPlatform {
+		targetPlatform = "linux/amd64"
+	}
+	require.NotEqual(t, string(nativePlatform), string(targetPlatform))
+
+	dockerfile := "FROM --platform=$BUILDPLATFORM " + busyboxImage + `
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+RUN printf '%s' "$BUILDPLATFORM" > /buildplatform.txt
+RUN printf '%s' "$TARGETPLATFORM" > /targetplatform.txt
+RUN uname -m > /uname.txt
+`
+	dir := c.Directory().WithNewFile("Dockerfile", dockerfile)
+
+	buildInfo := func(ctx context.Context, t *testctx.T, opts dagger.DirectoryDockerBuildOpts) (buildPlatform, targetPlatformArg, uname string) {
+		ctr := dir.DockerBuild(opts)
+		buildPlatform, err := ctr.File("/buildplatform.txt").Contents(ctx)
+		require.NoError(t, err)
+		targetPlatformArg, err = ctr.File("/targetplatform.txt").Contents(ctx)
+		require.NoError(t, err)
+		unameOut, err := ctr.File("/uname.txt").Contents(ctx)
+		require.NoError(t, err)
+		return buildPlatform, targetPlatformArg, strings.TrimSpace(unameOut)
+	}
+
+	t.Run("BUILDPLATFORM resolves to the native build platform, not the target", func(ctx context.Context, t *testctx.T) {
+		buildPlatform, targetPlatformArg, uname := buildInfo(ctx, t, dagger.DirectoryDockerBuildOpts{
+			Platform: targetPlatform,
+		})
+
+		// sanity: TARGETPLATFORM must reflect the requested target
+		require.Equal(t, string(targetPlatform), targetPlatformArg)
+
+		// BUILDPLATFORM must be the engine's native/build-host platform, NOT the target.
+		require.Equal(t, string(nativePlatform), buildPlatform,
+			"BUILDPLATFORM should be the native build platform, got the target platform instead")
+
+		// the $BUILDPLATFORM-pinned stage must run natively (no emulation), so uname reports
+		// the native architecture rather than the (emulated) target architecture.
+		require.Equal(t, nativeUname, uname,
+			"$BUILDPLATFORM stage should build for the native arch, not be emulated to the target")
+	})
+
+	t.Run("$BUILDPLATFORM stages are identical across target platforms", func(ctx context.Context, t *testctx.T) {
+		// The whole point of --platform=$BUILDPLATFORM is that these stages are identical
+		// regardless of which target arch we ultimately build for, so they share cache. If the
+		// build platform tracks the target, the two builds diverge into separate DAGs.
+		_, _, unameNativeTarget := buildInfo(ctx, t, dagger.DirectoryDockerBuildOpts{
+			Platform: nativePlatform,
+		})
+		_, _, unameCrossTarget := buildInfo(ctx, t, dagger.DirectoryDockerBuildOpts{
+			Platform: targetPlatform,
+		})
+		require.Equal(t, unameNativeTarget, unameCrossTarget,
+			"$BUILDPLATFORM stage differs across target platforms; the DAGs/cache keys have diverged")
+	})
+
+	t.Run("explicit BUILDPLATFORM build arg restores native behavior", func(ctx context.Context, t *testctx.T) {
+		// The reported workaround: pin BUILDPLATFORM to the native platform explicitly.
+		buildPlatform, _, uname := buildInfo(ctx, t, dagger.DirectoryDockerBuildOpts{
+			Platform: targetPlatform,
+			BuildArgs: []dagger.BuildArg{
+				{Name: "BUILDPLATFORM", Value: string(nativePlatform)},
+			},
+		})
+		require.Equal(t, string(nativePlatform), buildPlatform)
+		require.Equal(t, nativeUname, uname)
+	})
+}
+
 func (DockerfileSuite) TestBuildMergesWithParent(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 


### PR DESCRIPTION
## Problem

Users upgrading Dagger from 0.20.8 to 0.21.x reported losing layer caching that used to hit — most visibly when building a Dockerfile for a **non-native** platform.

Their setup: a large multi-stage Dockerfile built for both `linux/arm64` and `linux/amd64`, on an engine running `linux/amd64`. Most stages are pinned to the build host with `FROM --platform=$BUILDPLATFORM` so they run natively (no emulation), and only the final release stages are built for the target platform. On 0.20.8 the build took ~56s; on 0.21.6 the same build took ~1m52s.

The core symptom: in 0.21.x the amd64 and arm64 builds no longer shared cache for the `$BUILDPLATFORM`-pinned stages, even though those stages *should be identical* across target archs (they all target the same build platform). The reporters found that explicitly passing a `BUILDPLATFORM` build arg set to the native platform restored the caching, and noticed that without it, an amd64-target build reported `x86_64` where they expected the build-host arch.

## Root cause

The predefined `BUILDPLATFORM` (and `BUILDOS`/`BUILDARCH`/`BUILDVARIANT`) build args stopped resolving to the engine's native/build-host platform and instead tracked the **target** platform.

In the dagql-native Dockerfile build path, `(*Container).Build` in `core/container.go` constructs `dockerfile2llb.ConvertOpt` with `TargetPlatform` set but leaves `BuildPlatforms` (a field on the embedded `dockerui.Config`) unset. `buildPlatformOpt` in `internal/buildkit/frontend/dockerfile/dockerfile2llb/platform.go` then falls back to using the target platform as the build platform:

```go
if opt.TargetPlatform != nil && opt.BuildPlatforms == nil {
    buildPlatforms = []ocispecs.Platform{*opt.TargetPlatform}
}
```

so `getPlatformArgs` seeds `BUILDPLATFORM = platforms.Format(buildPlatforms[0])` = the target platform. That means `BUILDPLATFORM == TARGETPLATFORM`, which (a) emulates `$BUILDPLATFORM` stages that should run natively on the host, and (b) diverges the resulting cache key per target platform, so the "shared" build-host stages of an amd64 vs arm64 build no longer dedupe.

This is a regression from #11856 ("migrate all caching to dagql"), which switched off the BuildKit solver. Previously these builds went through BuildKit's `dockerui` frontend, whose `Client.init` (`internal/buildkit/frontend/dockerui/config.go`) always sets `BuildPlatforms` to the worker's native platform. The dagql-native path builds `ConvertOpt` directly and never replicated that.

## Fix

Set `BuildPlatforms` to the engine's native platform in the `ConvertOpt`, matching what the `dockerui` frontend does:

```go
BuildPlatforms: []specs.Platform{query.Platform().Spec()},
```

`query.Platform()` is the engine's default/host platform (`platforms.Normalize(platforms.DefaultSpec())`). With `BuildPlatforms` populated, `BUILDPLATFORM` resolves to the native platform again regardless of the target, while `TARGETPLATFORM`/`TARGETOS`/etc. continue to reflect the requested target. Users who explicitly set a `BUILDPLATFORM` build arg still override it (unchanged behavior).

The change is scoped to the Dockerfile build path; it's the only place in core that constructs `dockerfile2llb.ConvertOpt`. Dockerfiles that don't reference `$BUILDPLATFORM` are unaffected (the predefined args only materialize into the build when referenced), so this doesn't gratuitously invalidate existing caches.

## Test

Adds `TestDockerBuildBuildPlatformArg` in `core/integration/dockerfile_test.go`, which builds a small Dockerfile using `FROM --platform=$BUILDPLATFORM` for a non-native target and asserts:

1. `BUILDPLATFORM` resolves to the engine's native platform (not the target);
2. the `$BUILDPLATFORM` stage is identical across two different target platforms (i.e. it builds for the native arch, so the DAGs/cache keys don't diverge);
3. explicitly passing a `BUILDPLATFORM` build arg (the reported workaround) also yields native behavior.

This test fails on `main` before the fix and passes with it.
