### PR TITLE
fix: handle function arg name collision with inherited persistent flags

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -30,6 +30,16 @@ func (e *UnsupportedFlagError) Error() string {
 	return msg
 }
 
+// FlagExistsError is returned when a flag with the same name
+// already exists in the flag set.
+type FlagExistsError struct {
+	Name string
+}
+
+func (e *FlagExistsError) Error() string {
+	return fmt.Sprintf("flag already exists: %s", e.Name)
+}
+
 // GetCustomFlagValue returns a pflag.Value instance for a dagger.ObjectTypeDef name.
 func GetCustomFlagValue(name string) DaggerValue {
 	switch name {
@@ -644,7 +654,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 	usage := r.Description
 
 	if flags.Lookup(name) != nil {
-		return fmt.Errorf("flag already exists: %s", name)
+		return &FlagExistsError{Name: name}
 	}
 
 	switch r.TypeDef.Kind {

--- a/cmd/dagger/flags_test.go
+++ b/cmd/dagger/flags_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestFlagExistsError(t *testing.T) {
+	err := &FlagExistsError{Name: "workspace"}
+	if err.Error() != "flag already exists: workspace" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestAddFlag_FlagExistsError(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("workspace", "", "existing flag")
+
+	// Create a dummy arg using the modFunctionArg and its type definition.
+	// Since we only care about AddFlag erroring out early on Lookup(name),
+	// we just need Name and Description (via FlagName() and Description).
+	arg := &modFunctionArg{
+		Name:        "workspace",
+		Description: "workspace argument",
+	}
+
+	err := arg.AddFlag(fs)
+	if err == nil {
+		t.Fatal("expected error when flag already exists")
+	}
+
+	var fe *FlagExistsError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected FlagExistsError, got %T: %v", err, err)
+	}
+
+	if fe.Name != "workspace" {
+		t.Fatalf("expected flag name 'workspace', got %q", fe.Name)
+	}
+}

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -580,8 +580,19 @@ func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) 
 		}
 
 		if err := arg.AddFlag(cmd.Flags()); err != nil {
-			var e *UnsupportedFlagError
-			if errors.As(err, &e) {
+			var unsupportedErr *UnsupportedFlagError
+			if errors.As(err, &unsupportedErr) {
+				skipped = append(skipped, arg.FlagName())
+				continue
+			}
+			// NEW: Handle flag name collision with inherited persistent flags
+			var flagExistsErr *FlagExistsError
+			if errors.As(err, &flagExistsErr) {
+				// Flag name conflicts with an inherited persistent flag
+				// from a parent command. This is expected when a function
+				// arg name (e.g., "workspace") matches a global persistent
+				// flag. We skip it since the persistent flag already
+				// provides the needed functionality.
 				skipped = append(skipped, arg.FlagName())
 				continue
 			}


### PR DESCRIPTION
When a function argument name (e.g., 'workspace') matches a persistent flag inherited from a parent command, the CLI crashes with 'flag already exists: workspace'.

This change introduces a FlagExistsError type and handles it in addFlagsForFunction, skipping the flag gracefully (matching the existing behavior in addConstructorLocalFlags).

Fixes #13352