### PR TITLE
core: order asSDK.modules leaf-first by dependencies

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -329,6 +329,100 @@ func (m *ClientGeneratorFixture) GenerateClients(ctx context.Context) (*dagger.C
 	require.Equal(t, ".\n\n", two)
 }
 
+// TestSDKGeneratorModulesLeafFirst verifies that currentModule.asSDK.modules is
+// returned leaf-first: a workspace-managed module's locally-managed
+// dependencies come before it, deduplicated, regardless of dagger.toml
+// declaration order. The SDK generator reads asSDK.modules and folds over it in
+// order, so the engine must pre-order the list — no SDK-side sort. Uses a
+// self-contained fixture SDK (no dependency on any production SDK's codegen).
+//
+// Graph (declared a,b,c,d; edges via dagger-module.toml dependencies):
+//
+//	a -> b, a -> c, b -> d, c -> d   (d is a shared diamond dependency)
+//
+// Expected leaf-first output: d, b, c, a (d emitted once, before b and c).
+func (GeneratorsSuite) TestSDKGeneratorModulesLeafFirst(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	managedModule := func(name string, deps ...string) string {
+		toml := "name = \"" + name + "\"\nengineVersion = \"latest\"\nsource = \".\"\n\n[runtime]\nsource = \"go\"\n"
+		for _, dep := range deps {
+			toml += "\n[[dependencies]]\nname = \"" + dep + "\"\nsource = \"../" + dep + "\"\n"
+		}
+		return toml
+	}
+
+	base := goGitBase(t, c).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", testCLIBinPath).
+		With(nonNestedDevEngine(c)).
+		// Declaration order is deliberately NOT leaf-first.
+		WithNewFile("dagger.toml", `[modules.order-fixture]
+source = ".dagger/order-fixture"
+
+[modules.order-fixture.as-sdk]
+name = "fixture"
+
+[[modules.order-fixture.as-sdk.modules]]
+path = ".dagger/modules/a"
+
+[[modules.order-fixture.as-sdk.modules]]
+path = ".dagger/modules/b"
+
+[[modules.order-fixture.as-sdk.modules]]
+path = ".dagger/modules/c"
+
+[[modules.order-fixture.as-sdk.modules]]
+path = ".dagger/modules/d"
+`).
+		WithNewFile(".dagger/modules/a/dagger-module.toml", managedModule("a", "b", "c")).
+		WithNewFile(".dagger/modules/b/dagger-module.toml", managedModule("b", "d")).
+		WithNewFile(".dagger/modules/c/dagger-module.toml", managedModule("c", "d")).
+		WithNewFile(".dagger/modules/d/dagger-module.toml", managedModule("d")).
+		WithNewFile(".dagger/order-fixture/dagger.json", `{
+  "name": "order-fixture",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`).
+		WithNewFile(".dagger/order-fixture/main.go", `package main
+
+import (
+	"context"
+	"strings"
+
+	"dagger/order-fixture/internal/dagger"
+)
+
+type OrderFixture struct{}
+
+// +generate
+func (m *OrderFixture) GenerateModules(ctx context.Context) (*dagger.Changeset, error) {
+	mods, err := dag.CurrentModule().AsSDK().Modules(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, len(mods))
+	for _, mod := range mods {
+		path, err := mod.Path(ctx)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, path)
+	}
+
+	generated := dag.Directory().WithNewFile("order.txt", strings.Join(paths, "\n")+"\n")
+	return generated.Changes(dag.Directory()), nil
+}
+`)
+
+	generated := base.With(daggerExec("generate", "-y"))
+
+	order, err := generated.File("order.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, ".dagger/modules/d\n.dagger/modules/b\n.dagger/modules/c\n.dagger/modules/a\n", order)
+}
+
 func (GeneratorsSuite) TestGeneratorGroupChangesSyncWithNestedSDKCodegen(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -3,8 +3,12 @@ package schema
 import (
 	"context"
 	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 )
@@ -51,8 +55,12 @@ func (s *moduleSchema) currentModuleAsSDK(
 	}
 
 	result := &core.CurrentModuleAsSDK{Name: sdkName}
-	for _, mod := range entry.AsSDK.Modules {
-		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{Path: mod.Path})
+	orderedModules, err := orderSDKManagedModules(ctx, ws, entry.AsSDK.Modules)
+	if err != nil {
+		return nil, err
+	}
+	for _, modPath := range orderedModules {
+		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{Path: modPath})
 	}
 	for _, client := range entry.AsSDK.Clients {
 		result.Clients = append(result.Clients, &core.CurrentModuleAsSDKClient{
@@ -85,6 +93,46 @@ func (s *moduleSchema) currentModuleAsSDKModules(
 	_ struct{},
 ) ([]*core.CurrentModuleAsSDKModule, error) {
 	return parent.Modules, nil
+}
+
+// orderSDKManagedModules returns the managed module paths ordered leaf-first —
+// a module's locally-managed dependencies before it — so SDK generators that
+// fold over asSDK.modules in list order regenerate dependencies first. It reads
+// each managed module's dagger-module.toml (workspace-root-relative) for its
+// dependency edges; a module whose config can't be read or parsed contributes
+// no edges (treated as a leaf) rather than failing generation for the whole
+// workspace — a genuinely broken config surfaces later at module load.
+func orderSDKManagedModules(
+	ctx context.Context,
+	ws *core.Workspace,
+	managed []workspace.SDKManagedModule,
+) ([]string, error) {
+	nodes := make([]workspace.SDKManagedModuleConfig, 0, len(managed))
+	for _, m := range managed {
+		nodes = append(nodes, workspace.SDKManagedModuleConfig{
+			Path:   m.Path,
+			Config: readManagedModuleConfig(ctx, ws, m.Path),
+		})
+	}
+	return workspace.OrderSDKModulesLeafFirst(nodes)
+}
+
+func readManagedModuleConfig(ctx context.Context, ws *core.Workspace, modPath string) *modules.ModuleConfig {
+	// Boundary guard: never read a config outside the workspace root, so an
+	// absolute or root-escaping managed path degrades to a leaf.
+	cleaned := path.Clean(filepath.ToSlash(modPath))
+	if path.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return nil
+	}
+	data, err := readWorkspaceFileBytes(ctx, ws, path.Join(modPath, modules.Filename))
+	if err != nil {
+		return nil
+	}
+	modCfg, err := modules.ParseModuleConfigForFilename(data, modules.Filename)
+	if err != nil {
+		return nil
+	}
+	return &modCfg.ModuleConfig
 }
 
 func (s *moduleSchema) currentModuleAsSDKClients(

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -100,32 +100,43 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	return readWorkspaceFileBytes(ctx, ws, configFile)
+}
+
+// readWorkspaceFileBytes reads a workspace-root-relative file across every
+// workspace source backing: an in-memory source directory, a host workspace
+// (with any pending overlay edit for that path taking precedence over the host
+// file), or a remote rootfs.
+func readWorkspaceFileBytes(ctx context.Context, ws *core.Workspace, relPath string) ([]byte, error) {
+	if ws == nil {
+		return nil, fmt.Errorf("workspace is required")
+	}
 
 	if rootfs, ok := ws.SourceDirectory(); ok && rootfs.Self() != nil {
-		data, err := core.DirectoryReadFile(ctx, rootfs, configFile)
+		data, err := core.DirectoryReadFile(ctx, rootfs, relPath)
 		if err != nil {
-			return nil, fmt.Errorf("reading config: %w", err)
+			return nil, fmt.Errorf("reading %s: %w", relPath, err)
 		}
 		return data, nil
 	}
 
 	if ws.HostPath() != "" {
-		// Host overlay edits to the config live only in the changeset's delta
-		// side (host overlays store no full read root — see overlayEdit);
-		// untouched configs read straight from the host file below.
-		if deltaRoot, ok := ws.OverlayDeltaRoot(); ok && ws.OverlayPathTouched(configFile) {
-			data, err := core.DirectoryReadFile(ctx, deltaRoot, configFile)
+		// Host overlay edits live only in the changeset's delta side (host
+		// overlays store no full read root — see overlayEdit); untouched files
+		// read straight from the host file below.
+		if deltaRoot, ok := ws.OverlayDeltaRoot(); ok && ws.OverlayPathTouched(relPath) {
+			data, err := core.DirectoryReadFile(ctx, deltaRoot, relPath)
 			if err != nil {
-				return nil, fmt.Errorf("reading config: %w", err)
+				return nil, fmt.Errorf("reading %s: %w", relPath, err)
 			}
 			return data, nil
 		}
 
-		ctx, err = withWorkspaceClientContext(ctx, ws)
+		ctx, err := withWorkspaceClientContext(ctx, ws)
 		if err != nil {
 			return nil, err
 		}
-		configPath, err := workspaceHostPath(ws, configFile)
+		hostPath, err := workspaceHostPath(ws, relPath)
 		if err != nil {
 			return nil, err
 		}
@@ -134,9 +145,9 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 			return nil, err
 		}
 
-		data, err := bk.ReadCallerHostFile(ctx, configPath)
+		data, err := bk.ReadCallerHostFile(ctx, hostPath)
 		if err != nil {
-			return nil, fmt.Errorf("reading config: %w", err)
+			return nil, fmt.Errorf("reading %s: %w", relPath, err)
 		}
 		return data, nil
 	}
@@ -145,9 +156,9 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 	if rootfs.Self() == nil {
 		return nil, fmt.Errorf("workspace has no host path or rootfs")
 	}
-	data, err := core.DirectoryReadFile(ctx, rootfs, configFile)
+	data, err := core.DirectoryReadFile(ctx, rootfs, relPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading config: %w", err)
+		return nil, fmt.Errorf("reading %s: %w", relPath, err)
 	}
 	return data, nil
 }

--- a/core/workspace/sdkorder.go
+++ b/core/workspace/sdkorder.go
@@ -1,0 +1,156 @@
+package workspace
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/core/modules"
+)
+
+// SDKManagedModuleConfig pairs a workspace-managed SDK module's workspace-root-
+// relative directory with its parsed module config. Config is nil when the
+// module has no readable/parseable dagger-module.toml yet, in which case the
+// module contributes no ordering edges (treated as a leaf).
+type SDKManagedModuleConfig struct {
+	Path   string
+	Config *modules.ModuleConfig
+}
+
+type sdkOrderNode struct {
+	origPath  string
+	canonPath string
+	cfg       *modules.ModuleConfig
+	deps      []int
+}
+
+// visitState tracks how far a module has got through the depth-first walk.
+type visitState int
+
+const (
+	unvisited visitState = iota
+	// visiting marks a module on the walk's current path. Reaching it again
+	// means the path looped back on itself: a dependency cycle.
+	visiting
+	// emitted marks a module already appended to the result. Reaching it again
+	// is a diamond (two modules sharing a dependency), which is expected — it
+	// stays emitted exactly once.
+	emitted
+)
+
+// OrderSDKModulesLeafFirst orders workspace-managed SDK module paths so that
+// every module's locally-managed dependencies precede it (leaf-first) and each
+// path appears exactly once. Only a dependency that resolves to another module
+// in the managed set creates an ordering edge; external (git/registry) refs,
+// absolute sources, and locals pointing outside the managed set are treated as
+// leaves. Declaration order breaks ties, so a list of independent modules — or
+// one already in a valid order — is returned unchanged. The returned strings are
+// the original authored paths (not canonicalized). It errors, naming the cycle,
+// when the managed modules form a dependency cycle.
+func OrderSDKModulesLeafFirst(mods []SDKManagedModuleConfig) ([]string, error) {
+	// Dedup managed modules by canonical path; first declaration wins.
+	index := make(map[string]int, len(mods))
+	nodes := make([]sdkOrderNode, 0, len(mods))
+	for _, m := range mods {
+		cp := canonicalWorkspacePath(m.Path)
+		if _, ok := index[cp]; ok {
+			continue
+		}
+		index[cp] = len(nodes)
+		nodes = append(nodes, sdkOrderNode{
+			origPath:  m.Path,
+			canonPath: cp,
+			cfg:       m.Config,
+		})
+	}
+
+	// Edges are restricted to the managed set: external (git/registry) refs,
+	// absolute sources, and locals resolving outside the set are leaves.
+	for i := range nodes {
+		cfg := nodes[i].cfg
+		if cfg == nil {
+			continue
+		}
+		seen := make(map[int]struct{})
+		for _, dep := range cfg.Dependencies {
+			if dep == nil || !IsLocalRef(dep.Source, dep.Pin) {
+				continue
+			}
+			// An absolute source is not workspace-relative; the loader rejects
+			// absolute local deps, so it never denotes a managed module here.
+			if path.IsAbs(filepath.ToSlash(dep.Source)) {
+				continue
+			}
+			depPath := canonicalWorkspacePath(path.Join(nodes[i].canonPath, filepath.ToSlash(dep.Source)))
+			depIdx, ok := index[depPath]
+			if !ok {
+				continue
+			}
+			if _, dup := seen[depIdx]; dup {
+				continue
+			}
+			// A self-edge is kept: a self-dependency is a degenerate cycle and
+			// is reported like any other by the DFS below.
+			seen[depIdx] = struct{}{}
+			nodes[i].deps = append(nodes[i].deps, depIdx)
+		}
+	}
+
+	// Depth-first, appending each module only after every dependency it reaches
+	// — which is exactly leaf-first.
+	state := make([]visitState, len(nodes))
+	result := make([]string, 0, len(nodes))
+	var curPath []int
+
+	var visit func(i int) error
+	visit = func(i int) error {
+		switch state[i] {
+		case emitted:
+			return nil
+		case visiting:
+			return sdkModuleCycleError(nodes, curPath, i)
+		case unvisited:
+		}
+		state[i] = visiting
+		curPath = append(curPath, i)
+		for _, dep := range nodes[i].deps {
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		curPath = curPath[:len(curPath)-1]
+		state[i] = emitted
+		result = append(result, nodes[i].origPath)
+		return nil
+	}
+
+	for i := range nodes {
+		if err := visit(i); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func canonicalWorkspacePath(p string) string {
+	if p == "" {
+		return "."
+	}
+	return path.Clean(filepath.ToSlash(p))
+}
+
+func sdkModuleCycleError(nodes []sdkOrderNode, curPath []int, repeated int) error {
+	cycle := make([]string, 0, len(curPath)+1)
+	started := false
+	for _, i := range curPath {
+		if i == repeated {
+			started = true
+		}
+		if started {
+			cycle = append(cycle, nodes[i].canonPath)
+		}
+	}
+	cycle = append(cycle, nodes[repeated].canonPath)
+	return fmt.Errorf("workspace SDK modules form a dependency cycle: %s", strings.Join(cycle, " -> "))
+}

--- a/core/workspace/sdkorder_test.go
+++ b/core/workspace/sdkorder_test.go
@@ -1,0 +1,171 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/core/modules"
+	"github.com/stretchr/testify/require"
+)
+
+func mod(path string, deps ...string) SDKManagedModuleConfig {
+	cfg := &modules.ModuleConfig{}
+	for _, src := range deps {
+		cfg.Dependencies = append(cfg.Dependencies, &modules.ModuleConfigDependency{
+			Name:   src,
+			Source: src,
+		})
+	}
+	return SDKManagedModuleConfig{Path: path, Config: cfg}
+}
+
+func TestOrderSDKModulesLeafFirst(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst(nil)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("single leaf, no deps", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{mod("a")})
+		require.NoError(t, err)
+		require.Equal(t, []string{"a"}, got)
+	})
+
+	t.Run("linear chain c->b->a is emitted a,b,c", func(t *testing.T) {
+		// declaration order deliberately reversed to prove reordering happens
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/c", "../b"),
+			mod("mods/b", "../a"),
+			mod("mods/a"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"mods/a", "mods/b", "mods/c"}, got)
+	})
+
+	t.Run("diamond emits shared dep once, before both dependents", func(t *testing.T) {
+		// a->b, a->c, b->d, c->d (siblings under mods/, referenced via ../)
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/a", "../b", "../c"),
+			mod("mods/b", "../d"),
+			mod("mods/c", "../d"),
+			mod("mods/d"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"mods/d", "mods/b", "mods/c", "mods/a"}, got)
+		require.Len(t, got, 4, "shared dep d appears exactly once")
+	})
+
+	t.Run("independent roots keep declaration order", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("z"), mod("y"), mod("x"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"z", "y", "x"}, got)
+	})
+
+	t.Run("already-valid order returned unchanged", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/a"),
+			mod("mods/b", "../a"),
+			mod("mods/c", "../b"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"mods/a", "mods/b", "mods/c"}, got)
+	})
+
+	t.Run("remote and pinned deps are external leaves (no edge)", func(t *testing.T) {
+		cfg := &modules.ModuleConfig{Dependencies: []*modules.ModuleConfigDependency{
+			{Name: "remote", Source: "github.com/acme/dep@main"},
+			{Name: "pinned", Source: "b", Pin: "sha256:abc"},
+		}}
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			{Path: "a", Config: cfg},
+			mod("b"),
+		})
+		require.NoError(t, err)
+		// no a->b edge from a pinned local-looking source; declaration order kept
+		require.Equal(t, []string{"a", "b"}, got)
+	})
+
+	t.Run("local dep outside managed set is a leaf (no edge)", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("a", "../unmanaged"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"a"}, got)
+	})
+
+	t.Run("../ dep inside managed set creates an edge", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/b", "../a"),
+			mod("mods/a"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"mods/a", "mods/b"}, got)
+	})
+
+	t.Run("dep escaping the root is a leaf (no edge)", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("a", "../../x"),
+			mod("x"),
+		})
+		require.NoError(t, err)
+		// a's ../../x resolves to ../x, above the root, never matching managed "x"
+		require.Equal(t, []string{"a", "x"}, got)
+	})
+
+	t.Run("absolute dep source is ignored (no edge)", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("b", "/a"),
+			mod("a"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"b", "a"}, got)
+	})
+
+	t.Run("self-reference is reported as a cycle", func(t *testing.T) {
+		_, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("a", "."),
+		})
+		require.ErrorContains(t, err, "dependency cycle")
+	})
+
+	t.Run("duplicate paths with different spelling collapse to one", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/a"),
+			mod("./mods/a"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"mods/a"}, got)
+	})
+
+	t.Run("nil config is a leaf; dependents still ordered after it", func(t *testing.T) {
+		got, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/b", "../a"),
+			{Path: "mods/a", Config: nil},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"mods/a", "mods/b"}, got)
+	})
+
+	t.Run("direct cycle errors and names the members", func(t *testing.T) {
+		_, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/a", "../b"),
+			mod("mods/b", "../a"),
+		})
+		require.ErrorContains(t, err, "dependency cycle")
+		require.ErrorContains(t, err, "mods/a")
+		require.ErrorContains(t, err, "mods/b")
+	})
+
+	t.Run("longer cycle errors", func(t *testing.T) {
+		_, err := OrderSDKModulesLeafFirst([]SDKManagedModuleConfig{
+			mod("mods/a", "../b"),
+			mod("mods/b", "../c"),
+			mod("mods/c", "../a"),
+		})
+		require.ErrorContains(t, err, "dependency cycle")
+	})
+}

--- a/hack/designs/assdk-leaf-first-ordering.md
+++ b/hack/designs/assdk-leaf-first-ordering.md
@@ -1,0 +1,149 @@
+# `currentModule.asSDK.modules` — leaf-first dependency ordering
+
+## Problem
+
+SDK code generation over a workspace with many locally-managed modules runs
+"generate all" by iterating `currentModule.asSDK.modules`. Today that field is a
+pure pass-through of the `[[modules.<sdk>.as-sdk.modules]]` list in whatever
+order `dagger.toml` stores it — zero dependency awareness. When module C depends
+on module B depends on module A, generating in declaration order can regenerate
+C against a stale B. Order must be **leaf-first**: a module's locally-managed
+dependencies must be generated before it.
+
+The SDK generator (`dagger/go-sdk`'s `go-sdk.dang` `generateAll`) just folds over
+`currentModule.asSDK.modules` in list order:
+
+```
+currentModule.asSDK.modules
+  .map { m => Mod(path: m.path, ...) }
+  .filter { mod => mod.skipGenerate(ws) == false }
+  .reduce(pws.fork) { fork, mod => fork.merge(pws.moduleSource("/" + mod.path).generate) }
+```
+
+No SDK-side sorting. So the fix is entirely engine-side: return the list already
+ordered leaf-first. **Zero SDK changes** (confirmed against `go-sdk.dang`).
+
+## Approach
+
+Order the list once, where it is built, in `currentModuleAsSDK`
+(`core/schema/module_as_sdk.go`). `currentModuleAsSDKModules` stays a pure
+pass-through — the ordering is baked into the persisted `CurrentModuleAsSDK`
+object, computed once per `asSDK` resolution (the field is `DoNotCache`; it is
+queried once per generate-all, so N small toml reads once is fine).
+
+### Dependency source
+
+Each managed module's directory (`SDKManagedModule.Path`, **workspace-root**-
+relative — per its doc comment and the go-sdk consumer `moduleSource("/" +
+mod.path)`; *not* config-dir-relative) contains `dagger-module.toml`. Its
+`[[dependencies]]` list (`modules.ModuleConfigDependency`) carries the edges.
+Only current-schema **dependencies** are modeled — toolchains/blueprint are
+legacy `dagger.json` concepts not persisted in current `dagger-module.toml`, and
+`LocalModuleRefs` includes them only for migration. Only **local** deps
+(`workspace.IsLocalRef(dep.Source, dep.Pin)`) can point at another
+workspace-managed module; git/registry deps are external and already resolved
+independently — treat as leaves (no edge).
+
+A local dep's `Source` is relative to the referring module's config-file dir
+(= its `Path`). **Absolute** sources are rejected before joining (mirroring the
+loader's `ResolveDepToSource`, which rejects absolute local deps) — no edge.
+Otherwise resolve to a workspace-root-relative path
+`clean(join(m.Path, dep.Source))`, then match against the set of managed module
+`Path`s (both canonicalized with `path.Clean(filepath.ToSlash(...))`). A match
+is an ordering edge `m -> dep`; a local dep resolving outside the managed set
+(e.g. via `..` escaping the root) is an external leaf (no edge). A dep resolving
+to the module itself (self-ref) is skipped — no edge, not a reported cycle.
+
+Both the file-read path (`join(m.Path, dagger-module.toml)`) and the edge
+resolution use the workspace root as the base; `readWorkspaceFileBytes` reads
+relative to the workspace source root (`ws.HostPath()` / SourceDirectory root),
+exactly as `readConfigBytes` reads root-relative `ws.ConfigFile` today. Config
+dir is **not** prepended.
+
+### Where the tree is built
+
+- **`core/workspace/sdkorder.go`** (new, pure, unit-tested): `OrderSDKModulesLeafFirst([]SDKManagedModuleDeps) ([]string, error)`. Takes managed modules paired with their parsed `*modules.ModuleConfig` (nil = treat as leaf). Builds edges restricted to the managed set, returns the **original** path strings in leaf-first, deduplicated order. No filesystem access — fully testable.
+- **`core/schema/module_as_sdk.go`**: reads each managed module's `dagger-module.toml` (via a new package-level `readWorkspaceFileBytes`, extracted from `readConfigBytes` so both share the SourceDirectory / host-overlay / host-path / rootfs read paths), parses with `modules.ParseModuleConfigForFilename`, calls the pure orderer.
+- **`core/schema/workspace_config.go`**: factor `readConfigBytes` → `readWorkspaceFileBytes(ctx, ws, relPath)`.
+
+### Topological sort
+
+DFS post-order with white/grey/black coloring:
+
+- Dedup managed paths by canonical form, **first declaration wins**.
+- Edges = local deps resolving into the managed set, in declaration order.
+- Visit roots in **declaration order**; visit each node's deps in declaration
+  order; append the node *after* its deps (post-order ⇒ leaf-first).
+- Grey node re-encountered ⇒ cycle. Black ⇒ already emitted, skip (dedup +
+  diamonds handled: a shared dep is emitted once, before both dependents).
+
+Declaration-order tie-breaking means a list of independent modules (or an
+already-correct list) comes back unchanged — minimal churn. Module counts are
+small (tens), so recursion depth is a non-issue.
+
+```mermaid
+graph TD
+  C[moduleC] --> B[moduleB] --> A[moduleA]
+  C --> D[moduleD]
+  B --> D
+  %% leaf-first output: A, D, B, C  (D shared, emitted once before B and C)
+```
+
+### Cycle handling — **error, don't fall back**
+
+A dependency cycle between two locally-managed modules is a malformed workspace.
+Decision: **fail with a clear, actionable error naming the cycle**
+(`workspace SDK modules form a dependency cycle: b -> c -> b`). Reasoning:
+
+- Leaf-first ordering is only meaningful on a DAG; any emitted order for a cycle
+  is arbitrary and wrong.
+- Module dependency cycles are rejected by the engine's module loader anyway, so
+  generation already fails today for a real cycle — erroring here just surfaces
+  it earlier, at generate time, with the exact module names, instead of a
+  cryptic load-time failure. **No working scenario regresses.**
+
+The coloring guarantees no infinite loop / crash regardless.
+
+### Unreadable / unparseable module config → leaf (degrade, don't fail)
+
+If a managed module's `dagger-module.toml` can't be read or parsed (missing,
+mid-creation, version-skewed), that module contributes **no edges** (Config=nil,
+treated as leaf). A genuinely broken config surfaces later at module load;
+failing the whole generate here over one unreadable module would be a worse UX
+and a regression. Ordering is a best-effort enhancement — missing info degrades
+to "no reorder for that module", never to a hard failure.
+
+### Version gating — **no new gate**
+
+The whole `asSDK` surface is already `View(AfterVersion("v1.0.0-0"))`-gated
+(`core/schema/module.go:393-416`) and is unreleased v1 prerelease API. This
+change alters only the **runtime ordering** of an existing list field — not its
+type, shape, or schema definition. Ordering was never documented or guaranteed,
+so tightening an unspecified order to a specified one is inherently
+backward-compatible; nothing could depend on the old arbitrary order. No schema
+surface is added, so `TestBaseSchemaAllowlist` is unaffected. **No new
+`View(...)` gate needed.**
+
+## Files
+
+| File | Change |
+|------|--------|
+| `core/workspace/sdkorder.go` | new: pure `OrderSDKModulesLeafFirst` + cycle error |
+| `core/workspace/sdkorder_test.go` | new: chain, diamond, cycle, external/non-local deps, no-deps, empty, dedup, order-preservation |
+| `core/schema/module_as_sdk.go` | order the list in `currentModuleAsSDK`; read+parse each managed toml |
+| `core/schema/workspace_config.go` | extract `readWorkspaceFileBytes` from `readConfigBytes` |
+
+## Verification
+
+- Unit: `go test ./core/workspace/ -run SDKModules`. Shapes: chain, diamond
+  (shared dep emitted once, before both dependents), multiple independent roots
+  (declaration order preserved), zero-dep module, empty list, duplicate paths
+  with different spelling (`mods/a` vs `./mods/a`), `../a` dep inside the managed
+  set, `../../a` dep escaping the root (no edge), absolute dep source (no edge),
+  self-ref dep (no edge, no false cycle), a real cycle (errors, names it), and
+  nil/unparseable config in a dependent chain (degrades deterministically to a
+  leaf).
+- E2E (dev engine): workspace with a Go SDK managing A←B←C plus a diamond
+  (B,C both →D); assert `currentModule.asSDK.modules` returns leaf-first,
+  deduplicated; run `dagger generate` and confirm correct order with **zero**
+  edits to a `dagger/go-sdk` checkout. Cycle fixture ⇒ clear error.


### PR DESCRIPTION
Makes the engine return `currentModule.asSDK.modules` in **leaf-first dependency order** — a workspace-managed module's locally-managed dependencies come before it — instead of raw `dagger.toml` declaration order.

**Motivation:** SDK code generation over a workspace with many modules (e.g. right after `dagger setup`) currently generates them in declaration order, which breaks when modules depend on each other. SDK generators (`dagger/go-sdk`'s `generateAll`) just fold over this list in order, so the fix is **engine-side only — zero SDK changes** (verified against `go-sdk.dang`).

- Ordering is computed once in `currentModuleAsSDK` (`core/schema/module_as_sdk.go`), reading each managed module's `dagger-module.toml` for its `[[dependencies]]`; `currentModuleAsSDKModules` stays a pass-through.
- The graph algorithm is a pure, unit-tested `OrderSDKModulesLeafFirst` (`core/workspace/sdkorder.go`): depth-first post-order, dedup by canonical path, edges restricted to the managed set (git/registry, absolute, and out-of-set refs are external leaves).
- A real dependency **cycle errors** naming the cycle rather than emitting an arbitrary order — the module loader rejects cycles anyway, so nothing that works today regresses.
- An unreadable/unparseable managed config degrades to a leaf (no edges) rather than failing generation workspace-wide.
- **No new version gate:** only the runtime *ordering* of an existing list field changes, not its type/shape; the `asSDK` surface is already `View(AfterVersion("v1.0.0-0"))`-gated.

Design note: `hack/designs/assdk-leaf-first-ordering.md`.

## Verification

- `go build` / `go vet` / `gofmt` + `go test ./core/workspace/ ./core/schema/` green; staticcheck U1000 clean.
- e2e (`TestGenerators/TestSDKGeneratorModulesLeafFirst`): a diamond `a → {b, c} → d` on the real Go SDK runtime returns exactly `d, b, c, a`.

_No changelog entry: `asSDK` is unreleased v1-prerelease API, so a changie entry for an unshipped surface would be noise — happy to add one if a reviewer prefers._
