### PR TITLE
fix(telemetry): hide publishResult spans in Cloud

### DIFF
--- a/dagql/otelprof_hooks.go
+++ b/dagql/otelprof_hooks.go
@@ -78,15 +78,13 @@ func beginOTelCallExec(callCtx context.Context, callKey, class string) (context.
 // finishes.
 func beginOTelPublishResult(ctx context.Context) trace.Span {
 	_, span := Tracer(ctx).Start(ctx, publishResultSpanName,
-		// Internal, not Passthrough: publishResult is a childless leaf (nothing
-		// runs under its context — initCompletedResult runs under sharedWorkCtx,
-		// i.e. the call_exec span, not this one), so it never has children for the
-		// UI to promote in its place. Marking it Internal instead lets the
-		// per-client-DB live processor drop its live (OnStart) double-emit
-		// (see engine/telemetry NewInternalFilteringLiveSpanProcessor); it is by
-		// far the highest-volume profiling span (~1 per resolver cache miss).
-		// call_exec / exec.run / service.start stay Passthrough — they DO parent
-		// the real work, so their live snapshot must ship.
+		// Internal lets the per-client-DB live processor drop publishResult's
+		// live (OnStart) double-emit; it is a childless leaf and by far the
+		// highest-volume profiling span (~1 per resolver cache miss). Passthrough
+		// separately keeps it hidden in UIs that show internal spans by default.
+		// Both attributes are needed because the live processor only checks
+		// Internal, while UI filtering may only honor Passthrough.
+		telemetry.Passthrough(),
 		telemetry.Internal(),
 		trace.WithAttributes(
 			attribute.String(telemetryattrs.WcprofOpKindAttr, wcprof.OpKindInternal.String()),

--- a/dagql/otelprof_hooks_test.go
+++ b/dagql/otelprof_hooks_test.go
@@ -79,8 +79,8 @@ func attrBool(s sdktrace.ReadOnlySpan, key string) (bool, bool) {
 
 // TestEmitHooksProduceLoaderShape drives the real singleflight emit (one executor
 // caller + call_exec + publishResult + one joiner) and asserts the emitted
-// span/link attributes carry exactly the op-kind, dag.digest, ui.passthrough and
-// wait-edge (purpose/reason/decimal-ns/target) shape the offline analyzer consumes.
+// span/link attributes carry exactly the op-kind, dag.digest, UI hints and wait-edge
+// (purpose/reason/decimal-ns/target) shape the offline analyzer consumes.
 func TestEmitHooksProduceLoaderShape(t *testing.T) {
 	const digest = "xxh3:0123456789abcdef"
 	const class = "Container.stdout"
@@ -120,13 +120,13 @@ func TestEmitHooksProduceLoaderShape(t *testing.T) {
 	if got, _ := attrString(pub, telemetryattrs.WcprofOpKindAttr); got != wcprof.OpKindInternal.String() {
 		t.Fatalf("publishResult op kind = %q, want internal", got)
 	}
-	// ui.internal, NOT ui.passthrough: publishResult is a childless leaf (nothing
-	// nests under it), so there are no children to promote and Passthrough would be
-	// pointless. Marking it Internal lets the per-client-DB live processor drop its
-	// live double-emit (NewInternalFilteringLiveSpanProcessor). call_exec above
-	// stays passthrough because it DOES parent the resolver's real work.
-	if pass, ok := attrBool(pub, telemetry.UIInternalAttr); !ok || !pass {
+	// Internal lets the per-client-DB live processor drop the live double-emit;
+	// Passthrough keeps the span hidden in UIs that show internal spans by default.
+	if internal, ok := attrBool(pub, telemetry.UIInternalAttr); !ok || !internal {
 		t.Fatalf("publishResult must be ui.internal")
+	}
+	if pass, ok := attrBool(pub, telemetry.UIPassthroughAttr); !ok || !pass {
+		t.Fatalf("publishResult must be ui.passthrough")
 	}
 
 	// the caller span (not the like-named call_exec) carries the wait links.


### PR DESCRIPTION
## Problem

Commit 9ec29190f, part of #13670, reclassified `dagql.publishResult` from `ui.passthrough` to `ui.internal` so the per-client DB live processor could skip its live start snapshot. This span is a childless leaf and the highest-volume profiling span, but Dagger Cloud shows internal spans by default, causing publishResult spans to render throughout Cloud traces.

## Fix

Carry both attributes. `ui.internal` preserves the live-emission write reduction, while `ui.passthrough` restores UI hiding.

## Evidence

- [Pre-fix trace](https://dagger.cloud/dagger/traces/07168666594a135ea4084f65219c0d45): 218 internal-only publishResult spans rendered.
- [Fixed trace](https://dagger.cloud/dagger/traces/8459fd297b3df9948a3192041752c443): publishResult spans carry both attributes and zero render.
- The strict emitted-attribute-shape test now asserts both UI attributes.
