### PR TITLE
fix(telemetry): bound idle log-batch clone churn on client DB routes

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -888,11 +888,9 @@ func (srv *Server) initializeDaggerClient(
 		// record on the emitting goroutine; with enough concurrent emitters
 		// they all pile up on the DB's write lock (each busy-waiting in a
 		// syscall that pins an OS thread), which can exhaust the runtime's
-		// thread limit.
-		sdklog.WithProcessor(sdklog.NewBatchProcessor(
-			logs,
-			sdklog.WithExportInterval(telemetry.NearlyImmediate),
-		)),
+		// thread limit. Batched with bounded churn settings — see
+		// enginetel.NewLogBatchProcessor.
+		sdklog.WithProcessor(enginetel.NewLogBatchProcessor(logs)),
 	}
 
 	const metricReaderInterval = 5 * time.Second
@@ -915,10 +913,7 @@ func (srv *Server) initializeDaggerClient(
 			),
 		))
 		loggerOpts = append(loggerOpts, sdklog.WithProcessor(
-			sdklog.NewBatchProcessor(
-				srv.telemetryPubSub.Logs(parent),
-				sdklog.WithExportInterval(telemetry.NearlyImmediate),
-			),
+			enginetel.NewLogBatchProcessor(srv.telemetryPubSub.Logs(parent)),
 		))
 		meterOpts = append(meterOpts, sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(

--- a/engine/telemetry/logbatch.go
+++ b/engine/telemetry/logbatch.go
@@ -1,0 +1,41 @@
+package telemetry
+
+import (
+	"time"
+
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// Log-record batch settings for the per-client DB log routes (engine/server).
+//
+// The SDK BatchProcessor's poll loop clones its entire batchSize-long
+// []Record buffer on EVERY export tick while the exporter is ready — even
+// when zero records were dequeued (sdk/log batch.go: TryDequeue's write
+// callback does buf = slices.Clone(buf), and EnqueueExport returns true for
+// an empty slice). A Record is a large struct (~0.5 KiB inline), so the
+// resulting allocation churn is processors × ticks/sec × batchSize ×
+// sizeof(Record), INDEPENDENT of actual log volume. The engine registers one
+// processor per client per ancestor route, so a grouped session easily holds
+// 100+ of them; at the previous 100ms interval and default 512 batch this
+// produced tens of GB of allocation churn per run (measured: 22–37 GB of
+// slices.Clone[[]sdklog.Record] in a grouped python-sdk check run).
+//
+// Interval and batch size each scale that churn linearly. Crucially, OnEmit
+// self-flushes as soon as a full batch accumulates (pollTrigger), so a longer
+// interval delays only SPARSE log records — bursts still export immediately.
+// 250ms/128 cuts the volume-independent churn ~10x while keeping trickle
+// latency well below human-noticeable for log output.
+const (
+	LogExportInterval     = 250 * time.Millisecond
+	LogExportMaxBatchSize = 128
+)
+
+// NewLogBatchProcessor is the log analog of NewLargeQueueLiveSpanProcessor:
+// the batch processor for every per-client DB log route, with the bounded
+// churn settings above in place of the SDK defaults.
+func NewLogBatchProcessor(exp sdklog.Exporter) *sdklog.BatchProcessor {
+	return sdklog.NewBatchProcessor(exp,
+		sdklog.WithExportInterval(LogExportInterval),
+		sdklog.WithExportMaxBatchSize(LogExportMaxBatchSize),
+	)
+}

--- a/engine/telemetry/logbatch_test.go
+++ b/engine/telemetry/logbatch_test.go
@@ -1,0 +1,164 @@
+package telemetry
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	logapi "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// countingLogExporter records how many log records arrive and when the first
+// batch lands.
+type countingLogExporter struct {
+	mu       sync.Mutex
+	exported int
+	firstAt  time.Time
+}
+
+var _ sdklog.Exporter = (*countingLogExporter)(nil)
+
+func (e *countingLogExporter) Export(_ context.Context, recs []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.exported == 0 && len(recs) > 0 {
+		e.firstAt = time.Now()
+	}
+	e.exported += len(recs)
+	return nil
+}
+
+func (e *countingLogExporter) Shutdown(context.Context) error   { return nil }
+func (e *countingLogExporter) ForceFlush(context.Context) error { return nil }
+
+func (e *countingLogExporter) count() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exported
+}
+
+// TestLogBatchProcessorIdleChurnBounded guards the property that motivated
+// NewLogBatchProcessor: the SDK poll loop clones its full batchSize-long
+// []Record buffer on every ready tick even with zero log traffic, so idle
+// allocation churn is processors x ticks x batchSize x sizeof(Record). The
+// test runs idle processors for a fixed window and asserts total allocation
+// stays under a bound derived from the configured interval and batch size —
+// reverting to the previous settings (100ms interval, 512 batch: 10x the
+// churn) blows the bound.
+//
+// Deliberately NOT parallel: it reads runtime-global allocation counters.
+func TestLogBatchProcessorIdleChurnBounded(t *testing.T) {
+	const (
+		procs  = 16
+		window = 2 * time.Second
+	)
+
+	exps := make([]*countingLogExporter, procs)
+	bsps := make([]*sdklog.BatchProcessor, procs)
+	for i := range procs {
+		exps[i] = &countingLogExporter{}
+		bsps[i] = NewLogBatchProcessor(exps[i])
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		for _, p := range bsps {
+			require.NoError(t, p.Shutdown(ctx))
+		}
+	}()
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	time.Sleep(window)
+	runtime.ReadMemStats(&after)
+
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	// Expected idle churn: one full-buffer clone per processor per tick.
+	//
+	// The interval/batch factors below are deliberately literal copies of the
+	// intended settings, NOT the exported constants: the bound is a pinned
+	// budget. If someone reverts the constants toward the old 100ms/512
+	// settings (10x the churn), the processors allocate against THIS budget
+	// and the test fails; deriving the bound from the constants themselves
+	// would let it self-scale and guard nothing.
+	recSize := uint64(unsafe.Sizeof(sdklog.Record{}))
+	ticks := uint64(window/(250*time.Millisecond)) + 2 // +2 slack for timer skew
+	perClone := uint64(128) * recSize
+	// 3x margin for runtime noise (timers, GC bookkeeping, test harness).
+	bound := 3 * procs * ticks * perClone
+
+	require.Less(t, allocated, bound,
+		"idle log batch processors allocated %d bytes in %s; bound %d "+
+			"(churn must stay proportional to interval x batch size)",
+		allocated, window, bound)
+
+	// Sanity: idle means nothing was actually exported.
+	for _, e := range exps {
+		require.Zero(t, e.count())
+	}
+}
+
+// TestLogBatchProcessorBurstSelfFlush proves the property that makes the
+// longer export interval safe: OnEmit triggers an immediate export the moment
+// a full batch accumulates, so bursts do not wait for the interval tick.
+func TestLogBatchProcessorBurstSelfFlush(t *testing.T) {
+	t.Parallel()
+
+	exp := &countingLogExporter{}
+	proc := NewLogBatchProcessor(exp)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, proc.Shutdown(ctx))
+	}()
+
+	var rec sdklog.Record
+	rec.SetTimestamp(time.Now())
+	rec.SetBody(logapi.StringValue("burst"))
+
+	start := time.Now()
+	for range 2 * LogExportMaxBatchSize {
+		require.NoError(t, proc.OnEmit(context.Background(), &rec))
+	}
+
+	// A full batch must reach the exporter well before the export interval
+	// elapses; use half the interval as the deadline to prove the self-flush
+	// path (not the ticker) delivered it.
+	require.Eventually(t, func() bool {
+		return exp.count() >= LogExportMaxBatchSize
+	}, LogExportInterval/2, time.Millisecond,
+		"a full batch must self-flush immediately, not wait for the ticker")
+	require.Less(t, time.Since(start), LogExportInterval,
+		"burst delivery must not depend on the export interval")
+}
+
+// TestLogBatchProcessorTrickleDelivery proves sparse records still arrive
+// within roughly one export interval (the latency cost of the churn fix is
+// bounded and small).
+func TestLogBatchProcessorTrickleDelivery(t *testing.T) {
+	t.Parallel()
+
+	exp := &countingLogExporter{}
+	proc := NewLogBatchProcessor(exp)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, proc.Shutdown(ctx))
+	}()
+
+	var rec sdklog.Record
+	rec.SetTimestamp(time.Now())
+	rec.SetBody(logapi.StringValue("trickle"))
+	require.NoError(t, proc.OnEmit(context.Background(), &rec))
+
+	require.Eventually(t, func() bool { return exp.count() >= 1 },
+		2*LogExportInterval, 5*time.Millisecond,
+		"a single sparse record must arrive within ~one export interval")
+}


### PR DESCRIPTION
## Problem

Follow-up to #13695. Heap profiling of the beta.7 memory regression found a second, independent telemetry cost: `slices.Clone[[]sdklog.Record]` was the **dominant allocator** in engine heap profiles — 22–37 GB of cumulative allocations per grouped `python-sdk:**` check run, with GC cycle counts elevated 43–79%.

The mechanism is in the OTel `sdk/log` BatchProcessor (v0.16.0, `batch.go`): its poll loop calls `TryDequeue` on **every export tick while the exporter is ready — even when the queue is empty** — and the write callback then runs `buf = slices.Clone(buf)` over the **entire batchSize-long `[]Record` backing array** (`EnqueueExport` returns `true` for an empty slice, so the clone runs unconditionally). A `Record` is a large struct (~0.5 KiB inline), so the churn is:

```
processors × ticks/sec × batchSize × sizeof(Record)   — independent of log volume
```

The engine registers one log batch processor per client **per ancestor route**, so a grouped session holds 100+ (281 observed). At the previous `NearlyImmediate` (100 ms) interval and default 512 batch, idle sessions burned hundreds of MB/s of allocations doing nothing.

## Fix

Raise the log export interval to 250 ms and lower the export batch to 128 on every per-client DB log route (`engine/telemetry/logbatch.go`, both wiring sites in `engine/server/session.go`). Each factor scales the churn linearly: ~10× less.

This is safe for delivery semantics because `OnEmit` self-flushes the moment a full batch accumulates (`pollTrigger`) — **bursts still export immediately**; only sparse log records gain up to ~250 ms of latency. Queue size and drop behavior are unchanged.

## Evidence

Unit (in this PR): the idle-churn test pins the allocation budget with literal values (a bound derived from the constants would self-scale and guard nothing). 16 idle processors allocate ~7 MB over 2 s under these settings vs ~71 MB under the previous ones — reverting fails the test. Companion tests prove bursts self-flush well before the interval and sparse records arrive within ~one interval.

Empirical (same instrumented harness that profiled the beta.7 regression, matched processor counts and sample points, cold runs):

| Matched point | `slices.Clone[[]sdklog.Record]` | Total alloc | GC cycles |
|---|---:|---:|---:|
| grouped python @260s (281 procs) | 71.94 → 7.31 GB (**−90%**) | 89.6 → 21.9 GB | 279 → 110 |
| engine build @150s (160 procs) | 26.96 → 2.49 GB (**−91%**) | 37.9 → 12.0 GB | 155 → 84 |

Across full cold python runs: allocations −76%, GC cycles −65%, wall time unchanged. Peak cgroup memory is roughly neutral (BuildKit children/file cache dominate it) — this is an allocation-rate/GC-pressure fix, not a retention fix. No telemetry regression: log counts equivalent to baseline, engine-build span accounting exact (16,012/16,012 received/declared), all checks green with normal TUI output.

## Notes

- The underlying full-buffer clone is an upstream `sdk/log` inefficiency (there's a `TODO` in the SDK about pooling here); cloning only `buf[:n]` upstream would eliminate the idle term entirely. Worth an upstream issue/PR separately — this change is the engine-side mitigation and remains correct either way.
- `TestTelemetry/TestGolden/trace-function-calls` passes via `engine-dev test`.
