### PR TITLE
fix(core): load git workspace defaultPath context

### DIFF
--- a/core/integration/workspace_legacy_default_path_test.go
+++ b/core/integration/workspace_legacy_default_path_test.go
@@ -75,6 +75,44 @@ legacy-default-path = true
 	}
 }
 
+// TestToolchainDefaultPathResolvesFromGitWorkspace covers the same
+// legacy-default-path behavior for a remote (git) workspace. A repo migrated to
+// Dagger 1.0 has a root dagger.toml (a Workspace) and no dagger.json (a Module),
+// so the legacy-default-path context source — the workspace root — is a git ref
+// pointing at a config-less repo root. Git module sources require a dagger
+// config file, so without tolerating its absence this fails to resolve with
+// "does not contain a dagger config file", even though a local workspace (whose
+// module sources already tolerate a missing config) works fine.
+func (WorkspaceLegacyDefaultPathSuite) TestToolchainDefaultPathResolvesFromGitWorkspace(ctx context.Context, t *testctx.T) {
+	const (
+		workspaceMarker = "from workspace root"
+		toolMarker      = "from tool module source"
+	)
+
+	c := connect(ctx, t)
+
+	readerFixture := c.Host().Directory(testDataPath(t, "modules", "go/legacy-default-path-reader"))
+	workspaceDir := c.Directory().
+		WithNewFile("dagger.toml", `[modules.reader]
+source = "tool"
+legacy-default-path = true
+`).
+		WithNewFile("workspace-marker.txt", workspaceMarker).
+		WithDirectory("tool", readerFixture).
+		WithNewFile("tool/workspace-marker.txt", toolMarker)
+
+	remoteRef := workspaceSelectionRemoteRef(ctx, t, c, workspaceDir)
+
+	out, err := c.Container().From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/empty").
+		With(workspaceSelectionDaggerCall("-W", remoteRef, "reader", "read")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, workspaceMarker, strings.TrimSpace(out))
+	require.NotContains(t, out, toolMarker)
+}
+
 func legacyDefaultPathFixture(t testing.TB, c *dagger.Client, workspaceMarker, toolMarker string) *dagger.Container {
 	t.Helper()
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -337,7 +337,7 @@ func (s *moduleSourceSchema) moduleSource(
 			return inst, err
 		}
 	case core.ModuleSourceKindGit:
-		inst, err = s.gitModuleSource(ctx, query, parsedRef.Git, args.RefPin, !args.DisableFindUp)
+		inst, err = s.gitModuleSource(ctx, query, parsedRef.Git, args.RefPin, !args.DisableFindUp, args.AllowNotExists)
 		if err != nil {
 			return inst, err
 		}
@@ -478,7 +478,7 @@ func (s *moduleSourceSchema) localModuleSource(
 					depModPath := filepath.Join(defaultFindUpSourceRootDir, namedDep.Source)
 					return s.localModuleSource(ctx, query, bk, depModPath, false, allowNotExists)
 				case core.ModuleSourceKindGit:
-					return s.gitModuleSource(ctx, query, parsedRef.Git, namedDep.Pin, false)
+					return s.gitModuleSource(ctx, query, parsedRef.Git, namedDep.Pin, false, false)
 				}
 			}
 		}
@@ -647,6 +647,12 @@ func (s *moduleSourceSchema) gitModuleSource(
 	refPin string,
 	// whether to search up the directory tree for a module config file
 	doFindUp bool,
+	// whether to tolerate a git ref that has no dagger config file, returning a
+	// context-only source (ConfigExists=false) instead of erroring. Used when
+	// the ref is needed only as a +defaultPath context directory, e.g. a
+	// migrated workspace root that is a Workspace (dagger.toml), not a Module
+	// (dagger.json). Mirrors localModuleSource's allowNotExists behavior.
+	allowNotExists bool,
 ) (inst dagql.Result[*core.ModuleSource], err error) {
 	dag, err := query.Self().Server.Server(ctx)
 	if err != nil {
@@ -691,6 +697,7 @@ func (s *moduleSourceSchema) gitModuleSource(
 	gitSrc.OriginalSubpath = gitSrc.SourceRootSubpath
 
 	var configPath string
+	configFound := true
 	if !doFindUp {
 		statFS := &core.DirectoryStatFS{Dir: gitSrc.ContextDirectory}
 		configFilename, found, err := moduleConfigInDir(ctx, statFS, filepath.Join("/", gitSrc.SourceRootSubpath))
@@ -698,10 +705,14 @@ func (s *moduleSourceSchema) gitModuleSource(
 			return inst, fmt.Errorf("failed to find module config: %w", err)
 		}
 		if !found {
-			return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
+			if !allowNotExists {
+				return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
+			}
+			configFound = false
+		} else {
+			gitSrc.ConfigFilename = configFilename
+			configPath = filepath.Join(gitSrc.SourceRootSubpath, configFilename)
 		}
-		gitSrc.ConfigFilename = configFilename
-		configPath = filepath.Join(gitSrc.SourceRootSubpath, configFilename)
 	} else {
 		// first validate the given path exists at all, otherwise weird things like
 		// `dagger -m github.com/dagger/dagger/not/a/real/dir` can succeed because
@@ -721,11 +732,15 @@ func (s *moduleSourceSchema) gitModuleSource(
 			return inst, fmt.Errorf("failed to find-up module config: %w", err)
 		}
 		if !found {
-			return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
+			if !allowNotExists {
+				return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
+			}
+			configFound = false
+		} else {
+			gitSrc.ConfigFilename = configFilename
+			configPath = filepath.Join(configDir, configFilename)
+			gitSrc.SourceRootSubpath = strings.TrimPrefix(configDir, "/")
 		}
-		gitSrc.ConfigFilename = configFilename
-		configPath = filepath.Join(configDir, configFilename)
-		gitSrc.SourceRootSubpath = strings.TrimPrefix(configDir, "/")
 	}
 	if gitSrc.SourceRootSubpath == "" {
 		gitSrc.SourceRootSubpath = "."
@@ -739,6 +754,21 @@ func (s *moduleSourceSchema) gitModuleSource(
 	gitSrc.Git.HTMLURL, err = gitSrc.Git.Link(gitSrc.SourceRootSubpath, -1, -1)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get git module source HTML URL: %w", err)
+	}
+
+	if !configFound {
+		// The git ref has no dagger config file and the caller tolerates that
+		// (allowNotExists). It is being loaded purely as a +defaultPath context
+		// directory, so return a context-only source: the full git tree is
+		// already loaded into ContextDirectory/UnfilteredContextDir above, and
+		// LoadContext{Dir,File,Git} only need that plus SourceRootSubpath. Skip
+		// module config parsing, SDK loading, and dependency resolution.
+		gitSrc.ConfigExists = false
+		inst, err = dagql.NewResultForCurrentCall(ctx, gitSrc)
+		if err != nil {
+			return inst, fmt.Errorf("failed to create instance: %w", err)
+		}
+		return inst, nil
 	}
 
 	var configContents string
@@ -3258,6 +3288,13 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	if args.DefaultPathContextSourceRef != "" {
 		contextSourceArgs := []dagql.NamedInput{
 			{Name: "refString", Value: dagql.String(args.DefaultPathContextSourceRef)},
+			// The context source is used only as a +defaultPath context
+			// directory, never served as a module, so tolerate a ref with no
+			// dagger config file. A migrated workspace root is a Workspace
+			// (dagger.toml), not a Module (dagger.json); without this, a remote
+			// (git) workspace fails to resolve legacy-default-path modules while
+			// a local one succeeds (local module sources already tolerate this).
+			{Name: "allowNotExists", Value: dagql.Boolean(true)},
 		}
 		if args.DefaultPathContextSourcePin != "" {
 			contextSourceArgs = append(contextSourceArgs, dagql.NamedInput{

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -640,6 +640,60 @@ func (s *moduleSourceSchema) localModuleSource(
 	return dagql.NewResultForCurrentCall(ctx, localSrc)
 }
 
+// findGitModuleConfig locates the dagger config file for a git module source,
+// mutating gitSrc's ConfigFilename and SourceRootSubpath as needed. It returns
+// the path to the config file within the context directory and whether one was
+// found. When no config is found and allowNotExists is true it returns
+// ("", false, nil); otherwise a missing config is an error.
+func (s *moduleSourceSchema) findGitModuleConfig(
+	ctx context.Context,
+	gitSrc *core.ModuleSource,
+	doFindUp bool,
+	allowNotExists bool,
+) (configPath string, configFound bool, err error) {
+	statFS := &core.DirectoryStatFS{Dir: gitSrc.ContextDirectory}
+
+	if !doFindUp {
+		configFilename, found, err := moduleConfigInDir(ctx, statFS, filepath.Join("/", gitSrc.SourceRootSubpath))
+		if err != nil {
+			return "", false, fmt.Errorf("failed to find module config: %w", err)
+		}
+		if !found {
+			if !allowNotExists {
+				return "", false, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
+			}
+			return "", false, nil
+		}
+		gitSrc.ConfigFilename = configFilename
+		return filepath.Join(gitSrc.SourceRootSubpath, configFilename), true, nil
+	}
+
+	// first validate the given path exists at all, otherwise weird things like
+	// `dagger -m github.com/dagger/dagger/not/a/real/dir` can succeed because
+	// they find-up to a real module config file
+	if gitSrc.SourceRootSubpath != "" {
+		if _, exists, err := core.StatFSExists(ctx, statFS, gitSrc.SourceRootSubpath); err != nil {
+			return "", false, fmt.Errorf("failed to stat git module source: %w", err)
+		} else if !exists {
+			return "", false, fmt.Errorf("path %q does not exist in git repo", gitSrc.SourceRootSubpath)
+		}
+	}
+
+	configDir, configFilename, found, err := findUpModuleConfig(ctx, statFS, filepath.Join("/", gitSrc.SourceRootSubpath))
+	if err != nil {
+		return "", false, fmt.Errorf("failed to find-up module config: %w", err)
+	}
+	if !found {
+		if !allowNotExists {
+			return "", false, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
+		}
+		return "", false, nil
+	}
+	gitSrc.ConfigFilename = configFilename
+	gitSrc.SourceRootSubpath = strings.TrimPrefix(configDir, "/")
+	return filepath.Join(configDir, configFilename), true, nil
+}
+
 func (s *moduleSourceSchema) gitModuleSource(
 	ctx context.Context,
 	query dagql.ObjectResult[*core.Query],
@@ -696,51 +750,9 @@ func (s *moduleSourceSchema) gitModuleSource(
 	gitSrc.SourceRootSubpath = strings.TrimPrefix(parsed.RepoRootSubdir, "/")
 	gitSrc.OriginalSubpath = gitSrc.SourceRootSubpath
 
-	var configPath string
-	configFound := true
-	if !doFindUp {
-		statFS := &core.DirectoryStatFS{Dir: gitSrc.ContextDirectory}
-		configFilename, found, err := moduleConfigInDir(ctx, statFS, filepath.Join("/", gitSrc.SourceRootSubpath))
-		if err != nil {
-			return inst, fmt.Errorf("failed to find module config: %w", err)
-		}
-		if !found {
-			if !allowNotExists {
-				return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
-			}
-			configFound = false
-		} else {
-			gitSrc.ConfigFilename = configFilename
-			configPath = filepath.Join(gitSrc.SourceRootSubpath, configFilename)
-		}
-	} else {
-		// first validate the given path exists at all, otherwise weird things like
-		// `dagger -m github.com/dagger/dagger/not/a/real/dir` can succeed because
-		// they find-up to a real module config file
-		statFS := &core.DirectoryStatFS{Dir: gitSrc.ContextDirectory}
-
-		if gitSrc.SourceRootSubpath != "" {
-			if _, exists, err := core.StatFSExists(ctx, statFS, gitSrc.SourceRootSubpath); err != nil {
-				return inst, fmt.Errorf("failed to stat git module source: %w", err)
-			} else if !exists {
-				return inst, fmt.Errorf("path %q does not exist in git repo", gitSrc.SourceRootSubpath)
-			}
-		}
-
-		configDir, configFilename, found, err := findUpModuleConfig(ctx, statFS, filepath.Join("/", gitSrc.SourceRootSubpath))
-		if err != nil {
-			return inst, fmt.Errorf("failed to find-up module config: %w", err)
-		}
-		if !found {
-			if !allowNotExists {
-				return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
-			}
-			configFound = false
-		} else {
-			gitSrc.ConfigFilename = configFilename
-			configPath = filepath.Join(configDir, configFilename)
-			gitSrc.SourceRootSubpath = strings.TrimPrefix(configDir, "/")
-		}
+	configPath, configFound, err := s.findGitModuleConfig(ctx, gitSrc, doFindUp, allowNotExists)
+	if err != nil {
+		return inst, err
 	}
 	if gitSrc.SourceRootSubpath == "" {
 		gitSrc.SourceRootSubpath = "."


### PR DESCRIPTION
## What

A repo migrated to Dagger 1.0 has a root `dagger.toml` (a Workspace) and no `dagger.json` (a Module). Modules marked `legacy-default-path` resolve their `+defaultPath` inputs from the workspace root, which `asModule` loads as a "defaultPath context source" via `moduleSource`. Git module sources require a dagger config file, so a **remote** (git) workspace failed with `does not contain a dagger config file`, while a **local** workspace worked — local module sources already tolerate a missing config via `allowNotExists`, but git sources never got that affordance.

```
dagger -W github.com/eunomie/dagger@dagger-1-0-conversion check -l
! loading module ".../toolchains/changelog@dagger-1-0-conversion": failed to load
  defaultPath context source: git module source ".../dagger@dagger-1-0-conversion"
  does not contain a dagger config file
```

## How

The context source is only ever used as a directory context (for `LoadContext{Dir,File,Git}`), never served as a module, so this extends `allowNotExists` to `gitModuleSource` — returning a context-only source (`ConfigExists=false`, with the git tree and source-root subpath already populated) when no config is found — and loads the defaultPath context source with it. Normal git module loads are unaffected and still error clearly on a config-less ref, since the flag is set only for the internal context-source load.

## Why now

Needed on the outer/CI engines so the Dagger 1.0 conversion PR (which migrates this repo's own config to `dagger.toml`) can go green; those engines currently fail to resolve `legacy-default-path` modules from a remote workspace.

## Test

Adds `TestToolchainDefaultPathResolvesFromGitWorkspace`: a git-served workspace with a root `dagger.toml` (no `dagger.json`) and a `legacy-default-path` module whose `+defaultPath` reads a marker from the repo root. Confirmed it fails without the engine change (same `does not contain a dagger config file` error) and passes with it, alongside the existing local/compat cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
