### PR TITLE
bump dang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/dang v1.0.1
-	github.com/vito/dang/v2 v2.1.2-0.20260630144844-2d4f6c16aced
+	github.com/vito/dang/v2 v2.1.2-0.20260717032725-9689d13e8a99
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,8 @@ github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
 github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
-github.com/vito/dang/v2 v2.1.2-0.20260630144844-2d4f6c16aced h1:SCI0GMlufGZPV4KJAvTWXrdFF+/VK8Z9/GCQSFgEE0k=
-github.com/vito/dang/v2 v2.1.2-0.20260630144844-2d4f6c16aced/go.mod h1:DlbXb+x+e37dTHJMKzRZnOkAucBUC0RGky7l6BAiIjc=
+github.com/vito/dang/v2 v2.1.2-0.20260717032725-9689d13e8a99 h1:6AJzKGNaTFTr9hyVzvHwD33TajPIMuzgwNQdxal4J2E=
+github.com/vito/dang/v2 v2.1.2-0.20260717032725-9689d13e8a99/go.mod h1:DlbXb+x+e37dTHJMKzRZnOkAucBUC0RGky7l6BAiIjc=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=


### PR DESCRIPTION
Bumps `github.com/vito/dang/v2` to `9689d13e8a99`.

## What's new in Dang

### Error handling: try/catch replaced by postfix `rescue`

- The `try { } catch { }` block form is retired in favor of a postfix `rescue` operator, pairing with `raise` the way Ruby does. `expr rescue fallback` replaces any raised error with a value; `expr rescue { clauses }` dispatches on the error's type with case-style patterns and re-raises when nothing matches. `rescue` becomes a reserved word; `try` and `catch` return to being ordinary identifiers.
- Legacy try/catch still parses but emits a migration warning, and `dang fmt -w` rewrites it mechanically — the common unread-binding `catch { err => "" }` shape collapses to the idiomatic `rescue ""`. Bare catch-alls inside legacy try/catch are also demoted to warnings so already-published modules keep loading.
- Built-in error taxonomy: caught failures now classify into nameable prelude types — `assert {}` failures become `AssertionError`, GraphQL response errors become `GraphQLError` (carrying the response path and extensions as JSON text), other interpreter faults become `RuntimeError`, and `BasicError` now means exactly `raise "string"`. Handlers dispatch on failure kind with ordinary type patterns instead of string-matching `.message`.
- Richer diagnostics: uncaught errors render a full report (error type name, public data fields, cause chain, and concurrent sibling failures from `{{ }}`), a raise during a rescue arm implicitly records the rescued error as its cause, type-mismatch errors cite which control-flow arm each union member came from, and provably unreachable rescue/case clauses are compile errors.
- Static laziness analysis warns when a rescue is disconnected from where failures actually surface ("this rescue can never fire", "a lazy T leaves this rescue without executing"), delivered through a new non-fatal inference warning channel (highlighted stderr snippets on the CLI, Warning-severity diagnostics in the LSP).

### Scalars: bodies, statics, and a self-hosted Path

- Scalar declarations may now carry a body of methods and an optional `new()` materialization hook, making the string-refinement-scalar pattern fully definable in Dang; scalars can also carry directives.
- Static members via `self { }` blocks on objects and scalars — factory methods, namespaced constants, private helpers, and singleton state, reached as `Type.member`.
- New `Path` scalar for slash-separated paths, normalized on construction, with `name`, `stem`, `extension`, `parent`, `parts`, `isAbsolute`, `join`, `relativeTo`, `contains`, glob `matches`, and `ascend`/`descend`/`isRoot`. It is the first piece of stdlib self-hosted in Dang, living in an embedded prelude.
- `Regexp(...)` constructor and `Regexp.escape` static; `Regexp` is folded into the generic scalar machinery, which fixes regexp equality and codec-decode validation as a side effect.
- Custom scalar values (Path, URL, ID, schema scalars) now degrade to `String` at handoff boundaries (call args, typed slots, returns, `::`), so they can be passed anywhere a plain string is expected without a cast.
- Doc examples attach via a real `@example` directive instead of a magic first fenced code block.

### Modules: native Dang imports via path

- A dang.toml import may point at a local directory of `.dang` files with `path = "./dir"` — the first user-to-user module boundary. The directory compiles as its own module: public top-level declarations become the import's API, `let`s stay private, and import cycles are detected and reported as a chain.
- Per-module import identity: two modules importing the same directory get distinct type identities, so foreign types deliberately don't unify across the boundary — behavior is shared through interfaces, with a clarified error message for cross-module same-name mismatches.
- Module-level `let` visibility is now enforced on member selection with Go-package semantics: a `let` member is reachable anywhere within its declaring module and rejected across a module boundary.

### GraphQL interop

- Qualified inline fragments: narrow an imported union/interface with a module-qualified type name (`.{{ ... on Test.User }}`), including field sub-selections.
- `Float` and `Map` values now pass as GraphQL arguments (previously "unsupported value type").
- `Error` implementers can compute `message` with a method body.
- Type methods can call top-level functions (fixes vito/dang#162).

### Misc

- Formatter fixes: `new()` body indentation after a docstring, multiline-arg detection under prefix directives, and the legacy-catch rewrite noted above.
- Tree-sitter/editor updates for `rescue` and qualified fragments, plus a fix for `{{ record }}` on a new line being slurped as a block argument.
- Docs gain a landing-page feature carousel and a playground with a bundled in-process GraphQL schema; the stdlib reference now renders Dang-defined prelude members.

Full range: https://github.com/vito/dang/compare/2d4f6c16aced...9689d13e8a99

🤖 Generated with [Claude Code](https://claude.com/claude-code)