### PR TITLE
feat(workspace): let environments add modules

### DIFF
--- a/.changes/unreleased/Added-20260721-235721.yaml
+++ b/.changes/unreleased/Added-20260721-235721.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: |
+  Workspace environments can now add modules, not just override the settings of installed ones. An `[env.<name>.modules.<mod>]` entry with a `source` (and optional `pin`) installs a module that only exists when that environment is selected.
+time: 2026-07-21T23:57:21Z
+custom:
+  Author: vito
+  PR: 13708

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -105,8 +105,18 @@ type EnvOverlay struct {
 	Modules map[string]EnvModuleOverlay `json:"modules,omitempty" toml:"modules"`
 }
 
-// EnvModuleOverlay is the environment-specific overlay for one installed module.
+// EnvModuleOverlay is the environment-specific overlay for one module.
+//
+// An overlay may override the [modules.<name>.settings] of a module already
+// installed in the base config, and/or *add* a module that only exists in this
+// environment by giving it a Source (and optional Pin). An overlay that names a
+// module missing from the base config without a Source is an error.
 type EnvModuleOverlay struct {
+	// Source, when set, installs a module scoped to this environment. It mirrors
+	// [modules.<name>.source]: a workspace-relative path or a canonical ref.
+	Source string `json:"source,omitempty" toml:"source,omitempty"`
+	// Pin is the resolved version for Source, mirroring [modules.<name>.pin].
+	Pin      string         `json:"pin,omitempty" toml:"pin,omitempty"`
 	Settings map[string]any `json:"settings,omitempty" toml:"settings,omitempty"`
 }
 
@@ -194,9 +204,12 @@ func clientOptionsFromTree(tree *toml.Tree) map[string]string {
 }
 
 // ApplyEnvOverlay returns a copy of cfg with the named environment overlay
-// applied on top of the base module settings.
+// applied on top of the base module config.
 //
-// In v1, environments may only override [modules.<name>.settings] values.
+// Environments may override [modules.<name>.settings] of an installed module
+// and may add modules that only exist in the environment (by providing a
+// source). Naming a module that is neither installed in the base config nor
+// given a source is an error.
 func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 	if cfg == nil {
 		if envName == "" {
@@ -218,7 +231,21 @@ func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 	for moduleName, overlay := range env.Modules {
 		entry, ok := applied.Modules[moduleName]
 		if !ok {
-			return nil, fmt.Errorf("workspace env %q references unknown module %q", envName, moduleName)
+			if overlay.Source == "" {
+				return nil, fmt.Errorf("workspace env %q references unknown module %q", envName, moduleName)
+			}
+			if applied.Modules == nil {
+				applied.Modules = map[string]ModuleEntry{}
+			}
+			entry = ModuleEntry{}
+		}
+		// A source replaces the base module's source and its pin travels with
+		// it; a lone pin updates the existing pin in place.
+		if overlay.Source != "" {
+			entry.Source = overlay.Source
+			entry.Pin = overlay.Pin
+		} else if overlay.Pin != "" {
+			entry.Pin = overlay.Pin
 		}
 		if entry.Settings == nil {
 			entry.Settings = map[string]any{}
@@ -346,6 +373,8 @@ func cloneConfig(cfg *Config) *Config {
 				clonedEnv.Modules = make(map[string]EnvModuleOverlay, len(env.Modules))
 				for moduleName, overlay := range env.Modules {
 					clonedEnv.Modules[moduleName] = EnvModuleOverlay{
+						Source:   overlay.Source,
+						Pin:      overlay.Pin,
 						Settings: cloneConfigMap(overlay.Settings),
 					}
 				}
@@ -523,14 +552,29 @@ func writeEnvEntries(b *strings.Builder, envs map[string]EnvOverlay) bool {
 			if j > 0 {
 				b.WriteString("\n")
 			}
-			tablePath := strings.Join([]string{
+			overlay := env.Modules[moduleName]
+			modulePath := strings.Join([]string{
 				"env",
 				formatConfigPathSegment(name),
 				"modules",
 				formatConfigPathSegment(moduleName),
-				"settings",
 			}, ".")
-			writeConfigTable(b, tablePath, env.Modules[moduleName].Settings, false)
+			// A source-bearing overlay adds a module, so it renders its own
+			// [env.<name>.modules.<mod>] header with the source/pin scalars and
+			// a nested settings table. A settings-only overlay keeps the flat
+			// [env.<name>.modules.<mod>.settings] shape.
+			if overlay.Source != "" || overlay.Pin != "" {
+				fmt.Fprintf(b, "[%s]\n", modulePath)
+				if overlay.Source != "" {
+					fmt.Fprintf(b, "source = %q\n", overlay.Source)
+				}
+				if overlay.Pin != "" {
+					fmt.Fprintf(b, "pin = %q\n", overlay.Pin)
+				}
+				writeConfigTable(b, modulePath+".settings", overlay.Settings, true)
+			} else {
+				writeConfigTable(b, modulePath+".settings", overlay.Settings, false)
+			}
 		}
 	}
 
@@ -1125,7 +1169,7 @@ func setConfigValue(cfg *Config, parts []string, value any) error { //nolint:goc
 		cfg.Modules[moduleName] = entry
 		return nil
 	case "env":
-		if len(parts) < 5 || parts[2] != "modules" || parts[4] != "settings" || len(parts) < 6 {
+		if len(parts) < 5 || parts[2] != "modules" {
 			return fmt.Errorf("unknown config key %q", strings.Join(parts, "."))
 		}
 		if cfg.Env == nil {
@@ -1138,10 +1182,19 @@ func setConfigValue(cfg *Config, parts []string, value any) error { //nolint:goc
 		}
 		moduleName := parts[3]
 		module := env.Modules[moduleName]
-		if module.Settings == nil {
-			module.Settings = map[string]any{}
+		switch {
+		case parts[4] == "source" && len(parts) == 5:
+			module.Source = fmt.Sprint(value)
+		case parts[4] == "pin" && len(parts) == 5:
+			module.Pin = fmt.Sprint(value)
+		case parts[4] == "settings" && len(parts) >= 6:
+			if module.Settings == nil {
+				module.Settings = map[string]any{}
+			}
+			module.Settings[parts[5]] = value
+		default:
+			return fmt.Errorf("unknown config key %q", strings.Join(parts, "."))
 		}
-		module.Settings[parts[5]] = value
 		env.Modules[moduleName] = module
 		cfg.Env[envName] = env
 		return nil

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -214,6 +214,12 @@ func configDocumentMap(cfg *Config) map[string]any {
 				modules := make(map[string]any, len(env.Modules))
 				for moduleName, overlay := range env.Modules {
 					module := map[string]any{}
+					if overlay.Source != "" {
+						module["source"] = overlay.Source
+					}
+					if overlay.Pin != "" {
+						module["pin"] = overlay.Pin
+					}
 					if len(overlay.Settings) > 0 {
 						module["settings"] = cloneConfigMap(overlay.Settings)
 					}

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -123,6 +123,56 @@ greeting = "hola"
 `, string(out))
 }
 
+func TestEnvModuleSourceRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// An env may add a module by giving it a source (with optional pin and
+	// settings) alongside settings-only overrides of installed modules.
+	data := []byte(`[modules.greeter]
+source = "modules/greeter"
+
+[env.dev.modules.delegate]
+source = "modules/delegate"
+pin = "abc123"
+
+[env.dev.modules.delegate.settings]
+verbose = true
+
+[env.dev.modules.greeter.settings]
+greeting = "hey"
+`)
+
+	cfg, err := ParseConfig(data)
+	require.NoError(t, err)
+	require.Equal(t, EnvModuleOverlay{
+		Source: "modules/delegate",
+		Pin:    "abc123",
+		Settings: map[string]any{
+			"verbose": true,
+		},
+	}, cfg.Env["dev"].Modules["delegate"])
+	require.Equal(t, EnvModuleOverlay{
+		Settings: map[string]any{
+			"greeting": "hey",
+		},
+	}, cfg.Env["dev"].Modules["greeter"])
+
+	// Round-trips through the canonical serializer without loss.
+	reparsed, err := ParseConfig(SerializeConfig(cfg))
+	require.NoError(t, err)
+	require.Equal(t, cfg.Env, reparsed.Env)
+
+	// Applying the env installs the added module and overrides the settings.
+	applied, err := ApplyEnvOverlay(cfg, "dev")
+	require.NoError(t, err)
+	require.Equal(t, ModuleEntry{
+		Source:   "modules/delegate",
+		Pin:      "abc123",
+		Settings: map[string]any{"verbose": true},
+	}, applied.Modules["delegate"])
+	require.Equal(t, "hey", applied.Modules["greeter"].Settings["greeting"])
+}
+
 func TestWorkspaceCheckGeneratedSetting(t *testing.T) {
 	t.Parallel()
 
@@ -524,8 +574,8 @@ func TestWriteConfigValue(t *testing.T) {
 		_, err = WriteConfigValue(nil, "ignore.path", "value")
 		require.EqualError(t, err, "invalid key \"ignore.path\"; ignore does not have sub-keys")
 
-		_, err = WriteConfigValue(nil, "env.ci.modules.greeter.source", "github.com/acme/greeter")
-		require.EqualError(t, err, "unknown config key \"env.ci.modules.greeter.source\"; valid fields at this level: settings")
+		_, err = WriteConfigValue(nil, "env.ci.modules.greeter.unknown", "value")
+		require.EqualError(t, err, "unknown config key \"env.ci.modules.greeter.unknown\"; valid fields at this level: pin, settings, source")
 	})
 
 	t.Run("preserves comments and section layout", func(t *testing.T) {
@@ -578,6 +628,26 @@ region = "us-west-2"
 		require.Contains(t, out, "# region comment")
 		require.Contains(t, out, "[env.ci.modules.greeter.settings]")
 		require.Contains(t, out, `region = "us-east-1"`)
+	})
+
+	t.Run("adds a module to an env by writing its source", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`# top comment
+[modules.greeter]
+source = "modules/greeter"
+`)
+
+		updated, err := WriteConfigValue(data, "env.dev.modules.delegate.source", "modules/delegate")
+		require.NoError(t, err)
+
+		cfg, err := ParseConfig(updated)
+		require.NoError(t, err)
+		require.Equal(t, "modules/delegate", cfg.Env["dev"].Modules["delegate"].Source)
+
+		out := string(updated)
+		require.Contains(t, out, "# top comment")
+		require.Contains(t, out, `source = "modules/delegate"`)
 	})
 }
 
@@ -833,6 +903,75 @@ func TestApplyEnvOverlay(t *testing.T) {
 			},
 		}, "ci")
 		require.EqualError(t, err, `workspace env "ci" references unknown module "missing"`)
+	})
+
+	t.Run("adds a module that only exists in the environment", func(t *testing.T) {
+		t.Parallel()
+
+		base := &Config{
+			Modules: map[string]ModuleEntry{
+				"aws": {Source: "github.com/dagger/aws"},
+			},
+			Env: map[string]EnvOverlay{
+				"dev": {
+					Modules: map[string]EnvModuleOverlay{
+						"delegate": {
+							Source: "modules/delegate",
+							Pin:    "abc123",
+							Settings: map[string]any{
+								"verbose": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applied, err := ApplyEnvOverlay(base, "dev")
+		require.NoError(t, err)
+		require.Equal(t, ModuleEntry{
+			Source:   "modules/delegate",
+			Pin:      "abc123",
+			Settings: map[string]any{"verbose": true},
+		}, applied.Modules["delegate"])
+		// base config is left untouched.
+		require.NotContains(t, base.Modules, "delegate")
+	})
+
+	t.Run("env source overrides an installed module", func(t *testing.T) {
+		t.Parallel()
+
+		base := &Config{
+			Modules: map[string]ModuleEntry{
+				"editor": {
+					Source: "github.com/vito/editor",
+					Pin:    "old",
+					Settings: map[string]any{
+						"theme": "light",
+					},
+				},
+			},
+			Env: map[string]EnvOverlay{
+				"dev": {
+					Modules: map[string]EnvModuleOverlay{
+						"editor": {
+							Source: "modules/editor",
+							Settings: map[string]any{
+								"theme": "dark",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applied, err := ApplyEnvOverlay(base, "dev")
+		require.NoError(t, err)
+		require.Equal(t, ModuleEntry{
+			Source:   "modules/editor",
+			Pin:      "", // pin travels with the source it pinned
+			Settings: map[string]any{"theme": "dark"},
+		}, applied.Modules["editor"])
 	})
 }
 

--- a/docs/current_docs/reference/configuration/workspace.mdx
+++ b/docs/current_docs/reference/configuration/workspace.mdx
@@ -97,7 +97,14 @@ An [environment](../../using-dagger/environments.mdx) is a named overlay applied
 baseImageAddress = "node:22-alpine"
 ```
 
-Write overlays with `dagger settings --env <name> <module> <key> <value>` (or `dagger workspace config --env <name> …` for raw access). Reads with `--env` show the effective view — the base configuration with the overlay applied — and the base is what every environment inherits.
+An environment can also **add** a module that only exists when that environment is selected, by giving it a `source` (and optional `pin`) — the same fields as a base `[modules.<name>]` entry:
+
+```toml
+[env.dev.modules.debugger]
+source = "modules/debugger"
+```
+
+Write settings overlays with `dagger settings --env <name> <module> <key> <value>` (or `dagger workspace config --env <name> …` for raw access). Reads with `--env` show the effective view — the base configuration with the overlay applied — and the base is what every environment inherits.
 
 ## Other keys
 

--- a/docs/static/reference/dagger-workspace.schema.json
+++ b/docs/static/reference/dagger-workspace.schema.json
@@ -43,13 +43,21 @@
     },
     "EnvModuleOverlay": {
       "properties": {
+        "source": {
+          "type": "string",
+          "description": "Source, when set, installs a module scoped to this environment. It mirrors [modules.\u003cname\u003e.source]: a workspace-relative path or a canonical ref."
+        },
+        "pin": {
+          "type": "string",
+          "description": "Pin is the resolved version for Source, mirroring [modules.\u003cname\u003e.pin]."
+        },
         "settings": {
           "type": "object"
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "description": "EnvModuleOverlay is the environment-specific overlay for one installed module."
+      "description": "EnvModuleOverlay is the environment-specific overlay for one module."
     },
     "EnvOverlay": {
       "properties": {


### PR DESCRIPTION
## What

Workspace environment overlays (`[env.<name>...]` in `dagger.toml`) could only *override the settings* of a module already installed in the base config. Naming a module that only exists in the environment — even with a `source` — failed to load:

```
$ dagger --env dev agent -l
! workspace env "dev" references unknown module "delegate"
```

This lets an environment **add** a module, not just configure existing ones.

## How

`EnvModuleOverlay` gains a `source` (and optional `pin`), mirroring a base `[modules.<name>]` entry:

```toml
[env.dev.modules.delegate]
source = "modules/delegate"
```

- `ApplyEnvOverlay` installs a source-bearing overlay as a new module instead of erroring. A `source` on an existing module overrides its source (its pin travels with it); settings still merge on top. Referencing an unknown module with **no** source remains an error.
- Serialization, the format-preserving document writer, cloning, and `config` set/get all carry `source`/`pin`, so the config round-trips and `dagger workspace config env.<name>.modules.<mod>.source …` works.
- The `--env`-scoped bare-key sugar (`envScopedConfigKey`) is intentionally left settings-only. Adding a module is done via hand-edited TOML or the explicit `env.<name>.modules.<mod>.source` key; broadening that sugar (and `dagger install --env`) is a natural follow-up.

## Test plan

- Unit tests in `core/workspace` cover parse/apply/serialize round-trip, adding a module, source-override, and the `config set` path.
- Verified end-to-end against a dev engine: `dagger --env dev agent -l` now lists agents from environment-only modules instead of failing.
