### PR TITLE
Cache workspace git install resolution content-addressed by (ref, base lock)

### DIFF
--- a/core/integration/env_helpers_test.go
+++ b/core/integration/env_helpers_test.go
@@ -17,6 +17,9 @@ func nestedDaggerContainer(t *testctx.T, c *dagger.Client, modLang, modName stri
 	ctr := c.Container().
 		From(alpineImage).
 		WithWorkdir("/work").
+		// containerized CLI invocations don't inherit the test process env,
+		// so re-apply the widened shutdown budget (see TestMain)
+		WithEnvVariable(shutdownTimeoutEnvName, testShutdownTimeout).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c))
 	if modLang != "" && modName != "" {
 		ctr = ctr.

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -29,6 +29,16 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Session close drains workspace locks, services, and telemetry on the
+	// engine; under CI load that can legitimately exceed the client's default
+	// 10s shutdown budget, failing otherwise-passing tests at Close. Give test
+	// clients (SDK sessions and host-run CLI invocations both inherit this
+	// env) a wider budget: a real hang still fails, just attributably via the
+	// engine's shutdown drain phase spans/logs.
+	if os.Getenv(shutdownTimeoutEnvName) == "" {
+		os.Setenv(shutdownTimeoutEnvName, testShutdownTimeout)
+	}
+
 	// Preserve original SSH_AUTH_SOCK value and
 	// Ensure SSH_AUTH_SOCK does not pollute tests state
 	origAuthSock := os.Getenv("SSH_AUTH_SOCK")
@@ -41,6 +51,16 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(res)
 }
+
+const (
+	// shutdownTimeoutEnvName mirrors engine/client's
+	// _EXPERIMENTAL_DAGGER_SHUTDOWN_TIMEOUT (default 10s).
+	shutdownTimeoutEnvName = "_EXPERIMENTAL_DAGGER_SHUTDOWN_TIMEOUT"
+	// testShutdownTimeout widens the client shutdown budget for tests so a
+	// loaded CI engine draining a session doesn't flake otherwise-passing
+	// tests at Close.
+	testShutdownTimeout = "60s"
+)
 
 func Middleware() []testctx.Middleware[*testing.T] {
 	return []testctx.Middleware[*testing.T]{
@@ -270,6 +290,9 @@ func daggerCliBase(t testing.TB, c *dagger.Client) *dagger.Container {
 	t.Helper()
 	return c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		// containerized CLI invocations don't inherit the test process env,
+		// so re-apply the widened shutdown budget (see TestMain)
+		WithEnvVariable(shutdownTimeoutEnvName, testShutdownTimeout).
 		WithWorkdir("/work")
 }
 

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -161,6 +161,9 @@ func legacyBlueprintTestEnv(t *testctx.T, c *dagger.Client) *dagger.Container {
 		From(alpineImage).
 		WithExec([]string{"apk", "add", "git"}).
 		WithExec([]string{"git", "init"}).
+		// containerized CLI invocations don't inherit the test process env,
+		// so re-apply the widened shutdown budget (see TestMain)
+		WithEnvVariable(shutdownTimeoutEnvName, testShutdownTimeout).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithDirectory(".", c.Host().Directory("./testdata/test-blueprint")).
 		WithDirectory("app", c.Directory())

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -40,6 +40,14 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 
 	dagql.Fields[*core.Query]{
 		currentWorkspaceField,
+		dagql.Func("__workspaceInstallResolution", s.workspaceInstallResolution).
+			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
+			Doc("(Internal-only) Resolve a git module install ref against a base lockfile, returning the resolution and its lock deltas.").
+			Args(
+				dagql.Arg("ref").Doc("Git module reference to install."),
+				dagql.Arg("baseLock").Doc("Marshaled dagger.lock contents the resolution starts from."),
+			),
 	}.Install(srv)
 
 	dagql.Fields[*core.Workspace]{

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -266,13 +266,12 @@ func (s *workspaceSchema) withModuleInstall(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	lookupCtx := withWorkspaceLookupLockOverride(ctx, overlayLock.Lock)
-	resolved, err := s.resolveWorkspaceInstallForOverlay(lookupCtx, selected, args.Ref, args.Name, args.Here)
+	install, err := s.resolveInstallOutcomeForOverlay(ctx, selected, overlayLock, args)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 
-	plan, err := planWorkspaceInstallConfig(staged.Config, args, resolved.Name, resolved.ConfigSource)
+	plan, err := planWorkspaceInstallConfig(staged.Config, args, install.Name, install.ConfigSource)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
@@ -288,7 +287,10 @@ func (s *workspaceSchema) withModuleInstall(
 	}
 	var hints map[string][]workspace.ConstructorArgHint
 	if plan.Added {
-		hints = collectWorkspaceSettingsHintsFromSource(lookupCtx, resolved.Name, resolved.ModuleSource)
+		hints, err = install.applyAddedEffects()
+		if err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
 	}
 	updated, err := workspace.UpdateConfigBytesWithHints(staged.Data, staged.Config, hints)
 	if err != nil {

--- a/core/schema/workspace_install.go
+++ b/core/schema/workspace_install.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -300,4 +301,218 @@ func workspaceInstallModuleSourceSelector(ref string) dagql.Selector {
 			{Name: "disableFindUp", Value: dagql.Boolean(true)},
 		},
 	}
+}
+
+// workspaceInstallOutcome is a resolved install plus its deferred added-module
+// effects. Installs record lock lookups as they resolve; the hints phase (a
+// full module load) both produces settings hints and records more lookups, and
+// only applies when the config entry is actually added, so it stays deferred
+// behind applyAddedEffects.
+type workspaceInstallOutcome struct {
+	Name         string
+	ConfigSource string
+	// applyAddedEffects finishes the added-module side of the install: it
+	// applies the hints-phase lock recordings to the overlay lock and returns
+	// the settings hints to inject into the config.
+	applyAddedEffects func() (map[string][]workspace.ConstructorArgHint, error)
+}
+
+// resolveInstallOutcomeForOverlay resolves an install ref for the workspace
+// overlay, routing git refs through the content-addressed resolution cache.
+//
+// Live-path installs run under withWorkspaceLookupLockOverride, whose fresh
+// per-client cache scope forces full re-resolution on every call: the override
+// lock rides in context, invisible to dagql cache keys, so results resolved
+// under one lock must not be served to another. Git refs escape that cost:
+// their resolution depends only on the ref and the base lock contents, both of
+// which __workspaceInstallResolution captures in its cache key. Local and
+// ambiguous refs read live host or workspace state that the base lock cannot
+// content-address, so they stay on the live path.
+func (s *workspaceSchema) resolveInstallOutcomeForOverlay(
+	ctx context.Context,
+	ws *core.Workspace,
+	overlayLock *workspaceOverlayLock,
+	args workspaceInstallArgs,
+) (*workspaceInstallOutcome, error) {
+	if core.FastModuleSourceKindCheck(args.Ref, "") == core.ModuleSourceKindGit {
+		return s.cachedGitInstallOutcome(ctx, overlayLock, args)
+	}
+
+	lookupCtx := withWorkspaceLookupLockOverride(ctx, overlayLock.Lock)
+	resolved, err := s.resolveWorkspaceInstallForOverlay(lookupCtx, ws, args.Ref, args.Name, args.Here)
+	if err != nil {
+		return nil, err
+	}
+	return &workspaceInstallOutcome{
+		Name:         resolved.Name,
+		ConfigSource: resolved.ConfigSource,
+		applyAddedEffects: func() (map[string][]workspace.ConstructorArgHint, error) {
+			// Recordings land directly in the overlay lock via lookupCtx.
+			return collectWorkspaceSettingsHintsFromSource(lookupCtx, resolved.Name, resolved.ModuleSource), nil
+		},
+	}, nil
+}
+
+// cachedGitInstallOutcome resolves a git install ref through the
+// __workspaceInstallResolution cache and replays the returned lock deltas onto
+// the overlay lock, reproducing exactly what a live resolution would have
+// recorded.
+func (s *workspaceSchema) cachedGitInstallOutcome(
+	ctx context.Context,
+	overlayLock *workspaceOverlayLock,
+	args workspaceInstallArgs,
+) (*workspaceInstallOutcome, error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dagql server: %w", err)
+	}
+	baseLockData, err := overlayLock.Lock.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal base workspace lock: %w", err)
+	}
+
+	var payloadJSON dagql.String
+	if err := srv.Select(ctx, srv.Root(), &payloadJSON, dagql.Selector{
+		Field: "__workspaceInstallResolution",
+		Args: []dagql.NamedInput{
+			{Name: "ref", Value: dagql.String(args.Ref)},
+			{Name: "baseLock", Value: dagql.String(baseLockData)},
+		},
+	}); err != nil {
+		return nil, err
+	}
+	var payload workspaceInstallResolutionPayload
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		return nil, fmt.Errorf("decode workspace install resolution: %w", err)
+	}
+
+	resolveDelta, err := workspace.ParseLock([]byte(payload.ResolveDelta))
+	if err != nil {
+		return nil, fmt.Errorf("parse install resolve delta: %w", err)
+	}
+	if err := overlayLock.Lock.Merge(resolveDelta); err != nil {
+		return nil, fmt.Errorf("apply install resolve delta: %w", err)
+	}
+
+	name := args.Name
+	if name == "" {
+		name = payload.ModuleName
+	}
+	if name == "" {
+		return nil, fmt.Errorf("ref %q does not point to an initialized module", args.Ref)
+	}
+
+	return &workspaceInstallOutcome{
+		Name:         name,
+		ConfigSource: filepath.ToSlash(args.Ref),
+		applyAddedEffects: func() (map[string][]workspace.ConstructorArgHint, error) {
+			hintsDelta, err := workspace.ParseLock([]byte(payload.HintsDelta))
+			if err != nil {
+				return nil, fmt.Errorf("parse install hints delta: %w", err)
+			}
+			if err := overlayLock.Lock.Merge(hintsDelta); err != nil {
+				return nil, fmt.Errorf("apply install hints delta: %w", err)
+			}
+			if len(payload.ConstructorHints) == 0 {
+				return nil, nil
+			}
+			return map[string][]workspace.ConstructorArgHint{name: payload.ConstructorHints}, nil
+		},
+	}, nil
+}
+
+type workspaceInstallResolutionArgs struct {
+	Ref      string
+	BaseLock string
+}
+
+// workspaceInstallResolutionPayload is the JSON value returned by the internal
+// __workspaceInstallResolution field. Lock deltas are marshaled dagger.lock
+// documents; replaying them onto an overlay lock reproduces the recordings a
+// live resolution would have made, which is what makes the field safe to
+// cache: everything the resolution writes is part of its value.
+type workspaceInstallResolutionPayload struct {
+	ModuleName       string                         `json:"moduleName"`
+	ResolveDelta     string                         `json:"resolveDelta"`
+	HintsDelta       string                         `json:"hintsDelta"`
+	ConstructorHints []workspace.ConstructorArgHint `json:"constructorHints,omitempty"`
+}
+
+// workspaceInstallResolution resolves a git module install ref against a base
+// lockfile. It is cached per client keyed on its args: the ref and the full
+// base lock contents cover every input of a git resolution, so identical
+// installs (the common SDK pattern of evaluating one workspace chain several
+// times: changes, then export) reuse the first resolution instead of redoing
+// the module fetch, SDK load, and codegen behind it.
+func (s *workspaceSchema) workspaceInstallResolution(
+	ctx context.Context,
+	parent *core.Query,
+	args workspaceInstallResolutionArgs,
+) (dagql.String, error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return "", fmt.Errorf("dagql server: %w", err)
+	}
+	baseLock, err := workspace.ParseLock([]byte(args.BaseLock))
+	if err != nil {
+		return "", fmt.Errorf("parse base lock: %w", err)
+	}
+	overlay, err := baseLock.Clone()
+	if err != nil {
+		return "", fmt.Errorf("clone base lock: %w", err)
+	}
+
+	// Match the live install path: pins resolve through the overlay lock in
+	// pinned mode, and one lookup context spans both phases so the hints-phase
+	// module load reuses the resolve phase's results.
+	lookupCtx := withWorkspaceLookupLockOverride(
+		workspaceInstallContextWithLockMode(ctx, workspace.LockModePinned),
+		overlay,
+	)
+
+	var src dagql.ObjectResult[*core.ModuleSource]
+	if err := srv.Select(lookupCtx, srv.Root(), &src, workspaceInstallModuleSourceSelector(args.Ref)); err != nil {
+		return "", fmt.Errorf("load module source: %w", err)
+	}
+	source := src.Self()
+	if source == nil {
+		return "", fmt.Errorf("load module source: empty result")
+	}
+	if !source.ConfigExists {
+		return "", fmt.Errorf("ref %q does not point to an initialized module", args.Ref)
+	}
+
+	resolveDelta, err := overlay.Diff(baseLock)
+	if err != nil {
+		return "", fmt.Errorf("diff resolve lock recordings: %w", err)
+	}
+	resolveDeltaData, err := resolveDelta.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("marshal resolve delta: %w", err)
+	}
+
+	afterResolve, err := overlay.Clone()
+	if err != nil {
+		return "", fmt.Errorf("snapshot lock after resolve: %w", err)
+	}
+	hints := workspaceSettingsHintsFromSource(lookupCtx, source.ModuleName, src)
+	hintsDelta, err := overlay.Diff(afterResolve)
+	if err != nil {
+		return "", fmt.Errorf("diff hints lock recordings: %w", err)
+	}
+	hintsDeltaData, err := hintsDelta.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("marshal hints delta: %w", err)
+	}
+
+	data, err := json.Marshal(workspaceInstallResolutionPayload{
+		ModuleName:       source.ModuleName,
+		ResolveDelta:     string(resolveDeltaData),
+		HintsDelta:       string(hintsDeltaData),
+		ConstructorHints: hints,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode workspace install resolution: %w", err)
+	}
+	return dagql.String(data), nil
 }

--- a/core/schema/workspace_install.go
+++ b/core/schema/workspace_install.go
@@ -90,12 +90,13 @@ func (s *workspaceSchema) resolveWorkspaceInstall(
 	ref string,
 	name string,
 	here bool,
+	workspaceRoot dagql.ObjectResult[*core.Directory],
 ) (workspaceInstallResolution, error) {
 	var resolved workspaceInstallResolution
 	ctx = workspaceInstallLookupContext(ctx)
 
 	configDir := workspaceConfigDirectoryForWrite(ws, here)
-	src, sourcePath, err := s.resolveWorkspaceInstallSource(ctx, ws, ref, configDir)
+	src, sourcePath, err := s.resolveWorkspaceInstallSource(ctx, ws, ref, configDir, workspaceRoot)
 	if err != nil {
 		return resolved, err
 	}
@@ -124,6 +125,7 @@ func (s *workspaceSchema) resolveWorkspaceInstallSource(
 	ws *core.Workspace,
 	ref string,
 	configDir string,
+	workspaceRoot dagql.ObjectResult[*core.Directory],
 ) (dagql.ObjectResult[*core.ModuleSource], string, error) {
 	var src dagql.ObjectResult[*core.ModuleSource]
 	srv, err := core.CurrentDagqlServer(ctx)
@@ -132,11 +134,12 @@ func (s *workspaceSchema) resolveWorkspaceInstallSource(
 	}
 
 	kind := core.FastModuleSourceKindCheck(ref, "")
-	var workspaceRoot dagql.ObjectResult[*core.Directory]
 	if kind == "" {
-		workspaceRoot, err = s.workspaceOverlayRootfs(ctx, ws)
-		if err != nil {
-			return src, "", err
+		if workspaceRoot.Self() == nil {
+			workspaceRoot, err = s.workspaceOverlayRootfs(ctx, ws)
+			if err != nil {
+				return src, "", err
+			}
 		}
 		parsed, err := core.ParseRefString(ctx, &core.DirectoryStatFS{Dir: workspaceRoot}, ref, "")
 		if err != nil {
@@ -262,6 +265,7 @@ func (s *workspaceSchema) resolveWorkspaceInstallForOverlay(
 	ref string,
 	name string,
 	here bool,
+	workspaceRoot dagql.ObjectResult[*core.Directory],
 ) (workspaceInstallResolution, error) {
 	return s.resolveWorkspaceInstall(
 		workspaceInstallContextWithLockMode(ctx, workspace.LockModePinned),
@@ -269,6 +273,7 @@ func (s *workspaceSchema) resolveWorkspaceInstallForOverlay(
 		ref,
 		name,
 		here,
+		workspaceRoot,
 	)
 }
 
@@ -325,21 +330,39 @@ type workspaceInstallOutcome struct {
 // lock rides in context, invisible to dagql cache keys, so results resolved
 // under one lock must not be served to another. Git refs escape that cost:
 // their resolution depends only on the ref and the base lock contents, both of
-// which __workspaceInstallResolution captures in its cache key. Local and
-// ambiguous refs read live host or workspace state that the base lock cannot
+// which __workspaceInstallResolution captures in its cache key. Local refs
+// read live host or workspace state that the base lock cannot
 // content-address, so they stay on the live path.
+//
+// Ambiguous refs (e.g. github.com/org/repo without an explicit scheme) need a
+// stat against the workspace rootfs to classify; the rootfs is passed down to
+// the live path so it is only synced once.
 func (s *workspaceSchema) resolveInstallOutcomeForOverlay(
 	ctx context.Context,
 	ws *core.Workspace,
 	overlayLock *workspaceOverlayLock,
 	args workspaceInstallArgs,
 ) (*workspaceInstallOutcome, error) {
-	if core.FastModuleSourceKindCheck(args.Ref, "") == core.ModuleSourceKindGit {
+	kind := core.FastModuleSourceKindCheck(args.Ref, "")
+	var workspaceRoot dagql.ObjectResult[*core.Directory]
+	if kind == "" {
+		var err error
+		workspaceRoot, err = s.workspaceOverlayRootfs(ctx, ws)
+		if err != nil {
+			return nil, err
+		}
+		parsed, err := core.ParseRefString(ctx, &core.DirectoryStatFS{Dir: workspaceRoot}, args.Ref, "")
+		if err != nil {
+			return nil, fmt.Errorf("parse module ref %q: %w", args.Ref, err)
+		}
+		kind = parsed.Kind
+	}
+	if kind == core.ModuleSourceKindGit {
 		return s.cachedGitInstallOutcome(ctx, overlayLock, args)
 	}
 
 	lookupCtx := withWorkspaceLookupLockOverride(ctx, overlayLock.Lock)
-	resolved, err := s.resolveWorkspaceInstallForOverlay(lookupCtx, ws, args.Ref, args.Name, args.Here)
+	resolved, err := s.resolveWorkspaceInstallForOverlay(lookupCtx, ws, args.Ref, args.Name, args.Here, workspaceRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/workspace_settings_hints.go
+++ b/core/schema/workspace_settings_hints.go
@@ -20,6 +20,21 @@ func collectWorkspaceSettingsHintsFromSource(
 	name string,
 	source dagql.ObjectResult[*core.ModuleSource],
 ) map[string][]workspace.ConstructorArgHint {
+	hints := workspaceSettingsHintsFromSource(ctx, name, source)
+	if len(hints) == 0 {
+		return nil
+	}
+	return map[string][]workspace.ConstructorArgHint{name: hints}
+}
+
+// workspaceSettingsHintsFromSource loads the module behind source and returns
+// its constructor-arg hints. Hints are best-effort: failures degrade to no
+// hints rather than failing the surrounding install.
+func workspaceSettingsHintsFromSource(
+	ctx context.Context,
+	name string,
+	source dagql.ObjectResult[*core.ModuleSource],
+) []workspace.ConstructorArgHint {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		slog.Warn("could not prepare workspace settings hints", "error", err)
@@ -33,11 +48,7 @@ func collectWorkspaceSettingsHintsFromSource(
 		)
 		return nil
 	}
-	hints := constructorHintsFromModule(mod.Self())
-	if len(hints) == 0 {
-		return nil
-	}
-	return map[string][]workspace.ConstructorArgHint{name: hints}
+	return constructorHintsFromModule(mod.Self())
 }
 
 func (s *workspaceSchema) collectWorkspaceSettingsHintsFromConfig(

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -154,6 +154,31 @@ func (l *Lock) Merge(other *Lock) error {
 	return nil
 }
 
+// Diff returns a lock containing the entries of l that are absent from base
+// or whose result differs from base's entry.
+func (l *Lock) Diff(base *Lock) (*Lock, error) {
+	out := NewLock()
+	if l == nil {
+		return out, nil
+	}
+	entries, err := l.Entries()
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		baseResult, ok, err := base.GetLookup(entry.Namespace, entry.Operation, entry.Inputs)
+		if err == nil && ok && baseResult == entry.Result {
+			continue
+		}
+		// An unreadable base entry counts as differing, so the updated entry
+		// still lands in the diff.
+		if err := out.SetLookup(entry.Namespace, entry.Operation, entry.Inputs, entry.Result); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
 // GetLookup retrieves the lock result for a generic lookup tuple.
 func (l *Lock) GetLookup(namespace, operation string, inputs []any) (LookupResult, bool, error) {
 	if l == nil {

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -159,6 +159,67 @@ func TestMerge(t *testing.T) {
 	require.Equal(t, LookupResult{Value: "0123456789abcdef0123456789abcdef01234567", Policy: PolicyFloat}, result)
 }
 
+func TestDiff(t *testing.T) {
+	base := NewLock()
+	require.NoError(t, base.SetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"}, LookupResult{
+		Value:  "sha256:deadbeef",
+		Policy: PolicyPin,
+	}))
+	require.NoError(t, base.SetLookup("", "git.tag", []any{"https://github.com/dagger/dagger.git", "v0.1.0"}, LookupResult{
+		Value:  "0123456789abcdef0123456789abcdef01234567",
+		Policy: PolicyPin,
+	}))
+
+	updated, err := base.Clone()
+	require.NoError(t, err)
+	// New entry: should appear in the diff.
+	require.NoError(t, updated.SetLookup("", "git.branch", []any{"https://github.com/dagger/dagger.git", "main"}, LookupResult{
+		Value:  "89abcdef0123456789abcdef0123456789abcdef",
+		Policy: PolicyFloat,
+	}))
+	// Changed result for an existing tuple: should appear in the diff.
+	require.NoError(t, updated.SetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"}, LookupResult{
+		Value:  "sha256:cafebabe",
+		Policy: PolicyPin,
+	}))
+
+	diff, err := updated.Diff(base)
+	require.NoError(t, err)
+
+	entries, err := diff.Entries()
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	result, ok, err := diff.GetLookup("", "git.branch", []any{"https://github.com/dagger/dagger.git", "main"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, LookupResult{Value: "89abcdef0123456789abcdef0123456789abcdef", Policy: PolicyFloat}, result)
+
+	result, ok, err = diff.GetLookup("", "container.from", []any{"alpine:latest", "linux/amd64"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, LookupResult{Value: "sha256:cafebabe", Policy: PolicyPin}, result)
+
+	// Unchanged entries stay out of the diff.
+	_, ok, err = diff.GetLookup("", "git.tag", []any{"https://github.com/dagger/dagger.git", "v0.1.0"})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// A diff against an empty base contains everything.
+	full, err := updated.Diff(NewLock())
+	require.NoError(t, err)
+	fullEntries, err := full.Entries()
+	require.NoError(t, err)
+	require.Len(t, fullEntries, 3)
+
+	// Diffing identical locks yields nothing.
+	empty, err := base.Diff(base)
+	require.NoError(t, err)
+	emptyEntries, err := empty.Entries()
+	require.NoError(t, err)
+	require.Empty(t, emptyEntries)
+}
+
 func TestParseLockMode(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		mode, err := ParseLockMode("disabled")

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -149,6 +150,9 @@ type workspaceLockState struct {
 	delta    *workspace.Lock
 	loaded   bool
 	dirty    bool
+	// gen increments on every recorded lookup so a flush can tell whether the
+	// delta it exported is still current before clearing the dirty state.
+	gen uint64
 }
 
 // daggerSessionState is the lifecycle state of a session. It is intentionally
@@ -1839,6 +1843,13 @@ func (srv *Server) serveInit(w http.ResponseWriter, _ *http.Request, client *dag
 	return nil
 }
 
+// workspaceLockFlushTimeout bounds the shutdown-time workspace lock flush. The
+// flush is detached from the request context so a client-side shutdown
+// deadline (or request teardown race) can't lose lock data mid-write, but it
+// needs the client's session attachables to make progress, so a wedged host
+// roundtrip must not pin the handler forever once the client is gone.
+const workspaceLockFlushTimeout = 5 * time.Minute
+
 func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client *daggerClient) (rerr error) {
 	ctx := r.Context()
 	var shutdownErr error
@@ -1851,12 +1862,40 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		"mainClientID", sess.mainClientCallerID)
 
 	slog.Info("client shutdown")
-	defer slog.Debug("client shutdown done")
+	shutdownStart := time.Now()
+	defer func() {
+		slog.Debug("client shutdown done", "duration", time.Since(shutdownStart))
+	}()
+
+	// drainPhase runs one shutdown drain phase with an otel span and a timing
+	// log. The client enforces a hard deadline on the whole shutdown request,
+	// so a slow drain phase is otherwise indistinguishable from a hang; the
+	// spans land in the client's telemetry DB before the final telemetry flush
+	// ships them, making slow shutdowns attributable from traces.
+	drainPhase := func(ctx context.Context, name string, fn func(context.Context) error) (rerr error) {
+		if client.tracerProvider != nil {
+			var span trace.Span
+			ctx, span = client.tracerProvider.Tracer(InstrumentationLibrary).Start(ctx, name)
+			defer telemetry.EndWithCause(span, &rerr)
+		}
+		start := time.Now()
+		defer func() {
+			slog.Info("shutdown drain phase done", "phase", name, "duration", time.Since(start), "error", rerr)
+		}()
+		return fn(ctx)
+	}
+
+	flushLocks := func(ctx context.Context) error {
+		return drainPhase(ctx, "shutdown: flush workspace locks", func(ctx context.Context) error {
+			flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workspaceLockFlushTimeout)
+			defer cancel()
+			return srv.flushWorkspaceLocks(flushCtx, client)
+		})
+	}
 
 	if client.clientID == sess.mainClientCallerID {
 		slog.Info("main client is shutting down")
-		flushCtx := context.WithoutCancel(ctx)
-		if err := srv.flushWorkspaceLocks(flushCtx, client); err != nil {
+		if err := flushLocks(ctx); err != nil {
 			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush workspace locks: %w", err))
 			slog.Error("failed to flush workspace locks", "error", err)
 		}
@@ -1865,8 +1904,12 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		sess.beginClosing()
 
 		// Stop services, since the main client is going away, and we
-		// want the client to see them stop.
-		sess.services.StopSessionServices(ctx, sess.sessionID)
+		// want the client to see them stop. Stop errors are best-effort
+		// (matching prior behavior), so the phase always returns nil.
+		_ = drainPhase(ctx, "shutdown: stop session services", func(ctx context.Context) error {
+			sess.services.StopSessionServices(ctx, sess.sessionID)
+			return nil
+		})
 
 		defer func() {
 			// Signal shutdown at the very end, _after_ flushing telemetry/etc.,
@@ -1877,8 +1920,7 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 			})
 		}()
 	} else {
-		flushCtx := context.WithoutCancel(ctx)
-		if err := srv.flushWorkspaceLocks(flushCtx, client); err != nil {
+		if err := flushLocks(ctx); err != nil {
 			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush workspace locks: %w", err))
 			slog.Error("failed to flush workspace locks", "error", err)
 		}
@@ -1886,10 +1928,15 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 
 	// Flush telemetry across the entire session so that any child clients will
 	// save telemetry into their parent's DB, including to this client.
+	// (No span for this phase: it would race its own flush; the timing log
+	// below is the record.)
 	slog.ExtraDebug("flushing session telemetry")
+	telemetryStart := time.Now()
 	if err := sess.FlushTelemetry(ctx); err != nil {
-		slog.Error("failed to flush telemetry", "error", err)
+		slog.Error("failed to flush telemetry", "error", err, "duration", time.Since(telemetryStart))
 		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("flush session telemetry: %w", err))
+	} else {
+		slog.Info("shutdown drain phase done", "phase", "shutdown: flush telemetry", "duration", time.Since(telemetryStart))
 	}
 
 	client.closeShutdownOnce.Do(func() {
@@ -2062,6 +2109,7 @@ func (srv *Server) SetCurrentWorkspaceLookup(
 		return err
 	}
 	state.dirty = true
+	state.gen++
 	return nil
 }
 
@@ -2232,16 +2280,21 @@ func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient
 	sess := client.daggerSession
 
 	type pendingWorkspaceLockExport struct {
+		key      workspaceLockKey
 		ws       *core.Workspace
 		lockPath string
 		delta    *workspace.Lock
+		gen      uint64
 	}
 
 	var pending []pendingWorkspaceLockExport
 
 	sess.lockFileMu.RLock()
-	for _, state := range sess.lockFiles {
+	for key, state := range sess.lockFiles {
 		if state == nil || !state.loaded || !state.dirty {
+			continue
+		}
+		if state.ws.ClientID != client.clientID {
 			continue
 		}
 		delta, err := state.delta.Clone()
@@ -2249,13 +2302,13 @@ func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient
 			sess.lockFileMu.RUnlock()
 			return fmt.Errorf("clone workspace lock delta for %s: %w", state.lockPath, err)
 		}
-		if state.ws.ClientID == client.clientID {
-			pending = append(pending, pendingWorkspaceLockExport{
-				ws:       state.ws.Clone(),
-				lockPath: state.lockPath,
-				delta:    delta,
-			})
-		}
+		pending = append(pending, pendingWorkspaceLockExport{
+			key:      key,
+			ws:       state.ws.Clone(),
+			lockPath: state.lockPath,
+			delta:    delta,
+			gen:      state.gen,
+		})
 	}
 	sess.lockFileMu.RUnlock()
 
@@ -2263,19 +2316,52 @@ func (srv *Server) flushWorkspaceLocks(ctx context.Context, client *daggerClient
 	for _, export := range pending {
 		srv.locker.Lock(export.lockPath)
 
+		var flushed bool
 		workspaceCtx, bk, err := srv.workspaceOwnerAccess(ctx, sess, export.ws)
 		if err == nil {
 			var latest *workspace.Lock
 			latest, err = readWorkspaceLockState(workspaceCtx, bk, export.ws)
+			var before []byte
+			if err == nil {
+				before, err = latest.Marshal()
+			}
 			if err == nil {
 				err = latest.Merge(export.delta)
 			}
+			var after []byte
 			if err == nil {
-				err = exportWorkspaceLockToHost(workspaceCtx, bk, export.ws, latest)
+				after, err = latest.Marshal()
+			}
+			if err == nil {
+				if bytes.Equal(before, after) {
+					// The host lockfile already contains everything in this
+					// delta (e.g. a workspace export already wrote it): skip
+					// the redundant write roundtrip.
+					slog.Debug("workspace lock flush: host lock already up to date",
+						"lockPath", export.lockPath,
+						"clientID", client.clientID)
+					flushed = true
+				} else {
+					err = exportWorkspaceLockToHost(workspaceCtx, bk, export.ws, latest)
+					flushed = err == nil
+				}
 			}
 		}
 
 		srv.locker.Unlock(export.lockPath)
+
+		if flushed {
+			// The flushed delta is on the host now; mark the state clean
+			// (unless new lookups landed while flushing) so a repeated
+			// shutdown request doesn't redo host roundtrips for content that
+			// is already on disk.
+			sess.lockFileMu.Lock()
+			if state, ok := sess.lockFiles[export.key]; ok && state != nil && state.gen == export.gen {
+				state.dirty = false
+				state.delta = workspace.NewLock()
+			}
+			sess.lockFileMu.Unlock()
+		}
 
 		if err != nil {
 			flushErr = errors.Join(flushErr, fmt.Errorf("flush workspace lock %s: %w", export.lockPath, err))


### PR DESCRIPTION
> [!NOTE]
> Stacked on #13670 — this PR removes the redundant re-resolution that loads the engine at session close; #13670 makes the shutdown drain itself fast and attributable. The first CI run here was based on plain main and reproduced exactly the flake #13670 fixes (`TestWorkspaceModuleGenerate` failing at Close with the default 10s shutdown budget, plus an unrelated GitLab SSH auth flake), so the branch now stacks on `fix-shutdown-flake` and retargets to main automatically when it merges.

## The problem

The deeper fix deferred by #13670. `Workspace.withModule`/`withSDK` resolve their module source and settings hints under `withWorkspaceLookupLockOverride`, which salts every per-client dagql cache key beneath it with a fresh random scope (`dagql.WithPerClientCacheScope`). The salt is load-bearing today: the override lock rides in context, invisible to cache keys, so results resolved under one lock must not be served to a call under another — and resolution *records* pins into that lock as a side effect, which a cache hit would silently skip, producing a lockfile missing pins.

The cost is that every evaluation of an install chain redoes the full module fetch, SDK runtime load, and codegen. With `currentWorkspace` being per-call, the standard SDK pattern of evaluating one chain several times — `updated.Changes()`, then `updated.Export()` — re-resolves multi-minute installs from scratch. That redundant work is the engine load behind the shutdown flakes #13670 instrumented: in trace `935ae4ac58ec339e0985bef2c5d028b0`, `TestWorkspaceModuleInstall`'s wolfi chain was fully re-resolved a second time (2m55s, never completing) inside a 1m57s session.

## The fix

Make the expensive unit a pure, content-addressed function whose value includes its side effects:

- A hidden per-client field `Query.__workspaceInstallResolution(ref, baseLock)` resolves a git install ref against the full marshaled base lock contents. Marshaling is canonical (entries sort), so the args content-address everything a git resolution depends on: same ref + same lock state ⇒ legitimate cache hit.
- Its JSON value carries the resolved module name, constructor-arg hints, and the lock recordings of both phases as deltas (resolve, and the hints module load), computed with a new `Lock.Diff`. Callers replay the deltas onto their overlay lock — the resolve delta always, the hints delta only when the config entry is actually added — so a hit reproduces bit-for-bit what a live resolution would have recorded. That dissolves the side-effect objection to caching.
- `withModuleInstall` classifies refs the same way the live resolver does (fast kind check, then a stat against the workspace rootfs for ambiguous `github.com/...` forms, with the synced rootfs threaded down so the live path doesn't pay a second sync) and routes git refs through the cached unit. Local, external, and ambiguous-local refs keep the live path: they read host or workspace state the base lock can't content-address. The random scope also stays, both for that path and as the intra-resolution scope inside the cached unit.

Deliberately unchanged: `currentWorkspace` remains per-call (live host detection semantics untouched), and the shutdown drain machinery is #13670's layer.

## Verification

- `go build ./...`, `golangci-lint run ./core/schema/ ./core/workspace/` (0 issues), `go test ./core/workspace/` (including a new `Lock.Diff` unit test).
- `dagger call engine-dev test` on the victim and adjacent clusters: `TestWorkspaceModuleInstall` 9 passed (includes the wolfi golden lockfile assertions — `git.tag` pin present, no module-resolve entry, reinstall-after-export stays a no-op), `TestWorkspaceCompat/TestConstructorOptional` 11 passed, `TestWorkspaceModuleGenerate`/`Uninstall`/`Mutation`/`MultiSDKSharedDependency` all passed.
- Measured (temporary engine-side log in the resolver, since removed): the wolfi install subtest executes the resolution **2×** instead of 3× — one per session, with the `.Changes()`/`.Export()` pair of evaluations sharing a single cached resolution. The measurement also caught that the fast kind check alone never classified `github.com/...` refs as git — the third commit adds the stat-based disambiguation, without which the cache was inert for exactly the refs it exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

