### PR TITLE
feat(sdk/typescript): no codegen at runtime

### DIFF
--- a/cmd/codegen/generator/typescript/templates/entrypoint_functions.go
+++ b/cmd/codegen/generator/typescript/templates/entrypoint_functions.go
@@ -24,6 +24,11 @@ func EntrypointTemplateFuncs(module *TypedefModule, opts EntrypointOptions) temp
 		"renderTypeDef":        c.renderTypeDef,
 		"renderArgCall":        c.renderArgCall,
 		"renderFunctionExpr":   c.renderFunctionExpr,
+		"renderObjectDef":      c.renderObjectDef,
+		"renderFieldCall":      c.renderFieldCall,
+		"renderEnumDef":        c.renderEnumDef,
+		"renderEnumMemberCall": c.renderEnumMemberCall,
+		"renderInterfaceDef":   c.renderInterfaceDef,
 		"classRuntimeRef":      c.classRuntimeRef,
 		"classTypeRef":         c.classTypeRef,
 		"isExportedClass":      c.isExportedClass,
@@ -241,7 +246,9 @@ func (c *entrypointFuncCtx) renderArgCall(arg *TypedefArgument) string {
 	if arg.IsOptional {
 		td += ".withOptional(true)"
 	}
-	if hasDefault(arg) {
+	// An explicit `null` default must still be registered as the arg's default
+	// (unlike the coercion path's hasDefault, which excludes null on purpose).
+	if len(arg.DefaultValue) > 0 {
 		dv, ok := c.resolveDefaultValue(arg)
 		if !ok {
 			if !arg.IsOptional {
@@ -252,7 +259,85 @@ func (c *entrypointFuncCtx) renderArgCall(arg *TypedefArgument) string {
 			opts["defaultValue"] = fmt.Sprintf("JSON.stringify(%s) as string & { __JSON: never }", string(b))
 		}
 	}
+	if sm := sourceMapExpr(arg.Location); sm != "" {
+		opts["sourceMap"] = sm
+	}
 	return fmt.Sprintf(".withArg(%s, %s%s)", jsString(arg.Name), td, optsLit(opts))
+}
+
+// sourceMapExpr renders a `dag.sourceMap(path, line, col)` expression for a
+// location captured at codegen time, or "" when absent. The static entrypoint
+// replays these baked values at runtime so no-codegen modules keep the same
+// source-map comments in dependents' bindings as codegen-at-runtime modules.
+func sourceMapExpr(loc *TypedefLocation) string {
+	if loc == nil {
+		return ""
+	}
+	return fmt.Sprintf("dag.sourceMap(%s, %d, %d)", jsString(loc.Filepath), loc.Line, loc.Column)
+}
+
+func (c *entrypointFuncCtx) renderObjectDef(obj *TypedefObject) string {
+	opts := map[string]string{}
+	if obj.Description != "" {
+		opts["description"] = jsString(obj.Description)
+	}
+	if obj.Deprecated != "" {
+		opts["deprecated"] = jsString(obj.Deprecated)
+	}
+	if sm := sourceMapExpr(obj.Location); sm != "" {
+		opts["sourceMap"] = sm
+	}
+	return fmt.Sprintf("dag.typeDef().withObject(%s%s)", jsString(obj.Name), optsLit(opts))
+}
+
+func (c *entrypointFuncCtx) renderFieldCall(prop *TypedefProperty) string {
+	opts := map[string]string{}
+	if prop.Description != "" {
+		opts["description"] = jsString(prop.Description)
+	}
+	if prop.Deprecated != "" {
+		opts["deprecated"] = jsString(prop.Deprecated)
+	}
+	if sm := sourceMapExpr(prop.Location); sm != "" {
+		opts["sourceMap"] = sm
+	}
+	return fmt.Sprintf(".withField(%s, %s%s)", jsString(propFieldName(prop)), c.renderTypeDef(prop.Type), optsLit(opts))
+}
+
+func (c *entrypointFuncCtx) renderEnumDef(e *TypedefEnum) string {
+	opts := map[string]string{}
+	if e.Description != "" {
+		opts["description"] = jsString(e.Description)
+	}
+	if sm := sourceMapExpr(e.Location); sm != "" {
+		opts["sourceMap"] = sm
+	}
+	return fmt.Sprintf("dag.typeDef().withEnum(%s%s)", jsString(e.Name), optsLit(opts))
+}
+
+func (c *entrypointFuncCtx) renderEnumMemberCall(v *TypedefEnumValue) string {
+	opts := map[string]string{"value": jsString(v.Value)}
+	if v.Description != "" {
+		opts["description"] = jsString(v.Description)
+	}
+	if v.Deprecated != "" {
+		opts["deprecated"] = jsString(v.Deprecated)
+	}
+	if sm := sourceMapExpr(v.Location); sm != "" {
+		opts["sourceMap"] = sm
+	}
+	return fmt.Sprintf(".withEnumMember(%s%s)", jsString(v.Name), optsLit(opts))
+}
+
+func (c *entrypointFuncCtx) renderInterfaceDef(iface *TypedefInterface) string {
+	opts := map[string]string{}
+	if iface.Description != "" {
+		opts["description"] = jsString(iface.Description)
+	}
+	if sm := sourceMapExpr(iface.Location); sm != "" {
+		opts["sourceMap"] = sm
+	}
+	return fmt.Sprintf("dag.typeDef().withInterface(%s%s)", jsString(iface.Name), optsLit(opts))
 }
 
 func (c *entrypointFuncCtx) resolveDefaultValue(arg *TypedefArgument) (any, bool) {
@@ -287,6 +372,9 @@ func (c *entrypointFuncCtx) renderFunctionExpr(fn *TypedefFunction) string {
 	parts := []string{fmt.Sprintf("dag.function_(%s, %s)", jsString(fnName), c.renderTypeDef(fn.ReturnType))}
 	if fn.Description != "" {
 		parts = append(parts, fmt.Sprintf(".withDescription(%s)", jsString(fn.Description)))
+	}
+	if sm := sourceMapExpr(fn.Location); sm != "" {
+		parts = append(parts, fmt.Sprintf(".withSourceMap(%s)", sm))
 	}
 	for _, arg := range fn.Arguments {
 		parts = append(parts, c.renderArgCall(arg))

--- a/cmd/codegen/generator/typescript/templates/entrypoint_typedef.go
+++ b/cmd/codegen/generator/typescript/templates/entrypoint_typedef.go
@@ -43,49 +43,55 @@ type TypedefFunction struct {
 	IsCheck     bool               `json:"isCheck"`
 	IsGenerator bool               `json:"isGenerator"`
 	IsUp        bool               `json:"isUp"`
+	Location    *TypedefLocation   `json:"location,omitempty"`
 	ReturnType  *TypedefType       `json:"returnType,omitempty"`
 	Arguments   []*TypedefArgument `json:"arguments"`
 }
 
 type TypedefArgument struct {
-	Name           string          `json:"name"`
-	Description    string          `json:"description,omitempty"`
-	Deprecated     string          `json:"deprecated,omitempty"`
-	Type           *TypedefType    `json:"type,omitempty"`
-	IsVariadic     bool            `json:"isVariadic"`
-	IsNullable     bool            `json:"isNullable"`
-	IsOptional     bool            `json:"isOptional"`
-	DefaultValue   json.RawMessage `json:"defaultValue,omitempty"`
-	DefaultPath    string          `json:"defaultPath,omitempty"`
-	DefaultAddress string          `json:"defaultAddress,omitempty"`
-	Ignore         []string        `json:"ignore,omitempty"`
+	Name           string           `json:"name"`
+	Description    string           `json:"description,omitempty"`
+	Deprecated     string           `json:"deprecated,omitempty"`
+	Type           *TypedefType     `json:"type,omitempty"`
+	IsVariadic     bool             `json:"isVariadic"`
+	IsNullable     bool             `json:"isNullable"`
+	IsOptional     bool             `json:"isOptional"`
+	DefaultValue   json.RawMessage  `json:"defaultValue,omitempty"`
+	DefaultPath    string           `json:"defaultPath,omitempty"`
+	DefaultAddress string           `json:"defaultAddress,omitempty"`
+	Ignore         []string         `json:"ignore,omitempty"`
+	Location       *TypedefLocation `json:"location,omitempty"`
 }
 
 type TypedefProperty struct {
-	Name        string       `json:"name"`
-	Alias       string       `json:"alias,omitempty"`
-	Description string       `json:"description,omitempty"`
-	Deprecated  string       `json:"deprecated,omitempty"`
-	IsExposed   bool         `json:"isExposed"`
-	Type        *TypedefType `json:"type,omitempty"`
+	Name        string           `json:"name"`
+	Alias       string           `json:"alias,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Deprecated  string           `json:"deprecated,omitempty"`
+	IsExposed   bool             `json:"isExposed"`
+	Type        *TypedefType     `json:"type,omitempty"`
+	Location    *TypedefLocation `json:"location,omitempty"`
 }
 
 type TypedefEnum struct {
 	Name        string                       `json:"name"`
 	Description string                       `json:"description"`
+	Location    *TypedefLocation             `json:"location,omitempty"`
 	Values      map[string]*TypedefEnumValue `json:"values"`
 }
 
 type TypedefEnumValue struct {
-	Name        string `json:"name"`
-	Value       string `json:"value"`
-	Description string `json:"description"`
-	Deprecated  string `json:"deprecated,omitempty"`
+	Name        string           `json:"name"`
+	Value       string           `json:"value"`
+	Description string           `json:"description"`
+	Deprecated  string           `json:"deprecated,omitempty"`
+	Location    *TypedefLocation `json:"location,omitempty"`
 }
 
 type TypedefInterface struct {
 	Name        string                      `json:"name"`
 	Description string                      `json:"description"`
+	Location    *TypedefLocation            `json:"location,omitempty"`
 	Functions   map[string]*TypedefFunction `json:"functions"`
 }
 

--- a/cmd/codegen/generator/typescript/templates/src/entrypoint/register.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/entrypoint/register.ts.gtpl
@@ -7,10 +7,7 @@ async function register(): Promise<string> {
 {{- end }}
 {{- range $name := sortedKeysObjects $module.Objects }}
 {{- $obj := index $module.Objects $name }}
-  let obj_{{ $obj.Name }} = dag.typeDef().withObject({{ jsString $obj.Name }}
-    {{- if $obj.Description }}, { description: {{ jsString $obj.Description }}{{ if $obj.Deprecated }}, deprecated: {{ jsString $obj.Deprecated }}{{ end }} }
-    {{- else if $obj.Deprecated }}, { deprecated: {{ jsString $obj.Deprecated }} }
-    {{- end }})
+  let obj_{{ $obj.Name }} = {{ renderObjectDef $obj }}
 {{- range $mName := sortedKeysMethods $obj.Methods }}
 {{- $fn := index $obj.Methods $mName }}
   obj_{{ $obj.Name }} = obj_{{ $obj.Name }}.withFunction({{ renderFunctionExpr $fn }})
@@ -18,10 +15,7 @@ async function register(): Promise<string> {
 {{- range $pName := sortedKeysProps $obj.Properties }}
 {{- $prop := index $obj.Properties $pName }}
 {{- if $prop.IsExposed }}
-  obj_{{ $obj.Name }} = obj_{{ $obj.Name }}.withField({{ jsString (propFieldName $prop) }}, {{ renderTypeDef $prop.Type }}
-    {{- if $prop.Description }}, { description: {{ jsString $prop.Description }}{{ if $prop.Deprecated }}, deprecated: {{ jsString $prop.Deprecated }}{{ end }} }
-    {{- else if $prop.Deprecated }}, { deprecated: {{ jsString $prop.Deprecated }} }
-    {{- end }})
+  obj_{{ $obj.Name }} = obj_{{ $obj.Name }}{{ renderFieldCall $prop }}
 {{- end }}
 {{- end }}
 {{- if $obj.Constructor }}
@@ -32,20 +26,16 @@ async function register(): Promise<string> {
 {{- end }}
 {{- range $name := sortedKeysEnums $module.Enums }}
 {{- $e := index $module.Enums $name }}
-  let enum_{{ $e.Name }} = dag.typeDef().withEnum({{ jsString $e.Name }}
-    {{- if $e.Description }}, { description: {{ jsString $e.Description }} }{{ end }})
+  let enum_{{ $e.Name }} = {{ renderEnumDef $e }}
 {{- range $vName := sortedKeysEnumValues $e.Values }}
 {{- $v := index $e.Values $vName }}
-  enum_{{ $e.Name }} = enum_{{ $e.Name }}.withEnumMember({{ jsString $v.Name }}, { value: {{ jsString $v.Value }}
-    {{- if $v.Description }}, description: {{ jsString $v.Description }}{{ end }}
-    {{- if $v.Deprecated }}, deprecated: {{ jsString $v.Deprecated }}{{ end }} })
+  enum_{{ $e.Name }} = enum_{{ $e.Name }}{{ renderEnumMemberCall $v }}
 {{- end }}
   mod = mod.withEnum(enum_{{ $e.Name }})
 {{- end }}
 {{- range $name := sortedKeysIfaces $module.Interfaces }}
 {{- $iface := index $module.Interfaces $name }}
-  let iface_{{ $iface.Name }} = dag.typeDef().withInterface({{ jsString $iface.Name }}
-    {{- if $iface.Description }}, { description: {{ jsString $iface.Description }} }{{ end }})
+  let iface_{{ $iface.Name }} = {{ renderInterfaceDef $iface }}
 {{- range $fnName := sortedKeysMethods $iface.Functions }}
 {{- $fn := index $iface.Functions $fnName }}
   iface_{{ $iface.Name }} = iface_{{ $iface.Name }}.withFunction({{ renderFunctionExpr $fn }})

--- a/hack/designs/typescript-no-codegen-at-runtime.md
+++ b/hack/designs/typescript-no-codegen-at-runtime.md
@@ -1,0 +1,606 @@
+# TypeScript SDK — no codegen at runtime
+
+Status: draft / design
+Author: Tom Chauveau
+Base branch: `workspace-typescrip-no-codegen-at-runtime` (on top of PR #13381)
+
+## Implementation status (2026-07-10)
+
+Self calls are **deferred**: the `dag.Schema().Merge()` schematool is a dev/v1
+engine feature not present in the released engine available locally, so the
+Codegen merge (§4.3) is not wired and the generated bindings stay deps-only (no
+module self types). What is implemented on the branch now:
+
+- **Done:** the introspection emitter (§4.2, `introspection_json.ts`) +
+  `EMIT_INTROSPECTION_JSON_FILE` sink + unit test — tested, inert, staged for
+  when self calls are enabled.
+- **Done:** `ModuleTypes` removed from the TS SDK (method, `AsEntrypoint`, and
+  the dispatcher case in `dagger.gen.go`), so type discovery flows through the
+  runtime `getModDef` → the committed static entrypoint's `register()`, exactly
+  like the Go SDK. `dagger.gen.go` was hand-edited (dispatcher case only) rather
+  than regenerated, because a regen against the released engine would replace
+  the dev-engine client; a proper dev-engine regen is still pending.
+- **Done:** the no-codegen `SetupContainer` path (§4.4) for node/deno/bun +
+  `requireGeneratedFiles`, plus `ModuleRuntime`'s `introspectionJSON` marked
+  `+optional`. Inert until the engine omits the argument (§4.5, colleague's PR).
+- **Deferred (needs dev engine):** the Codegen self-type merge (§4.3) and the
+  `RuntimeCodegenDisabled`/`SelfCallsEnabled` engine wiring (§4.6).
+
+## 1. Goal
+
+Bring the TypeScript SDK to feature parity with the Go SDK work landed on this
+branch (commits `1fd00de3`, `0a9f2a8b`, `d4b21218`):
+
+- A module can **opt out of runtime codegen** by setting
+  `codegen.automaticGitignore = false` in `dagger.json`. It then commits its
+  generated files (`sdk/`, `__dagger.entrypoint.ts`, `package.json`,
+  `tsconfig.json`/`deno.json`, lockfile) and the runtime **trusts them as-is**:
+  no codegen pass, no entrypoint generation, no config rewriting at
+  `dagger call` / `dagger functions` time. We simply build a container, mount
+  the committed sources, install dependencies, and run the committed entrypoint.
+- Codegen still runs at `dagger init` / `dagger develop` / `dagger generate`
+  time, and it must now produce **complete** client bindings — including the
+  module's own types so **self-calls** work without a runtime regeneration.
+  All four self-call shapes the Go work covers (scalar fields, enum args,
+  secondary-object namespacing, object-arg-by-ID via `@expectedType`) are in
+  scope from the first cut.
+- Remove the `ModuleTypes` SDK function from the TypeScript SDK, mirroring the
+  Go SDK dropping `moduleTypes`. Type discovery moves to the runtime's
+  `getModDef` path (the static entrypoint's `register()`), exactly like Go.
+
+The net effect: for an opted-out module, `dagger call` starts a plain container
+that runs `tsx __dagger.entrypoint.ts` (or `deno run` / `bun`) against the
+committed tree, with zero codegen containers in the critical path.
+
+## 2. How Go does it today (reference)
+
+This is the model we mirror. Three moving parts:
+
+1. **Drop `moduleTypes`** — `core/sdk/go_sdk.go`:
+   - `AsModuleTypes()` now returns `nil, false`.
+   - `AlwaysEnablesSelfCalls()` returns `true`.
+   - The engine (`core/schema/modulesource.go` `runModuleDefInSDK`) sees
+     `AsModuleTypes()==false` and falls through to `moduleDefViaRuntime`: it
+     loads the runtime and calls the special empty-object/empty-function
+     `getModDef` to obtain the module definition.
+
+2. **Single-pass `generate-module` that merges the module's own types**
+   (`cmd/codegen/generator/go/generate_module.go` L120-172):
+   - Emit the module's own types as introspection JSON via
+     `templates.NewModuleIntrospectionEmitter(...).ModuleIntrospectionJSON(moduleName)`
+     (`cmd/codegen/generator/go/templates/introspect_emit.go`).
+   - Merge them into the deps introspection JSON with the engine schema tool:
+
+     ```go
+     merged, err := g.Config.Dag.
+         Schema(dagger.JSON(depsJSON)).
+         Merge(dagger.JSON(moduleTypesJSON), moduleName).
+         Contents(ctx)
+     ```
+
+   - Generate the client bindings from the **merged** schema, so the bindings
+     contain the module's own types (self-calls).
+   - `generate-module` therefore now needs an engine connection for Go
+     (`cmd/codegen/generate_module.go`: `getGlobalConfig(ctx, lang == Go)`).
+
+3. **Opt-out gate in the runtime** (`core/sdk/go_sdk.go` `Runtime` +
+   `useRuntimeCodegen` + `baseWithoutCodegen` + `requireGeneratedFiles`):
+   - `useRuntimeCodegen(src)` returns `true` (regenerate) unless
+     `codegen.automaticGitignore == false` **and** the module's pinned
+     `engineVersion` is at least as new as the running engine
+     (`!engine.CheckVersionCompatibility(src.EngineVersion, engine.Version)`).
+     Version skew ⇒ fall back to runtime codegen (so the repo's own dev modules,
+     pinned to the last stable release but run against an in-dev engine, keep
+     working).
+   - On the no-codegen path it verifies the committed files exist
+     (`dagger.gen.go`, `internal/dagger/dagger.gen.go`) and errors with a
+     "run `dagger generate`" message if not, then mounts the context dir as-is
+     and runs `go build` against it.
+
+The critical helper to port is **`introspect_emit.go`**: it converts the parsed
+module types into introspection JSON that matches, byte-for-byte in semantics,
+what the engine would have built (namespacing, nullability, `id` Node field,
+`@expectedType` on object/interface args, enum member SCREAMING_SNAKE, Query
+constructor field, and the **legacy per-type `<T>ID` scalars** for pre-v0.21
+schema views). The TypeScript emitter must reproduce the same shape.
+
+## 3. TypeScript SDK today (as-is)
+
+The TypeScript SDK runtime is itself a Dagger module written in **Go**, living
+under `sdk/typescript/runtime/`. It shells out to two things:
+
+- `cmd/codegen` (the `/codegen` binary) for client-binding and entrypoint
+  generation — same binary as Go.
+- `ts-introspector` (the `/bin/ts-introspector` binary, TS source under
+  `sdk/typescript/src/module/introspector/` + `entrypoint/`) which parses the
+  user's TS source with ts-morph into a `DaggerModule`.
+
+### 3.1 SDK functions (`sdk/typescript/runtime/main.go`)
+
+- `Codegen(modSource, introspectionJSON) -> GeneratedCode`
+  1. `analyzeModuleConfig` → detect runtime (node/deno/bun), package manager,
+     paths, base image, sdk-lib origin.
+  2. per-runtime `GenerateDir(ctx)` → produces the codegen overlay:
+     `package.json`, `tsconfig.json`/`deno.json`, lockfile, `sdk/` (bundled lib
+     - `client.gen.ts` + per-dep `<dep>.gen.ts`), and the wrapped source dir.
+     The bindings are generated **from `introspectionJSON`** (engine deps only)
+     via `LibGenerator.GenerateBundleLibrary` → `GenerateBindings` →
+     `codegen generate-module --introspection-json-path /schema.json`.
+  3. add default `src/index.ts` template if the module has no sources yet.
+  4. `NewIntrospector(...).EmitEntrypoint(...)` → runs `ts-introspector` in
+     `EMIT_TYPEDEF_JSON_FILE` mode to write `typedef.json`, then
+     `codegen generate-entrypoint --typedef-json-path typedef.json` to render
+     `__dagger.entrypoint.ts`. That file is added to the overlay.
+  5. returns `GeneratedCode` with `WithVCSGeneratedPaths([sdk/**, __dagger.entrypoint.ts])`
+     and `WithVCSIgnoredPaths([...])`.
+
+- `ModuleTypes(modSource, introspectionJSON, outputFilePath) -> Container`
+  **(to be removed)**
+  1. `LibGenerator.GenerateBindings(introspectionJSON, Bundle, ...)` → bindings.
+  2. `NewIntrospector(...).AsEntrypoint(outputFilePath, name, src, clientBindings)`
+     → returns a container whose entrypoint runs `ts-introspector` with
+     `TYPEDEF_OUTPUT_FILE` set; when executed, it registers the module via
+     `Register` and writes the module ID. This is the engine's `moduleTypes`
+     path.
+
+- `ModuleRuntime(modSource, introspectionJSON) -> Container`
+  1. `analyzeModuleConfig`.
+  2. per-runtime `SetupContainer(ctx)`.
+  (`introspectionJSON` becomes **`+optional`** — see §4.4.)
+
+- `GenerateClient(...)`, `RequiredClientGenerationFiles()` — standalone client
+  generation; **out of scope** here (no runtime execution), but the merge work
+  in §4.3 may be reused.
+
+### 3.2 `SetupContainer` (per runtime — node/deno/bun)
+
+Example `NodeRuntime.SetupContainer` (`runtime_node.go` L46-138), the others
+mirror it:
+
+- Build the SDK library lazily (`GenerateBundleLibrary(introspectionJSON, ...)`).
+- In an errgroup:
+  - `CreateOrUpdateTSConfigForModule` → `tsconfig.json`.
+  - sync the SDK library (`sdk/`).
+  - `NewIntrospector(...).EmitEntrypoint(...)` → regenerate `__dagger.entrypoint.ts`.
+  - `withPackageJSON` (rewrite package.json) + package-manager setup +
+    `withInstalledDependencies`.
+- Assemble the final container: mount `sdk/`, mount `node_modules/@dagger.io/dagger`
+  → the generated lib, mount `tsconfig.json`, overlay the wrapped source,
+  mount the generated entrypoint, set entrypoint
+  `tsx --tsconfig ... __dagger.entrypoint.ts`.
+
+So **today `SetupContainer` regenerates bindings + entrypoint + config on every
+`dagger call`**. That is exactly what we want to skip when opted out.
+
+### 3.3 `ts-introspector` outputs (`introspection_entrypoint.ts`)
+
+`scan(files, moduleName, ...)` → `DaggerModule`. Three sinks:
+
+- `DRY_RUN` → prints the module.
+- `EMIT_TYPEDEF_JSON_FILE` → `serializeModule()` (`typedef_json.ts`) → stable
+  typedef JSON (carries `kind`, `isExported`, **`location`** (source file),
+  `constructor`, `methods`, `properties`, arg flags…). Consumed by
+  `generate-entrypoint`.
+- `TYPEDEF_OUTPUT_FILE` (default) → `connection(() => new Register(result).run())`
+  → registers typedefs via the GraphQL API and writes the module ID. This is
+  the `moduleTypes` mechanism.
+
+`Register` (`register.ts`) is the canonical map from `DaggerModule` →
+`dag.typeDef().withObject(...).withFunction(...)...` — i.e. the source of truth
+for how each TS construct becomes an engine TypeDef. **The new introspection
+emitter must mirror `Register` the way `introspect_emit.go` mirrors Go's
+`TypeDef`.**
+
+## 4. Proposed changes
+
+### 4.1 Remove `ModuleTypes` from the TypeScript SDK
+
+- Delete `TypescriptSdk.ModuleTypes` (`main.go` L69-91) and
+  `Introspector.AsEntrypoint` (`introspector.go` L32-59) if unused afterwards.
+- Regenerate the TS SDK module's own `dagger.gen.go` so the `ModuleTypes`
+  function disappears from its object definition. The engine then sees
+  `AsModuleTypes()==false` for the TS SDK and takes the `moduleDefViaRuntime`
+  path (`core/schema/modulesource.go`), i.e. it loads the runtime and calls
+  `getModDef`.
+- **Verified safe:** the runtime already serves `getModDef`. The generated
+  static `__dagger.entrypoint.ts` dispatches the empty-`parentName` call to
+  `register()` — the dynamic entrypoint does the same
+  (`sdk/typescript/src/module/entrypoint/entrypoint.ts:24`:
+  `if (parentName === "") result = await new Register(scanResult).run()`), and
+  the static template renders an equivalent `register()` block. So type
+  discovery keeps working with `ModuleTypes` gone.
+- No further engine change is required: the `runModuleDefInSDK` fallback landed
+  on this branch already handles a capability-less SDK, and the
+  `ErrStaleSDKCapability` fallback covers sources persisted before the drop.
+
+### 4.2 New TypeScript introspection emitter (`introspect_emit.go` equivalent)
+
+Add a third serializer to the introspector, **in TypeScript, in the same
+`ts-introspector` execution that already writes the typedef JSON** (decision
+Q4). One `scan()` of the user's source produces the in-memory `DaggerModule`;
+we serialize it two ways from that single scan:
+
+- `serializeModule()` → typedef JSON (existing) → drives `generate-entrypoint`.
+- new `serializeIntrospection()` → **introspection JSON** of the module's own
+  types → drives the merge for client bindings.
+
+Add `sdk/typescript/src/module/introspector/introspection_json.ts` alongside
+`typedef_json.ts`, and a new env sink `EMIT_INTROSPECTION_JSON_FILE` in
+`introspection_entrypoint.ts` that writes it when set (independently of, and
+composable with, `EMIT_TYPEDEF_JSON_FILE`). It walks the `DaggerModule` and
+produces the introspection `Response`, reusing the exact type-mapping rules
+already encoded in `Register` (§3.3) — `Register` is the source of truth the way
+Go's `TypeDef` is for `introspect_emit.go`.
+
+**The consumer side already exists — this is the one big de-risk.** The TS
+binding generator already understands the shape Go's emitter produces: it reads
+`@expectedType` for object/interface-by-ID args and renders the legacy per-type
+`<T>ID` names (`cmd/codegen/generator/typescript/templates/functions.go`
+L193-284, via `legacyTypeScriptSDKCompat()` / `legacyIDName()` /
+`Directives.ExpectedType()`). So **no TS `generate-module` template changes are
+needed** for any of the four self-call shapes; the emitter simply has to emit
+the same introspection JSON as Go, and feeding the merged schema to
+`generate-module` yields self-call bindings.
+
+The emitter must reproduce **all** of the following from `introspect_emit.go`
+(this is the "keep compat with legacy iface" requirement):
+
+1. **Objects → Object types**, methods → fields, exposed properties → fields.
+   Skip any `id`-named member (engine-reserved) and append the synthetic
+   **Node `id` field** (`introspectNodeIDField`) to every object and interface.
+2. **Interfaces → Interface types** (methods → fields + Node `id`).
+3. **Enums → Enum types**, member names via the engine's
+   `gqlEnumMemberName` rule (already-conventional names kept, else
+   SCREAMING_SNAKE). Validated by the Go test `can self-call with enum arguments`.
+4. **Nullability** mirroring `Register`/TypeDef:
+   - non-optional scalar/object/enum/list → `NON_NULL`.
+   - optional scalar (`isOptional`/nullable) → strip `NON_NULL`.
+   - object/interface refs → `NON_NULL` (a pointer only changes the TS type).
+   - void/unknown → nullable `Void` scalar.
+5. **Namespacing** of module-local type names exactly as the engine's
+   `namespaceObject` (`TestBox` for type `Box` in module `test`), via a TS port
+   of `namespaceTypeName`. Validated by `can self-call through a secondary
+   object type`.
+6. **Object/interface arguments passed by ID**: emit an `ID` scalar TypeRef and
+   an `@expectedType(name: "<TypeName>")` directive, mirroring
+   `introspectArgTypeRef`. Validated by `can self-call with an object argument`.
+7. **Arg defaults / deprecation / descriptions**, honoring `+optional` semantics
+   (only true `optional`, not every default/variadic).
+8. **Query type** carrying the module's constructor field
+   (`strcase.ToLowerCamel(moduleName)` → main object, with constructor args).
+9. **Skip a module type whose namespaced name already exists** in the deps
+   schema (engine would reject/resolve to the existing type).
+10. **Legacy per-type `<T>ID` scalars** — the equivalent of
+    `legacyGoSDKCompat()`: for pre-cutover schema views the client templates
+    render `id` fields as a `<T>ID` alias, so every object/interface must also
+    contribute a `<T>ID` scalar type. Note this now requires
+    `core/schematool.go` to treat scalars as module-defined types — **already
+    done on this branch** (`isModuleDefinedType` includes `TypeKindScalar`).
+
+The "legacy iface" phrasing maps to the memory note
+`ts-deps-own-files-e2e-findings` (per-type ID imports + extendable-return
+augmentations). Whatever the TS client templates expect for a module's own `id`
+field must be satisfied by these emitted scalars, or the generated
+`client.gen.ts` won't type-check.
+
+### 4.3 `Codegen`: merge module types, feed bindings + entrypoint
+
+Rework `TypescriptSdk.Codegen` (and the per-runtime `GenerateDir`) so the
+module's own types are merged into the schema **before** generating bindings,
+mirroring Go's single-pass `generate-module`:
+
+1. Run the introspector once over the user's source to obtain the module's own
+   **introspection JSON** (§4.2) *and* the **typedef JSON** (for the entrypoint).
+   A single `ts-introspector` exec can write both files.
+2. Merge with the engine's introspection JSON using the schema tool from Go
+   (the TS runtime is Go, so it calls `dag.Schema(...).Merge(...)` directly —
+   the same call as `generate_module.go` L158-161):
+
+   ```go
+   merged, err := dag.
+       Schema(dagger.JSON(depsJSON)).
+       Merge(dagger.JSON(moduleIntrospectionJSON), cfg.name).
+       Contents(ctx)
+   ```
+
+   `depsJSON` is the contents of the `introspectionJSON *dagger.File` argument.
+   Guard with the same "dependency installed under the module's own name"
+   rejection as Go (`generate_module.go` L136-141) — merge idempotency keys on
+   `@sourceMap.module == moduleName`.
+   The merge is performed **unconditionally** (decision Q5): TS self-calls are
+   always-on, consistent with Go and Dang, so the committed bindings always
+   carry the module's own types. See §4.6 on why this needs no engine flag.
+3. Feed the **merged** introspection JSON to the **client-bindings generator**
+   (`generate-module`), so `client.gen.ts` (+ per-dep files) now include the
+   module's own types → self-calls work from committed bindings.
+4. Feed the module's **typedef JSON** (module's own types, from the same scan)
+   to the **entrypoint generator** (`generate-entrypoint`) — decision Q1. The
+   entrypoint needs source-file `location`s to import the user's classes, which
+   only the typedef JSON carries, so the entrypoint generator keeps its current
+   input.
+
+Concretely this means `LibGenerator.GenerateBindings` /
+`GenerateBundleLibrary` should accept the **merged** introspection file instead
+of the raw `introspectionJSON`. The merge is computed once in `Codegen` and the
+resulting `*dagger.File` threaded into the lib generator.
+
+`Codegen` always runs at `dagger develop` / `dagger generate` time and always
+receives a non-null introspection JSON; the null-vs-non-null runtime gate of
+§4.4 does **not** apply to `Codegen`.
+
+Because the merge needs `dag.Schema().Merge()`, the **TS SDK runtime module must
+be regenerated** against a v1 engine that ships the schema tool — the current
+`sdk/typescript/runtime/internal/dagger/dagger.gen.go` has no `Schema`/`Merge`
+(it only exposes `ModuleSource.IntrospectionSchemaJSON`). Mirror the Go SDK's
+`chore: regenerate with v1 engine` step. The codegen container that runs the
+merge must set `ExperimentalPrivilegedNesting: true` (it dials the engine),
+like Go's `baseWithCodegen` addition.
+
+### 4.4 `ModuleRuntime` / `SetupContainer`: the no-codegen path
+
+**The runtime path is selected purely by whether `introspectionJSON` is
+passed** (decision, 2026-07-09). The engine owns the opt-out gate and signals it
+to the module SDK by omitting the argument:
+
+- `introspectionJSON == nil` → **no codegen at runtime** (trust committed files).
+- `introspectionJSON != nil` → **codegen at runtime** (today's behavior).
+
+So `TypescriptSdk.ModuleRuntime` branches on `introspectionJSON == nil` and calls
+either the new no-codegen `SetupContainer` path or the existing one. The TS SDK
+module does **not** read `codegen.automaticGitignore` or the engine version
+itself — the engine decides (§4.5). The `introspectionJSON` argument of
+`ModuleRuntime` must be declared **`+optional`** so the engine can omit it.
+
+Add an opt-out branch to each runtime's `SetupContainer`
+(`runtime_node.go`, `runtime_deno.go`, `runtime_bun.go`):
+
+- **If `introspectionJSON == nil`** (no codegen): build a container that
+  1. `From(cfg.image)` with the runtime prelude (ca-certs / tsx symlink for
+     node, deno/bun cache mounts as today),
+  2. mounts the committed module source tree **as-is** (including committed
+     `sdk/`, `__dagger.entrypoint.ts`, `package.json`/`deno.json`,
+     `tsconfig.json`, lockfile),
+  3. makes `@dagger.io/dagger` resolvable by mounting the committed `sdk/` at
+     `node_modules/@dagger.io/dagger` (node/bun) — Deno resolves via committed
+     `deno.json`,
+  4. installs dependencies from the committed lockfile (reuse the existing
+     package-manager install path, but **do not** rewrite `package.json` /
+     `tsconfig.json` / `deno.json`, and **do not** generate a lockfile — the
+     committed one is authoritative),
+  5. sets the entrypoint to the committed `__dagger.entrypoint.ts`
+     (`tsx ... __dagger.entrypoint.ts` / `deno run ... __dagger.entrypoint.ts` /
+     bun equivalent).
+  No `NewLibGenerator`, no `EmitEntrypoint`, no `CreateOrUpdate*` calls.
+
+- **Otherwise** (`introspectionJSON != nil`): keep the current behavior verbatim
+  (regenerate lib + entrypoint + config, then assemble).
+
+- **Verify committed files exist** on the no-codegen path (mirror Go's
+  `requireGeneratedFiles`): check for the committed `sdk/client.gen.ts` and
+  `__dagger.entrypoint.ts` (and package.json/tsconfig or deno.json). If missing,
+  fail with an actionable "run `dagger generate` and commit the generated files"
+  error, rather than a confusing runtime `tsx`/module-resolution failure.
+
+### 4.5 Deciding whether to run runtime codegen (engine-side gate)
+
+The gate lives **in the engine**, so the decision has one implementation and the
+TS SDK module stays dumb (it only checks `introspectionJSON == nil`).
+
+For module-based SDKs the engine calls the SDK's `moduleRuntime` from
+`core/sdk/module_runtime.go` (`runtimeModule.Runtime`), which today
+unconditionally computes `deps.SchemaIntrospectionJSONFileForModule(ctx)` and
+passes it as the `introspectionJson` argument (L36-61). Change it to:
+
+1. Compute the opt-out decision with the existing helper
+   `useRuntimeCodegen(source)` (`core/sdk/go_sdk.go`, package `sdk`, so directly
+   reusable): run codegen unless `codegen.automaticGitignore == false` **and**
+   the module's pinned `engineVersion` is at least as new as the running engine
+   (`!engine.CheckVersionCompatibility(src.EngineVersion, engine.Version)`) —
+   identical rule to Go, incl. the version-skew fallback. It reads
+   `src.Self().CodegenConfig` directly from the core struct.
+2. If codegen is enabled → compute the schema JSON file and pass
+   `introspectionJson` as today.
+3. If codegen is disabled → **omit** `introspectionJson` (skip the
+   `SchemaIntrospectionJSONFileForModule` computation entirely — a nice perf
+   win) so the SDK receives `null`.
+
+Because `useRuntimeCodegen` and `engine.Version`/`CheckVersionCompatibility` all
+live engine-side, the running engine version is available here — no need to
+surface it to the module.
+
+**No opt-in capability marker** (decision). The engine applies the gate for
+module SDKs uniformly; the SDK's own `introspectionJSON` argument being
+**`+optional`** *is* the implicit signal that it supports the no-codegen path.
+An SDK that keeps the argument required simply never gets it omitted (a required
+arg with no value would be a dagql error), so `automaticGitignore=false` is a
+no-op for SDKs that haven't adopted the pattern — safe, and rolled out per SDK.
+TS adopts it here; Go has its own engine-builtin gate in `go_sdk.go` and is
+unaffected by this module path.
+
+**`ModuleSource.codegenConfig` GraphQL field: removed** (decision). It was only
+needed to read `automaticGitignore` inside the module; the engine now reads
+`src.Self().CodegenConfig` directly, so revert that field (both
+`core/modulesource.go` `field:"true"` tag and the
+`dagql.Fields[*modules.ModuleCodegenConfig]{}.Install` in
+`core/schema/modulesource.go`).
+
+### 4.6 Self-calls enabled when there is no runtime codegen
+
+Decision (2026-07-09): **self calls are considered enabled whenever the module
+is in no-codegen mode** — i.e. whenever the engine would omit `introspectionJSON`
+(§4.4/§4.5). This ties self-calls to the exact same signal as the runtime path,
+with **no per-SDK `AlwaysEnablesSelfCalls()` marker**.
+
+Two parts:
+
+1. **Codegen always merges** the module's own types into the bindings (§4.3),
+   so a no-codegen module always ships complete self-call bindings.
+2. **The engine treats self-calls as enabled for that module.** Implement one
+   shared predicate on `core.ModuleSource` and route both call sites through it:
+   - Add `RuntimeCodegenDisabled()` on `*core.ModuleSource` (core already imports
+     `engine`): returns true when
+     `CodegenConfig.AutomaticGitignore == false` **and** the committed files are
+     engine-compatible (`engine.CheckVersionCompatibility(src.EngineVersion,
+     engine.Version)`) — the negation of Go's `useRuntimeCodegen`.
+   - `SelfCallsEnabled()` (`core/modulesource.go:168`) gains a branch:
+     `if src.RuntimeCodegenDisabled() { return true }` (in addition to the
+     existing `SELF_CALLS` flag and `selfCallsAlwaysEnabler` paths).
+   - `useRuntimeCodegen(src)` (`core/sdk/go_sdk.go`) becomes
+     `!src.Self().RuntimeCodegenDisabled()`, so the runtime gate and self-calls
+     enablement can never disagree.
+
+This makes the shadow-tolerance check at `core/module.go:2226` pass for opted-out
+modules (a self type may share a name with a dependency type) without any
+`SELF_CALLS` flag or SDK marker — the previously-flagged edge case is now
+resolved by construction.
+
+Why no capability is needed for the *runtime resolution* itself, verified on this
+branch: Go dropped `ModuleTypes` (so `typeDefsEnabled == false` in
+`runModuleDefInSDK`), which means `mod.IncludeSelfInDeps` — set only under
+`if typeDefsEnabled && isSelfCallsEnabled(src)` at
+`core/schema/modulesource.go:3027` — is **not** set for Go, yet the self-calls
+fixture (`Print`/`PrintDefault` call `dag.Test().ContainerEcho()`, module calling
+itself) passes end to end. A runtime self-call resolves because the executing
+module is already loaded in the nested session its `dag` talks to, plus the
+merged bindings supply the types.
+
+Note: dropping `ModuleTypes` (§4.1) means the engine's `runCodegen` self-append
+(`core/schema/modulesource.go` L2483) no longer fires for TS
+(`AsModuleTypes()==false`), so `Codegen` receives **deps-only** introspection
+and the in-`Codegen` merge is now the only thing contributing self types to the
+bindings — exactly the Go arrangement.
+
+## 5. End-to-end flows after the change
+
+### 5.1 `dagger develop` / `dagger generate` (codegen time) — always regenerates
+
+1. Engine computes deps introspection JSON, calls `TypescriptSdk.Codegen`
+   (always with a non-null introspection JSON).
+2. `Codegen` runs the introspector → module introspection JSON + typedef JSON.
+3. Merge module introspection into deps → merged.
+4. `generate-module` on merged → `sdk/` bindings with self types.
+5. `generate-entrypoint` on typedef JSON → `__dagger.entrypoint.ts`.
+6. `GeneratedCode` overlay written to the user's tree. With
+   `automaticGitignore=false` the engine does **not** write the `.gitignore`
+   (`core/schema/modulesource.go` L2576-2577), so `sdk/` +
+   `__dagger.entrypoint.ts` get committed.
+
+### 5.2 `dagger call` — opted out (`automaticGitignore=false`, no skew)
+
+1. Engine's `runtimeModule.Runtime` computes `useRuntimeCodegen(source) == false`
+   → **omits** `introspectionJson`, calls `TypescriptSdk.ModuleRuntime` with
+   `introspectionJSON = null`.
+2. `ModuleRuntime` sees `introspectionJSON == nil` → no-codegen `SetupContainer`.
+3. Verify committed files present.
+4. Container: mount committed tree, mount committed `sdk/` as
+   `@dagger.io/dagger`, install deps from lockfile, entrypoint = committed
+   `__dagger.entrypoint.ts`. No codegen containers.
+5. Engine invokes the module (getModDef via the committed entrypoint's
+   `register()`, then the requested function via `invoke()`).
+
+### 5.3 `dagger call` — default (`automaticGitignore` unset/true) or version skew
+
+Engine's gate returns `useRuntimeCodegen == true` → passes `introspectionJson`
+as today → `ModuleRuntime` takes the existing `SetupContainer` path (regenerate
+lib + entrypoint + config, then run). Unchanged from today.
+
+## 6. Files to change (checklist)
+
+TypeScript SDK runtime (Go, `sdk/typescript/runtime/`):
+
+- `main.go` — remove `ModuleTypes`; mark `ModuleRuntime`'s `introspectionJSON`
+  `+optional` and branch on `nil`; rework `Codegen` to merge (§4.3); thread
+  merged introspection file into lib generation.
+- `introspector.go` — remove `AsEntrypoint`; add a mode to emit introspection
+  JSON (or a new `EmitModuleIntrospection`); keep `EmitEntrypoint`.
+- `lib_generator.go` — accept the merged introspection file for `generate-module`.
+- `runtime_node.go`, `runtime_deno.go`, `runtime_bun.go` — add the no-codegen
+  branch to `SetupContainer` (selected by `introspectionJSON == nil`);
+  `requireGeneratedFiles`-style check.
+- `internal/dagger/dagger.gen.go` — regenerate against a v1 engine (adds
+  `dag.Schema().Merge()`), and drop `ModuleTypes` from the SDK's own definition.
+- `config.go` — no change needed for the runtime gate (the engine decides). Only
+  touch it if the no-codegen `SetupContainer` needs extra config fields.
+
+TypeScript introspector (TS, `sdk/typescript/src/module/`):
+
+- `introspector/introspection_json.ts` (new) — `DaggerModule` → introspection
+  JSON mirroring `introspect_emit.go`, incl. legacy `<T>ID` scalars.
+- `entrypoint/introspection_entrypoint.ts` — add the
+  `EMIT_INTROSPECTION_JSON_FILE` sink (written in the same run as the typedef
+  JSON).
+- No `generate-module` template changes needed — `@expectedType` + legacy IDs
+  are already handled (§4.2).
+
+Engine:
+
+- `core/modulesource.go` — add `RuntimeCodegenDisabled()` on `*ModuleSource`;
+  make `SelfCallsEnabled()` return true when it holds (§4.6). Revert the
+  in-progress `ModuleSource.codegenConfig` GraphQL field (§4.5).
+- `core/sdk/go_sdk.go` — refactor `useRuntimeCodegen` to
+  `!src.Self().RuntimeCodegenDisabled()` (single source of truth) (§4.6).
+- `core/sdk/module_runtime.go` — compute `useRuntimeCodegen(source)` and omit
+  `introspectionJson` (skip `SchemaIntrospectionJSONFileForModule`) when codegen
+  is disabled (§4.5). No capability check.
+
+Already done on this branch (no further change needed):
+
+- `core/schematool.go` `isModuleDefinedType` includes `TypeKindScalar`.
+- `runModuleDefInSDK` / `moduleDefViaRuntime` fallback for capability-less SDKs.
+- `ErrStaleSDKCapability` handling for persisted sources.
+
+Docs / changie entry as usual.
+
+## 7. Testing
+
+- Port the Go `RuntimeCodegenSuite` idea to TS:
+  - `automaticGitignore=false` + pinned engine + **missing** committed files ⇒
+    actionable error mentioning `dagger generate`.
+  - `automaticGitignore=false` + **older** pinned engine ⇒ falls back to runtime
+    codegen and succeeds (version skew, i.e. `introspectionJSON != nil`).
+  - `automaticGitignore=false` + committed files present ⇒ `dagger call` runs
+    with no codegen container in the trace (`introspectionJSON == nil`).
+- Extend the self-calls suite (`TestSelfCalls`) to run for `sdk == "typescript"`:
+  scalar field exposure, enum args (SCREAMING_SNAKE), secondary object type
+  namespacing (`TestBox`), object arg by ID (`@expectedType`), self-calls as a
+  dependency and transitively.
+- Golden introspection JSON test for the new emitter mirroring
+  `introspect_emit_test.go`.
+
+## 8. Resolved decisions
+
+- **Runtime gate = null `introspectionJSON`** (2026-07-09). The engine owns the
+  opt-out decision and signals it by passing / omitting `introspectionJSON` to
+  `ModuleRuntime`. The TS SDK module just branches on `nil`. **No opt-in
+  capability marker** — the `+optional` argument is the implicit signal.
+  (§4.4, §4.5.)
+- **First cut supports all four self-call shapes** directly (scalar fields, enum
+  args, secondary-object namespacing, object-arg-by-ID). Confirmed to need no TS
+  `generate-module` template changes — `@expectedType`/legacy IDs already
+  handled. (§4.2.)
+- **Q1 — entrypoint generator input.** Send the module **typedef JSON** to
+  `generate-entrypoint` and the **merged introspection JSON** to the client
+  bindings generator. (§4.3.)
+- **Q2/Q3 — reading `automaticGitignore`.** Read engine-side from
+  `src.Self().CodegenConfig`; **revert** the `ModuleSource.codegenConfig`
+  GraphQL field — not needed. (§4.5.)
+- **Q4 — introspection emitter location.** Emit in TypeScript, in the same
+  `ts-introspector` execution that writes the typedef JSON. (§4.2.)
+- **Q5 — always-merge.** Merge is unconditional. **Self-calls are enabled
+  whenever there is no runtime codegen** (introspectionJSON omitted): a shared
+  `RuntimeCodegenDisabled()` predicate drives both the runtime gate and
+  `SelfCallsEnabled()`. No per-SDK `AlwaysEnablesSelfCalls()` marker. (§4.6.)
+- **Q6 — committed config files.** No runtime validation of
+  `package.json`/`tsconfig.json`/`deno.json` beyond the generated-files check:
+  `dagger generate` reruns `Codegen`, which updates them when needed.
+
+## 9. Residual items to confirm during implementation
+
+- **`introspectionJSON` optionality.** Confirm marking `ModuleRuntime`'s
+  `introspectionJSON` `+optional` lets the engine omit it cleanly (null
+  `*dagger.File` on the SDK side), and that no existing caller relies on it being
+  required.
+- **Deno / Bun no-codegen specifics.** Confirm how the committed `sdk/` is
+  referenced for `@dagger.io/dagger` resolution in the committed `deno.json` /
+  bun setup on the no-codegen path (node/bun mount `node_modules`; Deno uses
+  imports).

--- a/sdk/typescript/runtime/config.go
+++ b/sdk/typescript/runtime/config.go
@@ -523,6 +523,39 @@ func (c *moduleConfig) hasFile(name string) bool {
 	return ok
 }
 
+// requireGeneratedFiles verifies the module's committed generated files are
+// present. Called only on the no-codegen runtime path (introspectionJSON not
+// passed); the codegen path regenerates them so the check would be redundant.
+// Mirrors the Go SDK's requireGeneratedFiles.
+func (c *moduleConfig) requireGeneratedFiles(ctx context.Context) error {
+	required := []string{
+		filepath.Join(GenDir, "client.gen.ts"),
+		EntrypointExecutableFile,
+	}
+	// Node & Bun run `tsx --tsconfig tsconfig.json`; a missing committed
+	// tsconfig.json would otherwise surface as an opaque tsx error instead of
+	// this actionable one. Deno resolves through deno.json (checked by the
+	// caller), so it needs no tsconfig.json.
+	if c.runtime == Node || c.runtime == Bun {
+		required = append(required, "tsconfig.json")
+	}
+	for _, rel := range required {
+		exists, err := c.source.Exists(ctx, rel)
+		if err != nil {
+			return fmt.Errorf("check committed generated file %q: %w", rel, err)
+		}
+		if exists {
+			continue
+		}
+		return fmt.Errorf(
+			"module %q has runtime codegen disabled but committed generated file %q is missing; "+
+				"run `dagger generate` and commit every generated file: the whole %s/ directory "+
+				"and %s",
+			c.name, rel, GenDir, EntrypointExecutableFile)
+	}
+	return nil
+}
+
 // Return the path to the module source.
 func (c *moduleConfig) modulePath() string {
 	return filepath.Join(ModSourceDirPath, c.subPath)

--- a/sdk/typescript/runtime/dagger.gen.go
+++ b/sdk/typescript/runtime/dagger.gen.go
@@ -268,34 +268,6 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return (*TypescriptSdk).ModuleRuntime(&parent, ctx, modSource, introspectionJson)
-		case "ModuleTypes":
-			var parent TypescriptSdk
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			var modSource *dagger.ModuleSource
-			if inputArgs["modSource"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["modSource"]), &modSource)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg modSource", err))
-				}
-			}
-			var introspectionJson *dagger.File
-			if inputArgs["introspectionJSON"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["introspectionJSON"]), &introspectionJson)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg introspectionJSON", err))
-				}
-			}
-			var outputFilePath string
-			if inputArgs["outputFilePath"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["outputFilePath"]), &outputFilePath)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg outputFilePath", err))
-				}
-			}
-			return (*TypescriptSdk).ModuleTypes(&parent, ctx, modSource, introspectionJson, outputFilePath)
 		case "RequiredClientGenerationFiles":
 			var parent TypescriptSdk
 			err = json.Unmarshal(parentJSON, &parent)
@@ -328,36 +300,29 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("Codegen",
 							dag.TypeDef().WithObject("GeneratedCode")).
 							WithDescription("Codegen implements the `Codegen` method from the SDK module interface.\n\nIt returns the generated API client based on user's module as well as\nignore directive regarding the generated content.").
-							WithSourceMap(dag.SourceMap("main.go", 97, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 99, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 100, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 77, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 79, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 80, 2)})).
 					WithFunction(
 						dag.Function("GenerateClient",
 							dag.TypeDef().WithObject("Directory")).
 							WithDescription("Returns a directory with a standalone generated client and any necessary configuration\nfiles that are required to work.").
-							WithSourceMap(dag.SourceMap("main.go", 184, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 186, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 187, 2)}).
-							WithArg("outputDir", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 188, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 164, 1)).
+							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 166, 2)}).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 167, 2)}).
+							WithArg("outputDir", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 168, 2)})).
 					WithFunction(
 						dag.Function("ModuleRuntime",
 							dag.TypeDef().WithObject("Container")).
 							WithDescription("ModuleRuntime implements the `ModuleRuntime` method from the SDK module interface.\n\nIt returns a ready to call container with the correct node, bun or deno runtime setup.\nOn call, this will trigger the entrypoint that will either intropect and register the\nmodule in the Dagger engine or execute a function of that module.\n\nThe returned container has the codegen freshly generated and any necessary dependency\ninstalled.").
 							WithSourceMap(dag.SourceMap("main.go", 47, 1)).
 							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 49, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 50, 2)})).
-					WithFunction(
-						dag.Function("ModuleTypes",
-							dag.TypeDef().WithObject("Container")).
-							WithSourceMap(dag.SourceMap("main.go", 69, 1)).
-							WithArg("modSource", dag.TypeDef().WithObject("ModuleSource"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 71, 2)}).
-							WithArg("introspectionJSON", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 72, 2)}).
-							WithArg("outputFilePath", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 73, 2)})).
+							WithArg("introspectionJSON", dag.TypeDef().WithObject("File").WithOptional(true), dagger.FunctionWithArgOpts{Description: "introspectionJSON is omitted by the engine when the module opts out of\nruntime codegen (codegen.automaticGitignore=false). A nil value selects\nthe no-codegen path: the committed generated files are trusted as-is.", SourceMap: dag.SourceMap("main.go", 54, 2)})).
 					WithFunction(
 						dag.Function("RequiredClientGenerationFiles",
 							dag.TypeDef().WithListOf(dag.TypeDef().WithKind(dagger.TypeDefKindStringKind))).
 							WithDescription("Returns the list of files that are copied from the host when generating the client.").
-							WithSourceMap(dag.SourceMap("main.go", 174, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 154, 1))).
 					WithField("SDKSourceDir", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{SourceMap: dag.SourceMap("main.go", 23, 2)}).
 					WithConstructor(
 						dag.Function("New",

--- a/sdk/typescript/runtime/internal/dagger/typescript-sdk.gen.go
+++ b/sdk/typescript/runtime/internal/dagger/typescript-sdk.gen.go
@@ -120,6 +120,14 @@ func (r *TypescriptSDK) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
+// TypescriptSDKModuleRuntimeOpts contains options for TypescriptSDK.ModuleRuntime
+type TypescriptSDKModuleRuntimeOpts struct {
+	// introspectionJSON is omitted by the engine when the module opts out of
+	// runtime codegen (codegen.automaticGitignore=false). A nil value selects
+	// the no-codegen path: the committed generated files are trusted as-is.
+	IntrospectionJSON *File
+}
+
 // ModuleRuntime implements the `ModuleRuntime` method from the SDK module interface.
 //
 // It returns a ready to call container with the correct node, bun or deno runtime setup.
@@ -128,25 +136,16 @@ func (r *TypescriptSDK) UnmarshalJSON(bs []byte) error {
 //
 // The returned container has the codegen freshly generated and any necessary dependency
 // installed.
-func (r *TypescriptSDK) ModuleRuntime(modSource *ModuleSource, introspectionJson *File) *Container {
+func (r *TypescriptSDK) ModuleRuntime(modSource *ModuleSource, opts ...TypescriptSDKModuleRuntimeOpts) *Container {
 	assertNotNil("modSource", modSource)
-	assertNotNil("introspectionJson", introspectionJson)
 	q := r.query.Select("moduleRuntime")
-	q = q.Arg("modSource", modSource)
-	q = q.Arg("introspectionJson", introspectionJson)
-
-	return &Container{
-		query: q,
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `introspectionJson` optional argument
+		if !querybuilder.IsZeroValue(opts[i].IntrospectionJSON) {
+			q = q.Arg("introspectionJson", opts[i].IntrospectionJSON)
+		}
 	}
-}
-
-func (r *TypescriptSDK) ModuleTypes(modSource *ModuleSource, introspectionJson *File, outputFilePath string) *Container {
-	assertNotNil("modSource", modSource)
-	assertNotNil("introspectionJson", introspectionJson)
-	q := r.query.Select("moduleTypes")
 	q = q.Arg("modSource", modSource)
-	q = q.Arg("introspectionJson", introspectionJson)
-	q = q.Arg("outputFilePath", outputFilePath)
 
 	return &Container{
 		query: q,

--- a/sdk/typescript/runtime/introspector.go
+++ b/sdk/typescript/runtime/introspector.go
@@ -29,35 +29,6 @@ func NewIntrospector(sdkSourceDir *dagger.Directory) *Introspector {
 	}
 }
 
-func (i *Introspector) AsEntrypoint(
-	outputFilePath string,
-
-	moduleName string,
-
-	sourceCode *dagger.Directory,
-
-	// clientBindings is the directory of generated bindings: client.gen.ts plus
-	// any per-dependency <dep>.gen.ts files. The whole directory is mounted so
-	// that types re-exported from client.gen.ts (e.g. dep types) resolve.
-	clientBindings *dagger.Directory,
-) *dagger.Container {
-	// Synthesize a minimal @dagger.io/dagger package so TS can resolve the bare import.
-	sdkPkg := dag.Directory().
-		WithDirectory(".", clientBindings).
-		WithNewFile("index.ts", tsutils.StaticBundleModuleIndexTS).
-		WithNewFile("core.d.ts", tsutils.StaticBundleCoreDTS).
-		WithNewFile("telemetry.ts", tsutils.StaticBundleTelemetryTS)
-
-	return i.Ctr.
-		WithMountedDirectory("src", sourceCode).
-		// Make it resolvable by Node/TS: @dagger.io/dagger -> node_modules package
-		WithMountedDirectory("node_modules/@dagger.io/dagger", sdkPkg).
-		// Keep the old location too so the CLI arg still points to a file
-		WithMountedDirectory("sdk", sdkPkg).
-		WithEnvVariable("TYPEDEF_OUTPUT_FILE", outputFilePath).
-		WithEntrypoint([]string{introspectorBinPath, moduleName, "src", "sdk/client.gen.ts"})
-}
-
 // EmitEntrypoint runs the introspector binary in typedef-JSON mode and then
 // invokes the Go-side `cmd/codegen generate-entrypoint` subcommand to render
 // the static dispatch `__dagger.entrypoint.ts` file. Returns that file.

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -47,6 +47,10 @@ const (
 func (t *TypescriptSdk) ModuleRuntime(
 	ctx context.Context,
 	modSource *dagger.ModuleSource,
+	// introspectionJSON is omitted by the engine when the module opts out of
+	// runtime codegen (codegen.automaticGitignore=false). A nil value selects
+	// the no-codegen path: the committed generated files are trusted as-is.
+	// +optional
 	introspectionJSON *dagger.File,
 ) (*dagger.Container, error) {
 	cfg, err := analyzeModuleConfig(ctx, modSource)
@@ -64,30 +68,6 @@ func (t *TypescriptSdk) ModuleRuntime(
 	default:
 		return nil, fmt.Errorf("unknown runtime %s", cfg.runtime)
 	}
-}
-
-func (t *TypescriptSdk) ModuleTypes(
-	ctx context.Context,
-	modSource *dagger.ModuleSource,
-	introspectionJSON *dagger.File,
-	outputFilePath string,
-) (*dagger.Container, error) {
-	cfg, err := analyzeModuleConfig(ctx, modSource)
-	if err != nil {
-		return nil, fmt.Errorf("failed to analyze module config: %w", err)
-	}
-
-	// TODO(TomChv): Update the TypeScript Codegen so it doesn't rely on moduleSourcePath anymore.
-	clientBindings := NewLibGenerator(t.SDKSourceDir, cfg.libGeneratorOpts()).
-		GenerateBindings(introspectionJSON, Bundle, ModSourceDirPath)
-
-	return NewIntrospector(t.SDKSourceDir).
-		AsEntrypoint(
-			outputFilePath,
-			cfg.name,
-			modSource.ContextDirectory().Directory(cfg.subPath).Directory("src"),
-			clientBindings,
-		), nil
 }
 
 // Codegen implements the `Codegen` method from the SDK module interface.
@@ -142,7 +122,7 @@ func (t *TypescriptSdk) Codegen(
 	}
 
 	// Generate the static dispatch entrypoint from the (now-present) source
-	// and include it in the codegen overlay so `dagger develop` writes it to
+	// and include it in the codegen overlay so `dagger generate` writes it to
 	// the user's project tree, mirroring how Go's `dagger.gen.go` lands at the
 	// module root. The client bindings (`sdk/`, containing client.gen.ts and
 	// any per-dep <dep>.gen.ts files) were already emitted into the codegen

--- a/sdk/typescript/runtime/runtime_bun.go
+++ b/sdk/typescript/runtime/runtime_bun.go
@@ -41,6 +41,10 @@ func NewBunRuntime(
 }
 
 func (b *BunRuntime) SetupContainer(ctx context.Context) (*dagger.Container, error) {
+	if b.introspectionJSON == nil {
+		return b.setupContainerWithoutCodegen(ctx)
+	}
+
 	var tsConfig *dagger.File
 	var sdkLibrary *dagger.Directory
 	var runtimeWithDep *BunRuntime
@@ -118,6 +122,50 @@ func (b *BunRuntime) SetupContainer(ctx context.Context) (*dagger.Container, err
 		// Merge source code directory with current directory
 		WithDirectory(".", b.cfg.wrappedSourceCodeDirectory()).
 		WithMountedFile(entrypointPath, generatedEntrypoint).
+		WithEntrypoint([]string{
+			"bun", "run", entrypointPath,
+		})
+
+	if b.cfg.debug {
+		ctr = ctr.Terminal()
+	}
+
+	return ctr, nil
+}
+
+// setupContainerWithoutCodegen builds the runtime container when the module
+// opts out of runtime codegen (introspectionJSON not passed): it trusts the
+// committed generated files (sdk/, __dagger.entrypoint.ts, package.json), installs
+// dependencies and runs the committed entrypoint — no lib generation, no
+// entrypoint generation, no config rewrite.
+func (b *BunRuntime) setupContainerWithoutCodegen(ctx context.Context) (*dagger.Container, error) {
+	if err := b.cfg.requireGeneratedFiles(ctx); err != nil {
+		return nil, err
+	}
+	if b.cfg.packageJSONConfig == nil {
+		return nil, fmt.Errorf(
+			"module %q has runtime codegen disabled but no package.json is committed",
+			b.cfg.name)
+	}
+
+	// Trust the committed package.json as-is (no rewrite).
+	b.ctr = b.ctr.WithFile("package.json", b.cfg.source.File("package.json"))
+
+	runtimeWithDep, err := b.withInstalledDependencies().sync(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entrypointPath := filepath.Join(b.cfg.modulePath(), EntrypointExecutableFile)
+
+	ctr := runtimeWithDep.ctr.
+		// Overlay the committed tree (sdk/, __dagger.entrypoint.ts, user sources);
+		// node_modules is reinstalled above.
+		WithDirectory(".", b.cfg.source, dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{NodeModulesDir},
+		}).
+		// Make @dagger.io/dagger resolve to the committed bindings.
+		WithMountedDirectory("node_modules/@dagger.io/dagger", b.cfg.source.Directory(GenDir)).
 		WithEntrypoint([]string{
 			"bun", "run", entrypointPath,
 		})

--- a/sdk/typescript/runtime/runtime_deno.go
+++ b/sdk/typescript/runtime/runtime_deno.go
@@ -40,6 +40,10 @@ func NewDenoRuntime(
 }
 
 func (d *DenoRuntime) SetupContainer(ctx context.Context) (*dagger.Container, error) {
+	if d.introspectionJSON == nil {
+		return d.setupContainerWithoutCodegen(ctx)
+	}
+
 	var sdkLibrary *dagger.Directory
 	var denoRuntimeWithDep *DenoRuntime
 	var generatedEntrypoint *dagger.File
@@ -105,6 +109,49 @@ func (d *DenoRuntime) SetupContainer(ctx context.Context) (*dagger.Container, er
 		// Merge source code directory with current directory
 		WithDirectory(".", d.cfg.wrappedSourceCodeDirectory()).
 		WithMountedFile(entrypointPath, generatedEntrypoint).
+		WithEntrypoint([]string{
+			"deno", "run", "-q", "-A", entrypointPath,
+		})
+
+	if d.cfg.debug {
+		ctr = ctr.Terminal()
+	}
+
+	return ctr, nil
+}
+
+// setupContainerWithoutCodegen builds the runtime container when the module
+// opts out of runtime codegen (introspectionJSON not passed): it trusts the
+// committed generated files (sdk/, __dagger.entrypoint.ts, deno.json), installs
+// dependencies and runs the committed entrypoint — no lib generation, no
+// entrypoint generation, no config rewrite.
+func (d *DenoRuntime) setupContainerWithoutCodegen(ctx context.Context) (*dagger.Container, error) {
+	if err := d.cfg.requireGeneratedFiles(ctx); err != nil {
+		return nil, err
+	}
+	if d.cfg.denoJSONConfig == nil {
+		return nil, fmt.Errorf(
+			"module %q has runtime codegen disabled but no deno.json is committed",
+			d.cfg.name)
+	}
+
+	// Trust the committed deno.json as-is (no rewrite).
+	d.ctr = d.ctr.WithFile("deno.json", d.cfg.source.File("deno.json"))
+
+	denoRuntimeWithDep, err := d.withInstalledDependencies().sync(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entrypointPath := filepath.Join(d.cfg.modulePath(), EntrypointExecutableFile)
+
+	ctr := denoRuntimeWithDep.ctr.
+		WithMountedDirectory("node_modules/@dagger.io/dagger", d.cfg.source.Directory(GenDir)).
+		// Overlay the committed tree (sdk/, __dagger.entrypoint.ts, user sources);
+		// node_modules is reinstalled above (deno install --node-modules-dir=auto).
+		WithDirectory(".", d.cfg.source, dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{NodeModulesDir},
+		}).
 		WithEntrypoint([]string{
 			"deno", "run", "-q", "-A", entrypointPath,
 		})

--- a/sdk/typescript/runtime/runtime_node.go
+++ b/sdk/typescript/runtime/runtime_node.go
@@ -44,6 +44,10 @@ func NewNodeRuntime(
 }
 
 func (n *NodeRuntime) SetupContainer(ctx context.Context) (*dagger.Container, error) {
+	if n.introspectionJSON == nil {
+		return n.setupContainerWithoutCodegen(ctx)
+	}
+
 	var tsConfig *dagger.File
 	var sdkLibrary *dagger.Directory
 	var runtimeWithDep *NodeRuntime
@@ -126,6 +130,54 @@ func (n *NodeRuntime) SetupContainer(ctx context.Context) (*dagger.Container, er
 		// Merge source code directory with current directory
 		WithDirectory(".", n.cfg.wrappedSourceCodeDirectory()).
 		WithMountedFile(entrypointPath, generatedEntrypoint).
+		WithEntrypoint([]string{
+			"tsx", "--no-deprecation", "--tsconfig", n.cfg.tsConfigPath(), entrypointPath,
+		})
+
+	if n.cfg.debug {
+		ctr = ctr.Terminal()
+	}
+
+	return ctr, nil
+}
+
+// setupContainerWithoutCodegen builds the runtime container when the module
+// opts out of runtime codegen (introspectionJSON not passed): it trusts the
+// committed generated files (sdk/, __dagger.entrypoint.ts, package.json,
+// tsconfig.json, lockfile), installs dependencies and runs the committed
+// entrypoint — no lib generation, no entrypoint generation, no config rewrite.
+func (n *NodeRuntime) setupContainerWithoutCodegen(ctx context.Context) (*dagger.Container, error) {
+	if err := n.cfg.requireGeneratedFiles(ctx); err != nil {
+		return nil, err
+	}
+	if n.cfg.packageJSONConfig == nil {
+		return nil, fmt.Errorf(
+			"module %q has runtime codegen disabled but no package.json is committed",
+			n.cfg.name)
+	}
+
+	// Trust the committed package.json as-is (no rewrite).
+	n.ctr = n.ctr.WithFile("package.json", n.cfg.source.File("package.json"))
+
+	pkgManager := n.createPkgManagerCtr()
+	runtimeWithDep, err := pkgManager.
+		withSetupPackageManager().
+		withInstalledDependencies().
+		sync(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entrypointPath := filepath.Join(n.cfg.modulePath(), EntrypointExecutableFile)
+
+	ctr := runtimeWithDep.ctr.
+		// Overlay the committed tree (sdk/, __dagger.entrypoint.ts,
+		// tsconfig.json, user sources); node_modules is reinstalled above.
+		WithDirectory(".", n.cfg.source, dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{NodeModulesDir},
+		}).
+		// Make @dagger.io/dagger resolve to the committed bindings.
+		WithMountedDirectory("node_modules/@dagger.io/dagger", n.cfg.source.Directory(GenDir)).
 		WithEntrypoint([]string{
 			"tsx", "--no-deprecation", "--tsconfig", n.cfg.tsConfigPath(), entrypointPath,
 		})

--- a/sdk/typescript/runtime/tsutils/module/core.d.ts
+++ b/sdk/typescript/runtime/tsutils/module/core.d.ts
@@ -21,6 +21,7 @@ export type ArgumentOptions = {
 export function func(alias?: string): MethodDecorator
 export function check(): MethodDecorator
 export function generate(): MethodDecorator
+export function up(): MethodDecorator
 export function argument(opts?: ArgumentOptions): ParameterDecorator
 export function object(): ClassDecorator
 export function field(alias?: string): PropertyDecorator

--- a/sdk/typescript/runtime/tsutils/module/index.ts
+++ b/sdk/typescript/runtime/tsutils/module/index.ts
@@ -5,6 +5,7 @@ export {
   func,
   check,
   generate,
+  up,
   argument,
   object,
   field,

--- a/sdk/typescript/src/module/entrypoint/introspection_entrypoint.ts
+++ b/sdk/typescript/src/module/entrypoint/introspection_entrypoint.ts
@@ -3,6 +3,7 @@ import * as path from "path"
 
 import { connection } from "../../connect.js"
 import { scan } from "../introspector/index.js"
+import { serializeIntrospection } from "../introspector/introspection_json.js"
 import { serializeModule } from "../introspector/typedef_json.js"
 import { Register } from "./register.js"
 
@@ -94,9 +95,28 @@ async function main() {
   if (typedefJsonPath) {
     const json = serializeModule(result)
     await fs.promises.writeFile(typedefJsonPath, JSON.stringify(json))
-    if (!process.env.TYPEDEF_OUTPUT_FILE) {
-      return
-    }
+  }
+
+  // When EMIT_INTROSPECTION_JSON_FILE is set, write the module's own types as
+  // an introspection-shaped JSON. The Go-side Codegen merges it into the deps
+  // schema (dag.Schema().Merge) before generating the client bindings, so the
+  // bindings include the module's own types and self calls resolve without a
+  // runtime codegen pass. LEGACY_SHARED_ID_TYPES asks for per-type <T>ID
+  // scalars, needed by pre-cutover schema views.
+  const introspectionJsonPath = process.env.EMIT_INTROSPECTION_JSON_FILE
+  if (introspectionJsonPath) {
+    const legacySharedIDTypes = process.env.LEGACY_SHARED_ID_TYPES !== undefined
+    const json = serializeIntrospection(result, { legacySharedIDTypes })
+    await fs.promises.writeFile(introspectionJsonPath, JSON.stringify(json))
+  }
+
+  // The EMIT_* modes are file-only; only the legacy TYPEDEF_OUTPUT_FILE path
+  // needs an engine connection to register the module.
+  if (
+    (typedefJsonPath || introspectionJsonPath) &&
+    !process.env.TYPEDEF_OUTPUT_FILE
+  ) {
+    return
   }
 
   // TODO(TomChv): move that logic inside the engine at some point

--- a/sdk/typescript/src/module/introspector/introspection_json.ts
+++ b/sdk/typescript/src/module/introspector/introspection_json.ts
@@ -1,0 +1,689 @@
+import { TypeDefKind } from "../../api/client.gen.js"
+import { DaggerArgument } from "./dagger_module/argument.js"
+import { DaggerConstructor } from "./dagger_module/constructor.js"
+import { DaggerEnumBase } from "./dagger_module/enumBase.js"
+import { DaggerFunction } from "./dagger_module/function.js"
+import { DaggerInterface } from "./dagger_module/interface.js"
+import { DaggerInterfaceFunction } from "./dagger_module/interfaceFunction.js"
+import { DaggerModule } from "./dagger_module/module.js"
+import {
+  DaggerObjectBase,
+  DaggerObjectPropertyBase,
+} from "./dagger_module/objectBase.js"
+import {
+  EnumTypeDef,
+  InterfaceTypeDef,
+  ListTypeDef,
+  ObjectTypeDef,
+  ScalarTypeDef,
+  TypeDef,
+} from "./typedef.js"
+
+// This file is the TypeScript counterpart of the Go SDK's
+// `cmd/codegen/generator/go/templates/introspect_emit.go`. It walks a parsed
+// `DaggerModule` and emits an introspection-shaped JSON of the module's own
+// types, in the exact shape the engine schema tool (`dag.Schema().Merge`) and
+// the client-bindings generator consume. It mirrors `Register`
+// (`../entrypoint/register.ts`) — the source of truth for how each TypeScript
+// construct becomes an engine TypeDef — so the merged schema matches what the
+// engine builds from the same source, enabling self calls in the generated
+// bindings without a runtime codegen pass.
+
+type TypeRef = {
+  kind: string
+  name?: string
+  ofType?: TypeRef
+}
+
+type DirectiveArg = { name: string; value?: string }
+type Directive = { name: string; args: DirectiveArg[] }
+
+type InputValue = {
+  name: string
+  description: string
+  defaultValue?: string
+  type: TypeRef
+  directives?: Directive[]
+  isDeprecated?: boolean
+  deprecationReason?: string
+}
+
+type Field = {
+  name: string
+  description: string
+  type: TypeRef
+  args: InputValue[]
+  isDeprecated?: boolean
+  deprecationReason?: string
+  directives?: Directive[]
+}
+
+type EnumValue = {
+  name: string
+  description: string
+  isDeprecated?: boolean
+  deprecationReason?: string
+}
+
+type IntrospectionType = {
+  kind: string
+  name: string
+  description?: string
+  fields?: Field[]
+  enumValues?: EnumValue[]
+  interfaces: IntrospectionType[]
+}
+
+type IntrospectionResponse = {
+  __schema: {
+    queryType: { name: string }
+    types: IntrospectionType[]
+  }
+}
+
+const TypeKind = {
+  Scalar: "SCALAR",
+  Object: "OBJECT",
+  Interface: "INTERFACE",
+  Enum: "ENUM",
+  List: "LIST",
+  NonNull: "NON_NULL",
+} as const
+
+const Scalar = {
+  Int: "Int",
+  Float: "Float",
+  String: "String",
+  Boolean: "Boolean",
+  Void: "Void",
+} as const
+
+export type SerializeIntrospectionOptions = {
+  // When true, emit a per-type `<T>ID` scalar for every object and interface,
+  // matching the Go SDK's `legacyGoSDKCompat` path: legacy (pre-cutover) schema
+  // views render module `id` fields as a `<T>ID` alias, so those scalar types
+  // must exist in the merged schema or the generated bindings won't type-check.
+  legacySharedIDTypes?: boolean
+}
+
+/**
+ * Serialize a parsed DaggerModule into an introspection JSON of the module's
+ * own types. The output is the `moduleTypes` argument to `Schema.Merge`.
+ */
+export function serializeIntrospection(
+  module: DaggerModule,
+  opts: SerializeIntrospectionOptions = {},
+): IntrospectionResponse {
+  const moduleName = module.name
+  const localTypeNames = collectLocalTypeNames(module)
+
+  const types: IntrospectionType[] = []
+
+  for (const object of Object.values(module.objects)) {
+    types.push(introspectObject(object, moduleName, localTypeNames))
+  }
+  for (const iface of Object.values(module.interfaces)) {
+    types.push(introspectInterface(iface, moduleName, localTypeNames))
+  }
+  for (const enum_ of Object.values(module.enums)) {
+    types.push(introspectEnum(enum_, moduleName))
+  }
+
+  if (opts.legacySharedIDTypes) {
+    for (const t of [...types]) {
+      if (t.kind === TypeKind.Object || t.kind === TypeKind.Interface) {
+        types.push({
+          kind: TypeKind.Scalar,
+          name: `${t.name}ID`,
+          description: "A unique identifier for an object.",
+          interfaces: [],
+        })
+      }
+    }
+  }
+
+  types.push(introspectQuery(module, moduleName, localTypeNames))
+
+  return {
+    __schema: {
+      queryType: { name: "Query" },
+      types,
+    },
+  }
+}
+
+// collectLocalTypeNames returns the raw (un-namespaced) names of every type the
+// module declares. Used to decide whether a referenced type name is
+// module-local (and must be namespaced like the engine does) or a core /
+// dependency type (already carrying its final schema name).
+function collectLocalTypeNames(module: DaggerModule): Set<string> {
+  const names = new Set<string>()
+  for (const o of Object.values(module.objects)) names.add(o.name)
+  for (const i of Object.values(module.interfaces)) names.add(i.name)
+  for (const e of Object.values(module.enums)) names.add(e.name)
+  return names
+}
+
+function introspectObject(
+  object: DaggerObjectBase,
+  moduleName: string,
+  local: Set<string>,
+): IntrospectionType {
+  const name = introspectTypeName(object.name, moduleName)
+  const fields: Field[] = []
+
+  for (const method of Object.values(object.methods)) {
+    if (toLowerCamel(method.name) === "id") {
+      continue
+    }
+    fields.push(introspectMethod(method, moduleName, local))
+  }
+
+  for (const field of Object.values(object.properties)) {
+    if (!field.isExposed) {
+      continue
+    }
+    if (toLowerCamel(field.alias ?? field.name) === "id") {
+      continue
+    }
+    fields.push(introspectProperty(field, moduleName, local))
+  }
+
+  fields.push(nodeIDField(name))
+
+  return {
+    kind: TypeKind.Object,
+    name,
+    description: trim(object.description),
+    interfaces: [],
+    fields,
+  }
+}
+
+function introspectInterface(
+  iface: DaggerInterface,
+  moduleName: string,
+  local: Set<string>,
+): IntrospectionType {
+  const name = introspectTypeName(iface.name, moduleName)
+  const fields: Field[] = []
+  for (const fn of Object.values(iface.functions)) {
+    if (toLowerCamel(fn.name) === "id") {
+      continue
+    }
+    fields.push(introspectMethod(fn, moduleName, local))
+  }
+  fields.push(nodeIDField(name))
+  return {
+    kind: TypeKind.Interface,
+    name,
+    description: trim(iface.description),
+    interfaces: [],
+    fields,
+  }
+}
+
+function introspectEnum(
+  enum_: DaggerEnumBase,
+  moduleName: string,
+): IntrospectionType {
+  const values: EnumValue[] = []
+  for (const value of Object.values(enum_.values)) {
+    const ev: EnumValue = {
+      name: gqlEnumMemberName(value.name),
+      description: trim(value.description),
+    }
+    if (value.deprecated !== undefined) {
+      ev.isDeprecated = true
+      ev.deprecationReason = trim(value.deprecated)
+    }
+    values.push(ev)
+  }
+  return {
+    kind: TypeKind.Enum,
+    name: introspectTypeName(enum_.name, moduleName),
+    description: trim(enum_.description),
+    interfaces: [],
+    enumValues: values,
+  }
+}
+
+// nodeIDField mirrors the `id` field the engine adds to every module object and
+// interface (Node). The bindings key their ID marshalling on it, so without it a
+// module type could not be passed as an object argument.
+function nodeIDField(typeName: string): Field {
+  return {
+    name: "id",
+    description: `A unique identifier for this ${typeName}.`,
+    type: idRef(),
+    args: [],
+  }
+}
+
+function introspectMethod(
+  fn: DaggerFunction | DaggerInterfaceFunction,
+  moduleName: string,
+  local: Set<string>,
+): Field {
+  const returnType = (fn as DaggerFunction).returnType
+  const field: Field = {
+    name: toLowerCamel((fn as DaggerFunction).alias ?? fn.name),
+    description: trim(fn.description),
+    type: returnType
+      ? introspectTypeRef(returnType, moduleName, local)
+      : voidRef(),
+    args: introspectArgs(fn.arguments, moduleName, local),
+  }
+  const deprecated = (fn as DaggerFunction).deprecated
+  if (deprecated !== undefined) {
+    field.isDeprecated = true
+    field.deprecationReason = trim(deprecated)
+  }
+  return field
+}
+
+function introspectProperty(
+  field: DaggerObjectPropertyBase,
+  moduleName: string,
+  local: Set<string>,
+): Field {
+  const f: Field = {
+    name: toLowerCamel(field.alias ?? field.name),
+    description: trim(field.description),
+    type: field.type
+      ? introspectTypeRef(field.type, moduleName, local)
+      : voidRef(),
+    args: [],
+  }
+  if (field.deprecated !== undefined) {
+    f.isDeprecated = true
+    f.deprecationReason = trim(field.deprecated)
+  }
+  return f
+}
+
+function introspectArgs(
+  args: Record<string, DaggerArgument>,
+  moduleName: string,
+  local: Set<string>,
+): InputValue[] {
+  const out: InputValue[] = []
+  for (const arg of Object.values(args)) {
+    out.push(introspectArg(arg, moduleName, local))
+  }
+  return out
+}
+
+// introspectArg mirrors Register.addArg: object/interface args are passed by ID
+// with an `@expectedType` directive, optionality strips the NON_NULL wrapper and
+// resolvable primitive defaults are carried as a JSON-encoded defaultValue.
+function introspectArg(
+  arg: DaggerArgument,
+  moduleName: string,
+  local: Set<string>,
+): InputValue {
+  const { ref, expectedType } = introspectArgTypeRef(
+    arg.type,
+    moduleName,
+    local,
+  )
+
+  let type = ref
+  if (arg.isOptional && type.kind === TypeKind.NonNull && type.ofType) {
+    type = type.ofType
+  }
+
+  const iv: InputValue = {
+    name: toLowerCamel(arg.name),
+    description: trim(arg.description),
+    type,
+  }
+
+  if (expectedType) {
+    iv.directives = [
+      {
+        name: "expectedType",
+        args: [{ name: "name", value: JSON.stringify(expectedType) }],
+      },
+    ]
+  }
+
+  const defaultValue = resolveDefaultValue(arg)
+  if (defaultValue !== undefined) {
+    iv.defaultValue = JSON.stringify(defaultValue)
+  }
+
+  if (arg.deprecated !== undefined) {
+    iv.isDeprecated = true
+    iv.deprecationReason = trim(arg.deprecated)
+  }
+
+  return iv
+}
+
+// resolveDefaultValue mirrors Register.getDefaultValueFromArg: only primitive
+// (and enum) defaults are carried in the schema; non-primitive defaults are
+// resolved by the runtime instead, so they are omitted here.
+function resolveDefaultValue(arg: DaggerArgument): unknown | undefined {
+  if (arg.defaultValue === undefined) {
+    return undefined
+  }
+  if (!isPrimitiveKind(arg.type?.kind)) {
+    return undefined
+  }
+  // Enum defaults would need to resolve the raw value back to the member name
+  // (as the engine registers them); omit rather than risk emitting an invalid
+  // wire value. Enum-typed args with a default are rare and the arg stays
+  // usable (just not defaulted in the generated binding).
+  if (arg.type?.kind === TypeDefKind.EnumKind) {
+    return undefined
+  }
+  return arg.defaultValue
+}
+
+function introspectArgTypeRef(
+  spec: TypeDef<TypeDefKind> | undefined,
+  moduleName: string,
+  local: Set<string>,
+): { ref: TypeRef; expectedType: string } {
+  if (!spec) {
+    return { ref: voidRef(), expectedType: "" }
+  }
+  switch (spec.kind) {
+    case TypeDefKind.ListKind: {
+      const { ref, expectedType } = introspectArgTypeRef(
+        (spec as ListTypeDef).typeDef,
+        moduleName,
+        local,
+      )
+      return {
+        ref: nonNull({ kind: TypeKind.List, ofType: ref }),
+        expectedType,
+      }
+    }
+    case TypeDefKind.ObjectKind:
+      return {
+        ref: idRef(),
+        expectedType: refTypeName(
+          (spec as ObjectTypeDef).name,
+          moduleName,
+          local,
+        ),
+      }
+    case TypeDefKind.InterfaceKind:
+      return {
+        ref: idRef(),
+        expectedType: refTypeName(
+          (spec as InterfaceTypeDef).name,
+          moduleName,
+          local,
+        ),
+      }
+    default:
+      return {
+        ref: introspectTypeRef(spec, moduleName, local),
+        expectedType: "",
+      }
+  }
+}
+
+// introspectTypeRef converts a scanner TypeDef into its introspection TypeRef.
+// Nullability mirrors Register.addTypeDef: everything is NON_NULL except Void
+// (arg-level optionality is applied separately by introspectArg).
+function introspectTypeRef(
+  spec: TypeDef<TypeDefKind>,
+  moduleName: string,
+  local: Set<string>,
+): TypeRef {
+  switch (spec.kind) {
+    case TypeDefKind.StringKind:
+      return nonNull(scalarRef(Scalar.String))
+    case TypeDefKind.IntegerKind:
+      return nonNull(scalarRef(Scalar.Int))
+    case TypeDefKind.BooleanKind:
+      return nonNull(scalarRef(Scalar.Boolean))
+    case TypeDefKind.FloatKind:
+      return nonNull(scalarRef(Scalar.Float))
+    case TypeDefKind.VoidKind:
+      return voidRef()
+    case TypeDefKind.ScalarKind:
+      return nonNull(scalarRef((spec as ScalarTypeDef).name))
+    case TypeDefKind.ListKind:
+      return nonNull({
+        kind: TypeKind.List,
+        ofType: introspectTypeRef(
+          (spec as ListTypeDef).typeDef,
+          moduleName,
+          local,
+        ),
+      })
+    case TypeDefKind.ObjectKind:
+      return nonNull({
+        kind: TypeKind.Object,
+        name: refTypeName((spec as ObjectTypeDef).name, moduleName, local),
+      })
+    case TypeDefKind.InterfaceKind:
+      return nonNull({
+        kind: TypeKind.Interface,
+        name: refTypeName((spec as InterfaceTypeDef).name, moduleName, local),
+      })
+    case TypeDefKind.EnumKind:
+      return nonNull({
+        kind: TypeKind.Enum,
+        name: refTypeName((spec as EnumTypeDef).name, moduleName, local),
+      })
+    default:
+      return voidRef()
+  }
+}
+
+// introspectQuery builds the Query type carrying the module's constructor field,
+// used by Schema.Merge to install the module's entrypoint on the schema's Query.
+function introspectQuery(
+  module: DaggerModule,
+  moduleName: string,
+  local: Set<string>,
+): IntrospectionType {
+  const query: IntrospectionType = {
+    kind: TypeKind.Object,
+    name: "Query",
+    interfaces: [],
+    fields: [],
+  }
+
+  const mainObject = findMainObject(module, moduleName)
+  if (mainObject) {
+    const field: Field = {
+      name: toLowerCamel(moduleName),
+      description: "",
+      type: nonNull({
+        kind: TypeKind.Object,
+        name: introspectTypeName(mainObject.name, moduleName),
+      }),
+      args: mainObject._constructor
+        ? introspectConstructorArgs(mainObject._constructor, moduleName, local)
+        : [],
+    }
+    query.fields!.push(field)
+  }
+
+  return query
+}
+
+function introspectConstructorArgs(
+  ctor: DaggerConstructor,
+  moduleName: string,
+  local: Set<string>,
+): InputValue[] {
+  return introspectArgs(ctor.arguments, moduleName, local)
+}
+
+// findMainObject returns the module's main object — the one whose PascalCase
+// name matches the module name — which carries the constructor.
+function findMainObject(
+  module: DaggerModule,
+  moduleName: string,
+): DaggerObjectBase | undefined {
+  const target = toPascal(moduleName)
+  for (const object of Object.values(module.objects)) {
+    if (toPascal(object.name) === target) {
+      return object
+    }
+  }
+  return undefined
+}
+
+function scalarRef(name: string): TypeRef {
+  return { kind: TypeKind.Scalar, name }
+}
+
+function nonNull(ofType: TypeRef): TypeRef {
+  return { kind: TypeKind.NonNull, ofType }
+}
+
+function idRef(): TypeRef {
+  return nonNull(scalarRef("ID"))
+}
+
+// voidRef is emitted nullable (no NON_NULL wrapper) because the engine always
+// marks a Void return optional; a NON_NULL Void would diverge from the
+// engine-built schema.
+function voidRef(): TypeRef {
+  return scalarRef(Scalar.Void)
+}
+
+function isPrimitiveKind(kind: TypeDefKind | undefined): boolean {
+  return (
+    kind === TypeDefKind.BooleanKind ||
+    kind === TypeDefKind.IntegerKind ||
+    kind === TypeDefKind.StringKind ||
+    kind === TypeDefKind.FloatKind ||
+    kind === TypeDefKind.EnumKind
+  )
+}
+
+// refTypeName namespaces a referenced type name only when it is module-local,
+// exactly as the engine namespaces module objects/interfaces/enums; core and
+// dependency types already carry their final schema name.
+function refTypeName(
+  name: string,
+  moduleName: string,
+  local: Set<string>,
+): string {
+  return local.has(name) ? introspectTypeName(name, moduleName) : toPascal(name)
+}
+
+// introspectTypeName maps a module-local type name to the name the engine
+// installs it under, mirroring introspect_emit.go's namespaceTypeName.
+function introspectTypeName(name: string, moduleName: string): string {
+  return namespaceTypeName(name, moduleName)
+}
+
+// namespaceTypeName mirrors the engine's namespaceObject (core/gqlformat.go)
+// for the case where a type's final and original names are equal — always true
+// for the module's own view of itself. Keep in sync.
+function namespaceTypeName(typeName: string, moduleName: string): string {
+  const camel = toPascal(typeName)
+  const modName = toPascal(moduleName)
+  if (camel.startsWith(modName)) {
+    const rest = camel.slice(modName.length)
+    if (rest.length === 0) {
+      // The main module object keeps the module's name.
+      return modName
+    }
+    // Only treat the prefix as a namespace on a word boundary: type "Postman"
+    // in module "post" must become "PostPostman", while "PostMan" is already
+    // namespaced.
+    if (rest[0] >= "A" && rest[0] <= "Z") {
+      return camel
+    }
+  }
+  return toPascal(`${modName}_${typeName}`)
+}
+
+// gqlEnumMemberName mirrors the engine's enum member naming
+// (gqlEnumMemberName in core/gqlformat.go): already-conventional GraphQL member
+// names such as HTTP2 are kept as-is, everything else becomes SCREAMING_SNAKE.
+function gqlEnumMemberName(name: string): string {
+  if (isConventionalGraphQLEnumMemberName(name)) {
+    return name
+  }
+  return toScreamingSnake(name)
+}
+
+function isConventionalGraphQLEnumMemberName(name: string): boolean {
+  if (name === "" || name.startsWith("__")) {
+    return false
+  }
+  for (let i = 0; i < name.length; i++) {
+    const c = name[i]
+    if (c >= "A" && c <= "Z") {
+      continue
+    }
+    if (i > 0 && ((c >= "0" && c <= "9") || c === "_")) {
+      continue
+    }
+    return false
+  }
+  return true
+}
+
+function toScreamingSnake(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-zA-Z])([0-9])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase()
+}
+
+// toPascal / toLowerCamel are faithful ports of iancoleman/strcase
+// ToCamel / ToLowerCamel — the exact functions the engine uses for
+// gqlObjectName / gqlFieldName / gqlArgName. A different casing (e.g. the
+// scanner's convertToPascalCase, which splits on every case boundary) would
+// emit type/field names the engine never serves, breaking self calls.
+function toPascal(name: string): string {
+  return toCamelInitCase(name, true)
+}
+
+function toLowerCamel(name: string): string {
+  return toCamelInitCase(name, false)
+}
+
+function toCamelInitCase(s: string, initCase: boolean): string {
+  s = s.trim()
+  if (s === "") {
+    return s
+  }
+  let out = ""
+  let capNext = initCase
+  for (let i = 0; i < s.length; i++) {
+    let v = s[i]
+    const isCap = v >= "A" && v <= "Z"
+    const isLow = v >= "a" && v <= "z"
+    if (capNext) {
+      if (isLow) {
+        v = v.toUpperCase()
+      }
+    } else if (i === 0) {
+      if (isCap) {
+        v = v.toLowerCase()
+      }
+    }
+    if (isCap || isLow) {
+      out += v
+      capNext = false
+    } else if (v >= "0" && v <= "9") {
+      out += v
+      capNext = true
+    } else {
+      capNext = v === "_" || v === " " || v === "-" || v === "."
+    }
+  }
+  return out
+}
+
+function trim(s: string | undefined): string {
+  return (s ?? "").trim()
+}

--- a/sdk/typescript/src/module/introspector/test/introspection_json.spec.ts
+++ b/sdk/typescript/src/module/introspector/test/introspection_json.spec.ts
@@ -1,0 +1,107 @@
+import assert from "assert"
+import { describe, it } from "mocha"
+import path from "path"
+import { fileURLToPath } from "url"
+
+import { scan } from "../index.js"
+import { serializeIntrospection } from "../introspection_json.js"
+import { listFiles } from "../utils/files.js"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDirectory = `${__dirname}/testdata`
+
+// These types mirror the introspection JSON shape (a subset) so the test can
+// navigate the emitter output without `any`.
+type TypeRef = { kind: string; name?: string; ofType?: TypeRef }
+type Field = {
+  name: string
+  type: TypeRef
+  args: { name: string; type: TypeRef; directives?: unknown[] }[]
+}
+type IntrospectionType = {
+  kind: string
+  name: string
+  fields?: Field[]
+  enumValues?: { name: string }[]
+}
+type Introspection = {
+  __schema: { queryType: { name: string }; types: IntrospectionType[] }
+}
+
+async function introspect(
+  directory: string,
+): Promise<Introspection["__schema"]> {
+  const files = await listFiles(`${rootDirectory}/${directory}`)
+  const module = await scan(files, directory)
+  return serializeIntrospection(module as never).__schema
+}
+
+function typeByName(
+  schema: Introspection["__schema"],
+  name: string,
+): IntrospectionType | undefined {
+  return schema.types.find((t) => t.name === name)
+}
+
+function fieldByName(t: IntrospectionType | undefined, name: string) {
+  return t?.fields?.find((f) => f.name === name)
+}
+
+describe("serializeIntrospection", function () {
+  it("emits the main object, its methods and a Node id field", async function () {
+    this.timeout(60000)
+    const schema = await introspect("helloWorld")
+
+    const obj = typeByName(schema, "HelloWorld")
+    assert.ok(obj, "HelloWorld object type is emitted")
+    assert.equal(obj?.kind, "OBJECT")
+
+    const method = fieldByName(obj, "helloWorld")
+    assert.ok(method, "helloWorld method is emitted as a field")
+    // string return -> NON_NULL String
+    assert.equal(method?.type.kind, "NON_NULL")
+    assert.equal(method?.type.ofType?.name, "String")
+    // string arg -> NON_NULL String, named "name"
+    assert.equal(method?.args[0]?.name, "name")
+    assert.equal(method?.args[0]?.type.kind, "NON_NULL")
+
+    const id = fieldByName(obj, "id")
+    assert.ok(id, "synthetic Node id field is emitted")
+    assert.equal(id?.type.kind, "NON_NULL")
+    assert.equal(id?.type.ofType?.name, "ID")
+  })
+
+  it("emits a Query type carrying the module constructor field", async function () {
+    this.timeout(60000)
+    const schema = await introspect("helloWorld")
+
+    assert.equal(schema.queryType.name, "Query")
+    const query = typeByName(schema, "Query")
+    const ctor = fieldByName(query, "helloWorld")
+    assert.ok(ctor, "Query has the lowerCamel(moduleName) constructor field")
+    assert.equal(ctor?.type.kind, "NON_NULL")
+    assert.equal(ctor?.type.ofType?.kind, "OBJECT")
+    assert.equal(ctor?.type.ofType?.name, "HelloWorld")
+  })
+
+  it("namespaces module-local enums and keeps conventional member names", async function () {
+    this.timeout(60000)
+    const schema = await introspect("enums")
+
+    // enum "Status" in module "Enums" is namespaced to "EnumsStatus".
+    const enumType = typeByName(schema, "EnumsStatus")
+    assert.ok(enumType, "module enum is namespaced with the module name")
+    assert.equal(enumType?.kind, "ENUM")
+    const members = (enumType?.enumValues ?? []).map((v) => v.name)
+    assert.deepEqual(members, ["ACTIVE", "INACTIVE"])
+
+    // a method taking the enum refers to it by its namespaced name.
+    const obj = typeByName(schema, "Enums")
+    const setStatus = fieldByName(obj, "setStatus")
+    assert.equal(
+      setStatus?.args[0]?.type.ofType?.name ?? setStatus?.args[0]?.type.name,
+      "EnumsStatus",
+    )
+  })
+})

--- a/sdk/typescript/src/module/introspector/typedef_json.ts
+++ b/sdk/typescript/src/module/introspector/typedef_json.ts
@@ -72,6 +72,7 @@ function serializeFunction(fn: DaggerFunction | DaggerInterfaceFunction) {
     isCheck: f.isCheck === true,
     isGenerator: f.isGenerator === true,
     isUp: f.isUp === true,
+    location: f.getLocation(),
     returnType: f.returnType ? serializeType(f.returnType) : undefined,
     arguments: Object.values(f.arguments).map(serializeArgument),
   }
@@ -90,6 +91,7 @@ function serializeArgument(arg: DaggerArgument) {
     defaultPath: arg.defaultPath,
     defaultAddress: arg.defaultAddress,
     ignore: arg.ignore,
+    location: arg.getLocation(),
   }
 }
 
@@ -101,6 +103,7 @@ function serializeProperty(prop: DaggerObjectPropertyBase) {
     deprecated: prop.deprecated,
     isExposed: prop.isExposed === true,
     type: prop.type ? serializeType(prop.type) : undefined,
+    location: prop.getLocation(),
   }
 }
 
@@ -108,11 +111,13 @@ function serializeEnum(enum_: DaggerEnumBase) {
   return {
     name: enum_.name,
     description: enum_.description,
+    location: enum_.getLocation(),
     values: mapValues(enum_.values, (v: DaggerEnumBaseValue) => ({
       name: v.name,
       value: v.value,
       description: v.description,
       deprecated: v.deprecated,
+      location: v.getLocation(),
     })),
   }
 }
@@ -121,6 +126,7 @@ function serializeInterface(iface: DaggerInterface) {
   return {
     name: iface.name,
     description: iface.description,
+    location: iface.getLocation(),
     functions: mapValues(iface.functions, serializeFunction),
   }
 }


### PR DESCRIPTION
Align the TypeScript SDK with the Go SDK's no-codegen-at-runtime model: modules in the workspace config format (dagger-module.toml) run at `dagger call` time straight from their committed generated files, with no codegen pass. The engine gates this by config format and omits the moduleRuntime introspectionJson argument for those modules.

- Drop the `ModuleTypes` SDK function: remove the method, `Introspector.AsEntrypoint`, and the dispatcher case in the generated client. Type discovery now flows through the runtime `getModDef` path, served by the committed static `__dagger.entrypoint.ts` `register()`, mirroring the Go SDK.

- Add the no-codegen runtime path: mark `ModuleRuntime`'s `introspectionJSON` argument optional so the engine can omit it; each runtime's `SetupContainer` (node/deno/bun) then branches on nil and mounts the committed tree, installs dependencies and runs the committed entrypoint instead of regenerating. `requireGeneratedFiles` fails with an actionable "run `dagger generate`" error when a committed file is missing.

- Add a `DaggerModule` -> introspection-JSON emitter (`introspection_json.ts`) and an `EMIT_INTROSPECTION_JSON_FILE` introspector sink, mirroring the Go `introspect_emit.go`. Staged for self-call bindings; not yet wired into Codegen (self calls are a follow-up).

- Add the design doc under hack/designs.