### PR TITLE
cli, core: support unsetting workspace module settings with --unset

### DIFF
--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -390,6 +390,115 @@ region = "us-west-2"
 	})
 }
 
+// TestWorkspaceSettingsUnsetSemantics defines how settings are removed. Unset
+// mutates the selected scope's stored settings, mirroring writes: base scope
+// without --env, that environment's overlay with --env.
+func (WorkspaceSuite) TestWorkspaceSettingsUnsetSemantics(ctx context.Context, t *testctx.T) {
+	t.Run("base-scope unset removes the stored setting and keeps the rest", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+
+[modules.aws.settings]
+format = "json"
+region = "us-west-2"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "--unset")
+		require.NoError(t, err)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Modules["aws"].Settings, "region")
+		require.Equal(t, "json", cfg.Modules["aws"].Settings["format"])
+
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
+		require.Error(t, err)
+		requireErrOut(t, err, `key "modules.aws.settings.region" is not set`)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Empty(t, strings.TrimSpace(string(out)))
+	})
+
+	t.Run("env-scoped unset removes only the overlay value and leaves base intact", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+
+[modules.aws.settings]
+region = "us-west-2"
+
+[env.ci.modules.aws.settings]
+region = "us-east-1"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region", "--unset")
+		require.NoError(t, err)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
+		require.Contains(t, cfg.Env, "ci")
+		require.NotContains(t, cfg.Env["ci"].Modules, "aws")
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("unset requires exactly MODULE and KEY", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+
+[modules.aws.settings]
+region = "us-west-2"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "--unset")
+		require.Error(t, err)
+		requireErrOut(t, err, "--unset requires MODULE and KEY arguments")
+
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "value", "--unset")
+		require.Error(t, err)
+		requireErrOut(t, err, "--unset requires MODULE and KEY arguments")
+	})
+
+	t.Run("unset rejects unknown settings and errors when the setting is not stored", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+
+[modules.aws.settings]
+region = "us-west-2"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "missing", "--unset")
+		require.Error(t, err)
+		requireErrOut(t, err, `module "aws" has no setting "missing"`)
+
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "format", "--unset")
+		require.Error(t, err)
+		requireErrOut(t, err, `key "modules.aws.settings.format" is not set`)
+	})
+
+	t.Run("raw config unset removes any settings key", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+
+[modules.aws.settings]
+region = "us-west-2"
+stale = "left over"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.stale", "-u")
+		require.NoError(t, err)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Modules["aws"].Settings, "stale")
+		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
+
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "--unset")
+		require.Error(t, err)
+		requireErrOut(t, err, "--unset requires a KEY argument")
+	})
+}
+
 // TestWorkspaceSettingsConfigProjection locks in that `dagger settings` is an
 // ergonomic, typed projection over workspace config rather than a second
 // storage system with independent semantics.

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -199,6 +199,14 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("value").Doc("Value to set."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
+		dagql.NodeFunc("withoutConfigValue", s.withoutConfigValue).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Return this workspace with a configuration value removed.",
+				"Errors when the key is not currently set.").
+			Args(
+				dagql.Arg("key").Doc("Dotted key path (e.g. modules.greeter.settings.greeting)."),
+				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
+			),
 		dagql.NodeFunc("withConfigEnv", s.withConfigEnv).
 			View(AfterVersion("v1.0.0-0")).
 			Doc("Return this workspace with a named config environment created.").

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -154,6 +154,31 @@ func (s *workspaceSchema) withConfigValue(
 	return s.stageWorkspaceConfigBytes(ctx, parent, staged, updated)
 }
 
+func (s *workspaceSchema) withoutConfigValue(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceConfigKeyArgs,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	staged, err := s.loadWorkspaceConfigForOverlay(ctx, parent.Self(), workspaceConfigMustExist, args.Here)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+
+	unsetKey := args.Key
+	if envName, ok := selectedWorkspaceEnv(ctx); ok && !isExplicitEnvConfigKey(args.Key) {
+		unsetKey, err = envScopedConfigKey(staged.Config, envName, args.Key)
+		if err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+	}
+
+	updated, err := workspace.DeleteConfigValue(staged.Data, unsetKey)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	return s.stageWorkspaceConfigBytes(ctx, parent, staged, updated)
+}
+
 func (s *workspaceSchema) withConfigEnv(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -221,6 +221,11 @@ type workspaceConfigValueArgs struct {
 	Here  bool `default:"false"`
 }
 
+type workspaceConfigKeyArgs struct {
+	Key  string
+	Here bool `default:"false"`
+}
+
 func selectedWorkspaceEnv(ctx context.Context) (string, bool) {
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil || clientMetadata.WorkspaceEnv == nil || *clientMetadata.WorkspaceEnv == "" {

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -639,7 +639,7 @@ func WriteConfigValue(existingData []byte, key string, rawValue string) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	if err := validateConfigKeyParts(parts, key); err != nil {
+	if err := validateConfigKeyParts(parts, key, "set"); err != nil {
 		return nil, err
 	}
 
@@ -657,6 +657,107 @@ func WriteConfigValue(existingData []byte, key string, rawValue string) ([]byte,
 	}
 
 	return UpdateConfigBytes(existingData, cfg)
+}
+
+// DeleteConfigValue removes the value at the given dotted key from config TOML.
+// It errors when the key is not currently set.
+//
+// Deletion works on the TOML document rather than the typed config, so any
+// valid config key is removable without per-field handling; only keys whose
+// removal would break the containing entry are refused.
+func DeleteConfigValue(existingData []byte, key string) ([]byte, error) {
+	if key == "" {
+		return nil, fmt.Errorf("key is required for unsetting")
+	}
+	parts, err := splitConfigPath(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) == 2 && parts[0] == "modules" {
+		return nil, fmt.Errorf("cannot unset %q directly; use dagger uninstall to remove a module", key)
+	}
+	if err := validateConfigKeyParts(parts, key, "unset"); err != nil {
+		return nil, err
+	}
+	if err := refuseProtectedConfigDelete(parts, key); err != nil {
+		return nil, err
+	}
+
+	// Presence is judged on the raw document rather than the parsed config:
+	// explicit zero values (`entrypoint = false`, `ignore = []`) are set keys
+	// even though they parse to Go zero values, matching how configRead sees
+	// them.
+	tree, err := toml.LoadBytes(existingData)
+	if err != nil {
+		return nil, fmt.Errorf("parse existing config: %w", err)
+	}
+	if tree.GetPath(parts) == nil {
+		return nil, fmt.Errorf("key %q is not set", key)
+	}
+
+	collapsed := collapseEmptiedConfigTables(tree, parts)
+
+	if configPathRequiresSerializeFallback(collapsed) {
+		// Same trade-off as writes: document edits can't address quoted or
+		// all-digit path segments, so fall back to a full canonical rewrite.
+		if err := tree.DeletePath(collapsed); err != nil {
+			return nil, fmt.Errorf("delete config path %q: %w", JoinConfigPath(collapsed...), err)
+		}
+		rendered, err := tree.ToTomlString()
+		if err != nil {
+			return nil, fmt.Errorf("render config after delete: %w", err)
+		}
+		cfg, err := ParseConfig([]byte(rendered))
+		if err != nil {
+			return nil, err
+		}
+		return SerializeConfig(cfg), nil
+	}
+
+	return deleteConfigDocumentPath(existingData, parts, collapsed)
+}
+
+// refuseProtectedConfigDelete rejects keys whose removal would break the
+// containing entry rather than merely unset a value.
+func refuseProtectedConfigDelete(parts []string, key string) error {
+	switch {
+	case parts[0] == "ports":
+		return fmt.Errorf("cannot unset %q; edit or remove the [ports.<host>] section in dagger.toml", key)
+	case parts[0] == "modules" && len(parts) >= 3 && parts[2] == "source":
+		return fmt.Errorf("cannot unset %s; module entries require a source", key)
+	case parts[0] == "modules" && len(parts) >= 3 && parts[2] == "as-sdk":
+		return fmt.Errorf("cannot unset %q; SDK state is managed by dagger install", key)
+	}
+	return nil
+}
+
+// collapseEmptiedConfigTables widens the deletion to the topmost table this
+// removal empties, so no dangling section headers are left behind. Module
+// entries and env definitions are never collapsed: removing a module is
+// uninstall's job, and an env must stay defined for --env selection.
+func collapseEmptiedConfigTables(tree *toml.Tree, parts []string) []string {
+	del := parts
+	for len(del) > 2 {
+		parent := del[:len(del)-1]
+		if len(parent) == 2 && (parent[0] == "modules" || parent[0] == "env") {
+			break
+		}
+		sub, ok := tree.GetPath(parent).(*toml.Tree)
+		if !ok || len(sub.Keys()) > 1 {
+			break
+		}
+		del = parent
+	}
+	return del
+}
+
+func configPathRequiresSerializeFallback(parts []string) bool {
+	for _, part := range parts {
+		if pathSegmentUnsafeForDocumentUpdate(part) {
+			return true
+		}
+	}
+	return false
 }
 
 func flattenTOMLTree(prefix string, tree *toml.Tree) string {
@@ -753,11 +854,11 @@ func SplitConfigPath(key string) ([]string, error) {
 	return splitConfigPath(key)
 }
 
-func validateConfigKeyParts(parts []string, key string) error {
+func validateConfigKeyParts(parts []string, key, op string) error {
 	if len(parts) == 0 {
 		return fmt.Errorf("key is required")
 	}
-	return validateKeyAgainstType(parts, reflect.TypeOf(Config{}), key)
+	return validateKeyAgainstType(parts, reflect.TypeOf(Config{}), key, op)
 }
 
 // JoinConfigPath formats logical path segments as a TOML dotted key path.
@@ -1060,7 +1161,7 @@ func setConfigValue(cfg *Config, parts []string, value any) error { //nolint:goc
 	}
 }
 
-func validateKeyAgainstType(parts []string, t reflect.Type, fullKey string) error {
+func validateKeyAgainstType(parts []string, t reflect.Type, fullKey, op string) error {
 	if len(parts) == 0 {
 		return nil
 	}
@@ -1080,17 +1181,17 @@ func validateKeyAgainstType(parts []string, t reflect.Type, fullKey string) erro
 	switch fieldType.Kind() {
 	case reflect.Map:
 		if len(rest) == 0 {
-			return fmt.Errorf("cannot set %q directly; specify a sub-key", fullKey)
+			return fmt.Errorf("cannot %s %q directly; specify a sub-key", op, fullKey)
 		}
 
 		mapValueRest := rest[1:]
 		elemType := fieldType.Elem()
 		if elemType.Kind() == reflect.Struct {
 			if len(mapValueRest) == 0 {
-				return fmt.Errorf("cannot set %q directly; specify a field like %s.%s",
-					fullKey, fullKey, preferredExampleFieldName(elemType))
+				return fmt.Errorf("cannot %s %q directly; specify a field like %s.%s",
+					op, fullKey, fullKey, preferredExampleFieldName(elemType))
 			}
-			return validateKeyAgainstType(mapValueRest, elemType, fullKey)
+			return validateKeyAgainstType(mapValueRest, elemType, fullKey, op)
 		}
 		if len(mapValueRest) > 0 {
 			return fmt.Errorf("invalid key %q; config keys cannot be nested deeper", fullKey)
@@ -1098,10 +1199,10 @@ func validateKeyAgainstType(parts []string, t reflect.Type, fullKey string) erro
 		return nil
 	case reflect.Struct:
 		if len(rest) == 0 {
-			return fmt.Errorf("cannot set %q directly; specify a field like %s.%s",
-				fullKey, fullKey, preferredExampleFieldName(fieldType))
+			return fmt.Errorf("cannot %s %q directly; specify a field like %s.%s",
+				op, fullKey, fullKey, preferredExampleFieldName(fieldType))
 		}
-		return validateKeyAgainstType(rest, fieldType, fullKey)
+		return validateKeyAgainstType(rest, fieldType, fullKey, op)
 	default:
 		if len(rest) > 0 {
 			return fmt.Errorf("invalid key %q; %s does not have sub-keys", fullKey, parts[0])

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -96,6 +96,75 @@ func UpdateConfigBytesWithHints(
 	return insertWorkspaceSettingHintComments(out, cfg, hints), nil
 }
 
+// deleteConfigDocumentPath removes the value at parts from the raw document,
+// preserving surrounding formatting and comments. collapsed is the topmost
+// table the removal empties (a prefix of parts, or parts itself).
+func deleteConfigDocumentPath(data []byte, parts, collapsed []string) ([]byte, error) {
+	del := parts
+	if len(collapsed) < len(parts) {
+		// The document can only drop leaf keys or whole section headers —
+		// deleting an implied intermediate table path is a silent no-op — so
+		// widen to the shortest emptied prefix that is an actual section.
+		// Any levels implied by that section's dotted header vanish with it.
+		sections, err := configSectionSet(data)
+		if err != nil {
+			return nil, err
+		}
+		for probe := collapsed; len(probe) < len(parts); probe = parts[:len(probe)+1] {
+			if sections[JoinConfigPath(probe...)] {
+				del = probe
+				break
+			}
+		}
+	}
+
+	doc, err := neontoml.Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse existing config: %w", err)
+	}
+	path := JoinConfigPath(del...)
+	if err := doc.Delete(path); err != nil {
+		return nil, fmt.Errorf("delete config path %q: %w", path, err)
+	}
+
+	// Removing an env's last overlay may take its only section header with
+	// it; the env must stay defined so --env selection keeps working.
+	if parts[0] == "env" {
+		cfg, err := ParseConfig(doc.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("parse config after delete: %w", err)
+		}
+		if env, ok := cfg.Env[parts[1]]; !ok || len(env.Modules) == 0 {
+			if err := ensureEmptyEnvSections(doc, map[string]EnvOverlay{parts[1]: {}}); err != nil {
+				return nil, err
+			}
+			// The placeholder trick also creates an empty [env] parent
+			// header; deleting an exact section only drops that header.
+			if err := doc.Delete("env"); err != nil {
+				return nil, fmt.Errorf("drop empty env header: %w", err)
+			}
+		}
+	}
+
+	return doc.Bytes(), nil
+}
+
+// configSectionSet returns the dotted paths of the document's section headers.
+func configSectionSet(data []byte) (map[string]bool, error) {
+	doc, err := tomledit.Parse(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("parse config sections: %w", err)
+	}
+	set := map[string]bool{}
+	for _, section := range doc.Sections {
+		if section.Heading == nil {
+			continue
+		}
+		set[JoinConfigPath(section.Heading.Name...)] = true
+	}
+	return set, nil
+}
+
 func configDocumentMap(cfg *Config) map[string]any {
 	values := make(map[string]any)
 

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -835,5 +836,215 @@ func TestResolveModuleEntrySource(t *testing.T) {
 	t.Run("leaves remote source unchanged", func(t *testing.T) {
 		t.Parallel()
 		require.Equal(t, "github.com/dagger/dagger/modules/wolfi", ResolveModuleEntrySource(LockDirName, "github.com/dagger/dagger/modules/wolfi"))
+	})
+}
+
+func TestDeleteConfigValue(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`# workspace config
+[modules.greeter]
+source = "modules/greeter"
+entrypoint = true
+
+[modules.greeter.settings]
+greeting = "hello"
+enabled = true
+
+[env.ci.modules.greeter.settings]
+greeting = "hola"
+
+[env.local]
+`)
+
+	t.Run("removes a base setting and keeps the rest", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := DeleteConfigValue(data, "modules.greeter.settings.greeting")
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.NotContains(t, cfg.Modules["greeter"].Settings, "greeting")
+		require.Equal(t, true, cfg.Modules["greeter"].Settings["enabled"])
+		require.Equal(t, "hola", cfg.Env["ci"].Modules["greeter"].Settings["greeting"])
+		require.Contains(t, string(out), "# workspace config")
+	})
+
+	t.Run("removing the last base setting drops the settings section", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := DeleteConfigValue(data, "modules.greeter.settings.greeting")
+		require.NoError(t, err)
+		out, err = DeleteConfigValue(out, "modules.greeter.settings.enabled")
+		require.NoError(t, err)
+
+		require.NotContains(t, string(out), "[modules.greeter.settings]")
+		cfg, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Modules["greeter"].Settings)
+		require.Equal(t, "modules/greeter", cfg.Modules["greeter"].Source)
+	})
+
+	t.Run("removes an env setting and keeps the env defined", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := DeleteConfigValue(data, "env.ci.modules.greeter.settings.greeting")
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.Contains(t, cfg.Env, "ci")
+		require.NotContains(t, cfg.Env["ci"].Modules, "greeter")
+		require.Equal(t, "hello", cfg.Modules["greeter"].Settings["greeting"])
+		require.Contains(t, cfg.Env, "local")
+		require.Contains(t, string(out), "[env.ci]")
+		require.NotContains(t, string(out), "[env]\n")
+	})
+
+	t.Run("removes boolean and list fields", func(t *testing.T) {
+		t.Parallel()
+
+		listData := []byte(`ignore = ["dist"]
+defaults_from_dotenv = true
+check-generated = false
+
+[modules.greeter]
+source = "modules/greeter"
+entrypoint = true
+
+[modules.greeter.check]
+skip = ["slow"]
+`)
+
+		out, err := DeleteConfigValue(listData, "modules.greeter.entrypoint")
+		require.NoError(t, err)
+		out, err = DeleteConfigValue(out, "modules.greeter.check.skip")
+		require.NoError(t, err)
+		out, err = DeleteConfigValue(out, "ignore")
+		require.NoError(t, err)
+		out, err = DeleteConfigValue(out, "defaults_from_dotenv")
+		require.NoError(t, err)
+		out, err = DeleteConfigValue(out, "check-generated")
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.False(t, cfg.Modules["greeter"].Entrypoint)
+		require.Empty(t, cfg.Modules["greeter"].Check.Skip)
+		require.Empty(t, cfg.Ignore)
+		require.False(t, cfg.DefaultsFromDotEnv)
+		require.Nil(t, cfg.CheckGenerated)
+		require.NotContains(t, string(out), "entrypoint")
+		require.NotContains(t, string(out), "check-generated")
+	})
+
+	t.Run("removes explicitly set zero values", func(t *testing.T) {
+		t.Parallel()
+
+		zeroData := []byte(`ignore = []
+defaults_from_dotenv = false
+
+[modules.greeter]
+source = "modules/greeter"
+entrypoint = false
+`)
+
+		for _, tc := range []struct {
+			key  string
+			line string
+		}{
+			{"ignore", "ignore"},
+			{"defaults_from_dotenv", "defaults_from_dotenv"},
+			{"modules.greeter.entrypoint", "entrypoint"},
+		} {
+			out, err := DeleteConfigValue(zeroData, tc.key)
+			require.NoError(t, err, tc.key)
+			require.NotContains(t, string(out), tc.line, tc.key)
+
+			_, err = DeleteConfigValue(out, tc.key)
+			require.ErrorContains(t, err, fmt.Sprintf("key %q is not set", tc.key), tc.key)
+		}
+	})
+
+	t.Run("errors when the key is not set", func(t *testing.T) {
+		t.Parallel()
+
+		for _, key := range []string{
+			"modules.greeter.settings.missing",
+			"modules.missing.settings.greeting",
+			"env.missing.modules.greeter.settings.greeting",
+			"env.ci.modules.missing.settings.greeting",
+			"env.ci.modules.greeter.settings.enabled",
+			"modules.greeter.legacy-default-path",
+			"check-generated",
+			"ignore",
+		} {
+			_, err := DeleteConfigValue(data, key)
+			require.ErrorContains(t, err, fmt.Sprintf("key %q is not set", key), key)
+		}
+	})
+
+	t.Run("rejects invalid and protected keys", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := DeleteConfigValue(data, "")
+		require.ErrorContains(t, err, "key is required")
+
+		_, err = DeleteConfigValue(data, "modules.greeter.source")
+		require.ErrorContains(t, err, "cannot unset modules.greeter.source")
+
+		_, err = DeleteConfigValue(data, "modules.greeter")
+		require.ErrorContains(t, err, `cannot unset "modules.greeter" directly; use dagger uninstall to remove a module`)
+
+		_, err = DeleteConfigValue(data, "modules.greeter.settings")
+		require.ErrorContains(t, err, `cannot unset "modules.greeter.settings" directly`)
+
+		_, err = DeleteConfigValue(data, "modules.greeter.badfield")
+		require.ErrorContains(t, err, "unknown config key")
+
+		_, err = DeleteConfigValue(data, "modules.greeter.as-sdk.name")
+		require.ErrorContains(t, err, "SDK state is managed by dagger install")
+
+		portsData := []byte("[ports.3000]\nbackendService = \"web\"\nbackendPort = 8080\n")
+		_, err = DeleteConfigValue(portsData, "ports.3000.backendService")
+		require.ErrorContains(t, err, "cannot unset")
+	})
+
+	t.Run("removes keys without dedicated handling", func(t *testing.T) {
+		t.Parallel()
+
+		pinned := []byte(`[modules.greeter]
+source = "modules/greeter"
+pin = "abc123"
+`)
+
+		out, err := DeleteConfigValue(pinned, "modules.greeter.pin")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "pin")
+
+		cfg, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, "modules/greeter", cfg.Modules["greeter"].Source)
+	})
+
+	t.Run("removes quoted setting keys", func(t *testing.T) {
+		t.Parallel()
+
+		quoted := []byte(`[modules."my.module"]
+source = "modules/my.module"
+
+[modules."my.module".settings]
+"some.key" = "value"
+other = "kept"
+`)
+
+		out, err := DeleteConfigValue(quoted, `modules."my.module".settings."some.key"`)
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.NotContains(t, cfg.Modules["my.module"].Settings, "some.key")
+		require.Equal(t, "kept", cfg.Modules["my.module"].Settings["other"])
 	})
 }

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -50,7 +50,7 @@ dagger [options] [subcommand | file...]
 * [dagger module](#dagger-module)	 - Author a module: edit dependencies, engine version, etc.
 * [dagger sdk](#dagger-sdk)	 - Install and manage SDKs (the modules that author other modules)
 * [dagger search](#dagger-search)	 - Search for modules you can install
-* [dagger settings](#dagger-settings)	 - Get or set module settings (use --env for an env overlay)
+* [dagger settings](#dagger-settings)	 - Get, set, or unset module settings (use --env for an env overlay)
 * [dagger setup](#dagger-setup)	 - Ensure Dagger is properly set up and operational in the workspace
 * [dagger uninstall](#dagger-uninstall)	 - Uninstall a module from your workspace
 * [dagger up](#dagger-up)	 - Run your project's services for local development — databases, APIs, dev servers, etc.
@@ -2306,7 +2306,7 @@ dagger search wolfi
 
 ## dagger settings
 
-Get or set module settings (use --env for an env overlay)
+Get, set, or unset module settings (use --env for an env overlay)
 
 ```
 dagger settings [module] [key] [value]
@@ -2315,7 +2315,8 @@ dagger settings [module] [key] [value]
 ### Options
 
 ```
-      --here   Write workspace config at the selected workspace cwd
+      --here    Write workspace config at the selected workspace cwd
+  -u, --unset   Remove the setting from workspace config
 ```
 
 ### Options inherited from parent commands
@@ -2632,6 +2633,7 @@ Get or set workspace configuration values in dagger.toml.
 With no arguments, prints the full configuration.
 With one argument, prints the value at the given key.
 With two arguments, sets the value at the given key.
+With one argument and --unset, removes the value at the given key.
 
 With --env, reads show the effective env-applied view while writes target that
 environment's overlay. Explicit env.* keys always address raw overlay storage.
@@ -2645,7 +2647,8 @@ dagger workspace config [key] [value] [flags]
 ### Options
 
 ```
-      --here   Write workspace config at the selected workspace cwd
+      --here    Write workspace config at the selected workspace cwd
+  -u, --unset   Remove the value at the given key
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6456,6 +6456,19 @@ type Workspace implements Node {
     here: Boolean = false
   ): Workspace!
 
+  """
+  Return this workspace with a configuration value removed.
+
+  Errors when the key is not currently set.
+  """
+  withoutConfigValue(
+    """Dotted key path (e.g. modules.greeter.settings.greeting)."""
+    key: String!
+
+    """Write to the workspace config directory at the workspace cwd."""
+    here: Boolean = false
+  ): Workspace!
+
   """Return this workspace with a module removed from its config."""
   withoutModule(
     """Name of the installed module entry to remove."""

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -476,6 +476,16 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withoutConfigValue">withoutConfigValue</a>(string $key, bool|null $here = false)
+        
+                                            <p><p>Return this workspace with a configuration value removed.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withoutModule">withoutModule</a>(string $name, bool|null $here = false)
         
                                             <p><p>Return this workspace with a module removed from its config.</p></p>                </div>
@@ -2054,8 +2064,55 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_withoutConfigValue">
+        <div class="location">at line 511</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Return this workspace with a configuration value removed.</p></p>                <p><p>Errors when the key is not currently set.</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$key</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$here</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 509</div>
+        <div class="location">at line 524</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2102,7 +2159,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 522</div>
+        <div class="location">at line 537</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -2031,7 +2031,9 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::withUpdatedLock</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with refreshed lockfile state.</p></dd><dt><a href="Dagger/Workspace.html#method_withoutConfigEnv">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withoutConfigEnv</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a named config environment removed.</p></dd><dt><a href="Dagger/Workspace.html#method_withoutModule">
+                    <dd><p>Return this workspace with a named config environment removed.</p></dd><dt><a href="Dagger/Workspace.html#method_withoutConfigValue">
+<abbr title="Dagger\Workspace">Workspace</abbr>::withoutConfigValue</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Return this workspace with a configuration value removed.</p></dd><dt><a href="Dagger/Workspace.html#method_withoutModule">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withoutModule</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a module removed from its config.</p></dd><dt><a href="Dagger/Workspace.html#method_withoutSDK">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withoutSDK</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -6950,6 +6950,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Workspace::withoutConfigValue",
+			"p": "Dagger/Workspace.html#method_withoutConfigValue",
+			"d": "<p>Return this workspace with a configuration value removed.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Workspace::withoutModule",
 			"p": "Dagger/Workspace.html#method_withoutModule",
 			"d": "<p>Return this workspace with a module removed from its config.</p>"

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -56,17 +56,24 @@ func init() {
 	addWorkspaceHereFlag(settingsCmd)
 }
 
+var workspaceSettingsUnset bool
+
 func newSettingsCmd(hidden bool) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:    "settings [module] [key] [value]",
-		Short:  "Get or set module settings (use --env for an env overlay)",
+		Short:  "Get, set, or unset module settings (use --env for an env overlay)",
 		Hidden: hidden,
 		Args:   cobra.MaximumNArgs(3),
 		RunE:   runWorkspaceSettings,
 	}
+	cmd.Flags().BoolVarP(&workspaceSettingsUnset, "unset", "u", false, "Remove the setting from workspace config")
+	return cmd
 }
 
 func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
+	if workspaceSettingsUnset && len(args) != 2 {
+		return fmt.Errorf("--unset requires MODULE and KEY arguments")
+	}
 	return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
 		moduleName := ""
 		if len(args) > 0 {
@@ -76,6 +83,16 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 		state, err := loadWorkspaceSettingsState(ctx, engineClient.Dagger(), moduleName)
 		if err != nil {
 			return err
+		}
+
+		if workspaceSettingsUnset {
+			setting, err := state.lookupSetting(args[1])
+			if err != nil {
+				return err
+			}
+			return state.Workspace.
+				WithoutConfigValue(workspaceSettingConfigKey(setting.Module, setting.Key), dagger.WorkspaceWithoutConfigValueOpts{Here: workspaceHere}).
+				Export(ctx)
 		}
 
 		switch len(args) {

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -190,6 +190,7 @@ var workspaceConfigCmd = &cobra.Command{
 With no arguments, prints the full configuration.
 With one argument, prints the value at the given key.
 With two arguments, sets the value at the given key.
+With one argument and --unset, removes the value at the given key.
 
 With --env, reads show the effective env-applied view while writes target that
 environment's overlay. Explicit env.* keys always address raw overlay storage.
@@ -224,7 +225,11 @@ var activityCmd = &cobra.Command{
 
 var workspaceActivityAll bool
 
+var workspaceConfigUnset bool
+
 func init() {
+	workspaceConfigCmd.Flags().BoolVarP(&workspaceConfigUnset, "unset", "u", false, "Remove the value at the given key")
+
 	workspaceCmd.AddCommand(workspaceConfigCmd)
 	workspaceCmd.AddCommand(workspaceConfigFileCmd)
 	workspaceCmd.AddCommand(workspaceCwdCmd)
@@ -241,11 +246,18 @@ func addWorkspaceHereFlag(cmd *cobra.Command) {
 }
 
 func runWorkspaceConfig(cmd *cobra.Command, args []string) error {
+	if workspaceConfigUnset && len(args) != 1 {
+		return fmt.Errorf("--unset requires a KEY argument")
+	}
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,
 	}, func(ctx context.Context, engineClient *client.Client) error {
 		ws := engineClient.Dagger().CurrentWorkspace()
+
+		if workspaceConfigUnset {
+			return ws.WithoutConfigValue(args[0], dagger.WorkspaceWithoutConfigValueOpts{Here: workspaceHere}).Export(ctx)
+		}
 
 		switch len(args) {
 		case 0:

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -620,6 +620,25 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
+  Return this workspace with a configuration value removed.
+
+  Errors when the key is not currently set.
+  """
+  @spec without_config_value(t(), String.t(), [{:here, boolean() | nil}]) :: Dagger.Workspace.t()
+  def without_config_value(%__MODULE__{} = workspace, key, optional_args \\ []) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("withoutConfigValue")
+      |> QB.put_arg("key", key)
+      |> QB.maybe_put_arg("here", optional_args[:here])
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
+
+  @doc """
   Return this workspace with a module removed from its config.
   """
   @spec without_module(t(), String.t(), [{:here, boolean() | nil}]) :: Dagger.Workspace.t()

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16846,6 +16846,30 @@ func (r *Workspace) WithoutConfigEnv(name string, opts ...WorkspaceWithoutConfig
 	}
 }
 
+// WorkspaceWithoutConfigValueOpts contains options for Workspace.WithoutConfigValue
+type WorkspaceWithoutConfigValueOpts struct {
+	// Write to the workspace config directory at the workspace cwd.
+	Here bool
+}
+
+// Return this workspace with a configuration value removed.
+//
+// Errors when the key is not currently set.
+func (r *Workspace) WithoutConfigValue(key string, opts ...WorkspaceWithoutConfigValueOpts) *Workspace {
+	q := r.query.Select("withoutConfigValue")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `here` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Here) {
+			q = q.Arg("here", opts[i].Here)
+		}
+	}
+	q = q.Arg("key", key)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // WorkspaceWithoutModuleOpts contains options for Workspace.WithoutModule
 type WorkspaceWithoutModuleOpts struct {
 	// Write to the workspace config directory at the workspace cwd.

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -504,6 +504,21 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
+     * Return this workspace with a configuration value removed.
+     *
+     * Errors when the key is not currently set.
+     */
+    public function withoutConfigValue(string $key, ?bool $here = false): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutConfigValue');
+        $innerQueryBuilder->setArgument('key', $key);
+        if (null !== $here) {
+        $innerQueryBuilder->setArgument('here', $here);
+        }
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Return this workspace with a module removed from its config.
      */
     public function withoutModule(string $name, ?bool $here = false): Workspace

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -16515,6 +16515,30 @@ class Workspace(Type):
         _ctx = self._select("withoutConfigEnv", _args)
         return Workspace(_ctx)
 
+    def without_config_value(
+        self,
+        key: str,
+        *,
+        here: bool | None = False,
+    ) -> Self:
+        """Return this workspace with a configuration value removed.
+
+        Errors when the key is not currently set.
+
+        Parameters
+        ----------
+        key:
+            Dotted key path (e.g. modules.greeter.settings.greeting).
+        here:
+            Write to the workspace config directory at the workspace cwd.
+        """
+        _args = [
+            Arg("key", key),
+            Arg("here", here, False),
+        ]
+        _ctx = self._select("withoutConfigValue", _args)
+        return Workspace(_ctx)
+
     def without_module(
         self,
         name: str,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -16288,6 +16288,12 @@ pub struct WorkspaceWithoutConfigEnvOpts {
     pub here: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct WorkspaceWithoutConfigValueOpts {
+    /// Write to the workspace config directory at the workspace cwd.
+    #[builder(setter(into, strip_option), default)]
+    pub here: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceWithoutModuleOpts {
     /// Write to the workspace config directory at the workspace cwd.
     #[builder(setter(into, strip_option), default)]
@@ -17160,6 +17166,45 @@ impl Workspace {
     ) -> Workspace {
         let mut query = self.selection.select("withoutConfigEnv");
         query = query.arg("name", name.into());
+        if let Some(here) = opts.here {
+            query = query.arg("here", here);
+        }
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return this workspace with a configuration value removed.
+    /// Errors when the key is not currently set.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Dotted key path (e.g. modules.greeter.settings.greeting).
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_config_value(&self, key: impl Into<String>) -> Workspace {
+        let mut query = self.selection.select("withoutConfigValue");
+        query = query.arg("key", key.into());
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return this workspace with a configuration value removed.
+    /// Errors when the key is not currently set.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Dotted key path (e.g. modules.greeter.settings.greeting).
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_config_value_opts(
+        &self,
+        key: impl Into<String>,
+        opts: WorkspaceWithoutConfigValueOpts,
+    ) -> Workspace {
+        let mut query = self.selection.select("withoutConfigValue");
+        query = query.arg("key", key.into());
         if let Some(here) = opts.here {
             query = query.arg("here", here);
         }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2941,6 +2941,13 @@ export type WorkspaceWithoutConfigEnvOpts = {
   here?: boolean
 }
 
+export type WorkspaceWithoutConfigValueOpts = {
+  /**
+   * Write to the workspace config directory at the workspace cwd.
+   */
+  here?: boolean
+}
+
 export type WorkspaceWithoutModuleOpts = {
   /**
    * Write to the workspace config directory at the workspace cwd.
@@ -15565,6 +15572,21 @@ export class Workspace extends BaseClient {
     opts?: WorkspaceWithoutConfigEnvOpts,
   ): Workspace => {
     const ctx = this._ctx.select("withoutConfigEnv", { name, ...opts })
+    return new Workspace(ctx)
+  }
+
+  /**
+   * Return this workspace with a configuration value removed.
+   *
+   * Errors when the key is not currently set.
+   * @param key Dotted key path (e.g. modules.greeter.settings.greeting).
+   * @param opts.here Write to the workspace config directory at the workspace cwd.
+   */
+  withoutConfigValue = (
+    key: string,
+    opts?: WorkspaceWithoutConfigValueOpts,
+  ): Workspace => {
+    const ctx = this._ctx.select("withoutConfigValue", { key, ...opts })
     return new Workspace(ctx)
   }
 


### PR DESCRIPTION
Adds the ability to remove a stored workspace-module setting, completing the settings lifecycle (list/get/set/**unset**).

- `dagger settings MODULE KEY --unset` removes the setting from `dagger.toml`, validating KEY against the module's discoverable settings like set does. With `--env` it removes the value from that environment's overlay and leaves the base scope intact, mirroring write scoping.
- `dagger workspace config KEY --unset` is the raw counterpart, useful for stale keys a module no longer declares.
- Backed by a new `Workspace.withoutConfigValue(key, here)` GraphQL field (gated `AfterVersion("v1.0.0-0")` like its workspace-config siblings) and `workspace.DeleteConfigValue`, which deletes directly on the TOML document: any valid config key is removable without per-field handling, presence is judged on the raw document (explicit zeros like `entrypoint = false` are removable), removals that empty a table drop its section header, and module entries / env definitions are never collapsed. Module sources, ports, and CLI-managed as-sdk state are refused. The removal is staged as a pending overlay change and exported by the CLI, following the workspace overlay & export model (#13600).
- Unit tests (`TestDeleteConfigValue`), integration tests (`TestWorkspaceSettingsUnsetSemantics`), regenerated SDK bindings + reference docs.

