### PR TITLE
fix(cli): suggest installing known SDKs

### DIFF
--- a/core/integration/command_hints_test.go
+++ b/core/integration/command_hints_test.go
@@ -67,3 +67,21 @@ func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t
 	require.NoError(t, err, "%s", string(clientOut))
 	require.Contains(t, string(clientOut), "dagger generate")
 }
+
+// TestUninstalledSDKInitHint verifies that `dagger module init <sdk> <name>`
+// for a registry-known but uninstalled SDK, in a workspace with no dagger.toml,
+// fails with a hint to install the SDK rather than a generic unknown-command
+// error. Names the registry doesn't know keep the generic cobra error.
+func (CommandHintsSuite) TestUninstalledSDKInitHint(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+
+	out, err := hostDaggerExecRaw(ctx, t, workdir, "module", "init", "go", "myapp")
+	require.Error(t, err, "%s", string(out))
+	require.Contains(t, string(out), "dagger sdk install go")
+	require.NotContains(t, string(out), `unknown command "go"`)
+
+	unknownOut, err := hostDaggerExecRaw(ctx, t, workdir, "module", "init", "definitely-not-an-sdk", "myapp")
+	require.Error(t, err, "%s", string(unknownOut))
+	require.Contains(t, string(unknownOut), `unknown command "definitely-not-an-sdk"`)
+}

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -41,6 +41,10 @@ func registerInstalledSDKInitCommands(ctx context.Context, args []string) error 
 	if cfg == nil {
 		clearDynamicSDKInitCommands(moduleInitCmd)
 		clearDynamicSDKInitCommands(apiClientInitCmd)
+		// Without a workspace config nothing is installed, so there is no
+		// engine introspection to do; still offer an install hint when the
+		// requested SDK is one the registry knows about.
+		registerUninstalledSDKInitSuggestion(moduleInitCmd, apiClientInitCmd, kind, args, nil)
 		return nil
 	}
 
@@ -79,25 +83,7 @@ func registerSDKInitCommandsFromConfigForKind(
 		return err
 	}
 
-	// A known but uninstalled SDK has no engine-backed init command to register.
-	if sdkName, ok := sdkInitInvocationSDKName(args); ok {
-		installed := false
-		for _, sdk := range sdks {
-			if sdk.commandName == sdkName || sdk.moduleName == sdkName {
-				installed = true
-				break
-			}
-		}
-		if !installed {
-			if _, _, _, resolveErr := sdkResolveInstall(sdkName); resolveErr == nil {
-				parent := moduleParent
-				if kind == sdkInitKindClient {
-					parent = clientParent
-				}
-				parent.AddCommand(newUninstalledSDKInitCommand(kind, sdkName))
-			}
-		}
-	}
+	registerUninstalledSDKInitSuggestion(moduleParent, clientParent, kind, args, sdks)
 
 	for _, sdk := range sdks {
 		sdkRef, err := sdkInitModuleEntrySource(sdk.entry, cfgDir)
@@ -244,21 +230,47 @@ func newModuleInitSDKCommand(sdkName string) *cobra.Command {
 	return cmd
 }
 
+// registerUninstalledSDKInitSuggestion adds a temporary init subcommand for a
+// requested SDK that the embedded registry recognizes but that is not installed
+// in the workspace, so `dagger module init <sdk> ...` explains how to install it
+// instead of failing with a generic unknown-command error. Names the registry
+// doesn't know are left alone so cobra's usual error still applies.
+func registerUninstalledSDKInitSuggestion(moduleParent, clientParent *cobra.Command, kind sdkInitKind, args []string, sdks []configuredSDK) {
+	sdkName, ok := sdkInitInvocationSDKName(args)
+	if !ok {
+		return
+	}
+	for _, sdk := range sdks {
+		if sdk.commandName == sdkName || sdk.moduleName == sdkName {
+			return
+		}
+	}
+	if _, _, _, err := sdkResolveInstall(sdkName); err != nil {
+		return
+	}
+	parent := moduleParent
+	if kind == sdkInitKindClient {
+		parent = clientParent
+	}
+	parent.AddCommand(newUninstalledSDKInitCommand(kind, sdkName))
+}
+
 func newUninstalledSDKInitCommand(kind sdkInitKind, sdkName string) *cobra.Command {
 	use := sdkName + " <name>"
-	want := 1
 	if kind == sdkInitKindClient {
 		use = sdkName + " <path> <module>"
-		want = 2
 	}
 	return &cobra.Command{
-		Use:   use,
-		Short: fmt.Sprintf("Initialize with %s", sdkName),
-		Args: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.ExactArgs(want)(cmd, args); err != nil {
-				return err
-			}
-			return fmt.Errorf("SDK %q is not installed in this workspace; run `dagger sdk install %s` first", sdkName, sdkName)
+		Use:                   use,
+		Short:                 fmt.Sprintf("Initialize with the %s SDK (not installed)", sdkName),
+		DisableFlagsInUseLine: true,
+		// The SDK isn't installed, so there's no engine-backed init to run;
+		// accept any args and explain how to install it. The message must come
+		// from RunE, not Args: cobra returns help for a command that isn't
+		// Runnable (no Run/RunE) before it ever validates args.
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("%q is not installed as an SDK in this workspace; run `dagger sdk install %s` first", sdkName, sdkName)
 		},
 		Annotations: map[string]string{
 			dynamicSDKInitCommandAnnotation: "true",

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -55,7 +55,7 @@ func registerInstalledSDKInitCommands(ctx context.Context, args []string) error 
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,
 	}, func(ctx context.Context, ec *client.Client) error {
-		return registerSDKInitCommandsFromConfigForKind(ctx, ec.Dagger(), moduleInitCmd, apiClientInitCmd, cfg, cfgDir, kind)
+		return registerSDKInitCommandsFromConfigForKind(ctx, ec.Dagger(), moduleInitCmd, apiClientInitCmd, cfg, cfgDir, kind, args)
 	})
 }
 
@@ -66,6 +66,7 @@ func registerSDKInitCommandsFromConfigForKind(
 	cfg *workspace.Config,
 	cfgDir string,
 	kind sdkInitKind,
+	args []string,
 ) error {
 	clearDynamicSDKInitCommands(moduleParent)
 	clearDynamicSDKInitCommands(clientParent)
@@ -76,6 +77,26 @@ func registerSDKInitCommandsFromConfigForKind(
 	sdks, err := configuredSDKs(cfg)
 	if err != nil {
 		return err
+	}
+
+	// A known but uninstalled SDK has no engine-backed init command to register.
+	if sdkName, ok := sdkInitInvocationSDKName(args); ok {
+		installed := false
+		for _, sdk := range sdks {
+			if sdk.commandName == sdkName || sdk.moduleName == sdkName {
+				installed = true
+				break
+			}
+		}
+		if !installed {
+			if _, _, _, resolveErr := sdkResolveInstall(sdkName); resolveErr == nil {
+				parent := moduleParent
+				if kind == sdkInitKindClient {
+					parent = clientParent
+				}
+				parent.AddCommand(newUninstalledSDKInitCommand(kind, sdkName))
+			}
+		}
 	}
 
 	for _, sdk := range sdks {
@@ -223,6 +244,28 @@ func newModuleInitSDKCommand(sdkName string) *cobra.Command {
 	return cmd
 }
 
+func newUninstalledSDKInitCommand(kind sdkInitKind, sdkName string) *cobra.Command {
+	use := sdkName + " <name>"
+	want := 1
+	if kind == sdkInitKindClient {
+		use = sdkName + " <path> <module>"
+		want = 2
+	}
+	return &cobra.Command{
+		Use:   use,
+		Short: fmt.Sprintf("Initialize with %s", sdkName),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(want)(cmd, args); err != nil {
+				return err
+			}
+			return fmt.Errorf("SDK %q is not installed in this workspace; run `dagger sdk install %s` first", sdkName, sdkName)
+		},
+		Annotations: map[string]string{
+			dynamicSDKInitCommandAnnotation: "true",
+		},
+	}
+}
+
 func newAPIClientInitSDKCommand(sdkName string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   sdkName + " <path> <module>",
@@ -314,6 +357,19 @@ func sdkInitInvocationKind(args []string) (sdkInitKind, bool) {
 		}
 		if i+2 < len(tokens) && tokens[i] == "api" && tokens[i+1] == "client" && tokens[i+2] == "init" {
 			return sdkInitKindClient, true
+		}
+	}
+	return "", false
+}
+
+func sdkInitInvocationSDKName(args []string) (string, bool) {
+	tokens := sdkInitCommandTokens(args)
+	for i := 0; i < len(tokens); i++ {
+		if i+2 < len(tokens) && tokens[i] == "module" && tokens[i+1] == "init" {
+			return tokens[i+2], true
+		}
+		if i+3 < len(tokens) && tokens[i] == "api" && tokens[i+1] == "client" && tokens[i+2] == "init" {
+			return tokens[i+3], true
 		}
 	}
 	return "", false

--- a/internal/cmd/dagger/sdk_init_dynamic_test.go
+++ b/internal/cmd/dagger/sdk_init_dynamic_test.go
@@ -244,6 +244,54 @@ func TestShouldRegisterSDKInitCommands(t *testing.T) {
 	}
 }
 
+func TestUninstalledSDKInitSuggestion(t *testing.T) {
+	newParents := func() (*cobra.Command, *cobra.Command) {
+		return &cobra.Command{Use: "init", Args: cobra.NoArgs},
+			&cobra.Command{Use: "init", Args: cobra.NoArgs}
+	}
+
+	t.Run("known SDK, nothing installed", func(t *testing.T) {
+		moduleParent, clientParent := newParents()
+		registerUninstalledSDKInitSuggestion(moduleParent, clientParent, sdkInitKindModule,
+			[]string{"module", "init", "go", "myapp"}, nil)
+
+		cmd, _, err := moduleParent.Find([]string{"go", "myapp"})
+		require.NoError(t, err)
+		require.Equal(t, "go", cmd.Name())
+		// Must be runnable, otherwise cobra prints help instead of RunE's hint.
+		require.True(t, cmd.Runnable())
+		require.ErrorContains(t, cmd.RunE(cmd, []string{"myapp"}), "dagger sdk install go")
+	})
+
+	t.Run("unknown SDK is left to cobra", func(t *testing.T) {
+		moduleParent, clientParent := newParents()
+		registerUninstalledSDKInitSuggestion(moduleParent, clientParent, sdkInitKindModule,
+			[]string{"module", "init", "definitely-not-an-sdk", "myapp"}, nil)
+		require.Empty(t, moduleParent.Commands())
+	})
+
+	t.Run("installed SDK is left to the real command", func(t *testing.T) {
+		moduleParent, clientParent := newParents()
+		sdks := []configuredSDK{{moduleName: "go", commandName: "go"}}
+		registerUninstalledSDKInitSuggestion(moduleParent, clientParent, sdkInitKindModule,
+			[]string{"module", "init", "go", "myapp"}, sdks)
+		require.Empty(t, moduleParent.Commands())
+	})
+
+	t.Run("client kind registers under the client parent", func(t *testing.T) {
+		moduleParent, clientParent := newParents()
+		registerUninstalledSDKInitSuggestion(moduleParent, clientParent, sdkInitKindClient,
+			[]string{"api", "client", "init", "go", "./client", "."}, nil)
+		require.Empty(t, moduleParent.Commands())
+
+		cmd, _, err := clientParent.Find([]string{"go", "./client", "."})
+		require.NoError(t, err)
+		require.Equal(t, "go", cmd.Name())
+		require.True(t, cmd.Runnable())
+		require.ErrorContains(t, cmd.RunE(cmd, []string{"./client", "."}), "dagger sdk install go")
+	})
+}
+
 func sdkInitArgNames(args []*modFunctionArg) []string {
 	names := make([]string, len(args))
 	for i, arg := range args {


### PR DESCRIPTION
## Summary

Recognize known SDK names when an SDK init command has not been installed and suggest the corresponding `dagger sdk install` command.

Fixes #13622.

## Problem

SDK init commands are registered dynamically from installed workspace SDKs. When a user runs `dagger module init go myapp` without the Go SDK installed, Cobra sees no `go` subcommand and reports a generic unknown-command error.

## Solution

Use the embedded SDK registry to register a temporary command for a requested, known SDK that is not installed. The command reports that the SDK is missing and tells the user how to install it. Unknown SDK names keep the existing behavior.

## Validation

- Ran `gofmt`
- Ran `git diff --check`