### PR TITLE
fix(engine): take session teardown off the client shutdown path

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1334,59 +1334,81 @@ func (srv *Server) getOrInitClient(
 	}
 
 	return client, func() error {
-		if clientID != sess.mainClientCallerID {
-			client.stateMu.Lock()
-			client.activeCount--
-			activeCount := client.activeCount
-			client.stateMu.Unlock()
-
-			if activeCount > 0 {
-				return nil
-			}
-
-			slog.With(
-				"sessionID", sess.sessionID,
-				"clientID", client.clientID,
-			).Info("all client connections closed")
-			return nil
-		}
-
-		// Main client cleanup. Take lifecycleMu BEFORE client.stateMu (matching
-		// getOrInitClient's order) and hold it across the activeCount zero-check
-		// and the teardown decision, so a concurrent getOrInitClient (which bumps
-		// activeCount under lifecycleMu) cannot slip a new connection in between
-		// the check and removeDaggerSession.
-		sess.lifecycleMu.Lock()
-
-		client.stateMu.Lock()
-		client.activeCount--
-		activeCount := client.activeCount
-		client.stateMu.Unlock()
-
-		if activeCount > 0 {
-			sess.lifecycleMu.Unlock()
-			return nil
-		}
-
-		slog.With(
-			"sessionID", sess.sessionID,
-			"clientID", client.clientID,
-		).Info("all client connections closed")
-
-		if sess.state.Load() != sessionStateInitialized {
-			// Already removed, or never fully initialized: nothing to tear down.
-			sess.lifecycleMu.Unlock()
-			return nil
-		}
-
-		err := srv.removeDaggerSession(ctx, sess)
-		sess.lifecycleMu.Unlock()
-		// Drop the tombstone now that teardown is complete and lifecycleMu is
-		// released (pointer-conditional, so a fresh same-id session is never
-		// deleted).
-		srv.deleteSession(sess)
-		return err
+		return srv.releaseClientConnection(ctx, sess, client)
 	}, nil
+}
+
+// releaseClientConnection is the per-request cleanup for a connection obtained
+// via getOrInitClient. When the main client's last connection closes it only
+// SCHEDULES teardown (reapDaggerSession) rather than running it: this cleanup
+// runs in the request handler before the response is flushed — typically the
+// main client's /shutdown POST — and the client enforces a hard budget
+// (default 10s) on that response, while teardown is unbounded (the dagql cache
+// release alone is proportional to the session's cache footprint).
+func (srv *Server) releaseClientConnection(ctx context.Context, sess *daggerSession, client *daggerClient) error {
+	client.stateMu.Lock()
+	client.activeCount--
+	activeCount := client.activeCount
+	client.stateMu.Unlock()
+
+	if activeCount > 0 {
+		return nil
+	}
+
+	slog.With(
+		"sessionID", sess.sessionID,
+		"clientID", client.clientID,
+	).Info("all client connections closed")
+
+	if client.clientID != sess.mainClientCallerID {
+		return nil
+	}
+
+	// The teardown decision itself is (re-)made inside reapDaggerSession under
+	// lifecycleMu, so a concurrent getOrInitClient (which bumps activeCount
+	// under lifecycleMu) either lands before the reap and aborts it, or
+	// observes the removed tombstone and retries against a fresh session.
+	go srv.reapDaggerSession(context.WithoutCancel(ctx), sess, client)
+	return nil
+}
+
+// reapDaggerSession tears down a session in the background after the main
+// client's last connection closed. It re-checks the teardown conditions under
+// lifecycleMu because the session may have changed since the disconnect that
+// scheduled it: a reconnected main client abandons the reap (the next last
+// disconnect schedules a fresh one), and an already-removed session (a
+// concurrent reap or GracefulStop won the race) is left alone.
+func (srv *Server) reapDaggerSession(ctx context.Context, sess *daggerSession, mainClient *daggerClient) {
+	sess.lifecycleMu.Lock()
+
+	if sess.state.Load() != sessionStateInitialized {
+		// Already removed, or never fully initialized: nothing to tear down.
+		sess.lifecycleMu.Unlock()
+		return
+	}
+
+	mainClient.stateMu.RLock()
+	activeCount := mainClient.activeCount
+	mainClient.stateMu.RUnlock()
+	if activeCount > 0 {
+		// The main client reconnected before this reap ran; the session is
+		// live again.
+		sess.lifecycleMu.Unlock()
+		return
+	}
+
+	err := srv.removeDaggerSession(ctx, sess)
+	sess.lifecycleMu.Unlock()
+	// Drop the tombstone now that teardown is complete and lifecycleMu is
+	// released (pointer-conditional, so a fresh same-id session is never
+	// deleted).
+	srv.deleteSession(sess)
+	if err != nil {
+		slog.Error("session teardown failed",
+			"sessionID", sess.sessionID,
+			"error", err,
+		)
+	}
 }
 
 // ServeHTTP serves clients directly hitting the engine API (i.e. main client callers, not nested execs like module functions)

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
@@ -348,6 +349,204 @@ func TestSessionLifecycleObserverConcurrency(t *testing.T) {
 		_ = srv.Clients()
 		_ = srv.activeClientIDs()
 		_, _ = srv.clientFromIDs("s0", "c")
+	}
+}
+
+// newTeardownTestServer builds a Server with just enough real state for
+// removeDaggerSession to run: an empty in-memory dagql cache, a live wcprof
+// counter, and a stubbed GC callback (scheduled via time.AfterFunc at the end
+// of teardown).
+func newTeardownTestServer(t *testing.T) *Server {
+	t.Helper()
+	cache, err := dagql.NewCache(context.Background(), "", nil, nil)
+	require.NoError(t, err)
+	return &Server{
+		daggerSessions:  map[string]*daggerSession{},
+		engineCache:     cache,
+		wcprofSpanCount: newWcprofSpanCounter(),
+		throttledGC:     func() {},
+	}
+}
+
+// newTeardownTestSession publishes an initialized session whose main client
+// has the given number of active connections. dagqlInFlight starts at 1 so
+// teardown deterministically blocks in the in-flight drain until
+// releaseTeardownDrain is called.
+func newTeardownTestSession(srv *Server, sessionID, mainClientID string, activeCount int) (*daggerSession, *daggerClient) {
+	client := &daggerClient{
+		clientID:    mainClientID,
+		activeCount: activeCount,
+	}
+	sess := &daggerSession{
+		sessionID:          sessionID,
+		mainClientCallerID: mainClientID,
+		clients:            map[string]*daggerClient{mainClientID: client},
+		services:           core.NewServices(),
+		analytics:          analytics.New(analytics.Config{DoNotTrack: true}),
+		shutdownCh:         make(chan struct{}),
+	}
+	client.daggerSession = sess
+	sess.dagqlCond = sync.NewCond(&sess.dagqlMu)
+	sess.dagqlInFlight = 1
+	sess.closingCtx, sess.cancelClosing = context.WithCancelCause(context.Background())
+	sess.state.Store(sessionStateInitialized)
+
+	srv.daggerSessionsMu.Lock()
+	srv.daggerSessions[sessionID] = sess
+	srv.daggerSessionsMu.Unlock()
+	return sess, client
+}
+
+func releaseTeardownDrain(sess *daggerSession) {
+	sess.dagqlMu.Lock()
+	sess.dagqlInFlight = 0
+	sess.dagqlCond.Broadcast()
+	sess.dagqlMu.Unlock()
+}
+
+func sessionInRegistry(srv *Server, sessionID string) bool {
+	srv.daggerSessionsMu.RLock()
+	defer srv.daggerSessionsMu.RUnlock()
+	_, ok := srv.daggerSessions[sessionID]
+	return ok
+}
+
+func TestMainClientLastDisconnectDoesNotBlockOnTeardown(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the client-side `shutdown: ... context deadline exceeded`
+	// timeout: the main client's last connection cleanup runs in the request
+	// handler before the /shutdown response is flushed, so it must only
+	// SCHEDULE teardown, never run it. Teardown here is deterministically
+	// blocked in the in-flight dagql drain; the cleanup must return anyway.
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.releaseClientConnection(context.Background(), sess, client)
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("last-connection cleanup blocked on session teardown")
+	}
+
+	// The background reap marks the session removed (tombstone) but stays
+	// blocked in the drain, so the registry entry must survive for now.
+	require.Eventually(t, func() bool {
+		return sess.state.Load() == sessionStateRemoved
+	}, 10*time.Second, 10*time.Millisecond, "background teardown never started")
+	require.True(t, sessionInRegistry(srv, "s"), "tombstone dropped before teardown finished")
+
+	releaseTeardownDrain(sess)
+
+	require.Eventually(t, func() bool {
+		return !sessionInRegistry(srv, "s")
+	}, 10*time.Second, 10*time.Millisecond, "session never finished background teardown")
+	select {
+	case <-sess.shutdownCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("session shutdownCh never closed by background teardown")
+	}
+}
+
+func TestSameIDConnectDuringBackgroundTeardownGetsRetryable(t *testing.T) {
+	t.Parallel()
+
+	// While a background reap is mid-teardown (removed tombstone in the
+	// registry, lifecycleMu held), a same-id getOrInitClient must bail out
+	// fast with a retryable error instead of blocking on the teardown.
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 1)
+
+	require.NoError(t, srv.releaseClientConnection(context.Background(), sess, client))
+	require.Eventually(t, func() bool {
+		return sess.state.Load() == sessionStateRemoved
+	}, 10*time.Second, 10*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := srv.getOrInitClient(context.Background(), &ClientInitOpts{
+			ClientMetadata: &engine.ClientMetadata{
+				SessionID:         "s",
+				ClientID:          "m",
+				ClientSecretToken: "token",
+			},
+		})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		var retryable flightcontrol.RetryableError
+		require.ErrorAs(t, err, &retryable)
+	case <-time.After(10 * time.Second):
+		t.Fatal("same-id getOrInitClient blocked on background teardown")
+	}
+
+	releaseTeardownDrain(sess)
+	require.Eventually(t, func() bool {
+		return !sessionInRegistry(srv, "s")
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestReapAbandonedWhenMainClientReconnects(t *testing.T) {
+	t.Parallel()
+
+	// A new main-client connection can land between the last disconnect and
+	// the scheduled reap running. The reap re-checks activeCount under
+	// lifecycleMu and must leave the now-live session alone.
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 1)
+
+	// Simulate the reconnect winning the race: activeCount is back above zero
+	// by the time the reap runs.
+	client.stateMu.Lock()
+	client.activeCount = 1
+	client.stateMu.Unlock()
+
+	srv.reapDaggerSession(context.Background(), sess, client)
+
+	require.Equal(t, sessionStateInitialized, sess.state.Load())
+	require.True(t, sessionInRegistry(srv, "s"))
+	select {
+	case <-sess.shutdownCh:
+		t.Fatal("reap tore down a session with a live main client")
+	default:
+	}
+}
+
+func TestConcurrentReapsSingleTeardown(t *testing.T) {
+	t.Parallel()
+
+	// Duplicate reaps can be scheduled (disconnect, reconnect, disconnect).
+	// Whichever acquires lifecycleMu first tears down; the loser must observe
+	// the removed state and no-op (double teardown would double-close
+	// shutdownCh and panic).
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 0)
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			srv.reapDaggerSession(context.Background(), sess, client)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		return sess.state.Load() == sessionStateRemoved
+	}, 10*time.Second, 10*time.Millisecond)
+	releaseTeardownDrain(sess)
+	wg.Wait()
+
+	require.False(t, sessionInRegistry(srv, "s"))
+	select {
+	case <-sess.shutdownCh:
+	default:
+		t.Fatal("session shutdownCh not closed after teardown")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #13670 (now merged; this is rebased on main and down to a single commit).

## Problem

This is the *user-facing* flavor of `shutdown: do shutdown: Post "http://dagger/shutdown": context deadline exceeded` — reported on v0.21.7 in [#fastly](https://discord.com/channels/707636530424053791/1250515579333251115/1520033855183257651) and [#nine](https://discord.com/channels/707636530424053791/1516233801418805419/1524996250867335289) after upgrading from 0.20.x. It's worse with parallel pipelines, disappears on a fresh engine, and for one reporter a 20s shutdown budget still failed while 60s passed. (Distinct from, and complementary to, the CI telemetry-flush burst the latest #13670 commit fixes.)

## Root cause

The main client's `/shutdown` response can be blocked on the entire session teardown:

1. `serveShutdown` calls `beginClosing()`, which cancels the main client's long-lived session-attachables request (wrapped in `withClosingCancel`); that request's per-request cleanup decrements the client's `activeCount`.
2. The `/shutdown` POST is now usually the main client's **last** active connection, so its own deferred cleanup hits `activeCount == 0` and runs `removeDaggerSession` synchronously — inside the request handler, before the 200 is flushed (the success path never writes to the ResponseWriter, so the client sees nothing until the handler fully returns).
3. Teardown is unbounded: `engineCache.ReleaseSession` walks every session-owned result and runs the release funcs sequentially. Trace-level engine logs from the #nine report show the entire 10s budget consumed by ~11.8k sequential ref releases (`Cache.ReleaseSession` → `Container.OnRelease` → `immutableRef.Release`) on an engine with ~188k live dagql cache entries.

Whether the POST or the attachables connection ends up "last" is a race — when the attachables cleanup loses it, teardown runs on that goroutine instead and nobody times out. Hence intermittent, load-dependent, and hard to catch in CI.

## Fix

The last-disconnect cleanup now only **schedules** teardown on a background reaper; nothing user-visible waits on it. The reaper re-makes the teardown decision under `lifecycleMu` (state still `initialized`, main client still at zero active connections), so:

- a reconnect landing between the last disconnect and the reap abandons the reap (the next last-disconnect schedules a fresh one);
- duplicate reaps no-op via the `removed` state;
- `GracefulStop` coordinates through `lifecycleMu` exactly as before (it waits out an in-flight background teardown, then skips the tombstone);
- same-id reconnects during background teardown stay safe via the removed-tombstone machinery from #13542 (retryable error until the tombstone drops).

The client-critical drain in `serveShutdown` (workspace lock flush, service stop, telemetry flush) is untouched — only engine-internal reclamation moves off the ACK path.

Deliberately *not* done, to keep this minimal: parallelizing/batching the cache-release walk. Once it's off the client path its duration is an engine-internal concern; worth revisiting only if profiles show cross-session `egraphMu` contention.

## Validation

- New `-race` regression tests: last-disconnect cleanup returns while teardown is deterministically blocked mid-drain; same-id connects during background teardown fail retryable while the tombstone survives; a reconnect abandons a scheduled reap; concurrent reaps tear down exactly once.
- Full `engine/server` package green under `-race` locally and in the engine-dev harness (99/99 passed).

