### PR TITLE
core: compute changeset diffs from metadata instead of full-content g…

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -102,8 +102,10 @@ type DiffStat struct {
 	RemovedLines int          `field:"true" doc:"Number of removed lines for this path."`
 }
 
-var _ dagql.PersistedObject = (*DiffStat)(nil)
-var _ dagql.PersistedObjectDecoder = (*DiffStat)(nil)
+var (
+	_ dagql.PersistedObject        = (*DiffStat)(nil)
+	_ dagql.PersistedObjectDecoder = (*DiffStat)(nil)
+)
 
 func (*DiffStat) Type() *ast.Type {
 	return &ast.Type{
@@ -147,7 +149,8 @@ func (*DiffStat) DecodePersistedObject(_ context.Context, _ *dagql.Server, _ uin
 	}, nil
 }
 
-// ComputePaths computes the added, modified, and removed paths using git diff.
+// ComputePaths computes the added, modified, and removed paths using file
+// metadata and git diffs.
 func (ch *Changeset) ComputePaths(ctx context.Context) (*ChangesetPaths, error) {
 	ch.pathsOnce.Do(func() {
 		ch.cachedPaths, ch.pathsErr = ch.computePathsOnce(ctx)
@@ -170,7 +173,11 @@ func (ch *Changeset) computePathsOnce(ctx context.Context) (*ChangesetPaths, err
 
 	var result *ChangesetPaths
 	err = ch.withMountedDirs(ctx, func(beforeDir, afterDir string) (err error) {
-		result, err = computeChangesetPaths(ctx, beforeDir, afterDir)
+		result, _, err = computeChangesetPathsDelta(ctx, beforeDir, afterDir, false)
+		if err != nil {
+			slog.Warn("changeset delta diff failed; falling back to full content diff", "error", err)
+			result, err = computeChangesetPaths(ctx, beforeDir, afterDir)
+		}
 		return err
 	})
 	if err != nil {
@@ -410,10 +417,12 @@ func (*Changeset) TypeDescription() string {
 	return "A comparison between two directories representing changes that can be applied."
 }
 
-var _ Syncable = (*Changeset)(nil)
-var _ dagql.PersistedObject = (*Changeset)(nil)
-var _ dagql.PersistedObjectDecoder = (*Changeset)(nil)
-var _ dagql.HasDependencyResults = (*Changeset)(nil)
+var (
+	_ Syncable                     = (*Changeset)(nil)
+	_ dagql.PersistedObject        = (*Changeset)(nil)
+	_ dagql.PersistedObjectDecoder = (*Changeset)(nil)
+	_ dagql.HasDependencyResults   = (*Changeset)(nil)
+)
 
 func (ch *Changeset) Evaluate(context.Context) error {
 	return nil
@@ -480,6 +489,16 @@ func (ch *Changeset) IsEmpty(ctx context.Context) (bool, error) {
 
 	var isEmpty bool
 	err = ch.withMountedDirs(ctx, func(beforeDir, afterDir string) error {
+		paths, _, err := computeChangesetPathsDelta(ctx, beforeDir, afterDir, false)
+		if err == nil {
+			// Like `git diff --quiet`, only file-level changes count;
+			// directory-only changes (e.g. an added empty dir) don't.
+			isEmpty = len(paths.Modified) == 0 &&
+				!slices.ContainsFunc(paths.Added, isFilePath) &&
+				!slices.ContainsFunc(paths.AllRemoved, isFilePath)
+			return nil
+		}
+		slog.Warn("changeset delta diff failed; falling back to full content diff", "error", err)
 		identical, err := directoriesAreIdentical(ctx, beforeDir, afterDir)
 		if err != nil {
 			return err
@@ -497,17 +516,21 @@ func (ch *Changeset) DiffStats(ctx context.Context) ([]*DiffStat, error) {
 	var paths *ChangesetPaths
 	var statsByPath map[string]lineChanges
 	err := ch.withMountedDirs(ctx, func(beforeDir, afterDir string) error {
-		computedPaths, err := computeChangesetPaths(ctx, beforeDir, afterDir)
+		computedPaths, deltaStats, err := computeChangesetPathsDelta(ctx, beforeDir, afterDir, true)
 		if err != nil {
-			return fmt.Errorf("compute paths: %w", err)
+			slog.Warn("changeset delta diff failed; falling back to full content diff", "error", err)
+			computedPaths, err = computeChangesetPaths(ctx, beforeDir, afterDir)
+			if err != nil {
+				return fmt.Errorf("compute paths: %w", err)
+			}
+			deltaStats, err = compareDirectoriesNumStat(ctx, beforeDir, afterDir)
+			if err != nil {
+				slog.Debug("changeset numstat failed; returning path-only diff stat entries", "error", err)
+				deltaStats = nil
+			}
 		}
 		paths = computedPaths
-
-		statsByPath, err = compareDirectoriesNumStat(ctx, beforeDir, afterDir)
-		if err != nil {
-			slog.Debug("changeset numstat failed; returning path-only diff stat entries", "error", err)
-			statsByPath = nil
-		}
+		statsByPath = deltaStats
 		return nil
 	})
 	if err != nil {
@@ -613,11 +636,11 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 			return MountRef(ctx, newRef, func(root string, _ *mount.Mount) (rerr error) {
 				beforeMount := filepath.Join(root, "a")
 				afterMount := filepath.Join(root, "b")
-				if err := os.Mkdir(beforeMount, 0755); err != nil {
+				if err := os.Mkdir(beforeMount, 0o755); err != nil {
 					return err
 				}
 				defer os.RemoveAll(beforeMount)
-				if err := os.Mkdir(afterMount, 0755); err != nil {
+				if err := os.Mkdir(afterMount, 0o755); err != nil {
 					return err
 				}
 				defer os.RemoveAll(afterMount)

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -489,13 +489,9 @@ func (ch *Changeset) IsEmpty(ctx context.Context) (bool, error) {
 
 	var isEmpty bool
 	err = ch.withMountedDirs(ctx, func(beforeDir, afterDir string) error {
-		paths, _, err := computeChangesetPathsDelta(ctx, beforeDir, afterDir, false)
+		empty, err := changesetDeltaIsEmpty(ctx, beforeDir, afterDir)
 		if err == nil {
-			// Like `git diff --quiet`, only file-level changes count;
-			// directory-only changes (e.g. an added empty dir) don't.
-			isEmpty = len(paths.Modified) == 0 &&
-				!slices.ContainsFunc(paths.Added, isFilePath) &&
-				!slices.ContainsFunc(paths.AllRemoved, isFilePath)
+			isEmpty = empty
 			return nil
 		}
 		slog.Warn("changeset delta diff failed; falling back to full content diff", "error", err)

--- a/core/changeset_delta.go
+++ b/core/changeset_delta.go
@@ -70,8 +70,14 @@ func computeChangesetPathsDelta(ctx context.Context, beforeDir, afterDir string,
 		tmpBefore := filepath.Join(tmpRoot, "before")
 		tmpAfter := filepath.Join(tmpRoot, "after")
 
-		beforePaths := slices.Clone(modified)
-		afterPaths := slices.Clone(modified)
+		// Modified files exist at the same path on both sides, so they can
+		// never participate in rename pairing; stage them only when numstat
+		// needs their content.
+		var beforePaths, afterPaths []string
+		if materializeModified {
+			beforePaths = slices.Clone(modified)
+			afterPaths = slices.Clone(modified)
+		}
 		if detectRenames {
 			beforePaths = append(beforePaths, delta.removedFiles...)
 			afterPaths = append(afterPaths, delta.addedFiles...)
@@ -252,52 +258,86 @@ func verifyModifiedFiles(ctx context.Context, beforeDir, afterDir string, candid
 		if err := ctx.Err(); err != nil {
 			return nil, context.Cause(ctx)
 		}
-		beforePath := filepath.Join(beforeDir, rel)
-		afterPath := filepath.Join(afterDir, rel)
-		beforeFi, err := os.Lstat(beforePath)
-		if err != nil {
-			return nil, fmt.Errorf("stat %s: %w", beforePath, err)
-		}
-		afterFi, err := os.Lstat(afterPath)
-		if err != nil {
-			return nil, fmt.Errorf("stat %s: %w", afterPath, err)
-		}
-		if gitFileMode(beforeFi) != gitFileMode(afterFi) {
-			modified = append(modified, rel)
-			continue
-		}
-		if beforeFi.Mode()&os.ModeSymlink != 0 {
-			beforeTarget, err := os.Readlink(beforePath)
-			if err != nil {
-				return nil, fmt.Errorf("readlink %s: %w", beforePath, err)
-			}
-			afterTarget, err := os.Readlink(afterPath)
-			if err != nil {
-				return nil, fmt.Errorf("readlink %s: %w", afterPath, err)
-			}
-			if beforeTarget != afterTarget {
-				modified = append(modified, rel)
-			}
-			continue
-		}
-		if !beforeFi.Mode().IsRegular() || !afterFi.Mode().IsRegular() {
-			// Sockets, devices, etc.: metadata differs, so report the change.
-			modified = append(modified, rel)
-			continue
-		}
-		if beforeFi.Size() != afterFi.Size() {
-			modified = append(modified, rel)
-			continue
-		}
-		same, err := fileContentsEqual(beforePath, afterPath)
+		changed, err := modifiedFileDiffers(beforeDir, afterDir, rel)
 		if err != nil {
 			return nil, err
 		}
-		if !same {
+		if changed {
 			modified = append(modified, rel)
 		}
 	}
 	return modified, nil
+}
+
+// modifiedFileDiffers reports whether a single metadata-suspect candidate's
+// git-visible mode or content actually differ between the two trees.
+func modifiedFileDiffers(beforeDir, afterDir, rel string) (bool, error) {
+	beforePath := filepath.Join(beforeDir, rel)
+	afterPath := filepath.Join(afterDir, rel)
+	beforeFi, err := os.Lstat(beforePath)
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", beforePath, err)
+	}
+	afterFi, err := os.Lstat(afterPath)
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", afterPath, err)
+	}
+	if gitFileMode(beforeFi) != gitFileMode(afterFi) {
+		return true, nil
+	}
+	if beforeFi.Mode()&os.ModeSymlink != 0 {
+		beforeTarget, err := os.Readlink(beforePath)
+		if err != nil {
+			return false, fmt.Errorf("readlink %s: %w", beforePath, err)
+		}
+		afterTarget, err := os.Readlink(afterPath)
+		if err != nil {
+			return false, fmt.Errorf("readlink %s: %w", afterPath, err)
+		}
+		return beforeTarget != afterTarget, nil
+	}
+	if !beforeFi.Mode().IsRegular() || !afterFi.Mode().IsRegular() {
+		// Sockets, devices, etc.: metadata differs, so report the change.
+		return true, nil
+	}
+	if beforeFi.Size() != afterFi.Size() {
+		return true, nil
+	}
+	same, err := fileContentsEqual(beforePath, afterPath)
+	if err != nil {
+		return false, err
+	}
+	return !same, nil
+}
+
+// changesetDeltaIsEmpty reports whether the two trees differ in any
+// git-visible file, without staging files or running git. Like
+// `git diff --quiet`, only file-level changes count; directory-only changes
+// (e.g. an added empty dir) don't. Added or removed files prove the changeset
+// non-empty regardless of how git would pair them into renames, and
+// metadata-suspect files are verified by content with an early exit on the
+// first real difference.
+func changesetDeltaIsEmpty(ctx context.Context, beforeDir, afterDir string) (bool, error) {
+	delta, err := collectChangesetDelta(ctx, beforeDir, afterDir)
+	if err != nil {
+		return false, fmt.Errorf("collect delta: %w", err)
+	}
+	if len(delta.addedFiles) > 0 || len(delta.removedFiles) > 0 {
+		return false, nil
+	}
+	for _, rel := range delta.modifiedCandidates {
+		if err := ctx.Err(); err != nil {
+			return false, context.Cause(ctx)
+		}
+		changed, err := modifiedFileDiffers(beforeDir, afterDir, rel)
+		if err != nil {
+			return false, fmt.Errorf("verify modified file: %w", err)
+		}
+		if changed {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // gitFileMode maps a file's mode onto the modes git tracks: symlink, and
@@ -454,10 +494,4 @@ func countGitLines(path string) (lines int, ok bool, _ error) {
 		lines++
 	}
 	return lines, true, nil
-}
-
-// isFilePath reports whether a ChangesetPaths entry refers to a file;
-// directory entries carry a trailing "/".
-func isFilePath(p string) bool {
-	return !strings.HasSuffix(p, "/")
 }

--- a/core/changeset_delta.go
+++ b/core/changeset_delta.go
@@ -1,0 +1,463 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	continuityfs "github.com/containerd/continuity/fs"
+
+	"github.com/dagger/dagger/engine/snapshots/fsdiff"
+)
+
+// changesetDelta is the file-level delta between two mounted directory trees,
+// computed from filesystem metadata (like container layer diffing) instead of
+// content-diffing both full trees. Paths are relative; directories carry a
+// trailing "/" like listSubdirectories.
+type changesetDelta struct {
+	addedFiles []string
+	// modifiedCandidates are files whose metadata differs; content may still
+	// be identical (e.g. an mtime-only change), so they must be verified
+	// before being reported as modified.
+	modifiedCandidates []string
+	removedFiles       []string
+	addedDirs          []string
+	removedDirs        []string
+}
+
+// computeChangesetPathsDelta computes ChangesetPaths by walking filesystem
+// metadata and reading content only for files the metadata can't rule out,
+// instead of content-diffing both full trees like computeChangesetPaths.
+// Rename detection and line counts still come from git, but scoped to the
+// changed files only. When withStats is true it also returns per-path
+// line-change counts matching `git diff --numstat` semantics.
+func computeChangesetPathsDelta(ctx context.Context, beforeDir, afterDir string, withStats bool) (*ChangesetPaths, map[string]lineChanges, error) {
+	delta, err := collectChangesetDelta(ctx, beforeDir, afterDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("collect delta: %w", err)
+	}
+
+	modified, err := verifyModifiedFiles(ctx, beforeDir, afterDir, delta.modifiedCandidates)
+	if err != nil {
+		return nil, nil, fmt.Errorf("verify modified files: %w", err)
+	}
+
+	fc := fileChanges{
+		Added:    delta.addedFiles,
+		Modified: modified,
+		Removed:  delta.removedFiles,
+	}
+
+	// Renames are always an added/removed pair, so the changed files are the
+	// complete candidate set; running git over just them yields the same
+	// pairings as a full-tree diff.
+	detectRenames := len(delta.addedFiles) > 0 && len(delta.removedFiles) > 0
+	materializeModified := withStats && len(modified) > 0
+
+	var stats map[string]lineChanges
+	if detectRenames || materializeModified {
+		tmpRoot, err := os.MkdirTemp("", "dagger-changeset-delta-")
+		if err != nil {
+			return nil, nil, fmt.Errorf("create delta staging dir: %w", err)
+		}
+		defer os.RemoveAll(tmpRoot)
+		tmpBefore := filepath.Join(tmpRoot, "before")
+		tmpAfter := filepath.Join(tmpRoot, "after")
+
+		beforePaths := slices.Clone(modified)
+		afterPaths := slices.Clone(modified)
+		if detectRenames {
+			beforePaths = append(beforePaths, delta.removedFiles...)
+			afterPaths = append(afterPaths, delta.addedFiles...)
+		}
+		if err := materializeDeltaFiles(ctx, beforeDir, tmpBefore, beforePaths); err != nil {
+			return nil, nil, fmt.Errorf("stage before delta: %w", err)
+		}
+		if err := materializeDeltaFiles(ctx, afterDir, tmpAfter, afterPaths); err != nil {
+			return nil, nil, fmt.Errorf("stage after delta: %w", err)
+		}
+
+		if detectRenames {
+			gitFC, err := compareDirectories(ctx, tmpBefore, tmpAfter)
+			if err != nil {
+				return nil, nil, fmt.Errorf("compare delta files: %w", err)
+			}
+			fc.Added = gitFC.Added
+			fc.Removed = gitFC.Removed
+			fc.Renamed = gitFC.Renamed
+		}
+		if withStats {
+			stats, err = compareDirectoriesNumStat(ctx, tmpBefore, tmpAfter)
+			if err != nil {
+				return nil, nil, fmt.Errorf("numstat delta files: %w", err)
+			}
+		}
+	}
+
+	if withStats {
+		if stats == nil {
+			stats = make(map[string]lineChanges)
+		}
+		if !detectRenames {
+			// Added/removed files weren't staged for git; their counts are
+			// just the file's own line count.
+			for _, rel := range fc.Added {
+				lines, ok, err := countGitLines(filepath.Join(afterDir, rel))
+				if err != nil {
+					return nil, nil, fmt.Errorf("count lines of added %s: %w", rel, err)
+				}
+				if ok {
+					stats[rel] = lineChanges{Added: lines}
+				}
+			}
+			for _, rel := range fc.Removed {
+				lines, ok, err := countGitLines(filepath.Join(beforeDir, rel))
+				if err != nil {
+					return nil, nil, fmt.Errorf("count lines of removed %s: %w", rel, err)
+				}
+				if ok {
+					stats[rel] = lineChanges{Removed: lines}
+				}
+			}
+		}
+	}
+
+	renamedNew := make([]string, 0, len(fc.Renamed))
+	renamedOld := make([]string, 0, len(fc.Renamed))
+	for newPath, oldPath := range fc.Renamed {
+		renamedNew = append(renamedNew, newPath)
+		renamedOld = append(renamedOld, oldPath)
+	}
+
+	allRemoved := slices.Concat(fc.Removed, renamedOld, delta.removedDirs)
+	slices.Sort(allRemoved)
+	added := slices.Concat(fc.Added, renamedNew, delta.addedDirs)
+	slices.Sort(added)
+	slices.Sort(fc.Modified)
+
+	return &ChangesetPaths{
+		Added:      added,
+		Modified:   fc.Modified,
+		Removed:    collapseChildPaths(allRemoved),
+		AllRemoved: allRemoved,
+		Renamed:    fc.Renamed,
+	}, stats, nil
+}
+
+// collectChangesetDelta double-walks both trees comparing stat metadata,
+// reading content only when metadata alone is inconclusive: files backed by
+// the same inode are unchanged (snapshots sharing a lineage resolve unchanged
+// files to the same backing file), and distinct files whose stat happens to
+// match are content-compared rather than trusted.
+func collectChangesetDelta(ctx context.Context, beforeDir, afterDir string) (*changesetDelta, error) {
+	delta := &changesetDelta{}
+	err := fsdiff.WalkChanges(ctx, beforeDir, afterDir, fsdiff.CompareInodeThenContent, func(kind continuityfs.ChangeKind, path string, f os.FileInfo, prevErr error) error {
+		if prevErr != nil {
+			return prevErr
+		}
+		rel := strings.TrimPrefix(path, string(os.PathSeparator))
+		if rel == "" || rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		switch kind {
+		case continuityfs.ChangeKindAdd:
+			if f != nil && f.IsDir() {
+				delta.addedDirs = append(delta.addedDirs, rel+"/")
+			} else {
+				delta.addedFiles = append(delta.addedFiles, rel)
+			}
+		case continuityfs.ChangeKindDelete:
+			// The walker collapses deletions: a removed directory is emitted
+			// once, without its children. Changeset semantics (AllRemoved)
+			// need every removed path, so re-expand from the before tree.
+			fi, err := os.Lstat(filepath.Join(beforeDir, rel))
+			if err != nil {
+				return fmt.Errorf("stat removed path %s: %w", rel, err)
+			}
+			if fi.IsDir() {
+				return delta.appendRemovedTree(beforeDir, rel)
+			}
+			delta.removedFiles = append(delta.removedFiles, rel)
+		case continuityfs.ChangeKindModify:
+			if f == nil {
+				return nil
+			}
+			beforeFi, err := os.Lstat(filepath.Join(beforeDir, rel))
+			if err != nil {
+				return fmt.Errorf("stat modified path %s: %w", rel, err)
+			}
+			switch {
+			case beforeFi.IsDir() && f.IsDir():
+				// Attribute-only directory change; path-level diffs ignore
+				// directories that exist on both sides.
+			case beforeFi.IsDir():
+				// Directory replaced by a file.
+				if err := delta.appendRemovedTree(beforeDir, rel); err != nil {
+					return err
+				}
+				delta.addedFiles = append(delta.addedFiles, rel)
+			case f.IsDir():
+				// File replaced by a directory; its children arrive as adds.
+				delta.removedFiles = append(delta.removedFiles, rel)
+				delta.addedDirs = append(delta.addedDirs, rel+"/")
+			default:
+				delta.modifiedCandidates = append(delta.modifiedCandidates, rel)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return delta, nil
+}
+
+func (d *changesetDelta) appendRemovedTree(root, rel string) error {
+	d.removedDirs = append(d.removedDirs, rel+"/")
+	return filepath.WalkDir(filepath.Join(root, rel), func(p string, ent fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		sub, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		sub = filepath.ToSlash(sub)
+		if sub == rel {
+			return nil
+		}
+		if ent.IsDir() {
+			d.removedDirs = append(d.removedDirs, sub+"/")
+		} else {
+			d.removedFiles = append(d.removedFiles, sub)
+		}
+		return nil
+	})
+}
+
+// verifyModifiedFiles filters metadata-suspect candidates down to files whose
+// git-visible mode or content actually differ, matching the classification a
+// full-tree `git diff --no-index` would produce (which ignores e.g. mtime- or
+// ownership-only changes).
+func verifyModifiedFiles(ctx context.Context, beforeDir, afterDir string, candidates []string) ([]string, error) {
+	var modified []string
+	for _, rel := range candidates {
+		if err := ctx.Err(); err != nil {
+			return nil, context.Cause(ctx)
+		}
+		beforePath := filepath.Join(beforeDir, rel)
+		afterPath := filepath.Join(afterDir, rel)
+		beforeFi, err := os.Lstat(beforePath)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", beforePath, err)
+		}
+		afterFi, err := os.Lstat(afterPath)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", afterPath, err)
+		}
+		if gitFileMode(beforeFi) != gitFileMode(afterFi) {
+			modified = append(modified, rel)
+			continue
+		}
+		if beforeFi.Mode()&os.ModeSymlink != 0 {
+			beforeTarget, err := os.Readlink(beforePath)
+			if err != nil {
+				return nil, fmt.Errorf("readlink %s: %w", beforePath, err)
+			}
+			afterTarget, err := os.Readlink(afterPath)
+			if err != nil {
+				return nil, fmt.Errorf("readlink %s: %w", afterPath, err)
+			}
+			if beforeTarget != afterTarget {
+				modified = append(modified, rel)
+			}
+			continue
+		}
+		if !beforeFi.Mode().IsRegular() || !afterFi.Mode().IsRegular() {
+			// Sockets, devices, etc.: metadata differs, so report the change.
+			modified = append(modified, rel)
+			continue
+		}
+		if beforeFi.Size() != afterFi.Size() {
+			modified = append(modified, rel)
+			continue
+		}
+		same, err := fileContentsEqual(beforePath, afterPath)
+		if err != nil {
+			return nil, err
+		}
+		if !same {
+			modified = append(modified, rel)
+		}
+	}
+	return modified, nil
+}
+
+// gitFileMode maps a file's mode onto the modes git tracks: symlink, and
+// executable vs regular file. Other permission bits are invisible to git.
+func gitFileMode(fi os.FileInfo) uint32 {
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return 0o120000
+	}
+	if fi.Mode()&0o111 != 0 {
+		return 0o100755
+	}
+	return 0o100644
+}
+
+func fileContentsEqual(p1, p2 string) (bool, error) {
+	f1, err := os.Open(p1)
+	if err != nil {
+		return false, err
+	}
+	defer f1.Close()
+	f2, err := os.Open(p2)
+	if err != nil {
+		return false, err
+	}
+	defer f2.Close()
+
+	b1 := make([]byte, 32*1024)
+	b2 := make([]byte, 32*1024)
+	for {
+		n1, err1 := io.ReadFull(f1, b1)
+		n2, err2 := io.ReadFull(f2, b2)
+		if n1 != n2 || !bytes.Equal(b1[:n1], b2[:n2]) {
+			return false, nil
+		}
+		if err1 != nil || err2 != nil {
+			if (err1 == io.EOF || err1 == io.ErrUnexpectedEOF) && (err2 == io.EOF || err2 == io.ErrUnexpectedEOF) {
+				return true, nil
+			}
+			if err1 != nil && err1 != io.EOF && err1 != io.ErrUnexpectedEOF {
+				return false, err1
+			}
+			if err2 != nil && err2 != io.EOF && err2 != io.ErrUnexpectedEOF {
+				return false, err2
+			}
+			return false, nil
+		}
+	}
+}
+
+// materializeDeltaFiles copies the given files from srcRoot into dstRoot,
+// preserving relative layout, symlinks, and the exec bit, so git can operate
+// on just the changed files.
+func materializeDeltaFiles(ctx context.Context, srcRoot, dstRoot string, rels []string) error {
+	for _, rel := range rels {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
+		srcPath := filepath.Join(srcRoot, rel)
+		dstPath := filepath.Join(dstRoot, rel)
+		fi, err := os.Lstat(srcPath)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", srcPath, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+			return err
+		}
+		switch {
+		case fi.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.Symlink(target, dstPath); err != nil {
+				return err
+			}
+		case fi.Mode().IsRegular():
+			if err := copyFileContents(srcPath, dstPath, fi.Mode().Perm()); err != nil {
+				return err
+			}
+		default:
+			// Sockets, devices, etc. can't be diffed by git; skip them.
+		}
+	}
+	return nil
+}
+
+func copyFileContents(srcPath, dstPath string, perm os.FileMode) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		return err
+	}
+	return dst.Close()
+}
+
+// countGitLines counts lines the way `git diff --numstat` does for a fully
+// added or removed file: newline count, plus one for an unterminated final
+// line. Binary files (NUL byte within the first 8000 bytes, git's heuristic)
+// return ok=false, matching numstat's "-" columns.
+func countGitLines(path string) (lines int, ok bool, _ error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return 0, false, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		// git stores the target string as the blob: one unterminated line.
+		return 1, true, nil
+	}
+	if !fi.Mode().IsRegular() {
+		return 0, false, nil
+	}
+	if fi.Size() == 0 {
+		return 0, true, nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, false, err
+	}
+	defer f.Close()
+
+	buf := make([]byte, 32*1024)
+	var lastByte byte
+	firstChunk := true
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			if firstChunk {
+				checkLen := min(n, 8000)
+				if bytes.IndexByte(buf[:checkLen], 0) >= 0 {
+					return 0, false, nil
+				}
+				firstChunk = false
+			}
+			lines += bytes.Count(buf[:n], []byte{'\n'})
+			lastByte = buf[n-1]
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, false, err
+		}
+	}
+	if lastByte != '\n' {
+		lines++
+	}
+	return lines, true, nil
+}
+
+// isFilePath reports whether a ChangesetPaths entry refers to a file;
+// directory entries carry a trailing "/".
+func isFilePath(p string) bool {
+	return !strings.HasSuffix(p, "/")
+}

--- a/core/changeset_delta_test.go
+++ b/core/changeset_delta_test.go
@@ -1,0 +1,205 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeDeltaTestFile(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(contents), 0o644))
+}
+
+// requireSamePaths asserts the delta implementation and the git full-tree
+// implementation agree on the given before/after trees.
+func requireSamePaths(t *testing.T, beforeDir, afterDir string) *ChangesetPaths {
+	t.Helper()
+	ctx := context.Background()
+
+	gitPaths, err := computeChangesetPaths(ctx, beforeDir, afterDir)
+	require.NoError(t, err)
+	deltaPaths, _, err := computeChangesetPathsDelta(ctx, beforeDir, afterDir, true)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, gitPaths.Added, deltaPaths.Added, "Added")
+	require.ElementsMatch(t, gitPaths.Modified, deltaPaths.Modified, "Modified")
+	require.ElementsMatch(t, gitPaths.Removed, deltaPaths.Removed, "Removed")
+	require.ElementsMatch(t, gitPaths.AllRemoved, deltaPaths.AllRemoved, "AllRemoved")
+	require.Equal(t, gitPaths.Renamed, deltaPaths.Renamed, "Renamed")
+	return deltaPaths
+}
+
+func requireSameNumStat(t *testing.T, beforeDir, afterDir string) {
+	t.Helper()
+	ctx := context.Background()
+
+	gitStats, err := compareDirectoriesNumStat(ctx, beforeDir, afterDir)
+	require.NoError(t, err)
+	_, deltaStats, err := computeChangesetPathsDelta(ctx, beforeDir, afterDir, true)
+	require.NoError(t, err)
+	// git omits nothing; delta may omit zero-value entries. Compare as maps
+	// treating missing == zero.
+	for path, gs := range gitStats {
+		require.Equal(t, gs, deltaStats[path], "numstat for %s", path)
+	}
+	for path, ds := range deltaStats {
+		if _, ok := gitStats[path]; !ok {
+			require.Equal(t, lineChanges{}, ds, "extra numstat for %s", path)
+		}
+	}
+}
+
+func TestChangesetDeltaMatchesGit(t *testing.T) {
+	t.Run("add modify remove", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "keep.txt", "same\n")
+		writeDeltaTestFile(t, after, "keep.txt", "same\n")
+		writeDeltaTestFile(t, before, "mod.txt", "old\n")
+		writeDeltaTestFile(t, after, "mod.txt", "new\nnew2\n")
+		writeDeltaTestFile(t, before, "remove.txt", "bye\nbye\n")
+		writeDeltaTestFile(t, after, "add.txt", "hi\n")
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("pure rename", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "old.txt", "content of a decently sized file\nwith more than one line\n")
+		writeDeltaTestFile(t, after, "new.txt", "content of a decently sized file\nwith more than one line\n")
+
+		paths := requireSamePaths(t, before, after)
+		require.Equal(t, map[string]string{"new.txt": "old.txt"}, paths.Renamed)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("nested removed dir", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "keep.txt", "same\n")
+		writeDeltaTestFile(t, after, "keep.txt", "same\n")
+		writeDeltaTestFile(t, before, "gone/a.txt", "a\n")
+		writeDeltaTestFile(t, before, "gone/sub/b.txt", "b\n")
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("added dir tree", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "keep.txt", "same\n")
+		writeDeltaTestFile(t, after, "keep.txt", "same\n")
+		writeDeltaTestFile(t, after, "fresh/a.txt", "a\n")
+		writeDeltaTestFile(t, after, "fresh/sub/b.txt", "b\n")
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("empty before", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, after, "a.txt", "a\n")
+		writeDeltaTestFile(t, after, "sub/b.txt", "b1\nb2\nb3")
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("mtime-only change is not modified", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "f.txt", "same\n")
+		writeDeltaTestFile(t, after, "f.txt", "same\n")
+		past := time.Now().Add(-time.Hour)
+		require.NoError(t, os.Chtimes(filepath.Join(after, "f.txt"), past, past))
+
+		requireSamePaths(t, before, after)
+	})
+
+	t.Run("same size same mtime different content", func(t *testing.T) {
+		// The pathological stat collision: same size, same mtime (with
+		// non-zero nanoseconds, as fast successive writes can produce),
+		// different bytes. Must be detected via content comparison.
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "f.txt", "aaaa\n")
+		writeDeltaTestFile(t, after, "f.txt", "bbbb\n")
+		ts := time.Unix(1700000000, 123456789)
+		require.NoError(t, os.Chtimes(filepath.Join(before, "f.txt"), ts, ts))
+		require.NoError(t, os.Chtimes(filepath.Join(after, "f.txt"), ts, ts))
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("exec bit change", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "f.sh", "#!/bin/sh\n")
+		writeDeltaTestFile(t, after, "f.sh", "#!/bin/sh\n")
+		require.NoError(t, os.Chmod(filepath.Join(after, "f.sh"), 0o755))
+
+		requireSamePaths(t, before, after)
+	})
+
+	t.Run("symlink target change", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "t1", "x\n")
+		writeDeltaTestFile(t, after, "t1", "x\n")
+		require.NoError(t, os.Symlink("t1", filepath.Join(before, "link")))
+		require.NoError(t, os.Symlink("t2", filepath.Join(after, "link")))
+
+		requireSamePaths(t, before, after)
+	})
+
+	t.Run("file replaced by dir", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "thing", "file\n")
+		writeDeltaTestFile(t, after, "thing/nested.txt", "dir now\n")
+
+		requireSamePaths(t, before, after)
+	})
+
+	t.Run("dir replaced by file", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "thing/nested.txt", "dir\n")
+		writeDeltaTestFile(t, after, "thing", "file now\n")
+
+		requireSamePaths(t, before, after)
+	})
+
+	t.Run("binary files", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(before, "rm.bin"), []byte{0, 1, 2, 3}, 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(after, "add.bin"), []byte{7, 0, 9}, 0o644))
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("rename with modification stays paired like git", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		base := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n"
+		writeDeltaTestFile(t, before, "old.txt", base)
+		writeDeltaTestFile(t, after, "renamed.txt", base+"line9\n")
+
+		requireSamePaths(t, before, after)
+		requireSameNumStat(t, before, after)
+	})
+}

--- a/core/changeset_delta_test.go
+++ b/core/changeset_delta_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +35,22 @@ func requireSamePaths(t *testing.T, beforeDir, afterDir string) *ChangesetPaths 
 	require.ElementsMatch(t, gitPaths.Removed, deltaPaths.Removed, "Removed")
 	require.ElementsMatch(t, gitPaths.AllRemoved, deltaPaths.AllRemoved, "AllRemoved")
 	require.Equal(t, gitPaths.Renamed, deltaPaths.Renamed, "Renamed")
+
+	// The stats-less variant stages fewer files but must report the same paths.
+	deltaPathsNoStats, _, err := computeChangesetPathsDelta(ctx, beforeDir, afterDir, false)
+	require.NoError(t, err)
+	require.Equal(t, deltaPaths, deltaPathsNoStats, "withStats=false paths")
+
+	// The IsEmpty fast path must agree with whether git sees any file-level
+	// change (renames included; directory-only changes don't count).
+	isFile := func(p string) bool { return !strings.HasSuffix(p, "/") }
+	gitEmpty := len(gitPaths.Modified) == 0 &&
+		!slices.ContainsFunc(gitPaths.Added, isFile) &&
+		!slices.ContainsFunc(gitPaths.AllRemoved, isFile)
+	deltaEmpty, err := changesetDeltaIsEmpty(ctx, beforeDir, afterDir)
+	require.NoError(t, err)
+	require.Equal(t, gitEmpty, deltaEmpty, "IsEmpty")
+
 	return deltaPaths
 }
 
@@ -190,6 +208,27 @@ func TestChangesetDeltaMatchesGit(t *testing.T) {
 
 		requireSamePaths(t, before, after)
 		requireSameNumStat(t, before, after)
+	})
+
+	t.Run("identical trees", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "a.txt", "same\n")
+		writeDeltaTestFile(t, after, "a.txt", "same\n")
+		writeDeltaTestFile(t, before, "sub/b.txt", "b\n")
+		writeDeltaTestFile(t, after, "sub/b.txt", "b\n")
+
+		requireSamePaths(t, before, after)
+	})
+
+	t.Run("added empty dir only", func(t *testing.T) {
+		before := t.TempDir()
+		after := t.TempDir()
+		writeDeltaTestFile(t, before, "a.txt", "same\n")
+		writeDeltaTestFile(t, after, "a.txt", "same\n")
+		require.NoError(t, os.MkdirAll(filepath.Join(after, "empty"), 0o755))
+
+		requireSamePaths(t, before, after)
 	})
 
 	t.Run("rename with modification stays paired like git", func(t *testing.T) {

--- a/engine/snapshots/fsdiff/compare.go
+++ b/engine/snapshots/fsdiff/compare.go
@@ -5,4 +5,11 @@ type Comparison uint8
 const (
 	CompareCompat Comparison = iota
 	CompareContentOnMetadataMatch
+	// CompareInodeThenContent treats files backed by the same inode as
+	// unchanged and compares content whenever distinct files have otherwise
+	// matching metadata. Snapshots of a shared lineage resolve unchanged
+	// files to the same backing inode even across separate mounts, so this
+	// stays O(changed files) there while still catching files whose stat
+	// happens to collide (same size and mtime, different bytes).
+	CompareInodeThenContent
 )

--- a/engine/snapshots/fsdiff/compare_linux.go
+++ b/engine/snapshots/fsdiff/compare_linux.go
@@ -23,6 +23,15 @@ func samePathInfo(
 		return true, nil
 	}
 
+	if comparison == CompareInodeThenContent && sameInode(f1, f2) {
+		// Two mounts of snapshots sharing a lineage report different st_dev,
+		// so os.SameFile misses files that resolve to the same backing
+		// inode. Both trees live on the same backing filesystem and
+		// snapshots are immutable, so an equal inode (with matching type,
+		// size, and mtime) means the same file.
+		return true, nil
+	}
+
 	if !compareSysStat(f1.Sys(), f2.Sys()) {
 		return false, nil
 	}
@@ -60,7 +69,7 @@ func samePathInfo(
 			return compareFileContent(p1, p2)
 		}
 		return true, nil
-	case CompareContentOnMetadataMatch:
+	case CompareContentOnMetadataMatch, CompareInodeThenContent:
 		if (f1.Mode() & os.ModeSymlink) == os.ModeSymlink {
 			return compareSymlinkTarget(p1, p2)
 		}
@@ -71,6 +80,21 @@ func samePathInfo(
 	default:
 		return false, fmt.Errorf("unknown diff comparison mode %d", comparison)
 	}
+}
+
+func sameInode(f1, f2 os.FileInfo) bool {
+	s1, ok := f1.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	s2, ok := f2.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return s1.Ino == s2.Ino &&
+		f1.Mode()&os.ModeType == f2.Mode()&os.ModeType &&
+		f1.Size() == f2.Size() &&
+		f1.ModTime().Equal(f2.ModTime())
 }
 
 func compareSysStat(s1, s2 interface{}) bool {


### PR DESCRIPTION
…it diffs

Changeset.computePaths, diffStats, and isEmpty ran `git diff --no-index` over both fully mounted trees, reading every byte of before and after even for a one-file change. On large directories this floods the engine cgroup with gigabytes of page cache and dirty pages per query, showing up as an engine memory spike that can leave the host unresponsive.

Compute the delta with a stat-based double walk instead (fsdiff): files backed by the same inode are unchanged, metadata-suspect files are verified by content comparison, and the new CompareInodeThenContent mode closes the same-size/same-mtime stat collision hole. git still provides rename pairing and numstat, but scoped to materialized copies of only the changed files, making the whole path O(changed files) instead of O(tree). Falls back to the full-tree git diff on any error.