### PR TITLE
fix(clientdb): fan in telemetry writes per DB

### DIFF
--- a/engine/clientdb/dbs.go
+++ b/engine/clientdb/dbs.go
@@ -156,9 +156,9 @@ func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
 		lg.Trace("reusing open client DB", "clientID", clientID)
 	}
 
-	if db.Queries == nil {
+	if db.writeQueries == nil {
 		var err error
-		db.Queries, err = Prepare(ctx, db.writer)
+		db.writeQueries, err = Prepare(ctx, db.writer)
 		if err != nil {
 			return nil, fmt.Errorf("prepare write queries: %w", err)
 		}
@@ -169,6 +169,9 @@ func (dbs *DBs) Open(ctx context.Context, clientID string) (_ *DB, rerr error) {
 		if err != nil {
 			return nil, fmt.Errorf("prepare read queries: %w", err)
 		}
+	}
+	if db.writeAgent == nil {
+		db.writeAgent = newWriteAgent(db.writer, db.writeQueries)
 	}
 
 	return db, nil
@@ -185,11 +188,14 @@ func (dbs *DBs) close(db *DB, lg *slog.Logger) (rerr error) {
 	}
 	lg.ExtraDebug("closing client DB; no more references")
 
-	if db.Queries != nil {
-		if cerr := db.Queries.Close(); cerr != nil {
+	if db.writeAgent != nil {
+		db.writeAgent.Close()
+	}
+	if db.writeQueries != nil {
+		if cerr := db.writeQueries.Close(); cerr != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("error closing write queries: %w", cerr))
 		}
-		db.Queries = nil
+		db.writeQueries = nil
 	}
 	if db.readQueries != nil {
 		if cerr := db.readQueries.Close(); cerr != nil {
@@ -273,10 +279,11 @@ type DB struct {
 	dbs      *DBs
 	clientID string
 
-	// writer is the single-connection write pool; the embedded *Queries is
-	// prepared against it, so DB's Insert* methods write through it.
-	writer *sql.DB
-	*Queries
+	// writer is the single-connection write pool. Only writeAgent acquires it;
+	// writeQueries is private so callers cannot bypass the fan-in queue.
+	writer       *sql.DB
+	writeQueries *Queries
+	writeAgent   *writeAgent
 
 	// reader is the multi-connection read pool; readQueries is prepared
 	// against it and reached via Read(), so Select* reads run concurrently
@@ -294,21 +301,16 @@ func (db *DB) Read() *Queries {
 	return db.readQueries
 }
 
-func (db *DB) Begin() (*sql.Tx, error) {
-	return db.writer.Begin()
+// Write queues one telemetry batch on this DB's sole writer and blocks until
+// the coalesced transaction containing it commits. This guarantees that a nil
+// return means the batch is already visible through Read().
+func (db *DB) Write(ctx context.Context, write WriteBatch) (WriteTiming, error) {
+	return db.writeAgent.submit(ctx, write)
 }
 
-// BeginTx starts a write transaction on the write pool bound to ctx. Batched
-// writers use this so a whole export batch runs as one BEGIN IMMEDIATE..COMMIT
-// holding the single write connection once, instead of one auto-commit round
-// trip (and write-lock acquisition) per row.
-func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
-	return db.writer.BeginTx(ctx, opts)
-}
-
-// Stats reports the write pool's counters. It is capped at a single
-// connection, so WaitCount/WaitDuration measure how long writers queued behind
-// it (reads use the separate reader pool and do not show up here).
+// Stats reports the write pool's counters. It is capped at a single connection
+// and only acquired by the write agent, so WaitCount/WaitDuration should stay
+// near zero (reads use the separate reader pool and do not show up here).
 func (db *DB) Stats() sql.DBStats {
 	return db.writer.Stats()
 }

--- a/engine/clientdb/dbs_test.go
+++ b/engine/clientdb/dbs_test.go
@@ -35,8 +35,9 @@ func TestDBRefCount(t *testing.T) {
 	require.Len(t, dbs.open, 1)
 	require.NotNil(t, d1a.writer)
 	require.NotNil(t, d1a.reader)
-	require.NotNil(t, d1a.Queries)
+	require.NotNil(t, d1a.writeQueries)
 	require.NotNil(t, d1a.readQueries)
+	require.NotNil(t, d1a.writeAgent)
 	require.Equal(t, d1a.refCount, 1)
 
 	_, err = d1b.Read().SelectSpansSince(ctx, SelectSpansSinceParams{
@@ -57,12 +58,17 @@ func TestDBRefCount(t *testing.T) {
 	require.Nil(t, d1b.writer)
 	require.Nil(t, d1a.reader)
 	require.Nil(t, d1b.reader)
-	require.Nil(t, d1a.Queries)
-	require.Nil(t, d1b.Queries)
+	require.Nil(t, d1a.writeQueries)
+	require.Nil(t, d1b.writeQueries)
 	require.Nil(t, d1a.readQueries)
 	require.Nil(t, d1b.readQueries)
 	require.Equal(t, d1a.refCount, 0)
 	require.Equal(t, d1b.refCount, 0)
+	select {
+	case <-d1a.writeAgent.done:
+	default:
+		t.Fatal("client DB writer goroutine still running after final close")
+	}
 
 	_, err = d2a.Read().SelectSpansSince(ctx, SelectSpansSinceParams{
 		ID:    1,
@@ -74,9 +80,14 @@ func TestDBRefCount(t *testing.T) {
 	require.Len(t, dbs.open, 0)
 	require.Nil(t, d2a.writer)
 	require.Nil(t, d2a.reader)
-	require.Nil(t, d2a.Queries)
+	require.Nil(t, d2a.writeQueries)
 	require.Nil(t, d2a.readQueries)
 	require.Equal(t, d2a.refCount, 0)
+	select {
+	case <-d2a.writeAgent.done:
+	default:
+		t.Fatal("client DB writer goroutine still running after final close")
+	}
 }
 
 func TestDBCloseNil(t *testing.T) {

--- a/engine/clientdb/writer.go
+++ b/engine/clientdb/writer.go
@@ -1,0 +1,214 @@
+package clientdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// writeQueueSize bounds the number of telemetry batches retained by a client
+// DB's writer. Producers block when it is full; telemetry is never dropped.
+const writeQueueSize = 64
+
+var errWriterClosed = errors.New("client DB writer is closed")
+
+// WriteBatch performs one exporter's telemetry inserts. The duration it
+// returns is the slowest individual statement in the batch.
+type WriteBatch func(context.Context, *Queries) (time.Duration, error)
+
+// WriteTiming decomposes one queued batch's time through the client DB writer.
+// BeginWait is the time from submission until the batch starts inside a
+// coalesced transaction, including bounded-queue backpressure and earlier
+// queued batches. Commit is shared by every batch in the same transaction.
+type WriteTiming struct {
+	BeginWait time.Duration
+	MaxStmt   time.Duration
+	Commit    time.Duration
+}
+
+type writeRequest struct {
+	ctx    context.Context
+	start  time.Time
+	write  WriteBatch
+	result chan writeResponse
+}
+
+type writeResponse struct {
+	timing WriteTiming
+	err    error
+}
+
+// writeAgent is the sole acquirer of a client DB's write connection. It
+// coalesces every currently queued batch into one transaction, using a
+// savepoint to preserve per-batch rollback and error semantics.
+type writeAgent struct {
+	db      *sql.DB
+	queries *Queries
+	queue   chan *writeRequest
+	done    chan struct{}
+
+	// enqueueMu makes closing the queue safe against a producer blocked on
+	// bounded-queue backpressure. The writer never holds it during SQLite work.
+	enqueueMu sync.RWMutex
+	closed    bool
+}
+
+func newWriteAgent(db *sql.DB, queries *Queries) *writeAgent {
+	agent := &writeAgent{
+		db:      db,
+		queries: queries,
+		queue:   make(chan *writeRequest, writeQueueSize),
+		done:    make(chan struct{}),
+	}
+	go agent.run()
+	return agent
+}
+
+func (agent *writeAgent) submit(ctx context.Context, write WriteBatch) (WriteTiming, error) {
+	start := time.Now()
+	req := &writeRequest{
+		ctx:    ctx,
+		start:  start,
+		write:  write,
+		result: make(chan writeResponse, 1),
+	}
+
+	agent.enqueueMu.RLock()
+	if agent.closed {
+		agent.enqueueMu.RUnlock()
+		return WriteTiming{BeginWait: time.Since(start)}, errWriterClosed
+	}
+	select {
+	case agent.queue <- req:
+		agent.enqueueMu.RUnlock()
+	case <-ctx.Done():
+		agent.enqueueMu.RUnlock()
+		return WriteTiming{BeginWait: time.Since(start)}, context.Cause(ctx)
+	}
+
+	// Once admitted, wait for this batch's commit watermark. Returning early
+	// on ctx cancellation would let a successful export race the SSE reader.
+	res := <-req.result
+	return res.timing, res.err
+}
+
+func (agent *writeAgent) Close() {
+	agent.enqueueMu.Lock()
+	if !agent.closed {
+		agent.closed = true
+		close(agent.queue)
+	}
+	agent.enqueueMu.Unlock()
+	<-agent.done
+}
+
+func (agent *writeAgent) run() {
+	defer close(agent.done)
+
+	for {
+		first, ok := <-agent.queue
+		if !ok {
+			return
+		}
+
+		requests := []*writeRequest{first}
+		queueClosed := false
+	drain:
+		for {
+			select {
+			case req, ok := <-agent.queue:
+				if !ok {
+					queueClosed = true
+					break drain
+				}
+				requests = append(requests, req)
+			default:
+				break drain
+			}
+		}
+
+		agent.writeRequests(requests)
+		if queueClosed {
+			return
+		}
+	}
+}
+
+func (agent *writeAgent) writeRequests(requests []*writeRequest) {
+	pending := requests[:0]
+	for _, req := range requests {
+		if err := context.Cause(req.ctx); err != nil {
+			req.result <- writeResponse{
+				timing: WriteTiming{BeginWait: time.Since(req.start)},
+				err:    err,
+			}
+			continue
+		}
+		pending = append(pending, req)
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	tx, err := agent.db.BeginTx(context.Background(), nil)
+	timings := make([]WriteTiming, len(pending))
+	errs := make([]error, len(pending))
+	if err != nil {
+		for i, req := range pending {
+			timings[i].BeginWait = time.Since(req.start)
+		}
+		agent.respond(pending, timings, errs, fmt.Errorf("begin tx: %w", err))
+		return
+	}
+
+	q := agent.queries.WithTx(tx)
+	var txErr error
+	for i, req := range pending {
+		timings[i].BeginWait = time.Since(req.start)
+		if _, err := tx.ExecContext(context.Background(), "SAVEPOINT telemetry_batch"); err != nil {
+			txErr = fmt.Errorf("savepoint telemetry batch: %w", err)
+			break
+		}
+
+		timings[i].MaxStmt, errs[i] = req.write(context.WithoutCancel(req.ctx), q)
+		if errs[i] != nil {
+			if _, err := tx.ExecContext(context.Background(), "ROLLBACK TO SAVEPOINT telemetry_batch"); err != nil {
+				txErr = fmt.Errorf("rollback telemetry batch: %w", err)
+				break
+			}
+		}
+		if _, err := tx.ExecContext(context.Background(), "RELEASE SAVEPOINT telemetry_batch"); err != nil {
+			txErr = fmt.Errorf("release telemetry batch: %w", err)
+			break
+		}
+	}
+
+	if txErr != nil {
+		txErr = errors.Join(txErr, tx.Rollback())
+		agent.respond(pending, timings, errs, txErr)
+		return
+	}
+
+	commitStart := time.Now()
+	commitErr := tx.Commit()
+	commitDuration := time.Since(commitStart)
+	for i := range timings {
+		timings[i].Commit = commitDuration
+	}
+	if commitErr != nil {
+		commitErr = fmt.Errorf("commit telemetry batches: %w", commitErr)
+	}
+	agent.respond(pending, timings, errs, commitErr)
+}
+
+func (agent *writeAgent) respond(requests []*writeRequest, timings []WriteTiming, errs []error, transactionErr error) {
+	for i, req := range requests {
+		req.result <- writeResponse{
+			timing: timings[i],
+			err:    errors.Join(errs[i], transactionErr),
+		}
+	}
+}

--- a/engine/clientdb/writer_test.go
+++ b/engine/clientdb/writer_test.go
@@ -1,0 +1,193 @@
+package clientdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAgentConcurrentProducers(t *testing.T) {
+	const producers = 64
+
+	dbs := NewDBs(t.TempDir())
+	keepAlive, err := dbs.Open(t.Context(), "client")
+	require.NoError(t, err)
+	var closeOnce sync.Once
+	var closeErr error
+	closeKeepAlive := func() {
+		closeOnce.Do(func() { closeErr = keepAlive.Close() })
+	}
+	t.Cleanup(func() {
+		closeKeepAlive()
+		require.NoError(t, closeErr)
+	})
+
+	start := make(chan struct{})
+	errs := make(chan error, producers*2)
+	var wg sync.WaitGroup
+	for i := range producers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			db, err := dbs.Open(t.Context(), "client")
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer func() {
+				if err := db.Close(); err != nil {
+					errs <- err
+				}
+			}()
+
+			spanID := fmt.Sprintf("span-%d", i)
+			_, err = db.Write(t.Context(), insertSpanBatch(testSpan(spanID)))
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			// A successful return is this batch's commit watermark: the row
+			// must already be visible on the independent read pool.
+			span, err := db.Read().SelectSpan(t.Context(), SelectSpanParams{
+				TraceID: "trace",
+				SpanID:  spanID,
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if span.SpanID != spanID {
+				errs <- fmt.Errorf("selected span %q, expected %q", span.SpanID, spanID)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	spans, err := keepAlive.Read().SelectSpansSince(t.Context(), SelectSpansSinceParams{
+		Limit: producers + 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, spans, producers)
+	counts := make(map[string]int, producers)
+	for _, span := range spans {
+		counts[span.SpanID]++
+	}
+	for i := range producers {
+		require.Equal(t, 1, counts[fmt.Sprintf("span-%d", i)])
+	}
+
+	done := keepAlive.writeAgent.done
+	closeKeepAlive()
+	require.NoError(t, closeErr)
+	select {
+	case <-done:
+	default:
+		t.Fatal("client DB writer goroutine still running after final close")
+	}
+}
+
+func TestWriteAgentPropagatesBatchError(t *testing.T) {
+	dbs := NewDBs(t.TempDir())
+	db, err := dbs.Open(t.Context(), "client")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWrites := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseWrites)
+
+	blockerErr := make(chan error, 1)
+	go func() {
+		_, err := db.Write(t.Context(), func(context.Context, *Queries) (time.Duration, error) {
+			close(blocked)
+			<-release
+			return 0, nil
+		})
+		blockerErr <- err
+	}()
+	<-blocked
+
+	wantErr := errors.New("batch failed")
+	failed := testSpan("failed")
+	failedErr := make(chan error, 1)
+	go func() {
+		_, err := db.Write(t.Context(), func(ctx context.Context, q *Queries) (time.Duration, error) {
+			start := time.Now()
+			_, err := q.InsertSpan(ctx, failed)
+			if err != nil {
+				return time.Since(start), err
+			}
+			return time.Since(start), wantErr
+		})
+		failedErr <- err
+	}()
+
+	succeeded := testSpan("succeeded")
+	succeededErr := make(chan error, 1)
+	go func() {
+		_, err := db.Write(t.Context(), insertSpanBatch(succeeded))
+		succeededErr <- err
+	}()
+
+	// Hold the first transaction until both following batches are queued, so
+	// they are drained into the same transaction and exercise savepoint-level
+	// error isolation.
+	require.Eventually(t, func() bool {
+		return len(db.writeAgent.queue) == 2
+	}, 5*time.Second, time.Millisecond)
+	releaseWrites()
+	require.NoError(t, <-blockerErr)
+	require.ErrorIs(t, <-failedErr, wantErr)
+	require.NoError(t, <-succeededErr)
+
+	_, err = db.Read().SelectSpan(t.Context(), SelectSpanParams{
+		TraceID: failed.TraceID,
+		SpanID:  failed.SpanID,
+	})
+	require.ErrorIs(t, err, sql.ErrNoRows, "failed batch should roll back to its savepoint")
+
+	span, err := db.Read().SelectSpan(t.Context(), SelectSpanParams{
+		TraceID: succeeded.TraceID,
+		SpanID:  succeeded.SpanID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, succeeded.SpanID, span.SpanID)
+}
+
+func insertSpanBatch(span InsertSpanParams) WriteBatch {
+	return func(ctx context.Context, q *Queries) (time.Duration, error) {
+		start := time.Now()
+		_, err := q.InsertSpan(ctx, span)
+		return time.Since(start), err
+	}
+}
+
+func testSpan(spanID string) InsertSpanParams {
+	return InsertSpanParams{
+		TraceID:           "trace",
+		SpanID:            spanID,
+		Name:              spanID,
+		Kind:              "internal",
+		ResourceSchemaUrl: "",
+	}
+}

--- a/engine/clientdb/writer_test.go
+++ b/engine/clientdb/writer_test.go
@@ -174,6 +174,117 @@ func TestWriteAgentPropagatesBatchError(t *testing.T) {
 	require.Equal(t, succeeded.SpanID, span.SpanID)
 }
 
+func TestWriteAgentCloseWithBlockedProducers(t *testing.T) {
+	const blockedProducers = 4
+
+	dbs := NewDBs(t.TempDir())
+	db, err := dbs.Open(t.Context(), "client")
+	require.NoError(t, err)
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWriter := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+
+	var closeOnce sync.Once
+	var closeErr error
+	closeDB := func() {
+		closeOnce.Do(func() { closeErr = db.Close() })
+	}
+
+	t.Cleanup(func() {
+		releaseWriter()
+		closeDB()
+		require.NoError(t, closeErr)
+	})
+
+	writerBlocked := make(chan struct{})
+	blockerErr := make(chan error, 1)
+	go func() {
+		_, err := db.Write(t.Context(), func(context.Context, *Queries) (time.Duration, error) {
+			close(writerBlocked)
+			<-release
+			return 0, nil
+		})
+		blockerErr <- err
+	}()
+	<-writerBlocked
+
+	producerErrs := make(chan error, writeQueueSize+blockedProducers)
+	for range writeQueueSize {
+		go func() {
+			_, err := db.Write(t.Context(), emptyWriteBatch)
+			producerErrs <- err
+		}()
+	}
+	require.Eventually(t, func() bool {
+		return len(db.writeAgent.queue) == writeQueueSize
+	}, 5*time.Second, time.Millisecond)
+
+	// Done is evaluated inside submit's enqueue select, after enqueueMu.RLock
+	// is acquired. Waiting for every signal deterministically establishes that
+	// all overflow producers are blocked on the full queue while holding RLock.
+	for range blockedProducers {
+		ctx := &doneSignalingContext{
+			Context: t.Context(),
+			called:  make(chan struct{}),
+		}
+		go func() {
+			_, err := db.Write(ctx, emptyWriteBatch)
+			producerErrs <- err
+		}()
+		<-ctx.called
+	}
+
+	done := db.writeAgent.done
+	closeResult := make(chan error, 1)
+	go func() {
+		closeDB()
+		closeResult <- closeErr
+	}()
+
+	// Readers alone do not make TryRLock fail. A failure here establishes that
+	// Close is queued for enqueueMu.Lock behind the blocked producers.
+	require.Eventually(t, func() bool {
+		if db.writeAgent.enqueueMu.TryRLock() {
+			db.writeAgent.enqueueMu.RUnlock()
+			return false
+		}
+		return true
+	}, 5*time.Second, time.Millisecond)
+
+	releaseWriter()
+	require.NoError(t, <-blockerErr)
+	for range writeQueueSize + blockedProducers {
+		require.NoError(t, <-producerErrs)
+	}
+	require.NoError(t, <-closeResult)
+	select {
+	case <-done:
+	default:
+		t.Fatal("client DB writer goroutine still running after final close")
+	}
+
+	_, err = db.Write(t.Context(), emptyWriteBatch)
+	require.ErrorIs(t, err, errWriterClosed)
+}
+
+type doneSignalingContext struct {
+	context.Context
+	called chan struct{}
+	once   sync.Once
+}
+
+func (ctx *doneSignalingContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.called) })
+	return ctx.Context.Done()
+}
+
+func emptyWriteBatch(context.Context, *Queries) (time.Duration, error) {
+	return 0, nil
+}
+
 func insertSpanBatch(span InsertSpanParams) WriteBatch {
 	return func(ctx context.Context, q *Queries) (time.Duration, error) {
 		start := time.Now()

--- a/engine/server/telemetry.go
+++ b/engine/server/telemetry.go
@@ -210,22 +210,14 @@ const otlpBatchSize = 1000
 // client's shutdown budget (the CLI allows 10s for the whole shutdown drain).
 const slowTelemetryOp = 1 * time.Second
 
-// writeTiming decomposes how a batched client-DB write spent its wall-clock,
-// so "write N rows" is attributable to acquiring the single write connection
-// vs. the INSERTs themselves vs. the WAL commit.
-type writeTiming struct {
-	beginWait time.Duration // acquire the write connection + BEGIN IMMEDIATE
-	maxStmt   time.Duration // slowest single INSERT once the lock is held
-	commit    time.Duration // COMMIT (WAL append)
-}
-
 // logTelemetryWrite records how a client-DB write batch of N rows spent its
-// time. The write pool is a single connection per DB, so beginWait is the time
-// queued behind other writers for that connection (the writer convoy), while
-// maxStmtDuration/commitDuration are the actual SQLite work once it is held.
+// time. beginWait is now bounded-queue backpressure plus time waiting for the
+// per-DB write agent's next coalesced transaction, while maxStmtDuration and
+// commitDuration are the actual SQLite work once that transaction begins.
 // writeDuration is the whole batch write (beginWait + inserts + commit);
-// poolWaitDelta corroborates beginWait from database/sql's own accounting.
-func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart time.Time, t writeTiming, before, after sql.DBStats, err error) {
+// poolWaitDelta should remain near zero because only the agent acquires the
+// single write connection; it is retained so before/after captures compare.
+func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart time.Time, t clientdb.WriteTiming, before, after sql.DBStats, err error) {
 	total := time.Since(totalStart)
 	lg := slog.With(
 		"client", clientID,
@@ -233,9 +225,9 @@ func logTelemetryWrite(clientID, what string, rows int, totalStart, writeStart t
 		"rows", rows,
 		"duration", total,
 		"writeDuration", time.Since(writeStart),
-		"beginWait", t.beginWait,
-		"maxStmtDuration", t.maxStmt,
-		"commitDuration", t.commit,
+		"beginWait", t.BeginWait,
+		"maxStmtDuration", t.MaxStmt,
+		"commitDuration", t.Commit,
 		"poolWaitCountDelta", after.WaitCount-before.WaitCount,
 		"poolWaitDelta", after.WaitDuration-before.WaitDuration,
 		"error", err,
@@ -461,38 +453,21 @@ func (ps clientSpans) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 
 	statsBefore := db.Stats()
 	writeStart := time.Now()
-	var timing writeTiming
-	// Insert the whole batch under one write transaction so it takes the write
-	// lock once instead of once per row. The write pool is a single connection
-	// separate from the read pool, so holding it for the batch does not block
-	// SSE reads (which is why per-batch batching is safe here but was not on a
-	// shared connection).
-	insertErr := func() (rerr error) {
-		beginStart := time.Now()
-		tx, err := db.BeginTx(ctx, nil)
-		timing.beginWait = time.Since(beginStart)
-		if err != nil {
-			return fmt.Errorf("begin tx: %w", err)
-		}
-		defer func() {
-			if rerr != nil {
-				_ = tx.Rollback()
-			}
-		}()
-		q := db.WithTx(tx)
+	// Every producer targeting this DB submits to the same write agent. It
+	// coalesces pending span/log/metric batches into one transaction, while this
+	// callback preserves this span batch's own rollback and error result.
+	timing, insertErr := db.Write(ctx, func(writeCtx context.Context, q *clientdb.Queries) (time.Duration, error) {
+		var maxStmt time.Duration
 		for _, insert := range inserts {
 			stmtStart := time.Now()
-			_, err := q.InsertSpan(ctx, *insert)
-			timing.maxStmt = max(timing.maxStmt, time.Since(stmtStart))
+			_, err := q.InsertSpan(writeCtx, *insert)
+			maxStmt = max(maxStmt, time.Since(stmtStart))
 			if err != nil {
-				return fmt.Errorf("insert span: %w", err)
+				return maxStmt, fmt.Errorf("insert span: %w", err)
 			}
 		}
-		commitStart := time.Now()
-		err = tx.Commit()
-		timing.commit = time.Since(commitStart)
-		return err
-	}()
+		return maxStmt, nil
+	})
 	logTelemetryWrite(ps.client.clientID, "spans", len(inserts), start, writeStart, timing, statsBefore, db.Stats(), insertErr)
 	if insertErr != nil {
 		return insertErr
@@ -537,35 +512,24 @@ func (ps clientLogs) Export(ctx context.Context, logs []sdklog.Record) error {
 
 	statsBefore := db.Stats()
 	writeStart := time.Now()
-	var timing writeTiming
-	// Batch under one write transaction (see ExportSpans). Individual insert
-	// failures stay best-effort: log and continue rather than abort the batch.
-	beginStart := time.Now()
-	tx, err := db.BeginTx(ctx, nil)
-	timing.beginWait = time.Since(beginStart)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	q := db.WithTx(tx)
-	for _, insert := range inserts {
-		stmtStart := time.Now()
-		_, err := q.InsertLog(ctx, *insert)
-		timing.maxStmt = max(timing.maxStmt, time.Since(stmtStart))
-		if err != nil {
-			slog.Warn("failed to insert log record", "error", err)
-			continue
+	// Individual log insert failures stay best-effort, but queue, transaction,
+	// and commit errors propagate to this exporter after its commit watermark.
+	timing, writeErr := db.Write(ctx, func(writeCtx context.Context, q *clientdb.Queries) (time.Duration, error) {
+		var maxStmt time.Duration
+		for _, insert := range inserts {
+			stmtStart := time.Now()
+			_, err := q.InsertLog(writeCtx, *insert)
+			maxStmt = max(maxStmt, time.Since(stmtStart))
+			if err != nil {
+				slog.Warn("failed to insert log record", "error", err)
+				continue
+			}
 		}
-	}
-	commitStart := time.Now()
-	commitErr := tx.Commit()
-	timing.commit = time.Since(commitStart)
-	if commitErr != nil {
-		_ = tx.Rollback()
-		slog.Warn("failed to commit log records", "error", commitErr)
-	}
-	logTelemetryWrite(ps.client.clientID, "logs", len(inserts), start, writeStart, timing, statsBefore, db.Stats(), commitErr)
+		return maxStmt, nil
+	})
+	logTelemetryWrite(ps.client.clientID, "logs", len(inserts), start, writeStart, timing, statsBefore, db.Stats(), writeErr)
 
-	return nil
+	return writeErr
 }
 
 func (ps clientLogs) ForceFlush(ctx context.Context) error { return nil }
@@ -668,10 +632,12 @@ func (ps clientMetrics) Export(ctx context.Context, metrics *metricdata.Resource
 
 	statsBefore := db.Stats()
 	writeStart := time.Now()
-	_, err = db.InsertMetric(ctx, metricsPBBytes)
-	// Single auto-commit insert (not batched); the whole write shows up as
-	// maxStmt, with no separate begin/commit phases.
-	logTelemetryWrite(ps.client.clientID, "metrics", 1, start, writeStart, writeTiming{maxStmt: time.Since(writeStart)}, statsBefore, db.Stats(), err)
+	timing, err := db.Write(ctx, func(writeCtx context.Context, q *clientdb.Queries) (time.Duration, error) {
+		stmtStart := time.Now()
+		_, err := q.InsertMetric(writeCtx, metricsPBBytes)
+		return time.Since(stmtStart), err
+	})
+	logTelemetryWrite(ps.client.clientID, "metrics", 1, start, writeStart, timing, statsBefore, db.Stats(), err)
 	if err != nil {
 		return fmt.Errorf("insert metrics: %w", err)
 	}


### PR DESCRIPTION
## Problem

Even with #13670, #13681, #13695, and #13697 merged, the `/shutdown` deadline flake still occurs. In CI trace `e791c309b2ec180dfe3dbac46e09eab6`, the failing session's nested clients spent 8–10 seconds in the `flush client telemetry` drain phase, dominated by traces.

The engine-log timing decomposition shows a write convoy, not excess data volume. Writes targeting the main client's DB carried only 1–48 rows with millisecond statement times, but waited 1.3–3.2 seconds in `beginWait`, with as many as 111 queued acquisitions on the single write connection. Each nested client's own and per-ancestor processors, plus the OTLP POST handlers, independently serialized small writes on the same lock.

## Fix

Give each client DB one bounded writer goroutine. Every span, log, and metric batch submits to it, and each drain cycle coalesces the queued work into one transaction. A savepoint per batch preserves per-batch rollback and error propagation. Callers return only after their transaction commits, so the existing return-implies-visible flush contract remains unchanged.

The write pool is now unreachable except through the writer: the embedded `Queries`, `Begin`, and `BeginTx` escape hatches are removed. Writer lifetime follows the existing DB refcount lifecycle. The `slow client DB telemetry write` instrumentation retains all fields, with `beginWait` now measuring queue wait, so before/after CI captures remain directly comparable.

## Evidence

Deterministic tests cover concurrent-producer visibility through the independent read pool, savepoint error isolation inside a coalesced transaction, and close under saturated backpressure: overflow producers block, concurrent close neither panics nor loses admitted batches, and late writes fail cleanly. These pass under `-race`; the engine/server teardown race tests also pass. The full `TestTelemetry` suite passes all 54 cases via `engine-dev test --pkg ./dagql/idtui`.

This follows up on #13670, which identified per-DB fan-in as the remaining floor.

## Improvements
<img width="1021" height="209" alt="Screenshot 2026-07-21 at 7 15 10 PM" src="https://github.com/user-attachments/assets/6ba42697-edc5-4df1-ac93-e7f45f5b131a" />