### PR TITLE
fix(setup): resolve SDK installs in every migrated workspace config

### DIFF
--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -497,6 +497,10 @@ type Myapp {
 		require.NoError(t, err)
 		require.Contains(t, wsOut, `[modules.dagger-dang-sdk]`)
 		require.Contains(t, wsOut, `path = "libs/foo"`)
+		// The runtime is resolved to its real ref, matching `dagger sdk install`,
+		// not left as the bare "dang" short name.
+		require.Contains(t, wsOut, `source = "github.com/dagger/dang-sdk"`)
+		require.NotContains(t, wsOut, `source = "dang"`)
 
 		// The converted dependency loads from its own runtime field.
 		callOut, err := ctr.With(daggerCallAt("libs/foo", "message")).Stdout(ctx)
@@ -532,6 +536,72 @@ type Myapp {
 			_, err = ctr.WithExec([]string{"test", "!", "-e", dir + "/dagger.json"}).Sync(ctx)
 			require.NoError(t, err, "%s legacy config should be removed", dir)
 		}
+	})
+
+	t.Run("nested workspace plan resolves its SDK installs", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// A globbed .dagger/modules/tool config that itself must-migrate (its
+		// source is a non-root subdir) becomes its OWN workspace plan, with its
+		// own dagger.toml — separate from the top-level workspace the setup
+		// command runs in. Its SDK install (and any it owns for discovered deps)
+		// must still be resolved to a real ref, even though it lives in a config
+		// the current-workspace fixup pass doesn't read. The tool uses `php`,
+		// whose sdks.json ref (github.com/dagger/php-sdk) differs from the
+		// engine-side runtime mapping, so this also pins that the CLI registry —
+		// what `dagger sdk install` uses — wins for these nested configs.
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci"
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", "\ntype Myapp {\n  pub greet: String! { \"hi\" }\n}\n").
+				WithNewFile(".dagger/modules/tool/dagger.json", `{"name":"tool","sdk":{"source":"php"},"source":"src","dependencies":[{"name":"helper","source":"./helper"}]}`).
+				WithNewFile(".dagger/modules/tool/src/index.php", "<?php\n").
+				With(legacyDangModule(".dagger/modules/tool/helper", "helper", "Helper", "help"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		nested, err := ctr.WithExec([]string{"cat", ".dagger/modules/tool/dagger.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		// The tool's own runtime resolves to its sdks.json ref (CLI registry),
+		// and the discovered helper's dang runtime resolves too.
+		require.Contains(t, nested, `source = "github.com/dagger/php-sdk"`, nested)
+		require.Contains(t, nested, `source = "github.com/dagger/dang-sdk"`, nested)
+		require.NotContains(t, nested, `source = "php"`, nested)
+	})
+
+	t.Run("pre-existing nested workspace config is left untouched", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// A pre-existing dagger.toml under tools/ makes tools/ its own workspace,
+		// which migration treats as an ownership boundary and does not touch. SDK
+		// resolution must respect that boundary too: a bare short-name install
+		// there is not a migration artifact and must not be rewritten, even though
+		// "go" would otherwise resolve through sdks.json.
+		preExisting := `[modules.local-go]
+source = "go"
+
+[modules.local-go.as-sdk]
+name = "my-go"
+`
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci"
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", "\ntype Myapp {\n  pub greet: String! { \"hi\" }\n}\n").
+				WithNewFile("tools/dagger.toml", preExisting)
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		after, err := ctr.WithExec([]string{"cat", "tools/dagger.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, preExisting, after, "pre-existing nested workspace config must not be rewritten")
 	})
 
 	t.Run("diamond dependency is migrated once", func(ctx context.Context, t *testctx.T) {

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -65,9 +65,10 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 		// confirm form). The migrate write lands here; the session is closed
 		// before the install session opens so the workspace lock is released.
 		var (
-			recs     []recommendation
-			install  bool
-			migrated bool
+			recs            []recommendation
+			install         bool
+			migrated        bool
+			migratedConfigs []string
 		)
 		if err := func() error {
 			sess, closeSess, err := connect(ctx)
@@ -76,7 +77,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			}
 			defer closeSess()
 			dag := sess.Dagger()
-			migrated, err = setupStepMigrate(ctx, cmd, dag)
+			migrated, migratedConfigs, err = setupStepMigrate(ctx, cmd, dag)
 			if err != nil {
 				return fmt.Errorf("step 2 (migrate): %w", err)
 			}
@@ -103,7 +104,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			// Only a migration writes SDK installs by short name, so scope the
 			// resolution to that case — never rewrite an already-native config.
 			if migrated {
-				if err := setupResolveMigratedSDKs(ctx, cmd, dag); err != nil {
+				if err := setupResolveMigratedSDKs(ctx, cmd, dag, migratedConfigs); err != nil {
 					return fmt.Errorf("step 2 (resolve SDKs): %w", err)
 				}
 			}
@@ -164,8 +165,10 @@ const emptyWorkspaceSetupHint = `  No workspace loaded here yet — nothing to m
 `
 
 // setupStepMigrate reports whether a migration was needed (and thus a fresh
-// session should resolve SDKs migration may have recorded by short name).
-func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (bool, error) {
+// session should resolve SDKs migration may have recorded by short name) and
+// the workspace-root-relative paths of the dagger.toml configs it wrote — the
+// exact set the SDK resolution pass must scope itself to.
+func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (bool, []string, error) {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "\nStep 2: Workspace migration")
 
@@ -175,18 +178,18 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 
 	changesID, err := changes.ID(ctx)
 	if err != nil {
-		return false, fmt.Errorf("compute migration: %w", err)
+		return false, nil, fmt.Errorf("compute migration: %w", err)
 	}
 	changes = dagger.Ref[*dagger.Changeset](dag, changesID)
 
 	isEmpty, err := changes.IsEmpty(ctx)
 	if err != nil {
-		return false, fmt.Errorf("check migration: %w", err)
+		return false, nil, fmt.Errorf("check migration: %w", err)
 	}
 	if isEmpty {
 		configFile, err := ws.ConfigFile(ctx)
 		if err != nil {
-			return false, fmt.Errorf("check workspace config: %w", err)
+			return false, nil, fmt.Errorf("check workspace config: %w", err)
 		}
 		if configFile == "" {
 			// Nothing to migrate and no workspace config yet — don't seed an empty
@@ -194,19 +197,53 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 			if !silent {
 				fmt.Fprint(out, emptyWorkspaceSetupHint)
 			}
-			return false, nil
+			return false, nil, nil
 		}
 		fmt.Fprintln(out, "  No migration needed.")
-		return false, nil
+		return false, nil, nil
+	}
+
+	configs, err := migratedConfigPaths(ctx, changes)
+	if err != nil {
+		return false, nil, err
 	}
 
 	// handleWorkspaceResponse owns the apply prompt via a huh form when
 	// autoApply is false — we don't run our own confirm() here, otherwise
 	// the user would face two prompts back-to-back for the same action.
-	if _, err := handleWorkspaceResponse(ctx, dag, ws.WithChanges(changes), autoApply); err != nil {
-		return false, err
+	applied, err := handleWorkspaceResponse(ctx, dag, ws.WithChanges(changes), autoApply)
+	if err != nil {
+		return false, nil, err
 	}
-	return true, nil
+	if !applied {
+		// The user declined: the legacy config is left in place, so there is
+		// nothing to resolve and the migrated config files were never written.
+		return false, nil, nil
+	}
+	return true, configs, nil
+}
+
+// migratedConfigPaths returns the workspace-root-relative paths of the
+// dagger.toml files the migration changeset creates or rewrites. Scoping SDK
+// resolution to exactly these files avoids touching pre-existing workspace
+// configs the migration deliberately left alone (it treats them as ownership
+// boundaries).
+func migratedConfigPaths(ctx context.Context, changes *dagger.Changeset) ([]string, error) {
+	added, err := changes.AddedPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+	modified, err := changes.ModifiedPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var configs []string
+	for _, p := range append(added, modified...) {
+		if filepath.Base(p) == workspace.ConfigFileName {
+			configs = append(configs, p)
+		}
+	}
+	return configs, nil
 }
 
 // setupResolveMigratedSDKs rewrites SDK installs that migration recorded by bare
@@ -215,7 +252,7 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 // being treated as a local path. Runs in a post-migration session where the
 // workspace is native; a no-op when nothing was recorded by short name (and
 // when the user declined migration, leaving the legacy config in place).
-func setupResolveMigratedSDKs(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) error {
+func setupResolveMigratedSDKs(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, migratedConfigs []string) error {
 	ws := dag.CurrentWorkspace()
 	raw, err := ws.ConfigRead(ctx)
 	if err != nil {
@@ -226,20 +263,74 @@ func setupResolveMigratedSDKs(ctx context.Context, cmd *cobra.Command, dag *dagg
 		return err
 	}
 
+	out := cmd.OutOrStdout()
+	fixes := planMigratedSDKFixups(cfg)
+	if len(fixes) > 0 {
+		updated := ws
+		for _, fix := range fixes {
+			updated = updated.
+				WithConfigValue("modules."+fix.ModuleName+".source", fix.Ref).
+				WithConfigValue("modules."+fix.ModuleName+".as-sdk.name", fix.SDKName)
+		}
+		if err := updated.Export(ctx); err != nil {
+			return err
+		}
+		for _, fix := range fixes {
+			fmt.Fprintf(out, "  Resolved SDK %q to %s\n", fix.SDKName, fix.Ref)
+		}
+	}
+
+	// Migration also writes SDK installs into workspace configs other than the
+	// top-level one it runs in — nested workspace plans and synthesized parents.
+	// The workspace API above only reaches the current workspace, so resolve the
+	// short-name installs those carry directly on disk. The changeset is already
+	// applied in this session, and the paths are scoped to exactly the configs
+	// migration wrote, so pre-existing workspaces are never touched.
+	root, err := currentWorkspaceExportPath(ctx, ws)
+	if err != nil {
+		return err
+	}
+	for _, rel := range migratedConfigs {
+		if filepath.Clean(rel) == workspace.ConfigFileName {
+			// The top-level config is handled through the workspace API above.
+			continue
+		}
+		if err := resolveMigratedSDKsInConfigFile(out, filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resolveMigratedSDKsInConfigFile(out io.Writer, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	cfg, err := workspace.ParseConfig(data)
+	if err != nil {
+		return err
+	}
 	fixes := planMigratedSDKFixups(cfg)
 	if len(fixes) == 0 {
 		return nil
 	}
-	updated := ws
 	for _, fix := range fixes {
-		updated = updated.
-			WithConfigValue("modules."+fix.ModuleName+".source", fix.Ref).
-			WithConfigValue("modules."+fix.ModuleName+".as-sdk.name", fix.SDKName)
+		entry := cfg.Modules[fix.ModuleName]
+		entry.Source = fix.Ref
+		if entry.AsSDK == nil {
+			entry.AsSDK = &workspace.ModuleAsSDK{}
+		}
+		entry.AsSDK.Name = fix.SDKName
+		cfg.Modules[fix.ModuleName] = entry
 	}
-	if err := updated.Export(ctx); err != nil {
+	updated, err := workspace.UpdateConfigBytes(data, cfg)
+	if err != nil {
 		return err
 	}
-	out := cmd.OutOrStdout()
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		return err
+	}
 	for _, fix := range fixes {
 		fmt.Fprintf(out, "  Resolved SDK %q to %s\n", fix.SDKName, fix.Ref)
 	}


### PR DESCRIPTION
`dagger setup` migration records builtin-SDK installs by bare short name (e.g. `source = "go"`), and a CLI pass then resolves them to real refs via `sdks.json` (the same resolution as `dagger sdk install go`). That pass only ran against the **top-level** workspace config — so the SDK installs migration wrote into the *other* configs it creates (nested workspace plans, and locally-referenced modules discovered under them, from #13620) kept a non-functional bare `source`.

This scopes resolution to exactly the `dagger.toml` files the migration changeset wrote and resolves each, reusing the existing generic fixup logic. Pre-existing workspace configs (the migration's ownership boundaries) are never touched, and a declined migration resolves nothing.

- `internal/cmd/dagger/setup.go` — scope SDK-install resolution to the changeset-written configs.
- `core/integration/workspace_migration_test.go` — +3 regression tests.

Verified: real before/after repro via engine-dev (the nested-config bare `source` now resolves after the fix); full `TestWorkspaceMigration` suite (37 tests, incl. the 3 new) passes; `core/workspace` + `internal/cmd/dagger` unit tests pass; build / gofmt / vet clean.
