### PR TITLE
fix(engine): fix session shutdown Close flake (flush scoping + DB pool)

### DIFF
--- a/core/mcp.go
+++ b/core/mcp.go
@@ -1458,7 +1458,7 @@ func (m *MCP) captureLogs(ctx context.Context, spanID string) ([]string, error) 
 	var lastLogID int64
 
 	for {
-		logs, err := q.SelectLogsBeneathSpan(ctx, clientdb.SelectLogsBeneathSpanParams{
+		logs, err := q.Read().SelectLogsBeneathSpan(ctx, clientdb.SelectLogsBeneathSpanParams{
 			ID:     lastLogID,
 			SpanID: sql.NullString{Valid: true, String: spanID},
 			Limit:  llmLogsBatchSize,
@@ -1495,7 +1495,7 @@ func (m *MCP) captureLogs(ctx context.Context, spanID string) ([]string, error) 
 			}
 
 			if log.SpanID.Valid {
-				span, err := q.SelectSpan(ctx, clientdb.SelectSpanParams{
+				span, err := q.Read().SelectSpan(ctx, clientdb.SelectSpanParams{
 					TraceID: log.TraceID.String,
 					SpanID:  log.SpanID.String,
 				})

--- a/dagql/otelprof_hooks.go
+++ b/dagql/otelprof_hooks.go
@@ -78,7 +78,16 @@ func beginOTelCallExec(callCtx context.Context, callKey, class string) (context.
 // finishes.
 func beginOTelPublishResult(ctx context.Context) trace.Span {
 	_, span := Tracer(ctx).Start(ctx, publishResultSpanName,
-		telemetry.Passthrough(),
+		// Internal, not Passthrough: publishResult is a childless leaf (nothing
+		// runs under its context — initCompletedResult runs under sharedWorkCtx,
+		// i.e. the call_exec span, not this one), so it never has children for the
+		// UI to promote in its place. Marking it Internal instead lets the
+		// per-client-DB live processor drop its live (OnStart) double-emit
+		// (see engine/telemetry NewInternalFilteringLiveSpanProcessor); it is by
+		// far the highest-volume profiling span (~1 per resolver cache miss).
+		// call_exec / exec.run / service.start stay Passthrough — they DO parent
+		// the real work, so their live snapshot must ship.
+		telemetry.Internal(),
 		trace.WithAttributes(
 			attribute.String(telemetryattrs.WcprofOpKindAttr, wcprof.OpKindInternal.String()),
 		),

--- a/dagql/otelprof_hooks_test.go
+++ b/dagql/otelprof_hooks_test.go
@@ -120,8 +120,13 @@ func TestEmitHooksProduceLoaderShape(t *testing.T) {
 	if got, _ := attrString(pub, telemetryattrs.WcprofOpKindAttr); got != wcprof.OpKindInternal.String() {
 		t.Fatalf("publishResult op kind = %q, want internal", got)
 	}
-	if pass, ok := attrBool(pub, telemetry.UIPassthroughAttr); !ok || !pass {
-		t.Fatalf("publishResult must be ui.passthrough")
+	// ui.internal, NOT ui.passthrough: publishResult is a childless leaf (nothing
+	// nests under it), so there are no children to promote and Passthrough would be
+	// pointless. Marking it Internal lets the per-client-DB live processor drop its
+	// live double-emit (NewInternalFilteringLiveSpanProcessor). call_exec above
+	// stays passthrough because it DOES parent the resolver's real work.
+	if pass, ok := attrBool(pub, telemetry.UIInternalAttr); !ok || !pass {
+		t.Fatalf("publishResult must be ui.internal")
 	}
 
 	// the caller span (not the like-named call_exec) carries the wait links.

--- a/engine/clientdb/dbs.go
+++ b/engine/clientdb/dbs.go
@@ -42,13 +42,23 @@ func NewDBs(root string) *DBs {
 //go:embed schema.sql
 var Schema string
 
+// slowOpen flags Open calls that spent significant time waiting on the
+// per-DB lock (or on the initial SQLite open): every telemetry export batch
+// re-opens the DB by refcount, so contention here serializes exporters
+// before they even reach the connection pool.
+const slowOpen = 1 * time.Second
+
 // Open open a database for the given clientID if not open already and
 // runs the schema migration if needed.
 func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
 	lg := slog.Default().With("clientID", clientID)
 
+	openStart := time.Now()
 	dbs.perDBLock.Lock(clientID)
 	defer dbs.perDBLock.Unlock(clientID)
+	if waited := time.Since(openStart); waited > slowOpen {
+		lg.Warn("slow client DB open", "waited", waited)
+	}
 
 	dbs.mu.Lock()
 	db, ok := dbs.open[clientID]
@@ -226,6 +236,14 @@ type DB struct {
 
 func (db *DB) Begin() (*sql.Tx, error) {
 	return db.inner.Begin()
+}
+
+// Stats reports the underlying pool's counters. The pool is capped at a
+// single connection, so WaitCount/WaitDuration directly measure how long
+// callers queued behind the one connection (shared across ALL users of this
+// client's DB: every exporter hop targeting it plus its SSE drain reads).
+func (db *DB) Stats() sql.DBStats {
+	return db.inner.Stats()
 }
 
 func (db *DB) Close() (rerr error) {

--- a/engine/clientdb/dbs.go
+++ b/engine/clientdb/dbs.go
@@ -48,11 +48,19 @@ var Schema string
 // before they even reach the connection pool.
 const slowOpen = 1 * time.Second
 
-// maxOpenConns bounds each client DB's connection pool (see the rationale in
-// Open). A single connection serialized all readers and writers and convoyed
-// under load; unbounded pinned too many threads. A small bound balances the
-// two.
-const maxOpenConns = 10
+// Each client DB uses two connection pools against the same file. SQLite
+// permits exactly one writer, so the write pool is capped at a single
+// connection: extra write connections can't write in parallel, they only lose
+// the BEGIN IMMEDIATE race and busy-wait for the write lock up to busy_timeout
+// (10s, == the client shutdown budget — a cap of 10 was tried and did exactly
+// that, timing out shutdowns). One write connection serializes writers cheaply
+// in database/sql's queue with no SQLite-level busy-waiting. Reads get their
+// own pool so that, under WAL, SSE drains and log reads run concurrently with
+// the writer instead of queuing behind it on a shared connection.
+const (
+	writeMaxConns = 1
+	readMaxConns  = 4
+)
 
 // Open open a database for the given clientID if not open already and
 // runs the schema migration if needed.
@@ -85,7 +93,7 @@ func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
 		}
 	}()
 
-	if db.inner == nil {
+	if db.writer == nil {
 		lg.ExtraDebug("opening client DB", "clientID", clientID)
 
 		dbPath := db.dbs.path(db.clientID)
@@ -111,43 +119,55 @@ func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
 				"_txlock": []string{"immediate"}, // use BEGIN IMMEDIATE for transactions
 			}.Encode(),
 		}
-		sqlDB, err := sql.Open("sqlite", connURL.String())
-		if err != nil {
-			return nil, fmt.Errorf("open %s: %w", connURL, err)
-		}
-		// Bound the connection pool. SQLite allows only one writer at a time,
-		// and modernc.org/sqlite's busy handler waits by sleeping in a raw
-		// nanosleep syscall that pins an OS thread per waiting connection, so
-		// an *unbounded* pool let a burst of concurrent writers pin thousands
-		// of threads and exhaust the Go runtime's limit. Capping at 1 avoided
-		// that but funneled every reader and writer of a client DB through a
-		// single connection: under a parallel-teardown storm the resulting
-		// convoy blew the client shutdown budget (poolWaitDelta in the tens of
-		// seconds while individual statements stayed sub-second). A small bound
-		// keeps WAL's reader/writer concurrency and lets writes drain in
-		// parallel, while capping worst-case pinned threads per DB well below
-		// the runtime limit.
-		sqlDB.SetMaxOpenConns(maxOpenConns)
-		if err := sqlDB.Ping(); err != nil {
-			return nil, fmt.Errorf("ping %s: %w", connURL, err)
-		}
+		dsn := connURL.String()
 
-		db.inner = sqlDB
+		// Writer pool: a single connection (see writeMaxConns). The file is
+		// created and migrated here, before the reader pool opens against it.
+		writer, err := sql.Open("sqlite", dsn)
+		if err != nil {
+			return nil, fmt.Errorf("open writer %s: %w", connURL, err)
+		}
+		writer.SetMaxOpenConns(writeMaxConns)
+		if err := writer.Ping(); err != nil {
+			return nil, fmt.Errorf("ping writer %s: %w", connURL, err)
+		}
+		db.writer = writer
 
 		if !alreadyExists {
-			if _, err := db.inner.Exec(Schema); err != nil {
+			if _, err := db.writer.Exec(Schema); err != nil {
 				return nil, fmt.Errorf("migrate: %w", err)
 			}
 		}
+
+		// Reader pool: separate connections so WAL reads (SSE drains, log
+		// reads) run concurrently with the single writer instead of queuing
+		// behind it. Read-only by convention — only Select* is routed here (via
+		// DB.Read) — so these connections never take the write lock.
+		reader, err := sql.Open("sqlite", dsn)
+		if err != nil {
+			return nil, fmt.Errorf("open reader %s: %w", connURL, err)
+		}
+		reader.SetMaxOpenConns(readMaxConns)
+		if err := reader.Ping(); err != nil {
+			return nil, fmt.Errorf("ping reader %s: %w", connURL, err)
+		}
+		db.reader = reader
 	} else {
 		lg.Trace("reusing open client DB", "clientID", clientID)
 	}
 
 	if db.Queries == nil {
 		var err error
-		db.Queries, err = Prepare(ctx, db.inner)
+		db.Queries, err = Prepare(ctx, db.writer)
 		if err != nil {
-			return nil, fmt.Errorf("prepare queries: %w", err)
+			return nil, fmt.Errorf("prepare write queries: %w", err)
+		}
+	}
+	if db.readQueries == nil {
+		var err error
+		db.readQueries, err = Prepare(ctx, db.reader)
+		if err != nil {
+			return nil, fmt.Errorf("prepare read queries: %w", err)
 		}
 	}
 
@@ -167,15 +187,27 @@ func (dbs *DBs) close(db *DB, lg *slog.Logger) (rerr error) {
 
 	if db.Queries != nil {
 		if cerr := db.Queries.Close(); cerr != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("error closing queries: %w", cerr))
+			rerr = errors.Join(rerr, fmt.Errorf("error closing write queries: %w", cerr))
 		}
 		db.Queries = nil
 	}
-	if db.inner != nil {
-		if cerr := db.inner.Close(); cerr != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("error closing db: %w", cerr))
+	if db.readQueries != nil {
+		if cerr := db.readQueries.Close(); cerr != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("error closing read queries: %w", cerr))
 		}
-		db.inner = nil
+		db.readQueries = nil
+	}
+	if db.writer != nil {
+		if cerr := db.writer.Close(); cerr != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("error closing writer: %w", cerr))
+		}
+		db.writer = nil
+	}
+	if db.reader != nil {
+		if cerr := db.reader.Close(); cerr != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("error closing reader: %w", cerr))
+		}
+		db.reader = nil
 	}
 
 	dbs.mu.Lock()
@@ -241,22 +273,44 @@ type DB struct {
 	dbs      *DBs
 	clientID string
 
-	inner *sql.DB
+	// writer is the single-connection write pool; the embedded *Queries is
+	// prepared against it, so DB's Insert* methods write through it.
+	writer *sql.DB
 	*Queries
+
+	// reader is the multi-connection read pool; readQueries is prepared
+	// against it and reached via Read(), so Select* reads run concurrently
+	// with the writer under WAL.
+	reader      *sql.DB
+	readQueries *Queries
 
 	refCount int
 }
 
-func (db *DB) Begin() (*sql.Tx, error) {
-	return db.inner.Begin()
+// Read returns the queries bound to the read pool. Route all Select* reads
+// (SSE drains, log reads) through this so they use the reader connections and
+// never contend with writes on the single write connection.
+func (db *DB) Read() *Queries {
+	return db.readQueries
 }
 
-// Stats reports the underlying pool's counters. The pool is capped at a
-// single connection, so WaitCount/WaitDuration directly measure how long
-// callers queued behind the one connection (shared across ALL users of this
-// client's DB: every exporter hop targeting it plus its SSE drain reads).
+func (db *DB) Begin() (*sql.Tx, error) {
+	return db.writer.Begin()
+}
+
+// BeginTx starts a write transaction on the write pool bound to ctx. Batched
+// writers use this so a whole export batch runs as one BEGIN IMMEDIATE..COMMIT
+// holding the single write connection once, instead of one auto-commit round
+// trip (and write-lock acquisition) per row.
+func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return db.writer.BeginTx(ctx, opts)
+}
+
+// Stats reports the write pool's counters. It is capped at a single
+// connection, so WaitCount/WaitDuration measure how long writers queued behind
+// it (reads use the separate reader pool and do not show up here).
 func (db *DB) Stats() sql.DBStats {
-	return db.inner.Stats()
+	return db.writer.Stats()
 }
 
 func (db *DB) Close() (rerr error) {

--- a/engine/clientdb/dbs.go
+++ b/engine/clientdb/dbs.go
@@ -48,6 +48,12 @@ var Schema string
 // before they even reach the connection pool.
 const slowOpen = 1 * time.Second
 
+// maxOpenConns bounds each client DB's connection pool (see the rationale in
+// Open). A single connection serialized all readers and writers and convoyed
+// under load; unbounded pinned too many threads. A small bound balances the
+// two.
+const maxOpenConns = 10
+
 // Open open a database for the given clientID if not open already and
 // runs the schema migration if needed.
 func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
@@ -109,12 +115,19 @@ func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
 		if err != nil {
 			return nil, fmt.Errorf("open %s: %w", connURL, err)
 		}
-		// SQLite allows only one writer at a time, and modernc.org/sqlite's
-		// busy handler waits by sleeping in a raw nanosleep syscall, which
-		// pins an OS thread per waiting connection. Cap the pool at a single
-		// connection so concurrent queries queue cheaply in database/sql
-		// instead of busy-waiting against each other in SQLite.
-		sqlDB.SetMaxOpenConns(1)
+		// Bound the connection pool. SQLite allows only one writer at a time,
+		// and modernc.org/sqlite's busy handler waits by sleeping in a raw
+		// nanosleep syscall that pins an OS thread per waiting connection, so
+		// an *unbounded* pool let a burst of concurrent writers pin thousands
+		// of threads and exhaust the Go runtime's limit. Capping at 1 avoided
+		// that but funneled every reader and writer of a client DB through a
+		// single connection: under a parallel-teardown storm the resulting
+		// convoy blew the client shutdown budget (poolWaitDelta in the tens of
+		// seconds while individual statements stayed sub-second). A small bound
+		// keeps WAL's reader/writer concurrency and lets writes drain in
+		// parallel, while capping worst-case pinned threads per DB well below
+		// the runtime limit.
+		sqlDB.SetMaxOpenConns(maxOpenConns)
 		if err := sqlDB.Ping(); err != nil {
 			return nil, fmt.Errorf("ping %s: %w", connURL, err)
 		}

--- a/engine/clientdb/dbs_test.go
+++ b/engine/clientdb/dbs_test.go
@@ -25,7 +25,7 @@ func TestDBRefCount(t *testing.T) {
 	require.Len(t, dbs.open, 1)
 	require.Equal(t, d1a.refCount, 2)
 
-	_, err = d1a.SelectSpansSince(ctx, SelectSpansSinceParams{
+	_, err = d1a.Read().SelectSpansSince(ctx, SelectSpansSinceParams{
 		ID:    1,
 		Limit: 1,
 	})
@@ -33,11 +33,13 @@ func TestDBRefCount(t *testing.T) {
 
 	require.NoError(t, d1a.Close())
 	require.Len(t, dbs.open, 1)
-	require.NotNil(t, d1a.inner)
+	require.NotNil(t, d1a.writer)
+	require.NotNil(t, d1a.reader)
 	require.NotNil(t, d1a.Queries)
+	require.NotNil(t, d1a.readQueries)
 	require.Equal(t, d1a.refCount, 1)
 
-	_, err = d1b.SelectSpansSince(ctx, SelectSpansSinceParams{
+	_, err = d1b.Read().SelectSpansSince(ctx, SelectSpansSinceParams{
 		ID:    1,
 		Limit: 1,
 	})
@@ -51,14 +53,18 @@ func TestDBRefCount(t *testing.T) {
 
 	require.NoError(t, d1b.Close())
 	require.Len(t, dbs.open, 1)
-	require.Nil(t, d1a.inner)
-	require.Nil(t, d1b.inner)
+	require.Nil(t, d1a.writer)
+	require.Nil(t, d1b.writer)
+	require.Nil(t, d1a.reader)
+	require.Nil(t, d1b.reader)
 	require.Nil(t, d1a.Queries)
 	require.Nil(t, d1b.Queries)
+	require.Nil(t, d1a.readQueries)
+	require.Nil(t, d1b.readQueries)
 	require.Equal(t, d1a.refCount, 0)
 	require.Equal(t, d1b.refCount, 0)
 
-	_, err = d2a.SelectSpansSince(ctx, SelectSpansSinceParams{
+	_, err = d2a.Read().SelectSpansSince(ctx, SelectSpansSinceParams{
 		ID:    1,
 		Limit: 1,
 	})
@@ -66,8 +72,10 @@ func TestDBRefCount(t *testing.T) {
 
 	require.NoError(t, d2a.Close())
 	require.Len(t, dbs.open, 0)
-	require.Nil(t, d2a.inner)
+	require.Nil(t, d2a.writer)
+	require.Nil(t, d2a.reader)
 	require.Nil(t, d2a.Queries)
+	require.Nil(t, d2a.readQueries)
 	require.Equal(t, d2a.refCount, 0)
 }
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1977,14 +1977,28 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		}
 	}
 
-	// Flush telemetry across the entire session so that any child clients will
-	// save telemetry into their parent's DB, including to this client.
-	err := drainPhase("flush session telemetry", func() error {
-		return sess.FlushTelemetry(ctx, "client shutdown")
-	})
-	if err != nil {
-		slog.Error("failed to flush telemetry", "error", err)
-		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush session telemetry: %w", err))
+	// Flush telemetry so nested spans land in the DBs the CLI drains. A client's
+	// own providers already export its spans to its own DB *and every ancestor
+	// DB*, so a nested client only needs to flush itself; re-flushing every
+	// sibling on each nested shutdown is redundant and, under a parallel
+	// teardown storm, self-inflicts an O(n^2) burst of concurrent whole-session
+	// flushes that convoy on the per-DB single connection and blow the client's
+	// shutdown budget. The main client (which shuts down last and whose DB the
+	// CLI ultimately drains) still does a session-wide flush to sweep up any
+	// stragglers from clients that hadn't shut down yet.
+	var flushErr error
+	if client.clientID == sess.mainClientCallerID {
+		flushErr = drainPhase("flush session telemetry", func() error {
+			return sess.FlushTelemetry(ctx, "main client shutdown")
+		})
+	} else {
+		flushErr = drainPhase("flush client telemetry", func() error {
+			return client.FlushTelemetry(ctx)
+		})
+	}
+	if flushErr != nil {
+		slog.Error("failed to flush telemetry", "error", flushErr)
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush telemetry: %w", flushErr))
 	}
 
 	client.closeShutdownOnce.Do(func() {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -316,40 +316,80 @@ func (client *daggerClient) TelemetryDB(ctx context.Context) (*clientdb.DB, erro
 	return client.daggerSession.telemetryPubSub.srv.clientDBs.Open(ctx, client.clientID)
 }
 
+// slowDrainOp flags a shutdown-drain operation (a client's provider flush, a
+// session-wide telemetry flush, a workspace lock flush) that ate a meaningful
+// chunk of the drain budget: the CLI allows 10s for the whole shutdown, and a
+// session-level flush covers every client in the session.
+const slowDrainOp = 2 * time.Second
+
+// timedProviderOp times one provider's flush/shutdown within a client-level
+// telemetry flush, so slow flushes can be attributed to the traces vs. logs
+// vs. metrics pipeline.
+func timedProviderOp(ctx context.Context, errs *error, op func(context.Context) error) time.Duration {
+	start := time.Now()
+	*errs = errors.Join(*errs, op(ctx))
+	return time.Since(start)
+}
+
 func (client *daggerClient) FlushTelemetry(ctx context.Context) error {
 	slog := slog.With("client", client.clientID)
+	start := time.Now()
 	var errs error
+	var traceDur, logDur, metricDur time.Duration
 	if client.tracerProvider != nil {
 		slog.ExtraDebug("force flushing client traces")
-		errs = errors.Join(errs, client.tracerProvider.ForceFlush(ctx))
+		traceDur = timedProviderOp(ctx, &errs, client.tracerProvider.ForceFlush)
 	}
 	if client.loggerProvider != nil {
 		slog.ExtraDebug("force flushing client logs")
-		errs = errors.Join(errs, client.loggerProvider.ForceFlush(ctx))
+		logDur = timedProviderOp(ctx, &errs, client.loggerProvider.ForceFlush)
 	}
 	if client.meterProvider != nil {
 		slog.ExtraDebug("force flushing client metrics")
-		errs = errors.Join(errs, client.meterProvider.ForceFlush(ctx))
+		metricDur = timedProviderOp(ctx, &errs, client.meterProvider.ForceFlush)
 	}
+	logClientTelemetryOp(slog, "client telemetry flush", start, traceDur, logDur, metricDur, errs)
 	return errs
 }
 
 func (client *daggerClient) ShutdownTelemetry(ctx context.Context) error {
 	slog := slog.With("client", client.clientID)
+	start := time.Now()
 	var errs error
+	var traceDur, logDur, metricDur time.Duration
 	if client.tracerProvider != nil {
 		slog.ExtraDebug("force flushing client traces")
-		errs = errors.Join(errs, client.tracerProvider.Shutdown(ctx))
+		traceDur = timedProviderOp(ctx, &errs, client.tracerProvider.Shutdown)
 	}
 	if client.loggerProvider != nil {
 		slog.ExtraDebug("force flushing client logs")
-		errs = errors.Join(errs, client.loggerProvider.Shutdown(ctx))
+		logDur = timedProviderOp(ctx, &errs, client.loggerProvider.Shutdown)
 	}
 	if client.meterProvider != nil {
 		slog.ExtraDebug("force flushing client metrics")
-		errs = errors.Join(errs, client.meterProvider.Shutdown(ctx))
+		metricDur = timedProviderOp(ctx, &errs, client.meterProvider.Shutdown)
 	}
+	logClientTelemetryOp(slog, "client telemetry shutdown", start, traceDur, logDur, metricDur, errs)
 	return errs
+}
+
+func logClientTelemetryOp(lg *slog.Logger, what string, start time.Time, traceDur, logDur, metricDur time.Duration, errs error) {
+	total := time.Since(start)
+	lg = lg.With(
+		"duration", total,
+		"traces", traceDur,
+		"logs", logDur,
+		"metrics", metricDur,
+		"error", errs,
+	)
+	switch {
+	case total > slowDrainOp:
+		lg.Warn("slow " + what)
+	case total > 100*time.Millisecond:
+		lg.Debug(what)
+	default:
+		lg.ExtraDebug(what)
+	}
 }
 
 func (client *daggerClient) getMainClientCaller(ctx context.Context) (engineutil.SessionCaller, error) {
@@ -365,16 +405,46 @@ func (sess *daggerSession) StoreTelemetrySeenKey(key string) {
 	sess.seenKeys.Store(key, struct{}{})
 }
 
-func (sess *daggerSession) FlushTelemetry(ctx context.Context) error {
-	eg := new(errgroup.Group)
+// inflightSessionTelemetryFlushes counts engine-wide concurrent session-level
+// telemetry flushes. Every flush fans out to every client in its session, so
+// concurrent flushes multiply pressure on the same client DBs; the gauge makes
+// that amplification visible next to each flush's duration.
+var inflightSessionTelemetryFlushes atomic.Int64
+
+func (sess *daggerSession) FlushTelemetry(ctx context.Context, reason string) error {
+	inflight := inflightSessionTelemetryFlushes.Add(1)
+	defer inflightSessionTelemetryFlushes.Add(-1)
+
 	sess.clientMu.Lock()
+	clients := make([]*daggerClient, 0, len(sess.clients))
 	for _, client := range sess.clients {
+		clients = append(clients, client)
+	}
+	sess.clientMu.Unlock()
+
+	lg := slog.With(
+		"sessionID", sess.sessionID,
+		"reason", reason,
+		"clients", len(clients),
+		"inflightSessionFlushes", inflight)
+	lg.Debug("flushing session telemetry")
+
+	start := time.Now()
+	eg := new(errgroup.Group)
+	for _, client := range clients {
 		eg.Go(func() error {
 			return client.FlushTelemetry(ctx)
 		})
 	}
-	sess.clientMu.Unlock()
-	return eg.Wait()
+	err := eg.Wait()
+
+	lg = lg.With("duration", time.Since(start), "error", err)
+	if time.Since(start) > slowDrainOp {
+		lg.Warn("slow session telemetry flush")
+	} else {
+		lg.Debug("session telemetry flush done")
+	}
+	return err
 }
 
 // requires that sess.lifecycleMu is held
@@ -1851,12 +1921,29 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		"mainClientID", sess.mainClientCallerID)
 
 	slog.Info("client shutdown")
-	defer slog.Debug("client shutdown done")
+	shutdownStart := time.Now()
+	defer func() {
+		slog.Info("client shutdown done", "duration", time.Since(shutdownStart), "error", shutdownErr)
+	}()
+
+	// drainPhase times one shutdown drain phase, logging before and after: the
+	// client enforces a hard deadline on the whole shutdown request, so a
+	// phase that stalls (or wedges forever on an uncancellable context) must
+	// be attributable from the engine log alone.
+	drainPhase := func(name string, fn func() error) error {
+		slog.Debug("shutdown drain phase starting", "phase", name)
+		start := time.Now()
+		err := fn()
+		slog.Info("shutdown drain phase done", "phase", name, "duration", time.Since(start), "error", err)
+		return err
+	}
 
 	if client.clientID == sess.mainClientCallerID {
 		slog.Info("main client is shutting down")
-		flushCtx := context.WithoutCancel(ctx)
-		if err := srv.flushWorkspaceLocks(flushCtx, client); err != nil {
+		err := drainPhase("flush workspace locks", func() error {
+			return srv.flushWorkspaceLocks(context.WithoutCancel(ctx), client)
+		})
+		if err != nil {
 			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush workspace locks: %w", err))
 			slog.Error("failed to flush workspace locks", "error", err)
 		}
@@ -1865,8 +1952,12 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		sess.beginClosing()
 
 		// Stop services, since the main client is going away, and we
-		// want the client to see them stop.
-		sess.services.StopSessionServices(ctx, sess.sessionID)
+		// want the client to see them stop. Stop errors are not surfaced
+		// (matching prior behavior), so the phase always returns nil.
+		_ = drainPhase("stop session services", func() error {
+			sess.services.StopSessionServices(ctx, sess.sessionID)
+			return nil
+		})
 
 		defer func() {
 			// Signal shutdown at the very end, _after_ flushing telemetry/etc.,
@@ -1877,8 +1968,10 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 			})
 		}()
 	} else {
-		flushCtx := context.WithoutCancel(ctx)
-		if err := srv.flushWorkspaceLocks(flushCtx, client); err != nil {
+		err := drainPhase("flush workspace locks", func() error {
+			return srv.flushWorkspaceLocks(context.WithoutCancel(ctx), client)
+		})
+		if err != nil {
 			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush workspace locks: %w", err))
 			slog.Error("failed to flush workspace locks", "error", err)
 		}
@@ -1886,8 +1979,10 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 
 	// Flush telemetry across the entire session so that any child clients will
 	// save telemetry into their parent's DB, including to this client.
-	slog.ExtraDebug("flushing session telemetry")
-	if err := sess.FlushTelemetry(ctx); err != nil {
+	err := drainPhase("flush session telemetry", func() error {
+		return sess.FlushTelemetry(ctx, "client shutdown")
+	})
+	if err != nil {
 		slog.Error("failed to flush telemetry", "error", err)
 		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush session telemetry: %w", err))
 	}
@@ -2326,7 +2421,14 @@ func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient
 
 	var flushErr error
 	for _, export := range pending {
+		lg := slog.With("lockPath", export.lockPath, "clientID", client.clientID)
+		// Log before the host roundtrip: it runs on an uncancellable context
+		// against the client's session attachables, so if the client is gone
+		// it can wedge here and this line is the only breadcrumb.
+		lg.Debug("flushing workspace lock")
+		lockStart := time.Now()
 		srv.locker.Lock(export.lockPath)
+		lockWait := time.Since(lockStart)
 
 		workspaceCtx, bk, err := srv.workspaceOwnerAccess(ctx, sess, export.ws)
 		if err == nil {
@@ -2341,6 +2443,13 @@ func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient
 		}
 
 		srv.locker.Unlock(export.lockPath)
+
+		lg = lg.With("duration", time.Since(lockStart), "lockWait", lockWait, "error", err)
+		if time.Since(lockStart) > slowDrainOp {
+			lg.Warn("slow workspace lock flush")
+		} else {
+			lg.Debug("workspace lock flush done")
+		}
 
 		if err != nil {
 			flushErr = errors.Join(flushErr, fmt.Errorf("flush workspace lock %s: %w", export.lockPath, err))
@@ -2647,7 +2756,7 @@ func (srv *Server) FlushSessionTelemetry(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return client.daggerSession.FlushTelemetry(ctx)
+	return client.daggerSession.FlushTelemetry(ctx, "FlushSessionTelemetry API")
 }
 
 func (srv *Server) ClientTelemetry(ctx context.Context, sessID, clientID string) (*clientdb.DB, error) {
@@ -2659,7 +2768,7 @@ func (srv *Server) ClientTelemetry(ctx context.Context, sessID, clientID string)
 	// Spans from nested clients may still be buffered in their
 	// BatchSpanProcessor. A session-wide flush ensures the span tree
 	// is complete before captureLogs walks it via SelectLogsBeneathSpan.
-	if err := client.daggerSession.FlushTelemetry(ctx); err != nil {
+	if err := client.daggerSession.FlushTelemetry(ctx, "ClientTelemetry API"); err != nil {
 		return nil, fmt.Errorf("flush telemetry: %w", err)
 	}
 	return client.TelemetryDB(ctx)

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -944,8 +944,10 @@ func (srv *Server) initializeDaggerClient(
 		// save to our own client's DB. Large-queue BSP so a big burst (a cold engine
 		// build is ~15k spans, live-double-emitted ≈ 30k records) does not overflow the
 		// default 2048-slot queue and silently drop spans before they reach the DB the
-		// CLI drains toward Cloud (see enginetel.NewLargeQueueLiveSpanProcessor).
-		sdktrace.WithSpanProcessor(enginetel.NewLargeQueueLiveSpanProcessor(
+		// CLI drains toward Cloud. InternalFiltering: drop the live (OnStart) snapshot
+		// for dagger.io/ui.internal spans — they're hidden from the UI, so their live
+		// double-write is pure SQLite write volume (see NewInternalFilteringLiveSpanProcessor).
+		sdktrace.WithSpanProcessor(enginetel.NewInternalFilteringLiveSpanProcessor(
 			client.spanExporter,
 		)),
 	}
@@ -976,11 +978,12 @@ func (srv *Server) initializeDaggerClient(
 		)),
 	}
 
-	// export to parent client DBs too (same large-queue BSP — nested-client spans
-	// reach Cloud via the parent DB, so this hop must not drop on a burst either).
+	// export to parent client DBs too (same large-queue InternalFiltering BSP —
+	// nested-client spans reach Cloud via the parent DB, so this hop must not drop
+	// on a burst either, and internal spans skip their live double-emit here too).
 	for _, parent := range client.parents {
 		tracerOpts = append(tracerOpts, sdktrace.WithSpanProcessor(
-			enginetel.NewLargeQueueLiveSpanProcessor(
+			enginetel.NewInternalFilteringLiveSpanProcessor(
 				srv.telemetryPubSub.Spans(parent),
 			),
 		))

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -86,6 +86,7 @@ func (ps *PubSub) TracesHandler(rw http.ResponseWriter, r *http.Request) {
 	spans := telemetry.SpansFromPB(req.ResourceSpans)
 	slog.Debug("exporting spans to clients", "spans", len(spans), "clients", len(client.parents)+1)
 
+	start := time.Now()
 	eg := new(errgroup.Group)
 	for _, c := range append([]*daggerClient{client}, client.parents...) {
 		eg.Go(func() error {
@@ -96,9 +97,12 @@ func (ps *PubSub) TracesHandler(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		slog.Error("error exporting spans", "err", err)
+		slog.Error("error exporting spans", "err", err, "duration", time.Since(start))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if elapsed := time.Since(start); elapsed > slowTelemetryOp {
+		slog.Warn("slow span fan-out", "from", client.clientID, "clients", len(client.parents)+1, "spans", len(spans), "duration", elapsed)
 	}
 
 	rw.WriteHeader(http.StatusCreated)
@@ -130,6 +134,7 @@ func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) {
 
 	slog.Debug("exporting logs to clients", "clients", len(client.parents)+1)
 
+	start := time.Now()
 	eg := new(errgroup.Group)
 	for _, c := range append([]*daggerClient{client}, client.parents...) {
 		eg.Go(func() error {
@@ -140,9 +145,12 @@ func (ps *PubSub) LogsHandler(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		slog.Error("error exporting logs", "err", err)
+		slog.Error("error exporting logs", "err", err, "duration", time.Since(start))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if elapsed := time.Since(start); elapsed > slowTelemetryOp {
+		slog.Warn("slow log fan-out", "from", client.clientID, "clients", len(client.parents)+1, "duration", elapsed)
 	}
 
 	rw.WriteHeader(http.StatusCreated)
@@ -174,6 +182,7 @@ func (ps *PubSub) MetricsHandler(rw http.ResponseWriter, r *http.Request) {
 
 	slog.Debug("exporting metrics to clients", "clients", len(client.parents)+1)
 
+	start := time.Now()
 	eg := new(errgroup.Group)
 	for _, c := range append([]*daggerClient{client}, client.parents...) {
 		eg.Go(func() error {
@@ -184,15 +193,50 @@ func (ps *PubSub) MetricsHandler(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		slog.Error("error exporting metrics", "err", err)
+		slog.Error("error exporting metrics", "err", err, "duration", time.Since(start))
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if elapsed := time.Since(start); elapsed > slowTelemetryOp {
+		slog.Warn("slow metric fan-out", "from", client.clientID, "clients", len(client.parents)+1, "duration", elapsed)
 	}
 
 	rw.WriteHeader(http.StatusCreated)
 }
 
 const otlpBatchSize = 1000
+
+// slowTelemetryOp flags telemetry DB operations slow enough to threaten a
+// client's shutdown budget (the CLI allows 10s for the whole shutdown drain).
+const slowTelemetryOp = 1 * time.Second
+
+// logTelemetryWrite records how a client-DB write batch spent its time. The
+// pool is capped at one connection per DB, so the pool-stat deltas attribute
+// latency to queuing behind that connection (poolWaitCountDelta/poolWaitDelta,
+// inflated by every concurrent user of the same DB) vs. executing the
+// statements themselves (writeDuration with a small poolWaitDelta).
+func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart time.Time, maxStmt time.Duration, before, after sql.DBStats, err error) {
+	total := time.Since(totalStart)
+	lg := slog.With(
+		"client", clientID,
+		"what", what,
+		"rows", rows,
+		"duration", total,
+		"writeDuration", time.Since(writeStart),
+		"maxStmtDuration", maxStmt,
+		"poolWaitCountDelta", after.WaitCount-before.WaitCount,
+		"poolWaitDelta", after.WaitDuration-before.WaitDuration,
+		"error", err,
+	)
+	switch {
+	case total > slowTelemetryOp:
+		lg.Warn("slow client DB telemetry write")
+	case total > 100*time.Millisecond || rows >= 100:
+		lg.Debug("client DB telemetry write")
+	default:
+		lg.ExtraDebug("client DB telemetry write")
+	}
+}
 
 func (ps *PubSub) TracesSubscribeHandler(w http.ResponseWriter, r *http.Request, client *daggerClient) error {
 	return ps.sseHandler(w, r, client, func(ctx context.Context, db *clientdb.DB, lastID string) (*sse.Event, bool, error) {
@@ -320,6 +364,7 @@ func (ps *PubSub) Spans(client *daggerClient) sdktrace.SpanExporter {
 
 func (ps clientSpans) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
 	slog.ExtraDebug("pubsub exporting spans", "client", ps.client.clientID, "count", len(spans))
+	start := time.Now()
 
 	var inserts []*clientdb.InsertSpanParams
 	for _, span := range spans {
@@ -402,11 +447,21 @@ func (ps clientSpans) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 	}
 	defer db.Close()
 
+	statsBefore := db.Stats()
+	writeStart := time.Now()
+	var maxStmt time.Duration
+	var insertErr error
 	for _, insert := range inserts {
-		_, err = db.InsertSpan(ctx, *insert)
-		if err != nil {
-			return fmt.Errorf("insert span: %w", err)
+		stmtStart := time.Now()
+		_, insertErr = db.InsertSpan(ctx, *insert)
+		maxStmt = max(maxStmt, time.Since(stmtStart))
+		if insertErr != nil {
+			break
 		}
+	}
+	logTelemetryWrite(ps.client.clientID, "spans", len(inserts), start, writeStart, maxStmt, statsBefore, db.Stats(), insertErr)
+	if insertErr != nil {
+		return fmt.Errorf("insert span: %w", insertErr)
 	}
 
 	return nil
@@ -429,6 +484,7 @@ var _ sdklog.Exporter = clientLogs{}
 
 func (ps clientLogs) Export(ctx context.Context, logs []sdklog.Record) error {
 	slog.ExtraDebug("pubsub exporting logs", "client", ps.client.clientID, "count", len(logs))
+	start := time.Now()
 
 	var inserts []*clientdb.InsertLogParams
 	for _, rec := range logs {
@@ -445,12 +501,19 @@ func (ps clientLogs) Export(ctx context.Context, logs []sdklog.Record) error {
 	}
 	defer db.Close()
 
+	statsBefore := db.Stats()
+	writeStart := time.Now()
+	var maxStmt time.Duration
 	for _, insert := range inserts {
-		if _, err := db.InsertLog(ctx, *insert); err != nil {
+		stmtStart := time.Now()
+		_, err := db.InsertLog(ctx, *insert)
+		maxStmt = max(maxStmt, time.Since(stmtStart))
+		if err != nil {
 			slog.Warn("failed to insert log record", "error", err)
 			continue
 		}
 	}
+	logTelemetryWrite(ps.client.clientID, "logs", len(inserts), start, writeStart, maxStmt, statsBefore, db.Stats(), nil)
 
 	return nil
 }
@@ -535,6 +598,7 @@ func (ps clientMetrics) Export(ctx context.Context, metrics *metricdata.Resource
 	}
 
 	slog.ExtraDebug("pubsub exporting metrics", "client", ps.client.clientID, "count", len(metrics.ScopeMetrics))
+	start := time.Now()
 
 	pbMetrics, err := telemetry.ResourceMetricsToPB(metrics)
 	if err != nil {
@@ -552,7 +616,10 @@ func (ps clientMetrics) Export(ctx context.Context, metrics *metricdata.Resource
 	}
 	defer db.Close()
 
+	statsBefore := db.Stats()
+	writeStart := time.Now()
 	_, err = db.InsertMetric(ctx, metricsPBBytes)
+	logTelemetryWrite(ps.client.clientID, "metrics", 1, start, writeStart, time.Since(writeStart), statsBefore, db.Stats(), err)
 	if err != nil {
 		return fmt.Errorf("insert metrics: %w", err)
 	}
@@ -607,7 +674,13 @@ func (ps *PubSub) sseHandler(w http.ResponseWriter, r *http.Request, client *dag
 
 	var terminating bool
 	for {
+		fetchStart := time.Now()
 		event, hasData, err := fetcher(r.Context(), db, since)
+		if elapsed := time.Since(fetchStart); elapsed > slowTelemetryOp {
+			// The SELECT inside the fetch holds the DB's only connection,
+			// stalling every writer targeting the same client DB.
+			slog.Warn("slow SSE fetch", "duration", elapsed, "hasData", hasData, "error", err)
+		}
 		if err != nil {
 			slog.Warn("error fetching event", "err", err)
 			return fmt.Errorf("fetch: %w", err)

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -210,12 +210,22 @@ const otlpBatchSize = 1000
 // client's shutdown budget (the CLI allows 10s for the whole shutdown drain).
 const slowTelemetryOp = 1 * time.Second
 
-// logTelemetryWrite records how a client-DB write batch spent its time. The
-// pool is capped at one connection per DB, so the pool-stat deltas attribute
-// latency to queuing behind that connection (poolWaitCountDelta/poolWaitDelta,
-// inflated by every concurrent user of the same DB) vs. executing the
-// statements themselves (writeDuration with a small poolWaitDelta).
-func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart time.Time, maxStmt time.Duration, before, after sql.DBStats, err error) {
+// writeTiming decomposes how a batched client-DB write spent its wall-clock,
+// so "write N rows" is attributable to acquiring the single write connection
+// vs. the INSERTs themselves vs. the WAL commit.
+type writeTiming struct {
+	beginWait time.Duration // acquire the write connection + BEGIN IMMEDIATE
+	maxStmt   time.Duration // slowest single INSERT once the lock is held
+	commit    time.Duration // COMMIT (WAL append)
+}
+
+// logTelemetryWrite records how a client-DB write batch of N rows spent its
+// time. The write pool is a single connection per DB, so beginWait is the time
+// queued behind other writers for that connection (the writer convoy), while
+// maxStmtDuration/commitDuration are the actual SQLite work once it is held.
+// writeDuration is the whole batch write (beginWait + inserts + commit);
+// poolWaitDelta corroborates beginWait from database/sql's own accounting.
+func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart time.Time, t writeTiming, before, after sql.DBStats, err error) {
 	total := time.Since(totalStart)
 	lg := slog.With(
 		"client", clientID,
@@ -223,7 +233,9 @@ func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart t
 		"rows", rows,
 		"duration", total,
 		"writeDuration", time.Since(writeStart),
-		"maxStmtDuration", maxStmt,
+		"beginWait", t.beginWait,
+		"maxStmtDuration", t.maxStmt,
+		"commitDuration", t.commit,
 		"poolWaitCountDelta", after.WaitCount-before.WaitCount,
 		"poolWaitDelta", after.WaitDuration-before.WaitDuration,
 		"error", err,
@@ -247,7 +259,7 @@ func (ps *PubSub) TracesSubscribeHandler(w http.ResponseWriter, r *http.Request,
 				return nil, false, fmt.Errorf("invalid last ID: %w", err)
 			}
 		}
-		spans, err := db.SelectSpansSince(ctx, clientdb.SelectSpansSinceParams{
+		spans, err := db.Read().SelectSpansSince(ctx, clientdb.SelectSpansSinceParams{
 			ID:    since,
 			Limit: otlpBatchSize,
 		})
@@ -287,7 +299,7 @@ func (ps *PubSub) LogsSubscribeHandler(w http.ResponseWriter, r *http.Request, c
 				return nil, false, fmt.Errorf("invalid last ID: %w", err)
 			}
 		}
-		logs, err := db.SelectLogsSince(ctx, clientdb.SelectLogsSinceParams{
+		logs, err := db.Read().SelectLogsSince(ctx, clientdb.SelectLogsSinceParams{
 			ID:    since,
 			Limit: otlpBatchSize,
 		})
@@ -323,7 +335,7 @@ func (ps *PubSub) MetricsSubscribeHandler(w http.ResponseWriter, r *http.Request
 				return nil, false, fmt.Errorf("invalid last ID: %w", err)
 			}
 		}
-		metrics, err := db.SelectMetricsSince(ctx, clientdb.SelectMetricsSinceParams{
+		metrics, err := db.Read().SelectMetricsSince(ctx, clientdb.SelectMetricsSinceParams{
 			ID:    since,
 			Limit: otlpBatchSize,
 		})
@@ -449,19 +461,41 @@ func (ps clientSpans) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 
 	statsBefore := db.Stats()
 	writeStart := time.Now()
-	var maxStmt time.Duration
-	var insertErr error
-	for _, insert := range inserts {
-		stmtStart := time.Now()
-		_, insertErr = db.InsertSpan(ctx, *insert)
-		maxStmt = max(maxStmt, time.Since(stmtStart))
-		if insertErr != nil {
-			break
+	var timing writeTiming
+	// Insert the whole batch under one write transaction so it takes the write
+	// lock once instead of once per row. The write pool is a single connection
+	// separate from the read pool, so holding it for the batch does not block
+	// SSE reads (which is why per-batch batching is safe here but was not on a
+	// shared connection).
+	insertErr := func() (rerr error) {
+		beginStart := time.Now()
+		tx, err := db.BeginTx(ctx, nil)
+		timing.beginWait = time.Since(beginStart)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
 		}
-	}
-	logTelemetryWrite(ps.client.clientID, "spans", len(inserts), start, writeStart, maxStmt, statsBefore, db.Stats(), insertErr)
+		defer func() {
+			if rerr != nil {
+				_ = tx.Rollback()
+			}
+		}()
+		q := db.WithTx(tx)
+		for _, insert := range inserts {
+			stmtStart := time.Now()
+			_, err := q.InsertSpan(ctx, *insert)
+			timing.maxStmt = max(timing.maxStmt, time.Since(stmtStart))
+			if err != nil {
+				return fmt.Errorf("insert span: %w", err)
+			}
+		}
+		commitStart := time.Now()
+		err = tx.Commit()
+		timing.commit = time.Since(commitStart)
+		return err
+	}()
+	logTelemetryWrite(ps.client.clientID, "spans", len(inserts), start, writeStart, timing, statsBefore, db.Stats(), insertErr)
 	if insertErr != nil {
-		return fmt.Errorf("insert span: %w", insertErr)
+		return insertErr
 	}
 
 	return nil
@@ -503,17 +537,33 @@ func (ps clientLogs) Export(ctx context.Context, logs []sdklog.Record) error {
 
 	statsBefore := db.Stats()
 	writeStart := time.Now()
-	var maxStmt time.Duration
+	var timing writeTiming
+	// Batch under one write transaction (see ExportSpans). Individual insert
+	// failures stay best-effort: log and continue rather than abort the batch.
+	beginStart := time.Now()
+	tx, err := db.BeginTx(ctx, nil)
+	timing.beginWait = time.Since(beginStart)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	q := db.WithTx(tx)
 	for _, insert := range inserts {
 		stmtStart := time.Now()
-		_, err := db.InsertLog(ctx, *insert)
-		maxStmt = max(maxStmt, time.Since(stmtStart))
+		_, err := q.InsertLog(ctx, *insert)
+		timing.maxStmt = max(timing.maxStmt, time.Since(stmtStart))
 		if err != nil {
 			slog.Warn("failed to insert log record", "error", err)
 			continue
 		}
 	}
-	logTelemetryWrite(ps.client.clientID, "logs", len(inserts), start, writeStart, maxStmt, statsBefore, db.Stats(), nil)
+	commitStart := time.Now()
+	commitErr := tx.Commit()
+	timing.commit = time.Since(commitStart)
+	if commitErr != nil {
+		_ = tx.Rollback()
+		slog.Warn("failed to commit log records", "error", commitErr)
+	}
+	logTelemetryWrite(ps.client.clientID, "logs", len(inserts), start, writeStart, timing, statsBefore, db.Stats(), commitErr)
 
 	return nil
 }
@@ -619,7 +669,9 @@ func (ps clientMetrics) Export(ctx context.Context, metrics *metricdata.Resource
 	statsBefore := db.Stats()
 	writeStart := time.Now()
 	_, err = db.InsertMetric(ctx, metricsPBBytes)
-	logTelemetryWrite(ps.client.clientID, "metrics", 1, start, writeStart, time.Since(writeStart), statsBefore, db.Stats(), err)
+	// Single auto-commit insert (not batched); the whole write shows up as
+	// maxStmt, with no separate begin/commit phases.
+	logTelemetryWrite(ps.client.clientID, "metrics", 1, start, writeStart, writeTiming{maxStmt: time.Since(writeStart)}, statsBefore, db.Stats(), err)
 	if err != nil {
 		return fmt.Errorf("insert metrics: %w", err)
 	}

--- a/engine/telemetry/livespan.go
+++ b/engine/telemetry/livespan.go
@@ -1,6 +1,10 @@
 package telemetry
 
 import (
+	"context"
+	"sync/atomic"
+
+	"github.com/dagger/dagger/engine/slog"
 	telemetry "github.com/dagger/otel-go"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
@@ -34,17 +38,95 @@ const (
 )
 
 // NewLargeQueueLiveSpanProcessor is otel.NewLiveSpanProcessor with the enlarged
-// bounded queue above in place of the default 2048-slot one. Use it on every span
-// hop that feeds a Cloud trace — the engine's per-client DB processors
-// (engine/server) and the CLI→Cloud exporter (internal/cmd/dagger).
+// bounded queue above in place of the default 2048-slot one. Used on the CLI→Cloud
+// exporter (internal/cmd/dagger) so a big-burst trace arrives complete. The engine's
+// per-client DB processors use NewInternalFilteringLiveSpanProcessor instead.
 func NewLargeQueueLiveSpanProcessor(exp sdktrace.SpanExporter) *telemetry.LiveSpanProcessor {
 	return &telemetry.LiveSpanProcessor{
-		SpanProcessor: sdktrace.NewBatchSpanProcessor(
-			exp,
-			sdktrace.WithMaxQueueSize(LargeSpanQueueSize),
-			sdktrace.WithMaxExportBatchSize(LargeSpanExportBatchSize),
-			// Preserve near-immediate live export (matches otel.NewLiveSpanProcessor).
-			sdktrace.WithBatchTimeout(telemetry.NearlyImmediate),
-		),
+		SpanProcessor: newLargeQueueBSP(exp),
 	}
+}
+
+func newLargeQueueBSP(exp sdktrace.SpanExporter) sdktrace.SpanProcessor {
+	return sdktrace.NewBatchSpanProcessor(
+		exp,
+		sdktrace.WithMaxQueueSize(LargeSpanQueueSize),
+		sdktrace.WithMaxExportBatchSize(LargeSpanExportBatchSize),
+		// Preserve near-immediate live export (matches otel.NewLiveSpanProcessor).
+		sdktrace.WithBatchTimeout(telemetry.NearlyImmediate),
+	)
+}
+
+// liveSkipLogInterval is how many suppressed internal live-emits between progress
+// log lines (a coarse, process-global counter — one line per this many skips).
+const liveSkipLogInterval = 10000
+
+var (
+	// liveInternalSkipped counts live (OnStart) snapshots suppressed because the
+	// span is dagger.io/ui.internal, across every InternalFiltering processor in
+	// this engine process.
+	liveInternalSkipped atomic.Int64
+	// liveEmitted counts live snapshots actually emitted (non-internal spans).
+	// Together with liveInternalSkipped it gives the fraction of the live
+	// double-emit we dropped: skipped / (skipped + emitted).
+	liveEmitted atomic.Int64
+)
+
+// NewInternalFilteringLiveSpanProcessor is NewLargeQueueLiveSpanProcessor that
+// additionally SKIPS the live (OnStart) double-emit for dagger.io/ui.internal
+// spans. Those spans are hidden from the UI by default, so their live snapshot is
+// pure write volume on the per-client SQLite DBs with zero live-rendering value —
+// yet it doubles their write cost, and internal spans (the reflection/schema-walk
+// class, plus the childless dagql.publishResult leaf) are a large share of a
+// module-load trace. The final (OnEnd) span is still written, so nothing is lost
+// from the completed trace or Cloud; only the running snapshot is dropped.
+//
+// Only genuinely childless-or-hidden spans should be marked Internal: a span the
+// UI renders (or whose children it promotes, e.g. a Passthrough call_exec twin)
+// must keep its live snapshot, else its visible descendants are orphaned live.
+func NewInternalFilteringLiveSpanProcessor(exp sdktrace.SpanExporter) sdktrace.SpanProcessor {
+	return &internalFilteringLiveSpanProcessor{
+		SpanProcessor: newLargeQueueBSP(exp),
+	}
+}
+
+// internalFilteringLiveSpanProcessor is a LiveSpanProcessor (OnStart re-emits the
+// span as a live snapshot) that suppresses that snapshot for internal spans.
+type internalFilteringLiveSpanProcessor struct {
+	sdktrace.SpanProcessor // underlying large-queue BatchSpanProcessor
+}
+
+func (p *internalFilteringLiveSpanProcessor) OnStart(_ context.Context, span sdktrace.ReadWriteSpan) {
+	if spanIsInternal(span) {
+		n := liveInternalSkipped.Add(1)
+		if n%liveSkipLogInterval == 0 {
+			emitted := liveEmitted.Load()
+			var pct float64
+			if total := n + emitted; total > 0 {
+				pct = 100 * float64(n) / float64(total)
+			}
+			slog.Info("suppressed internal-span live double-emit (write-volume reduction)",
+				"skippedInternalLiveEmits", n,
+				"liveEmitted", emitted,
+				"skipPctOfLiveEmits", pct)
+		}
+		return
+	}
+	liveEmitted.Add(1)
+	// Send a read-only snapshot of the live span downstream (matches
+	// otel.LiveSpanProcessor.OnStart) so a running span is visible before it ends.
+	p.SpanProcessor.OnEnd(telemetry.SnapshotSpan(span))
+}
+
+// spanIsInternal reports whether the span carries dagger.io/ui.internal=true. The
+// attribute is set at span creation (telemetry.Internal() is a SpanStartOption),
+// so it is already present here in OnStart; spans marked internal only later via
+// SetAttributes are not caught and keep their live emit.
+func spanIsInternal(span sdktrace.ReadWriteSpan) bool {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == telemetry.UIInternalAttr {
+			return kv.Value.AsBool()
+		}
+	}
+	return false
 }


### PR DESCRIPTION
:robot::

## Summary

Fixes the intermittent `test-split:test-workspaces` (and occasionally other splits) flake where otherwise-passing tests failed at cleanup:

```
cleanup failed: "close dagger session": shutdown: do shutdown:
Post "http://dagger/shutdown": context deadline exceeded
```

The CLI gives session shutdown a 10s budget. At teardown the engine force-flushes each client's buffered telemetry to per-client SQLite DBs; under a parallel-teardown storm those writes convoy on SQLite's single writer and blow the budget. Several contention sources compounded; this PR fixes them and keeps the instrumentation that let us attribute each one.

## Why now

The flake appeared mid-July. Querying span volume per `test-split:test-workspaces` trace over time (Dagger Cloud / ClickHouse) shows it isn't gradual — median spans/trace **doubled overnight on Jul 14–15**, ~60k → ~120k, coinciding with #13588 (wall-clock OTel profiling emission). That change (a) added new profiling spans — `dagql.publishResult` alone is ~22% of a trace — and (b) enlarged the per-client DB span queue 128× (2048 → 256Ki), so bursts CI used to silently shed are now all retained and must be flushed at teardown. More teardown write volume on the same single-writer sink is what tipped a latent contention into an active flake.

## Root cause (two compounding contention sources)

**1. An O(n²) flush storm.** Every client shutdown called `sess.FlushTelemetry`, which ForceFlushes *every* client in the session. N clients tearing down = N whole-session flushes (instrumentation showed up to 30 concurrent, each fanning out to ~69 providers).

**2. A single-writer DB convoy.** SQLite permits one writer per DB file. A shared single-connection pool funneled every reader and writer through it; the hot main-client DB — the session-wide sink the CLI drains — serialized all writes, and flushes queued behind each other: `beginWait`/`poolWaitDelta` in the tens of seconds while individual statements stayed sub-second.

## The fix

- **Scope the shutdown flush.** A nested client's providers already export to its own DB *and every ancestor DB*, so it only needs to flush itself; only the main client keeps the session-wide sweep. Removes concurrent contenders without lengthening any single hold — the axis a tail-latency budget cares about.
- **Split the DB pools + batch writes.** A single-connection *write* pool (respecting SQLite's one-writer limit and the modernc thread-pinning tripwire) plus a multi-connection *read* pool (WAL readers run concurrently with the writer); each export batched into one transaction. Per-statement and commit costs drop to trivial, leaving only queue-for-the-writer time.
- **Skip the live double-emit for internal spans** (`fix(telemetry): skip live emit for internal spans`). The per-client DBs wrote every span twice — a live start snapshot plus the final span. For `dagger.io/ui.internal` spans that snapshot renders nothing, so it is pure write volume. Skipping it (and reclassifying the childless `dagql.publishResult` leaf from passthrough → internal so it is covered) removes ~20% of DB writes, directly attacking the volume #13588 added. The final span is still written, so nothing is lost from the completed trace or Cloud.

## Validation

Engine logs on comparable load (337 vs 330 total sessions; largest session 68 vs 73 clients):

| metric | before (RED, timed out) | after (this PR) |
|---|---|---|
| canceled / failed shutdowns | 1 (the flake) | **0** |
| max client shutdown | 9.998s (killed at budget) | **4.12s** (completed) |
| client shutdown >9s / >5s | 1 / 9 | **0 / 0** |
| DB-write `beginWait` max | 11.55s | 7.13s |
| `beginWait` >9s / >5s writes | 13 / 71 | **0 / 7** |

The failure mode — a flush killed at the 10s ceiling — is gone, with ~2.4× headroom under budget. A process-global counter logs suppressed live-emits for auditing; the capture dropped **80k internal live-emits (~39% of all live emits, ~20% of DB writes)**. Nested-client span delivery is preserved (`TestTelemetry/TestGolden/trace-function-calls`). Green across repeated CI re-runs.

The single-writer floor still produces multi-second holds under peak concurrent teardown (7 writes at 5–7s `beginWait`), so two levers remain in reserve if it regresses: normalizing the redundant per-row `resource`/`instrumentation_scope` blobs, and scoping the local-disk flush outside the network `Post /shutdown` deadline.

## Rejected approaches (documented so we don't relitigate)

- **Bump the client shutdown budget to 60s** — papers over legitimate contention; a healthy shutdown should never need >10s.
- **Pool cap = 10 on a shared pool** — reintroduced the modernc sqlite busy-wait (`busy_timeout` == the 10s budget), so one contended write could eat the whole budget. Superseded by the reader/writer split.
- **Batching writes on a shared pool** — long transactions starved SSE reads (tail 10s, 903 slow fetches); only safe once writes have a *dedicated* connection. Tail latency, not throughput, is the metric the budget cares about.
- **Dedupe span double-emission during the run** — would cripple the live TUI; the double-emit predates the regression and isn't the cause.

## Commits

1. `chore(engine): instrument shutdown drain and client DBs`
2. `fix(engine): scope shutdown telemetry flush`
3. `fix(clientdb): bump connection pool cap to 10` — now a no-op, fully superseded by #4 (squash candidate)
4. `fix(clientdb): split pools and batch writes`
5. `fix(telemetry): skip live emit for internal spans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
