### PR TITLE
core: sort fallback changeset paths to match the delta path

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -210,10 +210,17 @@ func computeChangesetPaths(ctx context.Context, beforeDir, afterDir string) (*Ch
 		renamedOld = append(renamedOld, oldPath)
 	}
 
+	// Sort to match computeChangesetPathsDelta: both paths must emit one
+	// canonical order, or which order a caller observes silently depends on
+	// whether the metadata delta walk succeeded on the underlying mounts.
 	allRemoved := slices.Concat(fc.Removed, renamedOld, removedDirs)
+	slices.Sort(allRemoved)
+	added := slices.Concat(fc.Added, renamedNew, addedDirs)
+	slices.Sort(added)
+	slices.Sort(fc.Modified)
 
 	return &ChangesetPaths{
-		Added:      slices.Concat(fc.Added, renamedNew, addedDirs),
+		Added:      added,
 		Modified:   fc.Modified,
 		Removed:    collapseChildPaths(allRemoved),
 		AllRemoved: allRemoved,

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -1078,7 +1078,7 @@ func (WorkspaceAPISuite) TestHostWorkspaceFunctionalOverlayAPIsChain(ctx context
 				}
 			}`,
 			variables:  map[string]any{"source": sourceID},
-			wantOutput: `{"currentWorkspace":{"withNewDirectory":{"changes":{"addedPaths":["dir/nested.txt","dir/"]}}}}`,
+			wantOutput: `{"currentWorkspace":{"withNewDirectory":{"changes":{"addedPaths":["dir/","dir/nested.txt"]}}}}`,
 		},
 		{
 			name: "withChanges",


### PR DESCRIPTION
## Problem

Since #13615, `Changeset` path computation has two implementations that emit **different orders** for the same changeset:

- `computeChangesetPathsDelta` (new, metadata-based) sorts its results: `slices.Sort(added)`, `slices.Sort(allRemoved)`, `slices.Sort(fc.Modified)`.
- `computeChangesetPaths` (the git-based fallback) never sorts: added paths come out as `concat(git-diff files, expanded renames, added dirs)`.

Which order a caller observes silently depends on whether the metadata delta walk succeeds on the underlying mounts — the fallback kicks in per `computePathsOnce`'s error path. Today `main` passes `TestWorkspaceAPI/TestHostWorkspaceFunctionalOverlayAPIsChain/withNewDirectory` only because that test happens to take the fallback (its expectation encodes the unsorted order `["dir/nested.txt","dir/"]`). In the merge ref of #13613, the same query resolves through the delta path and CI fails deterministically with the sorted order:

```
--- Expected
+++ Actual
-     (string) (len=14) "dir/nested.txt",
-     (string) (len=4) "dir/"
+     (string) (len=4) "dir/",
+     (string) (len=14) "dir/nested.txt"
```

There's also a latent flake in the fallback: when renames are present, `renamedNew`/`renamedOld` are collected from **map iteration**, so the unsorted fallback order was never fully deterministic to begin with.

## Fix

Mirror the delta path's sorting in the fallback so both implementations emit one canonical (lexicographic) order, and update the single exact-order expectation in the integration suite (`workspace_api_test.go`) to that order. Every other `addedPaths`/`removedPaths` assertion already uses `ElementsMatch`/`Contains`.

Found while investigating #13613's merge CI. cc @marcosnils (author of #13615) — flagging in case the delta/fallback split is expected to converge differently.

## Test plan

- `dagger call engine-dev test --pkg=./core/integration --run='^TestWorkspaceAPI$|^TestChangeset$'` green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
