### PR TITLE
cli: add module dependency update command

### DIFF
--- a/core/integration/module_dependency_cli_test.go
+++ b/core/integration/module_dependency_cli_test.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"context"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (CLISuite) TestModuleDependencyUpdate(ctx context.Context, t *testctx.T) {
+	const (
+		stalePin = "b20176e68d27edc9660960ec27f323d33dba633b"
+		v041Pin  = "5c8b312cd7c8493966d28c118834d4e9565c7c62"
+	)
+
+	c := connect(ctx, t)
+	ctr := goGitBase(t, c).
+		WithNewFile("dagger-module.toml", `name = "foo"
+
+[runtime]
+source = "go"
+
+[[dependencies]]
+name = "docker"
+source = "github.com/shykes/daggerverse/docker@docker/v0.4.1"
+pin = "`+stalePin+`"
+`).
+		With(daggerExec("module", "deps", "update", "docker"))
+
+	moduleConfig, err := ctr.File("dagger-module.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Contains(t, moduleConfig, v041Pin)
+	require.NotContains(t, moduleConfig, stalePin)
+}

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1830,6 +1830,7 @@ Manage this module's dependencies
 * [dagger module deps add](#dagger-module-deps-add)	 - Add one or more dependencies to the module
 * [dagger module deps list](#dagger-module-deps-list)	 - List the current module's dependencies
 * [dagger module deps rm](#dagger-module-deps-rm)	 - Remove one or more dependencies from the module
+* [dagger module deps update](#dagger-module-deps-update)	 - Update one or more module dependencies
 
 ## dagger module deps add
 
@@ -1913,6 +1914,50 @@ dagger module deps rm <name>... [flags]
 
 ```
 dagger module deps rm wolfi
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -d, --debug                        Show debug logs and full verbosity
+      --env string                   Apply the named workspace environment overlay
+  -i, --interactive                  Spawn a terminal on container exec failure
+      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
+      --lock string                  Lock lookup mode (disabled, live, pinned, frozen). Defaults to disabled.
+  -E, --no-exit                      Leave the TUI running after completion
+      --org string                   Dagger Cloud org name for Cloud-scoped commands
+      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent                       Do not show progress at all
+  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
+  -w, --web                          Open trace URL in a web browser
+  -W, --workspace string             Select the workspace location to load from (local path or git ref)
+      --x-release string             Run an experimental release from a Dagger git ref
+```
+
+### SEE ALSO
+
+* [dagger module deps](#dagger-module-deps)	 - Manage this module's dependencies
+
+## dagger module deps update
+
+Update one or more module dependencies
+
+### Synopsis
+
+Update one or more module dependencies.
+
+With no arguments, updates all non-local dependencies.
+
+```
+dagger module deps update [module]... [flags]
+```
+
+### Examples
+
+```
+dagger module deps update wolfi@v0.20.2
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/dagger/module_cmd.go
+++ b/internal/cmd/dagger/module_cmd.go
@@ -85,6 +85,30 @@ var moduleDepsRmCmd = &cobra.Command{
 	},
 }
 
+var moduleDepsUpdateCmd = &cobra.Command{
+	Use:   "update [module]...",
+	Short: "Update one or more module dependencies",
+	Long: `Update one or more module dependencies.
+
+With no arguments, updates all non-local dependencies.`,
+	Example: "dagger module deps update wolfi@v0.20.2",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
+			modSrc, contextDir, err := currentModuleSourceForEdit(ctx, engineClient.Dagger())
+			if err != nil {
+				return err
+			}
+
+			if _, err := modSrc.WithUpdateDependencies(args).UpdatedConfigDirectory().Export(ctx, contextDir); err != nil {
+				return fmt.Errorf("update dependencies: %w", err)
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Updated dependencies.\nRun 'dagger generate' to refresh generated bindings.")
+			return err
+		})
+	},
+}
+
 var moduleDepsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the current module's dependencies",
@@ -258,7 +282,7 @@ func currentModuleSourceForEdit(ctx context.Context, dag *dagger.Client) (*dagge
 
 func init() {
 	moduleCmd.AddCommand(moduleDepsCmd, moduleEngineCmd, moduleSdkCmd)
-	moduleDepsCmd.AddCommand(moduleDepsAddCmd, moduleDepsRmCmd, moduleDepsListCmd)
+	moduleDepsCmd.AddCommand(moduleDepsAddCmd, moduleDepsRmCmd, moduleDepsUpdateCmd, moduleDepsListCmd)
 	moduleEngineCmd.AddCommand(
 		moduleEngineRequiredCmd,
 		moduleEngineRequireCmd,


### PR DESCRIPTION
## Problem

The new `dagger module deps` command group has `add`, `rm`, and `list`, but no `update`.

The update plumbing is still there in `ModuleSource.withUpdateDependencies`; it just was not wired into the new CLI surface. Running `dagger module deps update docker` therefore printed the `deps` help and left `dagger-module.toml` unchanged.

## Solution

Add `dagger module deps update [module]...` and wire it to the existing update API.

Like `add` and `rm`, the command only updates the module config and leaves code generation explicit. Passing dependency names or refs updates those dependencies. Passing no arguments updates all non-local dependencies, which is the existing API behavior.

The test starts with a deliberately stale pin for a fixed tag, runs the command, and checks that the canonical pin is written back. This covers the actual CLI-to-config path that was missing.

## Testing

If you want to test this by hand, run the command in a module with a remote dependency:

```console
dagger module deps update <dependency>
```

The dependency pin in `dagger-module.toml` should be updated. Run the command without a dependency to update all non-local dependencies.

Closes #13655.
