### PR TITLE
fix: normalize module init directory permissions

### DIFF
--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -34,6 +34,27 @@ func TestWorkspaceModules(t *testing.T) {
 // TestWorkspaceModuleInstall covers module installation through both the CLI
 // and the Workspace overlay/export API.
 func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *testctx.T) {
+	t.Run("module init creates its explicit path with standard permissions", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "dang")
+		require.NoError(t, err)
+
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "dang", "editor", "--path", "editor")
+		require.NoError(t, err)
+
+		info, err := os.Stat(filepath.Join(workdir, "editor"))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+			"module directory mode: got %#o, want %#o", info.Mode().Perm(), os.FileMode(0o755))
+
+		_, err = os.Stat(filepath.Join(workdir, "editor", workspacecfg.ModuleConfigFileName))
+		require.NoError(t, err, "engine-authored module config should be preserved")
+		_, err = os.Stat(filepath.Join(workdir, "editor", "main.dang"))
+		require.NoError(t, err, "SDK-authored starter source should be preserved")
+	})
+
 	t.Run("Workspace.WithModule initializes config and lock for remote modules", func(ctx context.Context, t *testctx.T) {
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -194,7 +194,68 @@ func (s *workspaceSchema) initModuleChanges(
 		return res, err
 	}
 
-	return mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
+	merged, err := mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
+	if err != nil {
+		return res, err
+	}
+
+	// Changesets are merged through Git, which does not track directory modes.
+	// A newly added directory is therefore recreated using the engine process's
+	// umask instead of retaining the mode staged by the engine or SDK. Normalize
+	// only the module root here: it is owned by module init, while directories
+	// below it remain owned by the SDK and keep their explicitly authored modes.
+	return changesetWithDirectoryMode(ctx, merged, relPath, 0o755)
+}
+
+// changesetWithDirectoryMode returns changes with path's mode explicitly set
+// in the after snapshot. Overlaying an empty directory changes only the root
+// directory metadata and preserves all files and child-directory modes.
+func changesetWithDirectoryMode(
+	ctx context.Context,
+	changes dagql.ObjectResult[*core.Changeset],
+	path string,
+	mode int,
+) (dagql.ObjectResult[*core.Changeset], error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return changes, fmt.Errorf("dagql server: %w", err)
+	}
+
+	var empty dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, srv.Root(), &empty, dagql.Selector{Field: "directory"}); err != nil {
+		return changes, fmt.Errorf("create empty directory: %w", err)
+	}
+	emptyID, err := empty.ID()
+	if err != nil {
+		return changes, fmt.Errorf("empty directory ID: %w", err)
+	}
+
+	var after dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, changes.Self().After, &after, dagql.Selector{
+		Field: "withDirectory",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(filepath.ToSlash(path))},
+			{Name: "source", Value: dagql.NewID[*core.Directory](emptyID)},
+			{Name: "permissions", Value: dagql.Opt(dagql.Int(mode))},
+		},
+	}); err != nil {
+		return changes, fmt.Errorf("set directory mode for %q: %w", path, err)
+	}
+
+	beforeID, err := changes.Self().Before.ID()
+	if err != nil {
+		return changes, fmt.Errorf("changeset before ID: %w", err)
+	}
+	var normalized dagql.ObjectResult[*core.Changeset]
+	if err := srv.Select(ctx, after, &normalized, dagql.Selector{
+		Field: "changes",
+		Args: []dagql.NamedInput{
+			{Name: "from", Value: dagql.NewID[*core.Directory](beforeID)},
+		},
+	}); err != nil {
+		return changes, fmt.Errorf("rebuild changeset with directory mode: %w", err)
+	}
+	return normalized, nil
 }
 
 // validateSDKInitChangesetOwnership enforces the CLI-1.0 ownership split: the


### PR DESCRIPTION
## Context

`dagger module init --path <dir>` can export the new module directory as `0777`. The engine and SDK initialization Changesets are merged through Git, which does not track directory modes; the module root is therefore recreated using the engine process umask.

## Change

Normalize only the initialized module root to `0755` after the Changeset merge. The metadata-only overlay preserves engine- and SDK-authored files and leaves child directory modes untouched. Generic Changeset export is intentionally unchanged so caller-supplied permissions keep their existing behavior.

The first commit is the failing regression test; the second contains the scoped fix.

## Reproduce

```shell
dagger call engine-dev test --pkg=./core/integration --run='^TestWorkspaceModules/TestWorkspaceModuleInstall/module_init_creates_its_explicit_path_with_standard_permissions$'
```

Before the fix, the assertion reports `got 0777, want 0755`:
[pre-fix failure trace](https://dagger.cloud/dagger/traces/801ca4c56c3ada57ca86ebedd24fa4c6).

## Verification

```shell
go test ./core/schema
dagger call engine-dev test --pkg=./core/integration --run='^TestWorkspaceModules/TestWorkspaceModuleInstall$'
```

The integration test also verifies that the engine-authored config and SDK-authored starter source survive the metadata overlay.

- [Module install suite: 10 passed](https://dagger.cloud/dagger/traces/0f281b2deb77adb2273fd17e66535236)

Closes #13660.
