### PR TITLE
feat(setup): migrate local toolchains and dependencies in place

### DIFF
--- a/.changes/unreleased/Added-20260715-143312.yaml
+++ b/.changes/unreleased/Added-20260715-143312.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |
+  `dagger setup` now migrates the toolchains and dependencies that a legacy `dagger.json` references by a local path inside the project — and their transitive local dependencies — converting each to `dagger-module.toml` in place, and installing each converted module's runtime SDK in the workspace config.
+time: 2026-07-15T14:33:12Z
+custom:
+  Author: eunomie
+  PR: 13620

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -415,6 +415,269 @@ type Myapp {
 		require.NoError(t, err)
 		require.Equal(t, "hello from dot dagger source", strings.TrimSpace(out))
 	})
+
+	t.Run("local toolchain migrates in place", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "toolchains": [{"name": "tc", "source": "./toolchain"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				With(legacyDangModule("toolchain", "tc", "Tc", "hello from toolchain"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		cfgOut, err := ctr.WithExec([]string{"cat", "toolchain/dagger-module.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, cfgOut, `name = "tc"`)
+		require.Contains(t, cfgOut, `[runtime]`)
+
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "toolchain/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "legacy toolchain config should be removed after in-place conversion")
+
+		wsOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, wsOut, `[modules.tc]`)
+		require.Contains(t, wsOut, `source = "./toolchain"`)
+		// The converted toolchain's runtime is installed and pinned in the
+		// workspace, sharing the root module's dang SDK install.
+		require.Contains(t, wsOut, `[modules.dagger-dang-sdk]`)
+		require.Contains(t, wsOut, `path = "toolchain"`)
+
+		// The converted module loads from its own runtime field.
+		callOut, err := ctr.With(daggerCallAt("toolchain", "message")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from toolchain", strings.TrimSpace(callOut))
+	})
+
+	t.Run("local dependency migrates in place behind rebased reference", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "dependencies": [{"name": "foo", "source": "./libs/foo"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				With(legacyDangModule("libs/foo", "foo", "Foo", "hello from foo"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		cfgOut, err := ctr.WithExec([]string{"cat", "libs/foo/dagger-module.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, cfgOut, `name = "foo"`)
+
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "libs/foo/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "legacy dependency config should be removed after in-place conversion")
+
+		mainCfg, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, mainCfg, "../../../libs/foo",
+			"main module's dependency reference is rebased to the still-in-place converted dependency")
+
+		// The converted dependency's runtime is installed and pinned in the
+		// workspace.
+		wsOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, wsOut, `[modules.dagger-dang-sdk]`)
+		require.Contains(t, wsOut, `path = "libs/foo"`)
+
+		// The converted dependency loads from its own runtime field.
+		callOut, err := ctr.With(daggerCallAt("libs/foo", "message")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from foo", strings.TrimSpace(callOut))
+	})
+
+	t.Run("transitive local dependencies migrate", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "dependencies": [{"name": "foo", "source": "./libs/foo"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				WithNewFile("libs/foo/dagger.json", `{"name":"foo","sdk":{"source":"dang"},"dependencies":[{"name":"bar","source":"../bar"}]}`).
+				WithNewFile("libs/foo/main.dang", "\ntype Foo {\n  pub message: String! { \"foo\" }\n}\n").
+				With(legacyDangModule("libs/bar", "bar", "Bar", "hello from bar"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		for _, dir := range []string{"libs/foo", "libs/bar"} {
+			_, err = ctr.WithExec([]string{"test", "-f", dir + "/dagger-module.toml"}).Sync(ctx)
+			require.NoError(t, err, "%s should be converted", dir)
+			_, err = ctr.WithExec([]string{"test", "!", "-e", dir + "/dagger.json"}).Sync(ctx)
+			require.NoError(t, err, "%s legacy config should be removed", dir)
+		}
+	})
+
+	t.Run("diamond dependency is migrated once", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// main -> a, main -> b, a -> ../shared, b -> ../shared: shared is reached
+		// via two paths (a diamond) and must be converted exactly once — a second
+		// conversion would target the same path twice and fail the migration.
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "dependencies": [{"name": "a", "source": "./libs/a"}, {"name": "b", "source": "./libs/b"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", "\ntype Myapp {\n  pub greet: String! { \"hello from root\" }\n}\n").
+				WithNewFile("libs/a/dagger.json", `{"name":"a","sdk":{"source":"dang"},"dependencies":[{"name":"shared","source":"../shared"}]}`).
+				WithNewFile("libs/a/main.dang", "\ntype A {\n  pub message: String! { \"a\" }\n}\n").
+				WithNewFile("libs/b/dagger.json", `{"name":"b","sdk":{"source":"dang"},"dependencies":[{"name":"shared","source":"../shared"}]}`).
+				WithNewFile("libs/b/main.dang", "\ntype B {\n  pub message: String! { \"b\" }\n}\n").
+				With(legacyDangModule("libs/shared", "shared", "Shared", "hello from shared"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		for _, dir := range []string{"libs/a", "libs/b", "libs/shared"} {
+			_, err = ctr.WithExec([]string{"test", "-f", dir + "/dagger-module.toml"}).Sync(ctx)
+			require.NoError(t, err, "%s should be converted", dir)
+			_, err = ctr.WithExec([]string{"test", "!", "-e", dir + "/dagger.json"}).Sync(ctx)
+			require.NoError(t, err, "%s legacy config should be removed", dir)
+		}
+	})
+
+	t.Run("cyclic local dependencies terminate and migrate once", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// a -> ../b, b -> ../a is a dependency cycle; discovery must terminate
+		// (the visited set) and convert each module once rather than looping.
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "dependencies": [{"name": "a", "source": "./libs/a"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", "\ntype Myapp {\n  pub greet: String! { \"hello from root\" }\n}\n").
+				WithNewFile("libs/a/dagger.json", `{"name":"a","sdk":{"source":"dang"},"dependencies":[{"name":"b","source":"../b"}]}`).
+				WithNewFile("libs/a/main.dang", "\ntype A {\n  pub message: String! { \"a\" }\n}\n").
+				WithNewFile("libs/b/dagger.json", `{"name":"b","sdk":{"source":"dang"},"dependencies":[{"name":"a","source":"../a"}]}`).
+				WithNewFile("libs/b/main.dang", "\ntype B {\n  pub message: String! { \"b\" }\n}\n")
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		for _, dir := range []string{"libs/a", "libs/b"} {
+			_, err = ctr.WithExec([]string{"test", "-f", dir + "/dagger-module.toml"}).Sync(ctx)
+			require.NoError(t, err, "%s should be converted", dir)
+			_, err = ctr.WithExec([]string{"test", "!", "-e", dir + "/dagger.json"}).Sync(ctx)
+			require.NoError(t, err, "%s legacy config should be removed", dir)
+		}
+	})
+
+	t.Run("nested-workspace dependency is left as legacy", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "dependencies": [{"name": "nested", "source": "./nested"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				WithNewFile("nested/dagger.json", `{"name":"nested","sdk":{"source":"dang"},"toolchains":[{"name":"x","source":"./x"}]}`).
+				WithNewFile("nested/main.dang", "\ntype Nested {\n  pub message: String! { \"nested\" }\n}\n")
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		_, err = ctr.WithExec([]string{"test", "-f", "nested/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "a dependency that owns toolchains/blueprint is not converted in place")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "nested/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "nested workspace dependency should not be converted")
+	})
+
+	t.Run("absolute local reference is not migrated as an in-tree module", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// An absolute source is not a workspace-relative module; it must not be
+		// rebased under the workspace root and migrated. Use a toolchain, since a
+		// main-module dependency with an absolute source is rejected earlier.
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "toolchains": [{"name": "tc", "source": "/libs/foo"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				With(legacyDangModule("libs/foo", "foo", "Foo", "hello from foo"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		_, err = ctr.WithExec([]string{"test", "-f", "libs/foo/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "an absolute reference must not be resolved as ./libs/foo and migrated")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "libs/foo/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "libs/foo should not be converted from an absolute reference")
+	})
+
+	t.Run("hidden default-modules config does not pull in its dependencies", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// A hidden .dagger/modules/.scratch config is ignored by migration; it
+		// must not seed the dependency walk and drag its local deps in.
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci"
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				WithNewFile(".dagger/modules/.scratch/dagger.json", `{"name":"scratch","sdk":{"source":"dang"},"dependencies":[{"name":"shared","source":"../../../libs/shared"}]}`).
+				WithNewFile(".dagger/modules/.scratch/main.dang", "\ntype Scratch {\n  pub message: String! { \"scratch\" }\n}\n").
+				With(legacyDangModule("libs/shared", "shared", "Shared", "hello from shared"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		_, err = ctr.WithExec([]string{"test", "-f", "libs/shared/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "a dependency reached only through an ignored hidden config must not be migrated")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "libs/shared/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "libs/shared should not be converted")
+	})
 }
 
 // TestWorkspaceMigrateUserFeedback should cover the user-facing output of

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -82,13 +82,16 @@ func (s *workspaceSchema) migrate(
 		defer telemetry.EndWithCause(span, &rerr)
 	}
 
-	compatWorkspaces, err := s.workspaceMigrationCompatWorkspaces(ctx, ws)
+	compatWorkspaces, discoveryWarnings, err := s.workspaceMigrationCompatWorkspaces(ctx, ws)
 	if err != nil {
 		return nil, err
 	}
 	plans := make([]*workspace.MigrationPlan, 0, len(compatWorkspaces))
 	for _, compatWorkspace := range compatWorkspaces {
-		if !compatWorkspace.MustMigrateToWorkspaceConfig() {
+		// Discovered local modules are converted in place; never route them
+		// through PlanMigration, which would move and delete their dagger.json
+		// and break the reference that pointed at them.
+		if !compatWorkspace.MustMigrateToWorkspaceConfig() || compatWorkspace.DiscoveredLocalModule {
 			continue
 		}
 
@@ -107,12 +110,17 @@ func (s *workspaceSchema) migrate(
 	if err != nil {
 		return nil, err
 	}
+	parentPlans, err = workspaceMigrationInstallDiscoveredModuleSDKs(plans, parentPlans, compatWorkspaces)
+	if err != nil {
+		return nil, err
+	}
 	planBundle := workspaceMigrationPlanBundle{
 		WorkspacePlans:          plans,
 		ParentPlans:             parentPlans,
 		ModuleConfigConversions: moduleConfigConversions,
 	}
 	warnings := workspaceMigrationPlanBundleWarnings(planBundle)
+	warnings = append(warnings, discoveryWarnings...)
 
 	if planBundle.empty() {
 		return &core.WorkspaceMigration{
@@ -185,9 +193,9 @@ func (s *workspaceSchema) prepareWorkspaceMigrationPlan(
 func (s *workspaceSchema) workspaceMigrationCompatWorkspaces(
 	ctx context.Context,
 	ws *core.Workspace,
-) ([]*workspace.CompatWorkspace, error) {
+) ([]*workspace.CompatWorkspace, []string, error) {
 	if ws.HostPath() == "" {
-		return nil, fmt.Errorf("workspace migration is local-only")
+		return nil, nil, fmt.Errorf("workspace migration is local-only")
 	}
 
 	rootDir, err := s.resolveRootfs(ctx, ws, ".", core.CopyFilter{
@@ -199,37 +207,40 @@ func (s *workspaceSchema) workspaceMigrationCompatWorkspaces(
 		},
 	}, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	paths, err := workspaceMigrationLegacyConfigPaths(ctx, rootDir, ws)
+	configPaths, discoveryWarnings, err := workspaceMigrationLegacyConfigPaths(ctx, rootDir, ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	workspaceCtx, err := s.withWorkspaceClientContext(ctx, ws)
 	if err != nil {
-		return nil, fmt.Errorf("workspace client context: %w", err)
+		return nil, nil, fmt.Errorf("workspace client context: %w", err)
 	}
 	query, err := core.CurrentQuery(workspaceCtx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	bk, err := query.Engine(workspaceCtx)
 	if err != nil {
-		return nil, fmt.Errorf("engine client: %w", err)
+		return nil, nil, fmt.Errorf("engine client: %w", err)
 	}
 	statFS := core.NewCallerStatFS(bk)
 
-	compatWorkspaces := make([]*workspace.CompatWorkspace, 0, len(paths))
-	for _, relPath := range paths {
-		if workspaceMigrationHiddenPath(relPath) {
+	compatWorkspaces := make([]*workspace.CompatWorkspace, 0, len(configPaths))
+	for _, cp := range configPaths {
+		// A locally-referenced module may legitimately live under a hidden
+		// directory (e.g. ./.internal/foo); only filter hidden paths for the
+		// selected/glob discovery set, not for explicit dependency references.
+		if !cp.DiscoveredLocalModule && workspaceMigrationHiddenPath(cp.Path) {
 			continue
 		}
-		configPath := filepath.Join(ws.HostPath(), filepath.FromSlash(relPath))
+		configPath := filepath.Join(ws.HostPath(), filepath.FromSlash(cp.Path))
 		configDir := filepath.Dir(configPath)
 		hasWorkspaceConfig, err := workspaceMigrationHasExplicitConfigAncestor(workspaceCtx, statFS, ws.HostPath(), configDir)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if hasWorkspaceConfig {
 			// FIXME(workspace-migrate): Match the top-level explicit-config rule
@@ -239,32 +250,40 @@ func (s *workspaceSchema) workspaceMigrationCompatWorkspaces(
 
 		data, err := bk.ReadCallerHostFile(workspaceCtx, configPath)
 		if err != nil {
-			return nil, fmt.Errorf("reading legacy module config %s: %w", relPath, err)
+			return nil, nil, fmt.Errorf("reading legacy module config %s: %w", cp.Path, err)
 		}
 		compatWorkspace, err := workspaceMigrationCompatWorkspaceForLegacyConfig(data, configPath)
 		if err != nil {
-			return nil, fmt.Errorf("parsing legacy module config %s: %w", relPath, err)
+			return nil, nil, fmt.Errorf("parsing legacy module config %s: %w", cp.Path, err)
 		}
 		if compatWorkspace == nil {
 			continue
 		}
+		compatWorkspace.DiscoveredLocalModule = cp.DiscoveredLocalModule
 		compatWorkspaces = append(compatWorkspaces, compatWorkspace)
 	}
-	return compatWorkspaces, nil
+	return compatWorkspaces, discoveryWarnings, nil
+}
+
+// workspaceMigrationConfigPath is a legacy config discovered for migration,
+// tagged with whether it was reached by following a local module reference.
+type workspaceMigrationConfigPath struct {
+	Path                  string
+	DiscoveredLocalModule bool
 }
 
 func workspaceMigrationLegacyConfigPaths(
 	ctx context.Context,
 	rootDir dagql.ObjectResult[*core.Directory],
 	ws *core.Workspace,
-) ([]string, error) {
+) ([]workspaceMigrationConfigPath, []string, error) {
 	// Migration is intentionally scoped to the selected legacy project plus
 	// its conventional project-local module directory. A repo may contain
 	// unrelated dagger.json files in testdata, examples, or nested projects;
 	// those should only migrate when the user runs migration from that project.
 	selectedConfig, selected, err := workspaceMigrationSelectedLegacyConfigPath(ctx, rootDir, ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	projectRoot := workspaceMigrationCleanRelPath(ws.Cwd)
@@ -275,19 +294,172 @@ func workspaceMigrationLegacyConfigPaths(
 		}
 	}
 
-	paths := make([]string, 0, 1)
+	initial := make([]string, 0, 1)
 	if selected {
-		paths = append(paths, selectedConfig)
+		initial = append(initial, selectedConfig)
 	}
 
 	moduleConfigPattern := path.Join(projectRoot, workspace.LockDirName, "modules", "**", workspace.LegacyModuleConfigFileName)
 	modulePaths, err := rootDir.Self().Glob(ctx, rootDir, moduleConfigPattern)
 	if err != nil {
-		return nil, fmt.Errorf("find legacy module configs under %s: %w", path.Join(projectRoot, workspace.LockDirName, "modules"), err)
+		return nil, nil, fmt.Errorf("find legacy module configs under %s: %w", path.Join(projectRoot, workspace.LockDirName, "modules"), err)
 	}
-	paths = append(paths, modulePaths...)
+	initial = append(initial, modulePaths...)
+	initial = workspaceMigrationUniqueSortedPaths(initial)
 
-	return workspaceMigrationUniqueSortedPaths(paths), nil
+	// Seed the dependency walk from the configs that will actually be migrated,
+	// dropping hidden .dagger/modules/** glob hits (e.g. a scratch dir): an
+	// ignored hidden config must not be read, nor drag its own local deps into
+	// migration. Hidden modules reached from a non-hidden explicit reference are
+	// still discovered by the walk itself.
+	seeds := make([]string, 0, len(initial))
+	for _, p := range initial {
+		if workspaceMigrationHiddenPath(p) {
+			continue
+		}
+		seeds = append(seeds, p)
+	}
+	discovered, warnings, err := workspaceMigrationDiscoverLocalModules(ctx, rootDir, projectRoot, seeds)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Selected/glob origin wins over a discovered origin: a config that is both a
+	// .dagger/modules/** hit and locally referenced keeps its existing handling.
+	result := make([]workspaceMigrationConfigPath, 0, len(initial)+len(discovered))
+	seen := make(map[string]struct{}, len(initial)+len(discovered))
+	for _, p := range initial {
+		result = append(result, workspaceMigrationConfigPath{Path: p})
+		seen[path.Clean(p)] = struct{}{}
+	}
+	for _, p := range discovered {
+		if _, ok := seen[path.Clean(p)]; ok {
+			continue
+		}
+		seen[path.Clean(p)] = struct{}{}
+		result = append(result, workspaceMigrationConfigPath{Path: p, DiscoveredLocalModule: true})
+	}
+	return result, warnings, nil
+}
+
+// workspaceMigrationDiscoverLocalModules walks the local toolchain/dependency
+// references of every seed config, transitively, and returns the legacy config
+// paths of the locally-defined modules that should be migrated in place. The
+// traversal dedups by canonical directory (so a module reachable from several
+// places — a diamond — is migrated once) and is cycle-safe: the visited set is
+// seeded with every initial config dir and populated before recursing, and an
+// explicit worklist avoids unbounded recursion. Modules that resolve outside
+// the workspace, that have no dagger.json, or that define their own workspace
+// semantics (toolchains/blueprint) are skipped — safely, since a legacy
+// dagger.json still loads.
+func workspaceMigrationDiscoverLocalModules(
+	ctx context.Context,
+	rootDir dagql.ObjectResult[*core.Directory],
+	projectRoot string,
+	seedPaths []string,
+) (discovered []string, warnings []string, _ error) {
+	visited := make(map[string]struct{}, len(seedPaths))
+	for _, p := range seedPaths {
+		visited[workspaceMigrationCleanRelPath(path.Dir(p))] = struct{}{}
+	}
+
+	type frame struct {
+		dir string
+		cfg *modules.ModuleConfig
+	}
+	stack := make([]frame, 0, len(seedPaths))
+	for _, p := range seedPaths {
+		cfg, err := workspaceMigrationReadLegacyModuleConfig(ctx, rootDir, p)
+		if err != nil {
+			return nil, nil, err
+		}
+		stack = append(stack, frame{dir: workspaceMigrationCleanRelPath(path.Dir(p)), cfg: cfg})
+	}
+
+	for len(stack) > 0 {
+		f := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, ref := range workspace.LocalModuleRefs(f.cfg) {
+			// An absolute source is not workspace-relative; path.Join would
+			// silently rebase it under the referrer's dir and migrate the wrong
+			// in-tree module, so treat it like an out-of-workspace reference.
+			if path.IsAbs(filepath.ToSlash(ref.Source)) {
+				warnings = append(warnings, fmt.Sprintf(
+					"skipped migrating local module %q: %q is an absolute path outside the workspace and was left as-is",
+					ref.Name, ref.Source))
+				continue
+			}
+			modDir := workspaceMigrationJoinRelPath(f.dir, ref.Source)
+			// Migration is scoped to the selected project; a ref that resolves
+			// outside it (e.g. a toolchain shared from a sibling directory)
+			// belongs to another project and is left as legacy.
+			if !workspaceMigrationWithinProject(projectRoot, modDir) {
+				warnings = append(warnings, fmt.Sprintf(
+					"skipped migrating local module %q: %q resolves outside the migrated project and was left as-is",
+					ref.Name, ref.Source))
+				continue
+			}
+			if _, ok := visited[modDir]; ok {
+				continue
+			}
+			visited[modDir] = struct{}{}
+
+			cfgPath := path.Join(modDir, workspace.LegacyModuleConfigFileName)
+			exists, err := workspaceMigrationPathExists(ctx, rootDir, cfgPath)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !exists {
+				continue
+			}
+			cfg, err := workspaceMigrationReadLegacyModuleConfig(ctx, rootDir, cfgPath)
+			if err != nil {
+				return nil, nil, err
+			}
+			if workspace.HasOwnWorkspaceSemantics(cfg) {
+				warnings = append(warnings, fmt.Sprintf(
+					"skipped migrating local module %q at %q: it defines its own toolchains or blueprint and must be migrated separately",
+					ref.Name, modDir))
+				continue
+			}
+			discovered = append(discovered, cfgPath)
+			stack = append(stack, frame{dir: modDir, cfg: cfg})
+		}
+	}
+	sort.Strings(discovered)
+	warnings = workspaceMigrationUniqueSortedPaths(warnings)
+	return discovered, warnings, nil
+}
+
+func workspaceMigrationReadLegacyModuleConfig(
+	ctx context.Context,
+	rootDir dagql.ObjectResult[*core.Directory],
+	relPath string,
+) (*modules.ModuleConfig, error) {
+	data, err := core.DirectoryReadFile(ctx, rootDir, path.Clean(relPath))
+	if err != nil {
+		return nil, fmt.Errorf("read legacy module config %q: %w", relPath, err)
+	}
+	cfg, err := workspace.ParseLegacyModuleConfigTolerant(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse legacy module config %q: %w", relPath, err)
+	}
+	return cfg, nil
+}
+
+func workspaceMigrationJoinRelPath(dir, source string) string {
+	return workspaceMigrationCleanRelPath(path.Join(dir, filepath.ToSlash(source)))
+}
+
+// workspaceMigrationWithinProject reports whether the cleaned, root-relative
+// modDir is inside the migrated project (projectRoot, also root-relative; ""
+// means the workspace root). A ref that lands outside — a sibling reached via
+// ".." or anything above the root — is out of migration scope.
+func workspaceMigrationWithinProject(projectRoot, modDir string) bool {
+	if projectRoot == "" || projectRoot == "." {
+		return modDir != ".." && !strings.HasPrefix(modDir, "../")
+	}
+	return modDir == projectRoot || strings.HasPrefix(modDir, projectRoot+"/")
 }
 
 func workspaceMigrationSelectedLegacyConfigPath(

--- a/core/schema/workspace_migrate_module_config.go
+++ b/core/schema/workspace_migrate_module_config.go
@@ -26,11 +26,21 @@ func workspaceMigrationModuleConfigConversions(
 		if compatWorkspace == nil || compatWorkspace.Config == nil {
 			continue
 		}
-		if compatWorkspace.MustMigrateToWorkspaceConfig() {
-			continue
-		}
-		if compatWorkspace.Config.SDK != nil && !workspaceMigrationProjectRootInDefaultModules(compatWorkspace.ProjectRoot) {
-			continue
+		if compatWorkspace.DiscoveredLocalModule {
+			// A discovered local toolchain/dependency converts in place even
+			// when its source is a non-root subdir (a normal toolchain would
+			// otherwise be treated as workspace-shaped). Only a genuine nested
+			// workspace (its own toolchains/blueprint) is left as legacy.
+			if workspace.HasOwnWorkspaceSemantics(compatWorkspace.Config) {
+				continue
+			}
+		} else {
+			if compatWorkspace.MustMigrateToWorkspaceConfig() {
+				continue
+			}
+			if compatWorkspace.Config.SDK != nil && !workspaceMigrationProjectRootInDefaultModules(compatWorkspace.ProjectRoot) {
+				continue
+			}
 		}
 		if compatWorkspace.ProjectRoot == "" {
 			return nil, fmt.Errorf("legacy module config project root is required")

--- a/core/schema/workspace_migrate_parent.go
+++ b/core/schema/workspace_migrate_parent.go
@@ -59,6 +59,12 @@ func workspaceMigrationParentAssignments(
 		if compatWorkspace == nil || compatWorkspace.MustMigrateToWorkspaceConfig() {
 			continue
 		}
+		// A discovered local dependency/toolchain target is loaded through its
+		// referrer, not explicitly; it must not create a parent workspace, hoist
+		// its runtime, or warn about explicit loading.
+		if compatWorkspace.DiscoveredLocalModule {
+			continue
+		}
 		if compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil {
 			continue
 		}
@@ -149,6 +155,86 @@ func workspaceMigrationPlannedProjectRoots(plans []*workspace.MigrationPlan) map
 	return roots
 }
 
+// workspaceMigrationConfigTargets indexes the migrated workspace configs (both
+// migration plans and synthesized parent plans) by project root, so an SDK
+// install can locate the config that owns a module and update it in place.
+type workspaceMigrationConfigTargets struct {
+	workspacePlansByRoot map[string]*workspace.MigrationPlan
+	parentPlanIndexes    map[string]int
+	parentPlans          []workspaceMigrationParentPlan
+}
+
+func newWorkspaceMigrationConfigTargets(
+	workspacePlans []*workspace.MigrationPlan,
+	parentPlans []workspaceMigrationParentPlan,
+) workspaceMigrationConfigTargets {
+	byRoot := make(map[string]*workspace.MigrationPlan, len(workspacePlans))
+	for _, plan := range workspacePlans {
+		if plan != nil && plan.ProjectRoot != "" {
+			byRoot[filepath.Clean(plan.ProjectRoot)] = plan
+		}
+	}
+	indexes := make(map[string]int, len(parentPlans))
+	for i, plan := range parentPlans {
+		indexes[filepath.Clean(plan.ProjectRoot)] = i
+	}
+	return workspaceMigrationConfigTargets{
+		workspacePlansByRoot: byRoot,
+		parentPlanIndexes:    indexes,
+		parentPlans:          parentPlans,
+	}
+}
+
+// owningRoot returns the project root of the nearest planned workspace that
+// contains moduleRoot, or "" if none does.
+func (t workspaceMigrationConfigTargets) owningRoot(moduleRoot string) (string, error) {
+	var owning string
+	consider := func(root string) error {
+		contains, err := workspaceMigrationPathContains(root, moduleRoot)
+		if err != nil {
+			return err
+		}
+		if contains && (owning == "" || len(root) > len(owning)) {
+			owning = root
+		}
+		return nil
+	}
+	for root := range t.workspacePlansByRoot {
+		if err := consider(root); err != nil {
+			return "", err
+		}
+	}
+	for root := range t.parentPlanIndexes {
+		if err := consider(root); err != nil {
+			return "", err
+		}
+	}
+	return owning, nil
+}
+
+// update applies transform to the workspace config identified by root, which
+// must be an exact planned root (e.g. from owningRoot or a parent assignment).
+func (t workspaceMigrationConfigTargets) update(root string, transform func([]byte) ([]byte, error)) error {
+	clean := filepath.Clean(root)
+	if plan, ok := t.workspacePlansByRoot[clean]; ok {
+		updated, err := transform(plan.WorkspaceConfigData)
+		if err != nil {
+			return err
+		}
+		plan.WorkspaceConfigData = updated
+		return nil
+	}
+	if idx, ok := t.parentPlanIndexes[clean]; ok {
+		updated, err := transform(t.parentPlans[idx].WorkspaceConfigData)
+		if err != nil {
+			return err
+		}
+		t.parentPlans[idx].WorkspaceConfigData = updated
+		return nil
+	}
+	return fmt.Errorf("workspace config for %q is not planned", root)
+}
+
 func workspaceMigrationInstallParentSDKModules(
 	workspacePlans []*workspace.MigrationPlan,
 	parentPlans []workspaceMigrationParentPlan,
@@ -173,17 +259,7 @@ func workspaceMigrationInstallParentSDKModules(
 		return parentPlans, nil
 	}
 
-	workspacePlansByRoot := make(map[string]*workspace.MigrationPlan, len(workspacePlans))
-	for _, plan := range workspacePlans {
-		if plan == nil || plan.ProjectRoot == "" {
-			continue
-		}
-		workspacePlansByRoot[plan.ProjectRoot] = plan
-	}
-	parentPlanIndexes := make(map[string]int, len(parentPlans))
-	for i, plan := range parentPlans {
-		parentPlanIndexes[plan.ProjectRoot] = i
-	}
+	targets := newWorkspaceMigrationConfigTargets(workspacePlans, parentPlans)
 
 	parentRoots := make([]string, 0, len(modulesByParent))
 	for parentRoot := range modulesByParent {
@@ -196,28 +272,70 @@ func workspaceMigrationInstallParentSDKModules(
 		if len(mods) == 0 {
 			continue
 		}
-
-		if plan, ok := workspacePlansByRoot[parentRoot]; ok {
-			updated, err := workspaceMigrationConfigWithSDKModules(plan.WorkspaceConfigData, mods)
-			if err != nil {
-				return nil, fmt.Errorf("install SDK modules in migrated workspace config at %s: %w", parentRoot, err)
-			}
-			plan.WorkspaceConfigData = updated
-			continue
+		if err := targets.update(parentRoot, func(data []byte) ([]byte, error) {
+			return workspaceMigrationConfigWithSDKModules(data, mods)
+		}); err != nil {
+			return nil, fmt.Errorf("install SDK modules at %s: %w", parentRoot, err)
 		}
-
-		parentIndex, ok := parentPlanIndexes[parentRoot]
-		if !ok {
-			return nil, fmt.Errorf("parent workspace config for %s is not planned", parentRoot)
-		}
-		updated, err := workspaceMigrationConfigWithSDKModules(parentPlans[parentIndex].WorkspaceConfigData, mods)
-		if err != nil {
-			return nil, fmt.Errorf("install SDK modules in parent workspace config at %s: %w", parentRoot, err)
-		}
-		parentPlans[parentIndex].WorkspaceConfigData = updated
 	}
 
 	return parentPlans, nil
+}
+
+// workspaceMigrationInstallDiscoveredModuleSDKs records the runtime of every
+// discovered, converted-in-place local module in the workspace config that owns
+// it, so a module loaded from a local ref inside the workspace has its SDK
+// installed and pinned (with the module listed under [[modules.<sdk>.as-sdk.modules]]).
+// Discovered modules are converted in place and deliberately skip the parent-plan
+// flow (no "requires explicit loading" warning), so their SDK install is handled
+// here instead.
+func workspaceMigrationInstallDiscoveredModuleSDKs(
+	workspacePlans []*workspace.MigrationPlan,
+	parentPlans []workspaceMigrationParentPlan,
+	compatWorkspaces []*workspace.CompatWorkspace,
+) ([]workspaceMigrationParentPlan, error) {
+	targets := newWorkspaceMigrationConfigTargets(workspacePlans, parentPlans)
+
+	for _, compatWorkspace := range compatWorkspaces {
+		if compatWorkspace == nil || !compatWorkspace.DiscoveredLocalModule {
+			continue
+		}
+		if compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil || compatWorkspace.Config.SDK.Source == "" {
+			continue
+		}
+
+		owner, err := targets.owningRoot(compatWorkspace.ProjectRoot)
+		if err != nil {
+			return nil, err
+		}
+		if owner == "" {
+			// Every discovered module descends from a config that is itself
+			// migrated into a workspace, so a planned owner is expected.
+			return nil, fmt.Errorf("no migrated workspace owns discovered module %q", compatWorkspace.ProjectRoot)
+		}
+		modulePath, err := filepath.Rel(owner, compatWorkspace.ProjectRoot)
+		if err != nil {
+			return nil, fmt.Errorf("discovered module %q path: %w", compatWorkspace.ProjectRoot, err)
+		}
+		modulePath = filepath.ToSlash(filepath.Clean(modulePath))
+		sdkSource := compatWorkspace.Config.SDK.Source
+
+		if err := targets.update(owner, func(data []byte) ([]byte, error) {
+			return workspaceMigrationConfigWithMigratedModuleSDK(data, sdkSource, modulePath)
+		}); err != nil {
+			return nil, fmt.Errorf("install SDK for discovered module %q: %w", compatWorkspace.ProjectRoot, err)
+		}
+	}
+	return parentPlans, nil
+}
+
+func workspaceMigrationConfigWithMigratedModuleSDK(configData []byte, sdkSource, modulePath string) ([]byte, error) {
+	cfg, err := workspace.ParseConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+	workspace.AddMigratedModuleSDK(cfg, sdkSource, modulePath)
+	return workspace.UpdateConfigBytes(configData, cfg)
 }
 
 func workspaceMigrationSDKModule(compatWorkspace *workspace.CompatWorkspace) (coresdk.WorkspaceModule, bool, error) {

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -480,6 +481,69 @@ func TestWorkspaceMigrationModuleConfigConversions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "data", cfg.Name)
 	require.Nil(t, cfg.SDK)
+}
+
+func TestWorkspaceMigrationJoinRelPathAndScope(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		dir         string
+		source      string
+		wantDir     string
+		projectRoot string
+		wantWithin  bool
+	}{
+		{name: "child from root", dir: ".", source: "./toolchain", wantDir: "toolchain", projectRoot: "", wantWithin: true},
+		{name: "nested child", dir: "libs/foo", source: "./sub", wantDir: "libs/foo/sub", projectRoot: "", wantWithin: true},
+		{name: "sibling within project dir", dir: "app/libs/foo", source: "../bar", wantDir: "app/libs/bar", projectRoot: "app", wantWithin: true},
+		{name: "self", dir: "libs/foo", source: ".", wantDir: "libs/foo", projectRoot: "", wantWithin: true},
+		{name: "escapes workspace root", dir: ".", source: "../shared", wantDir: "../shared", projectRoot: "", wantWithin: false},
+		{name: "sibling outside project", dir: "app", source: "../hello", wantDir: "hello", projectRoot: "app", wantWithin: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workspaceMigrationJoinRelPath(tc.dir, tc.source)
+			require.Equal(t, tc.wantDir, got)
+			require.Equal(t, tc.wantWithin, workspaceMigrationWithinProject(tc.projectRoot, got))
+		})
+	}
+
+	// An absolute source must be caught before joining: path.Join silently
+	// strips the leading slash and rebases it under the referrer, so the scope
+	// check alone would not flag it — the DFS special-cases path.IsAbs first.
+	require.Equal(t, "app/tmp/foo", workspaceMigrationJoinRelPath("app", "/tmp/foo"))
+	require.True(t, path.IsAbs("/tmp/foo"))
+}
+
+func TestWorkspaceMigrationDiscoveredLocalModuleConversions(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "repo")
+
+	// A normal toolchain (sdk + non-root source) would look "workspace-shaped"
+	// to mustMigrateToWorkspaceConfig, but as a discovered local module it must
+	// convert in place, keeping its source.
+	toolchain := testRuntimeCompatWorkspace(t, filepath.Join(root, "toolchain"), `{
+  "name": "tc",
+  "sdk": {"source": "go"},
+  "source": "src"
+}`)
+	toolchain.DiscoveredLocalModule = true
+
+	// A discovered module that owns toolchains is a genuine nested workspace and
+	// must be left as legacy, not converted in place.
+	nested := testRuntimeCompatWorkspace(t, filepath.Join(root, "nested"), `{
+  "name": "nested",
+  "sdk": {"source": "go"},
+  "toolchains": [{"name": "x", "source": "./x"}]
+}`)
+	nested.DiscoveredLocalModule = true
+
+	conversions, err := workspaceMigrationModuleConfigConversions([]*workspace.CompatWorkspace{toolchain, nested})
+	require.NoError(t, err)
+	require.Len(t, conversions, 1, "the normal toolchain converts; the nested workspace is left as legacy")
+	require.Equal(t, filepath.Join(root, "toolchain"), conversions[0].ProjectRoot)
+	cfg, err := modules.ParseModuleConfigForFilename(conversions[0].ConfigData, workspace.ModuleConfigFileName)
+	require.NoError(t, err)
+	require.Equal(t, "tc", cfg.Name)
+	require.Equal(t, "go", cfg.SDK.Source)
+	require.Equal(t, "src", cfg.Source)
 }
 
 func TestWorkspaceMigrationLegacyLockProjectRootsIncludesModuleConfigConversions(t *testing.T) {

--- a/core/workspace/deptree.go
+++ b/core/workspace/deptree.go
@@ -1,0 +1,59 @@
+package workspace
+
+import (
+	"strings"
+
+	"github.com/dagger/dagger/core/modules"
+)
+
+// LocalModuleRefs returns the local-path module references declared by cfg,
+// drawn from its toolchains and dependencies in a stable order (toolchains
+// first, then dependencies, each in declaration order). Remote (git/registry)
+// references and the blueprint are skipped: migration recurses into the
+// locally-defined modules a config points at, and blueprints are out of scope.
+func LocalModuleRefs(cfg *modules.ModuleConfig) []*modules.ModuleConfigDependency {
+	if cfg == nil {
+		return nil
+	}
+	refs := make([]*modules.ModuleConfigDependency, 0, len(cfg.Toolchains)+len(cfg.Dependencies))
+	for _, tc := range cfg.Toolchains {
+		if tc != nil && IsLocalRef(tc.Source, tc.Pin) {
+			refs = append(refs, tc)
+		}
+	}
+	for _, dep := range cfg.Dependencies {
+		if dep != nil && IsLocalRef(dep.Source, dep.Pin) {
+			refs = append(refs, dep)
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+// HasOwnWorkspaceSemantics reports whether cfg defines workspace-level
+// semantics of its own — its own toolchains or a blueprint. Such a config
+// cannot be migrated by in-place format conversion; it would need the full
+// workspace treatment (PlanMigration moves and deletes its dagger.json), which
+// would break a referrer that expects the module to stay put. This is
+// deliberately narrower than mustMigrateToWorkspaceConfig, which also fires for
+// a plain module whose source is a non-root subdir (a normal toolchain).
+func HasOwnWorkspaceSemantics(cfg *modules.ModuleConfig) bool {
+	return cfg != nil && (cfg.Blueprint != nil || len(cfg.Toolchains) > 0)
+}
+
+// ParseLegacyModuleConfigTolerant parses a legacy dagger.json into a module
+// config, falling back to a shape-only parse when the config declares a newer
+// engine version than this binary supports. Migration still needs to read such
+// a config's dependency graph to recurse, and to convert what it can.
+func ParseLegacyModuleConfigTolerant(data []byte) (*modules.ModuleConfig, error) {
+	cfg, err := parseLegacyConfig(data)
+	if err != nil {
+		if !strings.Contains(err.Error(), "module requires dagger") {
+			return nil, err
+		}
+		return parseLegacyConfigShape(data)
+	}
+	return cfg, nil
+}

--- a/core/workspace/deptree_test.go
+++ b/core/workspace/deptree_test.go
@@ -1,0 +1,101 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/core/modules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalModuleRefs(t *testing.T) {
+	t.Parallel()
+
+	cfg := &modules.ModuleConfig{
+		Toolchains: []*modules.ModuleConfigDependency{
+			{Name: "tc-local", Source: "./toolchain"},
+			{Name: "tc-remote", Source: "github.com/acme/tc@main"},
+			nil,
+		},
+		Dependencies: []*modules.ModuleConfigDependency{
+			{Name: "dep-remote", Source: "github.com/acme/dep@main", Pin: "sha256:abc"},
+			{Name: "dep-local", Source: "../libs/foo"},
+		},
+		Blueprint: &modules.ModuleConfigDependency{Name: "bp", Source: "./blueprint"},
+	}
+
+	refs := LocalModuleRefs(cfg)
+	require.Len(t, refs, 2, "only local toolchains + deps, blueprint excluded")
+	require.Equal(t, "tc-local", refs[0].Name, "toolchains come first, in order")
+	require.Equal(t, "dep-local", refs[1].Name, "dependencies follow toolchains")
+}
+
+func TestLocalModuleRefsEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, LocalModuleRefs(nil))
+	require.Nil(t, LocalModuleRefs(&modules.ModuleConfig{
+		Dependencies: []*modules.ModuleConfigDependency{
+			{Name: "remote", Source: "github.com/acme/dep@main"},
+		},
+	}))
+}
+
+func TestAddMigratedModuleSDK(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates a builtin as-sdk install", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{}}
+		AddMigratedModuleSDK(cfg, "go", "libs/foo")
+		entry, ok := cfg.Modules["dagger-go-sdk"]
+		require.True(t, ok)
+		require.Equal(t, "go", entry.Source)
+		require.NotNil(t, entry.AsSDK)
+		require.Len(t, entry.AsSDK.Modules, 1)
+		require.Equal(t, "libs/foo", entry.AsSDK.Modules[0].Path)
+	})
+
+	t.Run("shares one entry across modules with the same runtime", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{}}
+		AddMigratedModuleSDK(cfg, "go", ".dagger/modules/myapp")
+		AddMigratedModuleSDK(cfg, "go", "libs/foo")
+		require.Len(t, cfg.Modules, 1)
+		require.ElementsMatch(t,
+			[]string{".dagger/modules/myapp", "libs/foo"},
+			[]string{cfg.Modules["dagger-go-sdk"].AsSDK.Modules[0].Path, cfg.Modules["dagger-go-sdk"].AsSDK.Modules[1].Path},
+		)
+	})
+
+	t.Run("separate entries for different runtimes", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{}}
+		AddMigratedModuleSDK(cfg, "go", "a")
+		AddMigratedModuleSDK(cfg, "python", "b")
+		require.Contains(t, cfg.Modules, "dagger-go-sdk")
+		require.Contains(t, cfg.Modules, "dagger-python-sdk")
+	})
+
+	t.Run("external SDK keeps its ref as source", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{}}
+		AddMigratedModuleSDK(cfg, "github.com/acme/custom-sdk", "libs/foo")
+		entry, ok := cfg.Modules["custom-sdk"]
+		require.True(t, ok)
+		require.Equal(t, "github.com/acme/custom-sdk", entry.Source)
+		require.NotNil(t, entry.AsSDK)
+		require.Len(t, entry.AsSDK.Modules, 1)
+	})
+}
+
+func TestHasOwnWorkspaceSemantics(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, HasOwnWorkspaceSemantics(nil))
+	require.False(t, HasOwnWorkspaceSemantics(&modules.ModuleConfig{
+		SDK:    &modules.SDK{Source: "go"},
+		Source: "src",
+	}), "a normal sdk+source:subdir toolchain must convert, not be treated as a nested workspace")
+	require.True(t, HasOwnWorkspaceSemantics(&modules.ModuleConfig{
+		Toolchains: []*modules.ModuleConfigDependency{{Name: "tc", Source: "./tc"}},
+	}))
+	require.True(t, HasOwnWorkspaceSemantics(&modules.ModuleConfig{
+		Blueprint: &modules.ModuleConfigDependency{Name: "bp", Source: "./bp"},
+	}))
+}

--- a/core/workspace/legacy.go
+++ b/core/workspace/legacy.go
@@ -35,6 +35,13 @@ type CompatWorkspace struct {
 	Config      *modules.ModuleConfig
 	ConfigPath  string
 	ProjectRoot string
+
+	// DiscoveredLocalModule marks a compat workspace that was reached by
+	// following a local toolchain/dependency reference from another migrated
+	// config (rather than being the selected project or a .dagger/modules
+	// glob hit). Such a module is converted in place regardless of a non-root
+	// source, and is never routed to PlanMigration or a parent plan.
+	DiscoveredLocalModule bool
 }
 
 // CompatWorkspaceModule is one workspace-owned module projected out of a

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -40,6 +40,52 @@ func migrationSDKInstallName(sdkRef string) string {
 	return name
 }
 
+// AddMigratedModuleSDK records, in a workspace config, the SDK/runtime a
+// migrated module uses: modulePath is added to the as-sdk managed-module list
+// of the install that exposes sdkSource. An existing as-sdk install for the
+// same runtime source is reused (so several locally-referenced modules sharing
+// a runtime collapse to one [modules.<sdk>] entry); otherwise a new one is
+// created, matching how the root module's SDK is recorded. This keeps every
+// locally-defined module's runtime installed and pinned in the workspace.
+func AddMigratedModuleSDK(wsCfg *Config, sdkSource, modulePath string) {
+	if wsCfg == nil || sdkSource == "" {
+		return
+	}
+	if wsCfg.Modules == nil {
+		wsCfg.Modules = map[string]ModuleEntry{}
+	}
+
+	// Reuse the existing as-sdk install for this runtime, if any, so the same
+	// runtime is not installed twice under different names.
+	for name, entry := range wsCfg.Modules {
+		if entry.AsSDK != nil && entry.Source == sdkSource {
+			entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: modulePath})
+			wsCfg.Modules[name] = entry
+			return
+		}
+	}
+
+	sdkName := migrationSDKInstallName(sdkSource)
+	sdkIsBuiltin := sdkmeta.IsBuiltin(ConventionalSDKShortName(sdkSource))
+	entry, exists := wsCfg.Modules[sdkName]
+	// A builtin SDK's legacy source (e.g. "go") is a runtime name, not a
+	// module source, so an existing same-named module is never the same
+	// install. For external/custom SDKs the source is a real ref/path, so
+	// reuse the entry only when it matches; otherwise don't clobber it.
+	if exists && (sdkIsBuiltin || entry.Source != sdkSource) {
+		sdkName = uniqueModuleName(wsCfg.Modules, sdkName)
+		exists = false
+	}
+	if !exists {
+		entry = ModuleEntry{Source: sdkSource}
+	}
+	if entry.AsSDK == nil {
+		entry.AsSDK = &ModuleAsSDK{}
+	}
+	entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: modulePath})
+	wsCfg.Modules[sdkName] = entry
+}
+
 // uniqueModuleName returns base if free, otherwise base with a numeric suffix,
 // so a migrated SDK install never silently overwrites an unrelated module that
 // happens to share its name.
@@ -134,28 +180,7 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 	// [modules.<sdk>.as-sdk.*]. This is the file-format catch-up for the
 	// runtime/SDK split.
 	if hasSDK {
-		sdkName := migrationSDKInstallName(cfg.SDK.Source)
-		sdkIsBuiltin := sdkmeta.IsBuiltin(ConventionalSDKShortName(cfg.SDK.Source))
-		entry, exists := wsCfg.Modules[sdkName]
-		// A builtin SDK's legacy source (e.g. "go") is a runtime name, not a
-		// module source, so an existing same-named module is never the same
-		// install. For external/custom SDKs the source is a real ref/path, so
-		// reuse the entry only when it matches; otherwise don't clobber it.
-		if exists && (sdkIsBuiltin || entry.Source != cfg.SDK.Source) {
-			sdkName = uniqueModuleName(wsCfg.Modules, sdkName)
-			exists = false
-		}
-		if !exists {
-			entry = ModuleEntry{Source: cfg.SDK.Source}
-		}
-		if needsProjectModuleMigration {
-			if entry.AsSDK == nil {
-				entry.AsSDK = &ModuleAsSDK{}
-			}
-			modulePath := filepath.Join(LockDirName, "modules", cfg.Name)
-			entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: modulePath})
-		}
-		wsCfg.Modules[sdkName] = entry
+		AddMigratedModuleSDK(wsCfg, cfg.SDK.Source, filepath.Join(LockDirName, "modules", cfg.Name))
 	}
 	workspaceConfigData, err := renderMigrationWorkspaceConfig(wsCfg, compatWorkspace.MainModule)
 	if err != nil {

--- a/hack/designs/done/recursive-local-dependency-migration.md
+++ b/hack/designs/done/recursive-local-dependency-migration.md
@@ -1,0 +1,232 @@
+# Recursive local-dependency migration during `dagger setup`
+
+Design + implementation plan. **Status: draft for review — no code written. Codex-reviewed (gpt-5.5, high). Seed set decided (O7 = toolchains + main-module deps).**
+
+This mirrors the owner-facing HTML design pane. It extends `dagger setup`'s legacy-config
+migration so that module dependencies referenced by a **local relative path** (and their
+transitive local deps) are migrated to the new format, discovered via a deduplicated
+dependency tree so each module is migrated exactly once, in a safe order.
+
+## 1. Verified understanding (correcting the recon)
+
+Two premises needed correcting; net, **Yves was essentially right and the recon's headline claim was wrong.**
+
+### 1.1 The `.dagger/modules/**/dagger.json` glob DOES exist
+
+The recon claimed there is no such glob-scan. It exists at `core/schema/workspace_migrate.go:283`,
+built from constants (which is why a literal grep missed it):
+
+```go
+moduleConfigPattern := path.Join(projectRoot, workspace.LockDirName, "modules", "**", workspace.LegacyModuleConfigFileName)
+// == "<projectRoot>/.dagger/modules/**/dagger.json"
+```
+
+Current discovery set = `{ selected root dagger.json }` ∪ `{ every dagger.json under <projectRoot>/.dagger/modules/** }`.
+
+### 1.2 Today's three handlers
+
+- **Workspace-shaped** config (`blueprint`/`toolchains`, or SDK with non-`.` `source`) → `workspace.PlanMigration`: writes `dagger.toml`, **moves the main module** into `.dagger/modules/<name>/dagger-module.toml`, records `[modules.<name>]`, rebases dep paths.
+- **Plain module** under `.dagger/modules/**` → `workspaceMigrationModuleConfigConversions`: **in-place** `dagger.json → dagger-module.toml`, no move, no rebasing.
+- **Plain module** elsewhere → `workspaceMigrationParentPlansForPlainModules`: creates a parent `dagger.toml`, installs the module's SDK runtime, warns "requires explicit loading"; the `dagger.json` is **not** converted.
+
+### 1.3 `PlanMigration` is PURE (the crux)
+
+`PlanMigration(compatWorkspace)` has no `ctx`/filesystem/engine client. It migrates one main
+module and **rebases** each local-ref dependency's `Source` (via `migratedModuleRelPath`) so the
+reference resolves from the moved config — but never reads that dependency's own `dagger.json`,
+never migrates it, never sees its transitive deps. **The recursive discovery cannot live in
+`PlanMigration`** — filesystem access exists only at the schema layer. This task is primarily a
+**discovery extension at the schema layer.**
+
+### 1.4 The gap
+
+Two flavors, both about local references in the root `dagger.json` whose own config lives
+*outside* `.dagger/modules/**`:
+
+- **Local toolchains (primary case).** A toolchain `{name: defaults, source: ./toolchain}` gets a
+  workspace `[modules.defaults]` entry pointing at `./toolchain`, but `./toolchain/dagger.json` is
+  **never converted** — it isn't under `.dagger/modules/**`. (The existing test only checks the
+  workspace entry, not the toolchain's config.)
+- **Main-module local dependencies.** For `myapp` with `dependencies: [{name: foo, source: ./libs/foo}]`,
+  `foo` is not discovered; myapp's dep is rebased to `../../../libs/foo`, which still holds an
+  unconverted legacy `dagger.json`.
+
+## 2. Key reframe: unconverted deps still LOAD
+
+`modules.ConfigFilenames()` returns **both** `dagger-module.toml` and `dagger.json`, and
+`moduleConfigInDir` / `selectFoundModuleConfig` (`core/schema/modulesource.go:361-393`) accept
+either. So a dep dir holding only a legacy `dagger.json` **still loads** in the migrated engine.
+
+Therefore the current dangling-reference state is **safe-but-incomplete, not broken**. The task
+is about **completeness of migration** (leave nothing in legacy format), and **"leave as legacy
+and warn" is a genuinely safe fallback** for every edge case we can't cleanly convert.
+
+## 3. Design
+
+### 3.1 Strategy: in-place, not move (recommend Strategy B)
+
+- **A — move into `.dagger/modules/<name>/`** (Yves's sketch): cascades a move+rebase to every node.
+- **B — convert in place** (recommended): nothing moves ⇒ nothing rebases; the referrer's dep
+  path (already rebased to the physical location) stays valid.
+
+Codex confirmed B is rebase-free for plain deps and matches the shipped `.dagger/modules/**`
+behavior. B avoids the whole class of "did we rebase referrer + source + transitive deps +
+includes consistently?" silent bugs. **Verdict: B.**
+
+### 3.2 Do NOT register transitive deps in `[modules.*]`
+
+Verified (`core/schema/modulesource.go:968, 614, 3402`): module deps are read from each module's
+own config and resolved via `ResolveDepToSource` — a workspace `[modules.*]` entry is **not
+required** for a dependency to load. Promoting a private transitive dep changes its visibility
+for no gain. Existing in-place `.dagger/modules/**` conversion already doesn't register them.
+
+### 3.3 Tree-building algorithm
+
+Pure "which local dep dirs" lives in `core/workspace`; impure "read + recurse" in the schema layer.
+
+```text
+localModuleRefs(cfg): return cfg.Toolchains ++ cfg.Dependencies   # NOT cfg.Blueprint (O7)
+hasOwnWorkspaceSemantics(cfg): return cfg.Blueprint != nil OR len(cfg.Toolchains) > 0
+
+discoverLocalModules(seedConfigs, projectRoot):
+    visited := {}                              # canonical rel-path of every config dir
+    for c in seedConfigs: visited.add(cleanRel(dir(c)))   # SEED with all initial dirs (Codex #2)
+    order := []
+    walk(cfg, cfgDir):
+      for ref in localModuleRefs(cfg):                            # root: toolchains + deps
+        if not IsLocalRef(ref.Source, ref.Pin): continue         # git/registry: leave as-is
+        modDir := cleanRel(join(cfgDir, ref.Source))             # canonical dedup key
+        if escapesProjectRoot(modDir):   warn+skip; continue     # e1
+        if modDir in visited:            continue                # diamond + cycle + seed guard
+        visited.add(modDir)
+        cfgPath := join(modDir, "dagger.json")
+        if not exists(cfgPath):          continue                # e2
+        modCfg := parseLegacyShapeTolerant(read(cfgPath))        # e4
+        if hasOwnWorkspaceSemantics(modCfg): warn+skip; continue # O6 — genuine nested workspace only
+        order.append({cfgPath, DiscoveredLocalModule})
+        walk(modCfg, modDir)                                     # recurse into ITS toolchains + deps
+    for c in seedConfigs: walk(parse(c), dir(c))
+    return order
+```
+
+- **Seeds = toolchains + main-module dependencies** of the root (O7); blueprint excluded. The root's
+  own main module keeps its existing `PlanMigration` handling; the walk only *discovers* the local
+  modules it references.
+- **Dedup key** = cleaned referenced-module **directory** path, not the declared string.
+- **Seed visited** with every initial config dir so a cycle back to a seed can't double-plan the root.
+- **Cycle safety**: `visited` populated before recursing; explicit worklist avoids stack blowups.
+- **Skip predicate is narrow (O6)**: skip only a module with its *own* `toolchains`/`blueprint`. A
+  normal `sdk`+`source:"src"` toolchain converts in place — do **not** use `mustMigrateToWorkspaceConfig`
+  (it over-fires on `source != "."`).
+
+### 3.4 Naming / collision
+
+Under B + no `[modules.*]` promotion there is **no destination-name allocation** — each dep keeps
+its dir; dedup key is its path; `uniqueModuleName` unnecessary. (If O2 = register: key by the
+module's own `Name`, fallback referrer entry `Name`, with `uniqueModuleName` collision handling.)
+
+### 3.5 Edge cases
+
+| # | Case | Decision |
+|---|------|----------|
+| e1 | escapes project root (`../shared`) | Skip + warn (plain dep still loads); escalate to actionable report if workspace-shaped/newer-engine |
+| e2 | dep dir has no `dagger.json` | Leave reference; info note |
+| e3 | dep already under `.dagger/modules/**` | Dedup across glob + walk; preserve glob behavior (origin precedence) |
+| e4 | dep requires newer engine | Shape fallback (`parseLegacyConfigShape`); also add to `workspaceMigrationCompatWorkspaceForLegacyConfig` (Codex #7) |
+| e5 | hidden-path dep (`./.internal/foo`) | Explicit dep bypasses `workspaceMigrationHiddenPath` (Codex #5) |
+| e6 | dep under existing `dagger.toml` ancestor | Skip + diagnostic (ancestor owns it) (Codex #6) |
+| e7 | symlink / `..` aliasing | Clean-path dedup; `EvalSymlinks` out of scope |
+| e8 | two dep entries, same source | Collapsed by `visited` |
+
+### 3.6 Path-rebasing correctness
+
+Under B, **only the main module moves** (existing, tested behavior). Its dep refs rebase to the
+physical dependency locations, which don't move ⇒ valid. Converted-in-place deps keep every
+relative path unchanged ⇒ valid. No dangling old-path references.
+
+### 3.7 Warnings
+
+Plain deps: no new gap warnings (customizations already preserved by `cloneCustomizations`). Add
+info notes for the skip cases (e1/e2/e5/e6).
+
+## 4. Diagram
+
+```mermaid
+graph TD
+  subgraph Before["Before — legacy dagger.json"]
+    A0["myapp/dagger.json<br/>sdk=go · deps: foo, bar"]
+    F0["libs/foo/dagger.json<br/>deps: ./sub, ../bar"]
+    B0["libs/bar/dagger.json"]
+    S0["libs/foo/sub/dagger.json"]
+    G0["acme/ext@v1 (remote)"]
+    A0 --> F0
+    A0 --> B0
+    A0 -. remote, untouched .-> G0
+    F0 --> S0
+    F0 -->|diamond| B0
+  end
+  subgraph After["After — Strategy B"]
+    W1["dagger.toml (workspace)<br/>[modules.myapp]"]
+    A1[".dagger/modules/myapp/…toml<br/>foo=../../../libs/foo (rebased)"]
+    F1["libs/foo/…-module.toml (in place)"]
+    B1["libs/bar/…-module.toml (in place)"]
+    S1["libs/foo/sub/…-module.toml (in place)"]
+    W1 --> A1
+    A1 --> F1
+    A1 --> B1
+    F1 --> S1
+    F1 -->|migrated once| B1
+  end
+  Before ==>|dagger setup| After
+```
+
+## 5. File-by-file implementation plan
+
+- **`core/workspace/` (pure):** new `LocalModuleRefs(cfg)` (local refs from **Toolchains + Dependencies**,
+  blueprint excluded) and `HasOwnWorkspaceSemantics(cfg) = Blueprint != nil || len(Toolchains) > 0` (the
+  O6 predicate — **not** `mustMigrateToWorkspaceConfig`). `PlanMigration` / `buildMigratedModuleConfig`
+  **unchanged** under B.
+- **`core/schema/workspace_migrate.go`:** new `workspaceMigrationLocalModuleConfigPaths` (the DFS of
+  §3.3, walking toolchains+deps, using `core.DirectoryReadFile` + `workspaceMigrationPathExists`).
+  Change `workspaceMigrationLegacyConfigPaths` to return paths with an **origin set**
+  (`{Selected, UnderDefaultModules, DiscoveredLocalModule}`, merged on dedup — Codex #3). Thread origin
+  onto `CompatWorkspace`; bypass `workspaceMigrationHiddenPath` for discovered modules.
+- **Routing (two edits):** the `workspace_migrate.go` main loop must **skip `DiscoveredLocalModule`
+  configs** for `PlanMigration` (even when `source != "."`); `workspace_migrate_module_config.go`
+  converts them in place via `legacyModuleConfigAsCurrent` unless `HasOwnWorkspaceSemantics` (O6).
+- **`core/schema/workspace_migrate_parent.go`:** `workspaceMigrationParentAssignments` skips a
+  **purely**-`DiscoveredLocalModule` config (no "explicit loading" warning, no runtime hoist).
+  Precedence: if also `UnderDefaultModules`, keep today's behavior (Codex #3).
+- **Tests:** unit for `LocalModuleRefs`/`HasOwnWorkspaceSemantics`/DFS (dedup, diamond, cycle, seed-cycle,
+  boundary); integration subtests: **local toolchain converted (incl. `source:"src"`)**, local dep
+  converted, transitive depth ≥2, diamond→once, cycle→terminates, cycle-to-root, no-dagger.json,
+  out-of-tree, nested-workspace (O6), remote untouched.
+
+## 6. Open decisions (recommendations in bold)
+
+- **O1 — in-place vs move:** **in-place (B).** Main pushback on the sketch.
+- **O2 — register transitive deps in `[modules.*]`:** **No** (top-level toolchains keep their existing
+  registration; only deeper transitive deps are excluded). Departs from sketch item 4.
+- **O3 — out-of-tree (`../shared`):** **skip + warn** (plain); escalate for nested-workspace/newer-engine.
+- **O4 — warnings for plain deps:** **none new**; info notes for skip cases.
+- **O5 — symlink dedup:** **out of scope.**
+- **O6 — genuine nested workspace as a discovered module (from Codex, corrected):** **leave legacy +
+  warn**, but only when it has its *own* `toolchains`/`blueprint` — `PlanMigration` would move+delete
+  its `dagger.json` and break the referrer. A normal `sdk`+`source:"src"` toolchain converts (predicate
+  is `hasOwnWorkspaceSemantics`, not `mustMigrateToWorkspaceConfig`).
+- **O7 — seed set (decided by Yves):** **toolchains + main-module dependencies** (and their transitive
+  local deps); blueprint excluded.
+
+**Scope:** with O1=B and O2=No, the change is new schema-layer discovery + a one-line gate + a
+parent-plan skip; `core/workspace/migrate.go` and `PlanMigration` stay untouched. O1=A / O2=Yes
+expands into per-node move+rebase and collision handling — materially larger and riskier.
+
+## 7. Codex review — findings folded in
+
+Confirmed: in-place is rebase-free for plain deps (#8); transitive deps load without `[modules.*]`
+(#9). Actionable gaps folded above: workspace-shaped nested dep (#1 → O6), cycle-to-seed (#2 →
+seed visited), origin-as-set precedence (#3 → §5), out-of-tree load safety (#4 → e1/O3), hidden
+paths (#5 → e5), `dagger.toml` ancestor shadowing (#6 → e6), newer-engine shape fallback in compat
+construction (#7 → e4).
+
+Signed-off-by: Yves Brissaud <yves@dagger.io>


### PR DESCRIPTION
Extends `dagger setup` migration so the root `dagger.json`'s locally-referenced toolchains and main-module dependencies — and their transitive local deps — are migrated from legacy `dagger.json` to `dagger-module.toml` **in place** (not moved), via a cycle/diamond-safe depth-first walk.

- Each converted module's runtime SDK is installed and pinned in the owning workspace config, recorded under `[[modules.<sdk>.as-sdk.modules]]`, sharing one install per runtime.
- Modules that resolve outside the workspace, have no `dagger.json`, are absolute refs, sit under a hidden `.dagger/modules` path, or own their own toolchains/blueprint are left as legacy (safe — a legacy `dagger.json` still loads) with a migration warning.
- Reuses `core/workspace/migrate.go`'s `PlanMigration` and `core/schema`'s install/conversion paths (shared `AddMigratedModuleSDK` helper + a shared config-targets helper).

## Verification

- `TestWorkspaceMigration` integration suite (32 subtests) passes via `dagger call engine-dev test`.
- All `core/workspace` + `core/schema` unit tests pass; `go build ./core/...`, `go vet`, and gofmt are clean.
