### PR TITLE
feat(dagui): retain self-time blocker chains

### DIFF
--- a/dagql/dagui/selftime.go
+++ b/dagql/dagui/selftime.go
@@ -26,6 +26,12 @@ import (
 // themselves. Segments whose blocker was reached through the chain are
 // marked Indirect (with Via naming the direct hop).
 
+// TimeBlocker is one operation in a resolved wait chain.
+type TimeBlocker struct {
+	Target SpanID
+	Label  string
+}
+
 // TimeSegment is one contiguous stretch of a row's painted time.
 type TimeSegment struct {
 	Start, End time.Time
@@ -35,6 +41,10 @@ type TimeSegment struct {
 	Waiting bool
 	Target  SpanID
 	Label   string
+	// Blockers contains the resolved wait chain, ordered from the direct
+	// blocker to the fundamental blocker identified by Target. Operations
+	// outside the trace have no entry.
+	Blockers []TimeBlocker
 	// Indirect marks a waiting segment whose blocker was reached by
 	// following the wait chain rather than being the row's direct target.
 	Indirect bool
@@ -83,6 +93,7 @@ type waitWindow struct {
 type resolvedWait struct {
 	start, end time.Time
 	blocker    *Span // nil when not in the trace
+	blockers   []*Span
 	indirect   bool
 	via        string
 }
@@ -143,7 +154,7 @@ func (span *Span) TimeBreakdown(now time.Time) *TimeBreakdown {
 			via = blockerLabel(direct)
 		}
 		visited := map[*Span]bool{}
-		resolved = append(resolved, resolveWaitChain(w, via, 0, visited, now)...)
+		resolved = append(resolved, resolveWaitChain(w, via, nil, 0, visited, now)...)
 	}
 	// A blocker rendered inside the row's own subtree is the row hosting its
 	// own nested work (a module call running its function, a group span
@@ -195,6 +206,12 @@ func (span *Span) TimeBreakdown(now time.Time) *TimeBreakdown {
 				End:      end,
 				Waiting:  true,
 				Indirect: w.indirect,
+			}
+			for _, blocker := range w.blockers {
+				seg.Blockers = append(seg.Blockers, TimeBlocker{
+					Target: blocker.ID,
+					Label:  blockerLabel(blocker),
+				})
 			}
 			if w.indirect {
 				seg.Via = w.via
@@ -254,11 +271,14 @@ func (span *Span) TimeBreakdown(now time.Time) *TimeBreakdown {
 // during it by recursing through the target's own waits. Stretches where the
 // target itself was working resolve to the target; stretches where it was in
 // turn waiting resolve deeper.
-func resolveWaitChain(win waitWindow, viaLabel string, depth int, visited map[*Span]bool, now time.Time) []resolvedWait {
+func resolveWaitChain(win waitWindow, viaLabel string, blockers []*Span, depth int, visited map[*Span]bool, now time.Time) []resolvedWait {
+	blocker := resolveBlocker(win.target)
+	blockers = appendResolvedBlocker(blockers, blocker)
 	self := resolvedWait{
 		start:    win.start,
 		end:      win.end,
-		blocker:  resolveBlocker(win.target),
+		blocker:  blocker,
+		blockers: append([]*Span(nil), blockers...),
 		indirect: depth > 0,
 		via:      viaLabel,
 	}
@@ -312,7 +332,7 @@ func resolveWaitChain(win waitWindow, viaLabel string, depth int, visited map[*S
 			gap.start, gap.end = cursor, sub.start
 			out = append(out, gap)
 		}
-		out = append(out, resolveWaitChain(sub, viaLabel, depth+1, visited, now)...)
+		out = append(out, resolveWaitChain(sub, viaLabel, blockers, depth+1, visited, now)...)
 		cursor = sub.end
 	}
 	if cursor.Before(win.end) {
@@ -323,7 +343,19 @@ func resolveWaitChain(win waitWindow, viaLabel string, depth int, visited map[*S
 	return out
 }
 
-// coalesceResolvedWaits merges adjacent windows with the same blocker.
+// appendResolvedBlocker copies path and adds blocker unless it is outside the
+// trace or is an adjacent duplicate of the last resolved operation. Copying
+// keeps sibling recursion from changing paths already stored on other slices.
+func appendResolvedBlocker(path []*Span, blocker *Span) []*Span {
+	out := append([]*Span(nil), path...)
+	if blocker == nil || (len(out) > 0 && out[len(out)-1] == blocker) {
+		return out
+	}
+	return append(out, blocker)
+}
+
+// coalesceResolvedWaits merges adjacent windows with the same blocker and
+// complete causal path.
 func coalesceResolvedWaits(wins []resolvedWait) []resolvedWait {
 	if len(wins) == 0 {
 		return nil
@@ -332,7 +364,9 @@ func coalesceResolvedWaits(wins []resolvedWait) []resolvedWait {
 	out := wins[:1]
 	for _, w := range wins[1:] {
 		last := &out[len(out)-1]
-		if w.blocker == last.blocker && !w.start.After(last.end) {
+		if w.blocker == last.blocker &&
+			sameResolvedBlockers(w.blockers, last.blockers) &&
+			!w.start.After(last.end) {
 			if w.end.After(last.end) {
 				last.end = w.end
 			}
@@ -345,6 +379,18 @@ func coalesceResolvedWaits(wins []resolvedWait) []resolvedWait {
 		out = append(out, w)
 	}
 	return out
+}
+
+func sameResolvedBlockers(a, b []*Span) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // absorbWaitSlivers folds windows too small to see (or click) into their
@@ -363,14 +409,16 @@ func absorbWaitSlivers(wins []resolvedWait, paintedTotal time.Duration) []resolv
 			last := &out[len(out)-1]
 			contiguous := !w.start.After(last.end)
 			if contiguous && w.end.Sub(w.start) < epsilon {
-				// too small to matter: extend the previous window over it
+				// Too small to matter: the previous window claims this time
+				// with its own complete blocker path.
 				if w.end.After(last.end) {
 					last.end = w.end
 				}
 				continue
 			}
 			if contiguous && last.end.Sub(last.start) < epsilon {
-				// previous was the sliver: let this window claim its space
+				// The previous window was the sliver: this window claims its
+				// time with this window's complete blocker path.
 				w.start = last.start
 				out[len(out)-1] = w
 				continue
@@ -389,6 +437,9 @@ func (hb *TimeBreakdown) addSegment(seg TimeSegment) {
 		if prev.Waiting == seg.Waiting &&
 			prev.Label == seg.Label &&
 			prev.Target == seg.Target &&
+			prev.Indirect == seg.Indirect &&
+			prev.Via == seg.Via &&
+			sameTimeBlockers(prev.Blockers, seg.Blockers) &&
 			!seg.Start.After(prev.End) {
 			if seg.End.After(prev.End) {
 				prev.End = seg.End
@@ -397,6 +448,18 @@ func (hb *TimeBreakdown) addSegment(seg TimeSegment) {
 		}
 	}
 	hb.Segments = append(hb.Segments, seg)
+}
+
+func sameTimeBlockers(a, b []TimeBlocker) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // collectWaitWindows appends span's wait edges as raw windows attributed to row.
@@ -564,33 +627,61 @@ func (span *Span) TimeBreakdownSpans(visit func(*Span)) {
 		return
 	}
 	seen := map[*Span]bool{span: true}
+	walkedAt := map[*Span]int{}
+	expandedAt := map[*Span]int{}
 	var walk func(s *Span, depth int)
-	emit := func(c *Span, depth int) {
+	var emit func(c *Span, depth int)
+	visitOnce := func(c *Span) {
 		if c == nil || seen[c] {
 			return
 		}
 		seen[c] = true
 		visit(c)
-		// the cause chain resolves markers to their ops
-		for _, cause := range c.causesViaLinks.Order {
-			if !seen[cause] {
-				seen[cause] = true
-				visit(cause)
-			}
+	}
+	// blockerLabel searches two child levels for exec argv attributes.
+	var visitLabelSpans func(*Span, int)
+	visitLabelSpans = func(c *Span, depth int) {
+		if c == nil || depth >= 2 {
+			return
 		}
-		// blockers' exec children carry the argv labels
 		for _, child := range c.ChildSpans.Order {
-			if !seen[child] {
-				seen[child] = true
-				visit(child)
-			}
+			visitOnce(child)
+			visitLabelSpans(child, depth+1)
+		}
+	}
+	emit = func(c *Span, depth int) {
+		if c == nil {
+			return
+		}
+		visitOnce(c)
+		if prev, ok := expandedAt[c]; ok && prev <= depth {
+			return
+		}
+		expandedAt[c] = depth
+
+		// Cause links and the parent fallback map resume markers to the
+		// operations retained in TimeSegment.Blockers. Expand those operations
+		// too: their waits form the next link and their descendants carry labels.
+		for _, cause := range c.causesViaLinks.Order {
+			// Preserve the existing dependency on every direct cause, even though
+			// resolveBlocker deterministically selects the first one.
+			visitOnce(cause)
+		}
+		resolved := resolveBlockerPath(c, visitOnce)
+		visitLabelSpans(resolved, 0)
+		if resolved != nil && resolved != c {
+			emit(resolved, depth)
 		}
 		walk(c, depth+1)
 	}
 	walk = func(s *Span, depth int) {
-		if depth > waitChainMaxDepth {
+		if s == nil || depth > waitChainMaxDepth {
 			return
 		}
+		if prev, ok := walkedAt[s]; ok && prev <= depth {
+			return
+		}
+		walkedAt[s] = depth
 		for i := range s.Links {
 			if s.Links[i].IsWait() {
 				emit(s.db.Spans.Map[s.Links[i].SpanContext.SpanID], depth)
@@ -602,6 +693,10 @@ func (span *Span) TimeBreakdownSpans(visit func(*Span)) {
 				for _, gc := range child.ChildSpans.Order {
 					emit(gc, depth)
 				}
+			} else if resolved := resolveBlocker(child); resolved != nil && resolved != child {
+				// collectInferredWaits inspects non-twin children which stand
+				// in for another operation, including live resume markers.
+				emit(child, depth)
 			}
 		}
 		for _, effect := range s.effectsViaLinks.Order {
@@ -618,6 +713,13 @@ func (span *Span) TimeBreakdownSpans(visit func(*Span)) {
 // to the user-meaningful op whose deferred work they represent: the resume's
 // causal source, falling back to its parent.
 func resolveBlocker(target *Span) *Span {
+	return resolveBlockerPath(target, nil)
+}
+
+// resolveBlockerPath resolves target and optionally visits each operation used
+// along the way. The callback lets TimeBreakdownSpans stream the exact inputs a
+// filtered frontend needs to perform the same resolution after import.
+func resolveBlockerPath(target *Span, visit func(*Span)) *Span {
 	for depth := 0; target != nil && depth < 10; depth++ {
 		if !strings.HasPrefix(target.Name, "resume ") {
 			return target
@@ -636,6 +738,9 @@ func resolveBlocker(target *Span) *Span {
 			return target
 		}
 		target = next
+		if visit != nil {
+			visit(target)
+		}
 	}
 	return target
 }

--- a/dagql/dagui/selftime_test.go
+++ b/dagql/dagui/selftime_test.go
@@ -39,6 +39,44 @@ func causeLink(target SpanID) SpanLink {
 	}
 }
 
+func waitingSegments(hb *TimeBreakdown) []TimeSegment {
+	var segs []TimeSegment
+	for _, seg := range hb.Segments {
+		if seg.Waiting {
+			segs = append(segs, seg)
+		}
+	}
+	return segs
+}
+
+func assertBlockers(t *testing.T, seg TimeSegment, want ...SpanID) {
+	t.Helper()
+	if len(seg.Blockers) != len(want) {
+		t.Fatalf("blocker path length: got %+v, want %v", seg.Blockers, want)
+	}
+	for i, target := range want {
+		if seg.Blockers[i].Target != target {
+			t.Fatalf("blocker path at %d: got %+v, want %v", i, seg.Blockers, want)
+		}
+		if seg.Blockers[i].Label == "" {
+			t.Fatalf("blocker path at %d has no label: %+v", i, seg.Blockers)
+		}
+	}
+	if seg.Target.IsValid() {
+		if len(seg.Blockers) == 0 || seg.Blockers[len(seg.Blockers)-1].Target != seg.Target {
+			t.Fatalf("valid target must equal final blocker: %+v", seg)
+		}
+	}
+}
+
+func visitedBreakdownSpans(span *Span) map[SpanID]bool {
+	visited := map[SpanID]bool{}
+	span.TimeBreakdownSpans(func(dep *Span) {
+		visited[dep.ID] = true
+	})
+	return visited
+}
+
 // buildLazyChainDB constructs the reference-trace shape:
 //
 //	q (query root) [0,16]
@@ -85,6 +123,408 @@ func buildLazyChainDB(t *testing.T) (*DB, SpanID, SpanID, SpanID) {
 	return db, s, w1, w2
 }
 
+func TestTimeBreakdownExplicitBlockerPathPrefixes(t *testing.T) {
+	db := NewDB()
+	q := testID(1)
+	a := testID(2)
+	b := testID(3)
+	c := testID(4)
+	n := testID(5)
+
+	db.ImportSnapshots([]SpanSnapshot{
+		{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+		{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+		{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(c, "test", at(2), at(8))}},
+		{ID: c, ParentID: q, Name: "C", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(n, "test", at(4), at(6))}},
+		{ID: n, ParentID: q, Name: "N", StartTime: at(0), EndTime: at(10)},
+	})
+
+	segs := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+	if len(segs) != 5 {
+		t.Fatalf("expected per-instant path prefixes, got %+v", segs)
+	}
+	want := [][]SpanID{{b}, {b, c}, {b, c, n}, {b, c}, {b}}
+	for i := range segs {
+		assertBlockers(t, segs[i], want[i]...)
+	}
+	if segs[0].Indirect || segs[4].Indirect {
+		t.Fatalf("direct B slices must remain direct: %+v", segs)
+	}
+	if segs[2].Target != n || !segs[2].Indirect || segs[2].Via != "B" {
+		t.Fatalf("deep slice must retain fundamental attribution via B: %+v", segs[2])
+	}
+}
+
+func TestTimeBreakdownLiveInferredBlockerPath(t *testing.T) {
+	db := NewDB()
+	q := testID(1)
+	n := testID(2)
+	nExec := testID(3)
+	c := testID(4)
+	mN := testID(5)
+	b := testID(6)
+	mC := testID(7)
+	a := testID(8)
+	aTwin := testID(9)
+	mB := testID(10)
+	now := at(8)
+
+	// Live inferred chain A -> B -> C -> N. None of the waits has ended, so
+	// there are no explicit wait links yet; the running resume markers are
+	// the only causal evidence.
+	db.ImportSnapshots([]SpanSnapshot{
+		{ID: q, Name: "query", StartTime: at(0)},
+		{ID: n, ParentID: q, Name: "N", StartTime: at(0.5), EndTime: at(1)},
+		{ID: nExec, ParentID: n, Name: "exec N", StartTime: at(1)},
+		{ID: c, ParentID: q, Name: "C", StartTime: at(1), EndTime: at(1.5)},
+		{ID: mN, ParentID: c, Name: "resume N", StartTime: at(1.5),
+			Links: []SpanLink{causeLink(n)}},
+		{ID: b, ParentID: q, Name: "B", StartTime: at(2), EndTime: at(2.5)},
+		{ID: mC, ParentID: b, Name: "resume C", StartTime: at(2.5),
+			Links: []SpanLink{causeLink(c)}},
+		{ID: a, ParentID: q, Name: "A", StartTime: at(3)},
+		{ID: aTwin, ParentID: a, Name: "A", StartTime: at(3)},
+		{ID: mB, ParentID: aTwin, Name: "resume B", StartTime: at(3),
+			Links: []SpanLink{causeLink(b)}},
+	})
+
+	seg, ok := db.Spans.Map[a].TimeBreakdown(now).BlockedNow(now)
+	if !ok {
+		t.Fatal("A should be blocked on the live inferred chain")
+	}
+	assertBlockers(t, seg, b, c, n)
+	if seg.Target != n || !seg.Indirect || seg.Via != "B" {
+		t.Fatalf("live path must preserve fundamental attribution via B: %+v", seg)
+	}
+}
+
+func TestTimeBreakdownCycleAndDepthPaths(t *testing.T) {
+	t.Run("cycle retains non-adjacent repeat", func(t *testing.T) {
+		db := NewDB()
+		q := testID(1)
+		a := testID(2)
+		b := testID(3)
+		c := testID(4)
+		db.ImportSnapshots([]SpanSnapshot{
+			{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+			{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+			{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(c, "test", at(0), at(10))}},
+			{ID: c, ParentID: q, Name: "C", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+		})
+
+		segs := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+		if len(segs) != 1 {
+			t.Fatalf("cycle should terminate as one deterministic slice: %+v", segs)
+		}
+		assertBlockers(t, segs[0], b, c, b)
+		if segs[0].Target != b {
+			t.Fatalf("cycle-capped target must be its final blocker: %+v", segs[0])
+		}
+	})
+
+	t.Run("maximum depth is bounded and deterministic", func(t *testing.T) {
+		db := NewDB()
+		q := testID(1)
+		a := testID(2)
+		ids := make([]SpanID, waitChainMaxDepth+3)
+		for i := range ids {
+			ids[i] = testID(byte(20 + i))
+		}
+		snaps := []SpanSnapshot{
+			{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+			{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(ids[0], "test", at(0), at(10))}},
+		}
+		for i, id := range ids {
+			snap := SpanSnapshot{ID: id, ParentID: q, Name: "blocker", StartTime: at(0), EndTime: at(10)}
+			if i+1 < len(ids) {
+				snap.Links = []SpanLink{waitLink(ids[i+1], "test", at(0), at(10))}
+			}
+			snaps = append(snaps, snap)
+		}
+		db.ImportSnapshots(snaps)
+
+		first := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+		second := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+		if len(first) != 1 || len(second) != 1 {
+			t.Fatalf("depth-capped chain should be one slice: first=%+v second=%+v", first, second)
+		}
+		want := ids[:waitChainMaxDepth+1]
+		assertBlockers(t, first[0], want...)
+		assertBlockers(t, second[0], want...)
+		if first[0].Target != want[len(want)-1] || second[0].Target != first[0].Target {
+			t.Fatalf("depth cap must be stable and end at the target: first=%+v second=%+v", first[0], second[0])
+		}
+	})
+}
+
+func TestTimeBreakdownResolvedMarkersDeduplicate(t *testing.T) {
+	db := NewDB()
+	q := testID(1)
+	a := testID(2)
+	b := testID(3)
+	r1 := testID(4)
+	r2 := testID(5)
+	db.ImportSnapshots([]SpanSnapshot{
+		{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+		{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(r1, "test", at(0), at(10))}},
+		{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10)},
+		{ID: r1, ParentID: q, Name: "resume B 1", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{causeLink(b), waitLink(r2, "test", at(0), at(10))}},
+		{ID: r2, ParentID: q, Name: "resume B 2", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{causeLink(b)}},
+	})
+
+	segs := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+	if len(segs) != 1 {
+		t.Fatalf("expected one resolved marker slice, got %+v", segs)
+	}
+	assertBlockers(t, segs[0], b)
+	if segs[0].Target == r1 || segs[0].Target == r2 {
+		t.Fatalf("raw resume marker leaked into attribution: %+v", segs[0])
+	}
+}
+
+func TestTimeBreakdownOutsideTraceRetainsPrefix(t *testing.T) {
+	db := NewDB()
+	q := testID(1)
+	a := testID(2)
+	b := testID(3)
+	missing := testID(99)
+	db.ImportSnapshots([]SpanSnapshot{
+		{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+		{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+		{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(missing, "test", at(0), at(10))}},
+	})
+
+	segs := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+	if len(segs) != 1 {
+		t.Fatalf("expected one outside-trace slice, got %+v", segs)
+	}
+	assertBlockers(t, segs[0], b)
+	if segs[0].Target.IsValid() || segs[0].Label != "an operation outside this trace" {
+		t.Fatalf("outside-trace attribution changed: %+v", segs[0])
+	}
+}
+
+func TestBlockerPathIdentityAndSliverAbsorption(t *testing.T) {
+	b := &Span{SpanSnapshot: SpanSnapshot{ID: testID(1), Name: "B"}}
+	c := &Span{SpanSnapshot: SpanSnapshot{ID: testID(2), Name: "C"}}
+	n := &Span{SpanSnapshot: SpanSnapshot{ID: testID(3), Name: "N"}}
+
+	t.Run("coalescing keeps routes to the same target distinct", func(t *testing.T) {
+		wins := coalesceResolvedWaits([]resolvedWait{
+			{start: at(0), end: at(1), blocker: n, blockers: []*Span{b, n}, indirect: true, via: "via"},
+			{start: at(1), end: at(2), blocker: n, blockers: []*Span{c, n}, indirect: true, via: "via"},
+		})
+		if len(wins) != 2 {
+			t.Fatalf("distinct causal routes were coalesced: %+v", wins)
+		}
+
+		hb := &TimeBreakdown{}
+		hb.addSegment(TimeSegment{
+			Start: at(0), End: at(1), Waiting: true, Target: n.ID, Label: "N",
+			Blockers: []TimeBlocker{{Target: b.ID, Label: "B"}, {Target: n.ID, Label: "N"}},
+			Indirect: true, Via: "via",
+		})
+		hb.addSegment(TimeSegment{
+			Start: at(1), End: at(2), Waiting: true, Target: n.ID, Label: "N",
+			Blockers: []TimeBlocker{{Target: c.ID, Label: "C"}, {Target: n.ID, Label: "N"}},
+			Indirect: true, Via: "via",
+		})
+		if len(hb.Segments) != 2 {
+			t.Fatalf("segment construction erased distinct causal routes: %+v", hb.Segments)
+		}
+		assertBlockers(t, hb.Segments[0], b.ID, n.ID)
+		assertBlockers(t, hb.Segments[1], c.ID, n.ID)
+	})
+
+	t.Run("outside-trace prefixes are segment identity", func(t *testing.T) {
+		wins := coalesceResolvedWaits([]resolvedWait{
+			{start: at(0), end: at(1), blockers: []*Span{b}, indirect: true, via: "via"},
+			{start: at(1), end: at(2), blockers: []*Span{c}, indirect: true, via: "via"},
+		})
+		if len(wins) != 2 {
+			t.Fatalf("outside-trace waits with different prefixes coalesced: %+v", wins)
+		}
+	})
+
+	t.Run("winning neighbor transfers its complete path", func(t *testing.T) {
+		leftWins := absorbWaitSlivers([]resolvedWait{
+			{start: at(0), end: at(5), blocker: n, blockers: []*Span{b, n}},
+			{start: at(5), end: at(5.05), blocker: n, blockers: []*Span{c, n}},
+		}, 10*time.Second)
+		if len(leftWins) != 1 || !sameResolvedBlockers(leftWins[0].blockers, []*Span{b, n}) || leftWins[0].end != at(5.05) {
+			t.Fatalf("left winner did not retain its complete path: %+v", leftWins)
+		}
+
+		rightWins := absorbWaitSlivers([]resolvedWait{
+			{start: at(0), end: at(0.05), blocker: n, blockers: []*Span{b, n}},
+			{start: at(0.05), end: at(5), blocker: n, blockers: []*Span{c, n}},
+		}, 10*time.Second)
+		if len(rightWins) != 1 || !sameResolvedBlockers(rightWins[0].blockers, []*Span{c, n}) || rightWins[0].start != at(0) {
+			t.Fatalf("right winner did not retain its complete path: %+v", rightWins)
+		}
+	})
+}
+
+func TestTimeBreakdownSliverKeepsWinningPath(t *testing.T) {
+	db := NewDB()
+	q := testID(1)
+	a := testID(2)
+	b := testID(3)
+	n := testID(4)
+	db.ImportSnapshots([]SpanSnapshot{
+		{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+		{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+		{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(n, "test", at(5), at(5.05))}},
+		{ID: n, ParentID: q, Name: "N", StartTime: at(0), EndTime: at(10)},
+	})
+
+	segs := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+	if len(segs) != 1 {
+		t.Fatalf("absorbed sliver should leave one B segment: %+v", segs)
+	}
+	assertBlockers(t, segs[0], b)
+	if segs[0].Target != b {
+		t.Fatalf("absorbed segment target must match the winning path: %+v", segs[0])
+	}
+}
+
+func TestTimeBreakdownRetainsInSubtreeIntermediate(t *testing.T) {
+	db := NewDB()
+	q := testID(1)
+	a := testID(2)
+	b := testID(3)
+	n := testID(4)
+	db.ImportSnapshots([]SpanSnapshot{
+		{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+		{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+		{ID: b, ParentID: a, Name: "B", StartTime: at(0), EndTime: at(10),
+			Links: []SpanLink{waitLink(n, "test", at(0), at(10))}},
+		{ID: n, ParentID: q, Name: "N", StartTime: at(0), EndTime: at(10)},
+	})
+
+	segs := waitingSegments(db.Spans.Map[a].TimeBreakdown(at(20)))
+	if len(segs) != 1 {
+		t.Fatalf("external fundamental blocker should survive subtree filtering: %+v", segs)
+	}
+	assertBlockers(t, segs[0], b, n)
+	if segs[0].Target != n {
+		t.Fatalf("final external blocker must remain fundamental: %+v", segs[0])
+	}
+}
+
+func TestTimeBreakdownSpansIncludesBlockerChains(t *testing.T) {
+	t.Run("explicit and label descendants", func(t *testing.T) {
+		db := NewDB()
+		q := testID(1)
+		a := testID(2)
+		b := testID(3)
+		c := testID(4)
+		n := testID(5)
+		cRun := testID(6)
+		cProcess := testID(7)
+		process := SpanSnapshot{ID: cProcess, ParentID: cRun, Name: "exec.processRun", StartTime: at(0), EndTime: at(10)}
+		process.ProcessAttribute("wcprof.exec.argv", `["intermediate","command"]`)
+		db.ImportSnapshots([]SpanSnapshot{
+			{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+			{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+			{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(c, "test", at(0), at(10))}},
+			{ID: c, ParentID: q, Name: "C", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(n, "test", at(0), at(10))}},
+			{ID: n, ParentID: q, Name: "N", StartTime: at(0), EndTime: at(10)},
+			{ID: cRun, ParentID: c, Name: "exec.run", StartTime: at(0), EndTime: at(10)},
+			process,
+		})
+
+		visited := visitedBreakdownSpans(db.Spans.Map[a])
+		for _, id := range []SpanID{b, c, n, cRun, cProcess} {
+			if !visited[id] {
+				t.Fatalf("missing explicit blocker dependency %v: %v", id, visited)
+			}
+		}
+	})
+
+	t.Run("live inferred intermediates", func(t *testing.T) {
+		db := NewDB()
+		q := testID(1)
+		a := testID(2)
+		aTwin := testID(3)
+		mB := testID(4)
+		b := testID(5)
+		mC := testID(6)
+		c := testID(7)
+		mN := testID(8)
+		n := testID(9)
+		db.ImportSnapshots([]SpanSnapshot{
+			{ID: q, Name: "query", StartTime: at(0)},
+			{ID: a, ParentID: q, Name: "A", StartTime: at(1)},
+			{ID: aTwin, ParentID: a, Name: "A", StartTime: at(1)},
+			{ID: mB, ParentID: aTwin, Name: "resume B", StartTime: at(1), Links: []SpanLink{causeLink(b)}},
+			{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(0.2)},
+			{ID: mC, ParentID: b, Name: "resume C", StartTime: at(1), Links: []SpanLink{causeLink(c)}},
+			{ID: c, ParentID: q, Name: "C", StartTime: at(0), EndTime: at(0.2)},
+			{ID: mN, ParentID: c, Name: "resume N", StartTime: at(1), Links: []SpanLink{causeLink(n)}},
+			{ID: n, ParentID: q, Name: "N", StartTime: at(0), EndTime: at(0.2)},
+		})
+
+		visited := visitedBreakdownSpans(db.Spans.Map[a])
+		for _, id := range []SpanID{mB, b, mC, c, mN, n} {
+			if !visited[id] {
+				t.Fatalf("missing live inferred dependency %v: %v", id, visited)
+			}
+		}
+	})
+
+	t.Run("later wait-edge import", func(t *testing.T) {
+		db := NewDB()
+		q := testID(1)
+		a := testID(2)
+		b := testID(3)
+		c := testID(4)
+		n := testID(5)
+		db.ImportSnapshots([]SpanSnapshot{
+			{ID: q, Name: "query", StartTime: at(0), EndTime: at(10)},
+			{ID: a, ParentID: q, Name: "A", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(b, "test", at(0), at(10))}},
+			{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10)},
+		})
+		first := visitedBreakdownSpans(db.Spans.Map[a])
+		if !first[b] || first[c] || first[n] {
+			t.Fatalf("unexpected initial dependencies: %v", first)
+		}
+
+		db.ImportSnapshots([]SpanSnapshot{
+			{ID: b, ParentID: q, Name: "B", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(c, "test", at(0), at(10))}},
+			{ID: c, ParentID: q, Name: "C", StartTime: at(0), EndTime: at(10),
+				Links: []SpanLink{waitLink(n, "test", at(0), at(10))}},
+			{ID: n, ParentID: q, Name: "N", StartTime: at(0), EndTime: at(10)},
+		})
+		second := visitedBreakdownSpans(db.Spans.Map[a])
+		for _, id := range []SpanID{b, c, n} {
+			if !second[id] {
+				t.Fatalf("later import did not expose dependency %v: %v", id, second)
+			}
+		}
+	})
+}
+
 func TestTimeBreakdownForcingOp(t *testing.T) {
 	db, s, w1, w2 := buildLazyChainDB(t)
 	span := db.Spans.Map[s]
@@ -117,9 +557,11 @@ func TestTimeBreakdownForcingOp(t *testing.T) {
 	if segs[0].Label != "go build -o /tmp/waitdemo ." {
 		t.Fatalf("blocker label should use the exec argv, got %q", segs[0].Label)
 	}
+	assertBlockers(t, segs[0], w1, w2)
 	if segs[1].Target != db.Spans.Map[w1].ID || segs[1].Indirect {
 		t.Fatalf("second stretch should be direct on w1: %+v", segs[1])
 	}
+	assertBlockers(t, segs[1], w1)
 
 	if hb.DominantTarget != w2 {
 		t.Fatalf("dominant blocker should be w2, got %v (%s)", hb.DominantTarget, hb.DominantLabel)
@@ -472,6 +914,7 @@ func TestLiveChainResolvesToWorkingOp(t *testing.T) {
 	if !seg.Indirect || seg.Via == "" || seg.Via == seg.Label {
 		t.Fatalf("segment should be indirect via the first hop, got %+v", seg)
 	}
+	assertBlockers(t, seg, bRow, cRow)
 
 	// b's own row also resolves through to c.
 	b := db.Spans.Map[bRow]


### PR DESCRIPTION
## Summary

Transitive self-time attribution currently keeps only the final blocker and loses its causal prefixes. A frontend therefore cannot fall back to a meaningful in-trace blocker when the fundamental target is hidden or outside the trace.

This change retains an ordered direct-to-fundamental blocker chain for each resolved time slice. It makes coalescing path-sensitive, keeps sliver ownership tied to the winning neighbor's complete path, preserves in-trace prefixes for outside-trace terminals, and expands `TimeBreakdownSpans` to include intermediate and final blockers plus label-bearing descendants.

Existing `Target`, `Label`, `Indirect`, and `Via` attribution semantics remain unchanged.

## Validation

- `go test ./dagql/dagui -run 'Test(TimeBreakdown|WaitingNow|Blocker|LiveChain)' -count=1`
- `go test ./dagql/dagui -count=1`
- `go vet ./dagql/dagui`
- `go vet ./dagql/... ./cmd/dagger` (reports the existing context-cancel warning in `dagql/cache.go`; that file is unchanged from `upstream/main`)
- `go build ./dagql/... ./cmd/dagger`
- `gofmt -d dagql/dagui/selftime.go dagql/dagui/selftime_test.go`, `git diff --check`, and `git show --check`
