### PR TITLE
fix: read frozen locks from remote commit workspaces

### DIFF
--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/util/lockfile"
 	"github.com/dagger/testctx"
@@ -32,6 +33,18 @@ func TestLockfile(t *testing.T) {
 const containerFromQuery = `{
   container {
     from(address: "alpine:latest") {
+      file(path: "/etc/alpine-release") {
+        contents
+      }
+    }
+  }
+}
+`
+
+const containerFromImageRefQuery = `{
+  container {
+    from(address: "alpine:latest") {
+      imageRef
       file(path: "/etc/alpine-release") {
         contents
       }
@@ -147,6 +160,97 @@ func (LockfileSuite) TestFromLockfileFrozenUsesFloatEntry(ctx context.Context, t
 	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "query", "--doc", queryPath)
 	require.Error(t, err)
 	require.ErrorContains(t, err, `invalid lock digest "not-a-digest"`)
+}
+
+func (LockfileSuite) TestFromLockfileFrozenRemoteCommitUsesPinEntry(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	lockContents := mustMarshalContainerFromLock(t, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyPin)
+	remote := newRemoteLockWorkspace(ctx, t, c, lockContents)
+
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "-W", remote.commitRef, "query", "--doc", queryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `invalid lock digest "not-a-digest"`)
+}
+
+func (LockfileSuite) TestFromLockfileFrozenRemoteCommitUsesValidPin(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	imageRef, err := c.Container().From("alpine:3.20").ImageRef(ctx)
+	require.NoError(t, err)
+	_, digest, found := strings.Cut(imageRef, "@")
+	require.True(t, found, "expected canonical image ref with digest: %q", imageRef)
+	require.True(t, strings.HasPrefix(digest, "sha256:"), digest)
+
+	lockContents := mustMarshalContainerFromLock(t, lockTestPlatform(ctx, t), digest, workspace.PolicyPin)
+	remote := newRemoteLockWorkspace(ctx, t, c, lockContents)
+	workdir := t.TempDir()
+	queryPath := writeQueryDoc(t, workdir, "image-ref.graphql", containerFromImageRefQuery)
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "-W", remote.commitRef, "query", "--doc", queryPath)
+	require.NoError(t, err)
+	require.Contains(t, string(out), digest)
+	require.Contains(t, string(out), "3.20")
+}
+
+func (LockfileSuite) TestFromLockfileFrozenRemoteCommitModuleCallUsesValidPin(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	imageRef, err := c.Container().From("alpine:3.20").ImageRef(ctx)
+	require.NoError(t, err)
+	_, digest, found := strings.Cut(imageRef, "@")
+	require.True(t, found, "expected canonical image ref with digest: %q", imageRef)
+
+	lockContents := mustMarshalContainerFromLock(t, lockTestPlatform(ctx, t), digest, workspace.PolicyPin)
+	remote := newRemoteWorkspace(ctx, t, c, c.Directory().
+		WithNewFile("dagger.toml", `[modules.lockmod]
+source = ".dagger/modules/lockmod"
+entrypoint = true
+`).
+		WithNewFile(workspace.LockFileName, lockContents).
+		WithDirectory(".dagger/modules/lockmod", c.Host().Directory(testDataPath(t, "modules", "dang", "lockmod"))))
+
+	workdir := t.TempDir()
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "-W", remote.commitRef, "call", "release")
+	require.NoError(t, err)
+	require.Contains(t, string(out), "3.20")
+}
+
+func (LockfileSuite) TestFromLockfileFrozenRemoteCommitRequiresEntry(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	remote := newRemoteLockWorkspace(ctx, t, c, "")
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "-W", remote.commitRef, "query", "--doc", queryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing lock entry for container.from")
+}
+
+func (LockfileSuite) TestFromLockfileLiveRemoteCommitDoesNotMutateLock(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	lockContents := mustMarshalContainerFromLock(t, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyPin)
+	remote := newRemoteLockWorkspace(ctx, t, c, lockContents)
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=live", "-W", remote.commitRef, "query", "--doc", queryPath)
+	require.NoError(t, err)
+	committedLock, err := c.Git(remote.repoURL).Commit(remote.commit).Tree().File(workspace.LockFileName).Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, lockContents, committedLock)
+}
+
+func (LockfileSuite) TestFromLockfileFrozenRemoteBranchRemainsUnavailable(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	lockContents := mustMarshalContainerFromLock(t, lockTestPlatform(ctx, t), "not-a-digest", workspace.PolicyPin)
+	remote := newRemoteLockWorkspace(ctx, t, c, lockContents)
+	workdir := t.TempDir()
+	queryPath := writeContainerFromQuery(t, workdir)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "-W", remote.branchRef, "query", "--doc", queryPath)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no writable workspace lockfile is available")
+	require.NotContains(t, err.Error(), `invalid lock digest "not-a-digest"`)
 }
 
 func (LockfileSuite) TestFromLockfileFrozenRequiresEntry(ctx context.Context, t *testctx.T) {
@@ -332,6 +436,35 @@ func (LockfileSuite) TestWorkspaceModuleLockUpdate(ctx context.Context, t *testc
 
 func writeContainerFromQuery(t *testctx.T, workdir string) string {
 	return writeQueryDoc(t, workdir, "query.graphql", containerFromQuery)
+}
+
+type remoteLockWorkspace struct {
+	repoURL   string
+	branchRef string
+	commitRef string
+	commit    string
+}
+
+func newRemoteLockWorkspace(ctx context.Context, t *testctx.T, c *dagger.Client, lockContents string) remoteLockWorkspace {
+	t.Helper()
+	return newRemoteWorkspace(ctx, t, c, c.Directory().
+		WithNewFile("dagger.toml", "").
+		WithNewFile(workspace.LockFileName, lockContents))
+}
+
+func newRemoteWorkspace(ctx context.Context, t *testctx.T, c *dagger.Client, content *dagger.Directory) remoteLockWorkspace {
+	t.Helper()
+	branchRef := workspaceSelectionRemoteRef(ctx, t, c, content)
+	repoURL := strings.TrimSuffix(branchRef, "@main")
+	commit, err := c.Git(repoURL).Branch("main").Commit(ctx)
+	require.NoError(t, err)
+	require.Len(t, commit, 40)
+	return remoteLockWorkspace{
+		repoURL:   repoURL,
+		branchRef: branchRef,
+		commitRef: repoURL + "@" + commit,
+		commit:    commit,
+	}
 }
 
 func writeQueryDoc(t *testctx.T, workdir, name, contents string) string {

--- a/core/query.go
+++ b/core/query.go
@@ -95,9 +95,9 @@ type Server interface {
 	// for operations like generate that may be exactly what repairs the module.
 	EnsureWorkspaceModules(ctx context.Context, include []string, bestEffort bool) (loadFailures []string, _ error)
 
-	// A snapshot of the current workspace lockfile for ambient live locking.
-	// Returns ok=false when lock-backed workspace access is unavailable.
-	CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error)
+	// A snapshot of the current workspace lockfile. When requireWritable is
+	// true, returns ok=false for read-only workspace lock sources.
+	CurrentWorkspaceLock(ctx context.Context, requireWritable bool) (*workspacepkg.Lock, bool, error)
 
 	// Stage a lockfile lookup result for the current workspace's live lock state.
 	SetCurrentWorkspaceLookup(context.Context, string, string, []any, workspacepkg.LookupResult) error

--- a/core/schema/lockfile.go
+++ b/core/schema/lockfile.go
@@ -17,9 +17,10 @@ import (
 const lockCoreNamespace = ""
 
 type workspaceLookupLock struct {
-	ctx   context.Context
-	query *core.Query
-	lock  *workspace.Lock
+	ctx      context.Context
+	query    *core.Query
+	lock     *workspace.Lock
+	writable bool
 }
 
 type workspaceLookupLockOverrideKey struct{}
@@ -29,12 +30,12 @@ func withWorkspaceLookupLockOverride(ctx context.Context, lock *workspace.Lock) 
 	return dagql.WithPerClientCacheScope(ctx)
 }
 
-func loadWorkspaceLookupLock(ctx context.Context, query *core.Query) (*workspaceLookupLock, error) {
+func loadWorkspaceLookupLock(ctx context.Context, query *core.Query, requireWritable bool) (*workspaceLookupLock, error) {
 	if lock, ok := ctx.Value(workspaceLookupLockOverrideKey{}).(*workspace.Lock); ok && lock != nil {
-		return &workspaceLookupLock{lock: lock}, nil
+		return &workspaceLookupLock{lock: lock, writable: requireWritable}, nil
 	}
 
-	lock, ok, err := query.CurrentWorkspaceLock(ctx)
+	lock, ok, err := query.CurrentWorkspaceLock(ctx, requireWritable)
 	if err != nil {
 		return nil, err
 	}
@@ -43,15 +44,19 @@ func loadWorkspaceLookupLock(ctx context.Context, query *core.Query) (*workspace
 	}
 
 	return &workspaceLookupLock{
-		ctx:   ctx,
-		query: query,
-		lock:  lock,
+		ctx:      ctx,
+		query:    query,
+		lock:     lock,
+		writable: requireWritable,
 	}, nil
 }
 
 func (l *workspaceLookupLock) SetLookup(namespace, operation string, inputs []any, result workspace.LookupResult) error {
 	if l == nil {
 		return fmt.Errorf("workspace lock is required")
+	}
+	if !l.writable {
+		return fmt.Errorf("workspace lock is not writable")
 	}
 	if l.query != nil {
 		if err := l.query.SetCurrentWorkspaceLookup(l.ctx, namespace, operation, inputs, result); err != nil {
@@ -73,10 +78,10 @@ func currentLookupLockMode(ctx context.Context) (workspace.LockMode, error) {
 }
 
 // lookupLockForMode is the policy boundary between ordinary lookups and
-// workspace lockfiles. Default/live/pinned lookups use a writable local
-// workspace lock binding when one exists; without one they resolve live and
-// skip lock writes. Frozen mode is different: it is an explicit request to
-// enforce a lockfile, so absence of a writable workspace lock is an error.
+// workspace lockfiles. Default/live/pinned lookups require a writable local
+// workspace lock binding; without one they resolve live and skip lock writes.
+// Frozen only reads, so it can also consume an immutable remote workspace's
+// committed lockfile. Absence of an eligible lock in frozen mode is an error.
 func lookupLockForMode(
 	ctx context.Context,
 	query *core.Query,
@@ -90,7 +95,7 @@ func lookupLockForMode(
 		return lockMode, nil, nil
 	}
 
-	lookupLock, err := loadWorkspaceLookupLock(ctx, query)
+	lookupLock, err := loadWorkspaceLookupLock(ctx, query, lockMode != workspace.LockModeFrozen)
 	if err != nil {
 		return "", nil, fmt.Errorf("%s lockfile: %w", operation, err)
 	}

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -160,7 +160,7 @@ func (s *currentTypeDefsTestServer) CloudEngineClient(context.Context, string, s
 
 func (s *currentTypeDefsTestServer) CleanMountNS() *os.File { return nil }
 
-func (s *currentTypeDefsTestServer) CurrentWorkspaceLock(context.Context) (*workspace.Lock, bool, error) {
+func (s *currentTypeDefsTestServer) CurrentWorkspaceLock(context.Context, bool) (*workspace.Lock, bool, error) {
 	return s.workspaceLock, s.workspaceLockOK, s.workspaceLockErr
 }
 

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -413,7 +413,7 @@ func syntheticWorkspaceFromGitRef(
 		Address:    "git-ref://" + ref.Self().Ref.SHA,
 	}
 	ws.SetRootfs(rootResult)
-	ws.SetSource(core.NewWorkspaceSourceGitRef(ref.Result))
+	ws.SetSource(core.NewWorkspaceSourceGitRef(ref.Result, false))
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws)
 }
 

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -137,7 +137,7 @@ func (ms *mockServer) SpecificClientAttachableConn(_ context.Context, clientID s
 	return conn, conn != nil, nil
 }
 
-func (ms *mockServer) CurrentWorkspaceLock(context.Context) (*workspacepkg.Lock, bool, error) {
+func (ms *mockServer) CurrentWorkspaceLock(context.Context, bool) (*workspacepkg.Lock, bool, error) {
 	return nil, false, nil
 }
 

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -102,6 +102,9 @@ func (*WorkspaceSourceDirectory) workspaceSource() {}
 
 type WorkspaceSourceGitRef struct {
 	Ref dagql.Result[*GitRef]
+	// ExplicitCommit distinguishes a workspace requested by immutable commit SHA
+	// from a mutable ref that happens to resolve to the same commit.
+	ExplicitCommit bool
 }
 
 func (*WorkspaceSourceGitRef) workspaceSource() {}
@@ -140,9 +143,10 @@ func NewWorkspaceSourceDirectory(root dagql.ObjectResult[*Directory]) WorkspaceS
 	}
 }
 
-func NewWorkspaceSourceGitRef(ref dagql.Result[*GitRef]) WorkspaceSource {
+func NewWorkspaceSourceGitRef(ref dagql.Result[*GitRef], explicitCommit bool) WorkspaceSource {
 	return &WorkspaceSourceGitRef{
-		Ref: ref,
+		Ref:            ref,
+		ExplicitCommit: explicitCommit,
 	}
 }
 
@@ -421,6 +425,7 @@ type persistedWorkspaceSource struct {
 	Kind           string                    `json:"kind"`
 	RootResultID   uint64                    `json:"rootResultID,omitempty"`
 	GitRefResultID uint64                    `json:"gitRefResultID,omitempty"`
+	ExplicitCommit bool                      `json:"explicitCommit,omitempty"`
 	ChangesID      uint64                    `json:"changesID,omitempty"`
 	TouchedPaths   []string                  `json:"touchedPaths,omitempty"`
 	HostPath       string                    `json:"hostPath,omitempty"`
@@ -462,6 +467,7 @@ func encodePersistedWorkspaceSource(cache dagql.PersistedObjectCache, src Worksp
 		return &persistedWorkspaceSource{
 			Kind:           persistedWorkspaceSourceGitRef,
 			GitRefResultID: refID,
+			ExplicitCommit: src.ExplicitCommit,
 		}, nil
 	case *WorkspaceSourceOverlay:
 		payload := &persistedWorkspaceSource{Kind: persistedWorkspaceSourceOverlay}
@@ -523,7 +529,7 @@ func decodePersistedWorkspaceSource(
 		if err != nil {
 			return nil, err
 		}
-		return NewWorkspaceSourceGitRef(ref.Result), nil
+		return NewWorkspaceSourceGitRef(ref.Result, persisted.ExplicitCommit), nil
 	case persistedWorkspaceSourceOverlay:
 		base, err := decodePersistedWorkspaceSource(ctx, dag, persisted.Base, rootfs, hostPath)
 		if err != nil {

--- a/core/workspace/detect.go
+++ b/core/workspace/detect.go
@@ -19,8 +19,8 @@ const (
 
 // Workspace represents a detected workspace boundary and selected files within
 // it. ConfigFile and LockFile are deliberately separate: dagger.toml may be
-// absent or projected from compat dagger.json, while the lockfile is a local
-// writable binding selected from the workspace tree.
+// absent or projected from compat dagger.json, while lockfile read/write
+// capabilities depend on the workspace source.
 type Workspace struct {
 	// Root is the workspace boundary: the detected Git root, or an explicit
 	// boundary supplied for a remote or legacy workspace.

--- a/docs/current_docs/reference/cli/lockfiles.mdx
+++ b/docs/current_docs/reference/cli/lockfiles.mdx
@@ -44,6 +44,12 @@ Typical uses:
 - `pinned`: day-to-day development and most CI
 - `frozen`: reproducible, hermetic, or offline runs
 
+For a remote Git workspace selected by a full commit SHA, `frozen` reads the
+committed `dagger.lock` without modifying the remote workspace. Mutable Git
+workspace refs such as branches cannot bootstrap `frozen`, because Dagger must
+resolve the workspace ref before its committed lockfile is available. Modes
+that may update lock entries require a writable local workspace lockfile.
+
 ## Lock policies
 
 Lock policy is stored on each lock entry.

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1992,10 +1992,16 @@ func isSameModuleReference(a *core.ModuleSource, b *core.ModuleSource) bool {
 	}
 	return a.Pin() == b.Pin()
 }
-func (srv *Server) CurrentWorkspaceLock(ctx context.Context) (*workspace.Lock, bool, error) {
+func (srv *Server) CurrentWorkspaceLock(ctx context.Context, requireWritable bool) (*workspace.Lock, bool, error) {
 	client, err := srv.clientFromContext(ctx)
 	if err != nil {
 		return nil, false, err
+	}
+	if !requireWritable {
+		lock, ok, err := readImmutableRemoteWorkspaceLock(ctx, client.workspace)
+		if err != nil || ok {
+			return lock, ok, err
+		}
 	}
 
 	ws, key, lockPath, ok, err := srv.currentWorkspaceLockBinding(client)
@@ -2179,6 +2185,65 @@ func readWorkspaceLockState(ctx context.Context, bk interface {
 		}
 	}
 
+	lock, err := workspace.ParseLock(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing lock: %w", err)
+	}
+	return lock, nil
+}
+
+func readImmutableRemoteWorkspaceLock(ctx context.Context, ws *core.Workspace) (*workspace.Lock, bool, error) {
+	if ws == nil || ws.LockFile == "" {
+		return nil, false, nil
+	}
+
+	// The remote loader records whether the original workspace selector was a
+	// commit. A resolved SHA alone is insufficient because branches and tags have
+	// one too.
+	source, ok := ws.Source().(*core.WorkspaceSourceGitRef)
+	if !ok || !source.ExplicitCommit {
+		return nil, false, nil
+	}
+
+	root := ws.Rootfs()
+	if root.Self() == nil {
+		return nil, true, fmt.Errorf("immutable remote Git workspace has no root filesystem")
+	}
+	lock, err := readWorkspaceLockFromRootfs(ctx, root, ws.LockFile)
+	return lock, true, err
+}
+
+func readWorkspaceLockFromRootfs(
+	ctx context.Context,
+	root dagql.ObjectResult[*core.Directory],
+	lockPath string,
+) (*workspace.Lock, error) {
+	lockPath = filepath.ToSlash(lockPath)
+	legacyPath := filepath.ToSlash(workspace.LegacyLockFilePathForCanonical(lockPath))
+	statFS := &core.DirectoryStatFS{Dir: root}
+
+	_, exists, err := core.StatFSExists(ctx, statFS, lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading lock: %w", err)
+	}
+	if !exists {
+		lockPath = legacyPath
+		_, exists, err = core.StatFSExists(ctx, statFS, lockPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading legacy lock: %w", err)
+		}
+	}
+	if !exists {
+		return workspace.NewLock(), nil
+	}
+
+	data, err := core.DirectoryReadFile(ctx, root, lockPath)
+	if err != nil {
+		if lockPath == legacyPath {
+			return nil, fmt.Errorf("reading legacy lock: %w", err)
+		}
+		return nil, fmt.Errorf("reading lock: %w", err)
+	}
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
 		return nil, fmt.Errorf("parsing lock: %w", err)

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -348,7 +348,7 @@ func (srv *Server) loadWorkspaceFromRemote(ctx context.Context, client *daggerCl
 		},
 		false, // isLocal
 		tree,  // pre-built rootfs for remote
-		core.NewWorkspaceSourceGitRef(gitRef.Result),
+		core.NewWorkspaceSourceGitRef(gitRef.Result, gitutil.IsCommitSHA(parsedRef.version)),
 	)
 }
 


### PR DESCRIPTION
## Summary

- let frozen lock mode read the committed `dagger.lock` from a remote Git workspace selected by a full commit SHA
- distinguish an explicitly requested commit from a branch or tag that happens to resolve to the same SHA
- keep remote locks outside writable session lock state, with no mutation or writeback to Git

## Problem

A reproducible remote workspace invocation such as:

```console
dagger --lock=frozen -W https://example.com/repo.git@<full-40-char-commit> call release
```

could not use a valid committed lock entry needed by a nested module operation. It failed before reading the entry:

```text
container.from lockfile: no writable workspace lockfile is available
```

Frozen mode only consumes existing entries, but workspace lock access was coupled to the writable local host-path binding. Remote Git workspaces have an immutable in-engine root filesystem rather than that binding.

## Fix

The remote workspace loader now records whether the original selector was a full commit SHA. For frozen mode only, current workspace lock lookup may read the canonical (or legacy) committed lockfile from `Workspace.Rootfs()`.

Write-capable access is unchanged:

- `SetCurrentWorkspaceLookup` still requires the existing local host-path binding
- remote lock snapshots never enter mutable session lock state and are never flushed
- live and pinned modes continue to require a writable local lockfile before using lock-backed state

Branches and tags remain unchanged. Only an explicitly selected full commit SHA enables this read-only path.

A missing entry and an invalid committed pin flow through the existing frozen missing-entry and invalid-pin errors.

## Tests

Added integration coverage using the existing smart-HTTP Git fixture and the real CLI remote workspace loader for:

- a valid committed hard pin, including an Apps-style nested entrypoint module call
- an invalid committed pin, proving the file was read
- a missing entry under frozen
- no mutation in a write-capable mode
- unchanged mutable branch behavior
- unchanged existing local writable behavior

Validated with:

```console
dagger api call engine-dev test --pkg ./core/integration --run='^TestLockfile$'
dagger api call golang lint-all
dagger api call markdown-lint lint
dagger api call docs check
```

The post-rebase lockfile suite passed all 24 tests: https://dagger.cloud/dagger/traces/bd1902f68c0f6c7f8d1f5097022c2374
