### PR TITLE
fix(telemetry): shrink live span export queues to bound engine memory

### DIFF
--- a/engine/telemetry/livespan.go
+++ b/engine/telemetry/livespan.go
@@ -5,28 +5,38 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-// Large, BOUNDED BatchSpanProcessor sizes for the span hops that carry a trace
+// Enlarged, BOUNDED BatchSpanProcessor sizes for the span hops that carry a trace
 // toward Dagger Cloud. The OTel BSP queue is non-blocking and silently DROPS spans
-// on overflow, and the default 2048 slots are far too small for a burst like a cold
-// engine build: that is ~15k spans, and live export double-emits each span (a start
-// snapshot plus the end) for ~30k records arriving in a tight burst. Sizing the
-// queue to 256Ki slots with a large export batch absorbs that burst with generous
-// headroom so nothing is dropped (e.g. the wcprof.session_complete completeness
-// carrier, which rides at the very tail and was the first thing to drop).
+// on overflow; the SDK default of 2048 slots is too small for a burst like a cold
+// engine build (~15k spans, live-double-emitted into ~30k records), which is why
+// these hops use a larger queue at all.
 //
-// Kept BOUNDED — never BlockOnQueueFull — so telemetry can NEVER stall the build; if
-// something still overflows, the wcprof completeness checksum catches it (received <
-// declared, hard-fail) rather than silently ranking on partial data. The queue holds
-// span POINTERS, so 256Ki slots is only a ~2MiB ring buffer, not 256Ki span copies.
+// The queue must stay MODEST as well as bounded, because its worst case is paid
+// per PROCESSOR, and processors multiply: every client gets one such processor for
+// its own DB plus one per ancestor client, each with an eagerly allocated ring
+// (16 bytes/slot) that can fill with full span snapshots whenever the SQLite
+// writer falls behind. A heavily grouped CI session can hold dozens of clients, so
+// per-processor worst case × processor count is the engine's telemetry memory
+// ceiling. At 16Ki slots the per-processor ceiling is ~16 MiB of retained
+// snapshots (at ~1 KiB each) plus a 256 KiB ring — 16x below the previous 256Ki
+// sizing, which put a loaded session's aggregate worst case far past the physical
+// memory of a typical CI runner — while still giving 8x the SDK default's burst
+// headroom.
+//
+// Kept BOUNDED — never BlockOnQueueFull — so telemetry can NEVER stall the build.
+// If a burst still overflows, spans are dropped rather than retained: the wcprof
+// completeness checksum (received < declared, see engine/server/wcprofcount.go)
+// catches the loss loudly and the offline analyzer refuses the trace instead of
+// silently ranking on partial data.
 const (
-	LargeSpanQueueSize       = 262144 // 256Ki — ~8x a cold engine build's ~30k live records
-	LargeSpanExportBatchSize = 16384  // drain the burst in a few large batches, not hundreds
+	LargeSpanQueueSize       = 16384 // 16Ki — 8x the SDK default; bounds retained snapshots per hop
+	LargeSpanExportBatchSize = 2048  // drains a full queue in 8 batches; bounds per-batch references
 )
 
-// NewLargeQueueLiveSpanProcessor is otel.NewLiveSpanProcessor with the large bounded
-// queue above in place of the default 2048-slot one. Use it on every span hop that
-// feeds a Cloud trace — the engine's per-client DB processors (engine/server) and the
-// CLI→Cloud exporter (internal/cmd/dagger) — so a big-burst trace arrives complete.
+// NewLargeQueueLiveSpanProcessor is otel.NewLiveSpanProcessor with the enlarged
+// bounded queue above in place of the default 2048-slot one. Use it on every span
+// hop that feeds a Cloud trace — the engine's per-client DB processors
+// (engine/server) and the CLI→Cloud exporter (internal/cmd/dagger).
 func NewLargeQueueLiveSpanProcessor(exp sdktrace.SpanExporter) *telemetry.LiveSpanProcessor {
 	return &telemetry.LiveSpanProcessor{
 		SpanProcessor: sdktrace.NewBatchSpanProcessor(

--- a/engine/telemetry/livespan_test.go
+++ b/engine/telemetry/livespan_test.go
@@ -1,0 +1,113 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// gatedExporter blocks every ExportSpans call until released, simulating a span
+// consumer (the per-client SQLite writer, or the Cloud exporter) that has
+// stalled or fallen behind.
+type gatedExporter struct {
+	gate chan struct{}
+
+	mu       sync.Mutex
+	exported int
+}
+
+var _ sdktrace.SpanExporter = (*gatedExporter)(nil)
+
+func (e *gatedExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	select {
+	case <-e.gate:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	e.mu.Lock()
+	e.exported += len(spans)
+	e.mu.Unlock()
+	return nil
+}
+
+func (e *gatedExporter) Shutdown(context.Context) error { return nil }
+
+func (e *gatedExporter) exportedCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exported
+}
+
+// TestLiveSpanProcessorBoundedNonBlocking proves the two properties the
+// live-span hop is sized for: with a completely stalled consumer, (1) emitting
+// far more spans than the queue holds never blocks the emitting goroutine, and
+// (2) the number of span snapshots the processor retains for later export is
+// bounded by the queue (plus at most one in-flight batch) — the overflow is
+// dropped, not buffered. The retained count is the processor's memory ceiling:
+// each retained snapshot is a full span copy held in heap until the consumer
+// drains it.
+func TestLiveSpanProcessorBoundedNonBlocking(t *testing.T) {
+	t.Parallel()
+
+	// A batch larger than the queue would be pointless and would inflate the
+	// preallocated per-processor batch slice; guard the relationship.
+	require.LessOrEqual(t, LargeSpanExportBatchSize, LargeSpanQueueSize)
+
+	exp := &gatedExporter{gate: make(chan struct{})}
+	proc := NewLargeQueueLiveSpanProcessor(exp)
+
+	// The batch processor only enqueues sampled spans.
+	snap := tracetest.SpanStub{
+		Name: "test-span",
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    trace.TraceID{1},
+			SpanID:     trace.SpanID{1},
+			TraceFlags: trace.FlagsSampled,
+		}),
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}.Snapshot()
+
+	// Emit 2x the queue capacity while the exporter is fully stalled.
+	emitted := 2 * LargeSpanQueueSize
+	start := time.Now()
+	for range emitted {
+		proc.OnEnd(snap)
+	}
+	elapsed := time.Since(start)
+
+	// Property 1: emission is non-blocking even with a stalled consumer. The
+	// loop is pure channel sends/drops (~ms); the generous bound only guards
+	// against a regression to blocking behavior.
+	require.Less(t, elapsed, 30*time.Second,
+		"span emission must not block on a stalled exporter")
+
+	// Release the consumer and drain everything that was retained.
+	close(exp.gate)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	require.NoError(t, proc.Shutdown(ctx))
+
+	got := exp.exportedCount()
+
+	// Property 2: retention is bounded. Everything that survives to the
+	// consumer was held in memory while the consumer was stalled, so the
+	// exported total is exactly the processor's worst-case snapshot retention:
+	// at most the full queue plus one in-flight batch (with one batch of
+	// slack for scheduling variance), and never the unbounded emitted total.
+	require.Less(t, got, emitted,
+		"overflow must be dropped, not retained")
+	require.LessOrEqual(t, got, LargeSpanQueueSize+2*LargeSpanExportBatchSize,
+		"retained snapshots must be bounded by queue + in-flight batch")
+
+	// And the queue genuinely buffers up to its capacity (the burst-headroom
+	// half of the trade): nothing below the full queue was dropped.
+	require.GreaterOrEqual(t, got, LargeSpanQueueSize,
+		"spans within queue capacity must be retained, not dropped")
+}


### PR DESCRIPTION
## Problem

v1.0.0-beta.7 engines are using considerably more memory than beta.6 under parallel CI load — heavily grouped checks (test-split, python) are getting cancelled and runners are OOMing. The same window's `/shutdown` deadline flake is being addressed separately in #13670.

The mechanism: #13588 raised the live span export queues from the SDK default of 2048 slots to 256Ki slots so a burst can never drop spans on the way to Dagger Cloud. But that worst case is paid **per processor, and processors multiply**: every client's tracer provider registers one live-export BatchSpanProcessor for its own telemetry DB **plus one per ancestor client**, each with an eagerly allocated 256Ki-slot ring (4 MiB per processor even when idle). Under load, live export double-emits a full span snapshot at start and end, and every one of those snapshots sits in the queue until the per-client SQLite writer (capped at a single connection since #13632) drains it. When the writer falls behind, each backed-up processor may retain up to 256Ki snapshots (~1 KiB each ≈ ~256 MiB) in heap. A heavily grouped CI session holds dozens of clients — #13670 observed sessions with 69 — so the aggregate worst case runs far past the physical memory of a typical CI runner.

beta.6 didn't have this problem because its 2048-slot queues **dropped** the backlog instead of retaining it.

## Fix

Shrink the queue to 16Ki slots and the export batch to 2048 (`engine/telemetry/livespan.go`, consumed unchanged by the engine's per-client DB processors and the CLI→Cloud exporter):

- **16× cut** to the idle ring cost (4 MiB → 256 KiB per processor) and to the worst-case retained-snapshot ceiling (~256 MiB → ~16 MiB per processor).
- Still **8× the SDK default's** burst headroom, so routine bursts don't drop.
- The batch shrinks with the queue: a batch equal to the whole queue only inflates the preallocated batch slice and per-batch snapshot references (and per #13670's findings, batch size doesn't meaningfully change SQLite contention).

The trade is explicit and observable: a burst that outruns the SQLite writer for long enough now drops spans instead of retaining them. Span emission still never blocks the build, and the wcprof completeness checksum (received < declared, #13588) flags any loss loudly — the offline analyzer refuses an incomplete trace rather than silently analyzing partial data. Runs that need guaranteed-complete capture for wall-clock profiling can get an opt-in override as a follow-up.

Shutdown also strictly improves: the final telemetry flush drains at most 16Ki+2Ki records per processor instead of 256Ki+16Ki, which shortens the drain inside the CLI's 10s `/shutdown` budget. (The flush-storm/convoy fix itself is #13670.)

## What's unchanged

- Non-blocking, bounded, drop-on-overflow semantics (`BlockOnQueueFull` stays off).
- Live start-snapshot emission, the log/metric processors, the per-span link cap, and all call sites.

## Tests

`TestLiveSpanProcessorBoundedNonBlocking` drives the real processor through a fully stalled exporter and proves the properties rather than the constants:

- emitting 2× the queue capacity never blocks the emitting goroutine;
- retained snapshots are bounded by queue + in-flight batch (the memory ceiling);
- overflow is dropped, not buffered;
- everything within queue capacity is retained (the burst-headroom half of the trade).

Passes with `-race -count=3`. `TestTelemetry/TestGolden/trace-function-calls` (nested-client span delivery through the client DB after Close) passes via `engine-dev test`.
