### PR TITLE
workspace: create missing envs on write, teach the read error

### DIFF
--- a/core/integration/workspace_env_management_test.go
+++ b/core/integration/workspace_env_management_test.go
@@ -154,6 +154,15 @@ source = "github.com/dagger/aws"
 		require.Error(t, err)
 		requireErrOut(t, err, `workspace env "ci" requires dagger.toml`)
 	})
+
+	t.Run("listing modules under an env without a dagger.toml fails too", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+
+		_, err := hostDaggerEnvExec(ctx, t, workdir, "--env=ci", "installed")
+		require.Error(t, err)
+		requireErrOut(t, err, `workspace env "ci" requires dagger.toml`)
+	})
 }
 
 // TestWorkspaceEnvConfigWriteSemantics defines where writes land when an env is
@@ -419,5 +428,210 @@ region = "base-region"
 		out, err = hostDaggerEnvExec(ctx, t, workdir, "call", "region")
 		require.NoError(t, err)
 		require.Equal(t, "base-region", strings.TrimSpace(string(out)))
+	})
+}
+
+// TestWorkspaceEnvModuleInstall covers env-scoped installs: with --env, `dagger
+// install` records the module under env.<name>.modules.* so it only exists when
+// that env is selected, creating the env on first write like other env-scoped
+// writes. Uninstall under --env removes only the env's overlay entry.
+func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *testctx.T) {
+	newEnvInstallWorkdir := func(ctx context.Context, t *testctx.T, configTOML string) string {
+		t.Helper()
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+		depDir := filepath.Join(workdir, "dep")
+		require.NoError(t, os.MkdirAll(depDir, 0o755))
+		copyTestdataFixture(ctx, t, depDir, "modules", "go", "minimal-dep")
+		if configTOML != "" {
+			require.NoError(t, os.WriteFile(filepath.Join(workdir, "dagger.toml"), []byte(configTOML), 0o644))
+		}
+		return workdir
+	}
+
+	t.Run("env-scoped install creates the env and records the module in its overlay", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
+`)
+
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		require.NoError(t, err)
+		outStr := string(out)
+		require.Contains(t, outStr, `Created env "dev"`)
+		require.Contains(t, outStr, `Installed module "dep" into env "dev"`)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Modules, "dep")
+		require.Equal(t, "dep", cfg.Env["dev"].Modules["dep"].Source)
+
+		// Reinstalling into the now-existing env is a no-op without the notice.
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Created env")
+		require.Contains(t, string(out), `Module "dep" is already installed in env "dev"`)
+	})
+
+	t.Run("env install with no dagger.toml creates config and env", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, "")
+
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		require.NoError(t, err)
+		outStr := string(out)
+		require.Contains(t, outStr, "Created workspace config in")
+		require.Contains(t, outStr, `Created env "dev"`)
+		require.Contains(t, outStr, `Installed module "dep" into env "dev"`)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Modules, "dep")
+		require.Equal(t, "dep", cfg.Env["dev"].Modules["dep"].Source)
+	})
+
+	t.Run("--here install writes the env module into the subdirectory config", func(ctx context.Context, t *testctx.T) {
+		// The workspace root defines env.dev, but the subdirectory config the
+		// --here install targets does not: both the Created-env notice and the
+		// overlay entry belong to the here-target, not the selected config.
+		workdir := newEnvInstallWorkdir(ctx, t, `[env.dev]
+`)
+		subdir := filepath.Join(workdir, "sub")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+		out, err := hostDaggerExecRaw(ctx, t, subdir, "--silent", "--env=dev", "install", "../dep", "--here")
+		require.NoError(t, err)
+		outStr := string(out)
+		require.Contains(t, outStr, `Created env "dev"`)
+		require.Contains(t, outStr, `Installed module "dep" into env "dev"`)
+
+		cfg := readInstalledWorkspaceConfig(t, subdir)
+		require.NotContains(t, cfg.Modules, "dep")
+		require.Contains(t, cfg.Env["dev"].Modules["dep"].Source, "dep")
+
+		rootCfg := readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, rootCfg.Env["dev"].Modules, "dep")
+	})
+
+	t.Run("settings on an env-added module can be written and unset", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
+`)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		require.NoError(t, err)
+
+		// minimal-dep has no constructor args, so exercise the raw config path:
+		// the point is that the env-scoped unset accepts a module the env itself
+		// added, which only exists in the overlay.
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "workspace", "config", "env.dev.modules.dep.settings.foo", "bar")
+		require.NoError(t, err)
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "bar", cfg.Env["dev"].Modules["dep"].Settings["foo"])
+
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "workspace", "config", "--unset", "modules.dep.settings.foo")
+		require.NoError(t, err)
+		cfg = readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Env["dev"].Modules["dep"].Settings, "foo")
+		require.Equal(t, "dep", cfg.Env["dev"].Modules["dep"].Source)
+	})
+
+	t.Run("env-scoped modules are listed only under their env", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
+`)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		require.NoError(t, err)
+
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "installed")
+		require.NoError(t, err)
+		require.Contains(t, string(out), "dep")
+
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "installed")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "dep")
+
+		// The env-scoped module actually loads and runs under its env.
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "call", "dep", "hello")
+		require.NoError(t, err)
+		require.Equal(t, "hello", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("env-scoped uninstall removes the overlay entry and leaves base alone", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules.dep]
+source = "dep"
+
+[env.dev.modules.other]
+source = "dep"
+`)
+
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "other")
+		require.NoError(t, err)
+		require.Contains(t, string(out), `Uninstalled module "other" from env "dev"`)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "dep", cfg.Modules["dep"].Source)
+		require.NotContains(t, cfg.Env["dev"].Modules, "other")
+
+		// A module only in base is not removable through an env selection.
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "dep")
+		require.Error(t, err)
+		requireErrOut(t, err, `module "dep" is not installed in env "dev"`)
+
+		// And a missing env stays a strict error for uninstall.
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=missing", "uninstall", "dep")
+		require.Error(t, err)
+		requireErrOut(t, err, `workspace env "missing" is not defined`)
+	})
+
+	t.Run("env uninstall drops the install but keeps settings overrides", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules.dep]
+source = "dep"
+`)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		require.NoError(t, err)
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "workspace", "config", "modules.dep.settings.foo", "bar")
+		require.NoError(t, err)
+
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "dep")
+		require.NoError(t, err)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "dep", cfg.Modules["dep"].Source)
+		// The install aspect is gone, the override the env still owns is not.
+		require.Empty(t, cfg.Env["dev"].Modules["dep"].Source)
+		require.Equal(t, "bar", cfg.Env["dev"].Modules["dep"].Settings["foo"])
+
+		// The settings-only leftover is not an install, so uninstall refuses it.
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "dep")
+		require.Error(t, err)
+		requireErrOut(t, err, `module "dep" is not installed in env "dev"`)
+	})
+
+	t.Run("SDK installs reject an env selection", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
+`)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "sdk", "install", "./dep")
+		require.Error(t, err)
+		requireErrOut(t, err, `SDKs cannot be installed in env "dev"`)
+	})
+
+	t.Run("SDK uninstall rejects an env selection", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules.dep]
+source = "dep"
+
+[modules.dep.as-sdk]
+
+[env.dev]
+`)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "sdk", "uninstall", "dep")
+		require.Error(t, err)
+		requireErrOut(t, err, "SDKs are not env-scoped")
+	})
+
+	t.Run("setup rejects an env selection", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[env.dev]
+`)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "setup")
+		require.Error(t, err)
+		requireErrOut(t, err, "setup does not support --env")
 	})
 }

--- a/core/integration/workspace_env_management_test.go
+++ b/core/integration/workspace_env_management_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/dagger/testctx"
@@ -129,6 +131,29 @@ region = "us-west-2"
 		require.Error(t, err)
 		requireErrOut(t, err, `workspace env "ci" is not defined`)
 	})
+
+	t.Run("missing env read error names the defined envs", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceConfigWorkdir(ctx, t, `[modules.aws]
+source = "github.com/dagger/aws"
+
+[env.ci]
+
+[env.prod]
+`)
+
+		_, err := hostDaggerEnvExec(ctx, t, workdir, "--env=prdo", "workspace", "config")
+		require.Error(t, err)
+		requireErrOut(t, err, `workspace env "prdo" is not defined (defined envs: ci, prod)`)
+	})
+
+	t.Run("selecting an env without a dagger.toml fails instead of printing nothing", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+
+		_, err := hostDaggerEnvExec(ctx, t, workdir, "--env=ci", "workspace", "config")
+		require.Error(t, err)
+		requireErrOut(t, err, `workspace env "ci" requires dagger.toml`)
+	})
 }
 
 // TestWorkspaceEnvConfigWriteSemantics defines where writes land when an env is
@@ -200,20 +225,50 @@ source = "github.com/dagger/aws"
 		}
 	})
 
-	t.Run("env-scoped writes reject missing envs and unknown module aliases", func(ctx context.Context, t *testctx.T) {
+	t.Run("env-scoped writes create missing envs with a notice", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceConfigWorkdir(ctx, t, `[modules.aws]
+source = "github.com/dagger/aws"
+
+[modules.aws.settings]
+region = "us-west-2"
+`)
+
+		out, err := hostDaggerEnvExec(ctx, t, workdir, "--env=staging", "workspace", "config", "modules.aws.settings.region", "us-east-1")
+		require.NoError(t, err)
+		require.Contains(t, string(out), `Created env "staging"`)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
+		require.Equal(t, "us-east-1", cfg.Env["staging"].Modules["aws"].Settings["region"])
+
+		// A write into the now-existing env doesn't repeat the notice.
+		out, err = hostDaggerEnvExec(ctx, t, workdir, "--env=staging", "workspace", "config", "modules.aws.settings.region", "eu-west-3")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Created env")
+	})
+
+	t.Run("env-scoped writes reject unknown module aliases", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceConfigWorkdir(ctx, t, `[modules.aws]
 source = "github.com/dagger/aws"
 
 [env.ci]
 `)
 
-		_, err := hostDaggerEnvExec(ctx, t, workdir, "--env=missing", "workspace", "config", "modules.aws.settings.region", "us-east-1")
-		require.Error(t, err)
-		requireErrOut(t, err, `workspace env "missing" is not defined`)
-
-		_, err = hostDaggerEnvExec(ctx, t, workdir, "--env=ci", "workspace", "config", "modules.missing.settings.region", "us-east-1")
+		_, err := hostDaggerEnvExec(ctx, t, workdir, "--env=ci", "workspace", "config", "modules.missing.settings.region", "us-east-1")
 		require.Error(t, err)
 		requireErrOut(t, err, `workspace env "ci" cannot set settings for unknown module "missing"`)
+	})
+
+	t.Run("env-scoped unsets still require the env to exist", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceConfigWorkdir(ctx, t, `[modules.aws]
+source = "github.com/dagger/aws"
+
+[env.ci]
+`)
+
+		_, err := hostDaggerEnvExec(ctx, t, workdir, "--env=missing", "workspace", "config", "--unset", "modules.aws.settings.region")
+		require.Error(t, err)
+		requireErrOut(t, err, `workspace env "missing" is not defined`)
 	})
 }
 
@@ -246,11 +301,43 @@ region = "us-east-1"
 source = "github.com/dagger/aws"
 `)
 
-		_, err := hostDaggerEnvExec(ctx, t, workdir, "workspace", "config", "env.ci.modules.aws.settings.region", "us-east-1")
+		out, err := hostDaggerEnvExec(ctx, t, workdir, "workspace", "config", "env.ci.modules.aws.settings.region", "us-east-1")
 		require.NoError(t, err)
+		require.Contains(t, string(out), `Created env "ci"`)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.Equal(t, "us-east-1", cfg.Env["ci"].Modules["aws"].Settings["region"])
+
+		out, err = hostDaggerEnvExec(ctx, t, workdir, "workspace", "config", "env.ci.modules.aws.settings.format", "json")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Created env")
+	})
+
+	t.Run("--here creation notice is detected against the here-targeted config", func(ctx context.Context, t *testctx.T) {
+		// The workspace root already defines env.staging, but the subdirectory
+		// config the --here write targets does not. The Created-env notice must
+		// be detected against the --here target, not the selected (root) config,
+		// so it still prints when --here creates the env in the subdir.
+		workdir := newWorkspaceConfigWorkdir(ctx, t, `[modules.aws]
+source = "github.com/dagger/aws"
+
+[env.staging]
+`)
+		subdir := filepath.Join(workdir, "sub")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+		out, err := hostDaggerEnvExec(ctx, t, subdir, "workspace", "config", "env.staging.modules.aws.settings.region", "us-east-1", "--here")
+		require.NoError(t, err)
+		require.Contains(t, string(out), `Created env "staging"`)
+
+		cfg := readInstalledWorkspaceConfig(t, subdir)
+		require.Equal(t, "us-east-1", cfg.Env["staging"].Modules["aws"].Settings["region"])
+
+		// A second --here write into the now-existing subdir env doesn't repeat
+		// the notice.
+		out, err = hostDaggerEnvExec(ctx, t, subdir, "workspace", "config", "env.staging.modules.aws.settings.format", "json", "--here")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Created env")
 	})
 
 	t.Run("explicit env-prefixed keys remain raw even when a current env is selected", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/workspace_env_management_test.go
+++ b/core/integration/workspace_env_management_test.go
@@ -603,6 +603,33 @@ source = "dep"
 		requireErrOut(t, err, `module "dep" is not installed in env "dev"`)
 	})
 
+	t.Run("env install over a base module announces the source override", func(ctx context.Context, t *testctx.T) {
+		workdir := newEnvInstallWorkdir(ctx, t, `[modules.dep]
+source = "dep"
+`)
+		forkDir := filepath.Join(workdir, "fork")
+		require.NoError(t, os.MkdirAll(forkDir, 0o755))
+		copyTestdataFixture(ctx, t, forkDir, "modules", "go", "minimal-dep")
+
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "--name=dep", "./fork")
+		require.NoError(t, err)
+		outStr := string(out)
+		require.Contains(t, outStr, `Installed module "dep" into env "dev"`)
+		require.Contains(t, outStr, `Module "dep" in env "dev" overrides source "dep"`)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "dep", cfg.Modules["dep"].Source)
+		require.Equal(t, "fork", cfg.Env["dev"].Modules["dep"].Source)
+
+		// Installing a genuinely new module into the env stays notice-free.
+		otherDir := filepath.Join(workdir, "other")
+		require.NoError(t, os.MkdirAll(otherDir, 0o755))
+		copyTestdataFixture(ctx, t, otherDir, "modules", "go", "minimal-dep")
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "--name=other", "./other")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "overrides source")
+	})
+
 	t.Run("SDK installs reject an env selection", func(ctx context.Context, t *testctx.T) {
 		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
 `)

--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -339,6 +339,40 @@ region = "us-west-2"
 		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
 	})
 
+	t.Run("env-scoped writes create a missing env with a notice", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+
+[modules.aws.settings]
+region = "us-west-2"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=staging", "settings", "aws", "region", "us-east-1")
+		require.NoError(t, err)
+		require.Contains(t, string(out), `Created env "staging"`)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
+		require.Equal(t, "us-east-1", cfg.Env["staging"].Modules["aws"].Settings["region"])
+
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=staging", "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
+
+		// Writing again into the now-existing env doesn't repeat the notice.
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=staging", "settings", "aws", "region", "eu-west-3")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Created env")
+
+		// Typed writes still validate the setting exists, even for a new env,
+		// and a rejected write doesn't create the env as a side effect.
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=another", "settings", "aws", "nope", "x")
+		require.Error(t, err)
+		requireErrOut(t, err, `module "aws" has no setting "nope"`)
+		cfg = readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Env, "another")
+	})
+
 	t.Run("typed writes use the same coercion rules as config writes", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.vitest]
 source = "modules/vitest"

--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -339,6 +339,34 @@ region = "us-west-2"
 		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
 	})
 
+	t.Run("typed settings work on a module the env itself installed", func(ctx context.Context, t *testctx.T) {
+		// The module exists only in the env overlay, so discovery has to run
+		// with the env applied to see it at all.
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules]
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "install", "./modules/aws")
+		require.NoError(t, err)
+
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "settings", "aws", "region", "us-east-1")
+		require.NoError(t, err)
+
+		cfg := readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Modules, "aws")
+		require.Equal(t, "us-east-1", cfg.Env["dev"].Modules["aws"].Settings["region"])
+
+		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
+
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "settings", "--unset", "aws", "region")
+		require.NoError(t, err)
+
+		cfg = readInstalledWorkspaceConfig(t, workdir)
+		require.NotContains(t, cfg.Env["dev"].Modules["aws"].Settings, "region")
+		require.Equal(t, "modules/aws", cfg.Env["dev"].Modules["aws"].Source)
+	})
+
 	t.Run("env-scoped writes create a missing env with a notice", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
 source = "modules/aws"

--- a/core/integration/workspace_user_config_test.go
+++ b/core/integration/workspace_user_config_test.go
@@ -94,6 +94,25 @@ profile = "alice-dev"
 		require.Equal(t, userConfigWorkspaceFixture, string(repoConfig))
 	})
 
+	t.Run("user-added modules list without an env selection", func(ctx context.Context, t *testctx.T) {
+		// A source-bearing always-on user entry adds a module for loading, so
+		// the listing must show it too — with or without --env, since the user
+		// overlay applies unconditionally in both.
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."github.com/acme/user-config-test".modules.personal]
+source = "github.com/acme/personal"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--silent", "installed")
+		require.NoError(t, err)
+		require.Contains(t, string(out), "personal")
+
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--silent", "--env=staging", "installed")
+		require.NoError(t, err)
+		require.Contains(t, string(out), "personal")
+	})
+
 	t.Run("equivalent remote URL forms match", func(ctx context.Context, t *testctx.T) {
 		// Repo origin is scp-style ssh; the user config keys the same remote
 		// in https form with a .git suffix.

--- a/core/integration/workspace_user_config_test.go
+++ b/core/integration/workspace_user_config_test.go
@@ -113,6 +113,30 @@ source = "github.com/acme/personal"
 		require.Contains(t, string(out), "personal")
 	})
 
+	t.Run("repo writes into a user-only env still print the creation notice", func(ctx context.Context, t *testctx.T) {
+		// The env exists only user-level, so the effective env list knows it —
+		// but a repo-level env-scoped write still adds [env.personal] to
+		// dagger.toml, and that creation must not happen silently.
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."github.com/acme/user-config-test".env.personal.modules.aws.settings]
+profile = "alice-personal"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=personal", "workspace", "config", "modules.aws.settings.region", "eu-west-1")
+		require.NoError(t, err)
+		require.Contains(t, string(out), `Created env "personal"`)
+
+		repoConfig, err := os.ReadFile(filepath.Join(workdir, "dagger.toml"))
+		require.NoError(t, err)
+		require.Contains(t, string(repoConfig), "[env.personal")
+
+		// The repo env now exists, so a second write doesn't repeat the notice.
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=personal", "workspace", "config", "modules.aws.settings.region", "eu-west-2")
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "Created env")
+	})
+
 	t.Run("equivalent remote URL forms match", func(ctx context.Context, t *testctx.T) {
 		// Repo origin is scp-style ssh; the user config keys the same remote
 		// in https form with a .git suffix.

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -190,7 +190,13 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withModule", s.withModule).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a module installed in its config.").
+			// Env-sensitive writes: what this records depends on the client's env
+			// selection, which travels in client metadata rather than the
+			// workspace ID, so a recipe recorded under one env must not replay
+			// under another.
+			WithInput(dagql.PerClientInput).
+			Doc("Return this workspace with a module installed in its config.",
+				"When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.").
 			Args(
 				dagql.Arg("ref").Doc("Module reference to install."),
 				dagql.Arg("name").Doc("Override name for the installed module entry."),
@@ -198,13 +204,16 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withoutModule", s.withoutModule).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a module removed from its config.").
+			WithInput(dagql.PerClientInput).
+			Doc("Return this workspace with a module removed from its config.",
+				"When the session selects an env, only that env's overlay entry is removed.").
 			Args(
 				dagql.Arg("name").Doc("Name of the installed module entry to remove."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
 		dagql.NodeFunc("withSDK", s.withSDK).
 			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
 			Doc("Return this workspace with an SDK installed in its config.").
 			Args(
 				dagql.Arg("ref").Doc("SDK module reference to install."),
@@ -214,6 +223,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withoutSDK", s.withoutSDK).
 			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
 			Doc("Return this workspace with an SDK removed from its config.").
 			Args(
 				dagql.Arg("name").Doc("Name of the installed SDK entry to remove."),
@@ -247,7 +257,9 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withConfigValue", s.withConfigValue).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a configuration value written.").
+			WithInput(dagql.PerClientInput).
+			Doc("Return this workspace with a configuration value written.",
+				"When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.").
 			Args(
 				dagql.Arg("key").Doc("Dotted key path."),
 				dagql.Arg("value").Doc("Value to set. Bools, integers, and comma-separated arrays are auto-detected."),
@@ -256,14 +268,17 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withoutConfigValue", s.withoutConfigValue).
 			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
 			Doc("Return this workspace with a configuration value removed.",
-				"Errors when the key is not currently set.").
+				"Errors when the key is not currently set.",
+				"When the session selects an env, the key is scoped to that env's overlay.").
 			Args(
 				dagql.Arg("key").Doc("Dotted key path (e.g. modules.greeter.settings.greeting)."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
 			),
 		dagql.NodeFunc("withConfigEnv", s.withConfigEnv).
 			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
 			Doc("Return this workspace with a named config environment created.").
 			Args(
 				dagql.Arg("name").Doc("Environment name."),
@@ -271,6 +286,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withoutConfigEnv", s.withoutConfigEnv).
 			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
 			Doc("Return this workspace with a named config environment removed.").
 			Args(
 				dagql.Arg("name").Doc("Environment name."),
@@ -315,10 +331,16 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Doc("List named environments defined in the workspace configuration."),
 		dagql.NodeFunc("modules", s.modules).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("List modules defined in the workspace configuration."),
+			// The listing is the env-effective view, and the selected env comes
+			// from client metadata rather than the workspace ID.
+			DoNotCache("Reads live config from host").
+			Doc("List modules defined in the workspace configuration.",
+				"Reflects the selected env's effective view."),
 		dagql.NodeFunc("module", s.module).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return a module defined in the workspace configuration.").
+			DoNotCache("Reads live config from host").
+			Doc("Return a module defined in the workspace configuration.",
+				"Reflects the selected env's effective view.").
 			Args(
 				dagql.Arg("name").Doc("Module name to inspect."),
 			),

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -141,7 +141,7 @@ func (s *workspaceSchema) withConfigValue(
 
 	writeKey := args.Key
 	if envName, ok := selectedWorkspaceEnv(ctx); ok && !isExplicitEnvConfigKey(args.Key) {
-		writeKey, err = envScopedConfigKey(staged.Config, envName, args.Key)
+		writeKey, err = envScopedConfigKey(staged.Config, envName, args.Key, workspaceConfigInitIfMissing)
 		if err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
 		}
@@ -178,7 +178,7 @@ func (s *workspaceSchema) withoutConfigValue(
 
 	unsetKey := args.Key
 	if envName, ok := selectedWorkspaceEnv(ctx); ok && !isExplicitEnvConfigKey(args.Key) {
-		unsetKey, err = envScopedConfigKey(staged.Config, envName, args.Key)
+		unsetKey, err = envScopedConfigKey(staged.Config, envName, args.Key, workspaceConfigMustExist)
 		if err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
 		}

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -272,7 +272,12 @@ func (s *workspaceSchema) withModuleInstall(
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 
-	plan, err := planWorkspaceInstallConfig(staged.Config, args, resolved.Name, resolved.ConfigSource)
+	var plan workspaceInstallConfigPlan
+	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		plan, err = planWorkspaceEnvInstallConfig(staged.Config, envName, args, resolved.Name, resolved.ConfigSource)
+	} else {
+		plan, err = planWorkspaceInstallConfig(staged.Config, args, resolved.Name, resolved.ConfigSource)
+	}
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
@@ -305,6 +310,11 @@ func (s *workspaceSchema) withSDK(
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceSDKInstallArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
+	// Reject before the ref is resolved and fetched; the plan keeps the same
+	// check as a backstop for other callers.
+	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("SDKs cannot be installed in env %q; install SDKs in the base workspace config", envName)
+	}
 	return s.withModuleInstall(ctx, parent, workspaceInstallArgs{
 		Ref:       args.Ref,
 		Name:      args.Name,
@@ -326,6 +336,9 @@ func (s *workspaceSchema) withoutModule(
 	staged, err := s.loadWorkspaceConfigForOverlay(ctx, parent.Self(), workspaceConfigMustExist, args.Here)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		return s.withoutEnvModule(ctx, parent, staged, envName, args.Name)
 	}
 	entry, ok := staged.Config.Modules[args.Name]
 	if !ok {
@@ -368,11 +381,56 @@ func (s *workspaceSchema) withoutModule(
 	})
 }
 
+// withoutEnvModule removes a module from the selected env's overlay only; the
+// base config is never touched under an env selection. Removal is env-strict
+// like unsets: the env must exist, and the module must be *installed* by it,
+// i.e. its overlay entry carries a source. A settings-only overlay entry does
+// not install anything, so it is cleared with `settings --unset`, not uninstall.
+//
+// Uninstalling removes the install aspect only: when the entry also carries
+// settings and the base config still installs the module, the entry is kept as
+// a settings-only overlay so the env's overrides survive. Without a base
+// module those settings would apply to nothing, so the entry goes entirely.
+func (s *workspaceSchema) withoutEnvModule(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	staged *stagedWorkspaceConfig,
+	envName string,
+	name string,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	env, ok := staged.Config.Env[envName]
+	if !ok {
+		return dagql.ObjectResult[*core.Workspace]{}, workspace.UndefinedEnvError(staged.Config, envName)
+	}
+	entry, ok := env.Modules[name]
+	if !ok || entry.Source == "" {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("module %q is not installed in env %q", name, envName)
+	}
+	_, baseInstalled := staged.Config.Modules[name]
+	if len(entry.Settings) > 0 && baseInstalled {
+		env.Modules[name] = workspace.EnvModuleOverlay{Settings: entry.Settings}
+	} else {
+		delete(env.Modules, name)
+		if len(env.Modules) == 0 {
+			env.Modules = nil
+		}
+	}
+	staged.Config.Env[envName] = env
+	updated, err := workspace.UpdateConfigBytes(staged.Data, staged.Config)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	return s.stageWorkspaceConfigBytes(ctx, parent, staged, updated)
+}
+
 func (s *workspaceSchema) withoutSDK(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceUninstallArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
+	if _, ok := selectedWorkspaceEnv(ctx); ok {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("SDKs are not env-scoped; uninstall SDKs in the base workspace config")
+	}
 	return s.withoutModule(ctx, parent, args)
 }
 

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -400,7 +400,7 @@ func (s *workspaceSchema) withoutEnvModule(
 ) (dagql.ObjectResult[*core.Workspace], error) {
 	env, ok := staged.Config.Env[envName]
 	if !ok {
-		return dagql.ObjectResult[*core.Workspace]{}, workspace.UndefinedEnvError(staged.Config, envName)
+		return dagql.ObjectResult[*core.Workspace]{}, workspace.NewUndefinedEnvError(staged.Config, envName)
 	}
 	entry, ok := env.Modules[name]
 	if !ok || entry.Source == "" {

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -294,7 +294,7 @@ func envScopedConfigKey(cfg *workspace.Config, envName, key string, policy works
 		return "", fmt.Errorf("workspace env %q requires dagger.toml", envName)
 	}
 	if _, ok := cfg.Env[envName]; !ok && policy == workspaceConfigMustExist {
-		return "", workspace.UndefinedEnvError(cfg, envName)
+		return "", workspace.NewUndefinedEnvError(cfg, envName)
 	}
 
 	parts, err := workspace.SplitConfigPath(key)

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -307,7 +307,11 @@ func envScopedConfigKey(cfg *workspace.Config, envName, key string, policy works
 
 	moduleName := parts[1]
 	if _, ok := cfg.Modules[moduleName]; !ok {
-		return "", fmt.Errorf("workspace env %q cannot set settings for unknown module %q", envName, moduleName)
+		// The module may be one the env itself adds, which only exists in the
+		// overlay.
+		if _, ok := cfg.Env[envName].Modules[moduleName]; !ok {
+			return "", fmt.Errorf("workspace env %q cannot set settings for unknown module %q", envName, moduleName)
+		}
 	}
 
 	return workspace.JoinConfigPath(append([]string{"env", envName}, parts...)...), nil

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -178,6 +178,9 @@ func (s *workspaceSchema) configRead(
 	args configReadArgs,
 ) (dagql.String, error) {
 	if parent.ConfigFile == "" {
+		if envName, ok := selectedWorkspaceEnv(ctx); ok {
+			return "", fmt.Errorf("workspace env %q requires dagger.toml", envName)
+		}
 		result, err := workspace.ReadConfigValue(nil, args.Key)
 		if err != nil {
 			return "", err
@@ -281,12 +284,17 @@ func effectiveWorkspaceConfigBytes(ws *core.Workspace, cfg *workspace.Config, en
 	return workspace.SerializeConfig(applied), nil
 }
 
-func envScopedConfigKey(cfg *workspace.Config, envName, key string) (string, error) {
+// envScopedConfigKey maps a modules.<name>.settings.* key into the selected
+// env's overlay storage. Under workspaceConfigInitIfMissing a missing env is
+// created by the write (writing a setting is the gesture that creates an env);
+// under workspaceConfigMustExist a missing env is rejected, so unsets keep
+// requiring the env to exist.
+func envScopedConfigKey(cfg *workspace.Config, envName, key string, policy workspaceConfigMutationPolicy) (string, error) {
 	if cfg == nil {
 		return "", fmt.Errorf("workspace env %q requires dagger.toml", envName)
 	}
-	if _, ok := cfg.Env[envName]; !ok {
-		return "", fmt.Errorf("workspace env %q is not defined", envName)
+	if _, ok := cfg.Env[envName]; !ok && policy == workspaceConfigMustExist {
+		return "", workspace.UndefinedEnvError(cfg, envName)
 	}
 
 	parts, err := workspace.SplitConfigPath(key)

--- a/core/schema/workspace_install.go
+++ b/core/schema/workspace_install.go
@@ -77,6 +77,71 @@ func planWorkspaceInstallConfig(
 	return plan, nil
 }
 
+// planWorkspaceEnvInstallConfig stages an install scoped to a workspace env:
+// the module is recorded under env.<envName>.modules.* so it is only present
+// when that env is selected. Installing is a write, so a missing env is
+// created by it, matching env-scoped config writes. The overlay entry is
+// recorded even when the base config has the same module, so the env keeps it
+// if the base install is later removed.
+//
+// An existing overlay entry without a source is a settings-only overlay, not an
+// install, so it is upgraded in place (keeping its settings) rather than
+// treated as already installed. When the base config installs the same module
+// from the same source, its pin is copied into the overlay entry: an overlay
+// source is authoritative in [workspace.ApplyEnvOverlay] and its pin travels
+// with it, so a pin-less overlay would silently unpin the module in that env.
+// Otherwise the entry stays pin-less and resolves through dagger.lock, like
+// base installs.
+func planWorkspaceEnvInstallConfig(
+	cfg *workspace.Config,
+	envName string,
+	args workspaceInstallArgs,
+	name string,
+	sourcePath string,
+) (workspaceInstallConfigPlan, error) {
+	plan := workspaceInstallConfigPlan{}
+	if args.AsSdk {
+		return plan, fmt.Errorf("SDKs cannot be installed in env %q; install SDKs in the base workspace config", envName)
+	}
+
+	if base, ok := cfg.Modules[name]; ok && base.AsSDK != nil {
+		return plan, fmt.Errorf("module %q is an SDK; SDKs cannot be installed in env %q", name, envName)
+	}
+
+	if workspace.EnsureEnv(cfg, envName) {
+		plan.Changed = true
+	}
+	env := cfg.Env[envName]
+	entry := workspace.EnvModuleOverlay{Source: sourcePath}
+	if existing, ok := env.Modules[name]; ok {
+		if existing.Source == sourcePath {
+			return plan, nil
+		}
+		if existing.Source != "" {
+			return plan, fmt.Errorf(
+				"module %q already exists in env %q with source %q (new source %q)",
+				name,
+				envName,
+				existing.Source,
+				sourcePath,
+			)
+		}
+		entry.Settings = existing.Settings
+	}
+	if base, ok := cfg.Modules[name]; ok && base.Source == sourcePath {
+		entry.Pin = base.Pin
+	}
+
+	if env.Modules == nil {
+		env.Modules = map[string]workspace.EnvModuleOverlay{}
+	}
+	env.Modules[name] = entry
+	cfg.Env[envName] = env
+	plan.Changed = true
+	plan.Added = true
+	return plan, nil
+}
+
 type workspaceInstallResolution struct {
 	Name         string
 	ConfigSource string

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -17,12 +17,32 @@ func (s *workspaceSchema) workspaceModules(
 ) (dagql.ObjectResultArray[*core.WorkspaceModule], error) {
 	ws := parent.Self()
 	if ws.ConfigFile == "" {
+		// An env selection has nowhere to resolve from without a config, and
+		// silently listing nothing would read as "the env is empty".
+		if envName, ok := selectedWorkspaceEnv(ctx); ok {
+			return nil, fmt.Errorf("workspace env %q requires dagger.toml", envName)
+		}
 		return dagql.ObjectResultArray[*core.WorkspaceModule]{}, nil
 	}
 
 	cfg, err := readWorkspaceConfig(ctx, ws)
 	if err != nil {
 		return nil, err
+	}
+	// The listing is the effective view, merged in the same order as module
+	// loading (base, user-level overlay, selected env overlay), so modules an
+	// overlay adds are discoverable. It inherits the env overlay's strictness
+	// too — a missing or broken env fails listing instead of silently falling
+	// back to the base config, deliberately matching env-selected config reads.
+	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		cfg, err = workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
+		if err != nil {
+			return nil, err
+		}
+		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	configDir, err := workspaceConfigDirectory(ws)
@@ -179,8 +199,9 @@ func (s *workspaceSchema) moduleSettings(
 		return nil, err
 	}
 
-	// Source comes from base config; values come from the user-level overlay
-	// and the selected env overlay, merged in the same order as module loading.
+	// Values come from the user-level overlay and the selected env overlay,
+	// merged in the same order as module loading. The entry lookup is also
+	// effective so modules an overlay itself adds resolve their settings.
 	effectiveCfg, err := workspace.ApplyUserOverlay(cfg, ws.Self().UserConfigOverlay())
 	if err != nil {
 		return nil, err
@@ -192,7 +213,7 @@ func (s *workspaceSchema) moduleSettings(
 		}
 	}
 
-	entry, ok := cfg.Modules[parent.Self().Name]
+	entry, ok := effectiveCfg.Modules[parent.Self().Name]
 	if !ok {
 		return nil, fmt.Errorf("module %q is not installed in the workspace", parent.Self().Name)
 	}

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -31,14 +31,16 @@ func (s *workspaceSchema) workspaceModules(
 	}
 	// The listing is the effective view, merged in the same order as module
 	// loading (base, user-level overlay, selected env overlay), so modules an
-	// overlay adds are discoverable. It inherits the env overlay's strictness
-	// too — a missing or broken env fails listing instead of silently falling
-	// back to the base config, deliberately matching env-selected config reads.
+	// overlay adds are discoverable — with or without an env selected, since
+	// loading applies the user overlay unconditionally too. It inherits the
+	// env overlay's strictness — a missing or broken env fails listing instead
+	// of silently falling back to the base config, deliberately matching
+	// env-selected config reads.
+	cfg, err = workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
+	if err != nil {
+		return nil, err
+	}
 	if envName, ok := selectedWorkspaceEnv(ctx); ok {
-		cfg, err = workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
-		if err != nil {
-			return nil, err
-		}
 		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
 		if err != nil {
 			return nil, err

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -819,6 +819,116 @@ func TestEnvScopedConfigKeyQuotesDynamicSegments(t *testing.T) {
 	require.Equal(t, `env."review env".modules."my.module".settings."some.key"`, key)
 }
 
+func TestPlanWorkspaceEnvInstallConfig(t *testing.T) {
+	t.Run("creates the env and records the module in its overlay", func(t *testing.T) {
+		cfg := &workspace.Config{Modules: map[string]workspace.ModuleEntry{}}
+
+		plan, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "dep", "dep")
+		require.NoError(t, err)
+		require.True(t, plan.Changed)
+		require.True(t, plan.Added)
+		require.Equal(t, "dep", cfg.Env["dev"].Modules["dep"].Source)
+		require.Empty(t, cfg.Modules)
+	})
+
+	t.Run("reinstall with the same source is a no-op", func(t *testing.T) {
+		cfg := &workspace.Config{
+			Env: map[string]workspace.EnvOverlay{
+				"dev": {Modules: map[string]workspace.EnvModuleOverlay{
+					"dep": {Source: "dep"},
+				}},
+			},
+		}
+
+		plan, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "dep", "dep")
+		require.NoError(t, err)
+		require.False(t, plan.Changed)
+	})
+
+	t.Run("conflicting source in the same env is rejected", func(t *testing.T) {
+		cfg := &workspace.Config{
+			Env: map[string]workspace.EnvOverlay{
+				"dev": {Modules: map[string]workspace.EnvModuleOverlay{
+					"dep": {Source: "dep"},
+				}},
+			},
+		}
+
+		_, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "dep", "other/dep")
+		require.ErrorContains(t, err, `module "dep" already exists in env "dev"`)
+	})
+
+	t.Run("base module with another source is overridden, not rejected", func(t *testing.T) {
+		cfg := &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"dep": {Source: "base/dep"},
+			},
+		}
+
+		plan, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "dep", "dep")
+		require.NoError(t, err)
+		require.True(t, plan.Changed)
+		require.Equal(t, "dep", cfg.Env["dev"].Modules["dep"].Source)
+		require.Equal(t, "base/dep", cfg.Modules["dep"].Source)
+		require.Empty(t, cfg.Env["dev"].Modules["dep"].Pin)
+	})
+
+	t.Run("redundant overlay of a base module carries the base pin", func(t *testing.T) {
+		cfg := &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"dep": {Source: "github.com/foo/dep", Pin: "abc123"},
+			},
+		}
+
+		plan, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "dep", "github.com/foo/dep")
+		require.NoError(t, err)
+		require.True(t, plan.Changed)
+		require.Equal(t, "github.com/foo/dep", cfg.Env["dev"].Modules["dep"].Source)
+		require.Equal(t, "abc123", cfg.Env["dev"].Modules["dep"].Pin)
+	})
+
+	t.Run("settings-only overlay entry is upgraded in place", func(t *testing.T) {
+		cfg := &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"dep": {Source: "base/dep"},
+			},
+			Env: map[string]workspace.EnvOverlay{
+				"dev": {Modules: map[string]workspace.EnvModuleOverlay{
+					"dep": {Settings: map[string]any{"region": "eu"}},
+				}},
+			},
+		}
+
+		plan, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "dep", "dep")
+		require.NoError(t, err)
+		require.True(t, plan.Changed)
+		require.True(t, plan.Added)
+		entry := cfg.Env["dev"].Modules["dep"]
+		require.Equal(t, "dep", entry.Source)
+		require.Equal(t, map[string]any{"region": "eu"}, entry.Settings)
+	})
+
+	t.Run("SDK installs are rejected under an env selection", func(t *testing.T) {
+		cfg := &workspace.Config{}
+
+		_, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{AsSdk: true}, "go-sdk", "go-sdk")
+		require.ErrorContains(t, err, `SDKs cannot be installed in env "dev"`)
+		require.Empty(t, cfg.Env)
+	})
+
+	t.Run("re-sourcing a base SDK entry is rejected", func(t *testing.T) {
+		cfg := &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"go-sdk": {Source: "sdk/go", AsSDK: &workspace.ModuleAsSDK{}},
+			},
+		}
+
+		_, err := planWorkspaceEnvInstallConfig(cfg, "dev", workspaceInstallArgs{}, "go-sdk", "other/go")
+		require.ErrorContains(t, err, `module "go-sdk" is an SDK; SDKs cannot be installed in env "dev"`)
+		require.Empty(t, cfg.Env)
+	})
+}
+
 func TestEnvScopedConfigKeyMissingEnv(t *testing.T) {
 	cfg := &workspace.Config{
 		Modules: map[string]workspace.ModuleEntry{

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -814,9 +814,26 @@ func TestEnvScopedConfigKeyQuotesDynamicSegments(t *testing.T) {
 		},
 	}
 
-	key, err := envScopedConfigKey(cfg, "review env", `modules."my.module".settings."some.key"`)
+	key, err := envScopedConfigKey(cfg, "review env", `modules."my.module".settings."some.key"`, workspaceConfigMustExist)
 	require.NoError(t, err)
 	require.Equal(t, `env."review env".modules."my.module".settings."some.key"`, key)
+}
+
+func TestEnvScopedConfigKeyMissingEnv(t *testing.T) {
+	cfg := &workspace.Config{
+		Modules: map[string]workspace.ModuleEntry{
+			"aws": {Source: "modules/aws"},
+		},
+	}
+
+	// Writes create the env, so the key maps even when the env is undefined.
+	key, err := envScopedConfigKey(cfg, "staging", "modules.aws.settings.region", workspaceConfigInitIfMissing)
+	require.NoError(t, err)
+	require.Equal(t, "env.staging.modules.aws.settings.region", key)
+
+	// Unsets still require the env to exist.
+	_, err = envScopedConfigKey(cfg, "staging", "modules.aws.settings.region", workspaceConfigMustExist)
+	require.ErrorContains(t, err, `workspace env "staging" is not defined`)
 }
 
 func TestWorkspaceSettingConfigKeyQuotesDynamicSegments(t *testing.T) {

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -225,7 +225,7 @@ func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 
 	env, ok := cfg.Env[envName]
 	if !ok {
-		return nil, fmt.Errorf("workspace env %q is not defined", envName)
+		return nil, UndefinedEnvError(cfg, envName)
 	}
 
 	if err := applyModuleOverlays(applied, env.Modules, fmt.Sprintf("workspace env %q", envName)); err != nil {
@@ -268,6 +268,28 @@ func applyModuleOverlays(applied *Config, overlays map[string]EnvModuleOverlay, 
 	return nil
 }
 
+// UndefinedEnvError reports a selected env that has no env.<name>.* entry in
+// the config. Enumerating the defined envs is the actionable part: a missing
+// env is most often a typo, and the list is what disambiguates. No creation
+// hint — envs come into being through env-scoped writes, but we can't know
+// which write the user meant.
+func UndefinedEnvError(cfg *Config, envName string) error {
+	return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(cfg))
+}
+
+// UndefinedEnvErrorPrefix is the format string every "undefined env" error
+// starts with, so callers matching on it (the CLI's create-on-write retry)
+// stay compile-coupled to the message they key off.
+const UndefinedEnvErrorPrefix = "workspace env %q is not defined"
+
+func definedEnvsFragment(cfg *Config) string {
+	names := EnvNames(cfg)
+	if len(names) == 0 {
+		return "no envs defined"
+	}
+	return "defined envs: " + strings.Join(names, ", ")
+}
+
 // EnvNames returns the configured environment names in deterministic order.
 func EnvNames(cfg *Config) []string {
 	if cfg == nil || len(cfg.Env) == 0 {
@@ -298,10 +320,10 @@ func EnsureEnv(cfg *Config, envName string) bool {
 // RemoveEnv removes the named environment from the config.
 func RemoveEnv(cfg *Config, envName string) error {
 	if cfg == nil || len(cfg.Env) == 0 {
-		return fmt.Errorf("workspace env %q is not defined", envName)
+		return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(cfg))
 	}
 	if _, ok := cfg.Env[envName]; !ok {
-		return fmt.Errorf("workspace env %q is not defined", envName)
+		return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(cfg))
 	}
 	delete(cfg.Env, envName)
 	if len(cfg.Env) == 0 {

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -225,7 +225,7 @@ func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 
 	env, ok := cfg.Env[envName]
 	if !ok {
-		return nil, UndefinedEnvError(cfg, envName)
+		return nil, NewUndefinedEnvError(cfg, envName)
 	}
 
 	if err := applyModuleOverlays(applied, env.Modules, fmt.Sprintf("workspace env %q", envName)); err != nil {
@@ -273,17 +273,40 @@ func applyModuleOverlays(applied *Config, overlays map[string]EnvModuleOverlay, 
 // env is most often a typo, and the list is what disambiguates. No creation
 // hint — envs come into being through env-scoped writes, but we can't know
 // which write the user meant.
-func UndefinedEnvError(cfg *Config, envName string) error {
-	return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(cfg))
+type UndefinedEnvError struct {
+	Env     string
+	Defined []string
 }
 
+func NewUndefinedEnvError(cfg *Config, envName string) error {
+	return &UndefinedEnvError{Env: envName, Defined: EnvNames(cfg)}
+}
+
+func (e *UndefinedEnvError) Error() string {
+	return fmt.Sprintf(UndefinedEnvErrorPrefix+" (%s)", e.Env, definedEnvsFragment(e.Defined))
+}
+
+// Extensions marks the error for structured detection across the GraphQL
+// boundary: dagql attaches these to the error response for any error in the
+// wrap chain, so the CLI's create-on-write retry can match _type and env
+// instead of parsing the message.
+func (e *UndefinedEnvError) Extensions() map[string]any {
+	return map[string]any{
+		"_type": UndefinedEnvErrorType,
+		"env":   e.Env,
+	}
+}
+
+// UndefinedEnvErrorType is the _type extension value identifying an
+// UndefinedEnvError in a GraphQL error response.
+const UndefinedEnvErrorType = "UNDEFINED_ENV_ERROR"
+
 // UndefinedEnvErrorPrefix is the format string every "undefined env" error
-// starts with, so callers matching on it (the CLI's create-on-write retry)
-// stay compile-coupled to the message they key off.
+// message starts with. Clients that cannot see extensions (version-skewed
+// engines, non-GraphQL boundaries) match on it as a fallback.
 const UndefinedEnvErrorPrefix = "workspace env %q is not defined"
 
-func definedEnvsFragment(cfg *Config) string {
-	names := EnvNames(cfg)
+func definedEnvsFragment(names []string) string {
 	if len(names) == 0 {
 		return "no envs defined"
 	}
@@ -320,10 +343,10 @@ func EnsureEnv(cfg *Config, envName string) bool {
 // RemoveEnv removes the named environment from the config.
 func RemoveEnv(cfg *Config, envName string) error {
 	if cfg == nil || len(cfg.Env) == 0 {
-		return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(cfg))
+		return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(EnvNames(cfg)))
 	}
 	if _, ok := cfg.Env[envName]; !ok {
-		return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(cfg))
+		return fmt.Errorf(UndefinedEnvErrorPrefix+" (%s)", envName, definedEnvsFragment(EnvNames(cfg)))
 	}
 	delete(cfg.Env, envName)
 	if len(cfg.Env) == 0 {

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -710,6 +710,21 @@ region = "us-east-1"
 		require.NotContains(t, out, `region = "us-east-1"`)
 	})
 
+	t.Run("undefined env removal lists the defined envs", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte("[env.dev]\n[env.prod]\n"))
+		require.NoError(t, err)
+
+		err = RemoveEnv(cfg, "ci")
+		require.ErrorContains(t, err, `workspace env "ci" is not defined (defined envs: dev, prod)`)
+		// Removal never teaches the create-by-writing gesture.
+		require.NotContains(t, err.Error(), "create it by writing a setting")
+
+		err = RemoveEnv(&Config{}, "ci")
+		require.ErrorContains(t, err, `workspace env "ci" is not defined (no envs defined)`)
+	})
+
 	t.Run("removes existing numeric path segments", func(t *testing.T) {
 		t.Parallel()
 
@@ -800,7 +815,16 @@ func TestApplyEnvOverlay(t *testing.T) {
 		t.Parallel()
 
 		_, err := ApplyEnvOverlay(&Config{}, "ci")
-		require.EqualError(t, err, `workspace env "ci" is not defined`)
+		require.EqualError(t, err, `workspace env "ci" is not defined (no envs defined)`)
+	})
+
+	t.Run("missing env error lists defined envs", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ApplyEnvOverlay(&Config{
+			Env: map[string]EnvOverlay{"ci": {}, "prod": {}},
+		}, "prdo")
+		require.ErrorContains(t, err, `workspace env "prdo" is not defined (defined envs: ci, prod)`)
 	})
 
 	t.Run("rejects unknown module alias", func(t *testing.T) {

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -1142,4 +1143,21 @@ other = "kept"
 		require.NotContains(t, cfg.Modules["my.module"].Settings, "some.key")
 		require.Equal(t, "kept", cfg.Modules["my.module"].Settings["other"])
 	})
+}
+
+func TestUndefinedEnvErrorExtensions(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{Env: map[string]EnvOverlay{"ci": {}, "prod": {}}}
+	err := NewUndefinedEnvError(cfg, "prdo")
+	require.EqualError(t, err, `workspace env "prdo" is not defined (defined envs: ci, prod)`)
+
+	// dagql attaches Extensions() from any error in the wrap chain via
+	// errors.As, so the marker must survive the fmt.Errorf wrapping the
+	// workspace-load path adds.
+	wrapped := fmt.Errorf("query module objects: loading workspace: %w", err)
+	var ext interface{ Extensions() map[string]any }
+	require.True(t, errors.As(wrapped, &ext))
+	require.Equal(t, UndefinedEnvErrorType, ext.Extensions()["_type"])
+	require.Equal(t, "prdo", ext.Extensions()["env"])
 }

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1482,6 +1482,9 @@ Install a module into the current workspace.
 If no workspace config is selected, this creates one at the workspace root first.
 Use --here to create the workspace config at the workspace cwd instead.
 
+With --env the module is recorded in that env's overlay (env.&lt;name&gt;.modules.*)
+and the env is created if missing.
+
 ```
 dagger install [options] <module>
 ```
@@ -2705,6 +2708,8 @@ Uninstall a module from your workspace
 ### Synopsis
 
 Uninstall a module from the current workspace, removing it from dagger.toml.
+
+With --env only the env's overlay entry is removed, never the base module.
 
 ```
 dagger uninstall [options] <module>

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -20,7 +20,7 @@ dagger [options] [subcommand | file...]
   -c, --command string               Execute a dagger shell command
   -d, --debug                        Show debug logs and full verbosity
       --eager-runtime                load module runtime eagerly
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
   -m, --load-module string           Use a one-off module (local path or git ref)
@@ -79,7 +79,7 @@ dagger activity
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -134,7 +134,7 @@ dagger agent [options] [name...]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -172,7 +172,7 @@ See https://docs.dagger.io/api for the full overview.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -220,7 +220,7 @@ dagger api call [options] [function]...
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -256,7 +256,7 @@ module that generates it.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -317,7 +317,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -355,7 +355,7 @@ dagger api client list
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -410,7 +410,7 @@ dagger api functions [options] [function]...
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -481,7 +481,7 @@ EOF
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -546,7 +546,7 @@ dagger api with-session python main.py
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -603,7 +603,7 @@ dagger check [options] [pattern...]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -631,7 +631,7 @@ Manage Dagger Cloud
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -677,7 +677,7 @@ dagger cloud billing
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -717,7 +717,7 @@ dagger cloud billing manage [org]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -750,7 +750,7 @@ dagger cloud billing plans
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -783,7 +783,7 @@ dagger cloud check
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -825,7 +825,7 @@ dagger cloud check list [version]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -857,7 +857,7 @@ dagger cloud check off [name]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -889,7 +889,7 @@ dagger cloud check on [name]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -921,7 +921,7 @@ dagger cloud check status [name]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -959,7 +959,7 @@ dagger cloud integration
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1006,7 +1006,7 @@ dagger cloud integration create github
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1039,7 +1039,7 @@ dagger cloud integration list [type]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1072,7 +1072,7 @@ dagger cloud integration rm <id>
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1111,7 +1111,7 @@ dagger cloud login [options] [org]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1143,7 +1143,7 @@ dagger cloud logout
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1199,7 +1199,7 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1237,7 +1237,7 @@ dagger cloud org [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1272,7 +1272,7 @@ dagger cloud org info [org] [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1305,7 +1305,7 @@ dagger cloud org list [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1338,7 +1338,7 @@ dagger cloud org use <org> [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1400,7 +1400,7 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1452,7 +1452,7 @@ dagger generate [options] [pattern...]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1504,7 +1504,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1536,7 +1536,7 @@ dagger installed
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1568,7 +1568,7 @@ Manage LLM provider configuration, API keys, and default models.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1618,7 +1618,7 @@ dagger llm add-key <provider>
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1650,7 +1650,7 @@ dagger llm config
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1682,7 +1682,7 @@ dagger llm remove-key <provider>
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1714,7 +1714,7 @@ dagger llm reset
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1746,7 +1746,7 @@ dagger llm set-default <provider> [model]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1778,7 +1778,7 @@ dagger llm setup
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1810,7 +1810,7 @@ dagger llm show-config
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1844,7 +1844,7 @@ Operates on the dagger-module.toml reachable from the current directory.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1876,7 +1876,7 @@ Manage this module's dependencies
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1918,7 +1918,7 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1950,7 +1950,7 @@ dagger module deps list [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -1988,7 +1988,7 @@ dagger module deps rm wolfi
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2032,7 +2032,7 @@ dagger module deps update wolfi@v0.20.2
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2060,7 +2060,7 @@ Manage this module's required engine version
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2102,7 +2102,7 @@ dagger module engine require v0.21.0
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2134,7 +2134,7 @@ dagger module engine require-current [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2166,7 +2166,7 @@ dagger module engine require-latest [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2198,7 +2198,7 @@ dagger module engine required [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2270,7 +2270,7 @@ dagger sdk install go && dagger module init go my-module
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2317,7 +2317,7 @@ dagger module sdk <subcommand> [args...] [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2350,7 +2350,7 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2412,7 +2412,7 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2449,7 +2449,7 @@ dagger sdk installed [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2488,7 +2488,7 @@ dagger sdk search [query] [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2536,7 +2536,7 @@ dagger sdk uninstall [options] <name> [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2580,7 +2580,7 @@ dagger search wolfi
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2620,7 +2620,7 @@ dagger settings [module] [key] [value...]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2679,7 +2679,7 @@ dagger setup
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2727,7 +2727,7 @@ dagger uninstall hello
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2775,7 +2775,7 @@ dagger up [options] [pattern...]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2819,7 +2819,7 @@ dagger update
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2858,7 +2858,7 @@ dagger version
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2903,7 +2903,7 @@ dagger workspace
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2963,7 +2963,7 @@ dagger workspace config [key] [value] [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -2995,7 +2995,7 @@ dagger workspace config-file [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -3027,7 +3027,7 @@ dagger workspace cwd [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -3059,7 +3059,7 @@ dagger workspace remote [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -3091,7 +3091,7 @@ dagger workspace remotes [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
@@ -3123,7 +3123,7 @@ dagger workspace root [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply the named workspace environment overlay
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5708,7 +5708,11 @@ type Workspace implements Node {
   """
   migrate: WorkspaceMigration!
 
-  """Return a module defined in the workspace configuration."""
+  """
+  Return a module defined in the workspace configuration.
+
+  Reflects the selected env's effective view.
+  """
   module(
     """Module name to inspect."""
     name: String!
@@ -5729,7 +5733,11 @@ type Workspace implements Node {
     path: String!
   ): ModuleSource!
 
-  """List modules defined in the workspace configuration."""
+  """
+  List modules defined in the workspace configuration.
+
+  Reflects the selected env's effective view.
+  """
   modules: [WorkspaceModule!]!
 
   """
@@ -5815,7 +5823,11 @@ type Workspace implements Node {
     here: Boolean = false
   ): Workspace!
 
-  """Return this workspace with a configuration value written."""
+  """
+  Return this workspace with a configuration value written.
+
+  When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
+  """
   withConfigValue(
     """Dotted key path."""
     key: String!
@@ -5892,7 +5904,11 @@ type Workspace implements Node {
     noGenerate: Boolean = false
   ): Workspace!
 
-  """Return this workspace with a module installed in its config."""
+  """
+  Return this workspace with a module installed in its config.
+
+  When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
+  """
   withModule(
     """Module reference to install."""
     ref: String!
@@ -6006,6 +6022,8 @@ type Workspace implements Node {
   Return this workspace with a configuration value removed.
 
   Errors when the key is not currently set.
+
+  When the session selects an env, the key is scoped to that env's overlay.
   """
   withoutConfigValue(
     """Dotted key path (e.g. modules.greeter.settings.greeting)."""
@@ -6035,7 +6053,11 @@ type Workspace implements Node {
     path: String!
   ): Workspace!
 
-  """Return this workspace with a module removed from its config."""
+  """
+  Return this workspace with a module removed from its config.
+
+  When the session selects an env, only that env's overlay entry is removed.
+  """
   withoutModule(
     """Name of the installed module entry to remove."""
     name: String!

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -1342,7 +1342,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_module">
-        <div class="location">at line 241</div>
+        <div class="location">at line 243</div>
         <code>                    <a href="../Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a>
     <strong>module</strong>(string $name)
         </code>
@@ -1352,7 +1352,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return a module defined in the workspace configuration.</p></p>                        
+                            <p><p>Return a module defined in the workspace configuration.</p></p>                <p><p>Reflects the selected env's effective view.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1384,7 +1384,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleSource">
-        <div class="location">at line 255</div>
+        <div class="location">at line 257</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>moduleSource</strong>(string $path)
         </code>
@@ -1427,7 +1427,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_modules">
-        <div class="location">at line 265</div>
+        <div class="location">at line 269</div>
         <code>                    array
     <strong>modules</strong>()
         </code>
@@ -1437,7 +1437,7 @@
             
 
         <div class="method-description">
-                            <p><p>List modules defined in the workspace configuration.</p></p>                        
+                            <p><p>List modules defined in the workspace configuration.</p></p>                <p><p>Reflects the selected env's effective view.</p></p>        
         </div>
         <div class="tags">
             
@@ -1459,7 +1459,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_reloaded">
-        <div class="location">at line 274</div>
+        <div class="location">at line 278</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>reloaded</strong>()
         </code>
@@ -1491,7 +1491,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 283</div>
+        <div class="location">at line 287</div>
         <code>                    <a href="../Dagger/WorkspaceSDK.html"><abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr></a>
     <strong>sdk</strong>(string $name)
         </code>
@@ -1533,7 +1533,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdks">
-        <div class="location">at line 293</div>
+        <div class="location">at line 297</div>
         <code>                    array
     <strong>sdks</strong>()
         </code>
@@ -1565,7 +1565,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_search">
-        <div class="location">at line 306</div>
+        <div class="location">at line 310</div>
         <code>                    array
     <strong>search</strong>(string $pattern, array|null $paths = [], array|null $globs = [], bool|null $literal = false, bool|null $multiline = false, bool|null $dotall = false, bool|null $insensitive = false, bool|null $skipIgnored = false, bool|null $skipHidden = false, bool|null $filesOnly = false, int|null $limit = null)
         </code>
@@ -1658,7 +1658,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 357</div>
+        <div class="location">at line 361</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1700,7 +1700,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 369</div>
+        <div class="location">at line 373</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withChanges</strong>(<a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a> $changes)
         </code>
@@ -1742,7 +1742,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConfigEnv">
-        <div class="location">at line 379</div>
+        <div class="location">at line 383</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -1789,7 +1789,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConfigValue">
-        <div class="location">at line 392</div>
+        <div class="location">at line 398</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withConfigValue</strong>(string $key, string $value, array|null $values = null, bool|null $here = false)
         </code>
@@ -1799,7 +1799,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a configuration value written.</p></p>                        
+                            <p><p>Return this workspace with a configuration value written.</p></p>                <p><p>When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1846,7 +1846,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 411</div>
+        <div class="location">at line 417</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -1913,7 +1913,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 440</div>
+        <div class="location">at line 446</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -1990,7 +1990,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 477</div>
+        <div class="location">at line 485</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -2000,7 +2000,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a module installed in its config.</p></p>                        
+                            <p><p>Return this workspace with a module installed in its config.</p></p>                <p><p>When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2042,7 +2042,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 495</div>
+        <div class="location">at line 503</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2089,7 +2089,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 508</div>
+        <div class="location">at line 516</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
         </code>
@@ -2136,7 +2136,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 519</div>
+        <div class="location">at line 527</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2183,7 +2183,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 530</div>
+        <div class="location">at line 538</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2235,7 +2235,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 544</div>
+        <div class="location">at line 552</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2292,7 +2292,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 563</div>
+        <div class="location">at line 571</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2324,7 +2324,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 572</div>
+        <div class="location">at line 580</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2366,7 +2366,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 582</div>
+        <div class="location">at line 590</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2413,7 +2413,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 597</div>
+        <div class="location">at line 607</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2423,7 +2423,8 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a configuration value removed.</p></p>                <p><p>Errors when the key is not currently set.</p></p>        
+                            <p><p>Return this workspace with a configuration value removed.</p></p>                <p><p>Errors when the key is not currently set.</p>
+<p>When the session selects an env, the key is scoped to that env's overlay.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2460,7 +2461,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 610</div>
+        <div class="location">at line 620</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2502,7 +2503,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 620</div>
+        <div class="location">at line 630</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2544,7 +2545,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 630</div>
+        <div class="location">at line 642</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2554,7 +2555,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a module removed from its config.</p></p>                        
+                            <p><p>Return this workspace with a module removed from its config.</p></p>                <p><p>When the session selects an env, only that env's overlay entry is removed.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2591,7 +2592,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 643</div>
+        <div class="location">at line 655</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -190,12 +190,15 @@ func workspaceRefFromClientMetadata(clientMD *engine.ClientMetadata) (string, bo
 }
 
 // workspaceEnvFromClientMetadata returns the explicitly declared workspace
-// environment selection, if present.
+// environment selection, if present. An explicit empty string means "no env"
+// (clients use it to opt a session out of overlay application, e.g. env-scoped
+// settings writes that create the env); it matches selectedWorkspaceEnv's
+// treatment of empty as not-set.
 func workspaceEnvFromClientMetadata(clientMD *engine.ClientMetadata) (string, bool) {
 	if clientMD == nil {
 		return "", false
 	}
-	if clientMD.WorkspaceEnv != nil {
+	if clientMD.WorkspaceEnv != nil && *clientMD.WorkspaceEnv != "" {
 		return *clientMD.WorkspaceEnv, true
 	}
 	return "", false

--- a/hack/designs/done/missing-env-handling.md
+++ b/hack/designs/done/missing-env-handling.md
@@ -1,0 +1,277 @@
+# Handling `--env=<name>` when the environment is not defined
+
+status: accepted (2026-07-16) — Option 1 (hybrid) approved with: read errors
+enumerate defined envs; raw env-scoped writes also auto-create; raw explicit
+env.* writes print the same creation notice.
+created: 2026-07-07
+updated: 2026-08-06 — extended with env-scoped module installs
+(`dagger --env=<name> install/uninstall`, see "Env-scoped installs" below), and
+re-checked against the workspace overlay & export rewrite (#13600, merged
+2026-07-13). All failure sites, error strings, and tests cited below are
+unchanged; only the mutation API renamed: `envCreate`/`envRemove` →
+`withConfigEnv`/`withoutConfigEnv`, now staged-overlay builders applied via
+`workspace.export()`. References updated accordingly.
+
+## Problem
+
+`dagger --env=MY_ENV settings` (and every other command that selects an env)
+fails with a dead-end error when `MY_ENV` has no `env.MY_ENV.*` entry in
+`dagger.toml`:
+
+```console
+$ dagger --env=MY_ENV settings
+Error: workspace env "MY_ENV" is not defined
+```
+
+Since the CLI 1.0 surface landed (`9b518f32f`, "cli: ship the CLI 1.0 command
+surface"), the explicit `dagger env create/list/rm` commands are gone. The
+error above is now a dead end: there is no porcelain command the user can run
+to make the env exist, short of hand-editing `dagger.toml`, using the raw
+config editor with an explicit `env.*` key, or calling the `withConfigEnv`
+API directly.
+
+## Current behavior (confirmed by repro against a v1.0.0-dev engine)
+
+| Command (env `MY_ENV` not defined) | Result |
+| --- | --- |
+| `dagger --env=MY_ENV settings` (read) | `workspace env "MY_ENV" is not defined` |
+| `dagger --env=MY_ENV settings <mod> <key> <val>` (typed write) | same error, fails at session load before the write is attempted |
+| `dagger --env=MY_ENV workspace config` (raw read) | same error |
+| `dagger --env=MY_ENV workspace config modules.<m>.settings.<k> <v>` (raw env-scoped write) | same error |
+| `dagger workspace config env.MY_ENV.modules.<m>.settings.<k> <v>` (raw explicit key, no `--env`) | **succeeds and silently creates the env** |
+| `currentWorkspace{withConfigEnv(name:...)}` + `export` via `dagger api query` (was `envCreate` pre-#13600) | succeeds (idempotent), still in the API |
+
+The behavior table above was confirmed by repro on 2026-07-07 (pre-#13600);
+the strictness sites below were re-verified on the post-#13600 code.
+
+The strictness lives in three engine-side sites, all funneling into the same
+error string:
+
+- `core/workspace/config.go` `ApplyEnvOverlay` — `workspace env %q is not
+  defined`. Called from:
+  - `engine/server/session_workspaces.go` `detectAndLoadWorkspaceWithRootfs`
+    — fires at **session/workspace load** for any client that loads workspace
+    modules (this is where `dagger --env=X settings` fails, read *or* write,
+    since `settings` loads modules for schema discovery);
+  - `core/schema/workspace_config.go` `configRead` (effective env-applied
+    view);
+  - `core/schema/workspace_module.go` module-settings resolution.
+- `core/schema/workspace_config.go` `envScopedConfigKey` — rejects env-scoped
+  **writes** for undefined envs (this is where `--env=X workspace config k v`
+  fails when module loading is skipped).
+
+The behavior is deliberate and test-locked: integration tests named
+*"missing env fails clearly instead of silently falling back to base"*
+(`workspace_settings_test.go`, `workspace_env_management_test.go`,
+`workspace_selection_test.go`) date from April–May 2026, when `dagger env
+create` still existed as the creation porcelain. The June 20 CLI 1.0 commit
+removed the porcelain without revisiting what the error should now point to.
+
+## What the design docs say
+
+`future/cli-1.0.md` (per-command decision table) is explicit about the
+intended model:
+
+> **`env` (removed)** — Originally a top-level group with `create` / `list` /
+> `rm`. Removed entirely after recognizing that `env` is *strictly a path
+> prefix in workspace config* (`env.<name>.modules.<m>.settings.<k>`), not a
+> first-class concept. **CRUD happens via `dagger settings --env <name>`
+> (typed) and `dagger workspace config` (raw).** Discoverability moves into
+> the `--env` flag's description.
+
+and rewrites the flag help to *"Apply **(or write to)** a named env overlay"*
+(the current flag help on main still reads "Apply the named workspace
+environment overlay" — the rewrite hasn't landed).
+
+`workspace-location-model.md` sets the creation philosophy for workspace
+config generally:
+
+> Read-only commands should not create config directories.
+> [...] the new model has no "initialize workspace" operation. **Prefer
+> implicit config creation through config-writing commands.**
+
+That philosophy is already implemented for `dagger.toml` itself: config-value
+writes and `withConfigEnv` use `workspaceConfigInitIfMissing`, so writing a
+config value creates the config file implicitly. Envs are currently the one exception:
+writes refuse to create them — except through the raw explicit-`env.*`-key
+path, which creates them silently today.
+
+So the docs point at a clear answer: **the typed write path is supposed to be
+the creation path**, and the current "is not defined" rejection on writes
+contradicts the intended model. For reads, the docs (and the test names)
+equally clearly want loud failure rather than silent fallback to base.
+
+## Where `--env` flows
+
+```mermaid
+sequenceDiagram
+    participant CLI as dagger CLI (--env=NAME)
+    participant Load as engine session load<br/>(detectAndLoadWorkspaceWithRootfs)
+    participant Read as configRead / settings read<br/>(effective view)
+    participant Write as configWrite / settings write<br/>(envScopedConfigKey)
+
+    CLI->>Load: client metadata WorkspaceEnv=NAME
+    Note over Load: only when loading workspace modules<br/>(settings, check, generate, up, ...)
+    Load->>Load: ApplyEnvOverlay(cfg, NAME)
+    Load-->>CLI: ERROR if NAME not in cfg.Env
+    CLI->>Read: effective env-applied read
+    Read-->>CLI: ERROR if NAME not in cfg.Env
+    CLI->>Write: env-scoped write key
+    Write-->>CLI: ERROR if NAME not in cfg.Env  ⟵ contradicts cli-1.0.md
+```
+
+## Options
+
+### 1. Hybrid: auto-create on write, actionable error on read (recommended)
+
+- Typed writes (`dagger settings --env=NAME <mod> <key> <val>`) and raw
+  env-scoped writes (`dagger --env=NAME workspace config
+  modules.<m>.settings.<k> <v>`) create the env implicitly, printing a
+  one-line notice (e.g. `created env "NAME" in dagger.toml`). Everything else
+  about the write (settings-schema validation, known-module validation) stays
+  strict.
+- Reads and module-loading commands with a missing env keep failing, but the
+  error becomes actionable and names the defined envs:
+
+  ```text
+  workspace env "MY_ENV" is not defined (defined envs: ci, prod)
+  ```
+
+  (Decision 2026-08-07: no "create it by ..." hint in the error. A missing env
+  is most often a typo, and even when it isn't, we can't know which env-scoped
+  write — a setting, an install — the user intends; the enumeration is the
+  actionable part.)
+
+Pros: fulfills the cli-1.0.md contract ("CRUD happens via `dagger settings
+--env`"); consistent with implicit `dagger.toml` creation on config writes and
+with the raw explicit-key path that already creates envs; preserves the typo
+protection where it matters — reads and `check`/`generate`/`up` in CI never
+silently run base settings under a misspelled env name.
+
+Cons: a typo'd env name on a *write* creates a junk `env.<typo>` section. The
+notice plus the `dagger.toml` diff make that visible and trivially reversible
+(`dagger workspace config` raw editing, or the `withoutConfigEnv` API). An
+empty-overlay env created this way always contains the key that was written,
+so nothing dangling is left behind.
+
+Implementation note (the one real wrinkle): for `settings` the missing-env
+rejection currently fires at **session load**, before the CLI can express
+write intent. Two ways through, in order of preference:
+
+1. Keep the engine invariant "applying an undefined env fails" untouched, and
+   make the CLI porcelain create-first. As built, the two write paths reach the
+   env by different mechanisms, intentionally: (a) typed `dagger settings
+   --env=NAME <mod> <key> <val>` first connects *with the env applied*, so an
+   existing env keeps full discovery — including the modules the env itself
+   adds, whose settings would otherwise be invisible — and writes the setting
+   straight onto that session's workspace. Only when that attempt fails with
+   the "is not defined" error does the CLI retry with the session env
+   *suppressed* (an explicit empty `WorkspaceEnv` in the client metadata, which
+   the engine uniformly treats as "no env"), loading module typedefs against
+   base config and addressing the setting through raw `env.NAME.*` storage
+   chained after an explicit `WithConfigEnv`; (b) raw `dagger --env=NAME
+   workspace config modules.<m>.settings.<k> <v>` keeps engine-side env scoping,
+   with `envScopedConfigKey` relaxed to create-on-write (`workspaceConfigInitIfMissing`)
+   while unsets stay strict (`workspaceConfigMustExist`); (c) the `Created env`
+   notice is printed by the CLI, not the engine, and is detected here-aware by
+   comparing config directories: a `--here` write targets the workspace cwd, and
+   since workspace detection selects the nearest `dagger.toml` walking up from
+   the cwd, a cwd that isn't the selected config's own directory has no config of
+   its own — so `--here` always writes a fresh config there, creating the env.
+   When the `--here` target and the selected config share a directory (or
+   `--here` is off), the write lands in the selected config and the env is new
+   iff `EnvList` (read from that same config) doesn't already list it. The split
+   CLI/engine mechanism is deliberate: `settings` must be able to fall back to
+   loading module schema without the overlay, since a missing env makes overlay
+   application fail before any write intent can be expressed, whereas raw
+   `workspace config` writes never load modules and so can scope the env inside
+   the engine.
+2. Alternatively, relax session load to treat a missing env as an empty
+   overlay and enforce existence only at the read surfaces. Rejected as the
+   primary path: it weakens the CI guarantee for workspaces whose modules
+   don't consult settings (a typo'd `--env` on `check` could pass silently).
+
+### 2. Better-error-only
+
+Keep strictness everywhere; upgrade the message (list defined envs, point at
+the raw creation gesture or hand-editing).
+
+Pros: minimal change, zero new typo surface.
+Cons: leaves the cli-1.0.md promise broken — the *typed* daily verb still
+can't create an env, and the error can only recommend the raw escape hatch
+(`dagger workspace config env.NAME.modules.<m>.settings.<k> <v>`), which is
+exactly the "advanced plumbing" the redesign wanted to keep out of the daily
+loop. Also leaves the C/D asymmetry (raw explicit keys create silently, raw
+env-scoped writes refuse).
+
+Reasonable as a stopgap if Option 1's porcelain work is deferred.
+
+### 3. Auto-create always (reads too / missing env = empty overlay)
+
+Pros: maximal convenience; philosophically consistent with "env is strictly a
+path prefix" (undefined env ≡ empty overlay).
+Cons: destroys the typo protection the current tests deliberately lock in —
+`dagger check --env=prdo` in CI would silently run base settings and go green.
+Reads that *create* config additionally violate "read-only commands should not
+create config directories". Rejected.
+
+### 4. Resurrect `dagger env create`
+
+Rejected: contradicts the deliberate, documented cli-1.0 decision that env is
+not a first-class concept, and re-opens the "workspace vs env vs --env vs
+settings" confusion the redesign eliminated.
+
+## Recommendation
+
+**Option 1 (hybrid)**, implemented CLI-side (create-first via the idempotent
+`withConfigEnv` builder chained into the write) so the engine's "undefined env
+fails" invariant and all existing missing-env tests stay intact, plus the
+improved read error. Land the
+cli-1.0.md flag-help rewrite ("Apply (or write to) a named env overlay ...")
+at the same time, since the flag description is now the only discovery
+affordance for envs.
+
+## Resolved questions (decision, 2026-07-16)
+
+- The read error enumerates defined envs: yes.
+- Raw env-scoped `workspace config --env=NAME` writes also auto-create: yes.
+- Raw explicit `env.*` writes print the same "created env" notice: yes.
+
+## Env-scoped installs (2026-08-05)
+
+`dagger --env=<name> install/uninstall` extends the same model from settings to
+module installs. Settled choices:
+
+- Install under `--env` records `env.<name>.modules.<m>`, auto-creating the env
+  when missing and printing the same `Created env "<name>"` notice as a
+  settings write.
+- The overlay entry is always recorded, even when it is redundant with the base
+  config, so the env keeps the module if the base install is later removed. When
+  the base installs the same source, its pin is carried into the overlay entry:
+  an overlay source is authoritative in `ApplyEnvOverlay` and its pin travels
+  with it, so a pin-less overlay would silently unpin the module in that env.
+- Uninstall under `--env` is strict — the env must exist and the module must be
+  *installed* by it — and removes only the install aspect. If the entry also
+  carries settings and the base config still installs the module, the entry is
+  kept as a settings-only overlay so the env's overrides survive; without a base
+  module the whole entry goes, since orphan settings apply to nothing.
+- SDKs stay base-only: `sdk install`/`sdk uninstall` reject `--env`, and an env
+  install that would re-source an SDK-marked base entry is rejected too. So do
+  the scaffolding verbs — `setup`, `module init`, and `api client init` — which
+  write into the base workspace config by definition.
+
+Known deferrals:
+
+- Nested execution pins the client ID, so it cannot take the suppressed retry
+  path; a typed settings write under a missing env from inside a module still
+  fails with the read error.
+- Address-based demand loading and `workspaceModuleSourceByName` still resolve
+  from the base config, so a module that only exists in an env overlay is not
+  reachable through those paths.
+
+## Open questions
+
+- `upstream/codex/user-level-envs` (not merged) adds user-level workspace
+  envs; if that lands, "where does auto-create write" (workspace vs user
+  scope) needs an answer — presumably workspace unless `--here`-style
+  targeting says otherwise.

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -65,6 +65,9 @@ func init() {
 }
 
 func runAPIClientInitWithSDK(cmd *cobra.Command, sdkName, clientPath, moduleRef string) error {
+	if workspaceEnv != "" {
+		return fmt.Errorf("client init does not support --env; it scaffolds clients into the base workspace config")
+	}
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -416,7 +416,7 @@ func checkCloudToken(ctx context.Context, w io.Writer) error {
 func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "Change the working directory before running the command")
 	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
-	flags.StringVar(&workspaceEnv, "env", "", "Apply the named workspace environment overlay")
+	flags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
 	flags.CountVarP(&quiet, "quiet", "q", "Reduce verbosity (show progress, but clean up at the end)")
 	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")

--- a/internal/cmd/dagger/module.go
+++ b/internal/cmd/dagger/module.go
@@ -114,7 +114,10 @@ func newWorkspaceInstallCmd(hidden bool, aliases []string) *cobra.Command {
 		Long: `Install a module into the current workspace.
 
 If no workspace config is selected, this creates one at the workspace root first.
-Use --here to create the workspace config at the workspace cwd instead.`,
+Use --here to create the workspace config at the workspace cwd instead.
+
+With --env the module is recorded in that env's overlay (env.<name>.modules.*)
+and the env is created if missing.`,
 		Example: "dagger install github.com/shykes/daggerverse/hello@v0.3.0",
 		Hidden:  hidden,
 		Args:    cobra.ExactArgs(1),
@@ -129,7 +132,9 @@ func newWorkspaceUninstallCmd(hidden bool, aliases []string) *cobra.Command {
 		Use:     "uninstall [options] <module>",
 		Aliases: aliases,
 		Short:   "Uninstall a module from your workspace",
-		Long:    `Uninstall a module from the current workspace, removing it from dagger.toml.`,
+		Long: `Uninstall a module from the current workspace, removing it from dagger.toml.
+
+With --env only the env's overlay entry is removed, never the base module.`,
 		Example: "dagger uninstall hello",
 		Hidden:  hidden,
 		Args:    cobra.ExactArgs(1),

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -167,6 +167,9 @@ func init() {
 }
 
 func runModuleInitWithSDK(cmd *cobra.Command, sdkName, name string) error {
+	if workspaceEnv != "" {
+		return fmt.Errorf("module init does not support --env; it scaffolds modules into the base workspace config")
+	}
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -2,6 +2,7 @@ package daggercmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/dagger/dagger/engine/client"
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/spf13/cobra"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 const workspaceSettingsQuery = `
@@ -102,7 +104,7 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 	}
 	envWrite := len(args) >= 3 && !workspaceSettingsUnset && workspaceEnv != ""
 	err := runWorkspaceSettingsSession(cmd, args, envWrite, false)
-	if envWrite && err != nil && strings.Contains(err.Error(), fmt.Sprintf(workspacepkg.UndefinedEnvErrorPrefix, workspaceEnv)) {
+	if envWrite && isUndefinedEnvError(err, workspaceEnv) {
 		// A write is the gesture that creates a missing env. The first attempt
 		// applies the overlay so existing envs keep full discovery (including
 		// modules the env itself adds); only when the env turns out not to
@@ -111,6 +113,23 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 		return runWorkspaceSettingsSession(cmd, args, envWrite, true)
 	}
 	return err
+}
+
+// isUndefinedEnvError reports whether err is the engine rejecting the named
+// env as undefined. The engine marks the error with GraphQL extensions
+// (workspace.UndefinedEnvError), so match those structurally when present;
+// fall back to the message prefix for errors that cross boundaries without
+// extensions (version-skewed engines, session-connect failures).
+func isUndefinedEnvError(err error, env string) bool {
+	if err == nil {
+		return false
+	}
+	var gqlErr *gqlerror.Error
+	if errors.As(err, &gqlErr) && gqlErr.Extensions["_type"] == workspacepkg.UndefinedEnvErrorType {
+		name, _ := gqlErr.Extensions["env"].(string)
+		return name == env
+	}
+	return strings.Contains(err.Error(), fmt.Sprintf(workspacepkg.UndefinedEnvErrorPrefix, env))
 }
 
 func runWorkspaceSettingsSession(cmd *cobra.Command, args []string, envWrite, suppressEnv bool) error {

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -100,7 +100,26 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 	if workspaceSettingsGlobal && !workspaceSettingsUnset && len(args) < 3 {
 		return fmt.Errorf("--global stores a setting in user-level config; pass MODULE KEY VALUE to set or use --unset (reads always show the effective value)")
 	}
-	return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
+	envWrite := len(args) >= 3 && !workspaceSettingsUnset && workspaceEnv != ""
+	err := runWorkspaceSettingsSession(cmd, args, envWrite, false)
+	if envWrite && err != nil && strings.Contains(err.Error(), fmt.Sprintf(workspacepkg.UndefinedEnvErrorPrefix, workspaceEnv)) {
+		// A write is the gesture that creates a missing env. The first attempt
+		// applies the overlay so existing envs keep full discovery (including
+		// modules the env itself adds); only when the env turns out not to
+		// exist retry without it, addressing the env explicitly in the config
+		// key instead.
+		return runWorkspaceSettingsSession(cmd, args, envWrite, true)
+	}
+	return err
+}
+
+func runWorkspaceSettingsSession(cmd *cobra.Command, args []string, envWrite, suppressEnv bool) error {
+	params := client.Params{}
+	if suppressEnv {
+		noEnv := ""
+		params.WorkspaceEnv = &noEnv
+	}
+	return withEngine(cmd.Context(), params, func(ctx context.Context, engineClient *client.Client) error {
 		moduleName := ""
 		if len(args) > 0 {
 			moduleName = args[0]
@@ -144,11 +163,37 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			if workspaceSettingsGlobal {
+				// User-level writes happen client-side; --env composes there
+				// through userScopedConfigKey, and a personal env comes into
+				// being by the write itself, so none of the env staging below
+				// applies.
 				return writeUserConfigValue(ctx, userScopedConfigKey(workspaceSettingConfigKey(setting.Module, setting.Key)), value, values)
 			}
-			return state.Workspace.
-				WithConfigValue(workspaceSettingConfigKey(setting.Module, setting.Key), value, dagger.WorkspaceWithConfigValueOpts{Values: values, Here: workspaceHere}).
-				Export(ctx)
+			key := workspaceSettingConfigKey(setting.Module, setting.Key)
+			target := state.Workspace
+			creates := false
+			if envWrite {
+				key = workspaceEnvSettingConfigKey(workspaceEnv, setting.Module, setting.Key)
+				// Only the suppressed retry can be creating the env: the first
+				// phase loaded with the env applied, so reaching here means it
+				// exists. --here still needs the check, since it can target a
+				// directory with no config of its own, where any env is new.
+				if suppressEnv || workspaceHere {
+					creates, target, err = workspaceEnvWriteCreates(ctx, state.Workspace, workspaceEnv, workspaceHere)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			if err := target.
+				WithConfigValue(key, value, dagger.WorkspaceWithConfigValueOpts{Values: values, Here: workspaceHere}).
+				Export(ctx); err != nil {
+				return err
+			}
+			if creates {
+				fmt.Fprintf(cmd.OutOrStdout(), "Created env %q\n", workspaceEnv)
+			}
+			return nil
 		}
 	})
 }
@@ -249,6 +294,13 @@ func (s *workspaceSettingsState) lookupSetting(name string) (workspaceSetting, e
 
 func workspaceSettingConfigKey(moduleName, settingName string) string {
 	return workspacepkg.JoinConfigPath("modules", moduleName, "settings", settingName)
+}
+
+// workspaceEnvSettingConfigKey addresses a setting in an env overlay through
+// raw env.<name>.* storage, which withConfigValue writes without requiring the
+// env to pre-exist (the write creates it).
+func workspaceEnvSettingConfigKey(envName, moduleName, settingName string) string {
+	return workspacepkg.JoinConfigPath("env", envName, "modules", moduleName, "settings", settingName)
 }
 
 func writeWorkspaceSettingsTable(out io.Writer, settings []workspaceSetting) error {

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -174,15 +174,13 @@ func runWorkspaceSettingsSession(cmd *cobra.Command, args []string, envWrite, su
 			creates := false
 			if envWrite {
 				key = workspaceEnvSettingConfigKey(workspaceEnv, setting.Module, setting.Key)
-				// Only the suppressed retry can be creating the env: the first
-				// phase loaded with the env applied, so reaching here means it
-				// exists. --here still needs the check, since it can target a
-				// directory with no config of its own, where any env is new.
-				if suppressEnv || workspaceHere {
-					creates, target, err = workspaceEnvWriteCreates(ctx, state.Workspace, workspaceEnv, workspaceHere)
-					if err != nil {
-						return err
-					}
+				// Always check, even when the first phase loaded with the env
+				// applied: the env may exist only in the user-level overlay,
+				// in which case this write still creates the repo-side env
+				// section and should say so.
+				creates, target, err = workspaceEnvWriteCreates(ctx, state.Workspace, workspaceEnv, workspaceHere)
+				if err != nil {
+					return err
 				}
 			}
 			if err := target.

--- a/internal/cmd/dagger/settings_test.go
+++ b/internal/cmd/dagger/settings_test.go
@@ -1,9 +1,13 @@
 package daggercmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	workspacepkg "github.com/dagger/dagger/core/workspace"
 )
 
 func TestWorkspaceSettingWriteValue(t *testing.T) {
@@ -44,4 +48,23 @@ func TestWorkspaceSettingWriteValue(t *testing.T) {
 		_, _, err := workspaceSettingWriteValue(workspaceSetting{Module: "m", Key: "k"}, []string{"one", "two"})
 		require.ErrorContains(t, err, "is not a list")
 	})
+}
+
+func TestIsUndefinedEnvError(t *testing.T) {
+	structured := &gqlerror.Error{
+		Message: "something wrapped beyond recognition",
+		Extensions: map[string]any{
+			"_type": workspacepkg.UndefinedEnvErrorType,
+			"env":   "dev",
+		},
+	}
+	require.True(t, isUndefinedEnvError(fmt.Errorf("wrap: %w", structured), "dev"))
+	// The structured match is authoritative: same _type, different env.
+	require.False(t, isUndefinedEnvError(structured, "prod"))
+
+	// Fallback for engines that don't attach extensions.
+	plain := fmt.Errorf(`connect: workspace env "dev" is not defined (no envs defined)`)
+	require.True(t, isUndefinedEnvError(plain, "dev"))
+	require.False(t, isUndefinedEnvError(plain, "prod"))
+	require.False(t, isUndefinedEnvError(nil, "dev"))
 }

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -58,6 +58,10 @@ default is to skip steps that would mutate state.`,
 }
 
 func runSetup(cmd *cobra.Command, _ []string) error {
+	if workspaceEnv != "" {
+		return fmt.Errorf("setup does not support --env; it configures the base workspace")
+	}
+
 	out := cmd.OutOrStdout()
 
 	if err := setupStepLogin(cmd); err != nil {

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -379,11 +379,22 @@ func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Clie
 	if err != nil {
 		return err
 	}
-	updated, err := materializeWorkspace(ctx, dag, current.WithModule(ref, dagger.WorkspaceWithModuleOpts{Name: name, Here: here}))
+	target := current
+	createsEnv := false
+	if workspaceEnv != "" {
+		// An env-scoped install is a write, so a missing env is created by it.
+		// Chaining the write on the env-staged workspace also keeps the
+		// before/after module diff below usable when the env didn't exist yet.
+		createsEnv, target, err = workspaceEnvWriteCreates(ctx, current, workspaceEnv, here)
+		if err != nil {
+			return err
+		}
+	}
+	updated, err := materializeWorkspace(ctx, dag, target.WithModule(ref, dagger.WorkspaceWithModuleOpts{Name: name, Here: here}))
 	if err != nil {
 		return err
 	}
-	resolvedName, err := workspaceInstalledModuleName(ctx, current, updated, ref, name)
+	resolvedName, err := workspaceInstalledModuleName(ctx, target, updated, ref, name)
 	if err != nil {
 		return err
 	}
@@ -403,6 +414,10 @@ func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Clie
 		return err
 	}
 	if isEmpty {
+		if workspaceEnv != "" {
+			_, err = fmt.Fprintf(out, "Module %q is already installed in env %q\n", resolvedName, workspaceEnv)
+			return err
+		}
 		_, err = fmt.Fprintf(out, "Module %q is already installed\n", resolvedName)
 		return err
 	}
@@ -410,6 +425,15 @@ func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Clie
 		if _, err := fmt.Fprintf(out, "Created workspace config in %s\n", filepath.Dir(configPath)); err != nil {
 			return err
 		}
+	}
+	if createsEnv {
+		if _, err := fmt.Fprintf(out, "Created env %q\n", workspaceEnv); err != nil {
+			return err
+		}
+	}
+	if workspaceEnv != "" {
+		_, err = fmt.Fprintf(out, "Installed module %q into env %q in %s\n", resolvedName, workspaceEnv, configPath)
+		return err
 	}
 	_, err = fmt.Fprintf(out, "Installed module %q in %s\n", resolvedName, configPath)
 	return err
@@ -483,6 +507,10 @@ func uninstallWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Cl
 		return err
 	}
 	if err := updated.Export(ctx); err != nil {
+		return err
+	}
+	if workspaceEnv != "" {
+		_, err = fmt.Fprintf(out, "Uninstalled module %q from env %q in %s\n", name, workspaceEnv, configPath)
 		return err
 	}
 	_, err = fmt.Fprintf(out, "Uninstalled module %q from %s\n", name, configPath)

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -366,11 +365,36 @@ func workspaceEnvWriteCreates(ctx context.Context, ws *dagger.Workspace, name st
 			return true, staged, nil
 		}
 	}
-	names, err := ws.EnvList(ctx)
+	// Probe the repository config file itself: every read through the API is
+	// user-overlay-effective, and an env defined only in the user-level
+	// config must not suppress the notice for the repo-side env section this
+	// write creates. Env-scoped writes are host-local by definition, so the
+	// selected config file is readable directly.
+	configFile, err := ws.ConfigFile(ctx)
 	if err != nil {
 		return false, nil, err
 	}
-	return !slices.Contains(names, name), staged, nil
+	if configFile == "" {
+		// No repo config at all yet; the write creates it and the env.
+		return true, staged, nil
+	}
+	configPath, err := workspaceConfigHostPath(ctx, ws)
+	if err != nil {
+		return false, nil, err
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, staged, nil
+		}
+		return false, nil, err
+	}
+	cfg, err := workspacepkg.ParseConfig(data)
+	if err != nil {
+		return false, nil, err
+	}
+	_, defined := cfg.Env[name]
+	return !defined, staged, nil
 }
 
 func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Client, ref, name string, here bool) error {

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -434,6 +434,19 @@ func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Clie
 	if err != nil {
 		return err
 	}
+	// Shadowing a module that already resolved to another source (base
+	// config, or another overlay) is intentional — pointing an env at a fork
+	// — but must be visible at install time. Compare before exporting: the
+	// pre-write chain re-resolves from the host, so after export it would
+	// already see the new env entry.
+	overridesFrom := ""
+	if workspaceEnv != "" && !isEmpty {
+		if before, err := target.Module(resolvedName).Source(ctx); err == nil && before != "" {
+			if after, err := updated.Module(resolvedName).Source(ctx); err == nil && after != before {
+				overridesFrom = before
+			}
+		}
+	}
 	if err := updated.Export(ctx); err != nil {
 		return err
 	}
@@ -456,8 +469,15 @@ func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Clie
 		}
 	}
 	if workspaceEnv != "" {
-		_, err = fmt.Fprintf(out, "Installed module %q into env %q in %s\n", resolvedName, workspaceEnv, configPath)
-		return err
+		if _, err := fmt.Fprintf(out, "Installed module %q into env %q in %s\n", resolvedName, workspaceEnv, configPath); err != nil {
+			return err
+		}
+		if overridesFrom != "" {
+			if _, err := fmt.Fprintf(out, "Module %q in env %q overrides source %q\n", resolvedName, workspaceEnv, overridesFrom); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	_, err = fmt.Fprintf(out, "Installed module %q in %s\n", resolvedName, configPath)
 	return err

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -280,7 +281,7 @@ func runWorkspaceConfig(cmd *cobra.Command, args []string) error {
 		case 1:
 			return printWorkspaceConfig(ctx, cmd.OutOrStdout(), ws, args[0])
 		case 2:
-			return writeWorkspaceConfig(ctx, ws, args[0], args[1])
+			return writeWorkspaceConfig(ctx, cmd.OutOrStdout(), ws, args[0], args[1])
 		default:
 			return fmt.Errorf("expected 0-2 arguments, got %d", len(args))
 		}
@@ -302,8 +303,74 @@ func printWorkspaceConfig(ctx context.Context, out io.Writer, ws *dagger.Workspa
 	return err
 }
 
-func writeWorkspaceConfig(ctx context.Context, ws *dagger.Workspace, key, value string) error {
-	return ws.WithConfigValue(key, value, dagger.WorkspaceWithConfigValueOpts{Here: workspaceHere}).Export(ctx)
+func writeWorkspaceConfig(ctx context.Context, out io.Writer, ws *dagger.Workspace, key, value string) error {
+	envName := writtenConfigEnvName(key)
+	target := ws
+	creates := false
+	if envName != "" {
+		var err error
+		creates, target, err = workspaceEnvWriteCreates(ctx, ws, envName, workspaceHere)
+		if err != nil {
+			return err
+		}
+	}
+	if err := target.WithConfigValue(key, value, dagger.WorkspaceWithConfigValueOpts{Here: workspaceHere}).Export(ctx); err != nil {
+		return err
+	}
+	if creates {
+		fmt.Fprintf(out, "Created env %q\n", envName)
+	}
+	return nil
+}
+
+// writtenConfigEnvName returns the env a config write lands in: the env named
+// by an explicit env.<name>.* key (which always addresses raw overlay storage,
+// even under --env), or the --env selection for other keys.
+func writtenConfigEnvName(key string) string {
+	if strings.HasPrefix(key, "env.") {
+		if parts, err := workspacepkg.SplitConfigPath(key); err == nil && len(parts) >= 2 {
+			return parts[1]
+		}
+		return ""
+	}
+	if key != "env" {
+		return workspaceEnv
+	}
+	return ""
+}
+
+// workspaceEnvWriteCreates reports whether writing to env `name` will create it,
+// and returns the workspace the write should chain onto (with the env staged so
+// creation stays explicit). Detection is here-aware by comparing config
+// directories, not by trusting EnvList alone: workspace detection selects the
+// nearest dagger.toml walking up from the cwd, so a --here write whose cwd isn't
+// the selected config's own directory targets a directory that has no config of
+// its own — it always writes a fresh config there, hence a new env. When the
+// --here target and the selected config share a directory (or --here is off),
+// the write lands in the selected config, where the env is new iff EnvList (read
+// from that same config) doesn't already list it.
+func workspaceEnvWriteCreates(ctx context.Context, ws *dagger.Workspace, name string, here bool) (bool, *dagger.Workspace, error) {
+	staged := ws.WithConfigEnv(name, dagger.WorkspaceWithConfigEnvOpts{Here: here})
+	if here {
+		configFile, err := ws.ConfigFile(ctx)
+		if err != nil {
+			return false, nil, err
+		}
+		if configFile == "" {
+			// No selected config: --here writes a fresh dagger.toml at the cwd.
+			return true, staged, nil
+		}
+		// configFile is cwd-relative, so the selected config lives in the
+		// --here target (the cwd) exactly when its directory is ".".
+		if path.Dir(configFile) != "." {
+			return true, staged, nil
+		}
+	}
+	names, err := ws.EnvList(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+	return !slices.Contains(names, name), staged, nil
 }
 
 func installWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Client, ref, name string, here bool) error {

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -284,6 +284,8 @@ defmodule Dagger.Workspace do
 
   @doc """
   Return a module defined in the workspace configuration.
+
+  Reflects the selected env's effective view.
   """
   @spec module(t(), String.t()) :: Dagger.WorkspaceModule.t()
   def module(%__MODULE__{} = workspace, name) do
@@ -316,6 +318,8 @@ defmodule Dagger.Workspace do
 
   @doc """
   List modules defined in the workspace configuration.
+
+  Reflects the selected env's effective view.
   """
   @spec modules(t()) :: {:ok, [Dagger.WorkspaceModule.t()]} | {:error, term()}
   def modules(%__MODULE__{} = workspace) do
@@ -490,6 +494,8 @@ defmodule Dagger.Workspace do
 
   @doc """
   Return this workspace with a configuration value written.
+
+  When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
   """
   @spec with_config_value(t(), String.t(), String.t(), [
           {:values, [String.t()]},
@@ -571,6 +577,8 @@ defmodule Dagger.Workspace do
 
   @doc """
   Return this workspace with a module installed in its config.
+
+  When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
   """
   @spec with_module(t(), String.t(), [{:name, String.t() | nil}, {:here, boolean() | nil}]) ::
           Dagger.Workspace.t()
@@ -734,6 +742,8 @@ defmodule Dagger.Workspace do
   Return this workspace with a configuration value removed.
 
   Errors when the key is not currently set.
+
+  When the session selects an env, the key is scoped to that env's overlay.
   """
   @spec without_config_value(t(), String.t(), [{:here, boolean() | nil}]) :: Dagger.Workspace.t()
   def without_config_value(%__MODULE__{} = workspace, key, optional_args \\ []) do
@@ -779,6 +789,8 @@ defmodule Dagger.Workspace do
 
   @doc """
   Return this workspace with a module removed from its config.
+
+  When the session selects an env, only that env's overlay entry is removed.
   """
   @spec without_module(t(), String.t(), [{:here, boolean() | nil}]) :: Dagger.Workspace.t()
   def without_module(%__MODULE__{} = workspace, name, optional_args \\ []) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16164,6 +16164,8 @@ func (r *Workspace) Migrate() *WorkspaceMigration {
 }
 
 // Return a module defined in the workspace configuration.
+//
+// Reflects the selected env's effective view.
 func (r *Workspace) Module(name string) *WorkspaceModule {
 	q := r.query.Select("module")
 	q = q.Arg("name", name)
@@ -16188,6 +16190,8 @@ func (r *Workspace) ModuleSource(path string) *ModuleSource {
 }
 
 // List modules defined in the workspace configuration.
+//
+// Reflects the selected env's effective view.
 func (r *Workspace) Modules(ctx context.Context) ([]WorkspaceModule, error) {
 	q := r.query.Select("modules")
 
@@ -16439,6 +16443,8 @@ type WorkspaceWithConfigValueOpts struct {
 }
 
 // Return this workspace with a configuration value written.
+//
+// When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
 func (r *Workspace) WithConfigValue(key string, value string, opts ...WorkspaceWithConfigValueOpts) *Workspace {
 	q := r.query.Select("withConfigValue")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -16561,6 +16567,8 @@ type WorkspaceWithModuleOpts struct {
 }
 
 // Return this workspace with a module installed in its config.
+//
+// When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
 func (r *Workspace) WithModule(ref string, opts ...WorkspaceWithModuleOpts) *Workspace {
 	q := r.query.Select("withModule")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -16729,6 +16737,8 @@ type WorkspaceWithoutConfigValueOpts struct {
 // Return this workspace with a configuration value removed.
 //
 // Errors when the key is not currently set.
+//
+// When the session selects an env, the key is scoped to that env's overlay.
 func (r *Workspace) WithoutConfigValue(key string, opts ...WorkspaceWithoutConfigValueOpts) *Workspace {
 	q := r.query.Select("withoutConfigValue")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -16771,6 +16781,8 @@ type WorkspaceWithoutModuleOpts struct {
 }
 
 // Return this workspace with a module removed from its config.
+//
+// When the session selects an env, only that env's overlay entry is removed.
 func (r *Workspace) WithoutModule(name string, opts ...WorkspaceWithoutModuleOpts) *Workspace {
 	q := r.query.Select("withoutModule")
 	for i := len(opts) - 1; i >= 0; i-- {

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -237,6 +237,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
 
     /**
      * Return a module defined in the workspace configuration.
+     *
+     * Reflects the selected env's effective view.
      */
     public function module(string $name): WorkspaceModule
     {
@@ -261,6 +263,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
 
     /**
      * List modules defined in the workspace configuration.
+     *
+     * Reflects the selected env's effective view.
      */
     public function modules(): array
     {
@@ -388,6 +392,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
 
     /**
      * Return this workspace with a configuration value written.
+     *
+     * When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
      */
     public function withConfigValue(string $key, string $value, ?array $values = null, ?bool $here = false): Workspace
     {
@@ -473,6 +479,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
 
     /**
      * Return this workspace with a module installed in its config.
+     *
+     * When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
      */
     public function withModule(string $ref, ?string $name = '', ?bool $here = false): Workspace
     {
@@ -593,6 +601,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
      * Return this workspace with a configuration value removed.
      *
      * Errors when the key is not currently set.
+     *
+     * When the session selects an env, the key is scoped to that env's overlay.
      */
     public function withoutConfigValue(string $key, ?bool $here = false): Workspace
     {
@@ -626,6 +636,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
 
     /**
      * Return this workspace with a module removed from its config.
+     *
+     * When the session selects an env, only that env's overlay entry is removed.
      */
     public function withoutModule(string $name, ?bool $here = false): Workspace
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15337,6 +15337,8 @@ class Workspace(Type):
     def module(self, name: str) -> "WorkspaceModule":
         """Return a module defined in the workspace configuration.
 
+        Reflects the selected env's effective view.
+
         Parameters
         ----------
         name:
@@ -15369,7 +15371,10 @@ class Workspace(Type):
         return ModuleSource(_ctx)
 
     async def modules(self) -> list["WorkspaceModule"]:
-        """List modules defined in the workspace configuration."""
+        """List modules defined in the workspace configuration.
+
+        Reflects the selected env's effective view.
+        """
         _args: list[Arg] = []
         _ctx = self._select("modules", _args)
         return await _ctx.execute_object_list(WorkspaceModule)
@@ -15533,6 +15538,9 @@ class Workspace(Type):
     ) -> Self:
         """Return this workspace with a configuration value written.
 
+        When the session selects an env, the key is scoped to that env's
+        overlay and the env is created if missing.
+
         Parameters
         ----------
         key:
@@ -15654,6 +15662,9 @@ class Workspace(Type):
         here: bool | None = False,
     ) -> Self:
         """Return this workspace with a module installed in its config.
+
+        When the session selects an env, the module is recorded in that env's
+        overlay and the env is created if missing.
 
         Parameters
         ----------
@@ -15851,6 +15862,9 @@ class Workspace(Type):
 
         Errors when the key is not currently set.
 
+        When the session selects an env, the key is scoped to that env's
+        overlay.
+
         Parameters
         ----------
         key:
@@ -15904,6 +15918,9 @@ class Workspace(Type):
         here: bool | None = False,
     ) -> Self:
         """Return this workspace with a module removed from its config.
+
+        When the session selects an env, only that env's overlay entry is
+        removed.
 
         Parameters
         ----------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -15346,6 +15346,7 @@ impl Workspace {
         }
     }
     /// Return a module defined in the workspace configuration.
+    /// Reflects the selected env's effective view.
     ///
     /// # Arguments
     ///
@@ -15376,6 +15377,7 @@ impl Workspace {
         }
     }
     /// List modules defined in the workspace configuration.
+    /// Reflects the selected env's effective view.
     pub async fn modules(&self) -> Result<Vec<WorkspaceModule>, DaggerError> {
         let query = self.selection.select("modules");
         let query = query.select("id");
@@ -15606,6 +15608,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a configuration value written.
+    /// When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
     ///
     /// # Arguments
     ///
@@ -15623,6 +15626,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a configuration value written.
+    /// When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
     ///
     /// # Arguments
     ///
@@ -15770,6 +15774,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a module installed in its config.
+    /// When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
     ///
     /// # Arguments
     ///
@@ -15785,6 +15790,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a module installed in its config.
+    /// When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
     ///
     /// # Arguments
     ///
@@ -16032,6 +16038,7 @@ impl Workspace {
     }
     /// Return this workspace with a configuration value removed.
     /// Errors when the key is not currently set.
+    /// When the session selects an env, the key is scoped to that env's overlay.
     ///
     /// # Arguments
     ///
@@ -16048,6 +16055,7 @@ impl Workspace {
     }
     /// Return this workspace with a configuration value removed.
     /// Errors when the key is not currently set.
+    /// When the session selects an env, the key is scoped to that env's overlay.
     ///
     /// # Arguments
     ///
@@ -16098,6 +16106,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a module removed from its config.
+    /// When the session selects an env, only that env's overlay entry is removed.
     ///
     /// # Arguments
     ///
@@ -16113,6 +16122,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a module removed from its config.
+    /// When the session selects an env, only that env's overlay entry is removed.
     ///
     /// # Arguments
     ///

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -15057,6 +15057,8 @@ export class Workspace extends BaseClient {
 
   /**
    * Return a module defined in the workspace configuration.
+   *
+   * Reflects the selected env's effective view.
    * @param name Module name to inspect.
    */
   module_ = (name: string): WorkspaceModule => {
@@ -15079,6 +15081,8 @@ export class Workspace extends BaseClient {
 
   /**
    * List modules defined in the workspace configuration.
+   *
+   * Reflects the selected env's effective view.
    */
   modules = async (): Promise<WorkspaceModule[]> => {
     type modules = {
@@ -15194,6 +15198,8 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a configuration value written.
+   *
+   * When the session selects an env, the key is scoped to that env's overlay and the env is created if missing.
    * @param key Dotted key path.
    * @param value Value to set. Bools, integers, and comma-separated arrays are auto-detected.
    * @param opts.values List value to set. Elements are stored verbatim, with no auto-detection. Mutually exclusive with value.
@@ -15258,6 +15264,8 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a module installed in its config.
+   *
+   * When the session selects an env, the module is recorded in that env's overlay and the env is created if missing.
    * @param ref Module reference to install.
    * @param opts.name Override name for the installed module entry.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
@@ -15362,6 +15370,8 @@ export class Workspace extends BaseClient {
    * Return this workspace with a configuration value removed.
    *
    * Errors when the key is not currently set.
+   *
+   * When the session selects an env, the key is scoped to that env's overlay.
    * @param key Dotted key path (e.g. modules.greeter.settings.greeting).
    * @param opts.here Write to the workspace config directory at the workspace cwd.
    */
@@ -15393,6 +15403,8 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a module removed from its config.
+   *
+   * When the session selects an env, only that env's overlay entry is removed.
    * @param name Name of the installed module entry to remove.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
    */


### PR DESCRIPTION
`dagger --env=<name>` against an undefined env has been a dead end since CLI 1.0 removed `dagger env create` — you couldn't create the env, and every command just errored on it.

This makes **writes auto-create the env they target**, and teaches the read/load error to guide you out of the dead end:

- **Writes create the missing env** (printing `Created env "NAME"` once): typed `dagger settings --env=NAME MOD KEY VAL`, raw env-scoped `--env=NAME workspace config modules.m.settings.k v`, and raw explicit `env.NAME.*` keys.
- **Reads and module-loading still fail** on a missing env — but the error now enumerates the defined envs and shows the creation gesture.
- `--unset` still requires the env to already exist.
- `--env` flag help updated; CLI reference docs regenerated.

Rationale and the recorded design decisions: `hack/designs/done/missing-env-handling.md`.

Verified: unit tests green; `core/integration` env/settings/selection suites green via engine-dev (68 passed); reviewed by a two-lens review with fixes applied.



**Env-scoped module install/uninstall.** `dagger --env=dev install MODULE` records the module under `env.dev.modules.*` (creating the env if missing, with the same `Created env` notice); `uninstall` under `--env` removes only that overlay entry (strict); SDK install/uninstall reject `--env` selections; and module listing/settings use the env-effective view, so env-scoped installs are discoverable.
