### PR TITLE
chore(deps): bump dang for positional directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb
 	github.com/vito/dang v1.0.1
-	github.com/vito/dang/v2 v2.1.2-0.20260717032725-9689d13e8a99
+	github.com/vito/dang/v2 v2.1.2-0.20260721205602-bfe66140e738
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
 	github.com/vito/midterm v0.2.5-0.20260312180916-3c2add750bea

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,8 @@ github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb h1:Ho4c8V5nikU9zaeXc
 github.com/vito/bubbline v0.0.0-20250312195236-5f4f49d6ebcb/go.mod h1:/641L6H9ILAQTmBZrVkUCCNpp1H1vOoQIQzBvQ6Fm7o=
 github.com/vito/dang v1.0.1 h1:N7EYVajlTVWHTndv2eGJ2+7WdeNpE9mYXf3477HWj/Y=
 github.com/vito/dang v1.0.1/go.mod h1:lIRyJMWfh0RuA4zOMfZeCfU1SQi2M7yjSoN/K+GE25Q=
-github.com/vito/dang/v2 v2.1.2-0.20260717032725-9689d13e8a99 h1:6AJzKGNaTFTr9hyVzvHwD33TajPIMuzgwNQdxal4J2E=
-github.com/vito/dang/v2 v2.1.2-0.20260717032725-9689d13e8a99/go.mod h1:DlbXb+x+e37dTHJMKzRZnOkAucBUC0RGky7l6BAiIjc=
+github.com/vito/dang/v2 v2.1.2-0.20260721205602-bfe66140e738 h1:KKoZB+fGCojVbnVObR0vSDGFQ+lwaJKk0XHGu+QEI6o=
+github.com/vito/dang/v2 v2.1.2-0.20260721205602-bfe66140e738/go.mod h1:DlbXb+x+e37dTHJMKzRZnOkAucBUC0RGky7l6BAiIjc=
 github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+GU=
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=


### PR DESCRIPTION
Bumps `github.com/vito/dang/v2` to pick up [vito/dang@bfe66140](https://github.com/vito/dang/commit/bfe66140e7385d40c39260c74b9e8d0db0462631).

## Why

The previous pin broke `TestDang/TestDirectives`. Positional directive arguments (e.g. `@defaultPath("./x")`, `@ignorePatterns([...])`) only had their argument keys resolved during full inference. The Dang SDK, however, installs module types from the **declaration-only** pass (`DeclareDir`) when self-calls are enabled, and reads directive arguments by name. With the keys left empty, positional directives were silently dropped — a dropped `@defaultPath` turned the argument back into a plain required one, failing the call.

This regressed in 610b6777e1 (`sdk(dang): use SelfCallsEnabled (always true)`), which flipped the module-types runner from full inference to the declaration-only pass for the Dang SDK.

## Fix

The upstream dang commit resolves positional directive argument keys during declaration as well (in `DeclareSignature`/`DeclareKnownSignature`), so positional `@defaultPath`/`@ignorePatterns` take effect again. Validation still reports errors exactly once (from the body-inference phase) to avoid double-reporting.

## Test

```
dagger call engine-dev test --run TestDang/Directive --pkg ./core/integration/
```

`github.com/dagger/dagger/core/integration` — 8 passed. The previously-failing subtests (`positional defaultPath`, `positional ignorePatterns`, `mixed syntax`) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)