### PR TITLE
bump node_version in typescript tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.1.26
@@ -466,7 +466,7 @@ jobs:
         shell: bash
       - uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.1.26


### PR DESCRIPTION
this is because the graphql@17.0.1 package requires node >= 22