### PR TITLE
ci: restore omitted CLI and unit test coverage

### DIFF
--- a/internal/cmd/dagger/shell_completion_test.go
+++ b/internal/cmd/dagger/shell_completion_test.go
@@ -85,7 +85,7 @@ func (DaggerCMDSuite) TestShellAutocomplete(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	require.NoError(t, os.CopyFS(dir, os.DirFS(filepath.Join(wd, "../../modules"))))
+	require.NoError(t, os.CopyFS(dir, os.DirFS(filepath.Join(wd, "../../../modules"))))
 	cmd := exec.Command("git", "init")
 	cmd.Dir = dir
 	require.NoError(t, cmd.Run())

--- a/toolchains/test-split/main.dang
+++ b/toolchains/test-split/main.dang
@@ -42,7 +42,40 @@ type TestSplit {
   """
   pub testBase: Void @check {
     testSkip(
-      skip: ["TestProvision", "TestTelemetry", "TestModule", "TestGo", "TestPython", "TestTypescript", "TestElixir", "TestPHP", "TestJava", "TestContainer", "TestDockerfile", "TestLLM", "TestCLI", "TestEngine", "TestCachePersistence", "TestLocalCache", "TestClientGenerator", "TestInterface", "TestCall", "TestShell", "TestDaggerCMD", "TestWorkspace"],
+      # Keep this list exact so similarly named unit tests outside the integration
+      # package remain in the base shard.
+      skip: [
+        "^TestCLI$",
+        "^TestCachePersistence$",
+        "^TestCall$",
+        "^TestClientGenerator$",
+        "^TestContainer$",
+        "^TestDaggerCMD$",
+        "^TestDockerfile$",
+        "^TestElixir$",
+        "^TestEngine$",
+        "^TestGo$",
+        "^TestInterface$",
+        "^TestJava$",
+        "^TestLLM$",
+        "^TestLocalCache$",
+        "^TestModule$",
+        "^TestModuleConfig$",
+        "^TestModuleLoading$",
+        "^TestPHP$",
+        "^TestProvision$",
+        "^TestPython$",
+        "^TestShell$",
+        "^TestTelemetry$",
+        "^TestTypescript$",
+        "^TestWorkspace$",
+        "^TestWorkspaceAPI$",
+        "^TestWorkspaceCompat$",
+        "^TestWorkspaceLegacyDefaultPath$",
+        "^TestWorkspaceMigration$",
+        "^TestWorkspaceModules$",
+        "^TestWorkspaceSelection$",
+      ],
       pkg: "./...",
       race: true,
     )
@@ -59,14 +92,20 @@ type TestSplit {
   Test Telemetry
   """
   pub testTelemetry: Void @check {
-    testSpecific(["TestTelemetry"], pkg: "./dagql/idtui")
+    testSpecific(["^TestTelemetry$"], pkg: "./dagql/idtui")
+    testSpecific(["^TestTelemetry$"])
+
+    null
   }
 
   """
   Test Call and Shell
   """
   pub testCallAndShell: Void @check {
-    testSpecific(["TestCall", "TestShell", "TestDaggerCMD"])
+    testSpecific(["^TestCall$", "^TestShell$"])
+    testSpecific(["^TestDaggerCMD$"], pkg: "./internal/cmd/dagger")
+
+    null
   }
 
   """


### PR DESCRIPTION
## Summary

- fix the shell-autocomplete test's repository-relative `modules` fixture path after the CLI package moved under `internal/cmd/dagger`
- route `TestDaggerCMD` explicitly through the call-and-shell shard
- make the base shard skip only exact, explicitly routed integration suites so similarly named unit tests remain covered
- restore the omitted `core/integration.TestTelemetry` route alongside the existing `dagql/idtui` telemetry suite

## Root cause

The CLI package move added one directory level without updating the test's `../../modules` path, so the fixture resolved to the nonexistent `internal/modules` directory.

CI did not catch that regression because the test split had a routing hole. `test-base` skipped `TestDaggerCMD` across `./...`, while `test-call-and-shell` requested that test but defaulted to `./core/integration`, where it does not exist. The same unanchored base skip patterns also filtered similarly prefixed unit tests outside the integration package.

The revised routing keeps the integration shards intact while enumerating their exact top-level suite names in the base exclusion list. `TestDaggerCMD` is now explicitly run from `./internal/cmd/dagger`, and the telemetry shard covers both intended packages.

## Validation

- `_EXPERIMENTAL_DAGGER_CLI_BIN="$(command -v dagger)" go test ./internal/cmd/dagger -count=1`
- `test-split test-call-and-shell`: 398 passed ([trace](https://dagger.cloud/dagger/traces/d89127d64063a00cb3fe02f0c0d18a30))
- restored base tests under the race detector: 180 passed ([trace](https://dagger.cloud/dagger/traces/6cad30b092a94155b29d36293c687600))
- `core/integration.TestTelemetry`: 3 passed ([trace](https://dagger.cloud/dagger/traces/892f767e3106b3b4e7a1b51a44cc8b72))
- test-split module load and `git diff --check`

The unchanged `dagql/idtui` telemetry golden suite can fail locally on cold-cache rendering differences such as `CACHED` versus fresh pull output; the newly restored core telemetry route passes independently.
