### PR TITLE
cli: prevent coding agents from hanging in generate

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -125,6 +125,64 @@ func (GeneratorsSuite) TestGeneratorsDirectSDK(ctx context.Context, t *testctx.T
 	}
 }
 
+func (GeneratorsSuite) TestGenerateApplyDisposition(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	modGen, err := generatorsTestEnv(t, c)
+	require.NoError(t, err)
+	modGen = modGen.WithWorkdir("hello-with-generators")
+	agent := modGen.WithEnvVariable("CODEX_CI", "1")
+
+	t.Run("agent requires an explicit choice before running", func(ctx context.Context, t *testctx.T) {
+		failed := agent.With(daggerExecFail("generate", "generate-files"))
+		out, err := failed.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "requires an explicit changeset choice")
+		require.Contains(t, out, "-y/--auto-apply")
+		require.Contains(t, out, "--no-apply")
+
+		exists, err := failed.Exists(ctx, "foo")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("agent list mode does not require a choice", func(ctx context.Context, t *testctx.T) {
+		out, err := agent.
+			With(daggerExec("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "generate-files")
+	})
+
+	t.Run("no apply previews without exporting", func(ctx context.Context, t *testctx.T) {
+		// Plain progress keeps the preview in the process output so this test can
+		// assert it directly. Agent detection still requires the explicit
+		// disposition independently of the selected progress frontend.
+		previewed := agent.With(daggerExec("generate", "generate-files", "--no-apply", "--progress=plain"))
+		out, err := previewed.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "foo")
+		require.Contains(t, out, "Generated changes were not applied (--no-apply).")
+
+		exists, err := previewed.Exists(ctx, "foo")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("report mode cannot wait for confirmation", func(ctx context.Context, t *testctx.T) {
+		failed := modGen.With(daggerExecFail("generate", "generate-files", "--progress=report"))
+		out, err := failed.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "interactive prompts are unavailable in report mode")
+		require.Contains(t, out, "-y/--auto-apply")
+		require.Contains(t, out, "--no-apply")
+
+		exists, err := failed.Exists(ctx, "foo")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+}
+
 // A generator whose changeset evaluates lazily and whose backing exec fails must
 // surface that failure -- the command, its stderr, and its exit code -- to the
 // user of `dagger generate`, rather than a bare "exit code: N" with the detail

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -155,10 +155,7 @@ func (GeneratorsSuite) TestGenerateApplyDisposition(ctx context.Context, t *test
 	})
 
 	t.Run("no apply previews without exporting", func(ctx context.Context, t *testctx.T) {
-		// Plain progress keeps the preview in the process output so this test can
-		// assert it directly. Agent detection still requires the explicit
-		// disposition independently of the selected progress frontend.
-		previewed := agent.With(daggerExec("generate", "generate-files", "--no-apply", "--progress=plain"))
+		previewed := agent.With(daggerExec("generate", "generate-files", "--no-apply"))
 		out, err := previewed.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 		require.Contains(t, out, "foo")

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -48,8 +48,9 @@ import (
 var historyFile = filepath.Join(xdg.DataHome, "dagger", "histfile")
 
 var (
-	ErrShellExited = errors.New("shell exited")
-	ErrInterrupted = errors.New("interrupted")
+	ErrShellExited    = errors.New("shell exited")
+	ErrInterrupted    = errors.New("interrupted")
+	ErrNonInteractive = errors.New("interactive prompts are unavailable in report mode")
 )
 
 // windowSize replaces tea.WindowSizeMsg for terminal dimensions.
@@ -1056,6 +1057,10 @@ func (fe *frontendPretty) HandlePrompt(ctx context.Context, title, prompt string
 }
 
 func (fe *frontendPretty) HandleForm(ctx context.Context, form *huh.Form) error {
+	if fe.reportOnly {
+		return ErrNonInteractive
+	}
+
 	done := make(chan struct{}, 1)
 	wrapCh := make(chan *teav1.Wrap, 1)
 

--- a/dagql/idtui/frontend_report_heartbeat_test.go
+++ b/dagql/idtui/frontend_report_heartbeat_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/huh"
 	"github.com/dagger/dagger/dagql/dagui"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/stretchr/testify/require"
@@ -130,4 +131,13 @@ func TestReportHeartbeatLineNoChecks(t *testing.T) {
 	line := fe.reportHeartbeatLine(30 * time.Second)
 	require.Contains(t, line, "30.0s elapsed")
 	require.NotContains(t, line, "checks:")
+}
+
+func TestReportHandleFormFailsFast(t *testing.T) {
+	fe := NewReporter(io.Discard)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	form := NewForm(huh.NewGroup(huh.NewConfirm().Title("Continue?")))
+	err := fe.HandleForm(ctx, form)
+	require.ErrorIs(t, err, ErrNonInteractive)
 }

--- a/dagql/idtui/output.go
+++ b/dagql/idtui/output.go
@@ -61,6 +61,7 @@ var agentEnvVars = []string{
 	"CURSOR_AGENT",         // Cursor CLI
 	"CURSOR_TRACE_ID",      // Cursor
 	"GEMINI_CLI",           // Gemini CLI
+	"CODEX_CI",             // OpenAI Codex
 	"CODEX_SANDBOX",        // OpenAI Codex
 	"CODEX_THREAD_ID",      // OpenAI Codex
 	"ANTIGRAVITY_AGENT",    // Antigravity
@@ -79,13 +80,17 @@ var agentEnvVars = []string{
 // Memoized: the render loop consults it per row per frame, the environment
 // can't change mid-process, and each os.Getenv takes the runtime's env lock.
 var RunningInAgent = sync.OnceValue(func() bool {
+	return runningInAgent(os.Getenv)
+})
+
+func runningInAgent(getenv func(string) string) bool {
 	for _, name := range agentEnvVars {
-		if os.Getenv(name) != "" {
+		if getenv(name) != "" {
 			return true
 		}
 	}
 	return false
-})
+}
 
 var (
 	bgOnce    = &sync.Once{}

--- a/dagql/idtui/output_test.go
+++ b/dagql/idtui/output_test.go
@@ -1,0 +1,29 @@
+package idtui
+
+import "testing"
+
+func TestRunningInAgentSignals(t *testing.T) {
+	for _, name := range agentEnvVars {
+		t.Run(name, func(t *testing.T) {
+			env := map[string]string{name: "1"}
+			if !runningInAgent(func(name string) string { return env[name] }) {
+				t.Fatalf("expected %s to indicate an agent", name)
+			}
+		})
+	}
+}
+
+func TestRunningInAgentIgnoresUnrelatedAndEmptySignals(t *testing.T) {
+	tests := map[string]map[string]string{
+		"empty":             {},
+		"CI":                {"CI": "true"},
+		"empty agent value": {"CODEX_CI": ""},
+	}
+	for name, env := range tests {
+		t.Run(name, func(t *testing.T) {
+			if runningInAgent(func(name string) string { return env[name] }) {
+				t.Fatal("unexpected agent detection")
+			}
+		})
+	}
+}

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1365,6 +1365,7 @@ Generate derived files for your project — code, SDKs, types, docs, etc.
 Examples:
   dagger generate                            # Generate all assets
   dagger generate -l                         # List all available generators
+  dagger generate --no-apply                 # Show generated changes without applying them
   dagger generate go:bin                     # Generate by selecting the generator function
   dagger -W github.com/acme/ws generate go:bin  # Generate against explicit workspace
 
@@ -1377,6 +1378,7 @@ dagger generate [options] [pattern...]
 
 ```
   -l, --list           List available generators
+      --no-apply       Compute and show a summary of generated changes without applying them
       --require-load   Fail if any workspace module cannot be loaded (default: report as a warning and generate the rest)
 ```
 

--- a/docs/current_docs/using-dagger/changesets.mdx
+++ b/docs/current_docs/using-dagger/changesets.mdx
@@ -12,7 +12,7 @@ Changesets come from **generators** (run by `dagger generate`) and from function
 
 ## Review and apply
 
-When a command returns a changeset, Dagger shows you the diff and waits for you to apply it. Nothing is written until you approve.
+When a command returns a changeset, Dagger shows you a summary of the changed paths and line counts, then waits for you to apply it. Nothing is written until you approve.
 
 ## Apply automatically
 
@@ -21,6 +21,16 @@ Pass `-y` / `--auto-apply` to apply changes without prompting — useful in scri
 ```shell
 dagger generate -y
 ```
+
+## Coding agents and non-interactive use
+
+When Dagger detects that a coding agent is running `dagger generate`, it requires an explicit choice before starting any generators. Pass `-y` / `--auto-apply` to apply the result, or pass `--no-apply` to run the generators and show the changes without writing them to your working tree:
+
+```shell
+dagger generate --no-apply
+```
+
+`--no-apply` exits successfully even when it finds pending changes, just like choosing **Discard** at the interactive prompt. It only prevents Dagger from exporting the returned changeset; generators still run and may perform other work. To make pending generated changes fail the command, use `dagger check --generate`.
 
 ## In CI
 

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -926,15 +926,41 @@ func toChangeset(dag *dagger.Client, item any) (*dagger.Changeset, error) {
 }
 
 func handleChangesetResponse(ctx context.Context, dag *dagger.Client, response any, autoApply bool) error {
-	_, err := handleChangesetResponseAt(ctx, dag, response, autoApply, ".")
+	_, err := handleChangesetResponseAt(ctx, dag, response, changesetDispositionForAutoApply(autoApply), ".", nil)
+	return err
+}
+
+type changesetDisposition int
+
+const (
+	changesetDispositionPrompt changesetDisposition = iota
+	changesetDispositionApply
+	changesetDispositionNoApply
+)
+
+func changesetDispositionForAutoApply(autoApply bool) changesetDisposition {
+	if autoApply {
+		return changesetDispositionApply
+	}
+	return changesetDispositionPrompt
+}
+
+func handleChangesetResponseWithDisposition(
+	ctx context.Context,
+	dag *dagger.Client,
+	response any,
+	disposition changesetDisposition,
+	previewOut io.Writer,
+) error {
+	_, err := handleChangesetResponseAt(ctx, dag, response, disposition, ".", previewOut)
 	return err
 }
 
 // handleChangesetResponseAt reports whether it actually applied the changeset,
 // so callers can print follow-up guidance only when files were written (not on
 // a no-op or a declined preview).
-func handleChangesetResponseAt(ctx context.Context, dag *dagger.Client, response any, autoApply bool, exportPath string) (applied bool, rerr error) {
-	return handleChangesetResponseWithApply(ctx, dag, response, autoApply, func(ctx context.Context, changeset *dagger.Changeset) error {
+func handleChangesetResponseAt(ctx context.Context, dag *dagger.Client, response any, disposition changesetDisposition, exportPath string, previewOut io.Writer) (applied bool, rerr error) {
+	return handleChangesetResponseWithApply(ctx, dag, response, disposition, previewOut, func(ctx context.Context, changeset *dagger.Changeset) error {
 		_, err := changeset.Export(ctx, exportPath)
 		return err
 	})
@@ -945,7 +971,7 @@ func handleWorkspaceResponse(ctx context.Context, dag *dagger.Client, workspace 
 	if err != nil {
 		return false, err
 	}
-	return handleChangesetResponseWithApply(ctx, dag, workspace.Changes(), autoApply, func(ctx context.Context, _ *dagger.Changeset) error {
+	return handleChangesetResponseWithApply(ctx, dag, workspace.Changes(), changesetDispositionForAutoApply(autoApply), nil, func(ctx context.Context, _ *dagger.Changeset) error {
 		return workspace.Export(ctx)
 	})
 }
@@ -962,7 +988,8 @@ func handleChangesetResponseWithApply(
 	ctx context.Context,
 	dag *dagger.Client,
 	response any,
-	autoApply bool,
+	disposition changesetDisposition,
+	previewOut io.Writer,
 	apply func(context.Context, *dagger.Changeset) error,
 ) (applied bool, rerr error) {
 	changeset, err := toChangeset(dag, response)
@@ -991,7 +1018,15 @@ func handleChangesetResponseWithApply(
 	patchpreview.Summarize(idtui.NewOutput(&descBuf), entries, summaryWidth)
 	description := descBuf.String()
 
-	if !autoApply {
+	switch disposition {
+	case changesetDispositionNoApply:
+		if previewOut == nil {
+			return false, errors.New("no preview output configured for --no-apply")
+		}
+		fmt.Fprintln(previewOut, description)
+		fmt.Fprintln(previewOut, "Generated changes were not applied (--no-apply).")
+		return false, nil
+	case changesetDispositionPrompt:
 		var confirm bool
 		form := idtui.NewForm(
 			huh.NewGroup(
@@ -1004,11 +1039,18 @@ func handleChangesetResponseWithApply(
 			),
 		)
 		if err := Frontend.HandleForm(ctx, form); err != nil {
+			if errors.Is(err, idtui.ErrNonInteractive) {
+				return false, fmt.Errorf("%w; pass -y/--auto-apply to apply changes without prompting", err)
+			}
 			return false, err
 		}
 		if !confirm {
 			return false, nil
 		}
+	case changesetDispositionApply:
+		// Apply below without prompting.
+	default:
+		return false, fmt.Errorf("unknown changeset disposition %d", disposition)
 	}
 
 	ctx, span := Tracer().Start(ctx, "applying changes")

--- a/internal/cmd/dagger/generators.go
+++ b/internal/cmd/dagger/generators.go
@@ -3,6 +3,7 @@ package daggercmd
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/dagql/dagui"
+	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/slog"
 	telemetry "github.com/dagger/otel-go"
@@ -20,6 +22,7 @@ import (
 var (
 	generateListMode    bool
 	generateRequireLoad bool
+	generateNoApply     bool
 )
 
 //go:embed generators.graphql
@@ -28,6 +31,7 @@ var loadGeneratorsQuery string
 func init() {
 	generateCmd.Flags().BoolVarP(&generateListMode, "list", "l", false, "List available generators")
 	generateCmd.Flags().BoolVar(&generateRequireLoad, "require-load", false, "Fail if any workspace module cannot be loaded (default: report as a warning and generate the rest)")
+	generateCmd.Flags().BoolVar(&generateNoApply, "no-apply", false, "Compute and show a summary of generated changes without applying them")
 }
 
 var generateCmd = &cobra.Command{
@@ -38,11 +42,17 @@ var generateCmd = &cobra.Command{
 Examples:
   dagger generate                            # Generate all assets
   dagger generate -l                         # List all available generators
+  dagger generate --no-apply                 # Show generated changes without applying them
   dagger generate go:bin                     # Generate by selecting the generator function
   dagger -W github.com/acme/ws generate go:bin  # Generate against explicit workspace
 `,
 	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		disposition, err := generateChangesetDisposition(generateListMode, autoApply, generateNoApply, idtui.RunningInAgent())
+		if err != nil {
+			return err
+		}
+
 		params := client.Params{
 			LoadWorkspaceModules: true,
 		}
@@ -75,10 +85,33 @@ Examples:
 				if generateListMode {
 					return listGenerators(ctx, dag, generators, cmd)
 				}
-				return runGenerators(ctx, dag, generators, cmd)
+				return runGenerators(ctx, dag, generators, cmd, disposition)
 			},
 		)
 	},
+}
+
+func generateChangesetDisposition(list, apply, noApply, runningInAgent bool) (changesetDisposition, error) {
+	if apply && noApply {
+		return changesetDispositionPrompt, errors.New("--auto-apply and --no-apply cannot be used together")
+	}
+	if list {
+		return changesetDispositionPrompt, nil
+	}
+	if apply {
+		return changesetDispositionApply, nil
+	}
+	if noApply {
+		return changesetDispositionNoApply, nil
+	}
+	if runningInAgent {
+		return changesetDispositionPrompt, errors.New(`dagger generate requires an explicit changeset choice when run by a coding agent:
+  pass -y/--auto-apply to apply generated changes
+  pass --no-apply to show generated changes without applying them
+
+For an up-to-date check that fails on pending changes, use dagger check --generate.`)
+	}
+	return changesetDispositionPrompt, nil
 }
 
 // generatorGroupLoadFailures reads the best-effort per-module load failures for
@@ -164,11 +197,20 @@ func listGenerators(ctx context.Context, dag *dagger.Client, generatorGroup *dag
 }
 
 // 'dagger generators' (runs by default)
-func runGenerators(ctx context.Context, dag *dagger.Client, generatorGroup *dagger.GeneratorGroup, _ *cobra.Command) (rerr error) {
+func runGenerators(ctx context.Context, dag *dagger.Client, generatorGroup *dagger.GeneratorGroup, cmd *cobra.Command, disposition changesetDisposition) (rerr error) {
 	ctx, zoomSpan := Tracer().Start(ctx, "generators", telemetry.Passthrough())
 	defer zoomSpan.End()
 	Frontend.SetPrimary(dagui.SpanID{SpanID: zoomSpan.SpanContext().SpanID()})
 	slog.SetDefault(slog.SpanLogger(ctx, InstrumentationLibrary))
+	previewOut := cmd.ErrOrStderr()
+	if disposition == changesetDispositionNoApply {
+		// SetPrimary above focuses rendering on the generators span. Attach the
+		// preview to that span too; command stderr is attached to the root span
+		// and would otherwise be hidden by plain/report progress frontends.
+		previewStdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+		defer previewStdio.Close()
+		previewOut = previewStdio.Stderr
+	}
 	// We don't actually use the API for rendering results
 	// Instead, we rely on telemetry
 	// FIXME: this feels a little weird. Can we move the relevant telemetry collection in the API?
@@ -182,5 +224,9 @@ func runGenerators(ctx context.Context, dag *dagger.Client, generatorGroup *dagg
 	if err != nil {
 		return err
 	}
-	return handleChangesetResponse(ctx, dag, cs, autoApply)
+	err = handleChangesetResponseWithDisposition(ctx, dag, cs, disposition, previewOut)
+	if errors.Is(err, idtui.ErrNonInteractive) {
+		return fmt.Errorf("%w; pass -y/--auto-apply to apply changes, or --no-apply to show them without applying", idtui.ErrNonInteractive)
+	}
+	return err
 }

--- a/internal/cmd/dagger/generators.go
+++ b/internal/cmd/dagger/generators.go
@@ -109,7 +109,7 @@ func generateChangesetDisposition(list, apply, noApply, runningInAgent bool) (ch
   pass -y/--auto-apply to apply generated changes
   pass --no-apply to show generated changes without applying them
 
-For an up-to-date check that fails on pending changes, use dagger check --generate.`)
+For an up-to-date check that fails on pending changes, use dagger check --generate`)
 	}
 	return changesetDispositionPrompt, nil
 }

--- a/internal/cmd/dagger/generators_test.go
+++ b/internal/cmd/dagger/generators_test.go
@@ -1,0 +1,47 @@
+package daggercmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateChangesetDisposition(t *testing.T) {
+	tests := []struct {
+		name           string
+		list           bool
+		apply          bool
+		noApply        bool
+		runningInAgent bool
+		want           changesetDisposition
+		wantErr        string
+	}{
+		{name: "human prompt", want: changesetDispositionPrompt},
+		{name: "agent requires choice", runningInAgent: true, want: changesetDispositionPrompt, wantErr: "requires an explicit changeset choice"},
+		{name: "agent apply", apply: true, runningInAgent: true, want: changesetDispositionApply},
+		{name: "agent no apply", noApply: true, runningInAgent: true, want: changesetDispositionNoApply},
+		{name: "human apply", apply: true, want: changesetDispositionApply},
+		{name: "human no apply", noApply: true, want: changesetDispositionNoApply},
+		{name: "agent list is exempt", list: true, runningInAgent: true, want: changesetDispositionPrompt},
+		{name: "conflicting choices", apply: true, noApply: true, want: changesetDispositionPrompt, wantErr: "cannot be used together"},
+		{name: "conflicting choices in list mode", list: true, apply: true, noApply: true, want: changesetDispositionPrompt, wantErr: "cannot be used together"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := generateChangesetDisposition(test.list, test.apply, test.noApply, test.runningInAgent)
+			require.Equal(t, test.want, got)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestGenerateNoApplyIsLongFormOnly(t *testing.T) {
+	flag := generateCmd.Flags().Lookup("no-apply")
+	require.NotNil(t, flag)
+	require.Empty(t, flag.Shorthand)
+}


### PR DESCRIPTION
## Summary

Coding agents can run `dagger generate` through a PTY and miss the confirmation prompt shown when generated changes need to be applied. The command then appears hung while it silently waits for input.

This change makes the disposition explicit when Dagger recognizes a coding-agent environment:

- fail before engine startup unless `-y` / `--auto-apply` or `--no-apply` is supplied;
- apply generated changes without prompting with `-y` / `--auto-apply`;
- run generators, show the change summary, skip changeset export, and exit successfully with `--no-apply`;
- keep `dagger generate -l` inspection-only and exempt from the disposition requirement;
- reject conflicting `--auto-apply` and `--no-apply` flags;
- preserve the existing interactive confirmation for normal human terminal use; and
- fail report-mode forms immediately with actionable guidance instead of waiting for input that cannot be provided.

Detection reuses the existing narrow coding-agent environment detector and adds the `CODEX_CI` signal. It intentionally does not claim to detect every possible agent. The documentation also distinguishes `--no-apply` from `dagger check --generate`: generators still run and may have secondary effects, while only changeset export is suppressed.

## Validation

Focused tests cover disposition precedence, the long-form-only flag, agent preflight, list behavior, no-export semantics, agent-default report output, and report-mode fail-fast behavior.

```console
dagger -W . api call engine-dev test --pkg ./core/integration --run='TestGenerators/TestGenerateApplyDisposition' --parallel=1
```

Result: 6 tests passed with a clean outer exit in 2m17s.

Trace: `555b0f3a23fb980ff2e91dbef25523f8`
