### PR TITLE
Targeted module loading for `dagger api call` / `api functions`

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -574,6 +574,128 @@ func (GeneratorsSuite) TestWorkspaceUpNarrowsToRequestedModule(ctx context.Conte
 	})
 }
 
+// TestWorkspaceCallNarrowsToRequestedModule mirrors
+// TestWorkspaceGenerateNarrowsToRequestedModule for `dagger api call`:
+// targeting a healthy module's function must not load every workspace module
+// just to build the command tree. The CLI forwards its leading token as the
+// workspace_module_scope client metadata hint and the engine narrows the
+// currentTypeDefs introspection to that module, so an unrelated broken/stale
+// module cannot block the call.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsToRequestedModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken")
+
+	t.Run("calling a healthy module's function skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("api", "call", "good", "verify", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("scoped help skips the broken module", func(ctx context.Context, t *testctx.T) {
+		// --help builds the same command tree without executing, so it
+		// exercises the narrowed introspection on its own.
+		out, err := base.
+			With(daggerExec("api", "call", "good", "--help")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing the healthy module's functions skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("api", "functions", "good", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("api", "functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+}
+
+// TestWorkspaceCallNarrowsByCliNameAndEntrypoint covers the two demand shapes
+// TestWorkspaceCallNarrowsToRequestedModule cannot see with its single-word
+// module names:
+//
+//   - the CLI targets modules by their kebab-case command name, so a module
+//     declared as "goodMod" is called as `dagger api call good-mod ...` and
+//     the engine must normalize both sides the same way to narrow loading;
+//   - with a workspace entrypoint configured, the first argument may be one of
+//     the entrypoint's root-proxied functions rather than a module name, in
+//     which case the entrypoint module must load — and suffice — to resolve
+//     the call.
+//
+// In both cases the broken sibling module must stay unloaded.
+func (GeneratorsSuite) TestWorkspaceCallNarrowsByCliNameAndEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "call-narrowing")
+
+	t.Run("kebab-case module target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("api", "call", "good-mod", "ping", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "pong from goodMod")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("entrypoint function target skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("api", "call", "greet", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello from entrypoint")
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case functions listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("api", "functions", "good-mod", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("kebab-case generate listing skips the broken module", func(ctx context.Context, t *testctx.T) {
+		// The selector resolvers (generate/check/up) match include patterns
+		// kebab-normalized; on-demand loading must normalize the same way.
+		out, err := base.
+			With(daggerExec("generate", "-l", "good-mod")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "intentionally invalid")
+	})
+
+	t.Run("listing all workspace functions still loads the broken module", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("api", "functions")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bad")
+	})
+
+	t.Run("scope is one-shot within a session", func(ctx context.Context, t *testctx.T) {
+		// Two invocations in one exec share the nested client: the first scoped
+		// introspection narrows; the second, bare listing must widen to every
+		// remaining module and surface the broken one.
+		out, err := base.
+			WithExec([]string{"sh", "-c", "set -e; dagger api call good-mod ping; if dagger api functions >/dev/null 2>&1; then echo BARE_LISTING_PASSED; else echo BARE_LISTING_FAILED; fi"}, dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true}).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "pong from goodMod")
+		require.Contains(t, out, "BARE_LISTING_FAILED")
+	})
+}
+
 func (GeneratorsSuite) TestWorkspaceGenerateSkip(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "entry"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/entry/main.dang
@@ -1,0 +1,9 @@
+type Entry {
+  """
+  A trivial entrypoint function, proxied onto the Query root. Used to prove
+  the entrypoint module loaded when it is the first `dagger call` argument.
+  """
+  pub greet: String! {
+    "hello from entrypoint"
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "goodMod"
+engineVersion = "v0.21.5"
+
+[runtime]
+source = "dang"

--- a/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
+++ b/core/integration/testdata/workspaces/call-narrowing/.dagger/modules/goodMod/main.dang
@@ -1,0 +1,17 @@
+type GoodMod {
+  """
+  A trivial function. Used to prove the module loaded when targeted by its
+  kebab-case CLI command name (good-mod).
+  """
+  pub ping: String! {
+    "pong from goodMod"
+  }
+
+  """
+  Regenerate by writing a marker file. Used to prove the kebab-case name also
+  narrows the generate/check/up selector path.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from goodMod").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/call-narrowing/dagger.toml
+++ b/core/integration/testdata/workspaces/call-narrowing/dagger.toml
@@ -1,0 +1,9 @@
+[modules.goodMod]
+source = ".dagger/modules/goodMod"
+
+[modules.entry]
+source = ".dagger/modules/entry"
+entrypoint = true
+
+[modules.bad]
+source = ".dagger/modules/bad"

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -145,6 +145,10 @@ type Params struct {
 	// WorkspaceEnv explicitly selects the workspace environment overlay for this client.
 	WorkspaceEnv *string
 
+	// WorkspaceModuleScope hints at the workspace module this client's first
+	// schema introspection targets (the leading CLI command token, unresolved).
+	WorkspaceModuleScope string
+
 	CloudAuth           *auth.Cloud
 	EnableCloudScaleOut bool
 
@@ -1458,6 +1462,11 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 	}
 	if c.Module == "" && c.LoadWorkspaceModules {
 		md.LoadWorkspaceModules = true
+	}
+	// The scope only narrows workspace module loading, so it travels only
+	// when this client asks for it.
+	if md.LoadWorkspaceModules {
+		md.WorkspaceModuleScope = c.WorkspaceModuleScope
 	}
 	if c.LockMode != "" {
 		md.LockMode = c.LockMode

--- a/engine/client/client_test.go
+++ b/engine/client/client_test.go
@@ -28,3 +28,28 @@ func TestClientMetadataUsesExplicitModuleInsteadOfWorkspaceModules(t *testing.T)
 		Entrypoint: true,
 	}}, md.ExtraModules)
 }
+
+func TestClientMetadataForwardsWorkspaceModuleScopeOnlyWithWorkspaceModules(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{
+		Params: Params{
+			ID:                   "client",
+			SessionID:            "session",
+			SecretToken:          "secret",
+			LoadWorkspaceModules: true,
+			WorkspaceModuleScope: "good-mod",
+		},
+	}
+
+	md := client.clientMetadata()
+	require.True(t, md.LoadWorkspaceModules)
+	require.Equal(t, "good-mod", md.WorkspaceModuleScope)
+
+	// With an explicit -m module there are no pending workspace modules to
+	// narrow, so the scope must not travel.
+	client.Params.Module = "./explicit"
+	md = client.clientMetadata()
+	require.False(t, md.LoadWorkspaceModules)
+	require.Empty(t, md.WorkspaceModuleScope)
+}

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -147,6 +147,16 @@ type ClientMetadata struct {
 	// this client. When unset, no environment overlay is applied.
 	WorkspaceEnv *string `json:"workspace_env,omitempty"`
 
+	// WorkspaceModuleScope hints at the workspace module this client's first
+	// schema introspection targets: the leading CLI command token, unresolved
+	// (it may name a module, an entrypoint-proxied function, or a typo). The
+	// engine may use it to defer loading unrelated workspace modules for the
+	// first request whose only full-schema demand is currentTypeDefs. An
+	// unrecognized token falls back to the entrypoint module when one is
+	// configured, else to loading everything; deferred modules load on demand
+	// from later requests.
+	WorkspaceModuleScope string `json:"workspace_module_scope,omitempty"`
+
 	// UseRecipeIDsByDefault asks id() to return recipe-form IDs unless the
 	// request explicitly passes a recipe argument. This is engine-internal
 	// nested-client state and must not be forwarded through client headers.

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -274,8 +274,12 @@ type daggerClient struct {
 	// served workspace module names, so demand filters recognize them without
 	// reloading
 	servedWorkspaceModuleNames map[string]struct{}
-	singleQueryMu              sync.Mutex
-	singleQueryServed          bool
+	// whether the client-declared workspace module scope was applied; the
+	// scope is one-shot so later introspections load everything (guarded by
+	// modulesMu)
+	workspaceModuleScopeConsumed bool
+	singleQueryMu                sync.Mutex
+	singleQueryServed            bool
 
 	// NOTE: do not use this field directly as it may not be open
 	// after the client has shutdown; use TelemetryDB() instead
@@ -1886,17 +1890,56 @@ func (client *daggerClient) claimSingleQueryRequest() error {
 // the request's root fields: fields naming pending modules demand those, and
 // full-schema or unrecognized fields demand everything. The rest stay pending.
 func (srv *Server) ensureRequestModulesLoaded(ctx context.Context, client *daggerClient, r *http.Request) error {
+	return srv.ensureRequestModulesLoadedWithPostLoad(ctx, client, r, nil)
+}
+
+// ensureRequestModulesLoadedWithPostLoad is split out so synchronization-
+// sensitive tests can observe the client immediately after module loading
+// returns, before any subsequent request finalization.
+func (srv *Server) ensureRequestModulesLoadedWithPostLoad(ctx context.Context, client *daggerClient, r *http.Request, postLoad func()) error {
 	var filter func([]pendingModule) []pendingModule
+	scopeApplied := false
 	if client.hasPendingWorkspaceModules() {
 		if ok, rootFields, err := dagql.PeekRootFields(r); err == nil && ok {
 			filter = func(mods []pendingModule) []pendingModule {
-				// runs under client.modulesMu, which also guards servedWorkspaceModuleNames
-				return filterPendingWorkspaceModulesForRootFields(mods, client.servedWorkspaceModuleNames, rootFields)
+				// runs under client.modulesMu, which also guards
+				// servedWorkspaceModuleNames and workspaceModuleScopeConsumed
+				scope := client.pendingWorkspaceModuleScopeLocked()
+				selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, client.servedWorkspaceModuleNames, rootFields, scope, client.entrypointServed)
+				if applied {
+					scopeApplied = true
+					names := make([]string, 0, len(selected))
+					for _, mod := range selected {
+						names = append(names, moduleProgressName(mod))
+					}
+					slog.Debug("narrowing workspace module load to client scope",
+						"scope", scope,
+						"modules", names)
+				}
+				return selected
 			}
 		}
 	}
-	_, err := srv.ensureModulesLoadedMode(ctx, client, filter, false)
+	_, err := srv.ensureModulesLoadedModeWithSuccess(ctx, client, filter, false, func() {
+		// Consume only after a successful load, but before modulesMu is
+		// released, so another request cannot claim the one-shot scope.
+		if scopeApplied {
+			client.workspaceModuleScopeConsumed = true
+		}
+	})
+	if postLoad != nil {
+		postLoad()
+	}
 	return err
+}
+
+// pendingWorkspaceModuleScopeLocked returns the client-declared workspace
+// module scope while it is still consumable. client.modulesMu must be held.
+func (client *daggerClient) pendingWorkspaceModuleScopeLocked() string {
+	if client.workspaceModuleScopeConsumed || client.clientMetadata == nil {
+		return ""
+	}
+	return client.clientMetadata.WorkspaceModuleScope
 }
 
 func (client *daggerClient) hasPendingWorkspaceModules() bool {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1300,6 +1300,9 @@ func (srv *Server) getOrInitClient(
 		if opts.SingleQuery {
 			client.clientMetadata.SingleQuery = true
 		}
+		if client.clientMetadata.WorkspaceModuleScope == "" {
+			client.clientMetadata.WorkspaceModuleScope = opts.WorkspaceModuleScope
+		}
 		if opts.SuppressCompatWorkspaceWarning {
 			client.clientMetadata.SuppressCompatWorkspaceWarning = true
 		}
@@ -1484,6 +1487,7 @@ func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.
 	var extraModules []engine.ExtraModule
 	var loadWorkspaceModules bool
 	var singleQuery bool
+	var workspaceModuleScope string
 	var eagerRuntime bool
 	var suppressCompatWorkspaceWarning bool
 	var workspaceRef *string
@@ -1494,6 +1498,10 @@ func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.
 		extraModules = md.ExtraModules
 		loadWorkspaceModules = md.LoadWorkspaceModules
 		singleQuery = md.SingleQuery
+		// A nested CLI declares its own scope in its own request headers; the
+		// parent's scope is never inherited (the struct copy above is reset
+		// here like the other load-shaping fields).
+		workspaceModuleScope = md.WorkspaceModuleScope
 		eagerRuntime = md.EagerRuntime
 		suppressCompatWorkspaceWarning = md.SuppressCompatWorkspaceWarning
 		if declaredWorkspace, ok := workspaceRefFromClientMetadata(md); ok {
@@ -1512,6 +1520,7 @@ func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.
 	clientMetadata.ExtraModules = extraModules
 	clientMetadata.LoadWorkspaceModules = loadWorkspaceModules
 	clientMetadata.SingleQuery = singleQuery
+	clientMetadata.WorkspaceModuleScope = workspaceModuleScope
 	clientMetadata.EagerRuntime = eagerRuntime
 	clientMetadata.SuppressCompatWorkspaceWarning = suppressCompatWorkspaceWarning
 	clientMetadata.Workspace = workspaceRef

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1489,6 +1489,7 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			LockMode:              string(workspace.LockModeFrozen),
 			Workspace:             stringPtr("github.com/dagger/base@main"),
 			WorkspaceEnv:          stringPtr("parent-ci"),
+			WorkspaceModuleScope:  "parent-scope",
 			UseRecipeIDsByDefault: true,
 		}
 	}
@@ -1514,6 +1515,7 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 		require.False(t, md.EagerRuntime)
 		require.Nil(t, md.Workspace)
 		require.Nil(t, md.WorkspaceEnv)
+		require.Empty(t, md.WorkspaceModuleScope)
 		require.True(t, md.UseRecipeIDsByDefault)
 
 		base.AllowedLLMModules[0] = "mutated"
@@ -1547,6 +1549,7 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			LockMode:                       string(workspace.LockModeLive),
 			Workspace:                      &workspaceRef,
 			WorkspaceEnv:                   &workspaceEnv,
+			WorkspaceModuleScope:           "good-mod",
 		}
 
 		md := nestedClientMetadataForRequest(forwarded.AppendToHTTPHeaders(http.Header{}), baseMetadata())
@@ -1567,6 +1570,7 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 		require.True(t, md.SuppressCompatWorkspaceWarning)
 		require.Equal(t, "github.com/dagger/dagger@main", *md.Workspace)
 		require.Equal(t, "ci", *md.WorkspaceEnv)
+		require.Equal(t, "good-mod", md.WorkspaceModuleScope)
 		require.Equal(t, []engine.ExtraModule{{
 			Ref:        "github.com/dagger/mod",
 			Entrypoint: true,

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -508,6 +510,153 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"loadSomethingFromID"})
 		require.Equal(t, mods, filtered)
 	})
+}
+
+func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
+	t.Parallel()
+
+	foo := pendingModule{Kind: moduleLoadKindAmbient, Name: "foo"}
+	barBaz := pendingModule{Kind: moduleLoadKindAmbient, Name: "barBaz"}
+	entry := pendingModule{Kind: moduleLoadKindAmbient, Name: "entry", Entrypoint: true}
+	mods := []pendingModule{foo, barBaz, entry}
+
+	t.Run("no scope delegates to root-field demand", func(t *testing.T) {
+		t.Parallel()
+
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "", false)
+		require.False(t, applied)
+		require.Equal(t, mods, selected)
+	})
+
+	t.Run("scoped typedefs loads target plus entrypoint", func(t *testing.T) {
+		t.Parallel()
+
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "foo", false)
+		require.True(t, applied)
+		require.Equal(t, []pendingModule{foo, entry}, selected)
+	})
+
+	t.Run("kebab-case token matches declared module name", func(t *testing.T) {
+		t.Parallel()
+
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "bar-baz", false)
+		require.True(t, applied)
+		require.Equal(t, []pendingModule{barBaz, entry}, selected)
+	})
+
+	t.Run("unknown token loads pending entrypoint alone", func(t *testing.T) {
+		t.Parallel()
+
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "greet", false)
+		require.True(t, applied)
+		require.Equal(t, []pendingModule{entry}, selected)
+	})
+
+	t.Run("unknown token without entrypoint loads all", func(t *testing.T) {
+		t.Parallel()
+
+		noEntry := []pendingModule{foo, barBaz}
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(noEntry, nil, []string{"currentTypeDefs"}, "greet", false)
+		require.True(t, applied)
+		require.Equal(t, noEntry, selected)
+	})
+
+	t.Run("another full-schema field loads all without consuming", func(t *testing.T) {
+		t.Parallel()
+
+		for _, field := range []string{"env", "__schema", "currentModule"} {
+			selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs", field}, "foo", false)
+			require.False(t, applied, field)
+			require.Equal(t, mods, selected, field)
+		}
+	})
+
+	t.Run("no typedefs field delegates without consuming", func(t *testing.T) {
+		t.Parallel()
+
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"foo"}, "barBaz", false)
+		require.False(t, applied)
+		require.Equal(t, []pendingModule{foo}, selected)
+	})
+
+	t.Run("typedefs plus module field unions both demands", func(t *testing.T) {
+		t.Parallel()
+
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs", "foo"}, "bar-baz", false)
+		require.True(t, applied)
+		require.Equal(t, []pendingModule{foo, barBaz, entry}, selected)
+	})
+
+	t.Run("served target contributes nothing to load", func(t *testing.T) {
+		t.Parallel()
+
+		served := map[string]struct{}{"my-mod": {}}
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, served, []string{"currentTypeDefs"}, "myMod", false)
+		require.True(t, applied)
+		require.Equal(t, []pendingModule{entry}, selected)
+	})
+
+	t.Run("unknown token with served entrypoint loads no siblings", func(t *testing.T) {
+		t.Parallel()
+
+		// A prior selective request may have loaded the entrypoint without
+		// consuming the scope. The later typedefs request is then already
+		// satisfied by that served entrypoint and must not fall back to every
+		// still-pending workspace module.
+		served := map[string]struct{}{"entry": {}}
+		pending := []pendingModule{foo, barBaz}
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(pending, served, []string{"currentTypeDefs"}, "greet", true)
+		require.True(t, applied)
+		require.Empty(t, selected)
+	})
+}
+
+func TestEnsureRequestModulesLoadedConsumesScopeBeforeUnlock(t *testing.T) {
+	client := &daggerClient{
+		clientID: "client",
+		clientMetadata: &engine.ClientMetadata{
+			WorkspaceModuleScope: "good",
+		},
+		pendingModules: []pendingModule{
+			{Kind: moduleLoadKindAmbient, Name: "bad"},
+		},
+		servedWorkspaceModuleNames: map[string]struct{}{"good": {}},
+	}
+	req := httptest.NewRequest(http.MethodPost, engine.QueryEndpoint, strings.NewReader(`{"query":"{ currentTypeDefs { name } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	postLoad := make(chan struct{})
+	resume := make(chan struct{})
+	var resumeOnce sync.Once
+	release := func() { resumeOnce.Do(func() { close(resume) }) }
+	t.Cleanup(release)
+
+	loadDone := make(chan error, 1)
+	go func() {
+		loadDone <- (&Server{}).ensureRequestModulesLoadedWithPostLoad(context.Background(), client, req, func() {
+			close(postLoad)
+			<-resume
+		})
+	}()
+
+	select {
+	case <-postLoad:
+	case <-time.After(10 * time.Second):
+		t.Fatal("module loading did not return")
+	}
+
+	client.modulesMu.Lock()
+	observedScope := client.pendingWorkspaceModuleScopeLocked()
+	client.modulesMu.Unlock()
+
+	release()
+	require.Empty(t, observedScope, "the one-shot scope was visible after the successful load released modulesMu")
+	select {
+	case err := <-loadDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("request module loading did not finish")
+	}
 }
 
 func TestFilterPendingWorkspaceModulesBySelectorInclude(t *testing.T) {

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -942,8 +942,20 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 // caller can surface them (e.g. GeneratorGroup.loadFailures). Genuine engine
 // errors (batch resolution, arbitration, serving) stay fatal regardless.
 func (srv *Server) ensureModulesLoadedMode(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool) (loadFailures []string, _ error) {
+	return srv.ensureModulesLoadedModeWithSuccess(ctx, client, filter, bestEffort, nil)
+}
+
+// ensureModulesLoadedModeWithSuccess runs onSuccessLocked after a successful
+// load while modulesMu is still held. Callers use it for state transitions
+// that must be atomic with the load becoming visible to another request.
+func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool, onSuccessLocked func()) (loadFailures []string, rerr error) {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
+	defer func() {
+		if rerr == nil && onSuccessLocked != nil {
+			onSuccessLocked()
+		}
+	}()
 
 	if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
 		return nil, err
@@ -1341,6 +1353,69 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map
 		}
 	}
 	return filtered
+}
+
+// filterPendingWorkspaceModulesForScopedRootFields applies the client-declared
+// workspace module scope on top of the root-field demand: when the request's
+// only full-schema demand is currentTypeDefs, the scope replaces its
+// load-everything contribution with the scoped module set. Any other
+// full-schema field keeps loading everything, scope untouched. The second
+// result reports whether the scope was applied, so the caller can consume it.
+func filterPendingWorkspaceModulesForScopedRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string, scope string, entrypointServed bool) ([]pendingModule, bool) {
+	if scope == "" || len(mods) == 0 {
+		return filterPendingWorkspaceModulesForRootFields(mods, served, rootFields), false
+	}
+
+	hasCurrentTypeDefs := false
+	remaining := make([]string, 0, len(rootFields))
+	for _, field := range rootFields {
+		if field == "currentTypeDefs" {
+			hasCurrentTypeDefs = true
+			continue
+		}
+		remaining = append(remaining, field)
+	}
+	if !hasCurrentTypeDefs || rootFieldsRequireFullWorkspaceSchema(remaining) {
+		return filterPendingWorkspaceModulesForRootFields(mods, served, rootFields), false
+	}
+
+	wanted := make(map[string]struct{})
+	for _, mod := range filterPendingWorkspaceModulesForRootFields(mods, served, remaining) {
+		wanted[moduleProgressName(mod)] = struct{}{}
+	}
+	for _, mod := range resolveWorkspaceModuleScope(mods, served, scope, entrypointServed) {
+		wanted[moduleProgressName(mod)] = struct{}{}
+	}
+	selected := make([]pendingModule, 0, len(wanted))
+	for _, mod := range mods {
+		if _, ok := wanted[moduleProgressName(mod)]; ok {
+			selected = append(selected, mod)
+		}
+	}
+	return selected, true
+}
+
+// resolveWorkspaceModuleScope maps the scope token to the pending modules it
+// demands: the named module plus the pending entrypoint module(s) -- the token
+// may be one of their root-proxied functions, and the command tree wants their
+// Query-root proxies either way. A token naming nothing known demands the
+// entrypoint alone when one is pending, or nothing when it is already served;
+// with no entrypoint to resolve it, everything loads (conservative: the token
+// could be anything).
+func resolveWorkspaceModuleScope(mods []pendingModule, served map[string]struct{}, scope string, entrypointServed bool) []pendingModule {
+	scopeName := canonicalWorkspaceModuleName(scope)
+	_, isModule := knownWorkspaceModuleNames(mods, served)[scopeName]
+
+	selected := make([]pendingModule, 0, len(mods))
+	for _, mod := range mods {
+		if (!entrypointServed && mod.Entrypoint) || (isModule && pendingModuleCliName(mod) == scopeName) {
+			selected = append(selected, mod)
+		}
+	}
+	if !isModule && !entrypointServed && len(selected) == 0 {
+		return mods
+	}
+	return selected
 }
 
 func rootFieldsRequireFullWorkspaceSchema(fields []string) bool {

--- a/hack/designs/done/targeted-module-loading-api-call-functions.md
+++ b/hack/designs/done/targeted-module-loading-api-call-functions.md
@@ -1,0 +1,134 @@
+# Targeted module loading for `dagger api call` / `api functions`
+
+This documents the as-implemented behavior. It builds on
+[Demand-Driven Workspace Module Loading](../demand-driven-module-loading.md),
+which narrowed `dagger generate` / `check` / `up` and left `call` / `functions`
+out of scope.
+
+## Problem
+
+A workspace can install several modules. To run one function —
+`dagger api call mymod build` — the CLI first asks the engine for the schema of
+everything loaded (`currentTypeDefs`) and builds its command tree from the
+answer. That request names no module, so the engine loaded **every** workspace
+module before answering. Two costs:
+
+1. Calling one module paid the load time of all its siblings.
+2. One broken module blocked calling *any* module.
+
+`generate` / `check` / `up` don't have this problem anymore: their queries
+carry the target (`generators(include: ["mymod"])`), so the engine loads just
+that. The `call` / `functions` introspection has no place to carry the target —
+so it must reach the engine some other way.
+
+## Solution
+
+The CLI sends its first command-line word to the engine as connection metadata,
+and the engine does the rest:
+
+```go
+// engine.ClientMetadata
+WorkspaceModuleScope string `json:"workspace_module_scope,omitempty"`
+```
+
+**The CLI does not interpret the word.** It may be a module name, a function of
+the entrypoint module (the module whose functions are promoted onto the root),
+or a typo. `dagger api call` and `dagger api functions` send it; `shell` and
+everything else don't.
+
+**The engine resolves it** when the introspection arrives:
+
+- the word names a module (kebab-insensitive: `good-mod` matches `goodMod`) →
+  load that module plus the entrypoint module;
+- it names nothing known → load just the entrypoint module when one is
+  configured (the word is probably one of its functions), otherwise everything;
+- the hint is honored once per session, then discarded (see below).
+
+Nothing else changes. `currentTypeDefs` itself is untouched — bare listings,
+`shell`, and the in-engine LLM tool builder still load everything — and the
+follow-up request that actually runs the function names the module in its
+query, so it was already narrowed.
+
+```mermaid
+sequenceDiagram
+    participant CLI as dagger api call good fn
+    participant Engine
+
+    Note over CLI: workspace = good, bad (broken)
+    CLI->>Engine: connect (workspace_module_scope: "good")
+    CLI->>Engine: currentTypeDefs (unchanged query)
+    Note over Engine: scope resolves to "good"<br/>load good only — bad stays unloaded
+    Engine-->>CLI: schema for core + good
+    CLI->>Engine: { good { fn } }
+    Engine-->>CLI: result — bad never loaded, cannot block
+```
+
+## Why connection metadata, not API
+
+The target has to cross the wire somehow. Earlier attempts (#13380, #13406
+then #13539 and #13543) tried the other channels:
+
+- **A new `include` argument on `currentTypeDefs`** (#13380, #13406): public
+  API change — version gating, SDK regeneration in every language, a CLI
+  fallback for older engines, and a cache-key fix — for a signal only the CLI
+  sends.
+- **Encoding the target in the GraphQL operation name** (#13539): no API
+  change, but a hidden magic-string contract between CLI and engine.
+- **A per-module typedefs field** (#13543): the CLI resolves the name itself
+  first, duplicating rules the engine already owns.
+
+Connection metadata is where this kind of session setup already lives
+(`LoadWorkspaceModules`, `ExtraModules` from `-m`, `Workspace` from `-W`). It
+never touches the GraphQL API — no gating, no SDK changes — and version skew
+resolves itself: an old engine ignores the unknown field and loads everything;
+an old CLI doesn't send it.
+
+A hint is also safe here: module loading is additive and per-request (from the
+demand-driven work), so a wrong or unused hint never excludes anything — a
+later request that needs more modules loads them then.
+
+## Behavior
+
+| Command | Loads |
+|---|---|
+| `api call good fn`, `api functions good`, `api call good --help` | `good` + entrypoint |
+| `api call good-mod fn` (module `goodMod`) | `goodMod` + entrypoint |
+| `api call deploy` (entrypoint function) | entrypoint only |
+| `api call typo fn` | entrypoint if configured, else all; the unknown-command error still fires, though its suggestions come from the smaller tree |
+| bare `api call` / `api functions` | all (a full listing needs everything, and still surfaces a broken module) |
+| `api call -o out.txt good fn` | all — the CLI can't safely tell which word is the target, so it sends nothing |
+| `-m <module>`, core mode, `shell`, `mcp`, `api query` | unchanged — no scope sent |
+
+## Details worth knowing
+
+**Used once per session.** `api call` can end in the interactive shell (a
+function returning `LLM`), which re-introspects in the same session and must
+see every module — so the first introspection the hint narrows also consumes
+it. Consumption only happens after a *successful* load; a transient failure
+leaves the hint usable for the retry. One consequence: a script running several
+dagger commands inside one nested exec shares one session, so only the first
+command narrows — the rest load everything, exactly the old behavior.
+
+**Works the same inside containers.** A dagger CLI running in a container (CI
+jobs, our integration tests) is a nested client. It never inherits the parent's
+scope and its own scope is honored — which requires two plumbing points in
+`engine/server/session.go`: `nestedClientMetadataForRequest` re-reads the field
+from the nested request's own headers, and `getOrInitClient`'s late-arriving
+fill-in picks it up, because the nested client is created by a headerless
+pre-request before the CLI's metadata arrives.
+
+**Scoped loads are strict.** Bare `dagger generate` tolerates and reports load
+failures; a scoped call does not — if the module you target fails to load, the
+call fails with that module's error.
+
+## Tests
+
+`TestWorkspaceCallNarrowsToRequestedModule` and
+`TestWorkspaceCallNarrowsByCliNameAndEntrypoint`
+(`core/integration/generators_test.go`, fixtures `generators-broken` and
+`call-narrowing`) cover: exact and kebab-case targets, entrypoint functions,
+scoped `--help`, one-shot consumption within a session, and that bare listings
+still load — and surface — a broken module. Unit tests cover the demand filter
+matrix (`engine/server/session_test.go`), metadata plumbing including the
+nested inherit/forward rules, and that `shell`'s shared param helper never
+sends a scope.

--- a/internal/cmd/dagger/call.go
+++ b/internal/cmd/dagger/call.go
@@ -89,6 +89,10 @@ Examples:
 
 func runFunctionList(cmd *cobra.Command, args []string) error {
 	params := initModuleParams(args)
+	// The leading token is the likely target module; the engine narrows
+	// workspace module loading from it (deliberately not set in
+	// initModuleParams: shell shares that helper and needs the full view).
+	params.WorkspaceModuleScope = functionName(args)
 	return withEngine(cmd.Context(), params, func(ctx context.Context, engineClient *client.Client) (rerr error) {
 		coreMode := moduleNoURL || isCoreModuleSelected()
 

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -191,6 +191,11 @@ func (fc *FuncCommand) Command() *cobra.Command {
 
 				params := initModuleParams(execArgs)
 				params.LoadWorkspaceModules = shouldLoadWorkspaceModules(fc.DisableModuleLoad)
+				// The leading token is the likely target module; the engine
+				// narrows workspace module loading from it (deliberately not
+				// set in initModuleParams: shell shares that helper and needs
+				// the full view).
+				params.WorkspaceModuleScope = functionName(execArgs)
 
 				return withEngine(c.Context(), params, func(ctx context.Context, engineClient *client.Client) (rerr error) {
 					fc.c = engineClient

--- a/internal/cmd/dagger/functions_test.go
+++ b/internal/cmd/dagger/functions_test.go
@@ -136,6 +136,10 @@ func TestCorePseudoModuleSelection(t *testing.T) {
 	require.True(t, isCoreModuleSelected())
 	require.False(t, shouldLoadWorkspaceModules(false))
 	require.False(t, initModuleParams([]string{"container"}).LoadWorkspaceModules)
+	// The scope is set per command site (api call/functions), never by the
+	// shared helper: shell also builds its params here and must keep the
+	// full workspace view.
+	require.Empty(t, initModuleParams([]string{"container"}).WorkspaceModuleScope)
 
 	ref, ok := getExplicitModuleSourceRef()
 	require.True(t, ok)


### PR DESCRIPTION
`dagger api call <module>` / `api functions <module>` build their command tree from a `currentTypeDefs` introspection that names no module — so they load **every** workspace module, and one broken sibling blocks calling *any* module. This completes #13548, which narrowed `generate`/`check`/`up` and left `call`/`functions` out of scope.

## Fix

The CLI forwards its leading argv token (already extracted by `functionName`) as a new **`workspace_module_scope`** `ClientMetadata` hint. The engine resolves it in `ensureRequestModulesLoaded` (kebab-normalized; a known module → that module's target + entrypoint; unknown → entrypoint, else all) and consumes it **one-shot** after the first successful load whose only full-schema demand is `currentTypeDefs`. Pre-request loading leaves `currentTypeDefs` and its cache key untouched.

- **No API / SDK / version-gate change** — no GraphQL schema change, no SDK regen, no version gate. Old engines ignore the unknown metadata key; old CLIs simply don't send it.
- **Nested clients** never inherit the parent's scope; they forward their own headers' scope (including `getOrInitClient`'s late-arriving fill-in, since the nested client is created by a headerless session-attachables pre-request).

```mermaid
sequenceDiagram
    autonumber
    participant CLI as dagger CLI
    participant H as serveQuery
    participant L as module loader
    participant R as currentTypeDefs resolver

    Note over CLI: dagger api call good fn<br/>(workspace = {good, bad-broken, entry*})
    Note over CLI: connect: workspace_module_scope: "good"
    CLI->>H: query { currentTypeDefs(...) }  — unchanged document
    H->>H: peek root fields → [currentTypeDefs]<br/>scope set → resolve + consume (one-shot)
    H->>L: demand = {good, entry} — bad stays pending
    L-->>H: good + entry served
    H->>R: resolve currentTypeDefs (unchanged resolver)
    R-->>CLI: typedefs (Query + good + entry closure)
    CLI->>H: query { goodMod { fn } }
    H-->>CLI: result — bad never loaded, cannot block
```

## Design doc

`hack/designs/targeted-module-loading-api-call-functions.md` (in-tree) — includes a post-mortem of #13380 / #13406 / #13539 / #13543 and the alternatives considered.

## Tests

Unit (demand-filter matrix, one-shot consumption, metadata plumbing incl. nested inherit/forward, CLI sites incl. shell guard) + integration `TestWorkspaceCall*` — targeting a module (exact + kebab), entrypoint-proxied function, scoped `--help`, one-shot within a session, bare listings still load all — all passing against a dev engine (27 passed), plus the merged generate/check/up narrowing tests as regression.
