### PR TITLE
fix(core): emit changeset patches without rename entries

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -636,7 +636,12 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 				}
 				defer patchFile.Close()
 
-				cmd := exec.CommandContext(ctx, "git", "diff", "--binary", "--no-prefix", "--no-index", "a", "b")
+				// --no-renames: with --no-prefix, git strips the a/ b/ mount dirs
+				// from the ---/+++ lines but not from rename from/to lines, so a
+				// rename entry makes the patch unapplyable ("inconsistent old
+				// filename"). Emitting renames as delete+add avoids the mismatch;
+				// with --binary the result is identical.
+				cmd := exec.CommandContext(ctx, "git", "diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b")
 				cmd.Dir = root
 				cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
 				cmd.Stderr = stdio.Stderr

--- a/core/integration/changeset_test.go
+++ b/core/integration/changeset_test.go
@@ -924,6 +924,41 @@ func (ChangesetSuite) testChangeApplying(t *testctx.T, apply func(*dagger.Direct
 		require.Equal(t, "new in subdir", newInSubdirContent)
 	})
 
+	t.Run("renamed file", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		// A file whose identical content moves to a new path reads as a
+		// rename to git. AsPatch shells out to `git diff --no-prefix
+		// --no-index` between the a/ and b/ mount dirs; git detects the
+		// rename and used to emit a rename entry whose "rename from"/"rename
+		// to" lines still carried the a/ b/ dirs (unlike the stripped ---/+++
+		// lines), producing a patch git apply rejected with "inconsistent old
+		// filename". Applying such a changeset must still land the rename.
+		baseDir := c.Directory().
+			WithNewFile("keep.txt", "unchanged").
+			WithNewFile("old-name.txt", "same content across the rename\n")
+
+		beforeDir := baseDir
+
+		afterDir := c.Directory().
+			WithNewFile("keep.txt", "unchanged").
+			WithNewFile("new-name.txt", "same content across the rename\n")
+
+		changes := afterDir.Changes(beforeDir)
+
+		resultDir := apply(baseDir, changes)
+
+		entries, err := resultDir.Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, entries, "keep.txt")
+		require.Contains(t, entries, "new-name.txt")
+		require.NotContains(t, entries, "old-name.txt")
+
+		renamedContent, err := resultDir.File("new-name.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "same content across the rename\n", renamedContent)
+	})
+
 	t.Run("only added files", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 


### PR DESCRIPTION
## What

`Changeset.AsPatch` builds its patch by shelling out to `git diff --binary --no-prefix --no-index a b` between the literal `a/` and `b/` mount directories. With `--no-prefix`, git strips those `a/`/`b/` dirs from the `---`/`+++` header lines (treating them like the usual diff prefixes) but leaves them intact on the `rename from`/`rename to` lines of a detected rename. The result is a patch that `git apply` rejects with `inconsistent old filename`.

Any changeset containing a detected rename hit this — it broke `dagger generate` the first time a docs regen renamed a reference page.

## Fix

Pass `--no-renames` so renames are emitted as delete + add. Combined with `--binary`, the applied result is identical, and the patch applies cleanly.

## Test

Adds a "renamed file" case to `testChangeApplying`, which runs under both `WithChanges` and `AsPatch`. The `AsPatch` variant is the regression guard (it fails without this fix); the `WithChanges` variant confirms both apply paths land the rename identically.
