### PR TITLE
telemetry: record cache-decision evidence on call spans

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path"
 	"slices"
@@ -213,13 +212,15 @@ func recordCacheEvidence(span trace.Span, ev *dagql.CacheDecision, res dagql.Any
 	}
 	if ev.SelfDigest != "" {
 		attrs = append(attrs, attribute.String(telemetryattrs.CacheSelfDigestAttr, ev.SelfDigest.String()))
+		// Native string-slice value: order is the contract (the miss
+		// unknown-input index points into it), and an EMPTY list is a recorded
+		// fact ("this call keys on no structural inputs"), distinct from the
+		// attribute being absent (no structural identity stamped at all).
 		inputs := make([]string, len(ev.StructuralInputs))
 		for i, dig := range ev.StructuralInputs {
 			inputs[i] = dig.String()
 		}
-		if enc, encErr := json.Marshal(inputs); encErr == nil {
-			attrs = append(attrs, attribute.String(telemetryattrs.CacheStructuralInputsAttr, string(enc)))
-		}
+		attrs = append(attrs, attribute.StringSlice(telemetryattrs.CacheStructuralInputsAttr, inputs))
 		if ev.PairingDigest != "" {
 			attrs = append(attrs, attribute.String(telemetryattrs.CachePairingDigestAttr, ev.PairingDigest.String()))
 		}

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -14,6 +16,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/engine/telemetryattrs"
 	telemetry "github.com/dagger/otel-go"
 )
 
@@ -144,6 +147,7 @@ func AroundFunc(
 	}
 
 	ctx, span := Tracer(ctx).Start(ctx, spanName, trace.WithAttributes(attrs...))
+	initCacheEvidence(span, req)
 
 	return ctx, func(res dagql.AnyResult, cached bool, err *error) {
 		slog.InfoContext(ctx, "end call",
@@ -155,8 +159,83 @@ func AroundFunc(
 		defer telemetry.EndWithCause(span, err)
 		recordStatus(ctx, res, span, cached, req.ResultCall)
 		recordPending(res, span)
+		recordCacheEvidence(span, req.CacheEvidence, res)
 		logResult(ctx, res, req.ResultCall)
 	}
+}
+
+// initCacheEvidence arms the request's cache-evidence carrier
+// (dagql.CacheDecision) exactly when this call's span records and the call is
+// not ProfileSkip-classified — the same volume class the OTel profiling source
+// uses — so suppressed/deduplicated/introspection/profile-skipped calls record
+// nothing and dagql needs no gating logic of its own (nil carrier ⇒ no-op).
+func initCacheEvidence(span trace.Span, req *dagql.CallRequest) {
+	if span == nil || !span.IsRecording() {
+		return
+	}
+	if req == nil || req.ResultCall == nil || req.ResultCall.ProfileSkip {
+		return
+	}
+	req.CacheEvidence = dagql.NewCacheDecision()
+}
+
+// recordCacheEvidence maps a populated cache-evidence carrier onto the call's
+// span as the dagger.io/cache.* contract (engine/telemetryattrs). Best-effort
+// like recordStatus: it stamps only facts that were recorded and never fails
+// the call. An empty Outcome means the invocation never reached a cache
+// decision (validation/derivation error) — nothing is stamped then, so the
+// contract marker never rides a fact-free span.
+func recordCacheEvidence(span trace.Span, ev *dagql.CacheDecision, res dagql.AnyResult) {
+	if ev == nil || ev.Outcome == "" {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String(telemetryattrs.CacheContractAttr, telemetryattrs.CacheContractV1),
+		attribute.String(telemetryattrs.CacheOutcomeAttr, string(ev.Outcome)),
+	}
+	if ev.Outcome == dagql.CacheOutcomeHit && ev.HitRoute != "" {
+		attrs = append(attrs, attribute.String(telemetryattrs.CacheHitRouteAttr, string(ev.HitRoute)))
+	}
+	if ev.Outcome == dagql.CacheOutcomeExecuted {
+		// Miss facts describe why the executed call's lookup found nothing
+		// reusable; emitted as "true"/index only when recorded, absent
+		// otherwise. Joined calls deliberately stamp none of these: their
+		// pre-join probe is not the decision that held.
+		if ev.MissIncompatibleCandidates {
+			attrs = append(attrs, attribute.String(telemetryattrs.CacheMissIncompatibleCandidatesAttr, "true"))
+		}
+		if ev.MissSawExpired {
+			attrs = append(attrs, attribute.String(telemetryattrs.CacheMissSawExpiredAttr, "true"))
+		}
+		if ev.MissUnknownInputIndex >= 0 {
+			attrs = append(attrs, attribute.String(telemetryattrs.CacheMissUnknownInputAttr, strconv.Itoa(ev.MissUnknownInputIndex)))
+		}
+	}
+	if ev.SelfDigest != "" {
+		attrs = append(attrs, attribute.String(telemetryattrs.CacheSelfDigestAttr, ev.SelfDigest.String()))
+		inputs := make([]string, len(ev.StructuralInputs))
+		for i, dig := range ev.StructuralInputs {
+			inputs[i] = dig.String()
+		}
+		if enc, encErr := json.Marshal(inputs); encErr == nil {
+			attrs = append(attrs, attribute.String(telemetryattrs.CacheStructuralInputsAttr, string(enc)))
+		}
+		if ev.PairingDigest != "" {
+			attrs = append(attrs, attribute.String(telemetryattrs.CachePairingDigestAttr, ev.PairingDigest.String()))
+		}
+	}
+	if res != nil {
+		// The recorded output content identity: the authoritative frame's last
+		// content-labeled extra digest at completion (never the derived
+		// content-preferred digest). Errors reading the frame just drop the
+		// optional fact.
+		if frame, frameErr := res.ResultCall(); frameErr == nil {
+			if contentDig := frame.ContentDigest(); contentDig != "" {
+				attrs = append(attrs, attribute.String(telemetryattrs.CacheOutputContentDigestAttr, contentDig.String()))
+			}
+		}
+	}
+	span.SetAttributes(attrs...)
 }
 
 type moduleCallRef struct {

--- a/core/telemetry_cache_evidence_test.go
+++ b/core/telemetry_cache_evidence_test.go
@@ -9,9 +9,11 @@ package core
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -42,24 +44,28 @@ func evidenceTestRecordingSpan(t *testing.T) (*tracetest.SpanRecorder, trace.Spa
 	return sr, span
 }
 
-func evidenceTestEndedAttrs(t *testing.T, sr *tracetest.SpanRecorder, span trace.Span) map[string]string {
+func evidenceTestEndedAttrs(t *testing.T, sr *tracetest.SpanRecorder, span trace.Span) []attribute.KeyValue {
 	t.Helper()
 	span.End()
 	ended := sr.Ended()
 	assert.Assert(t, len(ended) > 0)
-	got := map[string]string{}
-	for _, kv := range ended[len(ended)-1].Attributes() {
-		got[string(kv.Key)] = kv.Value.Emit()
-	}
-	return got
+	return ended[len(ended)-1].Attributes()
 }
 
-func evidenceTestCacheAttrs(attrs map[string]string) map[string]string {
+// evidenceTestCacheAttrs filters to the dagger.io/cache.* attributes, asserting
+// the contract's wire-type rule as it goes: every contract attribute must be an
+// OTel STRING value (the scalar-string shape the Cloud ingest round-trips
+// bit-exact), not merely Emit() text that happens to match.
+func evidenceTestCacheAttrs(t *testing.T, kvs []attribute.KeyValue) map[string]string {
+	t.Helper()
 	cacheAttrs := map[string]string{}
-	for k, v := range attrs {
-		if len(k) > len("dagger.io/cache.") && k[:len("dagger.io/cache.")] == "dagger.io/cache." {
-			cacheAttrs[k] = v
+	for _, kv := range kvs {
+		k := string(kv.Key)
+		if !strings.HasPrefix(k, "dagger.io/cache.") {
+			continue
 		}
+		assert.Equal(t, attribute.STRING, kv.Value.Type(), "contract attribute %s must be STRING-typed", k)
+		cacheAttrs[k] = kv.Value.AsString()
 	}
 	return cacheAttrs
 }
@@ -116,7 +122,7 @@ func TestRecordCacheEvidenceMappingHit(t *testing.T) {
 		PairingDigest:         pairDig,
 	}, res)
 
-	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr:            telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:             "hit",
@@ -143,7 +149,7 @@ func TestRecordCacheEvidenceMappingExecutedMissFacts(t *testing.T) {
 		PairingDigest:              selfDig,
 	}, nil)
 
-	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr:                   telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:                    "executed",
@@ -171,7 +177,7 @@ func TestRecordCacheEvidenceMappingJoinedStampsNoMissFacts(t *testing.T) {
 		PairingDigest:              selfDig,
 	}, nil)
 
-	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr:         telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:          "joined",
@@ -190,7 +196,7 @@ func TestRecordCacheEvidenceMappingUncached(t *testing.T) {
 		MissUnknownInputIndex: -1,
 	}, nil)
 
-	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr: telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:  "uncached",
@@ -207,7 +213,7 @@ func TestRecordCacheEvidenceMappingUndecidedStampsNothing(t *testing.T) {
 	recordCacheEvidence(span, dagql.NewCacheDecision(), nil)
 	recordCacheEvidence(span, nil, nil)
 
-	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
 	assert.Equal(t, 0, len(got))
 }
 
@@ -245,10 +251,7 @@ func TestAroundFuncCacheEvidenceLifecycle(t *testing.T) {
 
 	ended := sr.Ended()
 	assert.Equal(t, 1, len(ended))
-	got := map[string]string{}
-	for _, kv := range ended[0].Attributes() {
-		got[string(kv.Key)] = kv.Value.Emit()
-	}
+	got := evidenceTestCacheAttrs(t, ended[0].Attributes())
 	assert.Equal(t, got[telemetryattrs.CacheContractAttr], telemetryattrs.CacheContractV1)
 	assert.Equal(t, got[telemetryattrs.CacheOutcomeAttr], "executed")
 	assert.Equal(t, got[telemetryattrs.CacheSelfDigestAttr], digest.FromString("lifecycle-self").String())

--- a/core/telemetry_cache_evidence_test.go
+++ b/core/telemetry_cache_evidence_test.go
@@ -53,9 +53,10 @@ func evidenceTestEndedAttrs(t *testing.T, sr *tracetest.SpanRecorder, span trace
 }
 
 // evidenceTestCacheAttrs filters to the dagger.io/cache.* attributes, asserting
-// the contract's wire-type rule as it goes: every contract attribute must be an
-// OTel STRING value (the scalar-string shape the Cloud ingest round-trips
-// bit-exact), not merely Emit() text that happens to match.
+// the contract's wire-type rule as it goes: every contract attribute is an
+// OTel STRING value except the structural-input list, which must be a native
+// STRINGSLICE (collected via evidenceTestStructuralInputs) — actual value
+// types, not merely Emit() text that happens to match.
 func evidenceTestCacheAttrs(t *testing.T, kvs []attribute.KeyValue) map[string]string {
 	t.Helper()
 	cacheAttrs := map[string]string{}
@@ -64,10 +65,30 @@ func evidenceTestCacheAttrs(t *testing.T, kvs []attribute.KeyValue) map[string]s
 		if !strings.HasPrefix(k, "dagger.io/cache.") {
 			continue
 		}
+		if k == telemetryattrs.CacheStructuralInputsAttr {
+			// The one non-STRING value in the contract: a native ordered
+			// string slice (checked separately via evidenceTestStructuralInputs).
+			assert.Equal(t, attribute.STRINGSLICE, kv.Value.Type(), "contract attribute %s must be STRINGSLICE-typed", k)
+			continue
+		}
 		assert.Equal(t, attribute.STRING, kv.Value.Type(), "contract attribute %s must be STRING-typed", k)
 		cacheAttrs[k] = kv.Value.AsString()
 	}
 	return cacheAttrs
+}
+
+// evidenceTestStructuralInputs extracts the native structural-input slice:
+// (values, present). Present-and-empty and absent are distinct recorded facts.
+func evidenceTestStructuralInputs(t *testing.T, kvs []attribute.KeyValue) ([]string, bool) {
+	t.Helper()
+	for _, kv := range kvs {
+		if string(kv.Key) != telemetryattrs.CacheStructuralInputsAttr {
+			continue
+		}
+		assert.Equal(t, attribute.STRINGSLICE, kv.Value.Type())
+		return kv.Value.AsStringSlice(), true
+	}
+	return nil, false
 }
 
 func TestInitCacheEvidenceGates(t *testing.T) {
@@ -122,16 +143,20 @@ func TestRecordCacheEvidenceMappingHit(t *testing.T) {
 		PairingDigest:         pairDig,
 	}, res)
 
-	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
+	ended := evidenceTestEndedAttrs(t, sr, span)
+	got := evidenceTestCacheAttrs(t, ended)
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr:            telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:             "hit",
 		telemetryattrs.CacheHitRouteAttr:            "structural",
 		telemetryattrs.CacheSelfDigestAttr:          selfDig.String(),
-		telemetryattrs.CacheStructuralInputsAttr:    `["` + inputA.String() + `","` + inputB.String() + `"]`,
 		telemetryattrs.CachePairingDigestAttr:       pairDig.String(),
 		telemetryattrs.CacheOutputContentDigestAttr: contentDig.String(),
 	})
+	inputs, present := evidenceTestStructuralInputs(t, ended)
+	assert.Assert(t, present)
+	// Exact values in exact order — the miss unknown-input index points here.
+	assert.DeepEqual(t, inputs, []string{inputA.String(), inputB.String()})
 }
 
 func TestRecordCacheEvidenceMappingExecutedMissFacts(t *testing.T) {
@@ -149,7 +174,8 @@ func TestRecordCacheEvidenceMappingExecutedMissFacts(t *testing.T) {
 		PairingDigest:              selfDig,
 	}, nil)
 
-	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
+	ended := evidenceTestEndedAttrs(t, sr, span)
+	got := evidenceTestCacheAttrs(t, ended)
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr:                   telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:                    "executed",
@@ -157,9 +183,11 @@ func TestRecordCacheEvidenceMappingExecutedMissFacts(t *testing.T) {
 		telemetryattrs.CacheMissSawExpiredAttr:             "true",
 		telemetryattrs.CacheMissUnknownInputAttr:           "2",
 		telemetryattrs.CacheSelfDigestAttr:                 selfDig.String(),
-		telemetryattrs.CacheStructuralInputsAttr:           "[]",
 		telemetryattrs.CachePairingDigestAttr:              selfDig.String(),
 	})
+	inputs, present := evidenceTestStructuralInputs(t, ended)
+	assert.Assert(t, present)
+	assert.Equal(t, 0, len(inputs), "a nil carrier list records a present-and-empty slice")
 }
 
 func TestRecordCacheEvidenceMappingJoinedStampsNoMissFacts(t *testing.T) {
@@ -177,14 +205,17 @@ func TestRecordCacheEvidenceMappingJoinedStampsNoMissFacts(t *testing.T) {
 		PairingDigest:              selfDig,
 	}, nil)
 
-	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
+	ended := evidenceTestEndedAttrs(t, sr, span)
+	got := evidenceTestCacheAttrs(t, ended)
 	assert.DeepEqual(t, got, map[string]string{
-		telemetryattrs.CacheContractAttr:         telemetryattrs.CacheContractV1,
-		telemetryattrs.CacheOutcomeAttr:          "joined",
-		telemetryattrs.CacheSelfDigestAttr:       selfDig.String(),
-		telemetryattrs.CacheStructuralInputsAttr: "[]",
-		telemetryattrs.CachePairingDigestAttr:    selfDig.String(),
+		telemetryattrs.CacheContractAttr:      telemetryattrs.CacheContractV1,
+		telemetryattrs.CacheOutcomeAttr:       "joined",
+		telemetryattrs.CacheSelfDigestAttr:    selfDig.String(),
+		telemetryattrs.CachePairingDigestAttr: selfDig.String(),
 	})
+	inputs, present := evidenceTestStructuralInputs(t, ended)
+	assert.Assert(t, present)
+	assert.Equal(t, 0, len(inputs))
 }
 
 func TestRecordCacheEvidenceMappingUncached(t *testing.T) {
@@ -196,11 +227,15 @@ func TestRecordCacheEvidenceMappingUncached(t *testing.T) {
 		MissUnknownInputIndex: -1,
 	}, nil)
 
-	got := evidenceTestCacheAttrs(t, evidenceTestEndedAttrs(t, sr, span))
+	ended := evidenceTestEndedAttrs(t, sr, span)
+	got := evidenceTestCacheAttrs(t, ended)
 	assert.DeepEqual(t, got, map[string]string{
 		telemetryattrs.CacheContractAttr: telemetryattrs.CacheContractV1,
 		telemetryattrs.CacheOutcomeAttr:  "uncached",
 	})
+	// No structural identity stamped: the slice is ABSENT, not empty.
+	_, present := evidenceTestStructuralInputs(t, ended)
+	assert.Assert(t, !present)
 }
 
 func TestRecordCacheEvidenceMappingUndecidedStampsNothing(t *testing.T) {

--- a/core/telemetry_cache_evidence_test.go
+++ b/core/telemetry_cache_evidence_test.go
@@ -1,0 +1,281 @@
+package core
+
+// Cache-evidence stamping tests for the seam core owns: carrier allocation
+// gating (initCacheEvidence), the carrier→attribute mapping
+// (recordCacheEvidence), and the AroundFunc lifecycle end-to-end against an
+// in-memory SDK tracer — mirroring otelprof_services_test.go's discipline.
+// Carrier POPULATION is dagql's seam and is tested there; these tests never
+// re-test it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+	"gotest.tools/v3/assert"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine/telemetryattrs"
+)
+
+func evidenceTestFrame(field string) *dagql.ResultCall {
+	return &dagql.ResultCall{
+		Kind:  dagql.ResultCallKindField,
+		Type:  dagql.NewResultCallType(dagql.Int(0).Type()),
+		Field: field,
+	}
+}
+
+func evidenceTestRecordingSpan(t *testing.T) (*tracetest.SpanRecorder, trace.Span) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(sr),
+	)
+	_, span := tp.Tracer("cache-evidence-test").Start(context.Background(), "test-span")
+	return sr, span
+}
+
+func evidenceTestEndedAttrs(t *testing.T, sr *tracetest.SpanRecorder, span trace.Span) map[string]string {
+	t.Helper()
+	span.End()
+	ended := sr.Ended()
+	assert.Assert(t, len(ended) > 0)
+	got := map[string]string{}
+	for _, kv := range ended[len(ended)-1].Attributes() {
+		got[string(kv.Key)] = kv.Value.Emit()
+	}
+	return got
+}
+
+func evidenceTestCacheAttrs(attrs map[string]string) map[string]string {
+	cacheAttrs := map[string]string{}
+	for k, v := range attrs {
+		if len(k) > len("dagger.io/cache.") && k[:len("dagger.io/cache.")] == "dagger.io/cache." {
+			cacheAttrs[k] = v
+		}
+	}
+	return cacheAttrs
+}
+
+func TestInitCacheEvidenceGates(t *testing.T) {
+	t.Parallel()
+
+	// Recording span + ordinary call: armed.
+	_, span := evidenceTestRecordingSpan(t)
+	req := &dagql.CallRequest{ResultCall: evidenceTestFrame("ordinary")}
+	initCacheEvidence(span, req)
+	assert.Assert(t, req.CacheEvidence != nil)
+	assert.Equal(t, -1, req.CacheEvidence.MissUnknownInputIndex)
+
+	// ProfileSkip-classified call: never armed.
+	skipReq := &dagql.CallRequest{ResultCall: evidenceTestFrame("skipped")}
+	skipReq.ResultCall.ProfileSkip = true
+	initCacheEvidence(span, skipReq)
+	assert.Assert(t, skipReq.CacheEvidence == nil)
+
+	// Non-recording span: never armed.
+	_, noopSpan := tracenoop.NewTracerProvider().Tracer("t").Start(context.Background(), "noop")
+	noopReq := &dagql.CallRequest{ResultCall: evidenceTestFrame("nonrecording")}
+	initCacheEvidence(noopSpan, noopReq)
+	assert.Assert(t, noopReq.CacheEvidence == nil)
+
+	// Degenerate inputs: no panic, no arming.
+	initCacheEvidence(nil, req)
+	initCacheEvidence(span, nil)
+	initCacheEvidence(span, &dagql.CallRequest{})
+}
+
+func TestRecordCacheEvidenceMappingHit(t *testing.T) {
+	t.Parallel()
+	sr, span := evidenceTestRecordingSpan(t)
+
+	selfDig := digest.FromString("evidence-map-self")
+	pairDig := digest.FromString("evidence-map-pair")
+	inputA := digest.FromString("evidence-map-input-a")
+	inputB := digest.FromString("evidence-map-input-b")
+	contentDig := digest.FromString("evidence-map-content")
+
+	resFrame := evidenceTestFrame("producer")
+	resFrame.ExtraDigests = []call.ExtraDigest{{Label: call.ExtraDigestLabelContent, Digest: contentDig}}
+	res, err := dagql.NewResultForCall(dagql.NewInt(1), resFrame)
+	assert.NilError(t, err)
+
+	recordCacheEvidence(span, &dagql.CacheDecision{
+		Outcome:               dagql.CacheOutcomeHit,
+		HitRoute:              dagql.CacheHitRouteStructural,
+		MissUnknownInputIndex: -1,
+		SelfDigest:            selfDig,
+		StructuralInputs:      []digest.Digest{inputA, inputB},
+		PairingDigest:         pairDig,
+	}, res)
+
+	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	assert.DeepEqual(t, got, map[string]string{
+		telemetryattrs.CacheContractAttr:            telemetryattrs.CacheContractV1,
+		telemetryattrs.CacheOutcomeAttr:             "hit",
+		telemetryattrs.CacheHitRouteAttr:            "structural",
+		telemetryattrs.CacheSelfDigestAttr:          selfDig.String(),
+		telemetryattrs.CacheStructuralInputsAttr:    `["` + inputA.String() + `","` + inputB.String() + `"]`,
+		telemetryattrs.CachePairingDigestAttr:       pairDig.String(),
+		telemetryattrs.CacheOutputContentDigestAttr: contentDig.String(),
+	})
+}
+
+func TestRecordCacheEvidenceMappingExecutedMissFacts(t *testing.T) {
+	t.Parallel()
+	sr, span := evidenceTestRecordingSpan(t)
+
+	selfDig := digest.FromString("evidence-miss-self")
+	recordCacheEvidence(span, &dagql.CacheDecision{
+		Outcome:                    dagql.CacheOutcomeExecuted,
+		MissIncompatibleCandidates: true,
+		MissSawExpired:             true,
+		MissUnknownInputIndex:      2,
+		SelfDigest:                 selfDig,
+		StructuralInputs:           nil,
+		PairingDigest:              selfDig,
+	}, nil)
+
+	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	assert.DeepEqual(t, got, map[string]string{
+		telemetryattrs.CacheContractAttr:                   telemetryattrs.CacheContractV1,
+		telemetryattrs.CacheOutcomeAttr:                    "executed",
+		telemetryattrs.CacheMissIncompatibleCandidatesAttr: "true",
+		telemetryattrs.CacheMissSawExpiredAttr:             "true",
+		telemetryattrs.CacheMissUnknownInputAttr:           "2",
+		telemetryattrs.CacheSelfDigestAttr:                 selfDig.String(),
+		telemetryattrs.CacheStructuralInputsAttr:           "[]",
+		telemetryattrs.CachePairingDigestAttr:              selfDig.String(),
+	})
+}
+
+func TestRecordCacheEvidenceMappingJoinedStampsNoMissFacts(t *testing.T) {
+	t.Parallel()
+	sr, span := evidenceTestRecordingSpan(t)
+
+	selfDig := digest.FromString("evidence-joined-self")
+	recordCacheEvidence(span, &dagql.CacheDecision{
+		Outcome: dagql.CacheOutcomeJoined,
+		// Populated by the joiner's pre-join lookup probe; must not stamp.
+		MissIncompatibleCandidates: true,
+		MissSawExpired:             true,
+		MissUnknownInputIndex:      0,
+		SelfDigest:                 selfDig,
+		PairingDigest:              selfDig,
+	}, nil)
+
+	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	assert.DeepEqual(t, got, map[string]string{
+		telemetryattrs.CacheContractAttr:         telemetryattrs.CacheContractV1,
+		telemetryattrs.CacheOutcomeAttr:          "joined",
+		telemetryattrs.CacheSelfDigestAttr:       selfDig.String(),
+		telemetryattrs.CacheStructuralInputsAttr: "[]",
+		telemetryattrs.CachePairingDigestAttr:    selfDig.String(),
+	})
+}
+
+func TestRecordCacheEvidenceMappingUncached(t *testing.T) {
+	t.Parallel()
+	sr, span := evidenceTestRecordingSpan(t)
+
+	recordCacheEvidence(span, &dagql.CacheDecision{
+		Outcome:               dagql.CacheOutcomeUncached,
+		MissUnknownInputIndex: -1,
+	}, nil)
+
+	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	assert.DeepEqual(t, got, map[string]string{
+		telemetryattrs.CacheContractAttr: telemetryattrs.CacheContractV1,
+		telemetryattrs.CacheOutcomeAttr:  "uncached",
+	})
+}
+
+func TestRecordCacheEvidenceMappingUndecidedStampsNothing(t *testing.T) {
+	t.Parallel()
+	sr, span := evidenceTestRecordingSpan(t)
+
+	// Never-populated carrier (invocation errored before any decision) and nil
+	// carrier both stamp nothing — the contract marker never rides a fact-free
+	// span.
+	recordCacheEvidence(span, dagql.NewCacheDecision(), nil)
+	recordCacheEvidence(span, nil, nil)
+
+	got := evidenceTestCacheAttrs(evidenceTestEndedAttrs(t, sr, span))
+	assert.Equal(t, 0, len(got))
+}
+
+func TestAroundFuncCacheEvidenceLifecycle(t *testing.T) {
+	t.Parallel()
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(sr),
+	)
+	ctx, root := tp.Tracer("cache-evidence-test").Start(context.Background(), "root")
+	defer root.End()
+
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	ctx = dagql.ContextWithCache(ctx, cache)
+
+	// Ordinary call: AroundFunc starts a span and arms the carrier; the done
+	// callback maps whatever dagql recorded onto that span.
+	req := &dagql.CallRequest{
+		ResultCall:       evidenceTestFrame("evidenceLifecycle"),
+		ReceiverTypeName: "Container",
+	}
+	_, done := AroundFunc(ctx, req)
+	assert.Assert(t, req.CacheEvidence != nil)
+
+	// Simulate dagql's population for a plain executed call.
+	req.CacheEvidence.Outcome = dagql.CacheOutcomeExecuted
+	req.CacheEvidence.SelfDigest = digest.FromString("lifecycle-self")
+	req.CacheEvidence.PairingDigest = digest.FromString("lifecycle-self")
+
+	var rerr error
+	done(nil, false, &rerr)
+
+	ended := sr.Ended()
+	assert.Equal(t, 1, len(ended))
+	got := map[string]string{}
+	for _, kv := range ended[0].Attributes() {
+		got[string(kv.Key)] = kv.Value.Emit()
+	}
+	assert.Equal(t, got[telemetryattrs.CacheContractAttr], telemetryattrs.CacheContractV1)
+	assert.Equal(t, got[telemetryattrs.CacheOutcomeAttr], "executed")
+	assert.Equal(t, got[telemetryattrs.CacheSelfDigestAttr], digest.FromString("lifecycle-self").String())
+
+	// Introspection call: suppressed before any span exists — never armed.
+	introReq := &dagql.CallRequest{
+		ResultCall:       evidenceTestFrame("__schema"),
+		ReceiverTypeName: "Query",
+	}
+	_, _ = AroundFunc(ctx, introReq)
+	assert.Assert(t, introReq.CacheEvidence == nil)
+
+	// ProfileSkip-classified call (reflection receiver): its span exists but
+	// the carrier is never armed, so nothing can stamp.
+	skipReq := &dagql.CallRequest{
+		ResultCall:       evidenceTestFrame("load"),
+		ReceiverTypeName: "TypeDef",
+	}
+	_, skipDone := AroundFunc(ctx, skipReq)
+	assert.Assert(t, skipReq.ResultCall.ProfileSkip)
+	assert.Assert(t, skipReq.CacheEvidence == nil)
+	skipDone(nil, false, &rerr)
+	for _, ended := range sr.Ended() {
+		for _, kv := range ended.Attributes() {
+			if string(kv.Key) == telemetryattrs.CacheContractAttr && ended.Name() == "TypeDef.load" {
+				t.Fatalf("profile-skipped span must not carry the cache contract")
+			}
+		}
+	}
+}

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -1851,7 +1851,7 @@ func (c *Cache) canonicalEquivalentSharedResultLocked(sessionID string, res *sha
 			continue
 		}
 		for dig := range c.eqClassToDigests[outputEqID] {
-			c.appendDigestResultsLocked(candidates, digest.Digest(dig), nowUnix)
+			c.appendDigestResultsLocked(candidates, digest.Digest(dig), nowUnix, nil)
 		}
 	}
 
@@ -3644,9 +3644,17 @@ func (c *Cache) getOrInitCallInner(
 		return nil, fmt.Errorf("call request is nil")
 	}
 	ctx = ContextWithCall(ctx, req.ResultCall)
+	// Cache-evidence carrier for this invocation (nil unless core armed it);
+	// all writes below are plain field writes on the invoking goroutine.
+	ev := req.CacheEvidence
 
 	if req.DoNotCache {
 		// don't cache, don't dedupe calls, just call it
+		if ev != nil {
+			// Identity derivation is skipped on this path, so the outcome is
+			// the only fact recorded.
+			ev.Outcome = CacheOutcomeUncached
+		}
 
 		val, err := fn(ctx)
 		if err != nil {
@@ -3713,6 +3721,17 @@ func (c *Cache) getOrInitCallInner(
 		}
 		requestInputs = append(requestInputs, dig)
 	}
+	if ev != nil {
+		ev.SelfDigest = requestSelf
+		ev.StructuralInputs = requestInputs
+		// Best-effort optional fact: pairing derivation shares the self-digest
+		// code path, so an error here is not realistically reachable when the
+		// derivation above succeeded; if it ever errors, the fact is dropped
+		// rather than failing the call.
+		if pairingDig, pairingErr := req.pairingDigest(c); pairingErr == nil {
+			ev.PairingDigest = pairingDig
+		}
+	}
 	callKey := callDigest.String()
 	profOp.SetIdent(callKey)
 	if ctx.Value(cacheContextKey{callKey}) != nil {
@@ -3728,6 +3747,12 @@ func (c *Cache) getOrInitCallInner(
 		return nil, err
 	}
 	if hit {
+		if ev != nil {
+			// The lookup fact only: a hit on a still-pending lazy shell stays
+			// outcome=hit while dag.pending/dag.cached keep the evaluation
+			// facts (recordStatus is unchanged).
+			ev.Outcome = CacheOutcomeHit
+		}
 		c.captureSessionLazySpanContext(ctx, sessionID, hitRes)
 		c.captureSessionResultInstallSpan(ctx, sessionID, hitRes)
 		return hitRes, nil
@@ -3746,6 +3771,13 @@ func (c *Cache) getOrInitCallInner(
 			// already an ongoing call
 			oc.waiters++
 			c.callsMu.Unlock()
+			if ev != nil {
+				// This invocation's own decision: it deduplicated into the
+				// concurrent identical call. Its earlier lookup-miss facts
+				// stay in the carrier but are stamped only for executed
+				// outcomes (they describe the pre-join probe, not a miss).
+				ev.Outcome = CacheOutcomeJoined
+			}
 			profOp.SetOutcomeHint(wcprof.OutcomeJoined)
 			return c.wait(ctx, sessionID, resolver, oc, req, true)
 		}
@@ -3831,6 +3863,12 @@ func (c *Cache) getOrInitCallInner(
 	}()
 
 	c.callsMu.Unlock()
+	if ev != nil {
+		// The decision fact: the cache chose to execute. It stays recorded even
+		// if the resolver later errors — the span's own error/cancel status
+		// carries that separately.
+		ev.Outcome = CacheOutcomeExecuted
+	}
 	profOp.SetOutcomeHint(wcprof.OutcomeExecuted)
 	return c.wait(ctx, sessionID, resolver, oc, req, false)
 }

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -568,13 +568,23 @@ type lookupMatch struct {
 	candidates            *set.TreeSet[*sharedResult]
 	termDigest            string
 	termSetSize           int
+	// route records which index produced the current candidate set — the
+	// cache-evidence hit provenance (CacheHitRouteRecipe/Digest/Structural).
+	// Purely observational: candidate gathering and selection are unchanged.
+	route CacheHitRoute
+	// sawExpired records that expiry dropped at least one otherwise-matching
+	// result during candidate accumulation (cache-evidence miss fact).
+	sawExpired bool
 }
 
 func newSharedResultSet() *set.TreeSet[*sharedResult] {
 	return set.NewTreeSet(compareSharedResults)
 }
 
-func (c *Cache) appendDigestResultsLocked(candidates *set.TreeSet[*sharedResult], dig digest.Digest, nowUnix int64) {
+// sawExpired, when non-nil, is set to true if expiry drops at least one
+// otherwise-matching result during accumulation (cache-evidence miss fact);
+// candidate gathering itself is unchanged.
+func (c *Cache) appendDigestResultsLocked(candidates *set.TreeSet[*sharedResult], dig digest.Digest, nowUnix int64, sawExpired *bool) {
 	if dig == "" {
 		return
 	}
@@ -584,14 +594,20 @@ func (c *Cache) appendDigestResultsLocked(candidates *set.TreeSet[*sharedResult]
 	}
 	for resID := range resultSet.Items() {
 		res := c.resultsByID[resID]
-		if res == nil || c.resultExpiredAtLocked(res, nowUnix) {
+		if res == nil {
+			continue
+		}
+		if c.resultExpiredAtLocked(res, nowUnix) {
+			if sawExpired != nil {
+				*sawExpired = true
+			}
 			continue
 		}
 		candidates.Insert(res)
 	}
 }
 
-func (c *Cache) appendTermSetResultsLocked(candidates *set.TreeSet[*sharedResult], termSet *set.TreeSet[egraphTermID], nowUnix int64) {
+func (c *Cache) appendTermSetResultsLocked(candidates *set.TreeSet[*sharedResult], termSet *set.TreeSet[egraphTermID], nowUnix int64, sawExpired *bool) {
 	if termSet == nil {
 		return
 	}
@@ -599,7 +615,13 @@ func (c *Cache) appendTermSetResultsLocked(candidates *set.TreeSet[*sharedResult
 	for termID := range termSet.Items() {
 		for resID := range c.termResults[termID] {
 			res := c.resultsByID[resID]
-			if res == nil || c.resultExpiredAtLocked(res, nowUnix) {
+			if res == nil {
+				continue
+			}
+			if c.resultExpiredAtLocked(res, nowUnix) {
+				if sawExpired != nil {
+					*sawExpired = true
+				}
 				continue
 			}
 			candidates.Insert(res)
@@ -624,7 +646,7 @@ func (c *Cache) appendTermSetResultsLocked(candidates *set.TreeSet[*sharedResult
 		}
 		seenOutputEqClasses[outputEqID] = struct{}{}
 		for dig := range c.eqClassToDigests[outputEqID] {
-			c.appendDigestResultsLocked(candidates, digest.Digest(dig), nowUnix)
+			c.appendDigestResultsLocked(candidates, digest.Digest(dig), nowUnix, sawExpired)
 		}
 	}
 }
@@ -665,17 +687,19 @@ func (c *Cache) lookupMatchForDigestsLocked(recipeDigest digest.Digest, extraDig
 	}
 
 	candidates := newSharedResultSet()
-	c.appendDigestResultsLocked(candidates, recipeDigest, nowUnix)
+	c.appendDigestResultsLocked(candidates, recipeDigest, nowUnix, &match.sawExpired)
 	if !candidates.Empty() {
 		match.candidates = candidates
 		match.hitRecipeDigest = true
+		match.route = CacheHitRouteRecipe
 		return match
 	}
 	for _, extra := range extraDigests {
-		c.appendDigestResultsLocked(candidates, extra.Digest, nowUnix)
+		c.appendDigestResultsLocked(candidates, extra.Digest, nowUnix, &match.sawExpired)
 	}
 	if !candidates.Empty() {
 		match.candidates = candidates
+		match.route = CacheHitRouteDigest
 	}
 	return match
 }
@@ -725,9 +749,10 @@ func (c *Cache) lookupMatchForCallLocked(
 			match.termSetSize = termSet.Size()
 		}
 		candidates := newSharedResultSet()
-		c.appendTermSetResultsLocked(candidates, termSet, nowUnix)
+		c.appendTermSetResultsLocked(candidates, termSet, nowUnix, &match.sawExpired)
 		if !candidates.Empty() {
 			match.candidates = candidates
+			match.route = CacheHitRouteStructural
 		}
 	}
 	return match
@@ -819,6 +844,24 @@ func (c *Cache) lookupCacheForRequestLocked(
 	match := c.lookupMatchForCallLocked(req.ResultCall, requestDigest, requestSelf, requestInputs, nowUnix)
 	c.traceLookupAttempt(ctx, requestDigest.String(), match.selfDigest.String(), match.inputDigests, req.IsPersistable)
 	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates)
+
+	// Fill the request's cache-evidence carrier (when armed) with the facts
+	// that exist only at this decision point; plain field writes of values
+	// already in hand, changing nothing about the lookup itself.
+	if ev := req.CacheEvidence; ev != nil {
+		if hitRes != nil {
+			ev.HitRoute = match.route
+		} else {
+			ev.MissSawExpired = match.sawExpired
+			// Expiry is applied during accumulation, so a non-empty candidate
+			// set on a miss means every surviving candidate failed the
+			// session-resource filter.
+			ev.MissIncompatibleCandidates = match.candidates != nil && !match.candidates.Empty()
+			if !match.primaryLookupPossible {
+				ev.MissUnknownInputIndex = match.missingInputIndex
+			}
+		}
+	}
 
 	if hitRes == nil {
 		c.traceLookupMissNoMatch(ctx, requestDigest.String(), match.primaryLookupPossible, match.missingInputIndex, match.termDigest, match.termSetSize)

--- a/dagql/cache_evidence.go
+++ b/dagql/cache_evidence.go
@@ -1,0 +1,85 @@
+package dagql
+
+import (
+	"github.com/opencontainers/go-digest"
+
+	"github.com/dagger/dagger/engine/telemetryattrs"
+)
+
+// CacheOutcome is what the cache decided for one call. The values are the
+// telemetryattrs.CacheOutcome* wire tokens.
+type CacheOutcome string
+
+const (
+	CacheOutcomeHit      CacheOutcome = telemetryattrs.CacheOutcomeHit
+	CacheOutcomeExecuted CacheOutcome = telemetryattrs.CacheOutcomeExecuted
+	CacheOutcomeJoined   CacheOutcome = telemetryattrs.CacheOutcomeJoined
+	CacheOutcomeUncached CacheOutcome = telemetryattrs.CacheOutcomeUncached
+)
+
+// CacheHitRoute is how a cache hit was found. The values are the
+// telemetryattrs.CacheHitRoute* wire tokens.
+type CacheHitRoute string
+
+const (
+	CacheHitRouteRecipe     CacheHitRoute = telemetryattrs.CacheHitRouteRecipe
+	CacheHitRouteDigest     CacheHitRoute = telemetryattrs.CacheHitRouteDigest
+	CacheHitRouteStructural CacheHitRoute = telemetryattrs.CacheHitRouteStructural
+)
+
+// CacheDecision is the per-invocation cache-evidence carrier: a plain record of
+// the decision facts for one GetOrInitCall invocation, filled by dagql along
+// the existing control flow and consumed by core.AroundFunc's completion
+// callback, which maps it onto the caller's already-existing span as the
+// dagger.io/cache.* attribute vocabulary (engine/telemetryattrs).
+//
+// Ownership: core allocates it onto CallRequest.CacheEvidence exactly when the
+// call's span records and the call is not ProfileSkip-classified; dagql only
+// ever fills a non-nil carrier (nil means "record nothing" and costs nothing).
+// Every write happens on the invoking goroutine with values already in hand —
+// the carrier adds no locking and never alters any cache decision. Population
+// is best-effort: a fact whose derivation fails is dropped, never failing the
+// call.
+type CacheDecision struct {
+	// Outcome is the call's cache outcome. Empty means the invocation never
+	// reached a decision (e.g. it errored during validation or identity
+	// derivation); nothing is stamped then.
+	Outcome CacheOutcome
+
+	// HitRoute is how the hit was found. Set only for Outcome == CacheOutcomeHit.
+	HitRoute CacheHitRoute
+
+	// MissIncompatibleCandidates records that the lookup's post-expiry
+	// candidate set was non-empty but no candidate satisfied this session's
+	// resource requirements. Meaningful only for misses (Outcome executed).
+	MissIncompatibleCandidates bool
+
+	// MissSawExpired records that TTL expiry eliminated at least one
+	// otherwise-matching result during candidate accumulation. Meaningful only
+	// for misses (Outcome executed).
+	MissSawExpired bool
+
+	// MissUnknownInputIndex is the index into StructuralInputs of the first
+	// input digest that had no equivalence class at lookup time (making the
+	// structural lookup impossible), or -1 when every input was known.
+	// Meaningful only for misses (Outcome executed).
+	MissUnknownInputIndex int
+
+	// SelfDigest is the engine-derived structural self digest of the call.
+	// Empty for CacheOutcomeUncached, whose path skips identity derivation.
+	SelfDigest digest.Digest
+
+	// StructuralInputs is the exact ordered structural-input digest list used
+	// for the equivalence lookup (receiver, reference-valued arguments in
+	// order, digest witnesses, module). Nil for CacheOutcomeUncached.
+	StructuralInputs []digest.Digest
+
+	// PairingDigest is the self digest derived with implicit inputs excluded —
+	// the cross-run pairing anchor. Empty for CacheOutcomeUncached.
+	PairingDigest digest.Digest
+}
+
+// NewCacheDecision returns an empty carrier with its index sentinel set.
+func NewCacheDecision() *CacheDecision {
+	return &CacheDecision{MissUnknownInputIndex: -1}
+}

--- a/dagql/cache_evidence_test.go
+++ b/dagql/cache_evidence_test.go
@@ -210,6 +210,91 @@ func TestCacheEvidenceMissSawExpired(t *testing.T) {
 	assert.Equal(t, -1, ev.MissUnknownInputIndex)
 }
 
+func TestCacheEvidenceSawExpiredThroughEqClassExpansion(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	// Build the state where appendTermSetResultsLocked's SECOND loop — the
+	// output-eq-class digest expansion — is the only place expiry can be
+	// observed: the term survives with no directly-associated results (its
+	// observed result is collected), while the term's output eq-class still
+	// indexes an equivalent result that has expired.
+	contentDigest := digest.FromString("evidence-exp-content")
+	inputDigest := digest.FromString("evidence-exp-input")
+	consumerFrame := func() *ResultCall {
+		frame := cacheTestIntCall("evidence-exp-consumer")
+		frame.Args = []*ResultCallArg{{
+			Name: "src",
+			Value: &ResultCallLiteral{
+				Kind:                 ResultCallLiteralKindDigestedString,
+				DigestedStringValue:  "witnessed",
+				DigestedStringDigest: inputDigest,
+			},
+		}}
+		return frame
+	}
+
+	// 1. Observe the term once, in a scratch session, and teach its result a
+	// content digest so its output eq-class gains a second identity route.
+	scratchCtx := ContextWithCache(engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "dagql-test-client-exp",
+		SessionID: "evidence-exp-session",
+	}), c)
+	frameA := consumerFrame()
+	resC, err := c.GetOrInitCall(scratchCtx, "evidence-exp-session", noopTypeResolver{}, &CallRequest{ResultCall: frameA}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frameA, 1), nil
+	})
+	assert.NilError(t, err)
+	resC, err = resC.WithContentDigestAny(scratchCtx, contentDigest)
+	assert.NilError(t, err)
+	collectedID := resC.cacheSharedResult().id
+
+	// 2. An equivalent-by-content sibling result, owned by the main session,
+	// indexed under the shared content digest (same output eq-class).
+	producerFrame := cacheTestIntCall("evidence-exp-producer")
+	resP, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: producerFrame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(producerFrame, 2), nil
+	})
+	assert.NilError(t, err)
+	resP, err = resP.WithContentDigestAny(ctx, contentDigest)
+	assert.NilError(t, err)
+
+	// 3. Collect the term's observed result: release its only owning session,
+	// then prove it is gone so the first accumulation loop (direct term
+	// results) has nothing at all — live or expired — to visit.
+	assert.NilError(t, c.ReleaseSession(scratchCtx, "evidence-exp-session"))
+	c.egraphMu.Lock()
+	_, stillLive := c.resultsByID[collectedID]
+	c.egraphMu.Unlock()
+	assert.Assert(t, !stillLive)
+
+	// 4. Expire the surviving eq-class sibling.
+	c.egraphMu.Lock()
+	resP.cacheSharedResult().expiresAtUnix = time.Now().Add(-time.Hour).Unix()
+	c.egraphMu.Unlock()
+
+	// 5. Re-issue the consumer call: recipe index no longer holds the
+	// collected result, the request carries no extra digests, so the lookup
+	// reaches the structural term — whose only candidate route is the
+	// eq-class expansion, where the expired sibling is dropped.
+	frameB := consumerFrame()
+	req := cacheTestArmedRequest(frameB)
+	initCalls := 0
+	res, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		initCalls++
+		return cacheTestIntResult(frameB, 3), nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, initCalls)
+	assert.Assert(t, !res.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeExecuted, ev.Outcome)
+	assert.Assert(t, ev.MissSawExpired)
+	assert.Assert(t, !ev.MissIncompatibleCandidates)
+	assert.Equal(t, -1, ev.MissUnknownInputIndex)
+}
+
 func TestCacheEvidenceMissIncompatibleCandidates(t *testing.T) {
 	t.Parallel()
 	baseCtx := cacheTestContext(t.Context())

--- a/dagql/cache_evidence_test.go
+++ b/dagql/cache_evidence_test.go
@@ -1,0 +1,504 @@
+package dagql
+
+// Cache-evidence carrier population tests: drive GetOrInitCall directly with an
+// armed CacheDecision (simulating core.AroundFunc's allocation) and assert the
+// decision facts recorded for every cache route. dagql tests never observe
+// spans — attribute mapping is core's seam and is tested there.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagger/dagger/engine"
+	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
+
+	"github.com/dagger/dagger/dagql/call"
+)
+
+func cacheTestArmedRequest(frame *ResultCall) *CallRequest {
+	return &CallRequest{
+		ResultCall:    frame,
+		CacheEvidence: NewCacheDecision(),
+	}
+}
+
+func cacheTestEvidenceEnv(t *testing.T) (context.Context, *Cache) {
+	t.Helper()
+	ctx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	return ContextWithCache(ctx, cacheIface), cacheIface
+}
+
+func TestCacheEvidenceExecutedFreshCall(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-executed-fresh")
+	req := cacheTestArmedRequest(frame)
+	res, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1), nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !res.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeExecuted, ev.Outcome)
+	assert.Equal(t, CacheHitRoute(""), ev.HitRoute)
+	assert.Assert(t, !ev.MissIncompatibleCandidates)
+	assert.Assert(t, !ev.MissSawExpired)
+	assert.Equal(t, -1, ev.MissUnknownInputIndex)
+	assert.Assert(t, ev.SelfDigest != "")
+	assert.Equal(t, 0, len(ev.StructuralInputs))
+	// No implicit inputs: the pairing digest equals the self digest by
+	// construction.
+	assert.Equal(t, ev.SelfDigest, ev.PairingDigest)
+}
+
+func TestCacheEvidenceRecipeHit(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-recipe-hit")
+	_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1), nil
+	})
+	assert.NilError(t, err)
+
+	req := cacheTestArmedRequest(frame)
+	initCalls := 0
+	res, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		initCalls++
+		return cacheTestIntResult(frame, 2), nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 0, initCalls)
+	assert.Assert(t, res.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeHit, ev.Outcome)
+	assert.Equal(t, CacheHitRouteRecipe, ev.HitRoute)
+	assert.Assert(t, !ev.MissIncompatibleCandidates)
+	assert.Assert(t, !ev.MissSawExpired)
+	assert.Equal(t, -1, ev.MissUnknownInputIndex)
+	assert.Assert(t, ev.SelfDigest != "")
+}
+
+func TestCacheEvidenceDigestRouteHit(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	contentDigest := digest.FromString("evidence-digest-route-content")
+	producer := cacheTestIntCall("evidence-digest-route-producer")
+	_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: producer}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(producer, 7).(Result[Int]).WithContentDigest(ctx, contentDigest)
+	})
+	assert.NilError(t, err)
+
+	// A different operation whose request carries the produced content digest
+	// as equivalence evidence: recipe lookup misses, extra-digest lookup hits.
+	consumer := cacheTestIntCall("evidence-digest-route-consumer", call.ExtraDigest{
+		Label:  call.ExtraDigestLabelContent,
+		Digest: contentDigest,
+	})
+	req := cacheTestArmedRequest(consumer)
+	initCalls := 0
+	res, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		initCalls++
+		return cacheTestIntResult(consumer, 8), nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 0, initCalls)
+	assert.Assert(t, res.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeHit, ev.Outcome)
+	assert.Equal(t, CacheHitRouteDigest, ev.HitRoute)
+}
+
+func TestCacheEvidenceStructuralRouteHit(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	digA := digest.FromString("evidence-structural-input-a")
+	digB := digest.FromString("evidence-structural-input-b")
+	structuralFrame := func(src digest.Digest) *ResultCall {
+		frame := cacheTestIntCall("evidence-structural-op")
+		frame.Args = []*ResultCallArg{{
+			Name: "src",
+			Value: &ResultCallLiteral{
+				Kind:                 ResultCallLiteralKindDigestedString,
+				DigestedStringValue:  "witnessed",
+				DigestedStringDigest: src,
+			},
+		}}
+		return frame
+	}
+
+	frameA := structuralFrame(digA)
+	_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frameA}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frameA, 1), nil
+	})
+	assert.NilError(t, err)
+
+	// Teach digA ≡ digB by publishing a result carrying both as extra digests:
+	// publication accumulates them onto one output eq-class.
+	teacher := cacheTestIntCall("evidence-structural-teacher",
+		call.ExtraDigest{Label: call.ExtraDigestLabelContent, Digest: digA},
+		call.ExtraDigest{Label: call.ExtraDigestLabelContent, Digest: digB},
+	)
+	_, err = c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: teacher}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(teacher, 2), nil
+	})
+	assert.NilError(t, err)
+
+	// Same operation over the equivalent input: different recipe digest, same
+	// self digest, input digests in one eq-class → structural term hit.
+	frameB := structuralFrame(digB)
+	req := cacheTestArmedRequest(frameB)
+	initCalls := 0
+	res, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		initCalls++
+		return cacheTestIntResult(frameB, 3), nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 0, initCalls)
+	assert.Assert(t, res.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeHit, ev.Outcome)
+	assert.Equal(t, CacheHitRouteStructural, ev.HitRoute)
+	assert.Equal(t, 1, len(ev.StructuralInputs))
+	assert.Equal(t, digB, ev.StructuralInputs[0])
+}
+
+func TestCacheEvidenceMissSawExpired(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-saw-expired")
+	res1, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame, TTL: 3600}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1), nil
+	})
+	assert.NilError(t, err)
+	shared := res1.cacheSharedResult()
+	assert.Assert(t, shared != nil)
+	// Force the published result past its TTL without sleeping.
+	c.egraphMu.Lock()
+	shared.expiresAtUnix = time.Now().Add(-time.Hour).Unix()
+	c.egraphMu.Unlock()
+
+	req := cacheTestArmedRequest(frame)
+	req.TTL = 3600
+	initCalls := 0
+	res2, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		initCalls++
+		return cacheTestIntResult(frame, 2), nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, initCalls)
+	assert.Assert(t, !res2.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeExecuted, ev.Outcome)
+	assert.Assert(t, ev.MissSawExpired)
+	// Expiry dropped the only candidate during accumulation, so no incompatible
+	// (session-rejected) candidates remained.
+	assert.Assert(t, !ev.MissIncompatibleCandidates)
+	assert.Equal(t, -1, ev.MissUnknownInputIndex)
+}
+
+func TestCacheEvidenceMissIncompatibleCandidates(t *testing.T) {
+	t.Parallel()
+	baseCtx := cacheTestContext(t.Context())
+	cacheIface, err := NewCache(baseCtx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+	ctxA := ContextWithCache(baseCtx, c)
+
+	handle := SessionResourceHandle("evidence-incompatible-secret")
+	assert.NilError(t, c.BindSessionResource(ctxA, "test-session", "dagql-test-client", handle, "concrete"))
+
+	frame := cacheTestIntCall("evidence-incompatible")
+	_, err = c.GetOrInitCall(ctxA, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1).(Result[Int]).WithSessionResourceHandleAny(ctxA, handle)
+	})
+	assert.NilError(t, err)
+
+	// A second session that never bound the handle: the recipe candidate
+	// exists but fails the session-resource filter.
+	ctxB := ContextWithCache(engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "dagql-test-client-b",
+		SessionID: "test-session-b",
+	}), c)
+	req := cacheTestArmedRequest(frame)
+	initCalls := 0
+	res, err := c.GetOrInitCall(ctxB, "test-session-b", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		initCalls++
+		return cacheTestIntResult(frame, 2).(Result[Int]).WithSessionResourceHandleAny(ctxB, handle)
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, initCalls)
+	assert.Assert(t, !res.HitCache())
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeExecuted, ev.Outcome)
+	assert.Assert(t, ev.MissIncompatibleCandidates)
+	assert.Assert(t, !ev.MissSawExpired)
+}
+
+func TestCacheEvidenceJoinedAndExecutedCarriers(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-joined")
+	release := make(chan struct{})
+	started := make(chan struct{})
+	execDone := make(chan error, 1)
+
+	// Executor: same concurrency key, blocks inside the resolver until the
+	// joiner has been admitted.
+	execReq := cacheTestArmedRequest(frame)
+	execReq.ConcurrencyKey = "evidence-joined-key"
+	go func() {
+		_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, execReq, func(context.Context) (AnyResult, error) {
+			close(started)
+			<-release
+			return cacheTestIntResult(frame, 1), nil
+		})
+		execDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for executor start")
+	}
+
+	// Joiner: identical call and key, its own request and its own carrier.
+	joinReq := cacheTestArmedRequest(frame)
+	joinReq.ConcurrencyKey = "evidence-joined-key"
+	joinDone := make(chan error, 1)
+	var joinRes AnyResult
+	go func() {
+		var err error
+		joinRes, err = c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, joinReq, func(context.Context) (AnyResult, error) {
+			t.Error("joiner resolver must not run")
+			return cacheTestIntResult(frame, 2), nil
+		})
+		joinDone <- err
+	}()
+
+	// Wait for the joiner's admission via the mutex-guarded waiter count (the
+	// carrier itself is single-goroutine state owned by each invocation and
+	// must not be read while its invocation runs), then release the shared
+	// execution. Carriers are only read after both goroutines complete.
+	waitKeys := callConcurrencyKeys{
+		callKey:        cacheTestCallDigest(frame).String(),
+		concurrencyKey: "evidence-joined-key",
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c.callsMu.Lock()
+		waiters := 0
+		if oc := c.ongoingCalls[waitKeys]; oc != nil {
+			waiters = oc.waiters
+		}
+		c.callsMu.Unlock()
+		if waiters >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for joiner admission")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	assert.NilError(t, <-execDone)
+	assert.NilError(t, <-joinDone)
+
+	assert.Equal(t, CacheOutcomeExecuted, execReq.CacheEvidence.Outcome)
+	assert.Equal(t, CacheOutcomeJoined, joinReq.CacheEvidence.Outcome)
+	// Per-invocation carriers: distinct records, one shared execution.
+	assert.Assert(t, execReq.CacheEvidence != joinReq.CacheEvidence)
+	assert.Assert(t, joinRes != nil)
+	// Both carry the same identity facts, derived independently.
+	assert.Equal(t, execReq.CacheEvidence.SelfDigest, joinReq.CacheEvidence.SelfDigest)
+	assert.Equal(t, execReq.CacheEvidence.PairingDigest, joinReq.CacheEvidence.PairingDigest)
+}
+
+func TestCacheEvidenceDoNotCacheUncached(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-uncached")
+	req := cacheTestArmedRequest(frame)
+	req.DoNotCache = true
+	_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1), nil
+	})
+	assert.NilError(t, err)
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeUncached, ev.Outcome)
+	// The DoNotCache path skips identity derivation entirely.
+	assert.Equal(t, digest.Digest(""), ev.SelfDigest)
+	assert.Equal(t, digest.Digest(""), ev.PairingDigest)
+	assert.Equal(t, 0, len(ev.StructuralInputs))
+}
+
+func TestCacheEvidencePendingLazyHitIsHit(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-pending-lazy")
+	_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		res, err := NewResultForCall(&cacheTestObject{
+			Value:    1,
+			lazyEval: func(context.Context) error { return nil },
+		}, frame)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	})
+	assert.NilError(t, err)
+
+	req := cacheTestArmedRequest(frame)
+	res2, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		t.Error("resolver must not run on a lazy-shell hit")
+		return nil, nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, res2.HitCache())
+	// The lookup fact is a hit even though deferred work is still pending —
+	// the evaluation fact stays separate (dag.pending semantics unchanged).
+	assert.Assert(t, HasPendingLazyEvaluation(res2))
+	assert.Equal(t, CacheOutcomeHit, req.CacheEvidence.Outcome)
+	assert.Equal(t, CacheHitRouteRecipe, req.CacheEvidence.HitRoute)
+}
+
+func TestCacheEvidenceUnknownInputIndex(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-unknown-input")
+	frame.Args = []*ResultCallArg{{
+		Name: "src",
+		Value: &ResultCallLiteral{
+			Kind:                 ResultCallLiteralKindDigestedString,
+			DigestedStringValue:  "never-seen",
+			DigestedStringDigest: digest.FromString("evidence-unknown-input-digest"),
+		},
+	}}
+	req := cacheTestArmedRequest(frame)
+	_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, req, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1), nil
+	})
+	assert.NilError(t, err)
+
+	ev := req.CacheEvidence
+	assert.Equal(t, CacheOutcomeExecuted, ev.Outcome)
+	// The digest witness had no eq-class yet, so the structural lookup was
+	// impossible; the index points into the recorded structural-input list.
+	assert.Equal(t, 0, ev.MissUnknownInputIndex)
+	assert.Equal(t, 1, len(ev.StructuralInputs))
+	assert.Assert(t, !ev.MissIncompatibleCandidates)
+}
+
+func TestCacheEvidencePairingDigestExcludesImplicitInputs(t *testing.T) {
+	t.Parallel()
+
+	frameWithImplicit := func(scope string) *ResultCall {
+		frame := cacheTestIntCall("evidence-pairing")
+		frame.ImplicitInputs = []*ResultCallArg{{
+			Name: "cachePerClient",
+			Value: &ResultCallLiteral{
+				Kind:        ResultCallLiteralKindString,
+				StringValue: scope,
+			},
+		}}
+		return frame
+	}
+	frameA := frameWithImplicit("client-a")
+	frameB := frameWithImplicit("client-b")
+	framePlain := cacheTestIntCall("evidence-pairing")
+
+	selfA, _, err := frameA.selfDigestAndInputRefs(nil)
+	assert.NilError(t, err)
+	selfB, _, err := frameB.selfDigestAndInputRefs(nil)
+	assert.NilError(t, err)
+	selfPlain, _, err := framePlain.selfDigestAndInputRefs(nil)
+	assert.NilError(t, err)
+	pairA, err := frameA.pairingDigest(nil)
+	assert.NilError(t, err)
+	pairB, err := frameB.pairingDigest(nil)
+	assert.NilError(t, err)
+	pairPlain, err := framePlain.pairingDigest(nil)
+	assert.NilError(t, err)
+
+	// Implicit inputs scope the self digest but never the pairing digest.
+	assert.Assert(t, selfA != selfB)
+	assert.Equal(t, pairA, pairB)
+	// A frame with no implicit inputs pairs and selfs identically, and the
+	// scoped frames pair to exactly that unscoped identity.
+	assert.Equal(t, selfPlain, pairPlain)
+	assert.Equal(t, pairA, pairPlain)
+	// Sensitive-arg redaction applies to both derivations equally: a sensitive
+	// literal changes neither digest's relationship, and both redact.
+	sensitiveA := frameWithImplicit("client-a")
+	sensitiveA.Args = []*ResultCallArg{{
+		Name:        "token",
+		IsSensitive: true,
+		Value: &ResultCallLiteral{
+			Kind:        ResultCallLiteralKindString,
+			StringValue: "secret-one",
+		},
+	}}
+	sensitiveB := frameWithImplicit("client-a")
+	sensitiveB.Args = []*ResultCallArg{{
+		Name:        "token",
+		IsSensitive: true,
+		Value: &ResultCallLiteral{
+			Kind:        ResultCallLiteralKindString,
+			StringValue: "secret-two",
+		},
+	}}
+	sensPairA, err := sensitiveA.pairingDigest(nil)
+	assert.NilError(t, err)
+	sensPairB, err := sensitiveB.pairingDigest(nil)
+	assert.NilError(t, err)
+	assert.Equal(t, sensPairA, sensPairB)
+}
+
+func TestCacheEvidenceCloneDropsCarrier(t *testing.T) {
+	t.Parallel()
+
+	req := cacheTestArmedRequest(cacheTestIntCall("evidence-clone"))
+	assert.Assert(t, req.CacheEvidence != nil)
+	clone := req.Clone()
+	assert.Assert(t, clone.CacheEvidence == nil)
+}
+
+func TestCacheEvidenceNilCarrierIsNoop(t *testing.T) {
+	t.Parallel()
+	ctx, c := cacheTestEvidenceEnv(t)
+
+	frame := cacheTestIntCall("evidence-nil-carrier")
+	// Executed, hit, and uncached paths all run with a nil carrier.
+	res1, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 1), nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !res1.HitCache())
+	res2, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 2), nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, res2.HitCache())
+	_, err = c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{ResultCall: frame, DoNotCache: true}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(frame, 3), nil
+	})
+	assert.NilError(t, err)
+}

--- a/dagql/call_request.go
+++ b/dagql/call_request.go
@@ -24,6 +24,16 @@ type CallRequest struct {
 	// the call frame (ResultCall.ProfileSkip) — so the predicate needs no egraphMu
 	// receiver-resolution lookup per call.
 	ReceiverTypeName string
+
+	// CacheEvidence is the per-invocation cache-decision evidence carrier
+	// (request-only carrier state like ReceiverTypeName: never digested, never
+	// persisted, excluded from Clone). core.AroundFunc allocates it exactly
+	// when this call's span records and the call is not ProfileSkip-classified;
+	// getOrInitCallInner fills it along the existing decision flow; AroundFunc's
+	// completion callback stamps it onto the caller's span. Nil means "record
+	// nothing". It is scoped to one invocation — internal CallRequest
+	// constructions that never pass through AroundFunc leave it nil.
+	CacheEvidence *CacheDecision
 }
 
 func (req *CallRequest) Clone() *CallRequest {
@@ -42,6 +52,10 @@ func (req *CallRequest) Clone() *CallRequest {
 		IsPersistable:        req.IsPersistable,
 		PassthroughTelemetry: req.PassthroughTelemetry,
 		ReceiverTypeName:     req.ReceiverTypeName,
+		// CacheEvidence is deliberately NOT carried over: it is per-invocation
+		// state owned by the one AroundFunc-wrapped invocation that allocated
+		// it; a cloned request is a different (or internal) invocation and
+		// sharing the pointer would let two invocations write into one record.
 	}
 }
 

--- a/dagql/call_request.go
+++ b/dagql/call_request.go
@@ -25,14 +25,17 @@ type CallRequest struct {
 	// receiver-resolution lookup per call.
 	ReceiverTypeName string
 
-	// CacheEvidence is the per-invocation cache-decision evidence carrier
-	// (request-only carrier state like ReceiverTypeName: never digested, never
-	// persisted, excluded from Clone). core.AroundFunc allocates it exactly
-	// when this call's span records and the call is not ProfileSkip-classified;
-	// getOrInitCallInner fills it along the existing decision flow; AroundFunc's
-	// completion callback stamps it onto the caller's span. Nil means "record
-	// nothing". It is scoped to one invocation — internal CallRequest
-	// constructions that never pass through AroundFunc leave it nil.
+	// CacheEvidence is the per-invocation cache-decision evidence carrier.
+	// Like ReceiverTypeName it is request-only carrier state (never digested,
+	// never persisted); unlike ReceiverTypeName it is additionally scoped to a
+	// single invocation and therefore deliberately omitted by Clone — a cloned
+	// request is a different (or internal) invocation and must not share the
+	// record. core.AroundFunc allocates it exactly when this call's span
+	// records and the call is not ProfileSkip-classified; getOrInitCallInner
+	// fills it along the existing decision flow; AroundFunc's completion
+	// callback stamps it onto the caller's span. Nil means "record nothing" —
+	// internal CallRequest constructions that never pass through AroundFunc
+	// leave it nil.
 	CacheEvidence *CacheDecision
 }
 

--- a/dagql/result_call_frame.go
+++ b/dagql/result_call_frame.go
@@ -837,6 +837,20 @@ func (frame *ResultCall) SelfDigestAndInputRefs(ctx context.Context) (digest.Dig
 }
 
 func (frame *ResultCall) selfDigestAndInputRefs(c *Cache) (digest.Digest, []ResultCallStructuralInputRef, error) {
+	return frame.structuralSelfDigestAndInputRefs(c, true)
+}
+
+// pairingDigest is the structural self digest derived with implicit inputs
+// excluded: the engine-authored cross-run pairing anchor
+// (telemetryattrs.CachePairingDigestAttr). Sharing one parameterized derivation
+// with selfDigestAndInputRefs keeps the two digests structurally identical by
+// construction — for a frame with no implicit inputs they are equal.
+func (frame *ResultCall) pairingDigest(c *Cache) (digest.Digest, error) {
+	dig, _, err := frame.structuralSelfDigestAndInputRefs(c, false)
+	return dig, err
+}
+
+func (frame *ResultCall) structuralSelfDigestAndInputRefs(c *Cache, includeImplicitInputs bool) (digest.Digest, []ResultCallStructuralInputRef, error) {
 	if frame == nil {
 		return "", nil, nil
 	}
@@ -883,21 +897,23 @@ func (frame *ResultCall) selfDigestAndInputRefs(c *Cache) (digest.Digest, []Resu
 	}
 	h = h.WithDelim()
 
-	for _, input := range frame.ImplicitInputs {
-		input = redactedCallArgForDigest(input)
-		if input == nil {
-			continue
-		}
-		nextH, nextInputRefs, err := appendResultCallArgSelfRefs(c, input, h, inputRefs)
-		if err != nil {
-			if h != nil {
-				h.Close()
+	if includeImplicitInputs {
+		for _, input := range frame.ImplicitInputs {
+			input = redactedCallArgForDigest(input)
+			if input == nil {
+				continue
 			}
-			return "", nil, fmt.Errorf("result call frame %q implicit inputs: %w", field, err)
+			nextH, nextInputRefs, err := appendResultCallArgSelfRefs(c, input, h, inputRefs)
+			if err != nil {
+				if h != nil {
+					h.Close()
+				}
+				return "", nil, fmt.Errorf("result call frame %q implicit inputs: %w", field, err)
+			}
+			h = nextH
+			inputRefs = nextInputRefs
+			h = h.WithDelim()
 		}
-		h = nextH
-		inputRefs = nextInputRefs
-		h = h.WithDelim()
 	}
 
 	if frame.Module != nil {

--- a/engine/telemetryattrs/attrs.go
+++ b/engine/telemetryattrs/attrs.go
@@ -156,3 +156,130 @@ const (
 	// graph/replay is untouched) after reading its count.
 	WcprofSessionCompleteAttr = "wcprof.session_complete"
 )
+
+// Cache-evidence contract (dagger.io/cache.*).
+//
+// These attributes record, on the ordinary per-call span the engine already
+// emits, the cache-decision facts that otherwise exist only transiently inside
+// dagql's lookup: what the cache decided (outcome/route), why a miss missed
+// (expiry, session-resource filtering, unknown input), and the engine-derived
+// structural identity of the call (self digest, ordered structural inputs,
+// pairing digest, recorded output content digest). They exist so a trace
+// consumer can explain cache non-reuse from recorded facts instead of
+// re-deriving engine internals from span shapes.
+//
+// Wire shape: every value is an OTLP STRING, following the wcprof×OTel
+// precedent above and for the same reason — Cloud ingestion JSON-encodes each
+// attribute value into a ClickHouse Map(String,String) and the read path
+// re-decodes heuristically (bare or quoted true/false become bools,
+// leading-digit values become numbers, quoted strings round-trip as strings).
+// The value tokens below are chosen so that trip is loss-free: enum tokens and
+// digest values (algorithm-prefixed) can never collide with true/false/null or
+// a leading digit; the two boolean facts are emitted as "true" only when true
+// (absent means false) and intentionally decode into real bools; the
+// unknown-input index and the structural-input list are emitted as a
+// decimal-string and a single JSON-array-encoded string (the WcprofExecArgvAttr
+// pattern) whose leading '[' keeps them strings end to end.
+//
+// Producer gating: the attributes are stamped by core.AroundFunc's completion
+// callback from a request-only evidence carrier (dagql.CacheDecision) that
+// core allocates only when the call's span records and the call is not
+// ProfileSkip-classified — so suppressed, deduplicated, introspection and
+// profile-skipped calls record nothing, and no new spans are ever created.
+const (
+	// CacheContractAttr is the producer-contract version marker. Consumers must
+	// read cache.* facts only from spans carrying this marker and treat unknown
+	// versions as not eligible. Semantics of every fact within a version are
+	// frozen once released; new optional facts may be added under the same
+	// version (presence-detected); any semantic change to an existing fact
+	// requires bumping the version. Stamped whenever the evidence carrier
+	// stamps, so it governs every other cache.* attribute on the span.
+	CacheContractAttr = "dagger.io/cache.contract"
+	// CacheContractV1 is the current (and first) contract version value.
+	CacheContractV1 = "1"
+
+	// CacheOutcomeAttr is what the cache decided for this call: one of
+	// CacheOutcomeHit (reused a cached result), CacheOutcomeExecuted (miss —
+	// the resolver ran), CacheOutcomeJoined (deduplicated into concurrent
+	// identical in-flight work under the same concurrency key), or
+	// CacheOutcomeUncached (DoNotCache policy: no lookup, no dedupe, no
+	// publication). A hit on a still-pending lazy shell stamps
+	// CacheOutcomeHit — the lookup fact — while the separate evaluation facts
+	// (dagger.io/dag.cached, dagger.io/dag.pending) keep their existing
+	// meaning.
+	CacheOutcomeAttr     = "dagger.io/cache.outcome"
+	CacheOutcomeHit      = "hit"
+	CacheOutcomeExecuted = "executed"
+	CacheOutcomeJoined   = "joined"
+	CacheOutcomeUncached = "uncached"
+
+	// CacheHitRouteAttr (hits only) is how the hit was found:
+	// CacheHitRouteRecipe (exact recipe-digest match), CacheHitRouteDigest
+	// (extra-digest equivalence, e.g. a content digest carried by the request),
+	// or CacheHitRouteStructural (structural term over the call's self digest
+	// and its inputs' equivalence classes).
+	CacheHitRouteAttr       = "dagger.io/cache.hit.route"
+	CacheHitRouteRecipe     = "recipe"
+	CacheHitRouteDigest     = "digest"
+	CacheHitRouteStructural = "structural"
+
+	// CacheMissIncompatibleCandidatesAttr ("true", executed misses only, absent
+	// otherwise) records that non-expired candidate results existed but none
+	// satisfied this session's resource requirements (secrets/sockets the
+	// session has not loaded). It is an existence flag, not a count: expiry is
+	// applied during candidate accumulation, so on a miss a non-empty candidate
+	// set means every surviving candidate failed the session-resource filter.
+	CacheMissIncompatibleCandidatesAttr = "dagger.io/cache.miss.incompatible_candidates"
+
+	// CacheMissSawExpiredAttr ("true", executed misses only, absent otherwise)
+	// records that TTL expiry eliminated at least one otherwise-matching result
+	// during candidate accumulation.
+	CacheMissSawExpiredAttr = "dagger.io/cache.miss.saw_expired"
+
+	// CacheMissUnknownInputAttr (executed misses only) is the decimal-string
+	// index into this span's CacheStructuralInputsAttr list of the first input
+	// digest that had no equivalence class at lookup time, which made the
+	// structural (equivalence) lookup impossible. The semantics are
+	// deliberately narrow: "equivalence lookup was skipped because this input
+	// digest was unknown to the cache at that moment" — digest knowledge is
+	// current cache state, not history, so this does NOT mean "first run".
+	// Absent when every input was known.
+	CacheMissUnknownInputAttr = "dagger.io/cache.miss.unknown_input"
+
+	// CacheSelfDigestAttr is the engine-derived structural self digest of the
+	// call: the operation, its literal arguments (sensitive values redacted),
+	// implicit inputs, list selection and schema view — with reference-valued
+	// inputs factored out into CacheStructuralInputsAttr. Two calls with equal
+	// self digests are "the same operation over possibly different inputs".
+	CacheSelfDigestAttr = "dagger.io/cache.self_digest"
+
+	// CacheStructuralInputsAttr is the exact ordered structural-input digest
+	// list the engine's equivalence lookup keys on — receiver, reference-valued
+	// arguments in argument order, digest-witnessed strings, then the module
+	// reference — encoded as a single JSON-array-of-strings value (the
+	// WcprofExecArgvAttr pattern). This is the list CacheMissUnknownInputAttr
+	// indexes into. It is a different projection than dagger.io/dag.inputs
+	// (which deduplicates and omits the module), and that attribute is
+	// unchanged.
+	CacheStructuralInputsAttr = "dagger.io/cache.structural_inputs"
+
+	// CachePairingDigestAttr is the self digest computed with implicit inputs
+	// excluded: "this operation, these literal arguments, this view/selection —
+	// over whatever inputs, in whatever scope". It is the engine-authored
+	// cross-run pairing anchor: equal pairing digests are counterpart
+	// CANDIDATES for run-to-run comparison (an index, not proof), so
+	// per-client/per-session implicit inputs can never break candidate
+	// discovery, while remaining visible by name in dagger.io/dag.call. For a
+	// call with no implicit inputs it equals CacheSelfDigestAttr.
+	CachePairingDigestAttr = "dagger.io/cache.pairing_digest"
+
+	// CacheOutputContentDigestAttr is the completed result's RECORDED content
+	// digest — the last content-labeled extra digest on the result's
+	// authoritative call frame at span completion — for hits and executions
+	// alike, emitted only when non-empty. It is deliberately the recorded fact
+	// only (never the derived content-preferred digest): absence means "no
+	// recorded content identity at completion", nothing more. A lazy result may
+	// gain its content digest only after this span ends; that later fact is
+	// simply not claimed here.
+	CacheOutputContentDigestAttr = "dagger.io/cache.output.content_digest"
+)

--- a/engine/telemetryattrs/attrs.go
+++ b/engine/telemetryattrs/attrs.go
@@ -168,18 +168,19 @@ const (
 // consumer can explain cache non-reuse from recorded facts instead of
 // re-deriving engine internals from span shapes.
 //
-// Wire shape: every value is an OTLP STRING, following the wcprof×OTel
-// precedent above and for the same reason — Cloud ingestion JSON-encodes each
-// attribute value into a ClickHouse Map(String,String) and the read path
-// re-decodes heuristically (bare or quoted true/false become bools,
-// leading-digit values become numbers, quoted strings round-trip as strings).
-// The value tokens below are chosen so that trip is loss-free: enum tokens and
-// digest values (algorithm-prefixed) can never collide with true/false/null or
-// a leading digit; the two boolean facts are emitted as "true" only when true
-// (absent means false) and intentionally decode into real bools; the
-// unknown-input index and the structural-input list are emitted as a
-// decimal-string and a single JSON-array-encoded string (the WcprofExecArgvAttr
-// pattern) whose leading '[' keeps them strings end to end.
+// Wire shape: every value is an OTLP STRING except the structural-input
+// list, which is a native OTLP string ARRAY (StringSliceValue). The string
+// values follow the wcprof×OTel precedent above and for the same reason —
+// Cloud ingestion JSON-encodes each attribute value into a ClickHouse
+// Map(String,String) and the read path re-decodes heuristically (bare or
+// quoted true/false become bools, leading-digit values become numbers,
+// quoted strings round-trip as strings). The value tokens below are chosen
+// so that trip is loss-free: enum tokens and digest values
+// (algorithm-prefixed) can never collide with true/false/null or a leading
+// digit; the two boolean facts are emitted as "true" only when true (absent
+// means false) and intentionally decode into real bools; the unknown-input
+// index is a decimal-string. The array value survives the same trip as a
+// JSON array of strings, which is exactly how consumers read it back.
 //
 // Producer gating: the attributes are stamped by core.AroundFunc's completion
 // callback from a request-only evidence carrier (dagql.CacheDecision) that
@@ -256,11 +257,13 @@ const (
 	// CacheStructuralInputsAttr is the exact ordered structural-input digest
 	// list the engine's equivalence lookup keys on — receiver, reference-valued
 	// arguments in argument order, digest-witnessed strings, then the module
-	// reference — encoded as a single JSON-array-of-strings value (the
-	// WcprofExecArgvAttr pattern). This is the list CacheMissUnknownInputAttr
-	// indexes into. It is a different projection than dagger.io/dag.inputs
-	// (which deduplicates and omits the module), and that attribute is
-	// unchanged.
+	// reference — emitted as a native OTLP string ARRAY (StringSliceValue),
+	// the one non-STRING value in this contract. Order is semantic:
+	// CacheMissUnknownInputAttr indexes into this list. An empty-but-present
+	// array means "structural identity stamped, no structural inputs";
+	// absence means no structural identity was stamped at all. It is a
+	// different projection than dagger.io/dag.inputs (which deduplicates and
+	// omits the module), and that attribute is unchanged.
 	CacheStructuralInputsAttr = "dagger.io/cache.structural_inputs"
 
 	// CachePairingDigestAttr is the self digest computed with implicit inputs

--- a/engine/telemetryattrs/attrs.go
+++ b/engine/telemetryattrs/attrs.go
@@ -275,8 +275,9 @@ const (
 
 	// CacheOutputContentDigestAttr is the completed result's RECORDED content
 	// digest — the last content-labeled extra digest on the result's
-	// authoritative call frame at span completion — for hits and executions
-	// alike, emitted only when non-empty. It is deliberately the recorded fact
+	// authoritative call frame at span completion — emitted only when
+	// non-empty, for any stamped outcome that returned a result (hit,
+	// executed, and joined calls alike). It is deliberately the recorded fact
 	// only (never the derived content-preferred digest): absence means "no
 	// recorded content identity at completion", nothing more. A lazy result may
 	// gain its content digest only after this span ends; that later fact is


### PR DESCRIPTION
## What this does

Adds a versioned OpenTelemetry cache-decision evidence contract to Dagger call spans. The evidence explains why a call reused a result or had to run, without changing cache selection or execution behavior.

The contract records:

- cache outcome: hit, executed, joined, or uncached
- hit route: recipe, digest, or structural
- miss facts such as expired candidates, session-resource incompatibility, and unknown inputs
- stable self, pairing, structural-input, and output-content digests

Evidence is attached only to recorded user call spans. Internal, profile-skipped, suppressed, and deduplicated calls do not emit it.

## Why

Today a trace can show that an operation ran, but not the cache decision that caused it. Dagger Cloud will consume this contract to provide single-run cache invalidation explanations and optional comparisons between runs. The Cloud UI and derivation remain a separate dependent change.

## Validation

The implementation includes focused contract, lifecycle, equivalence-expansion, wire-type, and telemetry-mapping tests. It was also exercised end to end by the dependent Cloud implementation using real engine traces, including host-directory changes, transitive invalidation chains, same-content inputs from different paths, paired and unpaired explanations, and incremental trace loading.

The implementation and dependent consumer received independent cumulative review. No cache semantics, GraphQL surface, or OSS UI are changed.

Rollout note: the dependent Cloud acceptance keeps one instance-local duplicate-span page-load hang on its watchlist. It passed on a fresh byte-identical stack and does not affect this evidence contract; recurrence will be captured before Cloud rollout.