### PR TITLE
Fix command for opening VS Code with Python SDK

### DIFF
--- a/docs/versioned_docs/version-0.21.4/reference/ide-setup.mdx
+++ b/docs/versioned_docs/version-0.21.4/reference/ide-setup.mdx
@@ -52,7 +52,7 @@ To get your IDE to recognize a Dagger Python module and any added Dagger module 
 For example, to open the Visual Studio Code from the terminal, with functioning autocompletions (assuming the [Python extensions](https://github.com/microsoft/vscode-python) are installed):
 
 ```shell
-dagger develop
+dagger develop --sdk pyhton
 uv run code .
 ```
 


### PR DESCRIPTION
Corrected the command for opening Visual Studio Code with the Python SDK.