### PR TITLE
core: resolve module and client init paths per the workspace path contract

### DIFF
--- a/core/integration/workspace_module_init_test.go
+++ b/core/integration/workspace_module_init_test.go
@@ -1,0 +1,171 @@
+package core
+
+// These tests cover Workspace.moduleInit path handling, in particular the
+// workspace path contract: relative paths resolve from the caller cwd,
+// absolute paths resolve from the workspace root. See
+// future/synthetic-workspace.md ("Source Rules").
+//
+// They use the real go-sdk because moduleInit requires an installed SDK
+// implementing initModule, and loadWorkspaceSDK cannot load relative local
+// SDK refs today ("local module dep source path must be relative to a parent
+// module"), so a local fixture SDK cannot be dispatched to.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+type WorkspaceModuleInitSuite struct{}
+
+func TestWorkspaceModuleInit(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(WorkspaceModuleInitSuite{})
+}
+
+const goSDKWorkspaceConfig = `[modules.go-sdk]
+source = "github.com/dagger/go-sdk"
+
+[modules.go-sdk.as-sdk]
+name = "go"
+`
+
+func (WorkspaceModuleInitSuite) TestModuleInitFromSubdirectory(ctx context.Context, t *testctx.T) {
+	setupSubdirWorkspace := func(t *testctx.T) (workdir, subdir string) {
+		t.Helper()
+		workdir = t.TempDir()
+		subdir = filepath.Join(workdir, "subdir")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+		initGitRepo(ctx, t, workdir)
+		require.NoError(t, os.WriteFile(filepath.Join(subdir, "dagger.toml"), []byte(goSDKWorkspaceConfig), 0o644))
+		return workdir, subdir
+	}
+
+	t.Run("relative path resolves from cwd", func(ctx context.Context, t *testctx.T) {
+		_, subdir := setupSubdirWorkspace(t)
+		c := connect(ctx, t, dagger.WithWorkdir(subdir))
+
+		changes := c.CurrentWorkspace().ModuleInit("main", dagger.WorkspaceModuleInitOpts{
+			SDK:  "go",
+			Path: ".dagger",
+		})
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, added, "subdir/.dagger/dagger-module.toml")
+		require.Contains(t, added, "subdir/.dagger/main.go")
+
+		modified, err := changes.ModifiedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, modified, "subdir/dagger.toml")
+
+		config, err := changes.After().File("subdir/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = ".dagger"`)
+	})
+
+	t.Run("relative path resolves from cwd below the config directory", func(ctx context.Context, t *testctx.T) {
+		_, subdir := setupSubdirWorkspace(t)
+		subsubdir := filepath.Join(subdir, "subsubdir")
+		require.NoError(t, os.MkdirAll(subsubdir, 0o755))
+		c := connect(ctx, t, dagger.WithWorkdir(subsubdir))
+
+		changes := c.CurrentWorkspace().ModuleInit("main", dagger.WorkspaceModuleInitOpts{
+			SDK:  "go",
+			Path: ".dagger",
+		})
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, added, "subdir/subsubdir/.dagger/dagger-module.toml")
+		require.Contains(t, added, "subdir/subsubdir/.dagger/main.go")
+
+		config, err := changes.After().File("subdir/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = "subsubdir/.dagger"`)
+	})
+
+	t.Run("absolute path resolves from workspace boundary", func(ctx context.Context, t *testctx.T) {
+		_, subdir := setupSubdirWorkspace(t)
+		c := connect(ctx, t, dagger.WithWorkdir(subdir))
+
+		changes := c.CurrentWorkspace().ModuleInit("main", dagger.WorkspaceModuleInitOpts{
+			SDK:  "go",
+			Path: "/subdir/.dagger",
+		})
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, added, "subdir/.dagger/dagger-module.toml")
+		require.Contains(t, added, "subdir/.dagger/main.go")
+	})
+
+	t.Run("default path resolves from cwd and installs the module", func(ctx context.Context, t *testctx.T) {
+		_, subdir := setupSubdirWorkspace(t)
+		c := connect(ctx, t, dagger.WithWorkdir(subdir))
+
+		changes := c.CurrentWorkspace().ModuleInit("main", dagger.WorkspaceModuleInitOpts{
+			SDK: "go",
+		})
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, added, "subdir/.dagger/modules/main/dagger-module.toml")
+		require.Contains(t, added, "subdir/.dagger/modules/main/main.go")
+
+		config, err := changes.After().File("subdir/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = ".dagger/modules/main"`)
+		require.Contains(t, config, `source = ".dagger/modules/main"`)
+	})
+
+	t.Run("default path with workspace config at the boundary", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		subdir := filepath.Join(workdir, "subdir")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+		initGitRepo(ctx, t, workdir)
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, "dagger.toml"), []byte(goSDKWorkspaceConfig), 0o644))
+
+		c := connect(ctx, t, dagger.WithWorkdir(subdir))
+
+		changes := c.CurrentWorkspace().ModuleInit("main", dagger.WorkspaceModuleInitOpts{
+			SDK: "go",
+		})
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, added, "subdir/.dagger/modules/main/dagger-module.toml")
+		require.Contains(t, added, "subdir/.dagger/modules/main/main.go")
+
+		config, err := changes.After().File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = "subdir/.dagger/modules/main"`)
+		require.Contains(t, config, `source = "subdir/.dagger/modules/main"`)
+	})
+
+	t.Run("path at the workspace root from the root", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, "dagger.toml"), []byte(goSDKWorkspaceConfig), 0o644))
+
+		c := connect(ctx, t, dagger.WithWorkdir(workdir))
+
+		changes := c.CurrentWorkspace().ModuleInit("main", dagger.WorkspaceModuleInitOpts{
+			SDK:  "go",
+			Path: ".dagger",
+		})
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, added, ".dagger/dagger-module.toml")
+		require.Contains(t, added, ".dagger/main.go")
+
+		config, err := changes.After().File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = ".dagger"`)
+	})
+}

--- a/core/integration/workspace_module_init_test.go
+++ b/core/integration/workspace_module_init_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"dagger.io/dagger"
@@ -167,5 +168,63 @@ func (WorkspaceModuleInitSuite) TestModuleInitFromSubdirectory(ctx context.Conte
 		config, err := changes.After().File("dagger.toml").Contents(ctx)
 		require.NoError(t, err)
 		require.Contains(t, config, `path = ".dagger"`)
+	})
+}
+
+func (WorkspaceModuleInitSuite) TestClientInitFromSubdirectory(ctx context.Context, t *testctx.T) {
+	t.Run("relative client path and local module resolve from cwd", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		subdir := filepath.Join(workdir, "subdir")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+		initGitRepo(ctx, t, workdir)
+		copyTestdataFixture(ctx, t, filepath.Join(subdir, "mymod"), "modules", "go", "minimal-dep")
+		require.NoError(t, os.WriteFile(filepath.Join(subdir, "dagger.toml"), []byte(goSDKWorkspaceConfig), 0o644))
+
+		c := connect(ctx, t, dagger.WithWorkdir(subdir))
+
+		changes := c.CurrentWorkspace().ClientInit("lib/client", "go", "./mymod")
+
+		modified, err := changes.ModifiedPaths(ctx)
+		require.NoError(t, err)
+		require.Contains(t, modified, "subdir/dagger.toml")
+
+		config, err := changes.After().File("subdir/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = "lib/client"`)
+		require.Contains(t, config, `module = "mymod"`)
+	})
+
+	t.Run("clientGenerate materializes clients relative to the config directory", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		subdir := filepath.Join(workdir, "subdir")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+		initGitRepo(ctx, t, workdir)
+		copyTestdataFixture(ctx, t, filepath.Join(subdir, "mymod"), "modules", "go", "minimal-dep")
+		// The builtin go SDK implements generateClient; module-based SDKs
+		// don't yet, so generation dispatches on a builtin source ref. The
+		// client lives inside the module directory because the go generator
+		// rejects output paths above the module root.
+		require.NoError(t, os.WriteFile(filepath.Join(subdir, "dagger.toml"), []byte(`[modules.go-sdk]
+source = "go"
+
+[modules.go-sdk.as-sdk]
+name = "go"
+
+[[modules.go-sdk.as-sdk.clients]]
+path = "mymod/client"
+module = "mymod"
+`), 0o644))
+
+		c := connect(ctx, t, dagger.WithWorkdir(subdir))
+
+		changes := c.CurrentWorkspace().ClientGenerate()
+
+		added, err := changes.AddedPaths(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, added)
+		for _, p := range added {
+			require.Truef(t, strings.HasPrefix(p, "subdir/mymod/"),
+				"generated client path %q should live under subdir/mymod/", p)
+		}
 	})
 }

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -50,11 +50,10 @@ func (s *moduleSchema) currentModuleAsSDK(
 		sdkName = name
 	}
 
-	// as-sdk module paths are stored relative to the config file's directory
-	// (like module sources), while API consumers expect workspace-root-relative
-	// paths; resolve before exposing them. Client paths are still stored and
-	// consumed workspace-root-relative (see workspace_client.go), so they pass
-	// through unchanged.
+	// as-sdk paths are stored relative to the config file's directory (like
+	// module sources), while API consumers expect workspace-root-relative
+	// paths; resolve before exposing them. Client module refs resolve the
+	// same way when local, and pass through verbatim otherwise.
 	configDir, err := workspaceConfigDirectory(ws)
 	if err != nil {
 		return nil, err
@@ -68,8 +67,8 @@ func (s *moduleSchema) currentModuleAsSDK(
 	}
 	for _, client := range entry.AsSDK.Clients {
 		result.Clients = append(result.Clients, &core.CurrentModuleAsSDKClient{
-			Path:   client.Path,
-			Module: client.Module,
+			Path:   filepath.Clean(filepath.Join(configDir, client.Path)),
+			Module: workspace.ResolveModuleEntrySource(configDir, client.Module),
 			Pin:    client.Pin,
 		})
 	}

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
@@ -49,9 +50,21 @@ func (s *moduleSchema) currentModuleAsSDK(
 		sdkName = name
 	}
 
+	// as-sdk module paths are stored relative to the config file's directory
+	// (like module sources), while API consumers expect workspace-root-relative
+	// paths; resolve before exposing them. Client paths are still stored and
+	// consumed workspace-root-relative (see workspace_client.go), so they pass
+	// through unchanged.
+	configDir, err := workspaceConfigDirectory(ws)
+	if err != nil {
+		return nil, err
+	}
+
 	result := &core.CurrentModuleAsSDK{Name: sdkName}
 	for _, mod := range entry.AsSDK.Modules {
-		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{Path: mod.Path})
+		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{
+			Path: filepath.Clean(filepath.Join(configDir, mod.Path)),
+		})
 	}
 	for _, client := range entry.AsSDK.Clients {
 		result.Clients = append(result.Clients, &core.CurrentModuleAsSDKClient{

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2644,10 +2644,7 @@ func (s *moduleSourceSchema) runClientGenerator(
 
 	clientGeneratorImpl, ok := sdk.AsClientGenerator()
 	if !ok {
-		if srcInst.Self() == nil || srcInst.Self().SDK == nil {
-			return genDirInst, fmt.Errorf("module source has no SDK configured")
-		}
-		return genDirInst, ErrSDKClientGeneratorNotImplemented{SDK: srcInst.Self().SDK.Source}
+		return genDirInst, ErrSDKClientGeneratorNotImplemented{SDK: clientGeneratorConfig.Generator}
 	}
 
 	requiredClientGenerationFiles, err := clientGeneratorImpl.RequiredClientGenerationFiles(ctx)

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -149,7 +149,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("name").Doc("Name of the new module."),
 				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name to use."),
-				dagql.Arg("path").Doc(`Workspace-relative path for the new module. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].`),
+				dagql.Arg("path").Doc(`Path for the new module: relative paths resolve from the caller cwd, absolute paths from the workspace root. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].`),
 				dagql.Arg("source").Doc("Source subpath within the new module."),
 				dagql.Arg("include").Doc("Additional include patterns for the module."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -159,9 +159,9 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			DoNotCache("Plans workspace changes against live host filesystem").
 			Doc("Plan the workspace changes for initializing a generated API client: generated client files at `path` plus a [[modules.<sdk-name>.as-sdk.clients]] entry in dagger.toml. Returns the resulting Changeset for the caller to preview and apply.").
 			Args(
-				dagql.Arg("path").Doc("Workspace-relative output directory for the generated client."),
+				dagql.Arg("path").Doc("Output directory for the generated client: relative paths resolve from the caller cwd, absolute paths from the workspace root."),
 				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name to use."),
-				dagql.Arg("module").Doc("Workspace-relative path or canonical ref for the module the client binds to."),
+				dagql.Arg("module").Doc("Module the client binds to: a canonical ref, or a local path resolved from the caller cwd."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
 		dagql.Func("clientGenerate", s.clientGenerate).

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -41,11 +41,18 @@ func (s *workspaceSchema) clientInit(
 		return res, fmt.Errorf("module ref is required")
 	}
 
-	clientPath, err := cleanWorkspaceClientPath(args.Path)
+	// Resolve the client path per the workspace path contract: relative paths
+	// resolve from the caller cwd, absolute paths from the workspace root.
+	// clientPath is workspace-root-relative from here on, and so is the local
+	// form of moduleRef.
+	clientPath, err := resolveWorkspacePath(args.Path, parent.Cwd)
 	if err != nil {
-		return res, err
+		return res, fmt.Errorf("client path %q: %w", args.Path, err)
 	}
-	moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(parent, args.Module)
+	if clientPath == "." {
+		return res, fmt.Errorf("client path must point to a directory below the workspace root")
+	}
+	moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(parent, args.Module, parent.Cwd)
 	if err != nil {
 		return res, err
 	}
@@ -61,6 +68,28 @@ func (s *workspaceSchema) clientInit(
 	if err != nil {
 		return res, err
 	}
+	configRelPath, err := workspaceConfigFile(parent)
+	if err != nil {
+		return res, err
+	}
+	// Paths recorded in dagger.toml are relative to the config file's
+	// directory (see workspace.ResolveModuleEntrySource); clientPath and
+	// local moduleRef are workspace-root-relative, so convert before writing
+	// entries.
+	configDir := filepath.Dir(configRelPath)
+	entryPath, err := filepath.Rel(configDir, clientPath)
+	if err != nil {
+		return res, fmt.Errorf("client path %q relative to config directory %q: %w", clientPath, configDir, err)
+	}
+	entryPath = filepath.Clean(entryPath)
+	entryModule := moduleRef
+	if workspace.IsLocalRef(moduleRef, "") {
+		entryModule, err = filepath.Rel(configDir, moduleRef)
+		if err != nil {
+			return res, fmt.Errorf("module ref %q relative to config directory %q: %w", moduleRef, configDir, err)
+		}
+		entryModule = filepath.Clean(entryModule)
+	}
 
 	workspaceCtx, err := s.withWorkspaceClientContext(ctx, parent)
 	if err != nil {
@@ -74,11 +103,11 @@ func (s *workspaceSchema) clientInit(
 	}
 	modulePin := targetModule.Self().Pin()
 
-	removeClientEntryAtPath(cfg, clientPath)
+	removeClientEntryAtPath(cfg, configDir, clientPath)
 	sdkEntry = cfg.Modules[sdkName]
 	sdkEntry.AsSDK.Clients = append(sdkEntry.AsSDK.Clients, workspace.SDKManagedClient{
-		Path:   clientPath,
-		Module: moduleRef,
+		Path:   entryPath,
+		Module: entryModule,
 		Pin:    modulePin,
 	})
 	cfg.Modules[sdkName] = sdkEntry
@@ -90,11 +119,6 @@ func (s *workspaceSchema) clientInit(
 	newConfigBytes, err := workspace.UpdateConfigBytes(existingConfigBytes, cfg)
 	if err != nil {
 		return res, fmt.Errorf("update workspace config: %w", err)
-	}
-
-	configRelPath, err := workspaceConfigFile(parent)
-	if err != nil {
-		return res, err
 	}
 
 	baseDir, err := s.resolveRootfs(ctx, parent, ".", core.CopyFilter{}, false)
@@ -135,6 +159,14 @@ func (s *workspaceSchema) clientInit(
 		return res, err
 	}
 	sdkChanges, err := clientInitializer.InitClient(ctx, workspaceObj, clientPath, moduleRef, sdkArgs)
+	if err != nil {
+		return res, fmt.Errorf("sdk client init: %w", err)
+	}
+	// SDK initClient implementations return changesets in caller-cwd
+	// coordinates (standalone clients apply changesets relative to their
+	// cwd), while engineChanges and the final export target are rooted at
+	// the workspace root. Re-root before merging.
+	sdkChanges, err = rerootChangesetAtWorkspaceRoot(ctx, sdkChanges, parent.Cwd)
 	if err != nil {
 		return res, fmt.Errorf("sdk client init: %w", err)
 	}
@@ -180,6 +212,15 @@ func (s *workspaceSchema) clientGenerate(
 		return res, fmt.Errorf("dagql server: %w", err)
 	}
 
+	// Client entries in dagger.toml are stored relative to the config file's
+	// directory; resolve them to workspace-root coordinates before use.
+	// Compat workspaces have no native config file; their fallback config
+	// reads as rooted at the workspace root.
+	configDir := "."
+	if parent.ConfigFile != "" {
+		configDir = filepath.Dir(cleanWorkspaceRelPath(parent.ConfigFile))
+	}
+
 	for sdkName, entry := range cfg.Modules {
 		if entry.AsSDK == nil || len(entry.AsSDK.Clients) == 0 {
 			continue
@@ -189,7 +230,8 @@ func (s *workspaceSchema) clientGenerate(
 			return res, fmt.Errorf("SDK module %q has no source", sdkName)
 		}
 		for _, client := range entry.AsSDK.Clients {
-			moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(parent, client.Module)
+			clientPath := filepath.Clean(filepath.Join(configDir, client.Path))
+			moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(parent, client.Module, configDir)
 			if err != nil {
 				return res, err
 			}
@@ -197,7 +239,7 @@ func (s *workspaceSchema) clientGenerate(
 			if err != nil {
 				return res, fmt.Errorf("generate client %q for module %q: %w", client.Path, moduleRef, err)
 			}
-			sdkOutputPath, err := workspaceClientSDKOutputPath(client.Path, moduleRef)
+			sdkOutputPath, err := workspaceClientSDKOutputPath(clientPath, moduleRef)
 			if err != nil {
 				return res, fmt.Errorf("resolve client output path %q for module %q: %w", client.Path, moduleRef, err)
 			}
@@ -258,21 +300,13 @@ func (s *workspaceSchema) workspaceClientInitGeneratedDiff(
 	})
 }
 
-func cleanWorkspaceClientPath(path string) (string, error) {
-	cleaned := filepath.Clean(path)
-	if cleaned == "." || cleaned == string(filepath.Separator) {
-		return "", fmt.Errorf("client path must point to a directory below the workspace root")
-	}
-	if filepath.IsAbs(cleaned) {
-		return "", fmt.Errorf("client path %q must be workspace-relative, not absolute", path)
-	}
-	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("client path %q must not escape the workspace root", path)
-	}
-	return cleaned, nil
-}
-
-func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref string) (configRef string, loadRef string, _ error) {
+// resolveWorkspaceClientModuleRef resolves a client module ref into a
+// workspace-root-relative form plus the absolute host path used to load it.
+// base is where relative local refs resolve from: the caller cwd for user
+// input, the config directory for refs stored in dagger.toml. Host-absolute
+// paths keep their historical meaning and are converted from the workspace
+// host path.
+func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref, base string) (rootRef string, loadRef string, _ error) {
 	if !workspace.IsLocalRef(ref, "") {
 		return ref, ref, nil
 	}
@@ -283,12 +317,15 @@ func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref string) (configRef 
 			return "", "", fmt.Errorf("compute workspace-relative module path: %w", err)
 		}
 		cleaned = rel
-	}
-	if cleaned == "." || cleaned == "" {
-		cleaned = "."
-	}
-	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-		return "", "", fmt.Errorf("module ref %q must not escape the workspace root", ref)
+		if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			return "", "", fmt.Errorf("module ref %q must not escape the workspace root", ref)
+		}
+	} else {
+		var err error
+		cleaned, err = resolveWorkspacePath(cleaned, base)
+		if err != nil {
+			return "", "", fmt.Errorf("module ref %q: %w", ref, err)
+		}
 	}
 	loadPath, err := workspaceHostPath(ws, cleaned)
 	if err != nil {
@@ -311,7 +348,10 @@ func workspaceClientModuleSourceSelector(ref string, pin string) dagql.Selector 
 	}
 }
 
-func removeClientEntryAtPath(cfg *workspace.Config, clientPath string) {
+// removeClientEntryAtPath drops any client entry that resolves to the given
+// workspace-root-relative path. Stored client paths are config-dir-relative,
+// so both sides are resolved before comparing.
+func removeClientEntryAtPath(cfg *workspace.Config, configDir, clientPath string) {
 	if cfg == nil {
 		return
 	}
@@ -321,7 +361,7 @@ func removeClientEntryAtPath(cfg *workspace.Config, clientPath string) {
 			continue
 		}
 		entry.AsSDK.Clients = slices.DeleteFunc(entry.AsSDK.Clients, func(client workspace.SDKManagedClient) bool {
-			return filepath.Clean(client.Path) == cleanPath
+			return filepath.Clean(filepath.Join(configDir, client.Path)) == cleanPath
 		})
 		cfg.Modules[moduleName] = entry
 	}

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -18,9 +18,11 @@ import (
 // Workspace.moduleInit. The redesigned shape returns a Changeset rather
 // than applying immediately; callers preview and apply via the standard
 // changeset path. The SelfCalls arg is gone (the feature graduated to a
-// runtime-capability check), and Path is new (workspace-relative, defaults
-// to .dagger/modules/<name>). SDK is the user-facing SDK name from
-// [modules.<name>.as-sdk] or the module entry name, not a module source ref.
+// runtime-capability check), and Path is new (following the workspace path
+// contract: relative paths resolve from the caller cwd, absolute paths from
+// the workspace root; defaults to .dagger/modules/<name>). SDK is the
+// user-facing SDK name from [modules.<name>.as-sdk] or the module entry
+// name, not a module source ref.
 type workspaceModuleInitArgs struct {
 	Name    string
 	SDK     string    `default:""`
@@ -67,25 +69,37 @@ func (s *workspaceSchema) moduleInit(
 		return res, fmt.Errorf("SDK name is required")
 	}
 
-	// Resolve the workspace-relative path for the new module. Empty = default
-	// layout; we treat that as the signal to auto-install in [modules.*].
-	relPath := args.Path
-	usingDefaultPath := relPath == ""
+	// Resolve the module path per the workspace path contract: relative paths
+	// resolve from the caller cwd, absolute paths from the workspace root.
+	// Empty = default layout; we treat that as the signal to auto-install in
+	// [modules.*]. relPath is workspace-root-relative from here on.
+	pathArg := args.Path
+	usingDefaultPath := pathArg == ""
 	if usingDefaultPath {
-		relPath = filepath.Join(".dagger", "modules", args.Name)
+		pathArg = filepath.Join(".dagger", "modules", args.Name)
 	}
-	relPath = filepath.Clean(relPath)
-	if filepath.IsAbs(relPath) {
-		return res, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
-	}
-	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
-		return res, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
+	relPath, err := resolveWorkspacePath(pathArg, parent.Cwd)
+	if err != nil {
+		return res, fmt.Errorf("--path %q: %w", args.Path, err)
 	}
 
 	cfg, _, err := loadWorkspaceConfigForMutation(ctx, parent, workspaceConfigMustExist, args.Here)
 	if err != nil {
 		return res, err
 	}
+	configRelPath, err := workspaceConfigFile(parent)
+	if err != nil {
+		return res, err
+	}
+	// Paths recorded in dagger.toml are relative to the config file's
+	// directory (see workspace.ResolveModuleEntrySource); relPath is
+	// workspace-root-relative, so convert before writing entries.
+	configDir := filepath.Dir(configRelPath)
+	entryPath, err := filepath.Rel(configDir, relPath)
+	if err != nil {
+		return res, fmt.Errorf("module path %q relative to config directory %q: %w", relPath, configDir, err)
+	}
+	entryPath = filepath.Clean(entryPath)
 	if cfg.Modules == nil {
 		cfg.Modules = map[string]workspace.ModuleEntry{}
 	}
@@ -96,7 +110,8 @@ func (s *workspaceSchema) moduleInit(
 
 	// Reject name conflicts in installed modules and reject path conflicts
 	// across any SDK's authored modules. Two SDKs claiming the same path is
-	// a corruption we shouldn't silently extend.
+	// a corruption we shouldn't silently extend. Existing as-sdk paths are
+	// config-dir-relative, so compare in workspace-root coordinates.
 	if _, exists := cfg.Modules[args.Name]; exists {
 		return res, fmt.Errorf("module %q is already installed in this workspace", args.Name)
 	}
@@ -105,13 +120,13 @@ func (s *workspaceSchema) moduleInit(
 			continue
 		}
 		for _, m := range installed.AsSDK.Modules {
-			if m.Path == relPath {
-				return res, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", relPath, installedName)
+			if filepath.Clean(filepath.Join(configDir, m.Path)) == relPath {
+				return res, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", m.Path, installedName)
 			}
 		}
 	}
 
-	sdkEntry.AsSDK.Modules = append(sdkEntry.AsSDK.Modules, workspace.SDKManagedModule{Path: relPath})
+	sdkEntry.AsSDK.Modules = append(sdkEntry.AsSDK.Modules, workspace.SDKManagedModule{Path: entryPath})
 	cfg.Modules[sdkName] = sdkEntry
 
 	// Resolve which engine runtime ref the new module should declare. The
@@ -126,7 +141,7 @@ func (s *workspaceSchema) moduleInit(
 	}
 
 	if usingDefaultPath {
-		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: relPath}
+		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: entryPath}
 	}
 
 	// Render new dagger.toml bytes through the format-preserving editor.
@@ -147,12 +162,7 @@ func (s *workspaceSchema) moduleInit(
 	// they can never collide on a shared path ("added in both changesets").
 	// The diff is workspace-root-relative because the moduleSource is
 	// constructed against the local workspace context.
-	moduleDiff, err := s.workspaceModuleInitConfigDiff(ctx, args, relPath, runtimeRef)
-	if err != nil {
-		return res, err
-	}
-
-	configRelPath, err := workspaceConfigFile(parent)
+	moduleDiff, err := s.workspaceModuleInitConfigDiff(ctx, args, parent.Cwd, relPath, runtimeRef)
 	if err != nil {
 		return res, err
 	}
@@ -202,6 +212,14 @@ func (s *workspaceSchema) moduleInit(
 		return res, err
 	}
 	sdkChanges, err := moduleInitializer.InitModule(ctx, workspaceObj, args.Name, relPath, sdkArgs)
+	if err != nil {
+		return res, fmt.Errorf("sdk module init: %w", err)
+	}
+	// SDK initModule implementations return changesets in caller-cwd
+	// coordinates (standalone clients apply changesets relative to their
+	// cwd), while engineChanges and the final export target are rooted at
+	// the workspace root. Re-root before validating and merging.
+	sdkChanges, err = rerootChangesetAtWorkspaceRoot(ctx, sdkChanges, parent.Cwd)
 	if err != nil {
 		return res, fmt.Errorf("sdk module init: %w", err)
 	}
@@ -275,6 +293,7 @@ func validateSDKInitChangesetOwnership(
 func (s *workspaceSchema) workspaceModuleInitConfigDiff(
 	ctx context.Context,
 	args workspaceModuleInitArgs,
+	cwd string,
 	relPath string,
 	runtimeRef string,
 ) (dagql.ObjectResult[*core.Directory], error) {
@@ -284,7 +303,14 @@ func (s *workspaceSchema) workspaceModuleInitConfigDiff(
 		return res, fmt.Errorf("dagql server: %w", err)
 	}
 
-	baseSelector := workspaceModuleInitSourceSelector(relPath)
+	// moduleSource resolves local refs against the caller's host cwd, while
+	// relPath is workspace-root-relative; convert so the source lands at
+	// relPath within the workspace context.
+	callerRelPath, err := filepath.Rel(cleanWorkspaceRelPath(cwd), relPath)
+	if err != nil {
+		return res, fmt.Errorf("module path %q relative to cwd %q: %w", relPath, cwd, err)
+	}
+	baseSelector := workspaceModuleInitSourceSelector(callerRelPath)
 
 	var configExists dagql.Boolean
 	if err := srv.Select(ctx, srv.Root(), &configExists,

--- a/core/schema/workspace_sdk_init.go
+++ b/core/schema/workspace_sdk_init.go
@@ -88,6 +88,16 @@ func rerootChangesetAtWorkspaceRoot(ctx context.Context, changes dagql.ObjectRes
 		seen[p] = struct{}{}
 		include = append(include, dagql.String(p))
 	}
+	// No changed paths: return an empty changeset instead of nesting with an
+	// empty include list, which withDirectory treats as "no filter" and would
+	// reintroduce the full snapshots (and their .git) into the merge.
+	if len(include) == 0 {
+		var empty dagql.ObjectResult[*core.Changeset]
+		if err := srv.Select(ctx, srv.Root(), &empty, dagql.Selector{Field: "changeset"}); err != nil {
+			return changes, fmt.Errorf("empty changeset: %w", err)
+		}
+		return empty, nil
+	}
 
 	nest := func(dir dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		dirID, err := dir.ID()

--- a/core/schema/workspace_sdk_init.go
+++ b/core/schema/workspace_sdk_init.go
@@ -3,6 +3,9 @@ package schema
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/dagger/dagger/core"
 	coresdk "github.com/dagger/dagger/core/sdk"
@@ -41,6 +44,94 @@ func (s *workspaceSchema) currentWorkspaceObject(ctx context.Context) (dagql.Obj
 		return workspace, fmt.Errorf("current workspace: %w", err)
 	}
 	return workspace, nil
+}
+
+// rerootChangesetAtWorkspaceRoot converts a changeset whose paths are
+// relative to the caller cwd into one whose paths are workspace-root-relative
+// by nesting both sides under cwd. SDK init functions return changesets in
+// caller-cwd coordinates — standalone clients apply changesets relative to
+// their own cwd — but Workspace.moduleInit merges them with engine changes
+// and the CLI applies the result at the workspace root.
+//
+// Only the changed paths are carried into the re-rooted trees. SDK changesets
+// diff two full workspace snapshots, and nesting those wholesale would embed
+// the workspace's .git directory inside the merge trees, which breaks the
+// git-based changeset merge ("does not have a commit checked out") and can
+// leak snapshot races under .git into the diff.
+func rerootChangesetAtWorkspaceRoot(ctx context.Context, changes dagql.ObjectResult[*core.Changeset], cwd string) (dagql.ObjectResult[*core.Changeset], error) {
+	cwd = filepath.Clean(cwd)
+	if changes.Self() == nil || cwd == "" || cwd == "." {
+		return changes, nil
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return changes, fmt.Errorf("dagql server: %w", err)
+	}
+
+	paths, err := changes.Self().ComputePaths(ctx)
+	if err != nil {
+		return changes, fmt.Errorf("re-root changeset paths: %w", err)
+	}
+	seen := map[string]struct{}{}
+	include := dagql.ArrayInput[dagql.String]{}
+	for _, p := range slices.Concat(paths.Added, paths.Modified, paths.Removed) {
+		p = filepath.ToSlash(filepath.Clean(p))
+		if p == "." || p == "" {
+			continue
+		}
+		if p == ".git" || strings.HasPrefix(p, ".git/") {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		include = append(include, dagql.String(p))
+	}
+
+	nest := func(dir dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+		dirID, err := dir.ID()
+		if err != nil {
+			return dir, fmt.Errorf("directory id: %w", err)
+		}
+		var out dagql.ObjectResult[*core.Directory]
+		err = srv.Select(ctx, srv.Root(), &out,
+			dagql.Selector{Field: "directory"},
+			dagql.Selector{
+				Field: "withDirectory",
+				Args: []dagql.NamedInput{
+					{Name: "path", Value: dagql.String(cwd)},
+					{Name: "source", Value: dagql.NewID[*core.Directory](dirID)},
+					{Name: "include", Value: include},
+				},
+			},
+		)
+		return out, err
+	}
+
+	before, err := nest(changes.Self().Before)
+	if err != nil {
+		return changes, fmt.Errorf("re-root changeset before: %w", err)
+	}
+	after, err := nest(changes.Self().After)
+	if err != nil {
+		return changes, fmt.Errorf("re-root changeset after: %w", err)
+	}
+	beforeID, err := before.ID()
+	if err != nil {
+		return changes, fmt.Errorf("re-rooted before id: %w", err)
+	}
+
+	var rerooted dagql.ObjectResult[*core.Changeset]
+	if err := srv.Select(ctx, after, &rerooted, dagql.Selector{
+		Field: "changes",
+		Args: []dagql.NamedInput{
+			{Name: "from", Value: dagql.NewID[*core.Directory](beforeID)},
+		},
+	}); err != nil {
+		return changes, fmt.Errorf("re-root changeset: %w", err)
+	}
+	return rerooted, nil
 }
 
 func mergeWorkspaceInitChangeset(ctx context.Context, base dagql.ObjectResult[*core.Changeset], sdkChanges dagql.ObjectResult[*core.Changeset]) (dagql.ObjectResult[*core.Changeset], error) {

--- a/core/schema/workspace_sdk_test.go
+++ b/core/schema/workspace_sdk_test.go
@@ -92,7 +92,7 @@ func TestRemoveClientEntryAtPathPreservesSDKMarker(t *testing.T) {
 		},
 	}
 
-	removeClientEntryAtPath(cfg, "./lib/client")
+	removeClientEntryAtPath(cfg, ".", "./lib/client")
 
 	entry := cfg.Modules["go"]
 	require.NotNil(t, entry.AsSDK)

--- a/core/schema/workspace_uninstall.go
+++ b/core/schema/workspace_uninstall.go
@@ -80,7 +80,9 @@ func removeSDKManagedModuleReference(cfg *workspace.Config, configDir string, en
 		}
 
 		sdkEntry.AsSDK.Modules = slices.DeleteFunc(sdkEntry.AsSDK.Modules, func(mod workspace.SDKManagedModule) bool {
-			if filepath.ToSlash(filepath.Clean(mod.Path)) == sourcePath {
+			// as-sdk module paths are config-dir-relative, like module entry
+			// sources; resolve both sides before comparing.
+			if filepath.ToSlash(filepath.Clean(filepath.Join(configDir, mod.Path))) == sourcePath {
 				removed = true
 				return true
 			}

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -231,6 +231,9 @@ Initialize a generated API client at &lt;path&gt;.
 &lt;sdk&gt; is an SDK installed in this workspace. Run `dagger sdk install <sdk>`
 to add more choices.
 
+&lt;path&gt; and a local &lt;module&gt; resolve from the current directory; absolute
+paths resolve from the workspace root.
+
 The engine resolves &lt;sdk&gt; from dagger.toml, validates that it is installed as an
 SDK, plans the generated files and workspace config change, then returns a
 Changeset that the CLI previews and applies through the standard preview/apply
@@ -1732,9 +1735,10 @@ What the engine does (atomically, in one Changeset):
   4. When --path is the default (.dagger/modules/&lt;name&gt;), also installs
      the new module as [modules.&lt;name&gt;] so it's callable here.
 
---path defaults to .dagger/modules/&lt;name&gt;. Custom paths skip the
-[modules.&lt;name&gt;] install (the user is managing workspace layout
-explicitly).
+--path defaults to .dagger/modules/&lt;name&gt;. Relative paths resolve from the
+current directory; absolute paths resolve from the workspace root. Custom
+paths skip the [modules.&lt;name&gt;] install (the user is managing workspace
+layout explicitly).
 
 ```
 dagger module init <sdk> <name> [flags]
@@ -1749,7 +1753,7 @@ dagger module init go myapp
 ### Options
 
 ```
-      --path string   Module path relative to the workspace root (default: .dagger/modules/<name>)
+      --path string   Module path relative to the current directory; absolute paths resolve from the workspace root (default: .dagger/modules/<name>)
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6110,14 +6110,17 @@ type Workspace implements Node {
   apply.
   """
   clientInit(
-    """Workspace-relative output directory for the generated client."""
+    """
+    Output directory for the generated client: relative paths resolve from the
+    caller cwd, absolute paths from the workspace root.
+    """
     path: String!
 
     """Workspace SDK name or module entry name to use."""
     sdk: String!
 
     """
-    Workspace-relative path or canonical ref for the module the client binds to.
+    Module the client binds to: a canonical ref, or a local path resolved from the caller cwd.
     """
     module: String!
 
@@ -6318,7 +6321,8 @@ type Workspace implements Node {
     sdk: String = ""
 
     """
-    Workspace-relative path for the new module. Defaults to
+    Path for the new module: relative paths resolve from the caller cwd,
+    absolute paths from the workspace root. Defaults to
     ".dagger/modules/<name>"; using the default also installs the module in
     [modules.<name>].
     """

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -35,6 +35,9 @@ var apiClientInitCmd = &cobra.Command{
 <sdk> is an SDK installed in this workspace. Run ` + "`dagger sdk install <sdk>`" + `
 to add more choices.
 
+<path> and a local <module> resolve from the current directory; absolute
+paths resolve from the workspace root.
+
 The engine resolves <sdk> from dagger.toml, validates that it is installed as an
 SDK, plans the generated files and workspace config change, then returns a
 Changeset that the CLI previews and applies through the standard preview/apply

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -148,9 +148,10 @@ What the engine does (atomically, in one Changeset):
   4. When --path is the default (.dagger/modules/<name>), also installs
      the new module as [modules.<name>] so it's callable here.
 
---path defaults to .dagger/modules/<name>. Custom paths skip the
-[modules.<name>] install (the user is managing workspace layout
-explicitly).`,
+--path defaults to .dagger/modules/<name>. Relative paths resolve from the
+current directory; absolute paths resolve from the workspace root. Custom
+paths skip the [modules.<name>] install (the user is managing workspace
+layout explicitly).`,
 	Example: "dagger module init go myapp",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -159,7 +160,7 @@ explicitly).`,
 }
 
 func init() {
-	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Module path relative to the workspace root (default: .dagger/modules/<name>)")
+	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Module path relative to the current directory; absolute paths resolve from the workspace root (default: .dagger/modules/<name>)")
 	moduleCmd.AddCommand(moduleInitCmd)
 }
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16514,7 +16514,7 @@ func (r *Workspace) Migrate() *WorkspaceMigration {
 type WorkspaceModuleInitOpts struct {
 	// Workspace SDK name or module entry name to use.
 	SDK string
-	// Workspace-relative path for the new module. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
+	// Path for the new module: relative paths resolve from the caller cwd, absolute paths from the workspace root. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
 	Path string
 	// Source subpath within the new module.
 	Source string

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15787,12 +15787,13 @@ class Workspace(Type):
         Parameters
         ----------
         path:
-            Workspace-relative output directory for the generated client.
+            Output directory for the generated client: relative paths resolve
+            from the caller cwd, absolute paths from the workspace root.
         sdk:
             Workspace SDK name or module entry name to use.
         module:
-            Workspace-relative path or canonical ref for the module the client
-            binds to.
+            Module the client binds to: a canonical ref, or a local path
+            resolved from the caller cwd.
         here:
             Write to the workspace config directory at the workspace cwd.
         args:
@@ -16291,7 +16292,8 @@ class Workspace(Type):
         sdk:
             Workspace SDK name or module entry name to use.
         path:
-            Workspace-relative path for the new module. Defaults to
+            Path for the new module: relative paths resolve from the caller
+            cwd, absolute paths from the workspace root. Defaults to
             ".dagger/modules/<name>"; using the default also installs the
             module in [modules.<name>].
         source:

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -16175,7 +16175,7 @@ pub struct WorkspaceModuleInitOpts<'a> {
     /// Additional include patterns for the module.
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
-    /// Workspace-relative path for the new module. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
+    /// Path for the new module: relative paths resolve from the caller cwd, absolute paths from the workspace root. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
     /// Workspace SDK name or module entry name to use.
@@ -16309,9 +16309,9 @@ impl Workspace {
     ///
     /// # Arguments
     ///
-    /// * `path` - Workspace-relative output directory for the generated client.
+    /// * `path` - Output directory for the generated client: relative paths resolve from the caller cwd, absolute paths from the workspace root.
     /// * `sdk` - Workspace SDK name or module entry name to use.
-    /// * `module` - Workspace-relative path or canonical ref for the module the client binds to.
+    /// * `module` - Module the client binds to: a canonical ref, or a local path resolved from the caller cwd.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn client_init(
         &self,
@@ -16333,9 +16333,9 @@ impl Workspace {
     ///
     /// # Arguments
     ///
-    /// * `path` - Workspace-relative output directory for the generated client.
+    /// * `path` - Output directory for the generated client: relative paths resolve from the caller cwd, absolute paths from the workspace root.
     /// * `sdk` - Workspace SDK name or module entry name to use.
-    /// * `module` - Workspace-relative path or canonical ref for the module the client binds to.
+    /// * `module` - Module the client binds to: a canonical ref, or a local path resolved from the caller cwd.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn client_init_opts(
         &self,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2846,7 +2846,7 @@ export type WorkspaceModuleInitOpts = {
   sdk?: string
 
   /**
-   * Workspace-relative path for the new module. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
+   * Path for the new module: relative paths resolve from the caller cwd, absolute paths from the workspace root. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
    */
   path?: string
 
@@ -15080,9 +15080,9 @@ export class Workspace extends BaseClient {
 
   /**
    * Plan the workspace changes for initializing a generated API client: generated client files at `path` plus a [[modules.<sdk-name>.as-sdk.clients]] entry in dagger.toml. Returns the resulting Changeset for the caller to preview and apply.
-   * @param path Workspace-relative output directory for the generated client.
+   * @param path Output directory for the generated client: relative paths resolve from the caller cwd, absolute paths from the workspace root.
    * @param sdk Workspace SDK name or module entry name to use.
-   * @param module Workspace-relative path or canonical ref for the module the client binds to.
+   * @param module Module the client binds to: a canonical ref, or a local path resolved from the caller cwd.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
    */
   clientInit = (
@@ -15350,7 +15350,7 @@ export class Workspace extends BaseClient {
    * Plan the workspace changes for initializing a new module: dagger-module.toml + SDK codegen output at `path`, the authoring entry under [[modules.<sdk>.as-sdk.modules]], and (when path defaults) [modules.<name>]. The SDK must already be installed as an SDK. Returns the resulting Changeset for the caller to preview and apply.
    * @param name Name of the new module.
    * @param opts.sdk Workspace SDK name or module entry name to use.
-   * @param opts.path Workspace-relative path for the new module. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
+   * @param opts.path Path for the new module: relative paths resolve from the caller cwd, absolute paths from the workspace root. Defaults to ".dagger/modules/<name>"; using the default also installs the module in [modules.<name>].
    * @param opts.source Source subpath within the new module.
    * @param opts.include Additional include patterns for the module.
    * @param opts.here Write to the workspace config directory at the workspace cwd.


### PR DESCRIPTION
When creating a module, resolve `--path` as local to the current directory and not from the git root.

### Scenario:

```
. # git root
└── subdir
    └── dagger.toml
```

In this case, the `dagger.toml` is not at the root of the git repo. And we should be able to init a module from this `subdir` directory.

```console
subdir $ dagger module init SDK MODULE --path=.dagger
```

This should create:

```
. # git root
└── subdir
    ├── .dagger
    │   └── dagger-module.toml
    └── dagger.toml
```

And the path to the module in `dagger.toml` (in the `as-sdk` part) should be `.dagger`.

```toml
[[modules.SDK.as-sdk.modules]]
path = ".dagger"
```

If doing the same thing from a sub-sub directory:

```
. # git root
└── subdir
    ├── dagger.toml
    └── subsubdir
```

```console
subsubdir $ dagger module init SDK MODULE --path=.dagger
```

The result will be:

```
. # git root
└── subdir
    ├── dagger.toml
    └── subsubdir
        ├── dagger-module.toml
        └── .dagger
```

```toml
[[modules.SDK.as-sdk.modules]]
path = "subsubdir/.dagger"
```

## Fix

Resolve the path once, per the workspace path contract already used by `Workspace.directory` (`future/synthetic-workspace.md`, "Source Rules"): relative paths resolve from the caller cwd, absolute paths from the workspace root* From that single root-relative path:

- `dagger.toml` entries are written relative to the config directory, matching how they're resolved at load time; `CurrentModule.asSDK` resolves stored module paths back to workspace-root coordinates before exposing them to SDK generators, and uninstall's as-sdk matching resolves both sides the same way;
- `moduleSource` receives a caller-cwd-relative path so the module config lands at the resolved location;
- the SDK's `initModule` still receives the workspace-root-relative path (the polyfill contract), and its returned changeset is re-rooted at the workspace root before ownership validation and merge. The re-rooted trees carry only the changed paths (excluding anything under `.git`): SDK changesets diff two full workspace snapshots, and nesting those wholesale embeds the workspace's `.git` in the merge trees, which breaks the git-based changeset merge ("does not have a commit checked out") and can leak `.git` snapshot races into the applied diff.

Also fix `clientInit` the same way
