### PR TITLE
feat(cli): recommend the deno module during dagger setup

### DIFF
--- a/docs/current_docs/modules/deno.mdx
+++ b/docs/current_docs/modules/deno.mdx
@@ -1,0 +1,105 @@
+---
+title: "Deno"
+slug: /modules/deno
+description: "Test, lint, format, and type-check Deno projects across a workspace."
+---
+
+# Deno
+
+The Deno module gives a Deno workspace one shared way to test, lint, format, and
+type-check. It scans the workspace for `deno.json`/`deno.jsonc` files, treats
+each as a Deno project, reads the `workspace` array to fan out across members,
+and exposes workspace-level functions that run across all of them — a good fit
+for monorepos and repos where every project should share one Deno version and
+the same CI checks.
+
+Rather than wrapping the `deno` CLI, it models a Deno project as a typed object
+graph and maps Deno's toolchain onto Dagger's first-class verbs, so the same
+checks run locally, in CI, and in Dagger Cloud.
+
+Official module: [dagger/deno](https://github.com/dagger/deno)
+
+## Add it to your workspace
+
+```bash
+dagger install github.com/dagger/deno
+```
+
+## Run the checks
+
+```bash
+dagger check                       # run every check in the workspace
+dagger check deno:test-all         # deno test across every project
+dagger check deno:lint-all         # deno lint across every project
+dagger check deno:type-check-all   # deno check across every project
+dagger check deno:format-check-all # deno fmt --check across every project
+```
+
+The `-all` checks discover every `deno.json`/`deno.jsonc` in the workspace,
+treat each as a Deno project, and run against all of them. Deno permissions come
+from each project's `deno.json` (under `test.permissions` or
+`permissions.default`), not from flags.
+
+To run a check against a single project, call it directly:
+
+```bash
+dagger call deno project --path . test
+dagger call deno project --path apps/api type-check
+```
+
+## Format the source
+
+`format-check` only reports whether files are formatted; `format` rewrites them.
+Because formatting mutates the workspace, `format` returns a changeset: Dagger
+prints the diff and asks before writing. Add `-y` to apply it without prompting:
+
+```bash
+dagger call deno project --path . format      # preview the diff
+dagger -y call deno project --path . format   # apply it
+```
+
+## Compile a binary
+
+`compile` builds a standalone executable from an entrypoint and returns it as a
+file to export:
+
+```bash
+dagger call deno project --path . \
+  compile --entrypoint main.ts --target x86_64-unknown-linux-gnu \
+  export --path ./bin/app
+```
+
+## Configure it
+
+List the current settings with `dagger settings deno`, then change one with
+`dagger settings deno <key> <value>`. They live in `dagger.toml` under
+`[modules.deno.settings]`:
+
+- **`version`** (default `2.9.3`): the Deno version used to build the check
+  containers. Pin this so every project is tested, linted, and formatted against
+  the same Deno release.
+- **`base`**: the base container image Deno runs in (for example
+  `docker.io/denoland/deno:debian`). Override it to control the OS or runtime the
+  toolchain runs on.
+
+`base` and `version` are mutually exclusive: when `base` is set it already pins a
+Deno release, so `version` is ignored.
+
+```bash
+# Pin the Deno version for the whole workspace
+dagger settings deno version 2.9.3
+```
+
+```toml
+[modules.deno.settings]
+version = "2.9.3"
+base = "docker.io/denoland/deno:debian"
+```
+
+## Working with other modules
+
+Reach for this module whenever the repo contains one or more Deno projects,
+especially when they should share the same Deno version and CI checks. It
+composes with the rest of your workspace — the `base` and `install` functions
+expose a Deno-ready container you can hand to other modules, and `version` prints
+the configured toolchain version.

--- a/docs/current_docs/modules/index.mdx
+++ b/docs/current_docs/modules/index.mdx
@@ -21,6 +21,7 @@ Each guide explains what the module is for, which checks or generators to reach 
 | Guide | What it covers |
 | --- | --- |
 | [Go](./go.mdx) | Test, lint, and run generators across every Go module in a workspace. |
+| [Deno](./deno.mdx) | Test, lint, format, and type-check every Deno project in a workspace. |
 | [Pytest](./pytest.mdx) | Run Python tests with Pytest. |
 | [Jest](./jest.mdx) | Run Jest tests for JavaScript and TypeScript. |
 | [Vitest](./vitest.mdx) | Run Vitest tests for JavaScript and TypeScript. |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -131,6 +131,7 @@ module.exports = {
       collapsed: true,
       items: [
         "modules/go",
+        "modules/deno",
         "modules/pytest",
         "modules/jest",
         "modules/vitest",

--- a/internal/cmd/dagger/modules.json
+++ b/internal/cmd/dagger/modules.json
@@ -6,6 +6,12 @@
     "recommend": ["**/go.mod"]
   },
   {
+    "name": "deno",
+    "description": "Test, lint, format, and type-check Deno projects with Dagger",
+    "repo": "github.com/dagger/deno",
+    "recommend": ["**/deno.json", "**/deno.jsonc", "**/deno.lock"]
+  },
+  {
     "name": "eslint",
     "description": "Lint JavaScript and TypeScript with ESLint",
     "repo": "github.com/dagger/eslint",


### PR DESCRIPTION
## What

Adds [`github.com/dagger/deno`](https://github.com/dagger/deno) to the module registry so it participates in module discovery:

- `dagger setup` (step 3, "Recommended modules") now suggests it when a workspace contains a `deno.json`, `deno.jsonc`, or `deno.lock`.
- `dagger search` can surface it.

## Changes

- `internal/cmd/dagger/modules.json` — new registry entry with `recommend` globs `**/deno.json`, `**/deno.jsonc`, `**/deno.lock`.
- `docs/current_docs/modules/deno.mdx` — new setup guide, modeled on the Go module guide and the `dagger/deno` README (checks, format changeset, compile, `version`/`base` settings).
- `docs/current_docs/modules/index.mdx` + `docs/sidebars.ts` — list the new guide.

## Notes

- The feature is data-driven; no Go code changes were needed — the registry entry alone wires up discovery.
- `deno.lock` is included as an extra trigger since it is a Deno-only marker, even though the module keys off `deno.json`/`deno.jsonc`.