### PR TITLE
fix(elixir-sdk): fix Elixir 1.20 warning

### DIFF
--- a/sdk/elixir/lib/dagger/core/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/core/engine_conn.ex
@@ -48,7 +48,6 @@ defmodule Dagger.Core.EngineConn do
     else
       :error -> {:error, :no_executable}
       nil -> {:error, :no_executable}
-      otherwise -> otherwise
     end
   end
 


### PR DESCRIPTION
Fix the following warning:

```
Compiling 3 files (.ex)
    warning: the following clause is redundant:

        otherwise ->

    previous clauses have already matched on the following types:

        :error
        nil

    where "otherwise" was given the type:

        # type: dynamic(:error or nil)
        # from: lib/dagger/core/engine_conn.ex:51:7
        otherwise

    type warning found at:
    │
 51 │       otherwise -> otherwise
    │                 ~
    │
    └─ lib/dagger/core/engine_conn.ex:51:17: Dagger.Core.EngineConn.from_local_cli/1
```

The Elixir type checker warn that the `otherwise` consider as redundant because `with` clause already covered all the cases.