### PR TITLE
core: fix settings discovery for remote workspaces

### DIFF
--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -440,6 +440,43 @@ region = "us-west-2"
 	})
 }
 
+// TestWorkspaceSettingsRemoteWorkspace covers settings discovery against a
+// remote workspace selected with -W: local module sources must resolve from
+// the cloned workspace tree instead of requiring a host path.
+func (WorkspaceSuite) TestWorkspaceSettingsRemoteWorkspace(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	content := c.Directory().
+		WithNewFile("dagger.toml", `[modules.greeter]
+source = ".dagger/modules/greeter"
+
+[modules.greeter.settings]
+greeting = "hola"
+`).
+		WithNewFile(".dagger/modules/greeter/dagger.json", `{"name":"greeter","sdk":{"source":"dang"}}`).
+		WithNewFile(".dagger/modules/greeter/main.dang", `
+type Greeter {
+  pub greeting: String!
+
+  new(greeting: String! = "default") {
+    self.greeting = greeting
+    self
+  }
+}
+`)
+	remoteRef := workspaceSelectionRemoteRef(ctx, t, c, content)
+
+	out, err := c.Container().From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/empty").
+		With(workspaceSelectionDaggerExec("-W", remoteRef, "settings")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "greeter")
+	require.Contains(t, out, "greeting")
+	require.Contains(t, out, "hola")
+}
+
 type workspaceSettingsModuleFixture struct {
 	relDir string
 	name   string

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -138,11 +138,7 @@ func (s *workspaceSchema) moduleSettings(
 	if err != nil {
 		return nil, err
 	}
-	ref, err := workspaceSettingsModuleRef(ws.Self(), configDir, entry.Source)
-	if err != nil {
-		return nil, fmt.Errorf("resolve settings source for module %q: %w", parent.Self().Name, err)
-	}
-	if ref == "" {
+	if entry.Source == "" {
 		return nil, nil
 	}
 
@@ -151,7 +147,7 @@ func (s *workspaceSchema) moduleSettings(
 		return nil, err
 	}
 
-	hints, err := introspectConstructorArgs(ctx, srv, ref)
+	hints, err := introspectWorkspaceModuleSettings(ctx, srv, ws.Self(), configDir, entry.Source)
 	if err != nil {
 		return nil, fmt.Errorf("discover settings for module %q: %w", parent.Self().Name, err)
 	}
@@ -176,27 +172,28 @@ func (s *workspaceSchema) moduleSettings(
 	return settings, nil
 }
 
-func workspaceSettingsModuleRef(
+func introspectWorkspaceModuleSettings(
+	ctx context.Context,
+	srv *dagql.Server,
 	ws *core.Workspace,
 	configDir string,
 	source string,
-) (string, error) {
-	if source == "" {
-		return "", nil
-	}
-
+) ([]workspace.ConstructorArgHint, error) {
 	if core.FastModuleSourceKindCheck(source, "") != core.ModuleSourceKindLocal {
-		return source, nil
+		return introspectConstructorArgs(ctx, srv, source)
 	}
 
 	resolvedSource := workspace.ResolveModuleEntrySource(configDir, source)
 	if filepath.IsAbs(resolvedSource) {
-		return resolvedSource, nil
+		return introspectConstructorArgs(ctx, srv, resolvedSource)
 	}
-	if ws.HostPath() == "" {
-		return "", fmt.Errorf("workspace project root is required for local module source %q", source)
+	if ws.HostPath() != "" {
+		return introspectConstructorArgs(ctx, srv, filepath.Join(ws.HostPath(), resolvedSource))
 	}
-	return filepath.Join(ws.HostPath(), resolvedSource), nil
+	if rootfs := ws.Rootfs(); rootfs.Self() != nil {
+		return introspectConstructorArgsFromDirectory(ctx, srv, rootfs, resolvedSource)
+	}
+	return nil, fmt.Errorf("workspace project root is required for local module source %q", source)
 }
 
 func workspaceSettingConfigKey(moduleName, settingName string) string {


### PR DESCRIPTION
`dagger -W <git-ref> settings` failed for workspace modules with local sources: settings introspection required a workspace host path, which remote workspaces don't have. Introspect those modules from the cloned workspace rootfs instead.

Repro: `dagger -W github.com/dagger/java-sdk settings` → `resolve settings source for module "packager": workspace project root is required for local module source ".dagger/modules/packager"`. The same command in a local clone worked.