### PR TITLE
feat(dang): self-call support returning the module's own types

### DIFF
--- a/core/integration/module_dang_test.go
+++ b/core/integration/module_dang_test.go
@@ -410,6 +410,32 @@ func (DangSuite) TestSelfCallReturningOwnType(_ context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Equal(t, "hello from field", strings.TrimSpace(out))
 	})
+
+	// Self-calls are not limited to the module's main type: a field may return
+	// a secondary object type as it lives in the runtime schema (namespaced,
+	// carrying a GraphQL id), annotated Dagger.TestWidget. This exercises the
+	// declaration-phase injection of *every* declared type, not just the main
+	// one. The label is passed in through the API and must round-trip through
+	// the self-call's ID, so it's constructed via the API rather than hardcoded.
+	t.Run("return a secondary type from a self-call", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "self-calls").
+			With(daggerCall("widget", "--label", "constructed via api", "get-label")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "constructed via api", strings.TrimSpace(out))
+	})
+
+	t.Run("read a field off a self-returned secondary object", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "self-calls").
+			With(daggerCall("widget-label", "--label", "constructed via api")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "constructed via api", strings.TrimSpace(out))
+	})
 }
 
 func dangModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {

--- a/core/integration/module_dang_test.go
+++ b/core/integration/module_dang_test.go
@@ -385,6 +385,33 @@ func (DangSuite) TestNullableSDKInputObjectFields(_ context.Context, t *testctx.
 	}
 }
 
+func (DangSuite) TestSelfCallReturningOwnType(_ context.Context, t *testctx.T) {
+	// A self-call that returns the module's own object type surfaces as the
+	// object's GraphQL ID (a string), since the object lives in the module's
+	// runtime schema. The runtime must load that ID back into the object
+	// rather than choke on the raw string. Regression test for tui-qa's
+	// `stop`, which returns `tuiQa`.
+	t.Run("return own type from a self-call and read a field", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "self-calls").
+			With(daggerCall("fresh", "get-message")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from field", strings.TrimSpace(out))
+	})
+
+	t.Run("read a field off a self-returned object", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		out, err := dangModule(t, c, "self-calls").
+			With(daggerCall("self-message")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from field", strings.TrimSpace(out))
+	})
+}
+
 func dangModule(t *testctx.T, c *dagger.Client, moduleName string) *dagger.Container {
 	t.Helper()
 	modSrc, err := filepath.Abs(filepath.Join("./testdata/modules/dang", moduleName))

--- a/core/integration/testdata/modules/dang/self-calls/main.dang
+++ b/core/integration/testdata/modules/dang/self-calls/main.dang
@@ -1,4 +1,6 @@
 type Test {
+  let message: String! = "hello from field"
+
   pub containerEcho(stringArg: String! = "Hello Self Calls"): Container! {
     Dagger.container.from("alpine:latest").withExec(["echo", stringArg])
   }
@@ -9,5 +11,27 @@ type Test {
 
   pub printDefault: String! {
     test.containerEcho.stdout
+  }
+
+  # message is a computed field so it can be read back off a self-returned Test.
+  pub getMessage: String! {
+    message
+  }
+
+  # fresh self-calls the module's own constructor (`test`). A self-call yields
+  # the module's own type as it lives in the runtime schema — a Dagger.Test,
+  # which carries a GraphQL id — so the return is declared Dagger.Test! rather
+  # than the bare local Test!. The self-call return travels as the object's
+  # GraphQL ID (a string), which the runtime must load back into a Test object
+  # rather than choke on the raw ID string. This mirrors tui-qa's `stop`, which
+  # returns `tuiQa`.
+  pub fresh: Dagger.Test! {
+    test
+  }
+
+  # selfMessage exercises reading a field back off the self-returned object,
+  # proving the loaded object is usable and not just a bare ID.
+  pub selfMessage: String! {
+    test.fresh.getMessage
   }
 }

--- a/core/integration/testdata/modules/dang/self-calls/main.dang
+++ b/core/integration/testdata/modules/dang/self-calls/main.dang
@@ -34,4 +34,42 @@ type Test {
   pub selfMessage: String! {
     test.fresh.getMessage
   }
+
+  # makeWidget constructs a Widget locally and returns the bare local Widget!.
+  # It's a plain function, so it's exposed through the API.
+  pub makeWidget(label: String!): Widget! {
+    Widget(label)
+  }
+
+  # widget self-calls makeWidget *through the API* (test.makeWidget). A self-call
+  # yields the module's own type as it lives in the runtime schema — a namespaced
+  # Dagger.TestWidget carrying a GraphQL id — so the return is annotated
+  # Dagger.TestWidget! rather than the bare local Widget!. Constructing it locally
+  # (Widget(label)) would only produce the bare Widget!; only an actual API call
+  # yields the Dagger.TestWidget. This proves self-call support extends beyond the
+  # module's main type.
+  pub widget(label: String!): Dagger.TestWidget! {
+    test.makeWidget(label: label)
+  }
+
+  # widgetLabel reads a field back off a self-returned secondary object,
+  # proving the loaded Widget is a usable object and not just a bare ID.
+  pub widgetLabel(label: String!): String! {
+    test.widget(label: label).getLabel
+  }
+}
+
+# Widget is a secondary object type (not the module's main type). It exists in
+# the runtime schema under the namespaced name TestWidget.
+type Widget {
+  let label: String! = "default label"
+
+  new(label: String!) {
+    self.label = label
+    self
+  }
+
+  pub getLabel: String! {
+    label
+  }
 }

--- a/core/object.go
+++ b/core/object.go
@@ -51,6 +51,27 @@ func (t *ModuleObjectType) ConvertFromSDKResult(ctx context.Context, value any) 
 			return nil, fmt.Errorf("unexpected result value type %T for object %q", value, t.typeDef.Name)
 		}
 		return value, nil
+	case string:
+		// A self-call that returns one of the module's own object types
+		// serializes the result as the object's GraphQL ID (a string), since
+		// the object lives in the module's runtime schema. Decode the ID and
+		// load the concrete object, mirroring how InterfaceType handles IDs.
+		var id call.ID
+		if err := id.Decode(value); err != nil {
+			return nil, fmt.Errorf("decode object ID for %q: %w", t.typeDef.Name, err)
+		}
+		dag, err := CurrentDagqlServer(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("current dagql server: %w", err)
+		}
+		loaded, err := dag.Load(ctx, &id)
+		if err != nil {
+			return nil, fmt.Errorf("load object ID for %q: %w", t.typeDef.Name, err)
+		}
+		if loaded.Type() == nil || loaded.Type().Name() != t.typeDef.Name {
+			return nil, fmt.Errorf("loaded object type %q does not match expected type %q", loaded.Type().Name(), t.typeDef.Name)
+		}
+		return loaded, nil
 	case map[string]any:
 		res, err := dagql.NewResultForCurrentCall(ctx, &ModuleObject{
 			Module:  t.mod,

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -11,6 +11,8 @@ import (
 	"slices"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/iancoleman/strcase"
+
 	"github.com/dagger/dagger/core"
 	dangshared "github.com/dagger/dagger/core/sdk/dang/shared"
 	"github.com/dagger/dagger/dagql"
@@ -101,6 +103,15 @@ func evalDangSource(
 			return nil, fmt.Errorf("decode schema: %w", err)
 		}
 
+		// During the typedef/declaration phase (ModuleTypes) the schema handed to
+		// us is deps-only: it does not yet carry the module's own object types,
+		// because those are exactly what this pass produces. Self-call fields
+		// annotate their return as Dagger.<MainType> (the module's own type as it
+		// lives in the runtime schema, carrying a GraphQL id + Node), so make that
+		// name resolvable here. At runtime the served schema already includes the
+		// module's own types (Module.IncludeSelfInDeps), so this is a no-op then.
+		ensureModuleSelfTypes(intro.Schema, modSource.Self().ModuleName)
+
 		ctx = dang.ContextWithImportConfigs(ctx, dang.ImportConfig{
 			Name:       "Dagger",
 			Client:     gqlClient,
@@ -127,6 +138,45 @@ func evalDangSource(
 		}
 
 		return withEnv(ctx, env)
+	})
+}
+
+// ensureModuleSelfTypes makes the module's own main object type resolvable as
+// Dagger.<MainType> during the deps-only declaration phase (ModuleTypes), where
+// the schema does not yet carry the module's own installed types — those are
+// exactly what that pass produces. Self-call fields declare their return as
+// Dagger.<MainType> because a self-call (e.g. `tuiQa`) yields the module's own
+// type as it lives in the runtime schema (carrying a GraphQL id, implementing
+// Node), not the bare local type. The synthesized type is only ever used for
+// name resolution and typedef references (via `withObject(name:)`, which core
+// then namespaces consistently); it is never emitted as a TypeDef, so a minimal
+// shape suffices. Once the served runtime schema already carries the type
+// (Module.IncludeSelfInDeps), this is a no-op.
+func ensureModuleSelfTypes(schema *introspection.Schema, moduleName string) {
+	if schema == nil || moduleName == "" {
+		return
+	}
+	// The main object's installed name is the module name in capitalized camel
+	// case (matching core's gqlObjectName / Module.isMainObject rule).
+	mainType := strcase.ToCamel(moduleName)
+	if schema.Types.Get(mainType) != nil {
+		return
+	}
+	schema.Types = append(schema.Types, &introspection.Type{
+		Kind: introspection.TypeKindObject,
+		Name: mainType,
+		Fields: []*introspection.Field{
+			{
+				Name: "id",
+				TypeRef: &introspection.TypeRef{
+					Kind: introspection.TypeKindNonNull,
+					OfType: &introspection.TypeRef{
+						Kind: introspection.TypeKindScalar,
+						Name: "ID",
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"path/filepath"
 	"slices"
 
@@ -103,15 +104,6 @@ func evalDangSource(
 			return nil, fmt.Errorf("decode schema: %w", err)
 		}
 
-		// During the typedef/declaration phase (ModuleTypes) the schema handed to
-		// us is deps-only: it does not yet carry the module's own object types,
-		// because those are exactly what this pass produces. Self-call fields
-		// annotate their return as Dagger.<MainType> (the module's own type as it
-		// lives in the runtime schema, carrying a GraphQL id + Node), so make that
-		// name resolvable here. At runtime the served schema already includes the
-		// module's own types (Module.IncludeSelfInDeps), so this is a no-op then.
-		ensureModuleSelfTypes(intro.Schema, modSource.Self().ModuleName)
-
 		ctx = dang.ContextWithImportConfigs(ctx, dang.ImportConfig{
 			Name:       "Dagger",
 			Client:     gqlClient,
@@ -127,6 +119,19 @@ func evalDangSource(
 		var env dang.ValueScope
 		err = modCtx.Self().Mount(ctx, modCtx, func(path string) error {
 			modSrcDir := filepath.Join(path, modSource.Self().SourceSubpath)
+
+			// During the typedef/declaration phase (ModuleTypes) the schema
+			// handed to us is deps-only: it does not yet carry the module's own
+			// object/interface/enum types, because those are exactly what this
+			// pass produces. Self-call fields annotate their return as
+			// Dagger.<T> — the module's own type as it lives in the runtime
+			// schema, carrying a GraphQL id + Node, not the bare local type — so
+			// make every such name resolvable here by parsing the module source
+			// for its declared types. At runtime the served schema already
+			// includes the module's own types (Module.IncludeSelfInDeps), so
+			// this is a no-op then.
+			ensureModuleSelfTypes(intro.Schema, modSource.Self(), modSrcDir)
+
 			env, err = runSource(ctx, modSrcDir)
 			if err != nil {
 				return fmt.Errorf("run dir: %w", err)
@@ -141,43 +146,132 @@ func evalDangSource(
 	})
 }
 
-// ensureModuleSelfTypes makes the module's own main object type resolvable as
-// Dagger.<MainType> during the deps-only declaration phase (ModuleTypes), where
-// the schema does not yet carry the module's own installed types — those are
-// exactly what that pass produces. Self-call fields declare their return as
-// Dagger.<MainType> because a self-call (e.g. `tuiQa`) yields the module's own
-// type as it lives in the runtime schema (carrying a GraphQL id, implementing
-// Node), not the bare local type. The synthesized type is only ever used for
-// name resolution and typedef references (via `withObject(name:)`, which core
-// then namespaces consistently); it is never emitted as a TypeDef, so a minimal
-// shape suffices. Once the served runtime schema already carries the type
+// ensureModuleSelfTypes makes each of the module's own declared object,
+// interface, enum and scalar types resolvable as Dagger.<T> during the
+// deps-only declaration phase (ModuleTypes), where the schema does not yet
+// carry the module's own installed types — those are exactly what that pass
+// produces. Self-call fields declare their return as Dagger.<T> because a
+// self-call (e.g. `tuiQa`, or `test.fresh` returning the module's own type)
+// yields the type as it lives in the runtime schema (carrying a GraphQL id,
+// implementing Node), not the bare local type.
+//
+// The names are namespaced (via core.NamespaceObject) to match what the engine
+// installs and what the runtime schema exposes once Module.IncludeSelfInDeps is
+// in effect: the main object keeps the module's final name, secondary types are
+// module-prefixed (a `type Widget` in module `Test` becomes `TestWidget`).
+//
+// The synthesized types are only ever used for name resolution and typedef
+// references (via `withObject(name:)` / `withInterface(name:)`, which core then
+// namespaces consistently); they are never emitted as TypeDefs, so a minimal
+// shape suffices. Once the served runtime schema already carries the types
 // (Module.IncludeSelfInDeps), this is a no-op.
-func ensureModuleSelfTypes(schema *introspection.Schema, moduleName string) {
-	if schema == nil || moduleName == "" {
+func ensureModuleSelfTypes(schema *introspection.Schema, src *core.ModuleSource, modSrcDir string) {
+	if schema == nil || src == nil {
 		return
 	}
-	// The main object's installed name is the module name in capitalized camel
-	// case (matching core's gqlObjectName / Module.isMainObject rule).
-	mainType := strcase.ToCamel(moduleName)
-	if schema.Types.Get(mainType) != nil {
+	moduleName := src.ModuleName
+	if moduleName == "" {
+		moduleName = src.ModuleOriginalName
+	}
+	if moduleName == "" {
 		return
 	}
-	schema.Types = append(schema.Types, &introspection.Type{
-		Kind: introspection.TypeKindObject,
-		Name: mainType,
-		Fields: []*introspection.Field{
-			{
-				Name: "id",
-				TypeRef: &introspection.TypeRef{
-					Kind: introspection.TypeKindNonNull,
-					OfType: &introspection.TypeRef{
-						Kind: introspection.TypeKindScalar,
-						Name: "ID",
+
+	for _, localName := range moduleDeclaredTypeNames(modSrcDir, moduleName) {
+		schemaName := core.NamespaceObject(localName, moduleName, src.ModuleOriginalName)
+		if schema.Types.Get(schemaName) != nil {
+			continue
+		}
+		schema.Types = append(schema.Types, &introspection.Type{
+			Kind: introspection.TypeKindObject,
+			Name: schemaName,
+			Fields: []*introspection.Field{
+				{
+					Name: "id",
+					TypeRef: &introspection.TypeRef{
+						Kind: introspection.TypeKindNonNull,
+						OfType: &introspection.TypeRef{
+							Kind: introspection.TypeKindScalar,
+							Name: "ID",
+						},
 					},
 				},
 			},
-		},
-	})
+		})
+	}
+}
+
+// moduleDeclaredTypeNames parses the module's .dang source files and returns the
+// local names of every public top-level type declaration (object, interface,
+// enum, scalar). Only top-level declarations become module types in the schema,
+// so types nested inside a body are intentionally ignored. The main object type
+// — whose local name matches the module name — is always included even if the
+// source can't be parsed, so the common case keeps working. Parsing here is
+// best-effort: it drives name resolution only, and any genuine syntax error
+// surfaces later when the source is actually declared/run.
+func moduleDeclaredTypeNames(modSrcDir, moduleName string) []string {
+	seen := map[string]struct{}{}
+	var names []string
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	// The main object's local name matches the module name (capitalized camel
+	// case); NamespaceObject collapses it to the module's final name. Seed it
+	// unconditionally so a self-call returning the main type resolves even if
+	// the rest of the source fails to parse.
+	add(strcase.ToCamel(moduleName))
+
+	entries, err := os.ReadDir(modSrcDir)
+	if err != nil {
+		slog.Debug("ensureModuleSelfTypes: read module dir", "dir", modSrcDir, "error", err)
+		return names
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".dang" {
+			continue
+		}
+		root, err := dang.ParseFile(filepath.Join(modSrcDir, entry.Name()))
+		if err != nil {
+			slog.Debug("ensureModuleSelfTypes: parse module file", "file", entry.Name(), "error", err)
+			continue
+		}
+		file, ok := root.(*dang.FileBlock)
+		if !ok {
+			continue
+		}
+		// Only top-level type declarations become module types in the schema;
+		// types declared inside a body are not hoisted, so iterate the file's
+		// own forms rather than walking the AST recursively.
+		for _, form := range file.Forms {
+			switch decl := form.(type) {
+			case *dang.ObjectDecl:
+				if decl.Visibility >= dang.PublicVisibility && decl.Name != nil {
+					add(decl.Name.Name)
+				}
+			case *dang.InterfaceDecl:
+				if decl.Visibility >= dang.PublicVisibility && decl.Name != nil {
+					add(decl.Name.Name)
+				}
+			case *dang.EnumDecl:
+				if decl.Visibility >= dang.PublicVisibility && decl.Name != nil {
+					add(decl.Name.Name)
+				}
+			case *dang.ScalarDecl:
+				if decl.Visibility >= dang.PublicVisibility && decl.Name != nil {
+					add(decl.Name.Name)
+				}
+			}
+		}
+	}
+	return names
 }
 
 func runDangDirForModuleTypes(ctx context.Context, dirPath string) (dang.ValueScope, error) {

--- a/core/sdk/dang/v2/sdk.go
+++ b/core/sdk/dang/v2/sdk.go
@@ -50,7 +50,14 @@ func (Impl) ModuleTypes(
 	runner := dangSourceRunner(func(ctx context.Context, modSrcDir string) (dang.ValueScope, error) {
 		return dang.RunDir(ctx, modSrcDir, false)
 	})
-	if src.Self().SDK.ExperimentalFeatureEnabled(core.ModuleSourceExperimentalFeatureSelfCalls) {
+	// When self-calls are enabled the module's own types (and root fields like
+	// `tuiQa`) only exist in the *runtime* schema, after this ModuleTypes pass
+	// has installed them. So the declaration-only runner is required here: full
+	// inference would try to resolve self-referencing bodies against the deps
+	// schema, which does not yet carry the module's own API. The Dang SDK always
+	// enables self-calls (AlwaysEnablesSelfCalls), so gate on SelfCallsEnabled
+	// rather than the raw experimental flag.
+	if src.Self().SelfCallsEnabled() {
 		runner = runDangDirForModuleTypes
 	}
 


### PR DESCRIPTION
Adds self-call support to the Dang SDK: a module field can now return one of the module's **own** object types. Previously this was half-implemented; you could make self API-calls but you couldn't return your own types.

```graphql
type Test {
  let message: String! = "hello from field"

  getMessage: String! { message }

  # `test` self-calls the module's own constructor. The result travels as the
  # object's GraphQL id, so the return is Dagger.Test! — the type as it lives
  # in the runtime schema — not the bare local Test!.
  fresh: Dagger.Test! { test }

  # ...and the self-returned object is fully usable, not just an id:
  selfMessage: String! { test.fresh.getMessage }
}
```

Works for secondary types too, not just the module's main type (a `Widget` is namespaced as `Dagger.TestWidget` in the runtime schema):

```graphql
type Test {
  makeWidget(label: String!): Widget! { Widget(label) }
  widget(label: String!): Dagger.TestWidget! { test.makeWidget(label: label) }
  widgetLabel(label: String!): String! { test.widget(label: label).getLabel }
}
```

### How

A self-call yields the type as it lives in the runtime schema — a `Dagger.<T>` carrying a GraphQL id and implementing `Node` — so fields annotate their return `Dagger.<T>` rather than the bare local type.

- `core/object.go`: `ConvertFromSDKResult` decodes a self-call's id string and loads the concrete object back.
- `core/sdk/dang/v2/helpers.go`: during the deps-only declaration phase the schema lacks the module's own types, so `ensureModuleSelfTypes` parses the source and injects each declared type (namespaced) so `Dagger.<T>` resolves. No-op at runtime.
- `core/sdk/dang/v2/sdk.go`: gate the declaration-only runner on `SelfCallsEnabled()`.

Covered by `TestSelfCallReturningOwnType` in `core/integration/module_dang_test.go`.

Extracted from the `llm-workspace-llm-binding` branch.
