### PR TITLE
fix(core): keep dockerBuild layer cache on unrelated context changes

### DIFF
--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -1362,3 +1362,26 @@ RUN --mount=type=bind,source=app/main.txt,target=/mnt/main.txt head -c16 /dev/ur
 	copyStamp3, _ := stamps()
 	require.NotEqual(t, copyStamp1, copyStamp3, "COPY'd content change did not invalidate downstream RUN")
 }
+
+// TestDockerBuildEmptyWildcardCopy verifies that a COPY with a wildcard that
+// matches nothing (and a destination that never gets created) still builds:
+// content hashing the copy result must not fail on the absent destination.
+func (DockerfileSuite) TestDockerBuildEmptyWildcardCopy(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "present.txt"), []byte("hi"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(`FROM `+alpineImage+`
+COPY optional-* /out/
+COPY present.txt /present.txt
+`), 0o644))
+
+	ctr := c.Host().Directory(dir).DockerBuild()
+	contents, err := ctr.File("/present.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hi", contents)
+
+	exists, err := ctr.Exists(ctx, "/out")
+	require.NoError(t, err)
+	require.False(t, exists, "unmatched wildcard COPY should not create the destination")
+}

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -1320,4 +1321,44 @@ ADD --unpack=false archive.tar /out/
 		require.NoError(t, err)
 		require.False(t, found)
 	})
+}
+
+// TestDockerBuildContextChangeLayerCache verifies that COPY/ADD steps (and
+// anything downstream of them) keep their layer cache when files in the build
+// context that the COPY does not select are modified.
+func (DockerfileSuite) TestDockerBuildContextChangeLayerCache(ctx context.Context, t *testctx.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "app"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app", "main.txt"), []byte("v1"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated.txt"), []byte("one"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(`FROM `+alpineImage+`
+COPY app /app
+RUN head -c16 /dev/urandom | sha256sum > /copy-stamp
+RUN --mount=type=bind,source=app/main.txt,target=/mnt/main.txt head -c16 /dev/urandom | sha256sum > /bind-stamp
+`), 0o644))
+
+	// Use a fresh client per build: host.directory is cached per session, and
+	// the scenario being modeled is successive pipeline runs (one session
+	// each) against the same engine.
+	stamps := func() (string, string) {
+		c := connect(ctx, t)
+		defer c.Close()
+		ctr := c.Host().Directory(dir).DockerBuild()
+		copyStamp, err := ctr.File("/copy-stamp").Contents(ctx)
+		require.NoError(t, err)
+		bindStamp, err := ctr.File("/bind-stamp").Contents(ctx)
+		require.NoError(t, err)
+		return copyStamp, bindStamp
+	}
+
+	copyStamp1, bindStamp1 := stamps()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated.txt"), []byte("two"), 0o644))
+	copyStamp2, bindStamp2 := stamps()
+	require.Equal(t, copyStamp1, copyStamp2, "unrelated context change invalidated COPY layer cache")
+	require.Equal(t, bindStamp1, bindStamp2, "unrelated context change invalidated bind-mount RUN layer cache")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app", "main.txt"), []byte("v2"), 0o644))
+	copyStamp3, _ := stamps()
+	require.NotEqual(t, copyStamp1, copyStamp3, "COPY'd content change did not invalidate downstream RUN")
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -2648,9 +2648,11 @@ func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, p
 		return inst, err
 	}
 
-	// The mount's effect is fully determined by the parent container, the target/readOnly config,
-	// and the content at sourcePath, so key on those instead — mirroring BuildKit's
-	// content-checksummed bind-mount cache keys.
+	// Key the result on the mounted content rather than the source directory's
+	// recipe, mirroring BuildKit's content-checksummed bind-mount cache keys.
+	// A taught content digest is a global alias for the result's cache identity,
+	// so it must still include everything that distinguishes this container:
+	// the parent it was built from and the target/readOnly mount config.
 	parentDgst, err := parent.ContentPreferredDigest(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to content hash dockerfile bind mount: parent digest: %w", err)
@@ -2682,7 +2684,6 @@ func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, p
 		"__withMountedPathDockerfileCompat",
 		string(parentDgst),
 		target,
-		args.SourcePath,
 		strconv.FormatBool(args.ReadOnly),
 		srcHash,
 	))

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -2612,20 +2612,20 @@ type containerWithMountedPathDockerfileCompatArgs struct {
 	ReadOnly   bool   `default:"false"`
 }
 
-func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithMountedPathDockerfileCompatArgs) (*core.Container, error) {
+func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithMountedPathDockerfileCompatArgs) (inst dagql.ObjectResult[*core.Container], err error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get server: %w", err)
+		return inst, fmt.Errorf("failed to get server: %w", err)
 	}
 
 	dir, err := args.Source.Load(ctx, srv)
 	if err != nil {
-		return nil, err
+		return inst, err
 	}
 
 	ctr, _, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
-		return nil, err
+		return inst, err
 	}
 
 	target := absPath(parent.Self().Config.WorkingDir, args.Path)
@@ -2642,7 +2642,50 @@ func (s *containerSchema) withMountedPathDockerfileCompat(ctx context.Context, p
 		Readonly:        args.ReadOnly,
 		DirectorySource: new(core.LazyAccessor[*core.Directory, *core.Container]),
 	})
-	return ctr, nil
+
+	inst, err = dagql.NewObjectResultForCurrentCall(ctx, srv, ctr)
+	if err != nil {
+		return inst, err
+	}
+
+	// The mount's effect is fully determined by the parent container, the target/readOnly config,
+	// and the content at sourcePath, so key on those instead — mirroring BuildKit's
+	// content-checksummed bind-mount cache keys.
+	parentDgst, err := parent.ContentPreferredDigest(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to content hash dockerfile bind mount: parent digest: %w", err)
+	}
+	dagqlCache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return inst, err
+	}
+	if err := dagqlCache.Evaluate(ctx, dir); err != nil {
+		return inst, fmt.Errorf("failed to content hash dockerfile bind mount: evaluate source: %w", err)
+	}
+	srcSnapshot, err := dir.Self().Snapshot.GetOrEval(ctx, dir.Result)
+	if err != nil {
+		return inst, fmt.Errorf("failed to content hash dockerfile bind mount: source snapshot: %w", err)
+	}
+	srcRoot, err := dir.Self().Dir.GetOrEval(ctx, dir.Result)
+	if err != nil {
+		return inst, fmt.Errorf("failed to content hash dockerfile bind mount: source path: %w", err)
+	}
+	srcHash := "empty"
+	if srcSnapshot != nil {
+		dgst, err := core.GetContentHashFromFile(ctx, srcSnapshot, path.Join(srcRoot, args.SourcePath))
+		if err != nil {
+			return inst, fmt.Errorf("failed to content hash dockerfile bind mount at %q: %w", args.SourcePath, err)
+		}
+		srcHash = string(dgst)
+	}
+	return inst.WithContentDigest(ctx, hashutil.HashStrings(
+		"__withMountedPathDockerfileCompat",
+		string(parentDgst),
+		target,
+		args.SourcePath,
+		strconv.FormatBool(args.ReadOnly),
+		srcHash,
+	))
 }
 
 type containerWithMountedCacheArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -598,7 +598,8 @@ func (s *directorySchema) withDirectoryDockerfileCompat(ctx context.Context, par
 }
 
 // withDirectoryDockerfileCompatContentHashed wraps withDirectoryDockerfileCompat
-// and gives the result a content-based cache identity.
+// and gives the result a content-based cache identity so unrelated build-context
+// changes don't re-key downstream calls.
 func (s *directorySchema) withDirectoryDockerfileCompatContentHashed(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Directory],
@@ -611,35 +612,34 @@ func (s *directorySchema) withDirectoryDockerfileCompatContentHashed(
 	if res.Self() == nil {
 		return res, fmt.Errorf("failed to content hash dockerfile copy: nil directory result")
 	}
-
-	parentDgst, err := parent.ContentPreferredDigest(ctx)
-	if err != nil {
-		return res, fmt.Errorf("failed to content hash dockerfile copy: parent digest: %w", err)
+	// On errors past this point the result may hold a committed snapshot that
+	// dagql never attached, so release it instead of leaking the ref.
+	releaseErr := func(err error) (dagql.ObjectResult[*core.Directory], error) {
+		_ = res.Self().OnRelease(context.WithoutCancel(ctx))
+		return dagql.ObjectResult[*core.Directory]{}, err
 	}
 	if lazy := res.Self().LazyEvalFunc(); lazy != nil {
 		if err := lazy(ctx); err != nil {
-			return res, fmt.Errorf("failed to content hash dockerfile copy: %w", err)
+			return releaseErr(fmt.Errorf("failed to content hash dockerfile copy: %w", err))
 		}
 	}
 	snapshot, ok := res.Self().Snapshot.Peek()
 	if !ok {
-		return res, fmt.Errorf("failed to content hash dockerfile copy: snapshot unset")
+		return releaseErr(fmt.Errorf("failed to content hash dockerfile copy: snapshot unset"))
 	}
 	dirPath, ok := res.Self().Dir.Peek()
 	if !ok {
-		return res, fmt.Errorf("failed to content hash dockerfile copy: directory path unset")
+		return releaseErr(fmt.Errorf("failed to content hash dockerfile copy: directory path unset"))
 	}
-	destPath := path.Join(dirPath, args.Path)
-	destDgst, err := core.GetContentHashFromFile(ctx, snapshot, destPath)
+	dgst, err := core.GetContentHashFromDirectory(ctx, snapshot, dirPath)
 	if err != nil {
-		return res, fmt.Errorf("failed to content hash dockerfile copy at %q: %w", destPath, err)
+		return releaseErr(fmt.Errorf("failed to content hash dockerfile copy: %w", err))
 	}
-	return res.WithContentDigest(ctx, hashutil.HashStrings(
-		"__withDirectoryDockerfileCompat",
-		string(parentDgst),
-		destPath,
-		string(destDgst),
-	))
+	res, err = res.WithContentDigest(ctx, dgst)
+	if err != nil {
+		return releaseErr(fmt.Errorf("failed to content hash dockerfile copy: %w", err))
+	}
+	return res, nil
 }
 
 type FilterArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -165,7 +165,7 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 				dagql.Arg("permissions").Doc(`Permission given to the copied directory and contents (e.g., 0755).`).
 					View(AfterVersion("v0.21.0")),
 			),
-		dagql.NodeFunc("__withDirectoryDockerfileCompat", s.withDirectoryDockerfileCompat).
+		dagql.NodeFunc("__withDirectoryDockerfileCompat", s.withDirectoryDockerfileCompatContentHashed).
 			IsPersistable().
 			View(AllVersion).
 			Doc(`(Internal-only) Dockerfile-compat directory copy path.`).
@@ -180,7 +180,7 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 					`If the group is omitted, it defaults to the same as the user.`),
 				dagql.Arg("permissions").Doc(`Permission given to the copied directory and contents (e.g., 0755).`),
 			),
-		dagql.NodeFunc("filter", s.filter).
+		dagql.NodeFunc("filter", maintainContentHashing(s.filter)).
 			Doc(`Return a snapshot with some paths included or excluded`).
 			Args(
 				dagql.Arg("exclude").Doc(`If set, paths matching one of these glob patterns is excluded from the new snapshot. Example: ["node_modules/", ".git*", ".env"]`),
@@ -595,6 +595,51 @@ func (s *directorySchema) withDirectoryDockerfileCompat(ctx context.Context, par
 		dir.Dir.SetValue(parentDir)
 	}
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, dir)
+}
+
+// withDirectoryDockerfileCompatContentHashed wraps withDirectoryDockerfileCompat
+// and gives the result a content-based cache identity.
+func (s *directorySchema) withDirectoryDockerfileCompatContentHashed(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Directory],
+	args WithDirectoryDockerfileCompatArgs,
+) (dagql.ObjectResult[*core.Directory], error) {
+	res, err := s.withDirectoryDockerfileCompat(ctx, parent, args)
+	if err != nil {
+		return res, err
+	}
+	if res.Self() == nil {
+		return res, fmt.Errorf("failed to content hash dockerfile copy: nil directory result")
+	}
+
+	parentDgst, err := parent.ContentPreferredDigest(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed to content hash dockerfile copy: parent digest: %w", err)
+	}
+	if lazy := res.Self().LazyEvalFunc(); lazy != nil {
+		if err := lazy(ctx); err != nil {
+			return res, fmt.Errorf("failed to content hash dockerfile copy: %w", err)
+		}
+	}
+	snapshot, ok := res.Self().Snapshot.Peek()
+	if !ok {
+		return res, fmt.Errorf("failed to content hash dockerfile copy: snapshot unset")
+	}
+	dirPath, ok := res.Self().Dir.Peek()
+	if !ok {
+		return res, fmt.Errorf("failed to content hash dockerfile copy: directory path unset")
+	}
+	destPath := path.Join(dirPath, args.Path)
+	destDgst, err := core.GetContentHashFromFile(ctx, snapshot, destPath)
+	if err != nil {
+		return res, fmt.Errorf("failed to content hash dockerfile copy at %q: %w", destPath, err)
+	}
+	return res.WithContentDigest(ctx, hashutil.HashStrings(
+		"__withDirectoryDockerfileCompat",
+		string(parentDgst),
+		destPath,
+		string(destDgst),
+	))
 }
 
 type FilterArgs struct {
@@ -1226,7 +1271,8 @@ func (s *directorySchema) findUp(ctx context.Context, parent dagql.ObjectResult[
 
 func (s *directorySchema) changes(ctx context.Context, parent dagql.ObjectResult[*core.Directory], args struct {
 	From core.DirectoryID
-}) (res *core.Changeset, _ error) {
+},
+) (res *core.Changeset, _ error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return res, err
@@ -1371,8 +1417,7 @@ func (s *directorySchema) changesetEmpty(ctx context.Context, parent dagql.Objec
 	return dagql.Boolean(isEmpty), nil
 }
 
-type changesetPathsArgs struct {
-}
+type changesetPathsArgs struct{}
 
 func (s *directorySchema) changesetAddedPaths(ctx context.Context, parent dagql.ObjectResult[*core.Changeset], args changesetPathsArgs) (dagql.Array[dagql.String], error) {
 	paths, err := parent.Self().ComputePaths(ctx)
@@ -1398,8 +1443,7 @@ func (s *directorySchema) changesetRemovedPaths(ctx context.Context, parent dagq
 	return dagql.NewStringArray(paths.Removed...), nil
 }
 
-type changesetDiffStatsArgs struct {
-}
+type changesetDiffStatsArgs struct{}
 
 func (s *directorySchema) changesetDiffStats(ctx context.Context, parent dagql.ObjectResult[*core.Changeset], _ changesetDiffStatsArgs) (dagql.Array[*core.DiffStat], error) {
 	return parent.Self().DiffStats(ctx)


### PR DESCRIPTION
Dockerfile COPY/ADD and RUN --mount=type=bind converted through llbtodagger take the entire build-context Directory as their source argument, so their cache identity changed whenever anything in the context changed — even files the step never selected (e.g. .git metadata rewritten by every CI checkout). The compat results carried no content-based identity, so one context change re-keyed every downstream RUN layer. BuildKit does not have this problem: its COPY cache keys are content checksums of just the selected paths.

Fix by changing both compat calls to use a content-based cache identity after execution:

- __withDirectoryDockerfileCompat: H(parent content-preferred digest, dest path, content checksum of the dest subtree)
- __withMountedPathDockerfileCompat: H(parent content-preferred digest, target, sourcePath, readOnly, content checksum of source@sourcePath)

The copy still re-executes when the context changes, but byte-identical output merges back into the same cache equivalence class, so all downstream RUN layers keep hitting. Directory.filter is also wrapped with maintainContentHashing so dockerignore-filtered contexts stay content-addressed, letting the copy call itself cache-hit when only dockerignored files changed.

Narrowing the copy source with filter(include: [src]) was tried first and rejected: static include patterns cannot express symlink-target closures (breaks copy-through-symlink-context).