### PR TITLE
test: pin typescript in client generator tests

### DIFF
--- a/core/integration/client_generator_test.go
+++ b/core/integration/client_generator_test.go
@@ -1098,7 +1098,7 @@ func main() {
 			WithExec([]string{"npm", "install", "-g", "tsx@4.15.6"}).
 			WithExec([]string{"npm", "init", "-y"}).
 			WithExec([]string{"npm", "pkg", "set", "type=module"}).
-			WithExec([]string{"npm", "install", "-D", "typescript"}).
+			WithExec([]string{"npm", "install", "-D", "typescript@6.0.3"}).
 			WithNewFile("index.ts", `import { connection as c1, dag as dag1 } from "@my-app/dagger1";
 import { connection as c2, dag as dag2 } from "@my-app/dagger2";
 
@@ -2082,7 +2082,7 @@ func withTypeScriptSetup(content string, outputDir string) func(*dagger.Containe
 			WithExec([]string{"npm", "install", "-g", "tsx@4.15.6"}).
 			WithExec([]string{"npm", "init", "-y"}).
 			WithExec([]string{"npm", "pkg", "set", "type=module"}).
-			WithExec([]string{"npm", "install", "-D", "typescript"}).
+			WithExec([]string{"npm", "install", "-D", "typescript@6.0.3"}).
 			WithNewFile("index.ts", content).
 			WithNewFile("tsconfig.json", fmt.Sprintf(`{
   "compilerOptions": {


### PR DESCRIPTION
## What

Pin `typescript@6.0.3` in the two client-generator test setups that previously ran `npm install -D typescript` unpinned.

## Why

TypeScript **7.0.2** — the Go-native compiler rewrite — was published to npm on 2026-07-08 at 15:55 UTC. Its package no longer exposes the old compiler API (`ts.SyntaxKind`, `ts.isClassDeclaration`, …).

The generated TS client's bundled `sdk/core.js` externalizes its `typescript` import and resolves it from the client project's `node_modules` at runtime. With the unpinned install now resolving to 7.0.2, every typescript subtest of `TestClientGenerator` fails with:

```
TypeError: Cannot read properties of undefined (reading 'ClassDeclaration')
    at /work/sdk/core.js:134893
```

This breaks `test-split:test-client-generator` on **main** and on every PR — main's green badge predates the release (main's last run was ~10:40 UTC that day). Verified by running the failing subtest against an engine built from pristine main: identical failure.

`typescript@6.0.3` matches the SDK's own `^6.0.3` pin in `sdk/typescript/package.json`, and exact-pinning matches the tests' existing `tsx@4.15.6` style.

## Verified

`TestClientGenerator/TestHostCall/typescript` fails on main unpatched, passes with this change (via `engine-dev test`).

## Follow-up (not in this PR)

Real user projects hit the same breakage: a client generated by the typescript SDK breaks if the user's project installs TS 7. The generated `package.json` needs a `<7` constraint on `typescript` — that fix belongs in the typescript SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
