### PR TITLE
fix: update workspace install hint

### DIFF
--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -15,9 +15,9 @@ import (
 )
 
 const initialWorkspaceConfig = `# Dagger workspace configuration
-# Install modules with: dagger mod install <module>
+# Install modules with: dagger install <module>
 # Example:
-#   dagger mod install github.com/dagger/dagger/modules/wolfi
+#   dagger install github.com/dagger/dagger/modules/wolfi
 
 [modules]
 `


### PR DESCRIPTION
## Summary

- update the generated `dagger.toml` header to recommend `dagger install`
- update the example to use the same public CLI command

## Why

The generated workspace configuration still recommended `dagger mod install`, which no longer exists in the CLI 1.0 surface. Newly initialized workspaces therefore included a command that users could not run.

## Testing

- `git diff --check`
- No automated tests run; this is a comments-only change to the generated configuration header.
