### PR TITLE
idtui: paint the progress track background

### DIFF
--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -5550,6 +5550,13 @@ func (fe *frontendPretty) renderProgressCells(out TermOutput, sb *strings.Builde
 
 // renderProgressTrack renders a single item as a fixed-width left-to-right
 // track with eighth-cell resolution.
+//
+// The whole track is painted on a solid background color. The filled portion
+// is drawn as foreground blocks over it, and the partial boundary cell draws
+// its eighth-block in the fill color on the same background — so its unfilled
+// remainder blends into the empty track. Drawing the partial block on the
+// terminal's default background instead would leave a variable-width gap
+// (the block's unfilled remainder) between the fill and the empty portion.
 func (fe *frontendPretty) renderProgressTrack(out TermOutput, sb *strings.Builder, item *dagui.ProgressItem) {
 	eighths := int(item.Current * progressTrackWidth * 8 / item.Total)
 	eighths = max(min(eighths, progressTrackWidth*8), 0)
@@ -5558,14 +5565,17 @@ func (fe *frontendPretty) renderProgressTrack(out TermOutput, sb *strings.Builde
 	if item.Complete() {
 		color = termenv.ANSIGreen
 	}
+	track := termenv.ANSIBrightBlack
 	if full > 0 {
-		sb.WriteString(out.String(strings.Repeat(string(verticalEighths[8]), full)).Foreground(color).Faint().String())
+		sb.WriteString(out.String(strings.Repeat(string(horizontalEighths[8]), full)).Foreground(color).Background(track).Faint().String())
 	}
 	if rem > 0 {
-		sb.WriteString(out.String(string(horizontalEighths[rem])).Foreground(color).Faint().String())
+		sb.WriteString(out.String(string(horizontalEighths[rem])).Foreground(color).Background(track).Faint().String())
 	}
 	if empty := progressTrackWidth - full - min(rem, 1); empty > 0 {
-		sb.WriteString(out.String(strings.Repeat("░", empty)).Foreground(termenv.ANSIBrightBlack).Faint().String())
+		// fg == bg so the light-shade dissolves into a solid track in color
+		// mode, while still rendering as ░ where color is unavailable.
+		sb.WriteString(out.String(strings.Repeat("░", empty)).Foreground(track).Background(track).Faint().String())
 	}
 }
 


### PR DESCRIPTION
## What

The single-item horizontal progress bar (`renderProgressTrack` in `dagql/idtui`) had a visual artifact: a variable-width gap between the filled portion and the empty `░` track.

The bar renders in three pieces — solid `█` cells, one partial-block boundary cell (`▏▎▍▌▋▊▉`, a *left-anchored* glyph), then the empty remainder as `░`. The partial cell's unfilled right portion fell on the terminal's **default** background rather than the track, so a wedge of plain background sat between the fill and the `░`, and its width swung from ⅛ to ⅞ of a cell as the fraction changed.

## Fix

Paint the whole track on a solid background color and draw the block glyphs over it, so the partial block's unfilled remainder blends into the empty track instead of exposing the terminal background.

The empty cells now use the same color for foreground and background, so the light-shade glyph dissolves into a solid track in color mode (a clean two-tone bar) while still rendering as `░` where color is unavailable — so the plain-text / `NO_COLOR` output is byte-identical to before.

## Verification

- Decoded the emitted escape sequences across fill levels: every cell now carries the bright-black background, so the partial cell's remainder and the empty region are the exact same color (seamless), with no default-background cell anywhere.
- `TestRenderProgress*` pass unchanged (they assert the `NO_COLOR` form). No golden needs regenerating — the only progress golden exercises the 2-D vertical cells, and goldens are ANSI-stripped regardless.
