### PR TITLE
feat(elixir-sdk): bump Elixir to 1.20 with Erlang OTP 29

### DIFF
--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -18,7 +18,7 @@ const (
 	sdkSrc           = "/sdk"
 	genDir           = "dagger_sdk"
 	schemaPath       = "/schema.json"
-	elixirImage      = "elixir:1.19.5-otp-28-alpine@sha256:1747b3595b6742d2273d18608203457d5b925000cd38aca40c76e23c64d44def"
+	elixirImage      = "elixir:1.20.2-otp-29-alpine@sha256:4cede0b5a644d3c36941bfc59fe0b59433bfc3f6f67b38d87d600e8a807548f5"
 )
 
 //go:embed template/mix.exs

--- a/sdk/elixir/test/dagger/mod/object_test.exs
+++ b/sdk/elixir/test/dagger/mod/object_test.exs
@@ -90,8 +90,8 @@ defmodule Dagger.Mod.ObjectTest do
                      {:deprecated, nil},
                      {:default_path, nil},
                      {:doc, nil},
-                     {:default, "Foo"},
-                     {:type, {:optional, :string}}
+                     {:type, {:optional, :string}},
+                     {:default, "Foo"}
                    ]
                  ],
                  return: :string
@@ -104,8 +104,8 @@ defmodule Dagger.Mod.ObjectTest do
                      {:deprecated, nil},
                      {:default_path, nil},
                      {:doc, nil},
-                     {:default, 42},
-                     {:type, :integer}
+                     {:type, :integer},
+                     {:default, 42}
                    ]
                  ],
                  return: :integer
@@ -118,8 +118,8 @@ defmodule Dagger.Mod.ObjectTest do
                      {:deprecated, nil},
                      {:default_path, nil},
                      {:doc, nil},
-                     {:default, 1.6180342},
-                     {:type, :float}
+                     {:type, :float},
+                     {:default, 1.6180342}
                    ]
                  ],
                  return: :float
@@ -132,8 +132,8 @@ defmodule Dagger.Mod.ObjectTest do
                      {:deprecated, nil},
                      {:default_path, nil},
                      {:doc, nil},
-                     {:default, false},
-                     {:type, :boolean}
+                     {:type, :boolean},
+                     {:default, false}
                    ]
                  ],
                  return: :boolean
@@ -226,10 +226,10 @@ defmodule Dagger.Mod.ObjectTest do
                    dir: [
                      {:default, nil},
                      {:deprecated, nil},
-                     {:ignore, ["deps", "_build"]},
-                     {:default_path, "/sdk/elixir"},
+                     {:type, {:optional, Dagger.Directory}},
                      {:doc, "The directory to run on."},
-                     {:type, {:optional, Dagger.Directory}}
+                     {:default_path, "/sdk/elixir"},
+                     {:ignore, ["deps", "_build"]}
                    ]
                  ],
                  return: :string
@@ -466,16 +466,16 @@ defmodule Dagger.Mod.ObjectTest do
                      {:doc, nil},
                      {:default, nil},
                      {:default_path, nil},
-                     {:deprecated, "deprecated argument"},
-                     {:type, :string}
+                     {:type, :string},
+                     {:deprecated, "deprecated argument"}
                    ],
                    bar: [
                      {:ignore, nil},
                      {:doc, nil},
                      {:default, nil},
                      {:default_path, nil},
-                     {:deprecated, nil},
-                     {:type, :string}
+                     {:type, :string},
+                     {:deprecated, nil}
                    ]
                  ],
                  return: :string

--- a/toolchains/elixir-sdk-dev/elixir-sdk.dang
+++ b/toolchains/elixir-sdk-dev/elixir-sdk.dang
@@ -1,7 +1,7 @@
 pub description = "Develop the Dagger Elixir SDK (experimental)"
 
 type ElixirSdkDev {
-  pub baseImage: String! = "elixir:1.19.5-otp-28-alpine@sha256:1747b3595b6742d2273d18608203457d5b925000cd38aca40c76e23c64d44def"
+  pub baseImage: String! = "elixir:1.20.2-otp-29-alpine@sha256:4cede0b5a644d3c36941bfc59fe0b59433bfc3f6f67b38d87d600e8a807548f5"
 
   pub workspaceDir: Directory!
     @defaultPath(path: "/")


### PR DESCRIPTION
Update Elixir image to both toolchain and sdk/elixir/runtime. Plus fixed tests failed due to keyword ordering after bump to Elixir 1.20.