### PR TITLE
feat(core): add client-codegen schema primitives (v1.0.0-0)

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -11,6 +11,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -635,4 +636,111 @@ func (GeneratorsSuite) TestGeneratorResultFieldsRequireRun(ctx context.Context, 
 		require.NoError(t, err)
 		require.JSONEq(t, `{"currentWorkspace":{"generators":{"list":[{"run":{"isEmpty":false,"changes":{"isEmpty":false}}}]}}}`, out)
 	})
+}
+
+// TestClientSchemaIntrospectionJSON locks in that
+// moduleSource.clientSchemaIntrospectionJSON returns the *client-facing* schema
+// -- the one client codegen consumes. Unlike the module-facing
+// introspectionSchemaJSON, it hides no core types (Host and the Engine* family
+// stay visible) and installs the bound module namespaced on Query
+// (Query.minimal), so a client reaches its functions via dag.minimal -- never a
+// promoted root field (no Query.hello). The two schemas are deliberately
+// different; feeding the module-facing one to client codegen would produce an
+// incomplete client.
+func (GeneratorsSuite) TestClientSchemaIntrospectionJSON(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen := moduleFixture(t, c, "go/minimal")
+
+	clientTypes, clientQueryFields := introspectModuleSourceSchema(ctx, t, modGen, "clientSchemaIntrospectionJSON")
+	moduleTypes, moduleQueryFields := introspectModuleSourceSchema(ctx, t, modGen, "introspectionSchemaJSON")
+
+	// No hidden types in the client-facing schema: Host and Engine* (both hidden
+	// from the module-facing schema) are present.
+	require.Contains(t, clientTypes, "Host")
+	require.Contains(t, clientTypes, "EngineCache")
+	require.NotContains(t, moduleTypes, "Host")
+	require.NotContains(t, moduleTypes, "EngineCache")
+
+	// The bound module is namespaced on Query (dag.minimal), never promoted to
+	// the root: `minimal` is a Query field but its function `hello` is not.
+	require.Contains(t, clientQueryFields, "minimal")
+	require.NotContains(t, clientQueryFields, "hello")
+	// The module-facing schema installs neither the module nor its functions.
+	require.NotContains(t, moduleQueryFields, "minimal")
+	require.NotContains(t, moduleQueryFields, "hello")
+}
+
+// introspectModuleSourceSchema selects the named introspection-schema field on
+// the module source at ".", returning the schema's type names and its Query
+// root field names.
+func introspectModuleSourceSchema(ctx context.Context, t *testctx.T, ctr *dagger.Container, field string) (typeNames, queryFields []string) {
+	t.Helper()
+	out, err := ctr.
+		With(daggerQuery(`{moduleSource(refString:"."){%s{contents}}}`, field)).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	var resp struct {
+		ModuleSource map[string]struct {
+			Contents string `json:"contents"`
+		} `json:"moduleSource"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	contents := resp.ModuleSource[field].Contents
+	require.NotEmpty(t, contents)
+
+	schema := parseSchemaContents(t, contents)
+	for _, typ := range schema.Schema.Types {
+		if typ.Name == "Query" {
+			for _, f := range typ.Fields {
+				queryFields = append(queryFields, f.Name)
+			}
+		}
+	}
+	return schema.typeNames(), queryFields
+}
+
+// TestCurrentModuleAsSDKClientModuleSourceField is a lighter engine-level check
+// that CurrentModuleAsSDKClient exposes the moduleSource field (which resolves
+// the bound module from its stored {module, pin}). Exercising it end-to-end
+// requires an installed-SDK module execution context; here we assert the field
+// is registered on the v1.0 schema view with the right type.
+func (GeneratorsSuite) TestCurrentModuleAsSDKClientModuleSourceField(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	out, err := goGitBase(t, c).
+		With(daggerQuery(`{__type(name:"CurrentModuleAsSDKClient"){fields{name type{kind ofType{kind name}}}}}`)).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	var resp struct {
+		Type *struct {
+			Fields []struct {
+				Name string `json:"name"`
+				Type struct {
+					Kind   string `json:"kind"`
+					OfType *struct {
+						Kind string `json:"kind"`
+						Name string `json:"name"`
+					} `json:"ofType"`
+				} `json:"type"`
+			} `json:"fields"`
+		} `json:"__type"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	require.NotNil(t, resp.Type, "CurrentModuleAsSDKClient should be present in the v1.0 schema view")
+
+	var found bool
+	for _, f := range resp.Type.Fields {
+		if f.Name != "moduleSource" {
+			continue
+		}
+		found = true
+		require.Equal(t, "NON_NULL", f.Type.Kind, "moduleSource must be non-null")
+		require.NotNil(t, f.Type.OfType)
+		require.Equal(t, "OBJECT", f.Type.OfType.Kind)
+		require.Equal(t, "ModuleSource", f.Type.OfType.Name)
+	}
+	require.True(t, found, "CurrentModuleAsSDKClient should expose a moduleSource field")
 }

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -413,7 +413,11 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 			Doc(`The generated clients this SDK produces in the workspace.`),
 	}.Install(dag)
 	dagql.Fields[*core.CurrentModuleAsSDKModule]{}.Install(dag)
-	dagql.Fields[*core.CurrentModuleAsSDKClient]{}.Install(dag)
+	dagql.Fields[*core.CurrentModuleAsSDKClient]{
+		dagql.Func("moduleSource", s.currentModuleAsSDKClientModuleSource).
+			View(AfterVersion("v1.0.0-0")).
+			Doc(`The resolved module source this client is bound to, including its dependency closure and pinned version.`),
+	}.Install(dag)
 
 	dagql.Fields[*core.Function]{
 		dagql.Func("withDescription", s.functionWithDescription).

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
 )
 
 // currentModuleAsSDK treats the currently executing module as an SDK installed
@@ -92,4 +93,47 @@ func (s *moduleSchema) currentModuleAsSDKClients(
 	_ struct{},
 ) ([]*core.CurrentModuleAsSDKClient, error) {
 	return parent.Clients, nil
+}
+
+// currentModuleAsSDKClientModuleSource resolves the module a client is bound to
+// from its stored {module, pin}. Resolution goes through the same
+// resolveClientTargetModule the workspace client-generation path uses, so local
+// (workspace-relative) refs are expanded to host paths, the pin is applied, and
+// the load happens in the workspace client context -- correct for both local
+// and remote/git refs, unlike resolving the ref string directly.
+func (s *moduleSchema) currentModuleAsSDKClientModuleSource(
+	ctx context.Context,
+	client *core.CurrentModuleAsSDKClient,
+	_ struct{},
+) (dagql.ObjectResult[*core.ModuleSource], error) {
+	var res dagql.ObjectResult[*core.ModuleSource]
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return res, err
+	}
+	ws, err := query.Server.CurrentWorkspace(ctx)
+	if err != nil {
+		return res, fmt.Errorf("get current workspace: %w", err)
+	}
+	if isSyntheticWorkspace(ws) || ws.ConfigFile == "" {
+		return res, fmt.Errorf("current module is not installed as an SDK in this workspace")
+	}
+
+	_, moduleLoadRef, err := resolveWorkspaceClientModuleRef(ws, client.Module)
+	if err != nil {
+		return res, err
+	}
+
+	wsSchema := &workspaceSchema{}
+	workspaceCtx := ctx
+	if ws.ClientID != "" {
+		workspaceCtx, err = wsSchema.withWorkspaceClientContext(ctx, ws)
+		if err != nil {
+			return res, fmt.Errorf("workspace client context: %w", err)
+		}
+	}
+	workspaceCtx = workspaceInstallLookupContext(workspaceCtx)
+
+	return wsSchema.resolveClientTargetModule(workspaceCtx, ws, moduleLoadRef, client.Pin)
 }

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -238,6 +238,10 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 			Doc(`The introspection schema JSON file for this module source.`,
 				`This file represents the schema visible to the module's source code, including all core types and those from the dependencies.`,
 				`Note: this is in the context of a module, so some core types may be hidden.`),
+		dagql.NodeFunc("clientSchemaIntrospectionJSON", s.moduleSourceClientSchemaIntrospectionJSON).
+			View(AfterVersion("v1.0.0-0")).
+			Doc(`The client-facing introspection schema JSON file for this module source.`,
+				`This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.`),
 
 		dagql.NodeFunc("directory", s.moduleSourceDirectory).
 			Doc(`The directory containing the module configuration and source code (source code may be in a subdir).`).
@@ -2661,34 +2665,7 @@ func (s *moduleSourceSchema) runClientGenerator(
 		return genDirInst, fmt.Errorf("failed to add module source required files: %w", err)
 	}
 
-	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
-	if err != nil {
-		return genDirInst, fmt.Errorf("failed to load dependencies of this modules: %w", err)
-	}
-
-	// Build the client-facing schema. Dependencies get normal installation;
-	// the self module (when present) is installed as an entrypoint so its
-	// methods are promoted to Query.
-	codegenDeps := deps
-
-	// If the current module source has sources and its SDK implements the `Runtime` interface,
-	// we can transform it into a module to generate self bindings.
-	if srcInst.Self().SDK != nil {
-		// We must make sure to first check SDK to avoid checking a nil pointer on `SDKImpl`.
-		if _, ok := srcInst.Self().SDKImpl.AsRuntime(); ok {
-			var mod dagql.ObjectResult[*core.Module]
-			err = dag.Select(ctx, srcInst, &mod, dagql.Selector{
-				Field: "asModule",
-			})
-			if err != nil {
-				return genDirInst, fmt.Errorf("failed to transform module source into module: %w", err)
-			}
-
-			codegenDeps = codegenDeps.With(core.NewUserMod(mod), core.InstallOpts{Entrypoint: true})
-		}
-	}
-
-	schemaJSONFile, err := codegenDeps.SchemaIntrospectionJSONFileForClient(ctx)
+	schemaJSONFile, err := s.clientSchemaIntrospectionJSONFile(ctx, dag, srcInst)
 	if err != nil {
 		return genDirInst, fmt.Errorf("failed to get schema for client generation: %w", err)
 	}
@@ -3121,6 +3098,63 @@ func (s *moduleSourceSchema) moduleSourceIntrospectionSchemaJSON(
 	return file, nil
 }
 
+func (s *moduleSourceSchema) moduleSourceClientSchemaIntrospectionJSON(
+	ctx context.Context,
+	src dagql.ObjectResult[*core.ModuleSource],
+	args struct{},
+) (inst dagql.Result[*core.File], rerr error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	dag, err := query.Server.Server(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get dag server: %w", err)
+	}
+	return s.clientSchemaIntrospectionJSONFile(ctx, dag, src)
+}
+
+// clientSchemaIntrospectionJSONFile builds the client-facing introspection
+// schema for srcInst: only the bound module is installed, as a normal
+// namespaced module, so a generated client reaches its functions via
+// `dag.<moduleName>` and never through a promoted Query root. The module's own
+// dependencies are deliberately excluded -- a client is generated for a single
+// module plus core, not for its whole dependency graph. Unlike the
+// module-facing schema, it hides no core types. This is the schema client
+// codegen consumes.
+func (s *moduleSourceSchema) clientSchemaIntrospectionJSONFile(
+	ctx context.Context,
+	dag *dagql.Server,
+	srcInst dagql.ObjectResult[*core.ModuleSource],
+) (dagql.Result[*core.File], error) {
+	var inst dagql.Result[*core.File]
+
+	// Start from only the default (core) deps: the module's own dependencies
+	// must not leak into the client schema.
+	codegenDeps, err := s.loadDefaultSchemaBuilder(ctx, srcInst)
+	if err != nil {
+		return inst, fmt.Errorf("failed to load default dependencies: %w", err)
+	}
+
+	// Install the bound module like any dependency: namespaced under its own
+	// name, NOT as an entrypoint. Clients must never promote a module's
+	// functions to the Query root -- they are always reached via dag.<name>.
+	// Transforming the source into a module requires a runtime SDK.
+	if srcInst.Self().SDK != nil {
+		// We must make sure to first check SDK to avoid checking a nil pointer on `SDKImpl`.
+		if _, ok := srcInst.Self().SDKImpl.AsRuntime(); ok {
+			var mod dagql.ObjectResult[*core.Module]
+			if err := dag.Select(ctx, srcInst, &mod, dagql.Selector{Field: "asModule"}); err != nil {
+				return inst, fmt.Errorf("failed to transform module source into module: %w", err)
+			}
+
+			codegenDeps = codegenDeps.With(core.NewUserMod(mod), core.InstallOpts{})
+		}
+	}
+
+	return codegenDeps.SchemaIntrospectionJSONFileForClient(ctx)
+}
+
 // createStubModule creates an empty module definition (no SDK, no blueprints)
 func createStubModule(ctx context.Context, mod *core.Module, dag *dagql.Server) (*core.Module, error) {
 	typeDef, err := core.SelectTypeDefWithServer(ctx, dag, dagql.Selector{
@@ -3489,6 +3523,28 @@ func (s *moduleSourceSchema) loadDependencyModules(
 		return nil, fmt.Errorf("failed to load module dependencies: %w", err)
 	}
 
+	deps, err := s.loadDefaultSchemaBuilder(ctx, src)
+	if err != nil {
+		return nil, err
+	}
+	for _, depMod := range depMods {
+		deps = deps.Append(core.NewUserMod(depMod))
+	}
+
+	return deps, nil
+}
+
+// loadDefaultSchemaBuilder returns a SchemaBuilder seeded with only the default
+// (core) dependencies, with the core module pinned to src's engine version
+// view. Callers append the user modules they want to expose.
+func (s *moduleSourceSchema) loadDefaultSchemaBuilder(
+	ctx context.Context,
+	src dagql.ObjectResult[*core.ModuleSource],
+) (*core.SchemaBuilder, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
 	defaultDeps, err := query.DefaultDeps(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default dependencies: %w", err)
@@ -3499,12 +3555,7 @@ func (s *moduleSourceSchema) loadDependencyModules(
 			baseMods[i] = coreMod.WithView(call.View(engine.BaseVersion(engine.NormalizeVersion(src.Self().EngineVersion))))
 		}
 	}
-	deps := core.NewSchemaBuilder(query, baseMods)
-	for _, depMod := range depMods {
-		deps = deps.Append(core.NewUserMod(depMod))
-	}
-
-	return deps, nil
+	return core.NewSchemaBuilder(query, baseMods), nil
 }
 
 func (s *moduleSourceSchema) moduleSourceWithClient(

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1857,6 +1857,11 @@ type CurrentModuleAsSDKClient implements Node {
   """
   module: String!
 
+  """
+  The resolved module source this client is bound to, including its dependency closure and pinned version.
+  """
+  moduleSource: ModuleSource!
+
   """Workspace-root-relative path of the generated client."""
   path: String!
 
@@ -4824,6 +4829,17 @@ type ModuleSource implements Node & Syncer {
 
   """The blueprint referenced by the module source."""
   blueprint: ModuleSource! @deprecated(reason: "Legacy dagger.json field. Generic module loading no longer honors it; use workspace modules in dagger.toml instead.")
+
+  """
+  The client-facing introspection schema JSON file for this module source.
+
+  This is the schema consumed by client codegen: unlike introspectionSchemaJSON
+  (the module-facing schema), it hides no core types and installs this module
+  (reached via dag.<moduleName>) so a generated client can bind it. The module's
+  dependencies are excluded: a client is generated for a single module plus
+  core, not its dependency graph.
+  """
+  clientSchemaIntrospectionJSON: File!
 
   """
   The ref to clone the root of the git repo from. Only valid for git sources.

--- a/docs/static/reference/php/Dagger/CurrentModuleAsSDKClient.html
+++ b/docs/static/reference/php/Dagger/CurrentModuleAsSDKClient.html
@@ -163,6 +163,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_moduleSource">moduleSource</a>()
+        
+                                            <p><p>The resolved module source this client is bound to, including its dependency closure and pinned version.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     string
                 </div>
                 <div class="col-md-8">
@@ -341,8 +351,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_path">
+                    <h3 id="method_moduleSource">
         <div class="location">at line 37</div>
+        <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+    <strong>moduleSource</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The resolved module source this client is bound to, including its dependency closure and pinned version.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_path">
+        <div class="location">at line 46</div>
         <code>                    string
     <strong>path</strong>()
         </code>
@@ -374,7 +416,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_pin">
-        <div class="location">at line 46</div>
+        <div class="location">at line 55</div>
         <code>                    string
     <strong>pin</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/ModuleSource.html
+++ b/docs/static/reference/php/Dagger/ModuleSource.html
@@ -173,6 +173,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_clientSchemaIntrospectionJSON">clientSchemaIntrospectionJSON</a>()
+        
+                                            <p><p>The client-facing introspection schema JSON file for this module source.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     string
                 </div>
                 <div class="col-md-8">
@@ -853,8 +863,40 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_clientSchemaIntrospectionJSON">
+        <div class="location">at line 48</div>
+        <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
+    <strong>clientSchemaIntrospectionJSON</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The client-facing introspection schema JSON file for this module source.</p></p>                <p><p>This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.</p></p>        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_cloneRef">
-        <div class="location">at line 46</div>
+        <div class="location">at line 57</div>
         <code>                    string
     <strong>cloneRef</strong>()
         </code>
@@ -886,7 +928,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_commit">
-        <div class="location">at line 55</div>
+        <div class="location">at line 66</div>
         <code>                    string
     <strong>commit</strong>()
         </code>
@@ -918,7 +960,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_configClients">
-        <div class="location">at line 64</div>
+        <div class="location">at line 75</div>
         <code>                    array
     <strong>configClients</strong>()
         </code>
@@ -950,7 +992,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_configExists">
-        <div class="location">at line 73</div>
+        <div class="location">at line 84</div>
         <code>                    bool
     <strong>configExists</strong>()
         </code>
@@ -982,7 +1024,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_contextDirectory">
-        <div class="location">at line 82</div>
+        <div class="location">at line 93</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>contextDirectory</strong>()
         </code>
@@ -1014,7 +1056,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_dependencies">
-        <div class="location">at line 91</div>
+        <div class="location">at line 102</div>
         <code>                    array
     <strong>dependencies</strong>()
         </code>
@@ -1046,7 +1088,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_digest">
-        <div class="location">at line 100</div>
+        <div class="location">at line 111</div>
         <code>                    string
     <strong>digest</strong>()
         </code>
@@ -1078,7 +1120,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 109</div>
+        <div class="location">at line 120</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>(string $path)
         </code>
@@ -1120,7 +1162,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_engineVersion">
-        <div class="location">at line 119</div>
+        <div class="location">at line 130</div>
         <code>                    string
     <strong>engineVersion</strong>()
         </code>
@@ -1152,7 +1194,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedContextChangeset">
-        <div class="location">at line 128</div>
+        <div class="location">at line 139</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>generatedContextChangeset</strong>()
         </code>
@@ -1184,7 +1226,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedContextDirectory">
-        <div class="location">at line 137</div>
+        <div class="location">at line 148</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>generatedContextDirectory</strong>()
         </code>
@@ -1216,7 +1258,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_htmlRepoURL">
-        <div class="location">at line 146</div>
+        <div class="location">at line 157</div>
         <code>                    string
     <strong>htmlRepoURL</strong>()
         </code>
@@ -1248,7 +1290,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_htmlURL">
-        <div class="location">at line 155</div>
+        <div class="location">at line 166</div>
         <code>                    string
     <strong>htmlURL</strong>()
         </code>
@@ -1280,7 +1322,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 164</div>
+        <div class="location">at line 175</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1312,7 +1354,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_introspectionSchemaJSON">
-        <div class="location">at line 177</div>
+        <div class="location">at line 188</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>introspectionSchemaJSON</strong>()
         </code>
@@ -1345,7 +1387,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_kind">
-        <div class="location">at line 186</div>
+        <div class="location">at line 197</div>
         <code>                    <abbr title="Dagger\ModuleSourceKind">ModuleSourceKind</abbr>
     <strong>kind</strong>()
         </code>
@@ -1377,7 +1419,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_localContextDirectoryPath">
-        <div class="location">at line 195</div>
+        <div class="location">at line 206</div>
         <code>                    string
     <strong>localContextDirectoryPath</strong>()
         </code>
@@ -1409,7 +1451,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleName">
-        <div class="location">at line 204</div>
+        <div class="location">at line 215</div>
         <code>                    string
     <strong>moduleName</strong>()
         </code>
@@ -1441,7 +1483,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleOriginalName">
-        <div class="location">at line 213</div>
+        <div class="location">at line 224</div>
         <code>                    string
     <strong>moduleOriginalName</strong>()
         </code>
@@ -1473,7 +1515,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_originalSubpath">
-        <div class="location">at line 222</div>
+        <div class="location">at line 233</div>
         <code>                    string
     <strong>originalSubpath</strong>()
         </code>
@@ -1505,7 +1547,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_pin">
-        <div class="location">at line 231</div>
+        <div class="location">at line 242</div>
         <code>                    string
     <strong>pin</strong>()
         </code>
@@ -1537,7 +1579,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_repoRootPath">
-        <div class="location">at line 240</div>
+        <div class="location">at line 251</div>
         <code>                    string
     <strong>repoRootPath</strong>()
         </code>
@@ -1569,7 +1611,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 249</div>
+        <div class="location">at line 260</div>
         <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
     <strong>sdk</strong>()
         </code>
@@ -1601,7 +1643,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceRootSubpath">
-        <div class="location">at line 258</div>
+        <div class="location">at line 269</div>
         <code>                    string
     <strong>sourceRootSubpath</strong>()
         </code>
@@ -1633,7 +1675,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceSubpath">
-        <div class="location">at line 267</div>
+        <div class="location">at line 278</div>
         <code>                    string
     <strong>sourceSubpath</strong>()
         </code>
@@ -1665,7 +1707,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 276</div>
+        <div class="location">at line 287</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1697,7 +1739,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_toolchains">
-        <div class="location">at line 286</div>
+        <div class="location">at line 297</div>
         <code>                    array
     <strong>toolchains</strong>()
         </code>
@@ -1729,7 +1771,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_updatedConfigDirectory">
-        <div class="location">at line 297</div>
+        <div class="location">at line 308</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>updatedConfigDirectory</strong>()
         </code>
@@ -1761,7 +1803,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_userDefaults">
-        <div class="location">at line 306</div>
+        <div class="location">at line 317</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>userDefaults</strong>()
         </code>
@@ -1793,7 +1835,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 315</div>
+        <div class="location">at line 326</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -1825,7 +1867,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withBlueprint">
-        <div class="location">at line 324</div>
+        <div class="location">at line 335</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withBlueprint</strong>(<a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a> $blueprint)
         </code>
@@ -1867,7 +1909,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withClient">
-        <div class="location">at line 334</div>
+        <div class="location">at line 345</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withClient</strong>(string $generator, string $outputDir)
         </code>
@@ -1914,7 +1956,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDependencies">
-        <div class="location">at line 345</div>
+        <div class="location">at line 356</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withDependencies</strong>(array $dependencies)
         </code>
@@ -1956,7 +1998,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEngineVersion">
-        <div class="location">at line 355</div>
+        <div class="location">at line 366</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withEngineVersion</strong>(string $version)
         </code>
@@ -1998,7 +2040,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExperimentalFeatures">
-        <div class="location">at line 365</div>
+        <div class="location">at line 376</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withExperimentalFeatures</strong>(array $features)
         </code>
@@ -2040,7 +2082,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withIncludes">
-        <div class="location">at line 375</div>
+        <div class="location">at line 386</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withIncludes</strong>(array $patterns)
         </code>
@@ -2082,7 +2124,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withName">
-        <div class="location">at line 385</div>
+        <div class="location">at line 396</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withName</strong>(string $name)
         </code>
@@ -2124,7 +2166,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 395</div>
+        <div class="location">at line 406</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withSDK</strong>(string $source)
         </code>
@@ -2166,7 +2208,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSourceSubpath">
-        <div class="location">at line 405</div>
+        <div class="location">at line 416</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withSourceSubpath</strong>(string $path)
         </code>
@@ -2208,7 +2250,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withToolchains">
-        <div class="location">at line 415</div>
+        <div class="location">at line 426</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withToolchains</strong>(array $toolchains)
         </code>
@@ -2250,7 +2292,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateBlueprint">
-        <div class="location">at line 425</div>
+        <div class="location">at line 436</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateBlueprint</strong>()
         </code>
@@ -2282,7 +2324,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateDependencies">
-        <div class="location">at line 434</div>
+        <div class="location">at line 445</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateDependencies</strong>(array $dependencies)
         </code>
@@ -2324,7 +2366,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateToolchains">
-        <div class="location">at line 444</div>
+        <div class="location">at line 455</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateToolchains</strong>(array $toolchains)
         </code>
@@ -2366,7 +2408,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedClients">
-        <div class="location">at line 454</div>
+        <div class="location">at line 465</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdatedClients</strong>(array $clients)
         </code>
@@ -2408,7 +2450,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutBlueprint">
-        <div class="location">at line 464</div>
+        <div class="location">at line 475</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutBlueprint</strong>()
         </code>
@@ -2440,7 +2482,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutClient">
-        <div class="location">at line 473</div>
+        <div class="location">at line 484</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutClient</strong>(string $path)
         </code>
@@ -2482,7 +2524,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDependencies">
-        <div class="location">at line 483</div>
+        <div class="location">at line 494</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutDependencies</strong>(array $dependencies)
         </code>
@@ -2524,7 +2566,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExperimentalFeatures">
-        <div class="location">at line 493</div>
+        <div class="location">at line 504</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutExperimentalFeatures</strong>(array $features)
         </code>
@@ -2566,7 +2608,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutToolchains">
-        <div class="location">at line 503</div>
+        <div class="location">at line 514</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutToolchains</strong>(array $toolchains)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -394,7 +394,9 @@
 <abbr title="Dagger\Module">Module</abbr>::check</a>() &mdash; <em>Method in class <a href="Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a></em></dt>
                     <dd><p>Return the check defined by the module with the given name. Must match to exactly one check.</p></dd><dt><a href="Dagger/Module.html#method_checks">
 <abbr title="Dagger\Module">Module</abbr>::checks</a>() &mdash; <em>Method in class <a href="Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a></em></dt>
-                    <dd><p>Return all checks defined by the module</p></dd><dt><a href="Dagger/ModuleSource.html#method_cloneRef">
+                    <dd><p>Return all checks defined by the module</p></dd><dt><a href="Dagger/ModuleSource.html#method_clientSchemaIntrospectionJSON">
+<abbr title="Dagger\ModuleSource">ModuleSource</abbr>::clientSchemaIntrospectionJSON</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
+                    <dd><p>The client-facing introspection schema JSON file for this module source.</p></dd><dt><a href="Dagger/ModuleSource.html#method_cloneRef">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::cloneRef</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
                     <dd><p>The ref to clone the root of the git repo from. Only valid for git sources.</p></dd><dt><a href="Dagger/ModuleSource.html#method_commit">
 <abbr title="Dagger\ModuleSource">ModuleSource</abbr>::commit</a>() &mdash; <em>Method in class <a href="Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></em></dt>
@@ -1060,7 +1062,9 @@
 <abbr title="Dagger\CurrentModuleAsSDK">CurrentModuleAsSDK</abbr>::modules</a>() &mdash; <em>Method in class <a href="Dagger/CurrentModuleAsSDK.html"><abbr title="Dagger\CurrentModuleAsSDK">CurrentModuleAsSDK</abbr></a></em></dt>
                     <dd><p>The workspace-local modules this SDK authors and manages.</p></dd><dt><a href="Dagger/CurrentModuleAsSDKClient.html#method_module">
 <abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr>::module</a>() &mdash; <em>Method in class <a href="Dagger/CurrentModuleAsSDKClient.html"><abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr></a></em></dt>
-                    <dd><p>The module the client is bound to (workspace-relative path or canonical ref).</p></dd><dt><a href="Dagger/EngineCache.html#method_maxUsedSpace">
+                    <dd><p>The module the client is bound to (workspace-relative path or canonical ref).</p></dd><dt><a href="Dagger/CurrentModuleAsSDKClient.html#method_moduleSource">
+<abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr>::moduleSource</a>() &mdash; <em>Method in class <a href="Dagger/CurrentModuleAsSDKClient.html"><abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr></a></em></dt>
+                    <dd><p>The resolved module source this client is bound to, including its dependency closure and pinned version.</p></dd><dt><a href="Dagger/EngineCache.html#method_maxUsedSpace">
 <abbr title="Dagger\EngineCache">EngineCache</abbr>::maxUsedSpace</a>() &mdash; <em>Method in class <a href="Dagger/EngineCache.html"><abbr title="Dagger\EngineCache">EngineCache</abbr></a></em></dt>
                     <dd><p>The maximum bytes to keep in the cache without pruning.</p></dd><dt><a href="Dagger/EngineCache.html#method_minFreeSpace">
 <abbr title="Dagger\EngineCache">EngineCache</abbr>::minFreeSpace</a>() &mdash; <em>Method in class <a href="Dagger/EngineCache.html"><abbr title="Dagger\EngineCache">EngineCache</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -3374,6 +3374,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\CurrentModuleAsSDKClient::moduleSource",
+			"p": "Dagger/CurrentModuleAsSDKClient.html#method_moduleSource",
+			"d": "<p>The resolved module source this client is bound to, including its dependency closure and pinned version.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\CurrentModuleAsSDKClient::path",
 			"p": "Dagger/CurrentModuleAsSDKClient.html#method_path",
 			"d": "<p>Workspace-root-relative path of the generated client.</p>"
@@ -5819,6 +5825,12 @@
 			"n": "Dagger\\ModuleSource::blueprint",
 			"p": "Dagger/ModuleSource.html#method_blueprint",
 			"d": "<p>The blueprint referenced by the module source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\ModuleSource::clientSchemaIntrospectionJSON",
+			"p": "Dagger/ModuleSource.html#method_clientSchemaIntrospectionJSON",
+			"d": "<p>The client-facing introspection schema JSON file for this module source.</p>"
 		},
 		{
 			"t": "M",

--- a/hack/designs/client-codegen-engine-cleanup.md
+++ b/hack/designs/client-codegen-engine-cleanup.md
@@ -1,0 +1,91 @@
+# Client Codegen Engine Cleanup
+
+## Status
+
+Pending. Deferred cleanup, tracked here so it isn't lost.
+
+## Summary
+
+Phase 1 of the client-codegen workflow adds two additive, `v1.0.0-0`-gated
+engine primitives that let a `.dang` SDK module generate a TypeScript client
+itself from plain data (schema JSON + dependency list) instead of the engine
+driving generation through the SDK runtime:
+
+- `ModuleSource.clientSchemaIntrospectionJSON: File!` — the client-facing schema
+  (`SchemaIntrospectionJSONFileForClient`: no hidden types; **core plus the bound
+  module only**, installed namespaced on `Query` — reached via `dag.<moduleName>`,
+  never promoted to the Query root). The bound module's own dependencies are
+  **deliberately excluded**: a client is generated for one module, not its whole
+  dependency graph. Registered in `core/schema/modulesource.go`; the core-only
+  base build + namespaced module install is the shared helper
+  `clientSchemaIntrospectionJSONFile` (it starts from `loadDefaultSchemaBuilder`, a
+  core-only `SchemaBuilder`, then installs just the bound module), reused by
+  `runClientGenerator` — so both the new primitive and the old engine-driven path
+  produce deps-free clients.
+- `CurrentModuleAsSDKClient.moduleSource: ModuleSource!` — resolves the bound
+  module from the stored `{module, pin}` via `resolveClientTargetModule` (the
+  same path `clientGenerate` uses). Registered in `core/schema/module.go`,
+  resolver in `core/schema/module_as_sdk.go`.
+
+Both are purely additive. The **old engine-driven client path was intentionally
+left in place** so nothing regresses while the companion `dagger/dagger`
+proposal (`hack/designs/client-codegen-workflow.md`) and the split-out
+`.dang` SDK module (`dagger/typescript-sdk` `design/client-gen.md`) land the
+consuming side. Once the Dang SDK dispatches `generateAllClient` as a
+discoverable `@generate` rollup generator, the code below becomes dead and
+should be removed in a follow-up.
+
+## What to remove once `generateAllClient` ships
+
+Coordinate with the `.dang` SDK side landing first (it must dispatch
+`generateAllClient` before these are deleted).
+
+### Engine (this repo)
+
+- **`workspaceSchema.clientGenerate`** and its per-client loop
+  (`core/schema/workspace_client.go`): "Regenerate all generated API clients
+  registered in workspace config". Replaced by the SDK-side `generateAllClient`
+  rollup. Removing this also retires `workspaceClientInitGeneratedDiff`.
+- **`moduleSourceSchema.runClientGenerator`** special-case
+  (`core/schema/modulesource.go`) once no engine caller drives client
+  generation through the SDK runtime. Note: keep
+  `clientSchemaIntrospectionJSONFile` (extracted from it) — that is the new
+  primitive's backing helper and is still used.
+- **`AsClientInitializer` / `InitClient`** path
+  (`core/schema/workspace_client.go` `clientInit` → `loadedSDK.AsClientInitializer()`
+  → `InitClient`, and the corresponding SDK interface). Per companion doc Q7,
+  `clientInit` becomes a pure config write (empty Changeset); the SDK emits no
+  init-time files for a client. Remove the initializer selection and interface.
+- The Dang SDK's `GenerateClient` stub in `core/sdk/dang_sdk.go` (currently
+  returns "dang SDK does not have a client to generate") — superseded by the
+  `@generate` rollup dispatch.
+
+### `dagger/dagger` runtime (separate PR, per companion doc §6.2)
+
+- `sdk/typescript/runtime/GenerateClient` and its client fan-out.
+- `Local` lib origin end-to-end (`GenerateLocalLibrary`, `StaticLocalLib`, the
+  `Local` constant, `detectSDKLibOrigin` branches).
+- Client bundling in the runtime (`GenerateBundleLibrary` client arm,
+  `StaticBundleClientIndexTS`, `coexistWithModule`).
+- `analyzeClientConfig` (near-duplicate of `analyzeModuleConfig`).
+- `CreateOrUpdate*ForClient` runtime wrappers (logic moved into the `.dang`
+  side's `helpers/config-updator`).
+
+## Notes
+
+- The two new fields are gated `AfterVersion("v1.0.0-0")`, so they only appear
+  in the CLI-1.0+ schema view, matching the gating on `CurrentModule.asSDK`.
+- `clientSchemaIntrospectionJSON` must not be confused with the existing
+  module-facing `introspectionSchemaJSON` (`SchemaIntrospectionJSONFileForModule`),
+  which hides `TypesToIgnoreForModuleIntrospection` + `TypesHiddenFromModuleSDKs`
+  and does not install the bound module at all. Feeding the module-facing schema
+  to client codegen produces an incomplete/incorrect client.
+- A client never promotes a module's functions to the Query root: the bound
+  module is installed namespaced (`InstallOpts{}`, not `Entrypoint: true`) and
+  reached via `dag.<moduleName>`. It is the only user module in the client schema
+  — dependencies are excluded (see the summary), so a client has no `dag.<dep>()`
+  bindings.
+- Runtime serving is the companion half: a generated client must serve its bound
+  module into the session at connect time for `dag.<moduleName>()` to resolve.
+  Because deps are excluded here, only the bound module needs serving (never its
+  deps). See `hack/designs/generated-client-module-loading.md`.

--- a/sdk/elixir/lib/dagger/gen/current_module_as_sdk_client.ex
+++ b/sdk/elixir/lib/dagger/gen/current_module_as_sdk_client.ex
@@ -38,6 +38,20 @@ defmodule Dagger.CurrentModuleAsSDKClient do
   end
 
   @doc """
+  The resolved module source this client is bound to, including its dependency closure and pinned version.
+  """
+  @spec module_source(t()) :: Dagger.ModuleSource.t()
+  def module_source(%__MODULE__{} = current_module_as_sdk_client) do
+    query_builder =
+      current_module_as_sdk_client.query_builder |> QB.select("moduleSource")
+
+    %Dagger.ModuleSource{
+      query_builder: query_builder,
+      client: current_module_as_sdk_client.client
+    }
+  end
+
+  @doc """
   Workspace-root-relative path of the generated client.
   """
   @spec path(t()) :: {:ok, String.t()} | {:error, term()}

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -58,6 +58,22 @@ defmodule Dagger.ModuleSource do
   end
 
   @doc """
+  The client-facing introspection schema JSON file for this module source.
+
+  This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.
+  """
+  @spec client_schema_introspection_json(t()) :: Dagger.File.t()
+  def client_schema_introspection_json(%__MODULE__{} = module_source) do
+    query_builder =
+      module_source.query_builder |> QB.select("clientSchemaIntrospectionJSON")
+
+    %Dagger.File{
+      query_builder: query_builder,
+      client: module_source.client
+    }
+  end
+
+  @doc """
   The ref to clone the root of the git repo from. Only valid for git sources.
   """
   @spec clone_ref(t()) :: {:ok, String.t()} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4200,6 +4200,15 @@ func (r *CurrentModuleAsSDKClient) Module(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
+// The resolved module source this client is bound to, including its dependency closure and pinned version.
+func (r *CurrentModuleAsSDKClient) ModuleSource() *ModuleSource {
+	q := r.query.Select("moduleSource")
+
+	return &ModuleSource{
+		query: q,
+	}
+}
+
 // Workspace-root-relative path of the generated client.
 func (r *CurrentModuleAsSDKClient) Path(ctx context.Context) (string, error) {
 	if r.path != nil {
@@ -12318,6 +12327,17 @@ func (r *ModuleSource) Blueprint() *ModuleSource {
 	q := r.query.Select("blueprint")
 
 	return &ModuleSource{
+		query: q,
+	}
+}
+
+// The client-facing introspection schema JSON file for this module source.
+//
+// This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.
+func (r *ModuleSource) ClientSchemaIntrospectionJSON() *File {
+	q := r.query.Select("clientSchemaIntrospectionJSON")
+
+	return &File{
 		query: q,
 	}
 }

--- a/sdk/php/generated/CurrentModuleAsSDKClient.php
+++ b/sdk/php/generated/CurrentModuleAsSDKClient.php
@@ -32,6 +32,15 @@ class CurrentModuleAsSDKClient extends Client\AbstractObject implements Client\I
     }
 
     /**
+     * The resolved module source this client is bound to, including its dependency closure and pinned version.
+     */
+    public function moduleSource(): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('moduleSource');
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Workspace-root-relative path of the generated client.
      */
     public function path(): string

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -41,6 +41,17 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble, Node,
     }
 
     /**
+     * The client-facing introspection schema JSON file for this module source.
+     *
+     * This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.
+     */
+    public function clientSchemaIntrospectionJSON(): File
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('clientSchemaIntrospectionJSON');
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * The ref to clone the root of the git repo from. Only valid for git sources.
      */
     public function cloneRef(): string

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -4162,6 +4162,14 @@ class CurrentModuleAsSDKClient(Type):
         _ctx = self._select("module", _args)
         return await _ctx.execute(str)
 
+    def module_source(self) -> "ModuleSource":
+        """The resolved module source this client is bound to, including its
+        dependency closure and pinned version.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("moduleSource", _args)
+        return ModuleSource(_ctx)
+
     async def path(self) -> str:
         """Workspace-root-relative path of the generated client.
 
@@ -12332,6 +12340,21 @@ class ModuleSource(Type):
         _args: list[Arg] = []
         _ctx = self._select("blueprint", _args)
         return ModuleSource(_ctx)
+
+    def client_schema_introspection_json(self) -> File:
+        """The client-facing introspection schema JSON file for this module
+        source.
+
+        This is the schema consumed by client codegen: unlike
+        introspectionSchemaJSON (the module-facing schema), it hides no core
+        types and installs this module (reached via dag.<moduleName>) so a
+        generated client can bind it. The module's dependencies are excluded:
+        a client is generated for a single module plus core, not its
+        dependency graph.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("clientSchemaIntrospectionJSON", _args)
+        return File(_ctx)
 
     async def clone_ref(self) -> str:
         """The ref to clone the root of the git repo from. Only valid for git

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4737,6 +4737,15 @@ impl CurrentModuleAsSdkClient {
         let query = self.selection.select("module");
         query.execute(self.graphql_client.clone()).await
     }
+    /// The resolved module source this client is bound to, including its dependency closure and pinned version.
+    pub fn module_source(&self) -> ModuleSource {
+        let query = self.selection.select("moduleSource");
+        ModuleSource {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Workspace-root-relative path of the generated client.
     pub async fn path(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("path");
@@ -12894,6 +12903,16 @@ impl ModuleSource {
     pub fn blueprint(&self) -> ModuleSource {
         let query = self.selection.select("blueprint");
         ModuleSource {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// The client-facing introspection schema JSON file for this module source.
+    /// This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.
+    pub fn client_schema_introspection_json(&self) -> File {
+        let query = self.selection.select("clientSchemaIntrospectionJSON");
+        File {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -5785,6 +5785,14 @@ export class CurrentModuleAsSDKClient extends BaseClient {
   }
 
   /**
+   * The resolved module source this client is bound to, including its dependency closure and pinned version.
+   */
+  moduleSource = (): ModuleSource => {
+    const ctx = this._ctx.select("moduleSource")
+    return new ModuleSource(ctx)
+  }
+
+  /**
    * Workspace-root-relative path of the generated client.
    */
   path = async (): Promise<string> => {
@@ -12284,6 +12292,16 @@ export class ModuleSource extends BaseClient {
   blueprint = (): ModuleSource => {
     const ctx = this._ctx.select("blueprint")
     return new ModuleSource(ctx)
+  }
+
+  /**
+   * The client-facing introspection schema JSON file for this module source.
+   *
+   * This is the schema consumed by client codegen: unlike introspectionSchemaJSON (the module-facing schema), it hides no core types and installs this module (reached via dag.<moduleName>) so a generated client can bind it. The module's dependencies are excluded: a client is generated for a single module plus core, not its dependency graph.
+   */
+  clientSchemaIntrospectionJSON = (): File => {
+    const ctx = this._ctx.select("clientSchemaIntrospectionJSON")
+    return new File(ctx)
   }
 
   /**


### PR DESCRIPTION
Add two additive, v1.0.0-0-gated engine fields so a .dang SDK module can generate a client from plain data, rather than the engine driving client generation through the SDK runtime:

- ModuleSource.clientSchemaIntrospectionJSON: the client-facing schema (hides no core types; promotes the module's own types to Query for self-bindings). The deps-load + self-promotion logic is extracted from runClientGenerator into a shared helper reused by both.
- CurrentModuleAsSDKClient.moduleSource: resolves the bound module from its stored {module, pin} via resolveClientTargetModule, correct for local and remote/pinned refs alike (not a raw ref-string lookup).

These are the phase-1 primitives the companion client-codegen workflow consumes. The old engine-driven client path is intentionally left in place for now; the follow-up cleanup is tracked in hack/designs/client-codegen-engine-cleanup.md.

Add integration coverage in client_generator_test.go and regenerate the generated SDK bindings + GraphQL SDL.