### PR TITLE
cli: accept variadic values for list settings

### DIFF
--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -27,7 +27,7 @@ import (
 // implementation details. The command is intentionally positional and requires
 // an explicit module alias at every depth so it stays unambiguous.
 func (WorkspaceSuite) TestWorkspaceSettingsCommandGrammar(ctx context.Context, t *testctx.T) {
-	t.Run("settings supports exactly zero, one, two, or three positional args", func(ctx context.Context, t *testctx.T) {
+	t.Run("settings supports zero, one, two, or trailing value positional args", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
 source = "modules/aws"
 entrypoint = true
@@ -63,7 +63,7 @@ region = "us-west-2"
 
 		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "eu-central-1", "extra")
 		require.Error(t, err)
-		requireErrOut(t, err, "accepts at most 3 arg")
+		requireErrOut(t, err, `setting "region" of module "aws" is not a list and accepts a single value`)
 	})
 
 	t.Run("module omission is never supported, even for a single entrypoint module", func(ctx context.Context, t *testctx.T) {
@@ -551,8 +551,8 @@ region = "us-west-2"
 
 // TestWorkspaceSettingsListValues locks in how list settings reach a module's
 // constructor: TOML arrays deliver their elements as-is, comma-separated
-// strings split into elements, and JSON-array writes through `dagger settings`
-// round-trip to the same list.
+// strings split into elements, and variadic writes through `dagger settings`
+// store each trailing argument verbatim as one element.
 func (WorkspaceSuite) TestWorkspaceSettingsListValues(ctx context.Context, t *testctx.T) {
 	const vitestConfig = `[modules.vitest]
 source = "modules/vitest"
@@ -581,19 +581,49 @@ retries = 0
 		require.JSONEq(t, `["smoke", "regression"]`, strings.TrimSpace(string(out)))
 	})
 
-	t.Run("JSON array writes round-trip through settings to the constructor", func(ctx context.Context, t *testctx.T) {
+	t.Run("variadic writes round-trip through settings to the constructor", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", `["!docs","!integration"]`)
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke", "regression")
 		require.NoError(t, err)
 
 		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.tags")
 		require.NoError(t, err)
-		require.Equal(t, "[!docs, !integration]", strings.TrimSpace(string(out)))
+		require.Equal(t, "[smoke, regression]", strings.TrimSpace(string(out)))
 
 		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "call", "tags", "--json")
 		require.NoError(t, err)
-		require.JSONEq(t, `["!docs", "!integration"]`, strings.TrimSpace(string(out)))
+		require.JSONEq(t, `["smoke", "regression"]`, strings.TrimSpace(string(out)))
+	})
+
+	t.Run("variadic values keep commas and JSON-looking elements verbatim", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke,regression", `["docs"]`)
+		require.NoError(t, err)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "tags", "--json")
+		require.NoError(t, err)
+		require.JSONEq(t, `["smoke,regression", "[\"docs\"]"]`, strings.TrimSpace(string(out)))
+	})
+
+	t.Run("a single trailing value for a list setting keeps comma-splitting behavior", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke,regression")
+		require.NoError(t, err)
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "tags", "--json")
+		require.NoError(t, err)
+		require.JSONEq(t, `["smoke", "regression"]`, strings.TrimSpace(string(out)))
+	})
+
+	t.Run("multiple values for a scalar setting fail clearly", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "retries", "1", "2")
+		require.Error(t, err)
+		requireErrOut(t, err, `setting "retries" of module "vitest" is not a list and accepts a single value`)
 	})
 }
 

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -196,7 +196,8 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Doc("Return this workspace with a configuration value written.").
 			Args(
 				dagql.Arg("key").Doc("Dotted key path."),
-				dagql.Arg("value").Doc("Value to set."),
+				dagql.Arg("value").Doc("Value to set. Bools, integers, and comma-separated arrays are auto-detected."),
+				dagql.Arg("values").Doc("List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
 		dagql.NodeFunc("withoutConfigValue", s.withoutConfigValue).

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -147,7 +147,19 @@ func (s *workspaceSchema) withConfigValue(
 		}
 	}
 
-	updated, err := workspace.WriteConfigValue(staged.Data, writeKey, args.Value)
+	var updated []byte
+	if args.Values.Valid {
+		if args.Value != "" {
+			return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("value and values are mutually exclusive")
+		}
+		elements := make([]string, 0, len(args.Values.Value))
+		for _, v := range args.Values.Value {
+			elements = append(elements, v.String())
+		}
+		updated, err = workspace.WriteConfigValues(staged.Data, writeKey, elements)
+	} else {
+		updated, err = workspace.WriteConfigValue(staged.Data, writeKey, args.Value)
+	}
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -216,9 +216,10 @@ func (s *workspaceSchema) configRead(
 }
 
 type workspaceConfigValueArgs struct {
-	Key   string
-	Value string
-	Here  bool `default:"false"`
+	Key    string
+	Value  string
+	Values dagql.Optional[dagql.ArrayInput[dagql.String]]
+	Here   bool `default:"false"`
 }
 
 type workspaceConfigKeyArgs struct {

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -180,6 +180,7 @@ func (s *workspaceSchema) moduleSettings(
 			Key:         hint.Name,
 			Value:       value,
 			Description: hint.Description,
+			IsList:      hint.IsList,
 		})
 	}
 

--- a/core/schema/workspace_settings_hints.go
+++ b/core/schema/workspace_settings_hints.go
@@ -248,6 +248,7 @@ func buildHintFromArg(arg *core.FunctionArg) (workspace.ConstructorArgHint, bool
 	return workspace.ConstructorArgHint{
 		Name:         arg.Name,
 		TypeLabel:    typeLabel,
+		IsList:       arg.TypeDef.Self().Kind == core.TypeDefKindList,
 		Description:  arg.Description,
 		ExampleValue: exampleValue,
 	}, true

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -1,9 +1,7 @@
 package workspace
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -632,6 +630,21 @@ func readMissingConfigDefault(tree *toml.Tree, parts []string) (string, bool) {
 
 // WriteConfigValue writes a typed value to config TOML at the given dotted key.
 func WriteConfigValue(existingData []byte, key string, rawValue string) ([]byte, error) {
+	return writeConfigValueAtKey(existingData, key, func(parts []string) any {
+		return parseValueString(parts, rawValue)
+	})
+}
+
+// WriteConfigValues writes a string-array value to config TOML at the given
+// dotted key. Elements are stored verbatim, with no comma-splitting or type
+// auto-detection.
+func WriteConfigValues(existingData []byte, key string, values []string) ([]byte, error) {
+	return writeConfigValueAtKey(existingData, key, func([]string) any {
+		return values
+	})
+}
+
+func writeConfigValueAtKey(existingData []byte, key string, valueFor func(parts []string) any) ([]byte, error) {
 	if key == "" {
 		return nil, fmt.Errorf("key is required for writing")
 	}
@@ -651,8 +664,7 @@ func WriteConfigValue(existingData []byte, key string, rawValue string) ([]byte,
 		cfg = &Config{}
 	}
 
-	value := parseValueString(parts, rawValue)
-	if err := setConfigValue(cfg, parts, value); err != nil {
+	if err := setConfigValue(cfg, parts, valueFor(parts)); err != nil {
 		return nil, err
 	}
 
@@ -1267,9 +1279,6 @@ func parseValueString(parts []string, rawValue string) any {
 	if value, err := strconv.ParseFloat(rawValue, 64); err == nil {
 		return value
 	}
-	if values, ok := parseJSONArrayValue(rawValue); ok {
-		return values
-	}
 	if strings.Contains(rawValue, ",") {
 		items := strings.Split(rawValue, ",")
 		values := make([]string, len(items))
@@ -1280,39 +1289,4 @@ func parseValueString(parts []string, rawValue string) any {
 	}
 
 	return rawValue
-}
-
-// parseJSONArrayValue parses a JSON array of scalars into TOML-typed values.
-// Non-JSON values (e.g. glob patterns like "[abc]*") report false so callers
-// fall back to plain string handling.
-func parseJSONArrayValue(rawValue string) ([]any, bool) {
-	trimmed := strings.TrimSpace(rawValue)
-	if !strings.HasPrefix(trimmed, "[") {
-		return nil, false
-	}
-	dec := json.NewDecoder(strings.NewReader(trimmed))
-	dec.UseNumber()
-	var values []any
-	if err := dec.Decode(&values); err != nil {
-		return nil, false
-	}
-	if _, err := dec.Token(); err != io.EOF {
-		return nil, false
-	}
-	for i, item := range values {
-		switch v := item.(type) {
-		case string, bool:
-		case json.Number:
-			if n, err := strconv.ParseInt(v.String(), 10, 64); err == nil {
-				values[i] = n
-			} else if f, err := v.Float64(); err == nil {
-				values[i] = f
-			} else {
-				return nil, false
-			}
-		default:
-			return nil, false
-		}
-	}
-	return values, true
 }

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -1253,9 +1253,7 @@ func preferredExampleFieldName(t reflect.Type) string {
 }
 
 func parseValueString(parts []string, rawValue string) any {
-	leaf := parts[len(parts)-1]
-
-	if leaf == "entrypoint" || leaf == "legacy-default-path" ||
+	if (len(parts) == 3 && parts[0] == "modules" && (parts[2] == "entrypoint" || parts[2] == "legacy-default-path")) ||
 		(len(parts) == 1 && (parts[0] == "defaults_from_dotenv" || parts[0] == "check-generated")) {
 		return rawValue == "true"
 	}

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -14,6 +14,7 @@ import (
 type ConstructorArgHint struct {
 	Name         string
 	TypeLabel    string
+	IsList       bool
 	Description  string
 	ExampleValue string
 }

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -428,34 +428,14 @@ func TestWriteConfigValue(t *testing.T) {
 		require.Equal(t, "cmd/ci.go", cfg.Env["ci"].Modules["greeter"].Settings["entrypoint"])
 	})
 
-	t.Run("writes JSON array values as native arrays", func(t *testing.T) {
-		t.Parallel()
-
-		data, err := WriteConfigValue(nil, "modules.greeter.settings.lint", `["!docs","!x"]`)
-		require.NoError(t, err)
-		data, err = WriteConfigValue(data, "modules.greeter.settings.counts", `[1, 2]`)
-		require.NoError(t, err)
-		data, err = WriteConfigValue(data, "modules.greeter.settings.flags", `[true, false]`)
-		require.NoError(t, err)
-		data, err = WriteConfigValue(data, "modules.greeter.settings.ratios", `[0.5, 1.5]`)
-		require.NoError(t, err)
-
-		cfg, err := ParseConfig(data)
-		require.NoError(t, err)
-		require.Equal(t, map[string]any{
-			"lint":   []any{"!docs", "!x"},
-			"counts": []any{int64(1), int64(2)},
-			"flags":  []any{true, false},
-			"ratios": []any{0.5, 1.5},
-		}, cfg.Modules["greeter"].Settings)
-	})
-
-	t.Run("bracketed non-JSON values keep string handling", func(t *testing.T) {
+	t.Run("bracketed values keep string handling instead of JSON parsing", func(t *testing.T) {
 		t.Parallel()
 
 		data, err := WriteConfigValue(nil, "modules.greeter.settings.glob", `[abc]*`)
 		require.NoError(t, err)
 		data, err = WriteConfigValue(data, "modules.greeter.settings.globs", `[a]*,[b]*`)
+		require.NoError(t, err)
+		data, err = WriteConfigValue(data, "modules.greeter.settings.lint", `["!docs","!x"]`)
 		require.NoError(t, err)
 
 		cfg, err := ParseConfig(data)
@@ -463,7 +443,29 @@ func TestWriteConfigValue(t *testing.T) {
 		require.Equal(t, map[string]any{
 			"glob":  "[abc]*",
 			"globs": []any{"[a]*", "[b]*"},
+			"lint":  []any{`["!docs"`, `"!x"]`},
 		}, cfg.Modules["greeter"].Settings)
+	})
+
+	t.Run("WriteConfigValues stores elements verbatim as native arrays", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := WriteConfigValues(nil, "modules.greeter.settings.lint", []string{"!docs", "!x"})
+		require.NoError(t, err)
+		data, err = WriteConfigValues(data, "modules.greeter.settings.tags", []string{"a,b", `["c"]`, "", "true", "42"})
+		require.NoError(t, err)
+		data, err = WriteConfigValues(data, "env.ci.modules.greeter.settings.lint", []string{"ci-only"})
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(data)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"lint": []any{"!docs", "!x"},
+			"tags": []any{"a,b", `["c"]`, "", "true", "42"},
+		}, cfg.Modules["greeter"].Settings)
+		require.Equal(t, map[string]any{
+			"lint": []any{"ci-only"},
+		}, cfg.Env["ci"].Modules["greeter"].Settings)
 	})
 
 	t.Run("writes module skip fields", func(t *testing.T) {

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -414,6 +414,20 @@ func TestWriteConfigValue(t *testing.T) {
 		}, cfg.Env["ci"])
 	})
 
+	t.Run("settings named after module bool fields keep their written value", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := WriteConfigValue(nil, "modules.greeter.settings.entrypoint", "cmd/main.go")
+		require.NoError(t, err)
+		data, err = WriteConfigValue(data, "env.ci.modules.greeter.settings.entrypoint", "cmd/ci.go")
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(data)
+		require.NoError(t, err)
+		require.Equal(t, "cmd/main.go", cfg.Modules["greeter"].Settings["entrypoint"])
+		require.Equal(t, "cmd/ci.go", cfg.Env["ci"].Modules["greeter"].Settings["entrypoint"])
+	})
+
 	t.Run("writes JSON array values as native arrays", func(t *testing.T) {
 		t.Parallel()
 

--- a/core/workspace_module.go
+++ b/core/workspace_module.go
@@ -55,6 +55,7 @@ type WorkspaceModuleSetting struct {
 	Key         string `field:"true" doc:"The setting key."`
 	Value       string `field:"true" doc:"The configured value after applying the selected workspace environment, or empty when unset."`
 	Description string `field:"true" doc:"The constructor argument description."`
+	IsList      bool   `field:"true" doc:"Whether the setting accepts a list of values."`
 }
 
 var _ dagql.PersistedObject = (*WorkspaceModuleSetting)(nil)

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2310,7 +2310,7 @@ dagger search wolfi
 Get, set, or unset module settings (use --env for an env overlay)
 
 ```
-dagger settings [module] [key] [value]
+dagger settings [module] [key] [value...]
 ```
 
 ### Options

--- a/docs/current_docs/reference/configuration/workspace.mdx
+++ b/docs/current_docs/reference/configuration/workspace.mdx
@@ -41,7 +41,7 @@ dagger settings                              # list every module's settings
 dagger settings eslint packageManager yarn   # set one
 ```
 
-`dagger settings <module> <key> <value>` is a typed front-end over the config file — it writes `modules.<module>.settings.<key>`. List values can be passed as a JSON array (`dagger settings eslint paths '["src","lib"]'`) or a comma-separated string (`src,lib`); both are stored as a TOML array. `dagger workspace config <key> <value>` is the lower-level key/value interface to the same file.
+`dagger settings <module> <key> <value>` is a typed front-end over the config file — it writes `modules.<module>.settings.<key>`. List values can be passed as separate arguments (`dagger settings eslint paths src lib`), which are stored verbatim as TOML array elements; a single comma-separated value (`src,lib`) also splits into an array. `dagger workspace config <key> <value>` is the lower-level key/value interface to the same file.
 
 ### Skipping functions for a verb
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6347,8 +6347,15 @@ type Workspace implements Node {
     """Dotted key path."""
     key: String!
 
-    """Value to set."""
+    """
+    Value to set. Bools, integers, and comma-separated arrays are auto-detected.
+    """
     value: String!
+
+    """
+    List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value.
+    """
+    values: [String!]
 
     """Write to the workspace config directory at the workspace cwd."""
     here: Boolean = false
@@ -6569,6 +6576,9 @@ type WorkspaceModuleSetting implements Node {
 
   """A unique identifier for this WorkspaceModuleSetting."""
   id: ID!
+
+  """Whether the setting accepts a list of values."""
+  isList: Boolean!
 
   """The setting key."""
   key: String!

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -386,7 +386,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withConfigValue">withConfigValue</a>(string $key, string $value, bool|null $here = false)
+                    <a href="#method_withConfigValue">withConfigValue</a>(string $key, string $value, array|null $values = null, bool|null $here = false)
         
                                             <p><p>Return this workspace with a configuration value written.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1594,7 +1594,7 @@
                     <h3 id="method_withConfigValue">
         <div class="location">at line 357</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withConfigValue</strong>(string $key, string $value, bool|null $here = false)
+    <strong>withConfigValue</strong>(string $key, string $value, array|null $values = null, bool|null $here = false)
         </code>
     </h3>
     <div class="details">    
@@ -1616,6 +1616,11 @@
                     <tr>
                 <td>string</td>
                 <td>$value</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>array|null</td>
+                <td>$values</td>
                 <td></td>
             </tr>
                     <tr>
@@ -1644,7 +1649,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 371</div>
+        <div class="location">at line 374</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
         </code>
@@ -1706,7 +1711,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 394</div>
+        <div class="location">at line 397</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
         </code>
@@ -1778,7 +1783,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 427</div>
+        <div class="location">at line 430</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -1830,7 +1835,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 443</div>
+        <div class="location">at line 446</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -1877,7 +1882,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 454</div>
+        <div class="location">at line 457</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -1929,7 +1934,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 468</div>
+        <div class="location">at line 471</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -1986,7 +1991,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 487</div>
+        <div class="location">at line 490</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2018,7 +2023,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 496</div>
+        <div class="location">at line 499</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2065,7 +2070,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 511</div>
+        <div class="location">at line 514</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2112,7 +2117,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 524</div>
+        <div class="location">at line 527</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2159,7 +2164,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 537</div>
+        <div class="location">at line 540</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/Dagger/WorkspaceModuleSetting.html
+++ b/docs/static/reference/php/Dagger/WorkspaceModuleSetting.html
@@ -163,6 +163,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    bool
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_isList">isList</a>()
+        
+                                            <p><p>Whether the setting accepts a list of values.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     string
                 </div>
                 <div class="col-md-8">
@@ -341,8 +351,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_key">
+                    <h3 id="method_isList">
         <div class="location">at line 37</div>
+        <code>                    bool
+    <strong>isList</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Whether the setting accepts a list of values.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>bool</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_key">
+        <div class="location">at line 46</div>
         <code>                    string
     <strong>key</strong>()
         </code>
@@ -374,7 +416,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_value">
-        <div class="location">at line 46</div>
+        <div class="location">at line 55</div>
         <code>                    string
     <strong>value</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -982,7 +982,9 @@
 <abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a></em></dt>
                     <dd><p>A unique identifier for this WorkspaceModule.</p></dd><dt><a href="Dagger/WorkspaceModuleSetting.html#method_id">
 <abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
-                    <dd><p>A unique identifier for this WorkspaceModuleSetting.</p></dd><dt><a href="Dagger/WorkspaceSDK.html#method_id">
+                    <dd><p>A unique identifier for this WorkspaceModuleSetting.</p></dd><dt><a href="Dagger/WorkspaceModuleSetting.html#method_isList">
+<abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::isList</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
+                    <dd><p>Whether the setting accepts a list of values.</p></dd><dt><a href="Dagger/WorkspaceSDK.html#method_id">
 <abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceSDK.html"><abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr></a></em></dt>
                     <dd><p>A unique identifier for this WorkspaceSDK.</p></dd>        </dl><h2 id="letterJ">J</h2>
         <dl id="indexJ"><dt><a href="Dagger/Client.html#method_json">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -7082,6 +7082,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\WorkspaceModuleSetting::isList",
+			"p": "Dagger/WorkspaceModuleSetting.html#method_isList",
+			"d": "<p>Whether the setting accepts a list of values.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\WorkspaceModuleSetting::key",
 			"p": "Dagger/WorkspaceModuleSetting.html#method_key",
 			"d": "<p>The setting key.</p>"

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -677,7 +677,7 @@ func isWorkspaceConfigCommand(cmd *cobra.Command) bool {
 func isWorkspaceSettingsWriteCommand(cmd *cobra.Command, args []string) bool {
 	switch commandName(cmd) {
 	case "settings", "workspace settings":
-		return len(args) == 3
+		return len(args) >= 3
 	default:
 		return false
 	}

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -43,6 +43,25 @@ query WorkspaceModuleSettings($module: String!) {
 }
 `
 
+// workspaceModuleSettingsQueryWithIsList additionally requests isList, which
+// older engines don't expose. Only multi-value writes need it, so other flows
+// use the queries above and keep working against those engines.
+const workspaceModuleSettingsQueryWithIsList = `
+query WorkspaceModuleSettings($module: String!) {
+  currentWorkspace {
+    module(name: $module) {
+      name
+      settings {
+        key
+        value
+        description
+        isList
+      }
+    }
+  }
+}
+`
+
 var settingsCmd = newSettingsCmd(false)
 
 // workspaceSettingsCmd is retained as a hidden alias under `dagger workspace`
@@ -60,10 +79,10 @@ var workspaceSettingsUnset bool
 
 func newSettingsCmd(hidden bool) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "settings [module] [key] [value]",
+		Use:    "settings [module] [key] [value...]",
 		Short:  "Get, set, or unset module settings (use --env for an env overlay)",
 		Hidden: hidden,
-		Args:   cobra.MaximumNArgs(3),
+		Args:   cobra.ArbitraryArgs,
 		RunE:   runWorkspaceSettings,
 	}
 	cmd.Flags().BoolVarP(&workspaceSettingsUnset, "unset", "u", false, "Remove the setting from workspace config")
@@ -80,7 +99,7 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 			moduleName = args[0]
 		}
 
-		state, err := loadWorkspaceSettingsState(ctx, engineClient.Dagger(), moduleName)
+		state, err := loadWorkspaceSettingsState(ctx, engineClient.Dagger(), moduleName, len(args) > 3)
 		if err != nil {
 			return err
 		}
@@ -105,16 +124,18 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 			}
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), setting.Value)
 			return err
-		case 3:
+		default:
 			setting, err := state.lookupSetting(args[1])
 			if err != nil {
 				return err
 			}
+			value, values, err := workspaceSettingWriteValue(setting, args[2:])
+			if err != nil {
+				return err
+			}
 			return state.Workspace.
-				WithConfigValue(workspaceSettingConfigKey(setting.Module, setting.Key), args[2], dagger.WorkspaceWithConfigValueOpts{Here: workspaceHere}).
+				WithConfigValue(workspaceSettingConfigKey(setting.Module, setting.Key), value, dagger.WorkspaceWithConfigValueOpts{Values: values, Here: workspaceHere}).
 				Export(ctx)
-		default:
-			return fmt.Errorf("expected 0-3 arguments, got %d", len(args))
 		}
 	})
 }
@@ -124,6 +145,22 @@ type workspaceSetting struct {
 	Key         string
 	Value       string
 	Description string
+	IsList      bool
+}
+
+// workspaceSettingWriteValue maps trailing CLI args onto WithConfigValue's
+// value/values split. A single value passes through unchanged so existing
+// scalar and comma-separated forms keep their behavior. Multiple values are
+// only valid for list settings and are passed as an explicit list so elements
+// round-trip exactly, without comma-splitting.
+func workspaceSettingWriteValue(setting workspaceSetting, args []string) (string, []string, error) {
+	if len(args) == 1 {
+		return args[0], nil, nil
+	}
+	if !setting.IsList {
+		return "", nil, fmt.Errorf("setting %q of module %q is not a list and accepts a single value", setting.Key, setting.Module)
+	}
+	return "", args, nil
 }
 
 type workspaceSettingsState struct {
@@ -132,7 +169,7 @@ type workspaceSettingsState struct {
 	Settings  []workspaceSetting
 }
 
-func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleName string) (*workspaceSettingsState, error) {
+func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleName string, withIsList bool) (*workspaceSettingsState, error) {
 	type settingsModule struct {
 		Name     string
 		Settings []workspaceSetting
@@ -149,13 +186,17 @@ func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleN
 		}
 		modules = res.CurrentWorkspace.Modules
 	} else {
+		query := workspaceModuleSettingsQuery
+		if withIsList {
+			query = workspaceModuleSettingsQueryWithIsList
+		}
 		var res struct {
 			CurrentWorkspace struct {
 				Module settingsModule
 			}
 		}
 		if err := dag.Do(ctx, &dagger.Request{
-			Query:     workspaceModuleSettingsQuery,
+			Query:     query,
 			Variables: map[string]any{"module": moduleName},
 		}, &dagger.Response{Data: &res}); err != nil {
 			return nil, err

--- a/internal/cmd/dagger/settings_test.go
+++ b/internal/cmd/dagger/settings_test.go
@@ -1,0 +1,47 @@
+package daggercmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceSettingWriteValue(t *testing.T) {
+	listSetting := workspaceSetting{Module: "vitest", Key: "tags", IsList: true}
+	scalarSetting := workspaceSetting{Module: "aws", Key: "region"}
+
+	t.Run("a single value passes through unchanged", func(t *testing.T) {
+		for _, setting := range []workspaceSetting{listSetting, scalarSetting} {
+			for _, value := range []string{"plain", "a,b", "[abc]*", ""} {
+				got, values, err := workspaceSettingWriteValue(setting, []string{value})
+				require.NoError(t, err)
+				require.Equal(t, value, got)
+				require.Nil(t, values)
+			}
+		}
+	})
+
+	t.Run("multiple values for a list setting pass as an explicit list", func(t *testing.T) {
+		value, values, err := workspaceSettingWriteValue(listSetting, []string{"docs", "sdk/go"})
+		require.NoError(t, err)
+		require.Empty(t, value)
+		require.Equal(t, []string{"docs", "sdk/go"}, values)
+	})
+
+	t.Run("elements with commas or brackets stay verbatim", func(t *testing.T) {
+		value, values, err := workspaceSettingWriteValue(listSetting, []string{"a,b", `["c"]`})
+		require.NoError(t, err)
+		require.Empty(t, value)
+		require.Equal(t, []string{"a,b", `["c"]`}, values)
+	})
+
+	t.Run("multiple values for a scalar setting fail", func(t *testing.T) {
+		_, _, err := workspaceSettingWriteValue(scalarSetting, []string{"one", "two"})
+		require.ErrorContains(t, err, `setting "region" of module "aws" is not a list and accepts a single value`)
+	})
+
+	t.Run("multiple values fail when isList is unset", func(t *testing.T) {
+		_, _, err := workspaceSettingWriteValue(workspaceSetting{Module: "m", Key: "k"}, []string{"one", "two"})
+		require.ErrorContains(t, err, "is not a list")
+	})
+}

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -372,6 +372,7 @@ func TestWorkspaceFlagPolicy(t *testing.T) {
 
 	workspaceRef = "github.com/acme/ws"
 	require.ErrorContains(t, validateWorkspaceFlagPolicy(settingsCmd, []string{"foo", "bar", "baz"}), "must be a local path")
+	require.ErrorContains(t, validateWorkspaceFlagPolicy(settingsCmd, []string{"foo", "bar", "baz", "qux"}), "must be a local path")
 	require.NoError(t, validateWorkspaceFlagPolicy(settingsCmd, []string{"foo", "bar"}))
 	require.ErrorContains(t, validateWorkspaceFlagPolicy(workspaceSettingsCmd, []string{"foo", "bar", "baz"}), "must be a local path")
 	require.NoError(t, validateWorkspaceFlagPolicy(workspaceSettingsCmd, []string{"foo", "bar"}))

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -443,14 +443,17 @@ defmodule Dagger.Workspace do
   @doc """
   Return this workspace with a configuration value written.
   """
-  @spec with_config_value(t(), String.t(), String.t(), [{:here, boolean() | nil}]) ::
-          Dagger.Workspace.t()
+  @spec with_config_value(t(), String.t(), String.t(), [
+          {:values, [String.t()]},
+          {:here, boolean() | nil}
+        ]) :: Dagger.Workspace.t()
   def with_config_value(%__MODULE__{} = workspace, key, value, optional_args \\ []) do
     query_builder =
       workspace.query_builder
       |> QB.select("withConfigValue")
       |> QB.put_arg("key", key)
       |> QB.put_arg("value", value)
+      |> QB.maybe_put_arg("values", optional_args[:values])
       |> QB.maybe_put_arg("here", optional_args[:here])
 
     %Dagger.Workspace{

--- a/sdk/elixir/lib/dagger/gen/workspace_module_setting.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace_module_setting.ex
@@ -38,6 +38,17 @@ defmodule Dagger.WorkspaceModuleSetting do
   end
 
   @doc """
+  Whether the setting accepts a list of values.
+  """
+  @spec list?(t()) :: {:ok, boolean()} | {:error, term()}
+  def list?(%__MODULE__{} = workspace_module_setting) do
+    query_builder =
+      workspace_module_setting.query_builder |> QB.select("isList")
+
+    Client.execute(workspace_module_setting.client, query_builder)
+  end
+
+  @doc """
   The setting key.
   """
   @spec key(t()) :: {:ok, String.t()} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16630,6 +16630,8 @@ func (r *Workspace) WithConfigEnv(name string, opts ...WorkspaceWithConfigEnvOpt
 
 // WorkspaceWithConfigValueOpts contains options for Workspace.WithConfigValue
 type WorkspaceWithConfigValueOpts struct {
+	// List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value.
+	Values []string
 	// Write to the workspace config directory at the workspace cwd.
 	Here bool
 }
@@ -16638,6 +16640,10 @@ type WorkspaceWithConfigValueOpts struct {
 func (r *Workspace) WithConfigValue(key string, value string, opts ...WorkspaceWithConfigValueOpts) *Workspace {
 	q := r.query.Select("withConfigValue")
 	for i := len(opts) - 1; i >= 0; i-- {
+		// `values` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Values) {
+			q = q.Arg("values", opts[i].Values)
+		}
 		// `here` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Here) {
 			q = q.Arg("here", opts[i].Here)
@@ -17366,6 +17372,7 @@ type WorkspaceModuleSetting struct {
 
 	description *string
 	id          *ID
+	isList      *bool
 	key         *string
 	value       *string
 }
@@ -17427,6 +17434,19 @@ func (r *WorkspaceModuleSetting) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(id)
+}
+
+// Whether the setting accepts a list of values.
+func (r *WorkspaceModuleSetting) IsList(ctx context.Context) (bool, error) {
+	if r.isList != nil {
+		return *r.isList, nil
+	}
+	q := r.query.Select("isList")
+
+	var response bool
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The setting key.

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -354,11 +354,14 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * Return this workspace with a configuration value written.
      */
-    public function withConfigValue(string $key, string $value, ?bool $here = false): Workspace
+    public function withConfigValue(string $key, string $value, ?array $values = null, ?bool $here = false): Workspace
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withConfigValue');
         $innerQueryBuilder->setArgument('key', $key);
         $innerQueryBuilder->setArgument('value', $value);
+        if (null !== $values) {
+        $innerQueryBuilder->setArgument('values', $values);
+        }
         if (null !== $here) {
         $innerQueryBuilder->setArgument('here', $here);
         }

--- a/sdk/php/generated/WorkspaceModuleSetting.php
+++ b/sdk/php/generated/WorkspaceModuleSetting.php
@@ -32,6 +32,15 @@ class WorkspaceModuleSetting extends Client\AbstractObject implements Client\IdA
     }
 
     /**
+     * Whether the setting accepts a list of values.
+     */
+    public function isList(): bool
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('isList');
+        return (bool)$this->queryLeaf($leafQueryBuilder, 'isList');
+    }
+
+    /**
      * The setting key.
      */
     public function key(): string

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -16312,6 +16312,7 @@ class Workspace(Type):
         key: str,
         value: str,
         *,
+        values: list[str] | None = None,
         here: bool | None = False,
     ) -> Self:
         """Return this workspace with a configuration value written.
@@ -16321,13 +16322,18 @@ class Workspace(Type):
         key:
             Dotted key path.
         value:
-            Value to set.
+            Value to set. Bools, integers, and comma-separated arrays are
+            auto-detected.
+        values:
+            List value to set. Elements are stored verbatim, with no auto-
+            detection. Mutually exclusive with value.
         here:
             Write to the workspace config directory at the workspace cwd.
         """
         _args = [
             Arg("key", key),
             Arg("value", value),
+            Arg("values", values, None),
             Arg("here", here, False),
         ]
         _ctx = self._select("withConfigValue", _args)
@@ -16965,6 +16971,25 @@ class WorkspaceModuleSetting(Type):
         _args: list[Arg] = []
         _ctx = self._select("id", _args)
         return await _ctx.execute(str)
+
+    async def is_list(self) -> bool:
+        """Whether the setting accepts a list of values.
+
+        Returns
+        -------
+        bool
+            The `Boolean` scalar type represents `true` or `false`.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("isList", _args)
+        return await _ctx.execute(bool)
 
     async def key(self) -> str:
         """The setting key.

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -16228,10 +16228,13 @@ pub struct WorkspaceWithConfigEnvOpts {
     pub here: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct WorkspaceWithConfigValueOpts {
+pub struct WorkspaceWithConfigValueOpts<'a> {
     /// Write to the workspace config directory at the workspace cwd.
     #[builder(setter(into, strip_option), default)]
     pub here: Option<bool>,
+    /// List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value.
+    #[builder(setter(into, strip_option), default)]
+    pub values: Option<Vec<&'a str>>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceWithInitClientOpts {
@@ -16838,7 +16841,7 @@ impl Workspace {
     /// # Arguments
     ///
     /// * `key` - Dotted key path.
-    /// * `value` - Value to set.
+    /// * `value` - Value to set. Bools, integers, and comma-separated arrays are auto-detected.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_config_value(&self, key: impl Into<String>, value: impl Into<String>) -> Workspace {
         let mut query = self.selection.select("withConfigValue");
@@ -16855,17 +16858,20 @@ impl Workspace {
     /// # Arguments
     ///
     /// * `key` - Dotted key path.
-    /// * `value` - Value to set.
+    /// * `value` - Value to set. Bools, integers, and comma-separated arrays are auto-detected.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_config_value_opts(
+    pub fn with_config_value_opts<'a>(
         &self,
         key: impl Into<String>,
         value: impl Into<String>,
-        opts: WorkspaceWithConfigValueOpts,
+        opts: WorkspaceWithConfigValueOpts<'a>,
     ) -> Workspace {
         let mut query = self.selection.select("withConfigValue");
         query = query.arg("key", key.into());
         query = query.arg("value", value.into());
+        if let Some(values) = opts.values {
+            query = query.arg("values", values);
+        }
         if let Some(here) = opts.here {
             query = query.arg("here", here);
         }
@@ -17612,6 +17618,11 @@ impl WorkspaceModuleSetting {
     /// A unique identifier for this WorkspaceModuleSetting.
     pub async fn id(&self) -> Result<Id, DaggerError> {
         let query = self.selection.select("id");
+        query.execute(self.graphql_client.clone()).await
+    }
+    /// Whether the setting accepts a list of values.
+    pub async fn is_list(&self) -> Result<bool, DaggerError> {
+        let query = self.selection.select("isList");
         query.execute(self.graphql_client.clone()).await
     }
     /// The setting key.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -2854,6 +2854,11 @@ export type WorkspaceWithConfigEnvOpts = {
 
 export type WorkspaceWithConfigValueOpts = {
   /**
+   * List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value.
+   */
+  values?: string[]
+
+  /**
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
@@ -15465,7 +15470,8 @@ export class Workspace extends BaseClient {
   /**
    * Return this workspace with a configuration value written.
    * @param key Dotted key path.
-   * @param value Value to set.
+   * @param value Value to set. Bools, integers, and comma-separated arrays are auto-detected.
+   * @param opts.values List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
    */
   withConfigValue = (
@@ -15940,6 +15946,7 @@ export class WorkspaceModule extends BaseClient {
 export class WorkspaceModuleSetting extends BaseClient {
   private readonly _id?: ID = undefined
   private readonly _description?: string = undefined
+  private readonly _isList?: boolean = undefined
   private readonly _key?: string = undefined
   private readonly _value?: string = undefined
 
@@ -15950,6 +15957,7 @@ export class WorkspaceModuleSetting extends BaseClient {
     ctx?: Context,
     _id?: ID,
     _description?: string,
+    _isList?: boolean,
     _key?: string,
     _value?: string,
   ) {
@@ -15957,6 +15965,7 @@ export class WorkspaceModuleSetting extends BaseClient {
 
     this._id = _id
     this._description = _description
+    this._isList = _isList
     this._key = _key
     this._value = _value
   }
@@ -15987,6 +15996,21 @@ export class WorkspaceModuleSetting extends BaseClient {
     const ctx = this._ctx.select("description")
 
     const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * Whether the setting accepts a list of values.
+   */
+  isList = async (): Promise<boolean> => {
+    if (this._isList) {
+      return this._isList
+    }
+
+    const ctx = this._ctx.select("isList")
+
+    const response: Awaited<boolean> = await ctx.execute()
 
     return response
   }


### PR DESCRIPTION
Adds the variadic form requested in Discord for list-typed workspace module settings:

    dagger settings go lint docs sdk/go

Follow-up to #13602, and removes the JSON-array-string form that PR introduced — interpreting a single value as JSON is ambiguous (there is no way to tell whether the user meant a JSON-encoded array or a literal string that happens to look like one). The value forms are now:

- Two or more trailing values: only valid for list-typed settings; each argument is stored verbatim as one TOML array element (regular shell quoting, no comma-splitting). Multiple values for a scalar setting fail with a clear error.
- Exactly one value: unchanged scalar behavior; a comma-separated value still splits into an array. JSON-array strings are no longer interpreted — they are treated like any other string.

Under the hood, `Workspace.withConfigValue` gains an explicit optional `values: [String!]` arg that writes elements verbatim (no auto-detection), replacing write-side JSON parsing, and `WorkspaceModuleSetting` gains an `isList` field (derived from the constructor arg's typedef kind, v1-gated at the class level) so the CLI can tell list settings apart from scalars. The CLI only requests `isList` and sends `values` for multi-value writes, so reads and single-value writes keep working against older v1.0.0-beta engines.

Also fixes a pre-existing config bug this surfaced: any config key whose leaf was named `entrypoint`/`legacy-default-path` was bool-coerced, so a module *setting* named `entrypoint` silently became `false`; coercion now applies only to the exact `modules.<name>.<field>` path.

Verified: unit tests (internal/cmd/dagger, core/workspace, core/schema incl. base-schema allowlist), integration suites TestWorkspaceSettings{CommandGrammar,ListValues,WriteSemantics,Discovery,ConfigProjection} (32 subtests green), and end-to-end against a dev engine: variadic writes produce real TOML arrays with verbatim elements delivered to the module constructor; env-overlay writes, comma-separated form, and scalar settings unchanged; JSON-array strings confirmed no longer interpreted.

