### PR TITLE
core: make WorkspaceGit persistable in the dagql disk cache

### DIFF
--- a/core/workspace.go
+++ b/core/workspace.go
@@ -779,3 +779,57 @@ func (wg *WorkspaceGit) AttachDependencyResults(
 	wg.Workspace = typed
 	return []dagql.AnyResult{typed}, nil
 }
+
+var (
+	_ dagql.PersistedObject        = (*WorkspaceGit)(nil)
+	_ dagql.PersistedObjectDecoder = (*WorkspaceGit)(nil)
+)
+
+// persistedWorkspaceGitPayload is the on-disk encoding of a WorkspaceGit. Its
+// only state is a reference to the Workspace it wraps, which is itself
+// persistable, so persistence reduces to encoding that one ref.
+type persistedWorkspaceGitPayload struct {
+	WorkspaceResultID uint64 `json:"workspaceResultID,omitempty"`
+}
+
+func (wg *WorkspaceGit) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	if wg == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted workspace git: nil workspace git")
+	}
+	var payload persistedWorkspaceGitPayload
+	if wg.Workspace.Self() != nil {
+		wsID, err := encodePersistedObjectRef(cache, wg.Workspace, "workspace git workspace")
+		if err != nil {
+			return dagql.PersistedObjectEncoding{}, err
+		}
+		payload.WorkspaceResultID = wsID
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("marshal persisted workspace git payload: %w", err)
+	}
+	return encodePersistedObjectRawJSON(payloadBytes), nil
+}
+
+func (*WorkspaceGit) DecodePersistedObject(
+	ctx context.Context,
+	dag *dagql.Server,
+	_ uint64,
+	_ *dagql.ResultCall,
+	payload json.RawMessage,
+) (dagql.Typed, error) {
+	var persisted persistedWorkspaceGitPayload
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return nil, fmt.Errorf("decode persisted workspace git payload: %w", err)
+	}
+	wg := &WorkspaceGit{}
+	if persisted.WorkspaceResultID != 0 {
+		ws, err := loadPersistedObjectResultByResultID[*Workspace](ctx, dag, persisted.WorkspaceResultID, "workspace git workspace")
+		if err != nil {
+			return nil, err
+		}
+		wg.Workspace = ws
+	}
+	return wg, nil
+}


### PR DESCRIPTION
*Blocker for #13508*

## Context

The engine caches computed results so it doesn't redo expensive work. That cache lives in memory. On shutdown, the engine writes it to disk, so a restart can resume instead of rebuilding everything.

Writing to disk means each result has to be serializable — packed into bytes on the way out, rebuilt on the way back in. Types that support this implement `dagql.PersistedObject`: `EncodePersistedObject` ("pack me") and `DecodePersistedObject` ("unpack me").

## Problem

`WorkspaceGit`, returned by `Workspace.git()`, never implemented `PersistedObject`. Every other type in the family does — `Workspace`, `GitRef`, `Changeset`, `WorkspaceModule`.

So any build whose cache touched `Workspace.git()` couldn't be saved. On shutdown the engine walks the cache, hits the un-packable `WorkspaceGit`, and aborts the whole save:

```
dagql cache close exiting with error:
  encode persisted object payload: type "WorkspaceGit"
  does not implement persisted object encoding
```

Nothing persists. After a restart, the engine rebuilds from scratch.

## Solution

Teach `WorkspaceGit` to pack itself.

It's trivial, because a `WorkspaceGit` is just a pointer to its `Workspace`:

```go
type WorkspaceGit struct {
	Workspace dagql.ObjectResult[*Workspace]
}
```

And `Workspace` already persists. So packing is "write down a reference to that Workspace," and unpacking is "load it back and wrap it" — the pattern the other types already follow.