### PR TITLE
core: use host git credentials for private `git+https` SDK dependencies

### DIFF
--- a/.changes/unreleased/Added-20260703-221637.yaml
+++ b/.changes/unreleased/Added-20260703-221637.yaml
@@ -1,6 +1,6 @@
 kind: Added
 body: |
-  Private HTTPS git dependencies in Go modules now resolve with the host's git credential helper. When the Go SDK's `goprivate` setting names a host, the engine relays git credential requests from the dependency install to the host over a session-scoped socket — no `.netrc`, hardcoded URLs, or SSH setup required. Credentials are fetched on demand, scoped to the declared hosts, never written into the container, and removed before module code runs.
+  Private git+https dependencies now install using the host's git credentials in Go, Python and TypeScript modules. The engine relays git credential requests from the dependency install to the host's credential helper over a session-scoped socket — no `.netrc`, hardcoded URLs, or SSH setup required. Go modules opt in via the `goprivate` setting (`[modules.<name>.settings]` in `dagger.toml`); Python and TypeScript need no configuration: the allowed hosts come from the module's own manifests. Credentials are fetched on demand, scoped to those hosts, never written into the container, and removed before module code runs. Note: bun fetches `github.com` dependencies through GitHub's API without credentials (oven-sh/bun#19618), so private GitHub dependencies with bun need the Node runtime.
 time: 2026-07-03T22:16:37Z
 custom:
   Author: grouville

--- a/.changes/unreleased/Added-20260703-221637.yaml
+++ b/.changes/unreleased/Added-20260703-221637.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |
+  Private HTTPS git dependencies in Go modules now resolve with the host's git credential helper. When the Go SDK's `goprivate` setting names a host, the engine relays git credential requests from the dependency install to the host over a session-scoped socket — no `.netrc`, hardcoded URLs, or SSH setup required. Credentials are fetched on demand, scoped to the declared hosts, never written into the container, and removed before module code runs.
+time: 2026-07-03T22:16:37Z
+custom:
+  Author: grouville
+  PR: 13586

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/client/secretprovider"
+	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/engine/session/git"
 	"github.com/dagger/dagger/engine/session/h2c"
 )
@@ -32,6 +33,8 @@ func main() {
 		err = mainInit()
 	case "/proc/self/exe":
 		err = mainSession()
+	case distconsts.GitCredentialHelperInContainerPath:
+		err = mainGitCredential()
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -247,6 +250,54 @@ func startSessionSubprocess() error {
 	case <-time.After(5 * time.Minute):
 		return fmt.Errorf("timed out waiting for session subprocess to start")
 	}
+}
+
+// mainGitCredential is a git credential helper that relays requests to the
+// engine's git-credential socket mounted into the container. Invoked by git
+// as `<argv0> <socket-path> <operation>` (git appends the operation to the
+// helper command configured as `credential.helper = <argv0> <socket-path>`).
+func mainGitCredential() error {
+	if len(os.Args) < 3 {
+		return fmt.Errorf("usage: %s <socket-path> <operation>", os.Args[0])
+	}
+	sockPath, operation := os.Args[1], os.Args[2]
+	if operation != "get" {
+		// store/erase are no-ops
+		return nil
+	}
+
+	// matches the engine-side request size cap and exchange timeout
+	// (core/git_credential_socket.go), so a dead socket fails the install
+	// instead of hanging git forever
+	request, err := io.ReadAll(io.LimitReader(os.Stdin, 64<<10))
+	if err != nil {
+		return fmt.Errorf("failed to read credential request: %w", err)
+	}
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("failed to connect to git credential socket: %w", err)
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(60 * time.Second)); err != nil {
+		return fmt.Errorf("failed to set socket deadline: %w", err)
+	}
+
+	if _, err := conn.Write(request); err != nil {
+		return fmt.Errorf("failed to send credential request: %w", err)
+	}
+	if unixConn, ok := conn.(*net.UnixConn); ok {
+		_ = unixConn.CloseWrite()
+	}
+
+	response, err := io.ReadAll(conn)
+	if err != nil {
+		return fmt.Errorf("failed to read credential response: %w", err)
+	}
+	if _, err := os.Stdout.Write(response); err != nil {
+		return fmt.Errorf("failed to write credential response: %w", err)
+	}
+	return nil
 }
 
 func mainSession() error {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -310,6 +310,15 @@ func (container *Container) execMeta(
 		}
 	}
 
+	for _, socket := range container.Sockets {
+		if socket.Source.Self() != nil && socket.Source.Self().Kind == SocketKindGitCredential {
+			// git in the container needs the engine's credential helper binary
+			// to talk to the mounted git-credential socket
+			execMD.InjectGitCredentialHelper = true
+			break
+		}
+	}
+
 	return &execMD, nil
 }
 
@@ -1133,7 +1142,14 @@ type execSSHMount struct {
 }
 
 func (ssh *execSSHMount) Mount(ctx context.Context, _ bool) (bkcache.MountableRef, error) {
-	sock, cleanup, err := ssh.socket.Self().MountSSHAgent(ctx)
+	var sock string
+	var cleanup func() error
+	var err error
+	if ssh.socket.Self().Kind == SocketKindGitCredential {
+		sock, cleanup, err = ssh.socket.Self().MountGitCredentialSocket(ctx)
+	} else {
+		sock, cleanup, err = ssh.socket.Self().MountSSHAgent(ctx)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/core/git_credential_socket.go
+++ b/core/git_credential_socket.go
@@ -1,0 +1,288 @@
+package core
+
+import (
+	"bufio"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/session/git"
+	"github.com/dagger/dagger/engine/slog"
+)
+
+const gitCredentialSocketDigestVersion = "git-credential-socket-v1"
+
+// gitCredentialRequestTimeout bounds a single credential exchange over the
+// socket, including the round-trip to the host's git credential helper (which
+// itself has a 30s timeout).
+const gitCredentialRequestTimeout = 60 * time.Second
+
+// gitCredentialMaxRequestSize bounds a single request read from the socket.
+const gitCredentialMaxRequestSize = 64 << 10
+
+// ScopedGitCredentialSocketHandle derives the session resource handle for a
+// git-credential socket serving the given clients' credentials for the given
+// hosts. hosts must already be normalized (see NormalizeGitCredentialHosts).
+func ScopedGitCredentialSocketHandle(secretSalt []byte, clientIDs []string, hosts []string) dagql.SessionResourceHandle {
+	mac := hmac.New(sha256.New, secretSalt)
+	mac.Write([]byte(gitCredentialSocketDigestVersion))
+	mac.Write([]byte{0})
+	for _, clientID := range clientIDs {
+		mac.Write([]byte(clientID))
+		mac.Write([]byte{0})
+	}
+	mac.Write([]byte{0})
+	for _, host := range hosts {
+		mac.Write([]byte(host))
+		mac.Write([]byte{0})
+	}
+	return dagql.SessionResourceHandle(digest.NewDigestFromBytes(digest.SHA256, mac.Sum(nil)))
+}
+
+// NormalizeGitCredentialHosts lowercases, dedupes and sorts the given host
+// allowlist, dropping empty entries.
+func NormalizeGitCredentialHosts(hosts []string) []string {
+	normalized := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		host = strings.ToLower(strings.TrimSpace(host))
+		if host == "" {
+			continue
+		}
+		normalized = append(normalized, host)
+	}
+	slices.Sort(normalized)
+	return slices.Compact(normalized)
+}
+
+// gitCredentialRequest is a parsed git-credential protocol request
+// (https://git-scm.com/docs/git-credential#IOFMT).
+type gitCredentialRequest struct {
+	protocol string
+	host     string
+	path     string
+}
+
+func parseGitCredentialRequest(r io.Reader) (*gitCredentialRequest, error) {
+	req := &gitCredentialRequest{}
+	scanner := bufio.NewScanner(io.LimitReader(r, gitCredentialMaxRequestSize))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid git credential request: line doesn't match key=value pattern")
+		}
+		switch key {
+		case "protocol":
+			req.protocol = value
+		case "host":
+			req.host = value
+		case "path":
+			req.path = value
+		default:
+			// ignore unknown attributes (e.g. capability, wwwauth[])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read git credential request: %w", err)
+	}
+	if req.protocol == "" || req.host == "" {
+		return nil, errors.New("invalid git credential request: protocol and host are required")
+	}
+	return req, nil
+}
+
+func formatGitCredentialResponse(cred *git.CredentialInfo) []byte {
+	var sb strings.Builder
+	if cred.Protocol != "" {
+		fmt.Fprintf(&sb, "protocol=%s\n", cred.Protocol)
+	}
+	if cred.Host != "" {
+		fmt.Fprintf(&sb, "host=%s\n", cred.Host)
+	}
+	fmt.Fprintf(&sb, "username=%s\n", cred.Username)
+	fmt.Fprintf(&sb, "password=%s\n", cred.Password)
+	sb.WriteString("\n")
+	return []byte(sb.String())
+}
+
+// MountGitCredentialSocket serves the git-credential protocol on a fresh unix
+// socket. Each connection carries a single request; allowed requests are
+// relayed to the source client's git session attachable, everything else gets
+// an empty reply (no credentials).
+func (socket *Socket) MountGitCredentialSocket(ctx context.Context) (string, func() error, error) {
+	dir, err := os.MkdirTemp("", ".dagger-git-credential-sock")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
+	if err = os.Chmod(dir, 0o711); err != nil {
+		return "", nil, fmt.Errorf("failed to chmod temp dir: %w", err)
+	}
+	sockPath := filepath.Join(dir, "git_credential_sock")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to listen on unix socket: %w", err)
+	}
+
+	srvCtx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer l.Close()
+		<-srvCtx.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// close the listener on any accept failure so later connection
+		// attempts fail fast instead of queueing against a dead loop
+		defer cancel()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go socket.serveGitCredentialConn(srvCtx, conn)
+		}
+	}()
+
+	return sockPath, func() error {
+		cancel()
+		wg.Wait()
+		_ = os.RemoveAll(dir)
+		return nil
+	}, nil
+}
+
+func (socket *Socket) serveGitCredentialConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(ctx, gitCredentialRequestTimeout)
+	defer cancel()
+	_ = conn.SetDeadline(time.Now().Add(gitCredentialRequestTimeout))
+
+	req, err := parseGitCredentialRequest(conn)
+	if err != nil {
+		slog.Warn("git credential socket: invalid request", "error", err)
+		return
+	}
+
+	cred, err := socket.fetchGitCredential(ctx, req)
+	if err != nil {
+		// reply with nothing: the helper produces no output and git treats it
+		// as "no credentials from this helper"
+		slog.Warn("git credential socket: no credentials", "host", req.host, "error", err)
+		return
+	}
+
+	if _, err := conn.Write(formatGitCredentialResponse(cred)); err != nil {
+		slog.Warn("git credential socket: failed to write response", "host", req.host, "error", err)
+		return
+	}
+	slog.Debug("git credential socket: served credentials", "host", req.host)
+}
+
+func (socket *Socket) fetchGitCredential(ctx context.Context, req *gitCredentialRequest) (*git.CredentialInfo, error) {
+	if req.protocol != "http" && req.protocol != "https" {
+		return nil, fmt.Errorf("unsupported protocol %q", req.protocol)
+	}
+
+	if socket.Handle == "" {
+		return socket.fetchGitCredentialFromClient(ctx, req)
+	}
+
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve session socket %q: current client metadata: %w", socket.Handle, err)
+	}
+	if clientMetadata.SessionID == "" {
+		return nil, fmt.Errorf("resolve session socket %q: empty session ID", socket.Handle)
+	}
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve session socket %q: current dagql cache: %w", socket.Handle, err)
+	}
+	candidates, err := cache.ResolveSessionResourceCandidates(ctx, clientMetadata.SessionID, clientMetadata.ClientID, socket.Handle)
+	if err != nil {
+		return nil, err
+	}
+
+	var errs error
+	for _, candidate := range candidates {
+		resolved, ok := candidate.Value.(*Socket)
+		if !ok {
+			return nil, fmt.Errorf("resolve session socket %q: bound value for client %q is %T", socket.Handle, candidate.ClientID, candidate.Value)
+		}
+		cred, err := resolved.fetchGitCredentialFromClient(ctx, req)
+		if err == nil {
+			return cred, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("client %q: %w", candidate.ClientID, err))
+	}
+	if errs != nil {
+		return nil, errs
+	}
+	return nil, fmt.Errorf("resolve session socket %q: no available client binding", socket.Handle)
+}
+
+func (socket *Socket) fetchGitCredentialFromClient(ctx context.Context, req *gitCredentialRequest) (*git.CredentialInfo, error) {
+	if !slices.Contains(socket.GitCredentialHosts, strings.ToLower(req.host)) {
+		return nil, fmt.Errorf("host %q is not in the allowed hosts list", req.host)
+	}
+	if socket.SourceClientID == "" {
+		return nil, errors.New("git credential socket: missing source client ID")
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conn, ok, err := query.SpecificClientAttachableConn(ctx, socket.SourceClientID, SpecificClientAttachableConnOpts{
+		IfAvailable: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("no active session attachables for client %q", socket.SourceClientID)
+	}
+
+	resp, err := git.NewGitClient(conn).GetCredential(ctx, &git.GitCredentialRequest{
+		Protocol: req.protocol,
+		Host:     req.host,
+		Path:     req.path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query credentials: %w", err)
+	}
+	switch result := resp.Result.(type) {
+	case *git.GitCredentialResponse_Credential:
+		return result.Credential, nil
+	case *git.GitCredentialResponse_Error:
+		return nil, fmt.Errorf("git credential error: %s", result.Error.Message)
+	default:
+		return nil, errors.New("unexpected git credential response type")
+	}
+}

--- a/core/git_credential_socket.go
+++ b/core/git_credential_socket.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 )
 
-const gitCredentialSocketDigestVersion = "git-credential-socket-v1"
+const gitCredentialSocketDigestVersion = "git-credential-socket-v1" // #nosec G101 -- digest domain separator, not a credential.
 
 // gitCredentialRequestTimeout bounds a single credential exchange over the
 // socket, including the round-trip to the host's git credential helper (which
@@ -172,8 +172,7 @@ func (socket *Socket) MountGitCredentialSocket(ctx context.Context) (string, fun
 	return sockPath, func() error {
 		cancel()
 		wg.Wait()
-		_ = os.RemoveAll(dir)
-		return nil
+		return os.RemoveAll(dir)
 	}, nil
 }
 

--- a/core/git_credential_socket_test.go
+++ b/core/git_credential_socket_test.go
@@ -1,0 +1,159 @@
+package core
+
+import (
+	"context"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/session/git"
+)
+
+// testGitServer stands in for the host-side git session attachable that
+// fronts the user's git credential helper.
+type testGitServer struct {
+	creds map[string]*git.CredentialInfo // keyed by host
+}
+
+func (srv *testGitServer) GetCredential(_ context.Context, req *git.GitCredentialRequest) (*git.GitCredentialResponse, error) {
+	cred, ok := srv.creds[req.Host]
+	if !ok {
+		return &git.GitCredentialResponse{Result: &git.GitCredentialResponse_Error{Error: &git.ErrorInfo{
+			Type:    git.CREDENTIAL_RETRIEVAL_FAILED,
+			Message: "no matching credentials",
+		}}}, nil
+	}
+	return &git.GitCredentialResponse{Result: &git.GitCredentialResponse_Credential{Credential: cred}}, nil
+}
+
+func (srv *testGitServer) GetConfig(context.Context, *git.GitConfigRequest) (*git.GitConfigResponse, error) {
+	return &git.GitConfigResponse{Result: &git.GitConfigResponse_Config{Config: &git.GitConfig{}}}, nil
+}
+
+func newGitAttachableConn(t *testing.T, creds map[string]*git.CredentialInfo) *grpc.ClientConn {
+	t.Helper()
+	return newTestAttachableConn(t, func(server *grpc.Server) {
+		git.RegisterGitServer(server, &testGitServer{creds: creds})
+	})
+}
+
+func newGitCredentialTestContext(t *testing.T, attachables map[string]*grpc.ClientConn) (context.Context, *dagql.Cache) {
+	t.Helper()
+	cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+	assert.NilError(t, err)
+	ctx := ContextWithQuery(t.Context(), &Query{Server: &mockServer{attachables: attachables}})
+	ctx = dagql.ContextWithCache(ctx, cache)
+	ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+		SessionID: "test-session",
+		ClientID:  "test-client",
+	})
+	return ctx, cache
+}
+
+func mountGitCredentialSocket(t *testing.T, ctx context.Context, handle dagql.SessionResourceHandle) string {
+	t.Helper()
+	sockPath, cleanup, err := (&Socket{Kind: SocketKindGitCredential, Handle: handle}).MountGitCredentialSocket(ctx)
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+	return sockPath
+}
+
+// credentialFill exchanges one request over the socket exactly like the
+// in-container helper: write, half-close, read the reply.
+func credentialFill(t *testing.T, sockPath, request string) string {
+	t.Helper()
+	conn, err := net.Dial("unix", sockPath)
+	assert.NilError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(request))
+	assert.NilError(t, err)
+	assert.NilError(t, conn.(*net.UnixConn).CloseWrite())
+
+	reply, err := io.ReadAll(conn)
+	assert.NilError(t, err)
+	return string(reply)
+}
+
+func TestGitCredentialSocketRoundTrip(t *testing.T) {
+	ctx, cache := newGitCredentialTestContext(t, map[string]*grpc.ClientConn{
+		"cred-client": newGitAttachableConn(t, map[string]*git.CredentialInfo{
+			"github.com": {Protocol: "https", Host: "github.com", Username: "x-token-auth", Password: "s3cret"},
+		}),
+	})
+
+	handle := dagql.SessionResourceHandle("git-credential-handle")
+	assert.NilError(t, cache.BindSessionResource(ctx, "test-session", "test-client", handle, &Socket{
+		Kind:               SocketKindGitCredential,
+		SourceClientID:     "cred-client",
+		GitCredentialHosts: []string{"github.com"},
+	}))
+	sockPath := mountGitCredentialSocket(t, ctx, handle)
+
+	assert.Equal(t,
+		credentialFill(t, sockPath, "protocol=https\nhost=github.com\ncapability[]=authtype\n\n"),
+		"protocol=https\nhost=github.com\nusername=x-token-auth\npassword=s3cret\n\n")
+
+	// anything not allowlisted gets an empty reply: no credentials
+	assert.Equal(t, credentialFill(t, sockPath, "protocol=https\nhost=evil.com\n\n"), "")
+	assert.Equal(t, credentialFill(t, sockPath, "protocol=ftp\nhost=github.com\n\n"), "")
+}
+
+func TestGitCredentialSocketFallsBackToAvailableSessionResourceBinding(t *testing.T) {
+	ctx, cache := newGitCredentialTestContext(t, map[string]*grpc.ClientConn{
+		"live-client": newGitAttachableConn(t, map[string]*git.CredentialInfo{
+			"gitlab.com": {Protocol: "https", Host: "gitlab.com", Username: "user", Password: "pass"},
+		}),
+	})
+
+	handle := dagql.SessionResourceHandle("git-credential-handle")
+	for _, clientID := range []string{"dead-client", "live-client"} {
+		assert.NilError(t, cache.BindSessionResource(ctx, "test-session", clientID, handle, &Socket{
+			Kind:               SocketKindGitCredential,
+			SourceClientID:     clientID,
+			GitCredentialHosts: []string{"gitlab.com"},
+		}))
+	}
+	sockPath := mountGitCredentialSocket(t, ctx, handle)
+
+	reply := credentialFill(t, sockPath, "protocol=https\nhost=gitlab.com\n\n")
+	assert.Assert(t, is.Contains(reply, "password=pass\n"))
+}
+
+func TestParseGitCredentialRequest(t *testing.T) {
+	// git sends attributes we don't know (capability[], wwwauth[]); ignore them
+	req, err := parseGitCredentialRequest(strings.NewReader("protocol=https\nhost=github.com\npath=org/repo.git\ncapability[]=authtype\n\n"))
+	assert.NilError(t, err)
+	assert.Equal(t, *req, gitCredentialRequest{protocol: "https", host: "github.com", path: "org/repo.git"})
+
+	_, err = parseGitCredentialRequest(strings.NewReader("host=github.com\n\n"))
+	assert.ErrorContains(t, err, "protocol and host are required")
+
+	_, err = parseGitCredentialRequest(strings.NewReader("garbage\n\n"))
+	assert.ErrorContains(t, err, "key=value")
+}
+
+func TestNormalizeGitCredentialHosts(t *testing.T) {
+	assert.DeepEqual(t,
+		NormalizeGitCredentialHosts([]string{" GitHub.com ", "gitlab.com", "github.com", ""}),
+		[]string{"github.com", "gitlab.com"},
+	)
+}
+
+func TestScopedGitCredentialSocketHandle(t *testing.T) {
+	salt := []byte("salt")
+	hosts := []string{"github.com", "gitlab.com"}
+
+	clients := []string{"client-a"}
+	handle := ScopedGitCredentialSocketHandle(salt, clients, hosts)
+	assert.Equal(t, handle, ScopedGitCredentialSocketHandle(salt, clients, hosts))
+	assert.Assert(t, handle != ScopedGitCredentialSocketHandle(salt, []string{"client-b"}, hosts))
+	assert.Assert(t, handle != ScopedGitCredentialSocketHandle(salt, clients, []string{"github.com"}))
+}

--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -10,6 +10,7 @@ package core
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -262,5 +263,85 @@ func (m *Foo) HowCoolIsDagger() string {
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "private-transitive-go-dep:ubercool", howCoolIsDagger)
+	})
+
+	// same private go.mod dependency, but over HTTPS: the install resolves it
+	// through the host's git credential helper via the engine's git-credential
+	// socket, which must be gone by the time user code runs
+	t.Run("golang transitive existing go.mod https", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		encodedPAT := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
+		token, err := base64.StdEncoding.DecodeString(encodedPAT)
+		require.NoError(t, err)
+
+		const (
+			privateDep        = "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git/privatewrapper"
+			privateDepVersion = "v0.0.1"
+		)
+
+		modGen := goGitBase(t, c).
+			WithNewFile("/root/.gitconfig", makeGitCredentials("https://gitlab.com", "git", strings.TrimSpace(string(token)))).
+			WithNewFile("/work/dagger.toml", `[modules.foo]
+source = ".dagger/modules/foo"
+entrypoint = true
+`).
+			WithNewFile("/work/.dagger/modules/foo/dagger.json", `{
+  "name": "foo",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go",
+    "config": {
+      "goprivate": "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git"
+    }
+  }
+}`).
+			WithNewFile("/work/.dagger/modules/foo/go.mod", fmt.Sprintf(`module dagger/foo
+
+go 1.21.3
+
+require %s %s
+`, privateDep, privateDepVersion)).
+			WithNewFile("/work/.dagger/modules/foo/main.go", fmt.Sprintf(`package main
+
+import (
+	"os"
+
+	"%s/pkg/coolwrapper"
+)
+
+type Foo struct{}
+
+func (m *Foo) HowCoolIsDagger() string {
+	return coolwrapper.HowCoolIsThat()
+}
+
+// Leaks reports any git credential plumbing still visible to user code.
+func (m *Foo) Leaks() string {
+	if os.Getenv("GIT_CONFIG_COUNT") != "" {
+		return "env leaked"
+	}
+	if _, err := os.Stat("/.git-credential"); err == nil {
+		return "helper leaked"
+	}
+	if _, err := os.Stat("/tmp/dagger-git-credential.sock"); err == nil {
+		return "socket leaked"
+	}
+	return "clean"
+}
+`, privateDep)).
+			WithWorkdir("/work")
+
+		howCoolIsDagger, err := modGen.
+			With(daggerExec("call", "how-cool-is-dagger")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "private-transitive-go-dep:ubercool", howCoolIsDagger)
+
+		leaks, err := modGen.
+			With(daggerExec("call", "leaks")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "clean", leaks)
 	})
 }

--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -23,6 +23,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// gitlabTestPAT returns the read-only PAT for the private gitlab fixture
+// repo, base64-encoded in source to dodge token scanners.
+func gitlabTestPAT(t *testctx.T) string {
+	t.Helper()
+	token, err := base64.StdEncoding.DecodeString("Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx")
+	require.NoError(t, err)
+	return strings.TrimSpace(string(token))
+}
+
 func (ModuleSuite) TestSSHAgentConnection(ctx context.Context, t *testctx.T) {
 	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
 		t.Run("ConcurrentSetupAndCleanup", func(ctx context.Context, t *testctx.T) {
@@ -271,9 +280,7 @@ func (m *Foo) HowCoolIsDagger() string {
 	t.Run("golang transitive existing go.mod https", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
-		encodedPAT := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := base64.StdEncoding.DecodeString(encodedPAT)
-		require.NoError(t, err)
+		token := gitlabTestPAT(t)
 
 		const (
 			privateDep        = "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git/privatewrapper"
@@ -281,21 +288,22 @@ func (m *Foo) HowCoolIsDagger() string {
 		)
 
 		modGen := goGitBase(t, c).
-			WithNewFile("/root/.gitconfig", makeGitCredentials("https://gitlab.com", "git", strings.TrimSpace(string(token)))).
+			WithNewFile("/root/.gitconfig", makeGitCredentials("https://gitlab.com", "git", token)).
+			// goprivate through the workspace settings namespace; the legacy
+			// dagger.json sdk.config form is covered by TestSDKConfig
 			WithNewFile("/work/dagger.toml", `[modules.foo]
 source = ".dagger/modules/foo"
 entrypoint = true
+
+[modules.foo.settings]
+goprivate = "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git"
 `).
-			WithNewFile("/work/.dagger/modules/foo/dagger.json", `{
-  "name": "foo",
-  "engineVersion": "latest",
-  "sdk": {
-    "source": "go",
-    "config": {
-      "goprivate": "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git"
-    }
-  }
-}`).
+			WithNewFile("/work/.dagger/modules/foo/dagger-module.toml", `name = "foo"
+engineVersion = "latest"
+
+[runtime]
+source = "go"
+`).
 			WithNewFile("/work/.dagger/modules/foo/go.mod", fmt.Sprintf(`module dagger/foo
 
 go 1.21.3
@@ -343,5 +351,210 @@ func (m *Foo) Leaks() string {
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "clean", leaks)
+	})
+}
+
+// Public git+https dependencies in Python/TypeScript modules exercise the
+// full git-credential plumbing (manifest scan, socket mint, mount and helper
+// injection inside the runtime module's install execs, scrub before user
+// code) without needing private-repo credentials: git only consults the
+// helper on an auth challenge, so the install succeeds with an empty scope.
+func (ModuleSuite) TestGitDepInstall(ctx context.Context, t *testctx.T) {
+	t.Run("python", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := daggerCliBase(t, c).
+			With(withPythonModule(t, c, "python/base-test")).
+			// the [tool.uv.sources] sub-table form is what `uv add git+https://...` writes
+			With(pyprojectExtra([]string{"packaging"}, `
+[tool.uv.sources.packaging]
+git = "https://github.com/pypa/packaging"
+tag = "25.0"
+`)).
+			With(pythonSource(`
+import os
+import importlib.metadata
+
+import dagger
+
+@dagger.object_type
+class Test:
+    @dagger.function
+    def check(self) -> str:
+        version = importlib.metadata.version("packaging")
+        leaks = []
+        if os.environ.get("GIT_CONFIG_COUNT"):
+            leaks.append("env")
+        if os.path.exists("/.git-credential"):
+            leaks.append("helper")
+        if os.path.exists("/tmp/dagger-git-credential.sock"):
+            leaks.append("socket")
+        return version + ":" + (",".join(leaks) or "clean")
+`)).
+			With(daggerCallAt(".", "check")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "25.0:clean", out)
+	})
+
+	t.Run("python private", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		token := gitlabTestPAT(t)
+
+		const privateDep = "coolpy @ git+https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git@92ee0a59a10856b61ed9a18f0ff921cc31fb8f7d#subdirectory=privatepy"
+
+		out, err := daggerCliBase(t, c).
+			// the nested dagger session serves `git credential fill` from this container
+			WithExec([]string{"apk", "add", "git"}).
+			WithNewFile("/root/.gitconfig", makeGitCredentials("https://gitlab.com", "git", token)).
+			With(withPythonModule(t, c, "python/base-test")).
+			With(pyprojectExtra([]string{privateDep}, "")).
+			With(pythonSource(`
+import os
+
+import coolpy
+import dagger
+
+@dagger.object_type
+class Test:
+    @dagger.function
+    def check(self) -> str:
+        leaks = []
+        if os.environ.get("GIT_CONFIG_COUNT"):
+            leaks.append("env")
+        if os.path.exists("/.git-credential"):
+            leaks.append("helper")
+        if os.path.exists("/tmp/dagger-git-credential.sock"):
+            leaks.append("socket")
+        return coolpy.how_cool() + ":" + (",".join(leaks) or "clean")
+`)).
+			With(daggerCallAt(".", "check")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "private-python-git-dep:ubercool:clean", out)
+	})
+
+	t.Run("typescript", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := daggerCliBase(t, c).
+			With(withModuleFixture(t, c, ".", "typescript/base-test")).
+			WithNewFile("package.json", `{
+  "type": "module",
+  "dependencies": {
+    "typescript": "^5.5.4",
+    "ms": "git+https://github.com/vercel/ms.git#2.1.3"
+  }
+}`).
+			With(sdkSource("typescript", `
+import * as fs from "fs"
+import ms from "ms"
+import { object, func } from "@dagger.io/dagger"
+
+@object()
+export class Test {
+  @func()
+  check(): string {
+    const leaks = []
+    if (process.env.GIT_CONFIG_COUNT) leaks.push("env")
+    if (fs.existsSync("/.git-credential")) leaks.push("helper")
+    if (fs.existsSync("/tmp/dagger-git-credential.sock")) leaks.push("socket")
+    return ms(60000) + ":" + (leaks.join(",") || "clean")
+  }
+}
+`)).
+			With(daggerCallAt(".", "check")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "1m:clean", out)
+	})
+
+	t.Run("typescript private", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		token := gitlabTestPAT(t)
+
+		out, err := daggerCliBase(t, c).
+			// the nested dagger session serves `git credential fill` from this container
+			WithExec([]string{"apk", "add", "git"}).
+			WithNewFile("/root/.gitconfig", makeGitCredentials("https://gitlab.com", "git", token)).
+			With(withModuleFixture(t, c, ".", "typescript/base-test")).
+			WithNewFile("package.json", `{
+  "type": "module",
+  "dependencies": {
+    "typescript": "^5.5.4",
+    "cooljs": "git+https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git#d62b69ec32be39bf3c8b7386a066732a40d9f632"
+  }
+}`).
+			With(sdkSource("typescript", `
+import * as fs from "fs"
+import cooljs from "cooljs"
+import { object, func } from "@dagger.io/dagger"
+
+@object()
+export class Test {
+  @func()
+  check(): string {
+    const leaks = []
+    if (process.env.GIT_CONFIG_COUNT) leaks.push("env")
+    if (fs.existsSync("/.git-credential")) leaks.push("helper")
+    if (fs.existsSync("/tmp/dagger-git-credential.sock")) leaks.push("socket")
+    return cooljs + ":" + (leaks.join(",") || "clean")
+  }
+}
+`)).
+			With(daggerCallAt(".", "check")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "private-js-git-dep:ubercool:clean", out)
+	})
+
+	// bun never runs git for github.com dependencies (it downloads tarballs
+	// from the github API instead, currently without applying credentials:
+	// https://github.com/oven-sh/bun/issues/19618), so a github URL would
+	// bypass the credential helper entirely and prove nothing; a non-github
+	// host is what makes bun fall back to a real `git clone`
+	t.Run("typescript private bun", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		token := gitlabTestPAT(t)
+
+		out, err := daggerCliBase(t, c).
+			// the nested dagger session serves `git credential fill` from this container
+			WithExec([]string{"apk", "add", "git"}).
+			WithNewFile("/root/.gitconfig", makeGitCredentials("https://gitlab.com", "git", token)).
+			With(withModuleFixture(t, c, ".", "typescript/base-test")).
+			WithNewFile("package.json", `{
+  "type": "module",
+  "dagger": {
+    "runtime": "bun"
+  },
+  "dependencies": {
+    "typescript": "^5.5.4",
+    "cooljs": "git+https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git#d62b69ec32be39bf3c8b7386a066732a40d9f632"
+  }
+}`).
+			With(sdkSource("typescript", `
+import * as fs from "fs"
+import cooljs from "cooljs"
+import { object, func } from "@dagger.io/dagger"
+
+@object()
+export class Test {
+  @func()
+  check(): string {
+    const leaks = []
+    if (process.env.GIT_CONFIG_COUNT) leaks.push("env")
+    if (fs.existsSync("/.git-credential")) leaks.push("helper")
+    if (fs.existsSync("/tmp/dagger-git-credential.sock")) leaks.push("socket")
+    return cooljs + ":" + (leaks.join(",") || "clean")
+  }
+}
+`)).
+			With(daggerCallAt(".", "check")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "private-js-git-dep:ubercool:clean", out)
 	})
 }

--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -298,12 +298,15 @@ entrypoint = true
 [modules.foo.settings]
 goprivate = "gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git"
 `).
-			WithNewFile("/work/.dagger/modules/foo/dagger-module.toml", `name = "foo"
-engineVersion = "latest"
-
-[runtime]
-source = "go"
-`).
+			// Keep this synthetic auth fixture on the legacy runtime-codegen
+			// path. TOML modules require committed generated files before they
+			// can load; that separate contract is covered by RuntimeCodegenSuite.
+			WithNewFile("/work/.dagger/modules/foo/dagger.json", `{
+  "name": "foo",
+  "engineVersion": "latest",
+  "sdk": {"source": "go"},
+  "source": "."
+}`).
 			WithNewFile("/work/.dagger/modules/foo/go.mod", fmt.Sprintf(`module dagger/foo
 
 go 1.21.3

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -225,6 +225,8 @@ type ModuleConfigUserFields struct {
 // the current TOML schema. They survive on this struct only for back-compat
 // reading of legacy dagger.json. Writes to current TOML omit them; writes to
 // legacy JSON preserve them (the legacy format is not being rewritten).
+// Runtime config like goprivate lives in the workspace settings namespace
+// instead (dagger.toml [modules.<name>.settings]).
 type SDK struct {
 	Source string `json:"source" toml:"source"`
 	Pin    string `json:"pin,omitempty" toml:"pin,omitempty"`

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -84,6 +84,14 @@ func (s *hostSchema) Install(srv *dagql.Server) {
 				dagql.Arg("source").Doc(`Optional source socket to scope. If not set, uses the caller's SSH_AUTH_SOCK.`),
 			),
 
+		dagql.NodeFunc("_gitCredential", s.gitCredentialSocket).
+			WithInput(dagql.PerCallInput).
+			Doc(`Returns a socket that answers git's credential-helper protocol by relaying to the session's host git credential helper, restricted to the given hosts.`,
+				`The user's credentials are only resolved in trusted engine-driven SDK/dependency installs; any other caller gets its own scope.`).
+			Args(
+				dagql.Arg("hosts").Doc(`Exact hostnames the socket is allowed to serve credentials for.`),
+			),
+
 		dagql.Func("tunnel", s.tunnel).
 			WithInput(dagql.PerClientInput).
 			Doc(`Creates a tunnel that forwards traffic from the host to a service.`).
@@ -480,6 +488,90 @@ func (s *hostSchema) sshAuthSocket(ctx context.Context, host dagql.ObjectResult[
 	}
 	if err := cache.BindSessionResource(ctx, clientMetadata.SessionID, clientMetadata.ClientID, handle, concreteSelf); err != nil {
 		return inst, err
+	}
+
+	return inst, nil
+}
+
+type hostGitCredentialArgs struct {
+	Hosts []string
+}
+
+func (s *hostSchema) gitCredentialSocket(ctx context.Context, host dagql.ObjectResult[*core.Host], args hostGitCredentialArgs) (inst dagql.Result[*core.Socket], err error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dagql cache: %w", err)
+	}
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get client metadata: %w", err)
+	}
+
+	hosts := core.NormalizeGitCredentialHosts(args.Hosts)
+	if len(hosts) == 0 {
+		return inst, errors.New("at least one allowed host is required")
+	}
+
+	// Identity is derived from ctx, never from the call, following the same
+	// candidate rules as the git resolver's implicit HTTPS auth (git.go): the
+	// non-module parent client's credentials by default, plus the session's
+	// originating client under trusted module dependency/SDK resolution. A
+	// module client calling this directly only gets its own scope. One
+	// session resource binding per candidate; resolution at exec time picks
+	// the first client that can answer.
+	parentClientMetadata, err := query.NonModuleParentClientMetadata(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get non-module parent client metadata: %w", err)
+	}
+	isTrustedDepResolution := core.IsModuleDependencyResolution(ctx)
+	srcClientMetadatas := []*engine.ClientMetadata{parentClientMetadata}
+	if clientMetadata.ClientID != parentClientMetadata.ClientID && !isTrustedDepResolution {
+		srcClientMetadatas = []*engine.ClientMetadata{clientMetadata}
+	} else if isTrustedDepResolution {
+		mainClientMetadata, err := query.MainClientCallerMetadata(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get main client metadata: %w", err)
+		}
+		if mainClientMetadata.ClientID != parentClientMetadata.ClientID {
+			srcClientMetadatas = append(srcClientMetadatas, mainClientMetadata)
+		}
+	}
+
+	srcClientIDs := make([]string, len(srcClientMetadatas))
+	for i, md := range srcClientMetadatas {
+		srcClientIDs[i] = md.ClientID
+	}
+	handle := core.ScopedGitCredentialSocketHandle(query.SecretSalt(), srcClientIDs, hosts)
+
+	handleVal := &core.Socket{
+		Kind:   core.SocketKindGitCredential,
+		Handle: handle,
+	}
+	inst, err = dagql.NewResultForCurrentCall(ctx, handleVal)
+	if err != nil {
+		return inst, fmt.Errorf("failed to create instance: %w", err)
+	}
+	inst, err = inst.WithContentDigest(ctx, digest.Digest(handle))
+	if err != nil {
+		return inst, err
+	}
+	inst, err = inst.WithSessionResourceHandle(ctx, handle)
+	if err != nil {
+		return inst, err
+	}
+
+	for _, md := range srcClientMetadatas {
+		if err := cache.BindSessionResource(ctx, clientMetadata.SessionID, md.ClientID, handle, &core.Socket{
+			Kind:               core.SocketKindGitCredential,
+			SourceClientID:     md.ClientID,
+			GitCredentialHosts: hosts,
+		}); err != nil {
+			return inst, err
+		}
 	}
 
 	return inst, nil

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -137,6 +137,12 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 				dagql.Arg("source").Doc(`The SDK source to set.`),
 			),
 
+		dagql.Func("_withRuntimeSettings", s.moduleSourceWithRuntimeSettings).
+			Doc(`Apply engine-consumed runtime settings (e.g. goprivate) from the workspace settings namespace to this module source.`).
+			Args(
+				dagql.Arg("settingsJson").Doc(`JSON-encoded map of runtime setting keys to values.`),
+			),
+
 		dagql.Func("withEngineVersion", s.moduleSourceWithEngineVersion).
 			Doc(`Upgrade the engine version of the module to the given value.`).
 			Args(
@@ -1388,6 +1394,45 @@ func (s *moduleSourceSchema) moduleSourceWithSDK(
 	// New SDK means new exposed functions and types. Different .env entries might match.
 	if err := src.LoadUserDefaults(ctx); err != nil {
 		return nil, fmt.Errorf("load user defaults: %w", err)
+	}
+	return src, nil
+}
+
+func (s *moduleSourceSchema) moduleSourceWithRuntimeSettings(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		SettingsJson string //nolint:staticcheck // JSON casing matches sibling internal args
+	},
+) (*core.ModuleSource, error) {
+	if args.SettingsJson == "" {
+		return src, nil
+	}
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(args.SettingsJson), &settings); err != nil {
+		return nil, fmt.Errorf("decoding runtime settings: %w", err)
+	}
+	if len(settings) == 0 {
+		return src, nil
+	}
+
+	src = src.Clone()
+	if src.SDK == nil {
+		src.SDK = &core.SDKConfig{}
+	}
+	config := make(map[string]any, len(src.SDK.Config)+len(settings))
+	maps.Copy(config, src.SDK.Config)
+	maps.Copy(config, settings)
+	src.SDK.Config = config
+
+	// reload the sdk implementation so the new config reaches the runtime
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	src.SDKImpl, err = sdk.NewLoader().SDKForModule(ctx, query, src.SDK, src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load sdk for module source: %w", err)
 	}
 	return src, nil
 }

--- a/core/sdk/git_credentials.go
+++ b/core/sdk/git_credentials.go
@@ -1,0 +1,143 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
+)
+
+const gitCredentialsArgName = "gitCredentials"
+
+// files scanned for git dependency URLs; the referenced hosts become the
+// git-credential socket's exact-host allowlist. Lockfiles are included so
+// transitive git dependencies resolve too.
+var gitCredentialManifestFilesBySDK = map[string][]string{
+	"python-sdk":     {"pyproject.toml", "uv.lock", "requirements.lock"},
+	"typescript-sdk": {"package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lock"},
+}
+
+var gitCredentialManifestURLPatterns = []*regexp.Regexp{
+	// explicit git+http(s) URLs (PEP 508, package.json git deps, lockfiles)
+	regexp.MustCompile(`git\+https?://(?:[^/@\s"']*@)?([^/\s"'#]+)`),
+	// uv's [tool.uv.sources] / uv.lock form: pkg = { git = "https://host/..." }
+	regexp.MustCompile(`git\s*=\s*"https?://(?:[^/@\s"']*@)?([^/\s"'#]+)`),
+}
+
+func gitCredentialHostsFromManifests(manifests ...string) []string {
+	var hosts []string
+	for _, manifest := range manifests {
+		for _, pattern := range gitCredentialManifestURLPatterns {
+			for _, match := range pattern.FindAllStringSubmatch(manifest, -1) {
+				hosts = append(hosts, match[1])
+			}
+		}
+	}
+	return core.NormalizeGitCredentialHosts(hosts)
+}
+
+// mintGitCredentialSocket mints a git-credential socket for the given hosts
+// under trusted dependency resolution, so it may serve the non-module parent
+// client's credentials (session's originating client as fallback).
+func mintGitCredentialSocket(ctx context.Context, root *core.Query, hosts []string) (dagql.ID[*core.Socket], error) {
+	var zero dagql.ID[*core.Socket]
+
+	dag, err := root.Server.Server(ctx)
+	if err != nil {
+		return zero, fmt.Errorf("failed to get dag for git credential socket: %w", err)
+	}
+
+	ctx = core.WithModuleDependencyResolution(ctx)
+
+	hostsInput := make(dagql.ArrayInput[dagql.String], len(hosts))
+	for i, host := range hosts {
+		hostsInput[i] = dagql.NewString(host)
+	}
+	var sock dagql.Result[*core.Socket]
+	if err := dag.Select(ctx, dag.Root(), &sock,
+		dagql.Selector{Field: "host"},
+		dagql.Selector{Field: "_gitCredential", Args: []dagql.NamedInput{
+			{Name: "hosts", Value: hostsInput},
+		}},
+	); err != nil {
+		return zero, fmt.Errorf("failed to select git credential socket: %w", err)
+	}
+	sockID, err := sock.ID()
+	if err != nil {
+		return zero, fmt.Errorf("failed to get git credential socket ID: %w", err)
+	}
+	return dagql.NewID[*core.Socket](sockID), nil
+}
+
+// gitCredentialsInput returns the optional gitCredentials argument for the
+// named SDK function, or nil when it doesn't apply: the SDK must be builtin
+// (git-loaded and external SDKs fail closed), the function must declare the
+// argument, and the module's manifests must reference git+http(s)
+// dependencies.
+func (sdk *module) gitCredentialsInput(ctx context.Context, dag *dagql.Server, funcName string, source dagql.ObjectResult[*core.ModuleSource]) (*dagql.NamedInput, error) {
+	if !sdk.builtin {
+		return nil, nil
+	}
+	fn, ok := sdk.funcs[funcName]
+	if !ok {
+		return nil, nil
+	}
+	spec, err := fn.FieldSpec(ctx, core.NewUserMod(sdk.mod))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s field spec: %w", funcName, err)
+	}
+	declared := false
+	for _, input := range spec.Args.Inputs(dag.View) {
+		if input.Name == gitCredentialsArgName {
+			declared = true
+			break
+		}
+	}
+	if !declared {
+		return nil, nil
+	}
+
+	hosts, err := sdk.manifestGitCredentialHosts(ctx, source)
+	if err != nil || len(hosts) == 0 {
+		return nil, err
+	}
+	sockID, err := mintGitCredentialSocket(ctx, sdk.root, hosts)
+	if err != nil {
+		return nil, err
+	}
+	return &dagql.NamedInput{Name: gitCredentialsArgName, Value: dagql.Opt(sockID)}, nil
+}
+
+func (sdk *module) manifestGitCredentialHosts(ctx context.Context, source dagql.ObjectResult[*core.ModuleSource]) ([]string, error) {
+	if source.Self() == nil || source.Self().ContextDirectory.Self() == nil {
+		return nil, nil
+	}
+	manifestFiles := gitCredentialManifestFilesBySDK[sdk.mod.Self().Name()]
+	if len(manifestFiles) == 0 {
+		return nil, nil
+	}
+	rootDag, err := sdk.root.Server.Server(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dag for manifest scan: %w", err)
+	}
+
+	var manifests []string
+	for _, name := range manifestFiles {
+		var contents dagql.String
+		if err := rootDag.Select(ctx, source.Self().ContextDirectory, &contents,
+			dagql.Selector{Field: "file", Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(filepath.Join(source.Self().SourceSubpath, name))},
+			}},
+			dagql.Selector{Field: "contents"},
+		); err != nil {
+			// treated as "manifest absent": a real read failure only means no
+			// socket, and the install then fails with a visible auth error
+			continue
+		}
+		manifests = append(manifests, contents.String())
+	}
+	return gitCredentialHostsFromManifests(manifests...), nil
+}

--- a/core/sdk/git_credentials_test.go
+++ b/core/sdk/git_credentials_test.go
@@ -1,0 +1,46 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitCredentialHostsFromManifests(t *testing.T) {
+	t.Parallel()
+
+	pyproject := `
+[project]
+dependencies = [
+    "coolpy @ git+https://gitlab.com/org/private.git@v1#subdirectory=coolpy",
+    "requests>=2.0",
+]
+
+# the form 'uv add' actually writes
+[tool.uv.sources]
+mylib = { git = "https://git.corp.example.com/acme/mylib", tag = "v1" }
+`
+	packageJSON := `{
+  "dependencies": {
+    "cooljs": "git+https://user@github.com/org/private-js.git#main",
+    "left-pad": "^1.3.0",
+    "ssh-dep": "git+ssh://git@github.com/org/ignored.git"
+  }
+}`
+	uvLock := `
+[[package]]
+name = "translock"
+source = { git = "https://gitlab.example.com/acme/translock?tag=v2#abc123" }
+`
+
+	require.Equal(t,
+		[]string{"git.corp.example.com", "github.com", "gitlab.com"},
+		gitCredentialHostsFromManifests(pyproject, packageJSON),
+	)
+	// transitive git deps recorded only in lockfiles are allowlisted too
+	require.Equal(t,
+		[]string{"gitlab.example.com"},
+		gitCredentialHostsFromManifests(uvLock),
+	)
+	require.Empty(t, gitCredentialHostsFromManifests(`{"dependencies": {"left-pad": "^1.3.0"}}`))
+}

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/dagger/dagger/engine/slog"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/mitchellh/mapstructure"
 )
@@ -679,7 +681,90 @@ func (sdk *goSDK) moduleDependencyConfigSelectors(ctx context.Context) ([]dagql.
 	}
 	selectors = append(selectors, setSSHAuthSelectors...)
 
-	return selectors, unsetSSHAuthSelectors, nil
+	setGitCredSelectors, unsetGitCredSelectors, err := sdk.gitCredentialSelectors(ctx, config)
+	if err != nil {
+		return nil, nil, err
+	}
+	selectors = append(selectors, setGitCredSelectors...)
+
+	return selectors, append(unsetSSHAuthSelectors, unsetGitCredSelectors...), nil
+}
+
+// goSDKGitCredentialSockPath is where the git-credential socket is mounted in
+// the dependency install container; removed before user code runs.
+const goSDKGitCredentialSockPath = "/tmp/dagger-git-credential.sock"
+
+// gitCredentialHostsFromGoPrivate derives the socket's exact-host allowlist
+// from GOPRIVATE-style patterns (e.g. "github.com/myorg/*,gitlab.example.com").
+// Patterns with a wildcard in the host component are skipped: the socket only
+// does exact-host matching.
+func gitCredentialHostsFromGoPrivate(goPrivate string) []string {
+	var hosts []string
+	for pattern := range strings.SplitSeq(goPrivate, ",") {
+		host, _, _ := strings.Cut(strings.TrimSpace(pattern), "/")
+		if host == "" {
+			continue
+		}
+		if strings.Contains(host, "*") {
+			slog.Warn("git credential forwarding skips GOPRIVATE pattern with wildcard host (exact-host allowlist only)", "pattern", strings.TrimSpace(pattern))
+			continue
+		}
+		hosts = append(hosts, host)
+	}
+	return core.NormalizeGitCredentialHosts(hosts)
+}
+
+// gitCredentialSelectors makes the host's git credential helper available to
+// the dependency install (`go mod tidy` during codegen) for the hosts named
+// by the goprivate sdk config: it mounts a git-credential socket and points
+// git at the engine-injected helper. The unset selectors scrub the socket and
+// its git config before user code runs. Known limitation: any GIT_CONFIG_*
+// env the base image sets is masked during the install and dropped by the
+// scrub (file-based git config is untouched).
+func (sdk *goSDK) gitCredentialSelectors(ctx context.Context, config goSDKConfig) (set, unset []dagql.Selector, rerr error) {
+	hosts := gitCredentialHostsFromGoPrivate(config.GoPrivate)
+	if len(hosts) == 0 {
+		return nil, nil, nil
+	}
+
+	sockID, err := mintGitCredentialSocket(ctx, sdk.root, hosts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	set = []dagql.Selector{{
+		Field: "withUnixSocket",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(goSDKGitCredentialSockPath)},
+			{Name: "source", Value: sockID},
+		},
+	}}
+	unset = []dagql.Selector{{
+		Field: "withoutUnixSocket",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(goSDKGitCredentialSockPath)},
+		},
+	}}
+	for _, env := range [][2]string{
+		{"GIT_CONFIG_COUNT", "1"},
+		{"GIT_CONFIG_KEY_0", "credential.helper"},
+		{"GIT_CONFIG_VALUE_0", distconsts.GitCredentialHelperInContainerPath + " " + goSDKGitCredentialSockPath},
+	} {
+		set = append(set, dagql.Selector{
+			Field: "withEnvVariable",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.NewString(env[0])},
+				{Name: "value", Value: dagql.NewString(env[1])},
+			},
+		})
+		unset = append(unset, dagql.Selector{
+			Field: "withoutEnvVariable",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.NewString(env[0])},
+			},
+		})
+	}
+	return set, unset, nil
 }
 
 func (sdk *goSDK) base(ctx context.Context) (dagql.ObjectResult[*core.Container], error) {

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -692,7 +692,7 @@ func (sdk *goSDK) moduleDependencyConfigSelectors(ctx context.Context) ([]dagql.
 
 // goSDKGitCredentialSockPath is where the git-credential socket is mounted in
 // the dependency install container; removed before user code runs.
-const goSDKGitCredentialSockPath = "/tmp/dagger-git-credential.sock"
+const goSDKGitCredentialSockPath = "/tmp/dagger-git-credential.sock" // #nosec G101 -- filesystem path, not a credential.
 
 // gitCredentialHostsFromGoPrivate derives the socket's exact-host allowlist
 // from GOPRIVATE-style patterns (e.g. "github.com/myorg/*,gitlab.example.com").

--- a/core/sdk/go_sdk_test.go
+++ b/core/sdk/go_sdk_test.go
@@ -1,0 +1,17 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitCredentialHostsFromGoPrivate(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		[]string{"github.com", "gitlab.example.com"},
+		gitCredentialHostsFromGoPrivate("github.com/myorg/*, gitlab.example.com/repo.git, *.corp.example.com, github.com"),
+	)
+	require.Empty(t, gitCredentialHostsFromGoPrivate(""))
+}

--- a/core/sdk/loader.go
+++ b/core/sdk/loader.go
@@ -119,7 +119,7 @@ func (l *Loader) externalSDKForModule(
 		return nil, fmt.Errorf("failed to load sdk module %q: %w", sdk.Source, err)
 	}
 
-	return newModuleSDK(ctx, query, sdkMod, dagql.ObjectResult[*core.Directory]{}, sdk.Config)
+	return newModuleSDK(ctx, query, sdkMod, dagql.ObjectResult[*core.Directory]{}, sdk.Config, false)
 }
 
 func (l *Loader) namedSDK(
@@ -213,7 +213,7 @@ func (l *Loader) loadBuiltinSDK(
 		return nil, fmt.Errorf("failed to import module sdk %s: %w", sdk.Source, err)
 	}
 
-	return newModuleSDK(ctx, root, sdkMod, fullSDKDir, sdk.Config)
+	return newModuleSDK(ctx, root, sdkMod, fullSDKDir, sdk.Config, true)
 }
 
 // parse and validate the name and version from sdkName

--- a/core/sdk/module.go
+++ b/core/sdk/module.go
@@ -19,6 +19,12 @@ type module struct {
 	optionalFullSDKSourceDir dagql.ObjectResult[*core.Directory]
 	rawConfig                map[string]any
 
+	// builtin is true when the SDK module was loaded from the engine image
+	// (loadBuiltinSDK) rather than from a git/local source. Only builtin
+	// runtimes are trusted with a git-credential socket during dependency
+	// installs.
+	builtin bool
+
 	funcs map[string]*core.Function
 }
 
@@ -33,12 +39,14 @@ func newModuleSDK(
 	sdkModMeta dagql.ObjectResult[*core.Module],
 	optionalFullSDKSourceDir dagql.ObjectResult[*core.Directory],
 	rawConfig map[string]any,
+	builtin bool,
 ) (*module, error) {
 	sdk := &module{
 		root:                     root,
 		mod:                      sdkModMeta,
 		optionalFullSDKSourceDir: optionalFullSDKSourceDir,
 		rawConfig:                rawConfig,
+		builtin:                  builtin,
 		funcs:                    listImplementedFunctions(sdkModMeta.Self()),
 	}
 

--- a/core/sdk/module_code_generator.go
+++ b/core/sdk/module_code_generator.go
@@ -46,19 +46,28 @@ func (sdk *codeGeneratorModule) Codegen(
 		return nil, fmt.Errorf("failed to get schema introspection json ID during %s module sdk codegen: %w", sdk.mod.mod.Self().Name(), err)
 	}
 
+	codegenArgs := []dagql.NamedInput{
+		{
+			Name:  "modSource",
+			Value: dagql.NewID[*core.ModuleSource](sourceID),
+		},
+		{
+			Name:  "introspectionJson",
+			Value: dagql.NewID[*core.File](schemaJSONFileID),
+		},
+	}
+	gitCredInput, err := sdk.mod.gitCredentialsInput(ctx, dag, "codegen", source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare git credentials for sdk module %s codegen: %w", sdk.mod.mod.Self().Name(), err)
+	}
+	if gitCredInput != nil {
+		codegenArgs = append(codegenArgs, *gitCredInput)
+	}
+
 	var inst dagql.Result[*core.GeneratedCode]
 	err = dag.Select(ctx, sdkInst.sdk, &inst, dagql.Selector{
 		Field: "codegen",
-		Args: []dagql.NamedInput{
-			{
-				Name:  "modSource",
-				Value: dagql.NewID[*core.ModuleSource](sourceID),
-			},
-			{
-				Name:  "introspectionJson",
-				Value: dagql.NewID[*core.File](schemaJSONFileID),
-			},
-		},
+		Args:  codegenArgs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to call sdk module codegen: %w", err)

--- a/core/sdk/module_runtime.go
+++ b/core/sdk/module_runtime.go
@@ -62,6 +62,14 @@ func (sdk *runtimeModule) Runtime(
 		})
 	}
 
+	gitCredInput, err := sdk.mod.gitCredentialsInput(ctx, dag, "moduleRuntime", source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare git credentials for sdk module %s runtime: %w", sdk.mod.mod.Self().Name(), err)
+	}
+	if gitCredInput != nil {
+		args = append(args, *gitCredInput)
+	}
+
 	var inst dagql.ObjectResult[*core.Container]
 	err = dag.Select(ctx, sdkInst.sdk, &inst,
 		dagql.Selector{
@@ -80,6 +88,14 @@ func (sdk *runtimeModule) Runtime(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call sdk moduleRuntime: %w", err)
+	}
+
+	// backstop: user code runs in this container, so a leaky runtime must
+	// fail closed rather than expose the credential socket
+	for _, sock := range inst.Self().Sockets {
+		if sock.Source.Self() != nil && sock.Source.Self().Kind == core.SocketKindGitCredential {
+			return nil, fmt.Errorf("sdk module %s returned a runtime container that still mounts the git-credential socket", sdk.mod.mod.Self().Name())
+		}
 	}
 	return &core.ContainerRuntime{Container: inst}, nil
 }

--- a/core/socket.go
+++ b/core/socket.go
@@ -26,9 +26,10 @@ import (
 type SocketKind string
 
 const (
-	SocketKindSSHHandle  SocketKind = "ssh_handle"
-	SocketKindUnixOpaque SocketKind = "unix_opaque"
-	SocketKindHostIP     SocketKind = "host_ip"
+	SocketKindSSHHandle     SocketKind = "ssh_handle"
+	SocketKindUnixOpaque    SocketKind = "unix_opaque"
+	SocketKindHostIP        SocketKind = "host_ip"
+	SocketKindGitCredential SocketKind = "git_credential"
 )
 
 type Socket struct {
@@ -37,6 +38,11 @@ type Socket struct {
 	URLVal         string
 	PortForwardVal PortForward
 	SourceClientID string
+
+	// GitCredentialHosts is the exact-host allowlist a git-credential socket
+	// serves. Only set on the concrete (session-bound) value of a
+	// SocketKindGitCredential socket.
+	GitCredentialHosts []string
 }
 
 func (*Socket) Type() *ast.Type {

--- a/core/socket.go
+++ b/core/socket.go
@@ -29,7 +29,7 @@ const (
 	SocketKindSSHHandle     SocketKind = "ssh_handle"
 	SocketKindUnixOpaque    SocketKind = "unix_opaque"
 	SocketKindHostIP        SocketKind = "host_ip"
-	SocketKindGitCredential SocketKind = "git_credential"
+	SocketKindGitCredential SocketKind = "git_credential" // #nosec G101 -- socket kind label, not a credential.
 )
 
 type Socket struct {

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -32,6 +33,41 @@ type Config struct {
 type PortMapping struct {
 	BackendService string `json:"backendService" toml:"backendService"`
 	BackendPort    int    `json:"backendPort" toml:"backendPort"`
+}
+
+// runtimeSettingNamesBySDK maps a builtin SDK name to the module setting keys
+// consumed by that SDK's engine-side runtime install (via the module source's
+// SDK config) rather than by the module's constructor. They share the
+// [modules.<name>.settings] namespace with constructor-arg settings, so a key
+// is only reserved for the SDK that consumes it: other SDKs keep the same
+// name free for their own constructor args.
+var runtimeSettingNamesBySDK = map[string][]string{"go": {"goprivate"}}
+
+// RuntimeSettingNamesForSDK returns the runtime setting keys consumed by the
+// given SDK source ref (builtin name, optionally version-suffixed).
+func RuntimeSettingNamesForSDK(sdkSource string) []string {
+	name, _, _ := strings.Cut(sdkSource, "@")
+	return runtimeSettingNamesBySDK[name]
+}
+
+// RuntimeSettingsJSON extracts the runtime settings consumed by the given SDK
+// from a module settings map, JSON-encoded for the module source's
+// _withRuntimeSettings field. Returns "" when the SDK consumes none.
+func RuntimeSettingsJSON(sdkSource string, settings map[string]any) (string, error) {
+	runtimeSettings := map[string]any{}
+	for _, name := range RuntimeSettingNamesForSDK(sdkSource) {
+		if value, ok := settings[name]; ok {
+			runtimeSettings[name] = value
+		}
+	}
+	if len(runtimeSettings) == 0 {
+		return "", nil
+	}
+	out, err := json.Marshal(runtimeSettings)
+	if err != nil {
+		return "", fmt.Errorf("encoding runtime settings: %w", err)
+	}
+	return string(out), nil
 }
 
 // ModuleEntry represents a single module entry in the workspace config.

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -169,7 +169,25 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 
 	wsCfg := compatWorkspace.WorkspaceConfig()
 	if needsProjectModuleMigration && compatWorkspace.MainModule != nil {
-		wsCfg.Modules[cfg.Name] = compatWorkspace.MainModule.Entry
+		entry := compatWorkspace.MainModule.Entry
+		// Legacy sdk.config keys the engine consumes at install time
+		// (goprivate) move into the module's workspace settings namespace;
+		// dagger-module.toml no longer carries sdk config.
+		if cfg.SDK != nil {
+			for _, name := range RuntimeSettingNamesForSDK(cfg.SDK.Source) {
+				value, ok := cfg.SDK.Config[name] //nolint:staticcheck // deprecated; migration reads legacy JSON config
+				if !ok {
+					continue
+				}
+				if entry.Settings == nil {
+					entry.Settings = map[string]any{}
+				}
+				if _, exists := entry.Settings[name]; !exists {
+					entry.Settings[name] = value
+				}
+			}
+		}
+		wsCfg.Modules[cfg.Name] = entry
 	}
 
 	// Surface the legacy module's SDK ref as a workspace module installed

--- a/core/workspace/migrate_test.go
+++ b/core/workspace/migrate_test.go
@@ -339,3 +339,48 @@ func testCompatWorkspace(t *testing.T, projectRoot, cfg string) *CompatWorkspace
 	require.NotNil(t, compat)
 	return compat
 }
+
+func TestPlanMigrationMovesRuntimeSettingsToWorkspaceConfig(t *testing.T) {
+	t.Parallel()
+
+	plan := testMigrationPlan(t, "repo", `{
+  "name": "myapp",
+  "sdk": {
+    "source": "go",
+    "config": {"goprivate": "gitlab.example.com/acme"}
+  },
+  "source": "src"
+}`)
+
+	// goprivate moves into the module's workspace settings namespace...
+	configData := string(plan.WorkspaceConfigData)
+	require.Contains(t, configData, `goprivate = "gitlab.example.com/acme"`)
+	// ...and does not survive in the migrated dagger-module.toml
+	require.NotContains(t, string(plan.MigratedModuleConfigData), "goprivate")
+}
+
+func TestRuntimeSettingsJSON(t *testing.T) {
+	t.Parallel()
+
+	settings := map[string]any{
+		"goprivate": "gitlab.example.com/acme",
+		"someArg":   "constructor-owned",
+	}
+
+	out, err := RuntimeSettingsJSON("go", settings)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"goprivate": "gitlab.example.com/acme"}`, out)
+
+	// goprivate is only reserved for the go SDK: for any other SDK it stays a
+	// plain constructor setting and must not leak into the SDK config, where
+	// an unknown key fails module load.
+	for _, sdkSource := range []string{"python", "typescript", "github.com/acme/custom-sdk", ""} {
+		out, err = RuntimeSettingsJSON(sdkSource, settings)
+		require.NoError(t, err)
+		require.Empty(t, out)
+	}
+
+	out, err = RuntimeSettingsJSON("go", map[string]any{"someArg": "x"})
+	require.NoError(t, err)
+	require.Empty(t, out)
+}

--- a/docs/current_docs/extending/sdks/go.mdx
+++ b/docs/current_docs/extending/sdks/go.mdx
@@ -938,6 +938,17 @@ jobs:
           verb: check
 ```
 
+## Private Go module dependencies
+
+Private modules in `go.mod` need [`GOPRIVATE`](https://go.dev/ref/mod#private-modules) so `go` skips the public module proxy for them. Set it as a module setting in your workspace's `dagger.toml`:
+
+```toml
+[modules.my-module.settings]
+goprivate = "gitlab.example.com/acme"
+```
+
+With that set, the dependency install authenticates over HTTPS with your own git credentials — if `git clone` works on your machine, so does the dependency. Credentials are used on demand during the install and are never stored in the container or its cache. SSH keeps working as before: add a `url.insteadOf` rewrite to your `.gitconfig` and run an SSH agent.
+
 ## IDE setup, `go.mod` and `go.work`
 
 The first `dagger generate` creates a `go.mod` and `go.sum` inside your Dagger module. These files tell Go which dependencies the generated client needs. If the Dagger module lives inside a larger Go project, the additional `go.mod` can make an editor choose the wrong Go module for a file.

--- a/docs/current_docs/extending/sdks/python.mdx
+++ b/docs/current_docs/extending/sdks/python.mdx
@@ -597,6 +597,17 @@ class MyModule:
 
 See [Designing for composability](../type-system/designing-for-composability.mdx).
 
+## Private git dependencies
+
+Dependencies on private git repositories over HTTPS work out of the box:
+
+```toml
+[project]
+dependencies = ["mylib @ git+https://gitlab.example.com/acme/mylib.git@v1.2.0"]
+```
+
+The install authenticates with your own git credentials — if `git clone` works on your machine, so does the dependency. Credentials are used on demand during the install and are never stored in the container or its cache.
+
 ## Regenerate bindings
 
 The generated client (the `sdk/` directory and `dagger`/`dag` types) reflects the engine API plus your dependencies. Regenerate it after changing dependencies or the required engine version. `mod generate` returns a changeset:

--- a/docs/current_docs/extending/sdks/typescript.mdx
+++ b/docs/current_docs/extending/sdks/typescript.mdx
@@ -895,6 +895,25 @@ Commit the lockfile so builds are reproducible. Bun and Deno manage dependencies
 through their own native tooling; the module code and decorators are identical
 across runtimes — only dependency installation and lockfiles differ.
 
+### Private git dependencies
+
+Dependencies on private git repositories over HTTPS work out of the box on the
+Node and Bun runtimes (Deno has no git dependency support):
+
+```json
+"dependencies": {
+  "mylib": "git+https://gitlab.example.com/acme/mylib.git#v1.2.0"
+}
+```
+
+The install authenticates with your own git credentials — if `git clone` works
+on your machine, so does the dependency. Credentials are used on demand during
+the install and are never stored in the container or its cache.
+
+One exception: Bun fetches github.com dependencies through the GitHub API
+instead of git, so private GitHub repositories don't get these credentials on
+the Bun runtime — use the Node runtime for those.
+
 ### Editor type resolution
 
 Because `tsconfig.json` maps `@dagger.io/dagger` to the local `./sdk/index.ts`,

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -16,6 +16,11 @@ const (
 	DaggerInitPath = "/usr/local/bin/dagger-init"
 	TiniPath       = "/usr/local/bin/tini"
 
+	// GitCredentialHelperInContainerPath is where the engine bind-mounts its
+	// git credential helper (the dagger-init binary, which dispatches on
+	// argv[0]) inside containers that mount a git-credential socket.
+	GitCredentialHelperInContainerPath = "/.git-credential"
+
 	EngineDefaultStateDir = "/var/lib/dagger"
 
 	EngineContainerBuiltinContentDir   = "/usr/local/share/dagger/content"

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -19,7 +19,7 @@ const (
 	// GitCredentialHelperInContainerPath is where the engine bind-mounts its
 	// git credential helper (the dagger-init binary, which dispatches on
 	// argv[0]) inside containers that mount a git-credential socket.
-	GitCredentialHelperInContainerPath = "/.git-credential"
+	GitCredentialHelperInContainerPath = "/.git-credential" // #nosec G101 -- filesystem path, not a credential.
 
 	EngineDefaultStateDir = "/var/lib/dagger"
 

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -72,6 +72,10 @@ type ExecutionMetadata struct {
 	// If true, skip injecting dagger-init into the container.
 	NoInit bool
 
+	// If true, bind-mount the engine's git credential helper into the
+	// container (set when the container mounts a git-credential socket).
+	InjectGitCredentialHelper bool
+
 	// ProfArgs is the fully-resolved user command (entrypoint + args), captured
 	// in core at exec-run time BEFORE any engine shim (the QEMU emulator, the
 	// executor's /.init) wraps it, so wall-clock profiling can headline the user's
@@ -175,6 +179,7 @@ func (c *Client) Run(
 	err := c.run(ctx, state,
 		namedSetupFunc{"setupNetwork", c.setupNetwork},
 		namedSetupFunc{"injectInit", c.injectInit},
+		namedSetupFunc{"injectGitCredentialHelper", c.injectGitCredentialHelper},
 		namedSetupFunc{"generateBaseSpec", c.generateBaseSpec},
 		namedSetupFunc{"filterEnvs", c.filterEnvs},
 		namedSetupFunc{"setupRootfs", c.setupRootfs},

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -381,6 +381,21 @@ func (c *Client) injectInit(_ context.Context, state *execState) error {
 	return nil
 }
 
+func (c *Client) injectGitCredentialHelper(_ context.Context, state *execState) error {
+	if state.execMD == nil || !state.execMD.InjectGitCredentialHelper {
+		return nil
+	}
+
+	// same binary as dagger-init; it dispatches on argv[0]
+	state.mounts = append(state.mounts, executor.Mount{
+		Src:      hostBindMount{srcPath: distconsts.DaggerInitPath},
+		Dest:     distconsts.GitCredentialHelperInContainerPath,
+		Readonly: true,
+	})
+
+	return nil
+}
+
 func (c *Client) generateBaseSpec(ctx context.Context, state *execState) error {
 	var extraOpts []ctdoci.SpecOpts
 	if state.procInfo.Meta.ReadonlyRootFS {

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -1972,6 +1972,29 @@ func (srv *Server) resolveModuleSourceAsModule(
 		return dagql.ObjectResult[*core.Module]{}, err
 	}
 
+	// Runtime settings (e.g. goprivate) from the workspace settings namespace
+	// apply to the module source before the SDK runs. The extraction is keyed
+	// by SDK: a setting is only routed to the SDK config of the SDK that
+	// consumes it, so other SDKs keep the same name free for constructor args.
+	var sdkSource string
+	if src.Self() != nil && src.Self().SDK != nil {
+		sdkSource = src.Self().SDK.Source
+	}
+	runtimeSettingsJSON, err := workspace.RuntimeSettingsJSON(sdkSource, mod.ConfigDefaults)
+	if err != nil {
+		return dagql.ObjectResult[*core.Module]{}, err
+	}
+	if runtimeSettingsJSON != "" {
+		if err := dag.Select(ctx, src, &src, dagql.Selector{
+			Field: "_withRuntimeSettings",
+			Args: []dagql.NamedInput{
+				{Name: "settingsJson", Value: dagql.String(runtimeSettingsJSON)},
+			},
+		}); err != nil {
+			return dagql.ObjectResult[*core.Module]{}, fmt.Errorf("applying runtime settings for %q: %w", mod.Ref, err)
+		}
+	}
+
 	var resolved dagql.ObjectResult[*core.Module]
 	err = dag.Select(ctx, src, &resolved,
 		dagql.Selector{Field: "asModule", Args: asModuleArgs},

--- a/sdk/python/runtime/dagger.gen.go
+++ b/sdk/python/runtime/dagger.gen.go
@@ -74,6 +74,7 @@ func (r PythonSdk) MarshalJSON() ([]byte, error) {
 		SubPath        string
 		VendorPath     string
 		IsInit         bool
+		GitCredentials *dagger.Socket
 		Discovery      *Discovery
 	}
 	concrete.SdkSourceDir = r.SdkSourceDir
@@ -89,6 +90,7 @@ func (r PythonSdk) MarshalJSON() ([]byte, error) {
 	concrete.SubPath = r.SubPath
 	concrete.VendorPath = r.VendorPath
 	concrete.IsInit = r.IsInit
+	concrete.GitCredentials = r.GitCredentials
 	concrete.Discovery = r.Discovery
 	return json.Marshal(&concrete)
 }
@@ -108,6 +110,7 @@ func (r *PythonSdk) UnmarshalJSON(bs []byte) error {
 		SubPath        string
 		VendorPath     string
 		IsInit         bool
+		GitCredentials *dagger.Socket
 		Discovery      *Discovery
 	}
 	err := json.Unmarshal(bs, &concrete)
@@ -127,6 +130,7 @@ func (r *PythonSdk) UnmarshalJSON(bs []byte) error {
 	r.SubPath = concrete.SubPath
 	r.VendorPath = concrete.VendorPath
 	r.IsInit = concrete.IsInit
+	r.GitCredentials = concrete.GitCredentials
 	r.Discovery = concrete.Discovery
 	return nil
 }
@@ -343,7 +347,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg introspectionJSON", err))
 				}
 			}
-			return (*PythonSdk).Codegen(&parent, ctx, modSource, introspectionJson)
+			var gitCredentials *dagger.Socket
+			if inputArgs["gitCredentials"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitCredentials"]), &gitCredentials)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitCredentials", err))
+				}
+			}
+			return (*PythonSdk).Codegen(&parent, ctx, modSource, introspectionJson, gitCredentials)
 		case "Common":
 			var parent PythonSdk
 			err = json.Unmarshal(parentJSON, &parent)
@@ -427,7 +438,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg introspectionJSON", err))
 				}
 			}
-			return (*PythonSdk).ModuleRuntime(&parent, ctx, modSource, introspectionJson)
+			var gitCredentials *dagger.Socket
+			if inputArgs["gitCredentials"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitCredentials"]), &gitCredentials)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitCredentials", err))
+				}
+			}
+			return (*PythonSdk).ModuleRuntime(&parent, ctx, modSource, introspectionJson, gitCredentials)
 		case "ModuleTypesExp":
 			var parent PythonSdk
 			err = json.Unmarshal(parentJSON, &parent)

--- a/sdk/python/runtime/dagger.gen.go
+++ b/sdk/python/runtime/dagger.gen.go
@@ -673,16 +673,17 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("Codegen",
 							dag.TypeDef().WithObject("GeneratedCode")).
 							WithDescription("Generated code for the Python module").
-							WithSourceMap(dag.SourceMap("main.go", 147, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 149, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 150, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 154, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 156, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 157, 2)}).
+							WithArg("gitCredentials", dag.TypeDef().WithObject("Socket").WithOptional(true), dagger.FunctionWithArgOpts{Description: "Engine-provided git-credential socket for private git+https dependencies", SourceMap: dag.SourceMap("main.go", 160, 2)})).
 					WithFunction(
 						dag.Function("Common",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Common steps for the ModuleRuntime and Codegen functions").
-							WithSourceMap(dag.SourceMap("main.go", 214, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 216, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File").WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 218, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 229, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 231, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File").WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 233, 2)})).
 					WithFunction(
 						dag.Function("ExtraIndexURL",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
@@ -703,23 +704,24 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("Load",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Get all the needed information from the module's metadata and source files").
-							WithSourceMap(dag.SourceMap("main.go", 244, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 244, 47)})).
+							WithSourceMap(dag.SourceMap("main.go", 259, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 259, 47)})).
 					WithFunction(
 						dag.Function("ModuleRuntime",
 							dag.TypeDef().WithObject("Container")).
 							WithDescription("Container for executing the Python module runtime").
-							WithSourceMap(dag.SourceMap("main.go", 177, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 179, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 180, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 188, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 190, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 191, 2)}).
+							WithArg("gitCredentials", dag.TypeDef().WithObject("Socket").WithOptional(true), dagger.FunctionWithArgOpts{Description: "Engine-provided git-credential socket for private git+https dependencies", SourceMap: dag.SourceMap("main.go", 194, 2)})).
 					WithFunction(
 						dag.Function("ModuleTypesExp",
 							dag.TypeDef().WithObject("Container")).
 							WithDescription("Container for executing the Python module runtime").
-							WithSourceMap(dag.SourceMap("main.go", 195, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 197, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 198, 2)}).
-							WithArg("outputFilePath", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 199, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 210, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 212, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 213, 2)}).
+							WithArg("outputFilePath", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 214, 2)})).
 					WithFunction(
 						dag.Function("Source",
 							dag.TypeDef().WithObject("Directory")).
@@ -749,7 +751,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("WithBase",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Initialize the base Python container\n\nWorkdir is set to the module's source directory.").
-							WithSourceMap(dag.SourceMap("main.go", 263, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 278, 1))).
 					WithFunction(
 						dag.Function("WithBaseImage",
 							dag.TypeDef().WithObject("PythonSdk")).
@@ -766,28 +768,28 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("WithInstall",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Install the module's package and dependencies").
-							WithSourceMap(dag.SourceMap("main.go", 496, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 511, 1))).
 					WithFunction(
 						dag.Function("WithSDK",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Add the SDK package to the source directory\n\nThis includes regenerating the client bindings for the current API schema\n(codegen).").
-							WithSourceMap(dag.SourceMap("main.go", 390, 1)).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 390, 29)})).
+							WithSourceMap(dag.SourceMap("main.go", 405, 1)).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 405, 29)})).
 					WithFunction(
 						dag.Function("WithSource",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Add the module's source code").
-							WithSourceMap(dag.SourceMap("main.go", 442, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 457, 1))).
 					WithFunction(
 						dag.Function("WithTemplate",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Add the template files to skaffold a new module\n\nThe following files are added:\n- /runtime\n- <source>/pyproject.toml\n- <source>/src/<package_name>/__init__.py\n- <source>/src/<package_name>/main.py").
-							WithSourceMap(dag.SourceMap("main.go", 325, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 340, 1))).
 					WithFunction(
 						dag.Function("WithUpdates",
 							dag.TypeDef().WithObject("PythonSdk")).
 							WithDescription("Make any updates to current source").
-							WithSourceMap(dag.SourceMap("main.go", 459, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 474, 1))).
 					WithFunction(
 						dag.Function("WithUv",
 							dag.TypeDef().WithObject("PythonSdk")).

--- a/sdk/python/runtime/internal/dagger/python-sdk.gen.go
+++ b/sdk/python/runtime/internal/dagger/python-sdk.gen.go
@@ -104,11 +104,23 @@ func (r *PythonSDK) BaseImage(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
+// PythonSDKCodegenOpts contains options for PythonSDK.Codegen
+type PythonSDKCodegenOpts struct {
+	// Engine-provided git-credential socket for private git+https dependencies
+	GitCredentials *Socket
+}
+
 // Generated code for the Python module
-func (r *PythonSDK) Codegen(modSource *ModuleSource, introspectionJson *File) *GeneratedCode {
+func (r *PythonSDK) Codegen(modSource *ModuleSource, introspectionJson *File, opts ...PythonSDKCodegenOpts) *GeneratedCode {
 	assertNotNil("modSource", modSource)
 	assertNotNil("introspectionJson", introspectionJson)
 	q := r.query.Select("codegen")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `gitCredentials` optional argument
+		if !querybuilder.IsZeroValue(opts[i].GitCredentials) {
+			q = q.Arg("gitCredentials", opts[i].GitCredentials)
+		}
+	}
 	q = q.Arg("modSource", modSource)
 	q = q.Arg("introspectionJson", introspectionJson)
 
@@ -340,11 +352,23 @@ func (r *PythonSDK) ModSource() *ModuleSource {
 	}
 }
 
+// PythonSDKModuleRuntimeOpts contains options for PythonSDK.ModuleRuntime
+type PythonSDKModuleRuntimeOpts struct {
+	// Engine-provided git-credential socket for private git+https dependencies
+	GitCredentials *Socket
+}
+
 // Container for executing the Python module runtime
-func (r *PythonSDK) ModuleRuntime(modSource *ModuleSource, introspectionJson *File) *Container {
+func (r *PythonSDK) ModuleRuntime(modSource *ModuleSource, introspectionJson *File, opts ...PythonSDKModuleRuntimeOpts) *Container {
 	assertNotNil("modSource", modSource)
 	assertNotNil("introspectionJson", introspectionJson)
 	q := r.query.Select("moduleRuntime")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `gitCredentials` optional argument
+		if !querybuilder.IsZeroValue(opts[i].GitCredentials) {
+			q = q.Arg("gitCredentials", opts[i].GitCredentials)
+		}
+	}
 	q = q.Arg("modSource", modSource)
 	q = q.Arg("introspectionJson", introspectionJson)
 

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -138,6 +138,13 @@ type PythonSdk struct {
 	// It's assumed that this is the case if there's no pyproject.toml file.
 	IsInit bool
 
+	// Socket answering git's credential-helper protocol, provided by the
+	// engine during trusted dependency installs so private git+https
+	// dependencies resolve with the host's credentials. Mounted only around
+	// the install execs, never in the returned container.
+	// +private
+	GitCredentials *dagger.Socket
+
 	// Discovery holds the logic for getting more information from the target module.
 	// +private
 	Discovery *Discovery
@@ -148,7 +155,11 @@ func (m *PythonSdk) Codegen(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,
 	introspectionJSON *dagger.File,
+	// Engine-provided git-credential socket for private git+https dependencies
+	// +optional
+	gitCredentials *dagger.Socket,
 ) (*dagger.GeneratedCode, error) {
+	m.GitCredentials = gitCredentials
 	m, err := m.Common(ctx, modSource, introspectionJSON)
 	if err != nil {
 		return nil, err
@@ -178,7 +189,11 @@ func (m *PythonSdk) ModuleRuntime(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,
 	introspectionJSON *dagger.File,
+	// Engine-provided git-credential socket for private git+https dependencies
+	// +optional
+	gitCredentials *dagger.Socket,
 ) (*dagger.Container, error) {
+	m.GitCredentials = gitCredentials
 	runtime, err := m.Common(ctx, modSource, introspectionJSON)
 	if err != nil {
 		return nil, err
@@ -461,7 +476,7 @@ func (m *PythonSdk) WithUpdates() *PythonSdk {
 		return m
 	}
 
-	ctr := m.Container
+	ctr := m.withGitCredentials(m.Container)
 	d := m.Discovery
 
 	// Update lock file but without upgrading dependencies.
@@ -487,7 +502,7 @@ func (m *PythonSdk) WithUpdates() *PythonSdk {
 		ctr = ctr.WithExec(args)
 	}
 
-	m.Container = ctr
+	m.Container = m.withoutGitCredentials(ctr)
 
 	return m
 }
@@ -505,8 +520,8 @@ func (m *PythonSdk) WithInstall() *PythonSdk {
 		// uv.lock, user projects can have more required files for a minimally successful
 		// `uv sync --no-install-project --no-dev`.
 		// Besides, uv is fast enough that's not too bad to skip this optimization.
-		m.Container = ctr.
-			WithExec([]string{"uv", "sync", "--no-dev"}).
+		m.Container = m.withoutGitCredentials(
+			m.withGitCredentials(ctr).WithExec([]string{"uv", "sync", "--no-dev"})).
 			// Activate virtualenv to avoid having to prepend `uv run` to the entrypoint.
 			WithEnvVariable("VIRTUAL_ENV", "$UV_PROJECT_ENVIRONMENT", dagger.ContainerWithEnvVariableOpts{
 				Expand: true,
@@ -535,9 +550,52 @@ func (m *PythonSdk) WithInstall() *PythonSdk {
 		check = append([]string{"uv"}, check...)
 	}
 
-	m.Container = ctr.
-		WithExec(install).
-		WithExec(check)
+	m.Container = m.withoutGitCredentials(
+		m.withGitCredentials(ctr).
+			WithExec(install).
+			WithExec(check))
 
 	return m
+}
+
+const (
+	gitCredentialSockPath = "/tmp/dagger-git-credential.sock"
+	// where the engine bind-mounts its credential helper into execs that
+	// mount a git-credential socket
+	gitCredentialHelperPath = "/.git-credential"
+)
+
+// Mount the engine-provided git-credential socket and point git at its
+// helper, so package managers shelling out to git can authenticate against
+// private hosts. Must be paired with withoutGitCredentials before user code
+// runs. Known limitation: any GIT_CONFIG_* env a base image sets is masked
+// during the install and dropped by the scrub (file-based git config is
+// untouched).
+func (m *PythonSdk) withGitCredentials(ctr *dagger.Container) *dagger.Container {
+	if m.GitCredentials == nil {
+		return ctr
+	}
+	return ctr.
+		// uv shells out to the git CLI for git dependencies, but the default
+		// python:*-slim base image doesn't ship it
+		WithExec([]string{"sh", "-c", ensureGitCmd}).
+		WithUnixSocket(gitCredentialSockPath, m.GitCredentials).
+		WithEnvVariable("GIT_CONFIG_COUNT", "1").
+		WithEnvVariable("GIT_CONFIG_KEY_0", "credential.helper").
+		WithEnvVariable("GIT_CONFIG_VALUE_0", gitCredentialHelperPath+" "+gitCredentialSockPath)
+}
+
+// ensureGitCmd installs git if missing, covering the debian (default) and
+// alpine flavors a base-image override may use.
+const ensureGitCmd = "command -v git >/dev/null || { apt-get update -qq && apt-get install -qqy --no-install-recommends git; } || apk add --no-cache git"
+
+func (m *PythonSdk) withoutGitCredentials(ctr *dagger.Container) *dagger.Container {
+	if m.GitCredentials == nil {
+		return ctr
+	}
+	return ctr.
+		WithoutUnixSocket(gitCredentialSockPath).
+		WithoutEnvVariable("GIT_CONFIG_COUNT").
+		WithoutEnvVariable("GIT_CONFIG_KEY_0").
+		WithoutEnvVariable("GIT_CONFIG_VALUE_0")
 }

--- a/sdk/typescript/runtime/dagger.gen.go
+++ b/sdk/typescript/runtime/dagger.gen.go
@@ -218,7 +218,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg introspectionJSON", err))
 				}
 			}
-			return (*TypescriptSdk).Codegen(&parent, ctx, modSource, introspectionJson)
+			var gitCredentials *dagger.Socket
+			if inputArgs["gitCredentials"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitCredentials"]), &gitCredentials)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitCredentials", err))
+				}
+			}
+			return (*TypescriptSdk).Codegen(&parent, ctx, modSource, introspectionJson, gitCredentials)
 		case "GenerateClient":
 			var parent TypescriptSdk
 			err = json.Unmarshal(parentJSON, &parent)
@@ -267,7 +274,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg introspectionJSON", err))
 				}
 			}
-			return (*TypescriptSdk).ModuleRuntime(&parent, ctx, modSource, introspectionJson)
+			var gitCredentials *dagger.Socket
+			if inputArgs["gitCredentials"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["gitCredentials"]), &gitCredentials)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg gitCredentials", err))
+				}
+			}
+			return (*TypescriptSdk).ModuleRuntime(&parent, ctx, modSource, introspectionJson, gitCredentials)
 		case "ModuleTypes":
 			var parent TypescriptSdk
 			err = json.Unmarshal(parentJSON, &parent)

--- a/sdk/typescript/runtime/dagger.gen.go
+++ b/sdk/typescript/runtime/dagger.gen.go
@@ -342,36 +342,38 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("Codegen",
 							dag.TypeDef().WithObject("GeneratedCode")).
 							WithDescription("Codegen implements the `Codegen` method from the SDK module interface.\n\nIt returns the generated API client based on user's module as well as\nignore directive regarding the generated content.").
-							WithSourceMap(dag.SourceMap("main.go", 97, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 99, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 100, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 100, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 102, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 103, 2)}).
+							WithArg("gitCredentials", dag.TypeDef().WithObject("Socket").WithOptional(true), dagger.FunctionWithArgOpts{Description: "Engine-provided git-credential socket for private git+https dependencies", SourceMap: dag.SourceMap("main.go", 106, 2)})).
 					WithFunction(
 						dag.Function("GenerateClient",
 							dag.TypeDef().WithObject("Directory")).
 							WithDescription("Returns a directory with a standalone generated client and any necessary configuration\nfiles that are required to work.").
-							WithSourceMap(dag.SourceMap("main.go", 184, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 186, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 187, 2)}).
-							WithArg("outputDir", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 188, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 190, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 192, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 193, 2)}).
+							WithArg("outputDir", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 194, 2)})).
 					WithFunction(
 						dag.Function("ModuleRuntime",
 							dag.TypeDef().WithObject("Container")).
 							WithDescription("ModuleRuntime implements the `ModuleRuntime` method from the SDK module interface.\n\nIt returns a ready to call container with the correct node, bun or deno runtime setup.\nOn call, this will trigger the entrypoint that will either intropect and register the\nmodule in the Dagger engine or execute a function of that module.\n\nThe returned container has the codegen freshly generated and any necessary dependency\ninstalled.").
 							WithSourceMap(dag.SourceMap("main.go", 47, 1)).
 							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 49, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 50, 2)})).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 50, 2)}).
+							WithArg("gitCredentials", dag.TypeDef().WithObject("Socket").WithOptional(true), dagger.FunctionWithArgOpts{Description: "Engine-provided git-credential socket for private git+https dependencies", SourceMap: dag.SourceMap("main.go", 53, 2)})).
 					WithFunction(
 						dag.Function("ModuleTypes",
 							dag.TypeDef().WithObject("Container")).
-							WithSourceMap(dag.SourceMap("main.go", 69, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 71, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 72, 2)}).
-							WithArg("outputFilePath", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 73, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 72, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 74, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 75, 2)}).
+							WithArg("outputFilePath", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 76, 2)})).
 					WithFunction(
 						dag.Function("RequiredClientGenerationFiles",
 							dag.TypeDef().WithListOf(dag.TypeDef().WithKind(dagger.TypeDefKindStringKind))).
 							WithDescription("Returns the list of files that are copied from the host when generating the client.").
-							WithSourceMap(dag.SourceMap("main.go", 174, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 180, 1))).
 					WithField("SDKSourceDir", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{SourceMap: dag.SourceMap("main.go", 23, 2)}).
 					WithConstructor(
 						dag.Function("New",

--- a/sdk/typescript/runtime/gitcredentials.go
+++ b/sdk/typescript/runtime/gitcredentials.go
@@ -1,0 +1,44 @@
+package main
+
+import "typescript-sdk/internal/dagger"
+
+const (
+	gitCredentialSockPath = "/tmp/dagger-git-credential.sock"
+	// where the engine bind-mounts its credential helper into execs that
+	// mount a git-credential socket
+	gitCredentialHelperPath = "/.git-credential"
+)
+
+// ensureGitCmd installs git if missing: package managers shell out to the
+// git CLI for git dependencies, but neither node's alpine image nor bun's
+// debian image ships it.
+const ensureGitCmd = "command -v git >/dev/null || apk add --no-cache git || { apt-get update -qq && apt-get install -qqy --no-install-recommends git; }"
+
+// Mount the engine-provided git-credential socket and point git at its
+// helper, so package managers shelling out to git can authenticate against
+// private hosts. Must be paired with withoutGitCredentials before user code
+// runs. Known limitation: any GIT_CONFIG_* env a base image sets is masked
+// during the install and dropped by the scrub (file-based git config is
+// untouched).
+func withGitCredentials(ctr *dagger.Container, sock *dagger.Socket) *dagger.Container {
+	if sock == nil {
+		return ctr
+	}
+	return ctr.
+		WithExec([]string{"sh", "-c", ensureGitCmd}).
+		WithUnixSocket(gitCredentialSockPath, sock).
+		WithEnvVariable("GIT_CONFIG_COUNT", "1").
+		WithEnvVariable("GIT_CONFIG_KEY_0", "credential.helper").
+		WithEnvVariable("GIT_CONFIG_VALUE_0", gitCredentialHelperPath+" "+gitCredentialSockPath)
+}
+
+func withoutGitCredentials(ctr *dagger.Container, sock *dagger.Socket) *dagger.Container {
+	if sock == nil {
+		return ctr
+	}
+	return ctr.
+		WithoutUnixSocket(gitCredentialSockPath).
+		WithoutEnvVariable("GIT_CONFIG_COUNT").
+		WithoutEnvVariable("GIT_CONFIG_KEY_0").
+		WithoutEnvVariable("GIT_CONFIG_VALUE_0")
+}

--- a/sdk/typescript/runtime/internal/dagger/typescript-sdk.gen.go
+++ b/sdk/typescript/runtime/internal/dagger/typescript-sdk.gen.go
@@ -40,14 +40,26 @@ func (r *TypescriptSDK) WithGraphQLQuery(q *querybuilder.Selection) *TypescriptS
 	}
 }
 
+// TypescriptSDKCodegenOpts contains options for TypescriptSDK.Codegen
+type TypescriptSDKCodegenOpts struct {
+	// Engine-provided git-credential socket for private git+https dependencies
+	GitCredentials *Socket
+}
+
 // Codegen implements the `Codegen` method from the SDK module interface.
 //
 // It returns the generated API client based on user's module as well as
 // ignore directive regarding the generated content.
-func (r *TypescriptSDK) Codegen(modSource *ModuleSource, introspectionJson *File) *GeneratedCode {
+func (r *TypescriptSDK) Codegen(modSource *ModuleSource, introspectionJson *File, opts ...TypescriptSDKCodegenOpts) *GeneratedCode {
 	assertNotNil("modSource", modSource)
 	assertNotNil("introspectionJson", introspectionJson)
 	q := r.query.Select("codegen")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `gitCredentials` optional argument
+		if !querybuilder.IsZeroValue(opts[i].GitCredentials) {
+			q = q.Arg("gitCredentials", opts[i].GitCredentials)
+		}
+	}
 	q = q.Arg("modSource", modSource)
 	q = q.Arg("introspectionJson", introspectionJson)
 
@@ -120,6 +132,12 @@ func (r *TypescriptSDK) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// TypescriptSDKModuleRuntimeOpts contains options for TypescriptSDK.ModuleRuntime
+type TypescriptSDKModuleRuntimeOpts struct {
+	// Engine-provided git-credential socket for private git+https dependencies
+	GitCredentials *Socket
+}
+
 // ModuleRuntime implements the `ModuleRuntime` method from the SDK module interface.
 //
 // It returns a ready to call container with the correct node, bun or deno runtime setup.
@@ -128,10 +146,16 @@ func (r *TypescriptSDK) UnmarshalJSON(bs []byte) error {
 //
 // The returned container has the codegen freshly generated and any necessary dependency
 // installed.
-func (r *TypescriptSDK) ModuleRuntime(modSource *ModuleSource, introspectionJson *File) *Container {
+func (r *TypescriptSDK) ModuleRuntime(modSource *ModuleSource, introspectionJson *File, opts ...TypescriptSDKModuleRuntimeOpts) *Container {
 	assertNotNil("modSource", modSource)
 	assertNotNil("introspectionJson", introspectionJson)
 	q := r.query.Select("moduleRuntime")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `gitCredentials` optional argument
+		if !querybuilder.IsZeroValue(opts[i].GitCredentials) {
+			q = q.Arg("gitCredentials", opts[i].GitCredentials)
+		}
+	}
 	q = q.Arg("modSource", modSource)
 	q = q.Arg("introspectionJson", introspectionJson)
 

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -48,6 +48,9 @@ func (t *TypescriptSdk) ModuleRuntime(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,
 	introspectionJSON *dagger.File,
+	// Engine-provided git-credential socket for private git+https dependencies
+	// +optional
+	gitCredentials *dagger.Socket,
 ) (*dagger.Container, error) {
 	cfg, err := analyzeModuleConfig(ctx, modSource)
 	if err != nil {
@@ -56,11 +59,11 @@ func (t *TypescriptSdk) ModuleRuntime(
 
 	switch cfg.runtime {
 	case Bun:
-		return NewBunRuntime(cfg, t.SDKSourceDir, introspectionJSON).SetupContainer(ctx)
+		return NewBunRuntime(cfg, t.SDKSourceDir, introspectionJSON, gitCredentials).SetupContainer(ctx)
 	case Deno:
 		return NewDenoRuntime(cfg, t.SDKSourceDir, introspectionJSON).SetupContainer(ctx)
 	case Node:
-		return NewNodeRuntime(cfg, t.SDKSourceDir, introspectionJSON).SetupContainer(ctx)
+		return NewNodeRuntime(cfg, t.SDKSourceDir, introspectionJSON, gitCredentials).SetupContainer(ctx)
 	default:
 		return nil, fmt.Errorf("unknown runtime %s", cfg.runtime)
 	}
@@ -98,6 +101,9 @@ func (t *TypescriptSdk) Codegen(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,
 	introspectionJSON *dagger.File,
+	// Engine-provided git-credential socket for private git+https dependencies
+	// +optional
+	gitCredentials *dagger.Socket,
 ) (*dagger.GeneratedCode, error) {
 	cfg, err := analyzeModuleConfig(ctx, modSource)
 	if err != nil {
@@ -107,11 +113,11 @@ func (t *TypescriptSdk) Codegen(
 	var codegen *dagger.Directory
 	switch cfg.runtime {
 	case Bun:
-		codegen, err = NewBunRuntime(cfg, t.SDKSourceDir, introspectionJSON).GenerateDir(ctx)
+		codegen, err = NewBunRuntime(cfg, t.SDKSourceDir, introspectionJSON, gitCredentials).GenerateDir(ctx)
 	case Deno:
 		codegen, err = NewDenoRuntime(cfg, t.SDKSourceDir, introspectionJSON).GenerateDir(ctx)
 	case Node:
-		codegen, err = NewNodeRuntime(cfg, t.SDKSourceDir, introspectionJSON).GenerateDir(ctx)
+		codegen, err = NewNodeRuntime(cfg, t.SDKSourceDir, introspectionJSON, gitCredentials).GenerateDir(ctx)
 	default:
 		return nil, fmt.Errorf("unknown runtime %s", cfg.runtime)
 	}

--- a/sdk/typescript/runtime/runtime_bun.go
+++ b/sdk/typescript/runtime/runtime_bun.go
@@ -15,12 +15,14 @@ type BunRuntime struct {
 	introspectionJSON *dagger.File
 	cfg               *moduleConfig
 	ctr               *dagger.Container
+	gitCredentials    *dagger.Socket
 }
 
 func NewBunRuntime(
 	cfg *moduleConfig,
 	sdkSourceDir *dagger.Directory,
 	introspectionJSON *dagger.File,
+	gitCredentials *dagger.Socket,
 ) *BunRuntime {
 	// Q: Should the cacheVolumeName depends on the cfg.image version
 	cacheVolumeName := fmt.Sprintf("mod-bun-cache-%s", tsdistconsts.DefaultBunVersion)
@@ -37,6 +39,7 @@ func NewBunRuntime(
 		introspectionJSON: introspectionJSON,
 		cfg:               cfg,
 		ctr:               ctr,
+		gitCredentials:    gitCredentials,
 	}
 }
 
@@ -96,11 +99,18 @@ func (b *BunRuntime) SetupContainer(ctx context.Context) (*dagger.Container, err
 		if err != nil {
 			return err
 		}
+		runtimeWithDep.ctr = withGitCredentials(runtimeWithDep.ctr, b.gitCredentials)
 
 		runtimeWithDep, err = runtimeWithDep.
 			withInstalledDependencies().
 			sync(ctx)
-		return err
+		if err != nil {
+			return err
+		}
+		// user code runs in this container: scrub the credential socket
+		runtimeWithDep.ctr = withoutGitCredentials(runtimeWithDep.ctr, b.gitCredentials)
+
+		return nil
 	})
 
 	if err := eg.Wait(); err != nil {
@@ -138,6 +148,9 @@ func (b *BunRuntime) GenerateDir(ctx context.Context) (*dagger.Directory, error)
 	if err != nil {
 		return nil, err
 	}
+	// lock file generation resolves git dependencies too; only files are
+	// extracted from this container, so no scrub is needed
+	runtime.ctr = withGitCredentials(runtime.ctr, b.gitCredentials)
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() (err error) {

--- a/sdk/typescript/runtime/runtime_node.go
+++ b/sdk/typescript/runtime/runtime_node.go
@@ -16,12 +16,14 @@ type NodeRuntime struct {
 	introspectionJSON *dagger.File
 	cfg               *moduleConfig
 	ctr               *dagger.Container
+	gitCredentials    *dagger.Socket
 }
 
 func NewNodeRuntime(
 	cfg *moduleConfig,
 	sdkSourceDir *dagger.Directory,
 	introspectionJSON *dagger.File,
+	gitCredentials *dagger.Socket,
 ) *NodeRuntime {
 	ctr := dag.
 		Container().
@@ -40,6 +42,7 @@ func NewNodeRuntime(
 		introspectionJSON: introspectionJSON,
 		cfg:               cfg,
 		ctr:               ctr,
+		gitCredentials:    gitCredentials,
 	}
 }
 
@@ -100,6 +103,7 @@ func (n *NodeRuntime) SetupContainer(ctx context.Context) (*dagger.Container, er
 		if err != nil {
 			return err
 		}
+		runtimeWithPkgJSON.ctr = withGitCredentials(runtimeWithPkgJSON.ctr, n.gitCredentials)
 
 		pkgManager := runtimeWithPkgJSON.createPkgManagerCtr()
 
@@ -107,8 +111,13 @@ func (n *NodeRuntime) SetupContainer(ctx context.Context) (*dagger.Container, er
 			withSetupPackageManager().
 			withInstalledDependencies().
 			sync(ctx)
+		if err != nil {
+			return err
+		}
+		// user code runs in this container: scrub the credential socket
+		runtimeWithDep.ctr = withoutGitCredentials(runtimeWithDep.ctr, n.gitCredentials)
 
-		return err
+		return nil
 	})
 
 	if err := eg.Wait(); err != nil {
@@ -146,6 +155,9 @@ func (n *NodeRuntime) GenerateDir(ctx context.Context) (*dagger.Directory, error
 	if err != nil {
 		return nil, err
 	}
+	// lock file generation resolves git dependencies too; only files are
+	// extracted from this container, so no scrub is needed
+	runtime.ctr = withGitCredentials(runtime.ctr, n.gitCredentials)
 
 	pkgManager := runtime.createPkgManagerCtr()
 


### PR DESCRIPTION
## Problem

A Dagger module that depends on a private git-over-HTTPS package cannot be installed. When an SDK resolves module dependencies inside an engine container (`go mod tidy`, `uv sync`, `npm install`, `bun install`), that container has no credentials: the install fails with `could not read Username for 'https://...'`.

The frustrating part is that the credentials already exist — on the host. Every developer machine that can `git clone` the private repo has a working git credential helper (`gh`, `glab`, `osxkeychain`, Git Credential Manager, ...). They're just on the wrong side of the container boundary, and the workarounds are all bad: a `.netrc` or token env var baked into the install container is less universal than git+https, and rewriting URLs to SSH just excludes corporations (that usually restrict SSH)

We already bridge host credentials for one narrower case: resolving private *module sources* (`engine/session/git`'s `GetCredential` RPC, which runs `git credential fill` on the host). This PR extends that same bridge to dependency installs.

## How it works

Git never reads tokens itself: it asks a helper program over a small line protocol. So we put a relay in the middle of that conversation:

```
install container                    engine                              host CLI
─────────────────                    ──────                              ────────
git → /.git-credential ──unix socket──► credential listener ────gRPC────► git credential fill
      (injected helper)                 · parses the request                (your gh/glab/keychain)
                                        · enforces host allowlist
```

Credentials are fetched on demand per request and streamed back to git. They never touch the container filesystem, never enter the layer cache, and the socket + helper are gone before module code runs (install steps scrub them, and the engine refuses a runtime container that still has the socket mounted).

A few decisions worth knowing before you read the diff:

- It's a new socket kind (`git_credential`) that reuses all the SSH-agent forwarding plumbing (session resources, `withUnixSocket`, exec-scoped mounts) but has its own serving path in `core/git_credential_socket.go`. We tried refactoring both onto a shared listener early on and backed out: the SSH path is subtle and battle-tested, and it's untouched here.
- The host allowlist is enforced engine-side, per socket. The container is running third-party package-manager code, so nothing on that side is trusted.
- The socket is minted by an internal `host._gitCredential(hosts)` field, only reachable from the engine's SDK-install path. Credentials always belong to the session's non-module parent client (the user's CLI), same trust rule as `core/schema/git.go`. Under nesting the credential owner isn't the main client, so we register one binding per candidate client and fall back — same pattern SSH sockets use. Our first version got this wrong; the integration tests cover the nested path now.
- The in-container helper is the engine's own `dagger-init`, bind-mounted at `/.git-credential` by the executor when a credential socket is present (argv[0] dispatch, `GIT_CONFIG_*` env points git at it). We didn't bake it into SDK base images because users override those, the Go codegen container doesn't come from an image at all, and this keeps the helper version-locked to the engine that serves the socket.

Per SDK:

- **Go**: opt-in via `goprivate` (the setting Go devs already need for private modules). Hosts named in it become the allowlist. Since `sdk.config` is deprecated, the setting lives in the workspace settings namespace — `[modules.<name>.settings] goprivate = "..."` in `dagger.toml` — and `dagger setup` migrates legacy `dagger.json` values. We first prototyped a `[runtime.config]` section and killed it; it reintroduced the config surface ac6a507f1 had deliberately removed.
- **Python (uv)** and **TypeScript (npm/yarn/pnpm/bun)**: zero-config. The allowlist comes from git+https URLs in the module's own manifests (`pyproject.toml`/`uv.lock`, `package.json`/lockfiles). No git deps → no socket, no helper, nothing.

One trade-off to be conscious of: during the install exec, third-party code (a postinstall script, say) can query the helper for the allowlisted hosts. That's the same exposure as running `npm install` on your laptop with a credential helper configured — which is the experience being reproduced — but it's deliberate and worth judging consciously.

Known gaps: bun fetches `github.com` deps through GitHub's tarball API instead of git, without credentials (oven-sh/bun#19618), so private GitHub deps under bun need the Node runtime. SSH-remote deps and private registries (npm/PyPI auth) are out of scope — this only covers the git protocol.

## Reviewing

The stack is 11 commits, each building and passing tests on its own, and the commit messages carry most of the context — reading them in order is probably the easiest way in. The ones that deserve the most scrutiny are `core/schema: expose host._gitCredential` (the trust boundary), `engine: mount git-credential sockets...` (protocol parsing and allowlist enforcement, `core/git_credential_socket.go`), and `core: route goprivate from workspace settings...` (config surface + migration).

## Testing

Unit tests for the protocol, host scoping and settings routing:

```console
go test ./core/ -run GitCredential
go test ./core/workspace/
```

Integration tests run against real private GitLab repos (read-only PAT embedded, no env setup needed) and cover Go via `goprivate`, Python/TypeScript public + private installs, and bun with a private GitLab dep:

```console
dagger call engine-dev test --pkg ./core/integration \
  --run '^TestModule/(TestPrivateDeps|TestGitDepInstall)$' --test-verbose
```

13 tests, all green against a dev engine.
