### PR TITLE
core: support submodule and worktree checkouts for contextual git args

### DIFF
--- a/.changes/unreleased/Added-20260702-160000.yaml
+++ b/.changes/unreleased/Added-20260702-160000.yaml
@@ -9,4 +9,4 @@ body: |
 time: 2026-07-02T16:00:00Z
 custom:
   Author: vito
-  PR: ""
+  PR: 13577

--- a/.changes/unreleased/Added-20260702-160000.yaml
+++ b/.changes/unreleased/Added-20260702-160000.yaml
@@ -1,0 +1,12 @@
+kind: Added
+body: |
+  Contextual `GitRepository`/`GitRef` arguments now work from submodule and
+  git-worktree checkouts. Such checkouts have a `.git` pointer file whose
+  target lives outside the synced context; the engine now resolves the pointer
+  on the client host, loads the real git directory (and the shared common
+  directory for worktrees, including bare-repo layouts), and flattens it into
+  a standalone repository in the snapshot.
+time: 2026-07-02T16:00:00Z
+custom:
+  Author: vito
+  PR: ""

--- a/.changes/unreleased/Fixed-20260702-140000.yaml
+++ b/.changes/unreleased/Fixed-20260702-140000.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: |
+  An optional `GitRepository`/`GitRef` argument with a `defaultPath` no longer
+  fails the call when the context isn't a usable git repository — submodule and
+  git-worktree checkouts sync only a `.git` pointer file whose target lives
+  outside the context. The argument now resolves to null (with a warning) so the
+  function proceeds without git info; required arguments still fail.
+time: 2026-07-02T14:00:00Z
+custom:
+  Author: vito
+  PR: ""

--- a/.changes/unreleased/Fixed-20260702-140000.yaml
+++ b/.changes/unreleased/Fixed-20260702-140000.yaml
@@ -8,4 +8,4 @@ body: |
 time: 2026-07-02T14:00:00Z
 custom:
   Author: vito
-  PR: ""
+  PR: 13577

--- a/.changes/unreleased/Fixed-20260702-140000.yaml
+++ b/.changes/unreleased/Fixed-20260702-140000.yaml
@@ -1,10 +1,10 @@
 kind: Fixed
 body: |
-  An optional `GitRepository`/`GitRef` argument with a `defaultPath` no longer
-  fails the call when the context isn't a usable git repository — submodule and
-  git-worktree checkouts sync only a `.git` pointer file whose target lives
-  outside the context. The argument now resolves to null (with a warning) so the
-  function proceeds without git info; required arguments still fail.
+  A `GitRepository`/`GitRef` argument with a `defaultPath` no longer fails the
+  call when the context has no git checkout at all (e.g. `dagger init` before
+  `git init`, or an exported source tree): it resolves to null so the function
+  proceeds without git info. A `.git` that exists but is unusable still fails,
+  with a clear error.
 time: 2026-07-02T14:00:00Z
 custom:
   Author: vito

--- a/core/integration/module_path_inputs_test.go
+++ b/core/integration/module_path_inputs_test.go
@@ -1266,6 +1266,56 @@ public class Test {
 	}
 }
 
+func (ModuleSuite) TestContextGitUnusableRepo(ctx context.Context, t *testctx.T) {
+	// Submodule and git-worktree checkouts have a .git pointer *file* whose
+	// target lives outside the synced context, so the context can't be used
+	// as a git repository. An *optional* contextual GitRepository/GitRef arg
+	// resolves to null in that case, letting the function proceed without
+	// git info; a required arg still fails.
+
+	// Simulate a submodule checkout: worktree files present, .git is a
+	// pointer file whose target isn't part of the context.
+	brokenGit := func(c *dagger.Client) *dagger.Container {
+		return moduleFixture(t, c, "go/path-context-git-optional").
+			WithExec([]string{"sh", "-c", "rm -rf .git && echo 'gitdir: ../../.git/modules/work' > .git"})
+	}
+
+	t.Run("optional repo resolves to null", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := brokenGit(c).With(daggerCall("optional-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "no repo", out)
+	})
+
+	t.Run("optional ref resolves to null", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := brokenGit(c).With(daggerCall("optional-ref")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "no ref", out)
+	})
+
+	t.Run("required repo still fails", func(ctx context.Context, t *testctx.T) {
+		var logs safeBuffer
+		c := connect(ctx, t, dagger.WithLogOutput(&logs))
+		_, err := brokenGit(c).With(daggerCall("required-repo")).Sync(ctx)
+		require.Error(t, err)
+		require.NoError(t, c.Close())
+		require.Contains(t, logs.String(), "not a git repository")
+	})
+
+	t.Run("optional repo resolves in a real repo", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		modGen := moduleFixture(t, c, "go/path-context-git-optional").
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "initial commit"`})
+		headCommit, err := modGen.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+		require.NoError(t, err)
+
+		out, err := modGen.With(daggerCall("optional-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "repo@"+strings.TrimSpace(headCommit), out)
+	})
+}
+
 func (ModuleSuite) TestContextGitRemote(ctx context.Context, t *testctx.T) {
 	// pretty much exactly the same test as above, but calling a remote git repo instead
 

--- a/core/integration/module_path_inputs_test.go
+++ b/core/integration/module_path_inputs_test.go
@@ -1294,13 +1294,18 @@ func (ModuleSuite) TestContextGitUnusableRepo(ctx context.Context, t *testctx.T)
 		require.Equal(t, "no ref", out)
 	})
 
-	t.Run("required repo still fails", func(ctx context.Context, t *testctx.T) {
+	t.Run("defaultPath without optional degrades too", func(ctx context.Context, t *testctx.T) {
+		// The SDK marks every +defaultPath arg optional in the schema, so
+		// there is no schema-level "required" contextual git arg: the arg
+		// degrades to null and the module's own guard reports the failure.
+		// (The engine also logs a warning breadcrumb, but engine warnings
+		// only surface in the trace, not in session logs.)
 		var logs safeBuffer
 		c := connect(ctx, t, dagger.WithLogOutput(&logs))
 		_, err := brokenGit(c).With(daggerCall("required-repo")).Sync(ctx)
 		require.Error(t, err)
 		require.NoError(t, c.Close())
-		require.Contains(t, logs.String(), "not a git repository")
+		require.Contains(t, logs.String(), "no usable git repository in context")
 	})
 
 	t.Run("optional repo resolves in a real repo", func(ctx context.Context, t *testctx.T) {
@@ -1313,6 +1318,108 @@ func (ModuleSuite) TestContextGitUnusableRepo(ctx context.Context, t *testctx.T)
 		out, err := modGen.With(daggerCall("optional-repo")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "repo@"+strings.TrimSpace(headCommit), out)
+	})
+}
+
+func (ModuleSuite) TestContextGitSubmodule(ctx context.Context, t *testctx.T) {
+	// A submodule checkout's .git is a pointer file into the superproject's
+	// .git/modules. The engine resolves the pointer on the client host and
+	// reassembles a standalone repository, so contextual git args behave as
+	// in a plain clone.
+	c := connect(ctx, t)
+
+	ctr := goGitBase(t, c).
+		With(withModuleFixture(t, c, "/module-src", "go/path-context-git-optional")).
+		WithExec([]string{"sh", "-c", `git -C /module-src init && git -C /module-src add . && git -C /module-src commit -m "module fixture"`}).
+		WithExec([]string{"sh", "-c", `git -c protocol.file.allow=always submodule add /module-src sub && git commit -m "add submodule"`}).
+		WithWorkdir("/work/sub")
+
+	headCommit, err := ctr.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+	require.NoError(t, err)
+	headCommit = strings.TrimSpace(headCommit)
+
+	t.Run("optional repo resolves", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(daggerCall("optional-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "repo@"+headCommit, out)
+	})
+
+	t.Run("required repo resolves", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(daggerCall("required-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, headCommit, out)
+	})
+
+	t.Run("uncommitted changes detected", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(daggerCall("repo-state")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "clean", out)
+
+		out, err = ctr.
+			WithNewFile("/work/sub/scratch.txt", "uncommitted").
+			With(daggerCall("repo-state")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "dirty", out)
+	})
+}
+
+func (ModuleSuite) TestContextGitWorktree(ctx context.Context, t *testctx.T) {
+	// A linked worktree's .git is a pointer file into the main checkout's
+	// .git/worktrees/<name>, which holds only per-worktree state (HEAD,
+	// index) next to a commondir pointer at the shared git dir. The engine
+	// flattens all of it into a standalone repository.
+	t.Run("linked worktree", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		ctr := moduleFixture(t, c, "go/path-context-git-optional").
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "fixture"`}).
+			WithExec([]string{"git", "worktree", "add", "-b", "feature", "/wt"}).
+			WithWorkdir("/wt").
+			// Diverge from the main checkout to prove the per-worktree HEAD
+			// is honored, not the main checkout's.
+			WithNewFile("/wt/feature.txt", "feature work").
+			WithExec([]string{"sh", "-c", `git add feature.txt && git commit -m "feature commit"`})
+
+		wtHead, err := ctr.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+		require.NoError(t, err)
+		wtHead = strings.TrimSpace(wtHead)
+		mainHead, err := ctr.WithExec([]string{"git", "-C", "/work", "rev-parse", "HEAD"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.NotEqual(t, wtHead, strings.TrimSpace(mainHead))
+
+		out, err := ctr.With(daggerCall("optional-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "repo@"+wtHead, out)
+
+		out, err = ctr.With(daggerCall("repo-state")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "clean", out)
+
+		out, err = ctr.
+			WithNewFile("/wt/scratch.txt", "uncommitted").
+			With(daggerCall("repo-state")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "dirty", out)
+	})
+
+	t.Run("worktree of a bare repo", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		ctr := moduleFixture(t, c, "go/path-context-git-optional").
+			WithExec([]string{"sh", "-c", `git add . && git commit -m "fixture"`}).
+			WithExec([]string{"git", "clone", "--bare", "/work", "/repo.git"}).
+			WithExec([]string{"git", "-C", "/repo.git", "worktree", "add", "/wt", "master"}).
+			WithWorkdir("/wt")
+
+		headCommit, err := ctr.WithExec([]string{"git", "rev-parse", "HEAD"}).Stdout(ctx)
+		require.NoError(t, err)
+		headCommit = strings.TrimSpace(headCommit)
+
+		// The shared config says core.bare=true here; the flattened override
+		// is what makes the assembled repository usable.
+		out, err := ctr.With(daggerCall("optional-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "repo@"+headCommit, out)
 	})
 }
 

--- a/core/integration/module_path_inputs_test.go
+++ b/core/integration/module_path_inputs_test.go
@@ -1267,59 +1267,60 @@ public class Test {
 }
 
 func (ModuleSuite) TestContextGitUnusableRepo(ctx context.Context, t *testctx.T) {
-	// When the context can't be used as a git repository at all — no .git,
-	// or a .git pointer file whose target doesn't exist — a contextual
-	// GitRepository/GitRef arg resolves to null, letting the function
-	// proceed without git info. (Resolvable pointer files are covered by
-	// TestContextGitSubmodule/TestContextGitWorktree.)
+	// A context with no git checkout at all degrades contextual git args to
+	// null: absence is a legitimate environment (`dagger init` before `git
+	// init`, exported source trees). A .git that exists but is unusable — a
+	// dead submodule/worktree pointer — is a broken environment and fails
+	// loudly instead of silently stripping git info. (Resolvable pointer
+	// files are covered by TestContextGitSubmodule/TestContextGitWorktree.)
 
-	// Simulate a submodule checkout whose real git dir is gone: worktree
-	// files present, .git is a pointer file at a dead path.
+	// A module in a plain directory: no git checkout anywhere.
+	noGit := func(c *dagger.Client) *dagger.Container {
+		return c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(withModuleFixture(t, c, ".", "go/path-context-git-optional"))
+	}
+	// A submodule-shaped checkout whose real git dir is gone: worktree files
+	// present, .git is a pointer file at a dead path.
 	brokenGit := func(c *dagger.Client) *dagger.Container {
 		return moduleFixture(t, c, "go/path-context-git-optional").
 			WithExec([]string{"sh", "-c", "rm -rf .git && echo 'gitdir: ../../.git/modules/work' > .git"})
 	}
 
-	t.Run("optional repo resolves to null", func(ctx context.Context, t *testctx.T) {
+	t.Run("no git: optional repo resolves to null", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		out, err := brokenGit(c).With(daggerCall("optional-repo")).Stdout(ctx)
+		out, err := noGit(c).With(daggerCall("optional-repo")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "no repo", out)
 	})
 
-	t.Run("no git repository at all", func(ctx context.Context, t *testctx.T) {
-		// The `dagger init` before `git init` flow: a module in a plain
-		// directory. Modules with contextual git args must still be callable.
+	t.Run("no git: optional ref resolves to null", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		out, err := c.Container().From(golangImage).
-			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-			WithWorkdir("/work").
-			With(withModuleFixture(t, c, ".", "go/path-context-git-optional")).
-			With(daggerCall("optional-repo")).
-			Stdout(ctx)
-		require.NoError(t, err)
-		require.Equal(t, "no repo", out)
-	})
-
-	t.Run("optional ref resolves to null", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
-		out, err := brokenGit(c).With(daggerCall("optional-ref")).Stdout(ctx)
+		out, err := noGit(c).With(daggerCall("optional-ref")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "no ref", out)
 	})
 
-	t.Run("defaultPath without optional degrades too", func(ctx context.Context, t *testctx.T) {
+	t.Run("no git: module-level required guard fires", func(ctx context.Context, t *testctx.T) {
 		// The SDK marks every +defaultPath arg optional in the schema, so
 		// there is no schema-level "required" contextual git arg: the arg
 		// degrades to null and the module's own guard reports the failure.
-		// (The engine also logs a warning breadcrumb, but engine warnings
-		// only surface in the trace, not in session logs.)
 		var logs safeBuffer
 		c := connect(ctx, t, dagger.WithLogOutput(&logs))
-		_, err := brokenGit(c).With(daggerCall("required-repo")).Sync(ctx)
+		_, err := noGit(c).With(daggerCall("required-repo")).Sync(ctx)
 		require.Error(t, err)
 		require.NoError(t, c.Close())
 		require.Contains(t, logs.String(), "no usable git repository in context")
+	})
+
+	t.Run("dead git pointer fails loudly", func(ctx context.Context, t *testctx.T) {
+		var logs safeBuffer
+		c := connect(ctx, t, dagger.WithLogOutput(&logs))
+		_, err := brokenGit(c).With(daggerCall("optional-repo")).Sync(ctx)
+		require.Error(t, err)
+		require.NoError(t, c.Close())
+		require.Contains(t, logs.String(), ".git pointer target")
 	})
 
 	t.Run("optional repo resolves in a real repo", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_path_inputs_test.go
+++ b/core/integration/module_path_inputs_test.go
@@ -1267,14 +1267,14 @@ public class Test {
 }
 
 func (ModuleSuite) TestContextGitUnusableRepo(ctx context.Context, t *testctx.T) {
-	// Submodule and git-worktree checkouts have a .git pointer *file* whose
-	// target lives outside the synced context, so the context can't be used
-	// as a git repository. An *optional* contextual GitRepository/GitRef arg
-	// resolves to null in that case, letting the function proceed without
-	// git info; a required arg still fails.
+	// When the context can't be used as a git repository at all — no .git,
+	// or a .git pointer file whose target doesn't exist — a contextual
+	// GitRepository/GitRef arg resolves to null, letting the function
+	// proceed without git info. (Resolvable pointer files are covered by
+	// TestContextGitSubmodule/TestContextGitWorktree.)
 
-	// Simulate a submodule checkout: worktree files present, .git is a
-	// pointer file whose target isn't part of the context.
+	// Simulate a submodule checkout whose real git dir is gone: worktree
+	// files present, .git is a pointer file at a dead path.
 	brokenGit := func(c *dagger.Client) *dagger.Container {
 		return moduleFixture(t, c, "go/path-context-git-optional").
 			WithExec([]string{"sh", "-c", "rm -rf .git && echo 'gitdir: ../../.git/modules/work' > .git"})
@@ -1283,6 +1283,20 @@ func (ModuleSuite) TestContextGitUnusableRepo(ctx context.Context, t *testctx.T)
 	t.Run("optional repo resolves to null", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := brokenGit(c).With(daggerCall("optional-repo")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "no repo", out)
+	})
+
+	t.Run("no git repository at all", func(ctx context.Context, t *testctx.T) {
+		// The `dagger init` before `git init` flow: a module in a plain
+		// directory. Modules with contextual git args must still be callable.
+		c := connect(ctx, t)
+		out, err := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(withModuleFixture(t, c, ".", "go/path-context-git-optional")).
+			With(daggerCall("optional-repo")).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "no repo", out)
 	})

--- a/core/integration/testdata/modules/go/path-context-git-optional/dagger.json
+++ b/core/integration/testdata/modules/go/path-context-git-optional/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  }
+}

--- a/core/integration/testdata/modules/go/path-context-git-optional/main.go
+++ b/core/integration/testdata/modules/go/path-context-git-optional/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+
 	"dagger/test/internal/dagger"
 )
 
@@ -39,10 +41,36 @@ func (m *Test) OptionalRef(
 	return "ref@" + commit, nil
 }
 
+// RequiredRepo insists on the contextual repo. Note the SDK marks every
+// +defaultPath arg optional in the schema, so "required" is module-level
+// policy: the module still receives nil when the context has no usable git
+// repository and must guard for it.
 func (m *Test) RequiredRepo(
 	ctx context.Context,
 	// +defaultPath="/"
 	repo *dagger.GitRepository,
 ) (string, error) {
+	if repo == nil {
+		return "", errors.New("no usable git repository in context")
+	}
 	return repo.Head().Commit(ctx)
+}
+
+func (m *Test) RepoState(
+	ctx context.Context,
+	// +optional
+	// +defaultPath="/"
+	repo *dagger.GitRepository,
+) (string, error) {
+	if repo == nil {
+		return "no repo", nil
+	}
+	clean, err := repo.Uncommitted().IsEmpty(ctx)
+	if err != nil {
+		return "", err
+	}
+	if clean {
+		return "clean", nil
+	}
+	return "dirty", nil
 }

--- a/core/integration/testdata/modules/go/path-context-git-optional/main.go
+++ b/core/integration/testdata/modules/go/path-context-git-optional/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"dagger/test/internal/dagger"
+)
+
+type Test struct{}
+
+func (m *Test) OptionalRepo(
+	ctx context.Context,
+	// +optional
+	// +defaultPath="/"
+	repo *dagger.GitRepository,
+) (string, error) {
+	if repo == nil {
+		return "no repo", nil
+	}
+	commit, err := repo.Head().Commit(ctx)
+	if err != nil {
+		return "", err
+	}
+	return "repo@" + commit, nil
+}
+
+func (m *Test) OptionalRef(
+	ctx context.Context,
+	// +optional
+	// +defaultPath="/"
+	ref *dagger.GitRef,
+) (string, error) {
+	if ref == nil {
+		return "no ref", nil
+	}
+	commit, err := ref.Commit(ctx)
+	if err != nil {
+		return "", err
+	}
+	return "ref@" + commit, nil
+}
+
+func (m *Test) RequiredRepo(
+	ctx context.Context,
+	// +defaultPath="/"
+	repo *dagger.GitRepository,
+) (string, error) {
+	return repo.Head().Commit(ctx)
+}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -1070,12 +1070,15 @@ func (fn *ModuleFunction) loadContextualArg(
 	case "GitRepository", "GitRef":
 		id, err := fn.loadContextualGitArg(ctx, dag, arg)
 		if err != nil && arg.TypeDef.Self().Optional && errors.Is(err, gitutil.ErrGitNoRepo) {
-			// The context isn't a usable git repository: submodule and
-			// worktree checkouts sync only a .git pointer file whose target
-			// lives outside the context, and exported trees have no .git at
-			// all. For an optional arg that's an environmental condition, not
-			// a configuration error, so resolve to null and let the function
-			// proceed without git info.
+			// The context isn't a usable git repository: exported trees have
+			// no .git at all, and a submodule/worktree .git pointer file can
+			// be unresolvable (see ModuleSource.resolveGitPointer for the
+			// resolvable case). That's an environmental condition, not a
+			// configuration error, so resolve a nullable arg to null and let
+			// the function proceed without git info. SDK codegen marks every
+			// defaultPath arg optional in the schema, so in practice this
+			// covers all contextual git args; modules decide how strictly to
+			// treat a null.
 			slog.Warn("skipping contextual git argument: context is not a usable git repository",
 				"function", fn.metadata.Name,
 				"arg", arg.OriginalName,

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -1069,17 +1069,18 @@ func (fn *ModuleFunction) loadContextualArg(
 
 	case "GitRepository", "GitRef":
 		id, err := fn.loadContextualGitArg(ctx, dag, arg)
-		if err != nil && arg.TypeDef.Self().Optional && errors.Is(err, gitutil.ErrGitNoRepo) {
-			// The context isn't a usable git repository: exported trees have
-			// no .git at all, and a submodule/worktree .git pointer file can
-			// be unresolvable (see ModuleSource.resolveGitPointer for the
-			// resolvable case). That's an environmental condition, not a
-			// configuration error, so resolve a nullable arg to null and let
-			// the function proceed without git info. SDK codegen marks every
-			// defaultPath arg optional in the schema, so in practice this
-			// covers all contextual git args; modules decide how strictly to
-			// treat a null.
-			slog.Warn("skipping contextual git argument: context is not a usable git repository",
+		if err != nil && arg.TypeDef.Self().Optional && errors.Is(err, ErrNoGitContext) {
+			// The context simply isn't a git checkout (`dagger init` before
+			// `git init`, an exported source tree). That's a legitimate
+			// environment, not an error, so resolve a nullable arg to null
+			// and let the function proceed without git info. SDK codegen
+			// marks every defaultPath arg optional in the schema, so in
+			// practice this covers all contextual git args; modules decide
+			// how strictly to treat a null. A .git that exists but is
+			// unusable -- a dead submodule/worktree pointer, a corrupt repo
+			// -- is a broken environment and fails the call instead (see
+			// ModuleSource.resolveGitPointer).
+			slog.Warn("skipping contextual git argument: module context has no git checkout",
 				"function", fn.metadata.Name,
 				"arg", arg.OriginalName,
 				"defaultPath", arg.DefaultPath)

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -693,6 +693,11 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 				if err != nil {
 					return fmt.Errorf("load contextual arg %q: %w", arg.Name, err)
 				}
+				if ctxVal == nil {
+					// The contextual value is unavailable and the arg is
+					// optional: leave it unset.
+					return nil
+				}
 
 				ctxArgVals[i] = &argInput{
 					argName: arg.Name,
@@ -1063,7 +1068,21 @@ func (fn *ModuleFunction) loadContextualArg(
 		return dagql.NewID[*File](fileID), nil
 
 	case "GitRepository", "GitRef":
-		return fn.loadContextualGitArg(ctx, dag, arg)
+		id, err := fn.loadContextualGitArg(ctx, dag, arg)
+		if err != nil && arg.TypeDef.Self().Optional && errors.Is(err, gitutil.ErrGitNoRepo) {
+			// The context isn't a usable git repository: submodule and
+			// worktree checkouts sync only a .git pointer file whose target
+			// lives outside the context, and exported trees have no .git at
+			// all. For an optional arg that's an environmental condition, not
+			// a configuration error, so resolve to null and let the function
+			// proceed without git info.
+			slog.Warn("skipping contextual git argument: context is not a usable git repository",
+				"function", fn.metadata.Name,
+				"arg", arg.OriginalName,
+				"defaultPath", arg.DefaultPath)
+			return nil, nil
+		}
+		return id, err
 	}
 
 	return nil, fmt.Errorf("unknown contextual argument type %q", arg.TypeDef.Self().AsObject.Value.Self().Name)

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -1796,6 +1796,13 @@ func (src *ModuleSource) LoadContextGit(
 		return inst, fmt.Errorf("failed to load contextual git: %w", err)
 	}
 
+	// Submodule and worktree checkouts have a .git pointer file whose target
+	// lives outside the context; resolve it into a real .git directory.
+	dir, err = src.resolveGitPointer(ctx, dag, dir)
+	if err != nil {
+		return inst, fmt.Errorf("failed to load contextual git: %w", err)
+	}
+
 	err = dag.Select(ctx, dir, &inst,
 		dagql.Selector{
 			Field: "asGit",

--- a/core/modulesource_gitfile.go
+++ b/core/modulesource_gitfile.go
@@ -1,0 +1,231 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/util/gitutil"
+)
+
+// Checkouts created by `git submodule` and `git worktree` don't have a .git
+// *directory* at the tree root: they have a .git pointer file (a "gitfile")
+// whose `gitdir:` target lives outside the tree, typically inside the
+// superproject's or main checkout's .git directory. Syncing such a tree gives
+// the engine only the pointer file, so git operations against the snapshot
+// fail with "not a git repository".
+//
+// resolveGitPointer reassembles such a context: it resolves the gitfile
+// against the module's host context path, loads the real git directory (and
+// the shared common directory, for worktrees) from the client, and flattens
+// everything into a normal .git directory in the snapshot, so downstream git
+// operations behave as if the context were a plain clone.
+//
+// Only local module sources are handled: they're the only kind with a client
+// host to resolve the pointer against. Anything unresolvable is reported as
+// gitutil.ErrGitNoRepo, the same class as a plain non-repository context, so
+// callers that degrade gracefully on missing git info treat both alike.
+func (src *ModuleSource) resolveGitPointer(
+	ctx context.Context,
+	dag *dagql.Server,
+	dir dagql.ObjectResult[*Directory],
+) (dagql.ObjectResult[*Directory], error) {
+	st, err := dir.Self().Stat(ctx, dir, dag, ".git", true)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// No .git at all; let asGit report the plain failure.
+			return dir, nil
+		}
+		return dir, err
+	}
+	if st.FileType != FileTypeRegular {
+		// A normal .git directory; nothing to resolve.
+		return dir, nil
+	}
+	if src.Kind != ModuleSourceKindLocal {
+		return dir, nil
+	}
+
+	pointer, err := readDirFile(ctx, dag, dir, ".git")
+	if err != nil {
+		return dir, fmt.Errorf("read .git pointer file: %w", err)
+	}
+	target, ok := strings.CutPrefix(strings.TrimSpace(string(pointer)), "gitdir:")
+	if !ok {
+		return dir, notAGitRepo("malformed .git pointer file %q", strings.TrimSpace(string(pointer)))
+	}
+	// A relative gitdir is relative to the directory containing the pointer
+	// file, i.e. the context root, which for a local source is a client host
+	// path.
+	hostGitDir := strings.TrimSpace(target)
+	if !filepath.IsAbs(hostGitDir) {
+		hostGitDir = filepath.Join(src.Local.ContextDirectoryPath, hostGitDir)
+	}
+
+	gitDir, err := src.loadClientDir(ctx, dag, hostGitDir)
+	if err != nil {
+		return dir, notAGitRepo("load .git pointer target %q: %s", hostGitDir, err)
+	}
+
+	// A worktree's git dir holds only per-worktree state (HEAD, index, ...)
+	// plus a "commondir" pointer to the shared git dir; everything else
+	// (objects, refs, config) lives there. A submodule's git dir is complete.
+	// Flatten either shape into a single normal .git directory: shared state
+	// as the base, per-worktree state layered on top.
+	layers := []dagql.ObjectResult[*Directory]{gitDir}
+	switch _, err := gitDir.Self().Stat(ctx, gitDir, dag, "commondir", false); {
+	case err == nil:
+		commonRel, err := readDirFile(ctx, dag, gitDir, "commondir")
+		if err != nil {
+			return dir, fmt.Errorf("read git commondir pointer: %w", err)
+		}
+		hostCommonDir := strings.TrimSpace(string(commonRel))
+		if !filepath.IsAbs(hostCommonDir) {
+			hostCommonDir = filepath.Join(hostGitDir, hostCommonDir)
+		}
+		commonDir, err := src.loadClientDir(ctx, dag, hostCommonDir)
+		if err != nil {
+			return dir, notAGitRepo("load git common dir %q: %s", hostCommonDir, err)
+		}
+		layers = []dagql.ObjectResult[*Directory]{commonDir, gitDir}
+	case !errors.Is(err, fs.ErrNotExist):
+		return dir, err
+	}
+
+	// The base layer must look like an actual git dir before we present it as
+	// one. This also guards against a crafted pointer smuggling unrelated
+	// host paths into the context as ".git".
+	base := layers[0]
+	for _, marker := range []string{"HEAD", "objects", "refs"} {
+		if _, err := base.Self().Stat(ctx, base, dag, marker, false); err != nil {
+			return dir, notAGitRepo(".git pointer target %q is not a git directory (missing %s)", hostGitDir, marker)
+		}
+	}
+
+	sels := []dagql.Selector{{
+		Field: "withoutFile",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(".git")},
+		},
+	}}
+	for _, layer := range layers {
+		layerID, err := layer.ID()
+		if err != nil {
+			return dir, fmt.Errorf("git dir layer ID: %w", err)
+		}
+		sels = append(sels, dagql.Selector{
+			Field: "withDirectory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(".git")},
+				{Name: "source", Value: dagql.NewID[*Directory](layerID)},
+			},
+		})
+	}
+	// Drop worktree plumbing that only makes sense in the original layout:
+	// other worktrees' registrations and this worktree's pointers back to the
+	// host filesystem. All are no-ops for the submodule shape.
+	sels = append(sels,
+		dagql.Selector{
+			Field: "withoutDirectory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(".git/worktrees")},
+			},
+		},
+		dagql.Selector{
+			Field: "withoutFiles",
+			Args: []dagql.NamedInput{
+				{Name: "paths", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(
+					".git/commondir", ".git/gitdir", ".git/locked",
+				))},
+			},
+		},
+	)
+
+	var flattened dagql.ObjectResult[*Directory]
+	if err := dag.Select(ctx, dir, &flattened, sels...); err != nil {
+		return dir, fmt.Errorf("assemble flattened .git directory: %w", err)
+	}
+
+	// The copied config still describes the original layout: a submodule's
+	// sets core.worktree to the old checkout path, and a bare main repo's
+	// sets core.bare. Git honors the last definition of a single-valued key,
+	// so append overrides describing the flattened shape instead of parsing
+	// and rewriting the file. core.worktree is relative to the .git dir, so
+	// ".." is the context root.
+	cfg, err := readDirFile(ctx, dag, flattened, ".git/config")
+	if err != nil {
+		return dir, notAGitRepo(".git pointer target %q has no config: %s", hostGitDir, err)
+	}
+	const overrides = "\n# Appended by Dagger: the checkout was flattened from a submodule or\n# worktree layout into a standalone repository.\n[core]\n\tbare = false\n\tworktree = ..\n"
+	if err := dag.Select(ctx, flattened, &flattened, dagql.Selector{
+		Field: "withNewFile",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(".git/config")},
+			{Name: "contents", Value: dagql.String(string(cfg) + overrides)},
+		},
+	}); err != nil {
+		return dir, fmt.Errorf("override flattened git config: %w", err)
+	}
+
+	return flattened, nil
+}
+
+// loadClientDir loads an absolute path from the module's client host. Unlike
+// contextual paths this is not bounded to the context directory: gitfile
+// targets legitimately live outside it (e.g. the superproject's .git). The
+// caller is responsible for validating what it loads.
+func (src *ModuleSource) loadClientDir(
+	ctx context.Context,
+	dag *dagql.Server,
+	hostPath string,
+) (inst dagql.ObjectResult[*Directory], err error) {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	md, err := query.NonModuleParentClientMetadata(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get client metadata: %w", err)
+	}
+	clientCtx := engine.ContextWithClientMetadata(ctx, md)
+	err = dag.Select(clientCtx, dag.Root(), &inst,
+		dagql.Selector{
+			Field: "host",
+		},
+		dagql.Selector{
+			Field: "directory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(hostPath)},
+				{Name: "noCache", Value: dagql.Boolean(true)},
+			},
+		},
+	)
+	return inst, err
+}
+
+func readDirFile(
+	ctx context.Context,
+	dag *dagql.Server,
+	dir dagql.ObjectResult[*Directory],
+	path string,
+) ([]byte, error) {
+	var f dagql.ObjectResult[*File]
+	if err := dag.Select(ctx, dir, &f, dagql.Selector{
+		Field: "file",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(path)},
+		},
+	}); err != nil {
+		return nil, err
+	}
+	return f.Self().Contents(ctx, f, nil, nil)
+}
+
+func notAGitRepo(format string, args ...any) error {
+	return fmt.Errorf(format+": %w", append(args, gitutil.ErrGitNoRepo)...)
+}

--- a/core/modulesource_gitfile.go
+++ b/core/modulesource_gitfile.go
@@ -13,6 +13,13 @@ import (
 	"github.com/dagger/dagger/util/gitutil"
 )
 
+// ErrNoGitContext reports that the module context has no git checkout at
+// all: no .git entry at its root. Unlike a .git that exists but is unusable
+// (which is a broken environment and fails the call), absence is a
+// legitimate state -- `dagger init` before `git init`, an exported source
+// tree -- so contextual GitRepository/GitRef args degrade to null on it.
+var ErrNoGitContext = errors.New("module context has no git checkout")
+
 // Checkouts created by `git submodule` and `git worktree` don't have a .git
 // *directory* at the tree root: they have a .git pointer file (a "gitfile")
 // whose `gitdir:` target lives outside the tree, typically inside the
@@ -27,9 +34,9 @@ import (
 // operations behave as if the context were a plain clone.
 //
 // Only local module sources are handled: they're the only kind with a client
-// host to resolve the pointer against. Anything unresolvable is reported as
-// gitutil.ErrGitNoRepo, the same class as a plain non-repository context, so
-// callers that degrade gracefully on missing git info treat both alike.
+// host to resolve the pointer against. A missing .git reports
+// ErrNoGitContext (degradable); a .git that exists but can't be used as a
+// git repository is a hard error.
 func (src *ModuleSource) resolveGitPointer(
 	ctx context.Context,
 	dag *dagql.Server,
@@ -38,8 +45,7 @@ func (src *ModuleSource) resolveGitPointer(
 	st, err := dir.Self().Stat(ctx, dir, dag, ".git", true)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			// No .git at all; let asGit report the plain failure.
-			return dir, nil
+			return dir, ErrNoGitContext
 		}
 		return dir, err
 	}


### PR DESCRIPTION
## Problem

Since #13313, `toolchains/go` (and anything mirroring it) takes an optional `repo *GitRepository` arg with `+defaultPath="/"`. Resolving that default runs `Directory.asGit` over the synced context — which eagerly introspects the repo. Two common checkout shapes broke every `dagger call` outright:

- **Submodule checkouts**: `.git` is a pointer file (`gitdir: ../../.git/modules/...`) whose target lives outside the synced context.
- **Git worktrees**: same pointer-file shape (`gitdir: <main>/.git/worktrees/<name>`), plus a second `commondir` indirection to the shared git dir.

Both died with an opaque `failed to compute cache key for Query.go: ... git error: not a git repository` before module code (whose VCS stamping is explicitly best-effort) could react. Plain non-git directories — `dagger init` before `git init`, exported source trees — hit the same wall.

## What this does

**Follow the pointer** (`core/modulesource_gitfile.go`): for local module sources, `LoadContextGit` now detects a `.git` pointer file, resolves the target against the host context path, loads the real git directory from the client (plus the shared common dir for worktrees, including bare-repo layouts), and flattens everything into a standalone `.git` in the snapshot. The copied config still describes the original layout, so `[core] bare = false / worktree = ..` overrides are *appended* — git honors the last definition of a single-valued key — rather than parsing and rewriting the file. Head/ref/`uncommitted` all behave as in a plain clone, with per-worktree HEAD and index honored.

**Degrade only on absence, fail loudly on breakage** (`core/modfunc.go`): a context with *no* `.git` at all is a legitimate environment, so a nullable contextual git arg resolves to null there (SDK codegen marks every `+defaultPath` arg optional in the schema, so this covers all of them; modules decide how strictly to treat a null — `toolchains/go` already guards). A `.git` that exists but can't be used — a dead pointer, a target that doesn't look like a git dir — is a broken environment and now fails the call with a clear error instead of silently stripping VCS info. The gate keys on a precise `ErrNoGitContext` sentinel, not the broad `ErrGitNoRepo` class.

## Security note

Pointer resolution reads host paths *outside* the workspace root (that's inherently where submodule/superproject git dirs live). It is restricted to local module sources — the same client whose filesystem the context already came from — and the loaded base layer must look like an actual git directory (`HEAD`, `objects`, `refs`) before it is presented as one, so a crafted pointer can't smuggle arbitrary host paths into the context as `.git`.

## Behavior change to ratify

A checkout with a *broken* submodule/worktree pointer that limped along silently before #13313 now fails loudly. That's the intended trade: with resolvable pointers actually working, everything left in that bucket is genuine breakage worth surfacing.

## Known limitations / follow-ups

- `objects/info/alternates` is not followed; an alternates-dependent repo (`--reference` clones) passes validation but fails lazily on missing objects.
- `Workspace.git` still rejects pointer files ("git worktrees are not supported yet"); wiring this resolution into it is a natural follow-up when #13508 unblocks.

## Tests

All via `dagger call engine-dev test` (41 passed):

- `TestContextGitSubmodule`: real `git submodule add` layout — head commit via optional and non-optional args, clean→dirty via `Uncommitted().IsEmpty` (exactly what `toolchains/go` stamps with).
- `TestContextGitWorktree`: linked worktree *diverged from the main checkout* (proves per-worktree HEAD wins), plus a worktree of a bare clone (proves the `core.bare=true` override matters).
- `TestContextGitUnusableRepo`: no-git contexts degrade to null (repo, ref, and the module-level "required" guard); dead pointers fail loudly with the `.git pointer target` breadcrumb.
- `TestContextGit` (go/python/typescript/java) unchanged, green.

Refs: #13313, #13287, #13508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
