### PR TITLE
core: canonicalize dev engine version

### DIFF
--- a/engine/version.go
+++ b/engine/version.go
@@ -11,7 +11,8 @@ import (
 
 var (
 	// Version is the engine/CLI semver, derived from internal/version.Version
-	// (which embeds VERSION at build time) with a "v" prefix.
+	// (which embeds VERSION at build time). Dev builds include the canonical
+	// build identifier from internal/version.Canonical.
 	//
 	// DAGGER_VERSION overrides at init for tests.
 	Version string
@@ -55,6 +56,9 @@ var (
 func init() {
 	if Version == "" {
 		Version = iversion.Version
+		if IsDevVersion(Version) {
+			Version = iversion.Canonical()
+		}
 	}
 
 	// hack: dynamically populate version env vars


### PR DESCRIPTION
Set engine.Version to the canonical build identifier during init
when the built-in VERSION is a dev version.

For example, a dev build that used to initialize engine.Version as:

    v1.0.0-dev

now initializes it as:

    v1.0.0-dev+8a0e5463.dirty

The core version field can continue returning engine.Version directly.