### PR TITLE
ci: pin inception-health/otel-export-trace-action@latest to a full commit SHA

### DIFF
--- a/.github/workflows/trace-workflows.yml
+++ b/.github/workflows/trace-workflows.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ github.repository == 'dagger/dagger' }}
     steps:
       - name: Export Workflow Trace
-        uses: inception-health/otel-export-trace-action@latest
+        uses: inception-health/otel-export-trace-action@7eabc7de1f4753f0b45051b44bb0ba46d05a21ef # v1.8.0
         with:
           otlpEndpoint: grpc://api.honeycomb.io:443/
           otlpHeaders: ${{ secrets.HONEYCOMB_GITHUB_ACTIONS_WORKFLOWS }}


### PR DESCRIPTION
Hi, and thank you for Dagger.

Small supply-chain hardening for `.github/workflows/trace-workflows.yml`. The "Export trace" step uses the third-party action `inception-health/otel-export-trace-action@latest`. `@latest` is a mutable tag, and that step receives `secrets.HONEYCOMB_GITHUB_ACTIONS_WORKFLOWS` (a Honeycomb API key) and the `GITHUB_TOKEN`. The action's upstream repo hasn't been pushed to since 2024, so a repoint of `@latest` (or a maintainer-account compromise) would run unreviewed code with those secrets on the next traced `workflow_run` — the `tj-actions/changed-files` class of risk.

This PR pins it to a full commit SHA. I used `v1.8.0`, which is exactly what `@latest` currently resolves to, so behaviour is unchanged — it just removes the mutable reference. Happy to adjust.

For transparency: I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself.
