### PR TITLE
cli: fail when check patterns match nothing

### DIFF
--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -105,6 +105,19 @@ func (ChecksSuite) TestChecksDirectSDK(ctx context.Context, t *testctx.T) {
 	}
 }
 
+func (ChecksSuite) TestChecksNoMatch(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := checksTestEnv(t, c)
+	require.NoError(t, err)
+
+	out, err := modGen.
+		WithWorkdir("hello-with-checks").
+		With(daggerExecFail("--progress=report", "check", "missing-check")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `no checks matched pattern "missing-check"`)
+}
+
 func (ChecksSuite) TestChecksViaLegacyBlueprintConfig(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	for _, tc := range []struct {

--- a/internal/cmd/dagger/checks.go
+++ b/internal/cmd/dagger/checks.go
@@ -76,7 +76,7 @@ func runChecksCommand(cmd *cobra.Command, args []string) error {
 			if checksListMode {
 				return listChecks(ctx, dag, checks, cmd)
 			}
-			return runChecks(ctx, dag, checks, cmd)
+			return runChecks(ctx, dag, checks, cmd, args)
 		},
 	)
 }
@@ -214,7 +214,7 @@ func writeCheckList(w io.Writer, checks []*CheckInfo) error {
 }
 
 // 'dagger checks' (runs by default)
-func runChecks(ctx context.Context, dag *dagger.Client, checkgroup *dagger.CheckGroup, _ *cobra.Command) error {
+func runChecks(ctx context.Context, dag *dagger.Client, checkgroup *dagger.CheckGroup, _ *cobra.Command, include []string) error {
 	ctx, zoomSpan := Tracer().Start(ctx, "checks", telemetry.Passthrough())
 	defer zoomSpan.End()
 	Frontend.SetPrimary(dagui.SpanID{SpanID: zoomSpan.SpanContext().SpanID()})
@@ -254,6 +254,9 @@ func runChecks(ctx context.Context, dag *dagger.Client, checkgroup *dagger.Check
 	if err != nil {
 		return err
 	}
+	if err := validateCheckSelection(include, len(res.CheckGroup.Run.List)); err != nil {
+		return err
+	}
 
 	var failed int
 	for _, check := range res.CheckGroup.Run.List {
@@ -265,4 +268,19 @@ func runChecks(ctx context.Context, dag *dagger.Client, checkgroup *dagger.Check
 		return idtui.ExitError{OriginalCode: 1, Original: fmt.Errorf("%d checks failed", failed)}
 	}
 	return nil
+}
+
+func validateCheckSelection(include []string, selected int) error {
+	if len(include) == 0 || selected > 0 {
+		return nil
+	}
+	if len(include) == 1 {
+		return fmt.Errorf("no checks matched pattern %q", include[0])
+	}
+
+	patterns := make([]string, 0, len(include))
+	for _, pattern := range include {
+		patterns = append(patterns, fmt.Sprintf("%q", pattern))
+	}
+	return fmt.Errorf("no checks matched any of the patterns: %s", strings.Join(patterns, ", "))
 }

--- a/internal/cmd/dagger/checks_test.go
+++ b/internal/cmd/dagger/checks_test.go
@@ -47,3 +47,27 @@ func TestWriteCheckListWithoutGenerateChecks(t *testing.T) {
 	require.Regexp(t, `lint\s+Run lint`, text)
 	require.NotContains(t, text, "Generators")
 }
+
+func TestValidateCheckSelection(t *testing.T) {
+	t.Run("unfiltered empty selection is allowed", func(t *testing.T) {
+		require.NoError(t, validateCheckSelection(nil, 0))
+	})
+
+	t.Run("non-empty selection is allowed", func(t *testing.T) {
+		require.NoError(t, validateCheckSelection([]string{"lint"}, 1))
+	})
+
+	t.Run("single unmatched pattern fails", func(t *testing.T) {
+		require.EqualError(t,
+			validateCheckSelection([]string{"missing"}, 0),
+			`no checks matched pattern "missing"`,
+		)
+	})
+
+	t.Run("multiple unmatched patterns fail", func(t *testing.T) {
+		require.EqualError(t,
+			validateCheckSelection([]string{"missing-one", "missing-two"}, 0),
+			`no checks matched any of the patterns: "missing-one", "missing-two"`,
+		)
+	})
+}


### PR DESCRIPTION
## Summary

- make `dagger check <pattern>` fail when explicit include patterns select no checks
- keep unfiltered empty workspaces and check list mode unchanged
- add focused unit and integration coverage for the no-match case

## Why

An explicit check selector that matched nothing produced an empty `CheckGroup`. The CLI counted zero failed checks in that empty result and exited successfully, creating a convincing false green when a check had been renamed or a selector was mistyped.

The Checks API continues to use normal filtering semantics and may return an empty group. The CLI now validates the final selection only when executing checks with positional include patterns.

## Behavior

Before:

```console
$ dagger check missing-check
$ echo $?
0
```

After:

```console
$ dagger check missing-check
Error: no checks matched pattern "missing-check"
$ echo $?
1
```

## Validation

- `go test ./internal/cmd/dagger -run '^TestValidateCheckSelection$' -count=1`
- `dagger api call engine-dev test --pkg ./core/integration --run='^TestChecks/TestChecksNoMatch$'`
  - trace: https://dagger.cloud/dagger/traces/afeb42c58ba7bc97b388a12aff95dbf5
- `dagger check golang:lint-all`
- `git diff --check`
