### PR TITLE
fix(core): surface underlying exec error when merging generator changesets

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -431,8 +431,17 @@ var (
 	_ dagql.HasDependencyResults   = (*Changeset)(nil)
 )
 
-func (ch *Changeset) Evaluate(context.Context) error {
-	return nil
+// Evaluate forces the changeset's before/after directories to materialize. This
+// is where a generator's underlying exec (e.g. SDK codegen) actually runs, so
+// syncing a changeset within a generator's span attributes any failure to that
+// span -- the frontend then renders a red generator with its exec logs, instead
+// of the failure surfacing later, unattributed, during the merge.
+func (ch *Changeset) Evaluate(ctx context.Context) error {
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return err
+	}
+	return cache.Evaluate(ctx, ch.Before, ch.After)
 }
 
 func (ch *Changeset) Sync(ctx context.Context) error {

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -125,6 +125,32 @@ func (GeneratorsSuite) TestGeneratorsDirectSDK(ctx context.Context, t *testctx.T
 	}
 }
 
+// A generator whose changeset evaluates lazily and whose backing exec fails must
+// surface that failure -- the command, its stderr, and its exit code -- to the
+// user of `dagger generate`, rather than a bare "exit code: N" with the detail
+// hidden. The failing exec is now forced inside the generator's span (see
+// ModTreeNode.runGeneratorLocally), so the run fails there. Regression for
+// #13606; the rendered-attribution half (a red generator row) is pinned by the
+// generate-fail golden in dagql/idtui.
+func (GeneratorsSuite) TestGeneratorLazyExecFailureSurfacesStderr(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen, err := generatorsTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-generators")
+
+	out, err := modGen.
+		WithExec([]string{"dagger", "generate", "lazy-exec-failure", "-y", "--progress=plain"}, dagger.ContainerWithExecOpts{
+			Expect:                        dagger.ReturnTypeAny,
+			ExperimentalPrivilegedNesting: true,
+		}).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "STDERR_ONLY_MARKER") // stderr surfaced
+	require.Contains(t, out, "exit code: 3")       // exit code surfaced
+	require.Contains(t, out, "sh -c")              // failed command surfaced
+}
+
 func (GeneratorsSuite) TestGeneratorsViaLegacyBlueprintConfig(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	for _, tc := range []struct {

--- a/core/integration/testdata/generators/hello-with-generators/main.go
+++ b/core/integration/testdata/generators/hello-with-generators/main.go
@@ -37,6 +37,21 @@ func (m *HelloWithGenerators) ChangesetFailure() (*dagger.Changeset, error) {
 	return nil, errors.New("could not generate the changeset")
 }
 
+// Return a changeset whose evaluation fails lazily: the function succeeds, but
+// the exec backing the changeset only runs (and fails) when the changeset is
+// merged/forced during `dagger generate`. The stderr marker is passed via an
+// env var so it does NOT appear in the command text — the test can then prove
+// the message surfaces stderr specifically, not just the failed command.
+// +generate
+func (m *HelloWithGenerators) LazyExecFailure() *dagger.Changeset {
+	failed := dag.Container().
+		From("alpine").
+		WithEnvVariable("MARKER", "STDERR_ONLY_MARKER").
+		WithExec([]string{"sh", "-c", "echo $MARKER >&2; exit 3"}).
+		Directory("/")
+	return failed.Changes(dag.Directory())
+}
+
 func (m *HelloWithGenerators) WorkspaceGeneratorsEmpty(ctx context.Context, ws *dagger.Workspace) (bool, error) {
 	generated := ws.Generators(dagger.WorkspaceGeneratorsOpts{
 		Include: []string{"toolchain-generators:*"},

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -499,6 +499,13 @@ func (node *ModTreeNode) runGeneratorLocally(ctx context.Context) (dagql.ObjectR
 	if err := node.DagqlValue(ctx, &changes); err != nil {
 		return dagql.ObjectResult[*Changeset]{}, err
 	}
+	// DagqlValue only grabs the lazy Changeset; force it here, inside the
+	// generator's span, so the underlying exec runs (and any failure attributes)
+	// here rather than later during the merge. Generators already run in
+	// parallel and the changeset must sync eventually, so nothing is lost.
+	if err := changes.Self().Sync(ctx); err != nil {
+		return dagql.ObjectResult[*Changeset]{}, err
+	}
 	return changes, nil
 }
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -4545,8 +4545,11 @@ func (fe *frontendPretty) renderRowContentRest(ctx tuist.Context, out TermOutput
 				unindent := *row
 				unindent.Depth = -1
 				fe.renderLogs(out, r, &unindent, logs, logs.UsedHeight(), prefix, false)
-			} else if row.Span.RollUpLogs && row.IsRunningOrChildRunning {
-				// Only show rolled-up logs while the span is running.
+			} else if row.Span.RollUpLogs && (row.IsRunningOrChildRunning || row.Span.IsFailedOrCausedFailure()) {
+				// Show rolled-up logs while the span is running, and keep them on
+				// failure so the reason survives in the final report -- otherwise a
+				// failed rolled-up span (e.g. a generator whose exec failed)
+				// collapses to a bare status with its stderr hidden.
 				fe.renderStepLogs(ctx, out, r, row, prefix, focused)
 			}
 		}

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -157,6 +157,11 @@ entrypoint = true
 		{Function: "revealed-spans"},
 		{Function: "partial-progress"},
 
+		// a generator whose changeset fails lazily during `dagger generate`'s
+		// merge must surface the underlying exec error -- the failed command and
+		// its stderr -- not a bare "exit code: N" (dagger/dagger#13606).
+		{Name: "generate-fail", Function: "generate-fail", Generate: true, Fail: true},
+
 		{Function: "git-readme", Args: []string{
 			"--remote", "https://github.com/dagger/dagger",
 			"--version", "v0.18.6",
@@ -327,6 +332,7 @@ type Example struct {
 	Function string
 	Args     []string
 	Check    bool
+	Generate bool
 	// verbosities 3 and higher do not work well with golden, they're not very deterministic atm
 	Verbosity int
 	Fail      bool
@@ -356,12 +362,18 @@ func (ex Example) Run(ctx context.Context, t *testctx.T, s TelemetrySuite) (stri
 	}
 
 	var daggerArgs []string
-	if ex.Check {
+	switch {
+	case ex.Check:
 		daggerArgs = []string{"--progress=report", "-v", "--workdir", ex.Module, "check"}
 		if ex.Function != "" {
 			daggerArgs = append(daggerArgs, ex.Function)
 		}
-	} else {
+	case ex.Generate:
+		daggerArgs = []string{"--progress=report", "-v", "--workdir", ex.Module, "generate", "-y"}
+		if ex.Function != "" {
+			daggerArgs = append(daggerArgs, ex.Function)
+		}
+	default:
 		daggerArgs = []string{"--progress=report", "-v", "call", "-m", ex.Module, ex.Function}
 	}
 	daggerArgs = append(daggerArgs, ex.Args...)

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/generate-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/generate-fail
@@ -1,0 +1,5 @@
+Expected stderr:
+
+✘ viztest:generate-fail X.Xs ⡀⡄⡆⡇⣇⣧⣷⣿ ERROR
+┃ boom
+! exit code: 3

--- a/dagql/idtui/viztest/dagger.gen.go
+++ b/dagql/idtui/viztest/dagger.gen.go
@@ -421,6 +421,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				}
 			}
 			return nil, (*Viztest).FailSlow(&parent, ctx, after)
+		case "GenerateFail":
+			var parent Viztest
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Viztest).GenerateFail(&parent), nil
 		case "GitReadme":
 			var parent Viztest
 			err = json.Unmarshal(parentJSON, &parent)
@@ -805,33 +812,33 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							dag.TypeDef().WithObject("Container")).
 							WithDescription("Accounting returns a container that sleeps for 1 second and then sleeps for\n2 seconds.\n\nIt can be used to test UI cues for tracking down the place where a slow\noperation is configured, which is more interesting than the place where it\nis un-lazied when you're trying to figure out where to optimize.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 424, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 437, 1))).
 					WithFunction(
 						dag.Function("Add",
 							dag.TypeDef().WithObject("Viztest")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 441, 1)).
-							WithArg("diff", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 444, 2), DefaultValue: dagger.JSON("1")})).
+							WithSourceMap(dag.SourceMap("main.go", 454, 1)).
+							WithArg("diff", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 457, 2), DefaultValue: dagger.JSON("1")})).
 					WithFunction(
 						dag.Function("CachedExecService",
 							dag.TypeDef().WithObject("Service")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 501, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 514, 1))).
 					WithFunction(
 						dag.Function("CachedExecs",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 515, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 528, 1))).
 					WithFunction(
 						dag.Function("CallBubblingDep",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 779, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 792, 1))).
 					WithFunction(
 						dag.Function("CallFailingDep",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 774, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 787, 1))).
 					WithFunction(
 						dag.Function("Changeset",
 							dag.TypeDef().WithObject("Changeset")).
@@ -841,55 +848,55 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("Colors16",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 610, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 623, 1))).
 					WithFunction(
 						dag.Function("Colors256",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 626, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 639, 1))).
 					WithFunction(
 						dag.Function("CountFiles",
 							dag.TypeDef().WithObject("Viztest")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 451, 1)).
-							WithArg("dir", dag.TypeDef().WithObject("Directory"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 451, 50)})).
+							WithSourceMap(dag.SourceMap("main.go", 464, 1)).
+							WithArg("dir", dag.TypeDef().WithObject("Directory"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 464, 50)})).
 					WithFunction(
 						dag.Function("CustomSpan",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 278, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 291, 1))).
 					WithFunction(
 						dag.Function("DeepSleep",
 							dag.TypeDef().WithObject("Container")).
 							WithDescription("DeepSleep sleeps forever.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 434, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 447, 1))).
 					WithFunction(
 						dag.Function("DiskMetrics",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 687, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 700, 1))).
 					WithFunction(
 						dag.Function("DockerBuild",
 							dag.TypeDef().WithObject("Container")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 653, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 666, 1))).
 					WithFunction(
 						dag.Function("DockerBuildCached",
 							dag.TypeDef().WithObject("Container")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 643, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 656, 1))).
 					WithFunction(
 						dag.Function("DockerBuildFail",
 							dag.TypeDef().WithObject("Container")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 665, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 678, 1))).
 					WithFunction(
 						dag.Function("Echo",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 393, 1)).
-							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 393, 43)})).
+							WithSourceMap(dag.SourceMap("main.go", 406, 1)).
+							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 406, 43)})).
 					WithFunction(
 						dag.Function("Encapsulate",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
@@ -900,7 +907,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("ExecService",
 							dag.TypeDef().WithObject("Service")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 539, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 552, 1))).
 					WithFunction(
 						dag.Function("FailEffect",
 							dag.TypeDef().WithObject("Container")).
@@ -918,13 +925,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("FailLog runs a container that logs a message and then fails.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 467, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 480, 1))).
 					WithFunction(
 						dag.Function("FailLogNative",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("FailLogNative prints a message and then returns an error.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 478, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 491, 1))).
 					WithFunction(
 						dag.Function("FailMulti",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
@@ -936,22 +943,28 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("FailSlow fails after waiting for a certain amount of time.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 486, 1)).
-							WithArg("after", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 489, 2), DefaultValue: dagger.JSON("\"10\"")})).
+							WithSourceMap(dag.SourceMap("main.go", 499, 1)).
+							WithArg("after", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 502, 2), DefaultValue: dagger.JSON("\"10\"")})).
+					WithFunction(
+						dag.Function("GenerateFail",
+							dag.TypeDef().WithObject("Changeset")).
+							WithDescription("GenerateFail is a generator whose changeset only evaluates -- and fails -- when\nit is forced during `dagger generate`'s merge. It exercises exec-error\nsurfacing: the reported error must name the failed command and its stderr, not\na bare \"exit code: N\". See dagger/dagger#13606.").
+							WithSourceMap(dag.SourceMap("main.go", 189, 1)).
+							WithGenerator()).
 					WithFunction(
 						dag.Function("GitReadme",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 704, 1)).
-							WithArg("remote", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 704, 48)}).
-							WithArg("version", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 704, 63)})).
+							WithSourceMap(dag.SourceMap("main.go", 717, 1)).
+							WithArg("remote", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 717, 48)}).
+							WithArg("version", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 717, 63)})).
 					WithFunction(
 						dag.Function("HTTPReadme",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 711, 1)).
-							WithArg("remote", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 711, 49)}).
-							WithArg("version", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 711, 64)})).
+							WithSourceMap(dag.SourceMap("main.go", 724, 1)).
+							WithArg("remote", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 724, 49)}).
+							WithArg("version", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 724, 64)})).
 					WithFunction(
 						dag.Function("HelloWorld",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
@@ -962,13 +975,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("List",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 695, 1)).
-							WithArg("dir", dag.TypeDef().WithObject("Directory"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 695, 43)})).
+							WithSourceMap(dag.SourceMap("main.go", 708, 1)).
+							WithArg("dir", dag.TypeDef().WithObject("Directory"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 708, 43)})).
 					WithFunction(
 						dag.Function("LogStderr",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 461, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 474, 1))).
 					WithFunction(
 						dag.Function("LogStdout",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
@@ -978,88 +991,88 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("LogWithChildren",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 806, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 819, 1))).
 					WithFunction(
 						dag.Function("ManyLines",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 194, 1)).
-							WithArg("n", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 194, 27)})).
+							WithSourceMap(dag.SourceMap("main.go", 207, 1)).
+							WithArg("n", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 207, 27)})).
 					WithFunction(
 						dag.Function("ManySpans",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 327, 1)).
-							WithArg("n", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 329, 2)}).
-							WithArg("delayMs", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 331, 2), DefaultValue: dagger.JSON("0")})).
+							WithSourceMap(dag.SourceMap("main.go", 340, 1)).
+							WithArg("n", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 342, 2)}).
+							WithArg("delayMs", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 344, 2), DefaultValue: dagger.JSON("0")})).
 					WithFunction(
 						dag.Function("ModuleTypeReturnFail",
 							dag.TypeDef().WithObject("ModuleTypeReturn")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 676, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 689, 1))).
 					WithFunction(
 						dag.Function("NestedCalls",
 							dag.TypeDef().WithListOf(dag.TypeDef().WithKind(dagger.TypeDefKindStringKind))).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 742, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 755, 1))).
 					WithFunction(
 						dag.Function("NoExecService",
 							dag.TypeDef().WithObject("Service")).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 580, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 593, 1))).
 					WithFunction(
 						dag.Function("ObjectLists",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 729, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 742, 1))).
 					WithFunction(
 						dag.Function("PartialProgress",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("PartialProgress emits synthetic streaming-progress log records (the\ndagger.io/progress.* convention) with hard-coded values that never reach\ncompletion, so the final frame deterministically renders partially filled\nbraille bars: complete, in-flight at various fractions, untouched, and\nindeterminate (unknown total). A child span overflows the per-row item\ncap to exercise +N truncation.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 207, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 220, 1))).
 					WithFunction(
 						dag.Function("PathArgs",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 761, 1)).
-							WithArg("file", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 763, 2)}).
-							WithArg("dir", dag.TypeDef().WithObject("Directory"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 764, 2)}).
-							WithArg("contextFile", dag.TypeDef().WithObject("File").WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 766, 2), DefaultPath: "main.go"}).
-							WithArg("contextDir", dag.TypeDef().WithObject("Directory").WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 768, 2), DefaultPath: "."})).
+							WithSourceMap(dag.SourceMap("main.go", 774, 1)).
+							WithArg("file", dag.TypeDef().WithObject("File"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 776, 2)}).
+							WithArg("dir", dag.TypeDef().WithObject("Directory"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 777, 2)}).
+							WithArg("contextFile", dag.TypeDef().WithObject("File").WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 779, 2), DefaultPath: "main.go"}).
+							WithArg("contextDir", dag.TypeDef().WithObject("Directory").WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 781, 2), DefaultPath: "."})).
 					WithFunction(
 						dag.Function("Pending",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 598, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 611, 1))).
 					WithFunction(
 						dag.Function("PrimaryLines",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 185, 1)).
-							WithArg("n", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 185, 30)})).
+							WithSourceMap(dag.SourceMap("main.go", 198, 1)).
+							WithArg("n", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 198, 30)})).
 					WithFunction(
 						dag.Function("RevealAndLog",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 314, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 327, 1))).
 					WithFunction(
 						dag.Function("RevealedSpans",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 285, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 298, 1))).
 					WithFunction(
 						dag.Function("SameDiffClients",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 410, 1)).
-							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 410, 54)})).
+							WithSourceMap(dag.SourceMap("main.go", 423, 1)).
+							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 423, 54)})).
 					WithFunction(
 						dag.Function("ServiceErrorAttribution",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("ServiceErrorAttribution binds a container to a service that logs and then\nexits non-zero, exercising service-exit failure attribution back to the\n.asService call that returned it.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 563, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 576, 1))).
 					WithFunction(
 						dag.Function("Spam",
 							dag.TypeDef().WithObject("Container")).
@@ -1071,17 +1084,17 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("Continuously prints batches of logs on an interval (default 1 per second).").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 368, 1)).
-							WithArg("batchSize", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 372, 2), DefaultValue: dagger.JSON("1")}).
-							WithArg("delayMs", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 375, 2), DefaultValue: dagger.JSON("1000")})).
+							WithSourceMap(dag.SourceMap("main.go", 381, 1)).
+							WithArg("batchSize", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 385, 2), DefaultValue: dagger.JSON("1")}).
+							WithArg("delayMs", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 388, 2), DefaultValue: dagger.JSON("1000")})).
 					WithFunction(
 						dag.Function("StreamingLogs",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("Continuously prints batches of logs on an interval (default 1 per second).").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 342, 1)).
-							WithArg("batchSize", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 346, 2), DefaultValue: dagger.JSON("1")}).
-							WithArg("delayMs", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 349, 2), DefaultValue: dagger.JSON("1000")})).
+							WithSourceMap(dag.SourceMap("main.go", 355, 1)).
+							WithArg("batchSize", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 359, 2), DefaultValue: dagger.JSON("1")}).
+							WithArg("delayMs", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 362, 2), DefaultValue: dagger.JSON("1000")})).
 					WithFunction(
 						dag.Function("Terminal",
 							dag.TypeDef().WithObject("Container")).
@@ -1098,39 +1111,39 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 						dag.Function("TraceFunctionCalls",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 784, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 797, 1))).
 					WithFunction(
 						dag.Function("TraceRemoteFunctionCalls",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 800, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 813, 1))).
 					WithFunction(
 						dag.Function("TransientProgress",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("TransientProgress runs a long-lived \"syncing layers\" span (collapsed by\ndefault, so its descendants' progress rolls up onto its row) containing\na storm of transfers that complete instantly and one that stays in\nflight. Exercises the roll-up's quick-transfer fold: the quick ones\nnever earn a live row and merge into one summary line in the final\nreport (\"1 transfer, 3 fetches ...\"), while the in-flight transfer\nappears live once it's been active past the threshold and keeps its own\nrow in the report.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 251, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 264, 1))).
 					WithFunction(
 						dag.Function("Uppercase",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 401, 1)).
-							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 401, 48)})).
+							WithSourceMap(dag.SourceMap("main.go", 414, 1)).
+							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 414, 48)})).
 					WithFunction(
 						dag.Function("UseCachedExecService",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 528, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 541, 1))).
 					WithFunction(
 						dag.Function("UseExecService",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 549, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 562, 1))).
 					WithFunction(
 						dag.Function("UseNoExecService",
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 588, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 601, 1))).
 					WithField("Num", dag.TypeDef().WithKind(dagger.TypeDefKindIntegerKind), dagger.TypeDefWithFieldOpts{SourceMap: dag.SourceMap("main.go", 21, 2)})).
 			WithObject(
 				dag.TypeDef().WithObject("ModuleTypeReturn", dagger.TypeDefWithObjectOpts{SourceMap: dag.SourceMap("main.go", 24, 6)}).

--- a/dagql/idtui/viztest/internal/dagger/viztest.gen.go
+++ b/dagql/idtui/viztest/internal/dagger/viztest.gen.go
@@ -359,6 +359,18 @@ func (r *Viztest) FailSlow(ctx context.Context, opts ...ViztestFailSlowOpts) err
 	return q.Execute(ctx)
 }
 
+// GenerateFail is a generator whose changeset only evaluates -- and fails -- when
+// it is forced during `dagger generate`'s merge. It exercises exec-error
+// surfacing: the reported error must name the failed command and its stderr, not
+// a bare "exit code: N". See dagger/dagger#13606.
+func (r *Viztest) GenerateFail() *Changeset {
+	q := r.query.Select("generateFail")
+
+	return &Changeset{
+		query: q,
+	}
+}
+
 func (r *Viztest) GitReadme(ctx context.Context, remote string, version string) (string, error) {
 	if r.gitReadme != nil {
 		return *r.gitReadme, nil

--- a/dagql/idtui/viztest/main.go
+++ b/dagql/idtui/viztest/main.go
@@ -181,6 +181,19 @@ func (*Viztest) Changeset() *dagger.Changeset {
 		Changes(dag.Directory())
 }
 
+// GenerateFail is a generator whose changeset only evaluates -- and fails -- when
+// it is forced during `dagger generate`'s merge. It exercises exec-error
+// surfacing: the reported error must name the failed command and its stderr, not
+// a bare "exit code: N". See dagger/dagger#13606.
+// +generate
+func (*Viztest) GenerateFail() *dagger.Changeset {
+	failed := dag.Container().
+		From("alpine").
+		WithExec([]string{"sh", "-c", "echo boom >&2; exit 3"}).
+		Directory("/")
+	return failed.Changes(dag.Directory())
+}
+
 // +cache="session"
 func (*Viztest) PrimaryLines(n int) string {
 	buf := new(strings.Builder)

--- a/hack/designs/generate-surface-exec-error.md
+++ b/hack/designs/generate-surface-exec-error.md
@@ -1,0 +1,105 @@
+# `dagger generate` — surface the underlying exec error
+
+Scope: generator execution + changeset evaluation, as consumed by `dagger
+generate`. Fixes [#13606](https://github.com/dagger/dagger/issues/13606).
+
+## Problem
+
+When a generator's changeset fails to evaluate, `dagger generate` hides the real
+failure. The generator renders as a **green ✔ check**, and the error the user is
+left with — plain summary and pretty/report TUI alike — is content-free:
+
+```text
+Error: compute their paths: evaluate changeset directories: exit code: 3
+```
+
+It names neither the command that failed nor its stderr. Running the changeset
+directly does show it (`dagger call golang --generate=sdk/go generate-all
+is-empty`), so the information exists — `dagger generate` just drops it.
+
+## Why it's broken
+
+A `+generate` function returns a **lazy** `Changeset`: its `Before`/`After`
+directories are backed by an exec (the SDK codegen) that has not run yet.
+
+`ModTreeNode.runGeneratorLocally` runs *inside* the per-generator span
+(`RunGenerator` opens it revealed, with rolled-up logs), but it only grabs the
+lazy `Changeset` — it never forces it. And `Changeset.Evaluate` was a **no-op**
+(`return nil`), so even `changeset.sync` forced nothing.
+
+So the exec is forced much later, during the changeset **merge**
+(`ComputePaths`/`AsPatch` → `cache.Evaluate`), *after* the generator span has
+already ended successfully. Two consequences:
+
+1. The generator row renders **green** even though it failed — a false positive
+   (this is the tell that the failure is attributed to the wrong place).
+2. The failure lands on the merge, not the generator. Worse, the failing exec is
+   never a *visible* span there, and the merge error still carries the
+   `*ExecError`'s origin annotation — which makes `renderStepError` suppress the
+   merge span's own message in favor of an origin span it cannot render. Net: the
+   user gets a bare `exit code: N`, and in the TUI, nothing at all.
+
+## Fix
+
+Force the changeset to evaluate **inside the generator's span**, so the exec runs
+— and any failure is attributed — there, exactly like any other `withExec`
+failure. Two small changes in `core`:
+
+- **`Changeset.Evaluate(ctx)`** now evaluates its before/after directories
+  (`dagql.EngineCache(ctx).Evaluate(ctx, ch.Before, ch.After)`) instead of being
+  a no-op. `changeset.sync` (a registered `Syncer`) therefore actually forces the
+  changeset now — the intended semantics of `sync`.
+- **`ModTreeNode.runGeneratorLocally`** calls `changes.Self().Sync(ctx)` after
+  grabbing the lazy changeset. Generators already run in parallel and the
+  changeset has to sync eventually, so nothing that wasn't going to run is
+  deferred — it just runs where it can be attributed.
+
+Now a failing generator's exec runs within the revealed generator span: the row
+goes **red**, its stderr and exit code surface through the span tree, and the run
+fails at the generator instead of limping on to the merge. No error-message
+reconstruction is needed — the earlier `mergeEvalError` message-building helper
+is removed, and the merge wrap sites go back to plain `fmt.Errorf`.
+
+Credit: this is [@vito's](https://github.com/dagger/dagger/pull/13664) direction
+— an earlier revision reconstructed the message at the merge boundary, which left
+the false-green check in place; forcing evaluation in the span fixes the
+attribution at the root.
+
+## Test strategy
+
+**1. Integration — real `dagger generate` (`core/integration/generators_test.go`).**
+A `lazy-exec-failure` `+generate` fixture whose changeset's exec fails only when
+forced (stderr marker via `$MARKER` so it is distinct from the command text):
+
+```go
+// +generate
+func (m *HelloWithGenerators) LazyExecFailure() *dagger.Changeset {
+  failed := dag.Container().From("alpine").
+    WithEnvVariable("MARKER", "STDERR_ONLY_MARKER").
+    WithExec([]string{"sh", "-c", "echo $MARKER >&2; exit 3"}).
+    Directory("/")
+  return failed.Changes(dag.Directory())
+}
+```
+
+Drive `dagger generate lazy-exec-failure --progress=plain` and assert the output
+surfaces the command (`sh -c`), the stderr (`STDERR_ONLY_MARKER`), and the exit
+code (`exit code: 3`). Keep the existing eager `changeset-failure` `"error"`
+subtest.
+
+**2. Golden — rendered TUI (`dagql/idtui/golden_test.go`).** The
+`TestTelemetry/TestGolden` flow only drove `call`/`check`; add a `Generate` mode
+(`dagger --workdir <mod> generate <fn> -y`) plus a `GenerateFail` `+generate`
+generator in `viztest`. The committed golden
+(`testdata/TestTelemetry/TestGolden/generate-fail`) pins the rendered output —
+now a **red generator row** with the exec's logs, which is the attribution the
+fix is really about and is visible in the PR diff. Regenerate with
+`dagger -c 'engine-dev | test-telemetry --update | export .'`.
+
+## Notes
+
+- `dagger check` generate-as-check and other callers benefit for free: any
+  generator whose evaluation fails now fails within its own span.
+- Making `Changeset.Evaluate` real is a behavior change to the public
+  `changeset.sync` field — but forcing evaluation is what `sync` is supposed to
+  do, and no caller relied on the no-op.


### PR DESCRIPTION
## Problem

When a generator's changeset evaluates lazily and its backing exec fails, `dagger generate` leaves you with a content-free summary:

```text
Error: compute their paths: evaluate changeset directories: exit code: 3
```

It names neither the command that failed nor its stderr. The failing exec's stderr does still stream into the live progress tree, but the **error summary** — the artifact that survives a failed run and lands in CI logs — drops it, so the user has to scroll a (possibly collapsed) tree or re-run the changeset by hand.

Fixes #13606.

## Why

The exec produces an `*ExecError` (`Cmd`, `Stderr`, `ExitCode`), but `ExecError.Error()` returns only `"exit code: N"` — the command and stderr live on the struct / `Extensions()`, never in the message. The changeset **merge** (`WithChangeset` / `WithChangesets`) then wraps it with bare `%w` context. The exec is forced lazily deep inside the merge, so the summary is all that's left.

## Fix

Lift the `*ExecError`'s command, exit code, and stderr into the message at the merge boundary via a small `mergeEvalError` helper, applied in `WithChangeset`, `WithChangesets`, and `checkAllPairwiseConflicts`. The `*ExecError` stays in the `%w` chain so its extensions/origin still propagate.

The shared **direct**-eval path (`ComputePaths` / `withMountedDirs` / `IsEmpty`, used by `dagger call … is-empty`) is deliberately left untouched — the TUI already renders its exec span's stderr there, so enriching it would double-print.

## Tests

- Unit: `TestMergeEvalError` (`core/changeset_test.go`) — cmd+stderr lifted, chain preserved, plain/bare errors unchanged.
- Integration: `TestGeneratorLazyExecFailureSurfacesStderr` (`core/integration/generators_test.go`) — drives real `dagger generate` against a lazily-failing exec. Verified it **fails** on `main` (summary is bare `exit code: 3`) and **passes** with the fix.

Design notes in `hack/designs/generate-surface-exec-error.md`.