### PR TITLE
fix: clean legacy generated-code ignores during setup

### DIFF
--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -125,6 +125,27 @@ type Myapp {
 	})
 }
 
+// Generated SDK files become part of the module source after migration. Setup
+// must therefore remove the ignore rules written for the legacy runtime-codegen
+// model while leaving the user's own rules alone.
+func (WorkspaceMigrationSuite) TestWorkspaceMigrateGeneratedCodeGitignore(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	ctr := legacySDKOnlyGoSource(t, c, "hello after migration").
+		WithNewFile(".gitignore", "# user-owned rules\n*.log\n").
+		With(materializeModuleFiles(".")).
+		WithExec([]string{"grep", "-Fx", "/dagger.gen.go", ".gitignore"}).
+		With(daggerExec("setup", "--auto-apply"))
+
+	gitignore, err := ctr.File(".gitignore").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "# user-owned rules\n*.log\n/.env\n", gitignore)
+
+	out, err := ctr.With(daggerCallAt(".", "greet")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hello after migration", strings.TrimSpace(out))
+}
+
 // TestWorkspaceMigrateOutcomes should cover the main result classes of a
 // migration.
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateOutcomes(ctx context.Context, t *testctx.T) {

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -129,21 +129,66 @@ type Myapp {
 // must therefore remove the ignore rules written for the legacy runtime-codegen
 // model while leaving the user's own rules alone.
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateGeneratedCodeGitignore(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
+	t.Run("migrated module ignores are cleaned", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
-	ctr := legacySDKOnlyGoSource(t, c, "hello after migration").
-		WithNewFile(".gitignore", "# user-owned rules\n*.log\n").
-		With(materializeModuleFiles(".")).
-		WithExec([]string{"grep", "-Fx", "/dagger.gen.go", ".gitignore"}).
-		With(daggerExec("setup", "--auto-apply"))
+		ctr := legacySDKOnlyGoSource(t, c, "hello after migration").
+			WithNewFile(".gitignore", "# user-owned rules\n*.log\n").
+			With(materializeModuleFiles(".")).
+			WithExec([]string{"grep", "-Fx", "/dagger.gen.go", ".gitignore"}).
+			With(daggerExec("setup", "--auto-apply"))
 
-	gitignore, err := ctr.File(".gitignore").Contents(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "# user-owned rules\n*.log\n/.env\n", gitignore)
+		gitignore, err := ctr.File(".gitignore").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "# user-owned rules\n*.log\n/.env\n", gitignore)
 
-	out, err := ctr.With(daggerCallAt(".", "greet")).Stdout(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "hello after migration", strings.TrimSpace(out))
+		out, err := ctr.With(daggerCallAt(".", "greet")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello after migration", strings.TrimSpace(out))
+	})
+
+	t.Run("nested-workspace dependency keeps its ignores", func(ctx context.Context, t *testctx.T) {
+		// A dependency with its own toolchains stays legacy and keeps runtime
+		// codegen, so its generated-code ignore rules must survive the
+		// migration happening around it.
+		c := connect(ctx, t)
+
+		nestedGitignore := "# nested rules\n/dagger.gen.go\n/internal/dagger\n/internal/telemetry\n"
+		ctr := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "sdk": {"source": "dang"},
+  "source": "ci",
+  "dependencies": [{"name": "nested", "source": "./nested"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+			return ctr.
+				WithNewFile("ci/main.dang", `
+type Myapp {
+  pub greet: String! { "hello from root" }
+}
+`).
+				WithNewFile("nested/dagger.json", `{"name":"nested","sdk":{"source":"go"},"toolchains":[{"name":"x","source":"./x"}]}`).
+				WithNewFile("nested/main.go", `package main
+
+type Nested struct{}
+
+func (m *Nested) Message() string {
+	return "nested"
+}
+`).
+				WithNewFile("nested/.gitignore", nestedGitignore).
+				With(legacyDangModule("nested/x", "x", "X", "hello from toolchain"))
+		}).With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		_, err = ctr.WithExec([]string{"test", "-f", "nested/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "the nested workspace dependency should stay legacy")
+
+		gitignore, err := ctr.File("nested/.gitignore").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, nestedGitignore, gitignore, "a module left in legacy format keeps runtime codegen; its ignore rules must stay")
+	})
 }
 
 // TestWorkspaceMigrateOutcomes should cover the main result classes of a

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2521,6 +2521,27 @@ func ignoresGeneratedPath(ignore string, generated []string) bool {
 	return false
 }
 
+func (s *moduleSourceSchema) runSDKCodegen(
+	ctx context.Context,
+	srcInst dagql.ObjectResult[*core.ModuleSource],
+) (*core.GeneratedCode, error) {
+	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dependencies as modules: %w", err)
+	}
+
+	generatedCodeImpl, ok := srcInst.Self().SDKImpl.AsCodeGenerator()
+	if !ok {
+		return nil, ErrSDKCodegenNotImplemented{SDK: srcInst.Self().SDK.Source}
+	}
+
+	generatedCode, err := generatedCodeImpl.Codegen(ctx, deps, srcInst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate code: %w", err)
+	}
+	return generatedCode, nil
+}
+
 func (s *moduleSourceSchema) runCodegen(
 	ctx context.Context,
 	srcInst dagql.ObjectResult[*core.ModuleSource],
@@ -2530,21 +2551,10 @@ func (s *moduleSourceSchema) runCodegen(
 		return res, fmt.Errorf("failed to get current dag: %w", err)
 	}
 
-	// load the deps as actual Modules
-	deps, err := s.loadDependencyModules(ctx, srcInst, srcInst)
-	if err != nil {
-		return res, fmt.Errorf("failed to load dependencies as modules: %w", err)
-	}
-
-	generatedCodeImpl, ok := srcInst.Self().SDKImpl.AsCodeGenerator()
-	if !ok {
-		return res, ErrSDKCodegenNotImplemented{SDK: srcInst.Self().SDK.Source}
-	}
-
 	// run codegen to get the generated context directory
-	generatedCode, err := generatedCodeImpl.Codegen(ctx, deps, srcInst)
+	generatedCode, err := s.runSDKCodegen(ctx, srcInst)
 	if err != nil {
-		return res, fmt.Errorf("failed to generate code: %w", err)
+		return res, err
 	}
 	genDirInst := generatedCode.Code
 

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -24,6 +25,12 @@ type workspaceMigrationPlanBundle struct {
 	WorkspacePlans          []*workspace.MigrationPlan
 	ParentPlans             []workspaceMigrationParentPlan
 	ModuleConfigConversions []workspaceMigrationModuleConfigConversion
+	GitignoreCleanups       []workspaceMigrationGitignoreCleanup
+}
+
+type workspaceMigrationGitignoreCleanup struct {
+	Path    string
+	Entries []string
 }
 
 type workspaceMigrationLegacyLockMove struct {
@@ -114,12 +121,15 @@ func (s *workspaceSchema) migrate(
 	if err != nil {
 		return nil, err
 	}
+	gitignoreCleanups, gitignoreWarnings := s.workspaceMigrationGitignoreCleanups(ctx, ws, compatWorkspaces)
 	planBundle := workspaceMigrationPlanBundle{
 		WorkspacePlans:          plans,
 		ParentPlans:             parentPlans,
 		ModuleConfigConversions: moduleConfigConversions,
+		GitignoreCleanups:       gitignoreCleanups,
 	}
 	warnings := workspaceMigrationPlanBundleWarnings(planBundle)
+	warnings = append(warnings, gitignoreWarnings...)
 	warnings = append(warnings, discoveryWarnings...)
 
 	if planBundle.empty() {
@@ -144,6 +154,94 @@ func (s *workspaceSchema) migrate(
 				Changes:     changes,
 			},
 		},
+	}, nil
+}
+
+func (s *workspaceSchema) workspaceMigrationGitignoreCleanups(
+	ctx context.Context,
+	ws *core.Workspace,
+	compatWorkspaces []*workspace.CompatWorkspace,
+) ([]workspaceMigrationGitignoreCleanup, []string) {
+	ctx, err := s.withWorkspaceClientContext(ctx, ws)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("could not prepare legacy .gitignore cleanup: %v", err)}
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("could not prepare legacy .gitignore cleanup: %v", err)}
+	}
+
+	cleanups := make([]workspaceMigrationGitignoreCleanup, 0, len(compatWorkspaces))
+	warnings := make([]string, 0)
+	for _, compatWorkspace := range compatWorkspaces {
+		if compatWorkspace == nil || compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil {
+			continue
+		}
+		cleanup, err := s.workspaceMigrationGitignoreCleanup(ctx, srv, ws, compatWorkspace)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf(
+				"could not clean legacy .gitignore for module %q: %v",
+				compatWorkspace.Config.Name,
+				err,
+			))
+			continue
+		}
+		if cleanup != nil {
+			cleanups = append(cleanups, *cleanup)
+		}
+	}
+	return cleanups, warnings
+}
+
+func (s *workspaceSchema) workspaceMigrationGitignoreCleanup(
+	ctx context.Context,
+	srv *dagql.Server,
+	ws *core.Workspace,
+	compatWorkspace *workspace.CompatWorkspace,
+) (*workspaceMigrationGitignoreCleanup, error) {
+	var source dagql.ObjectResult[*core.ModuleSource]
+	if err := srv.Select(ctx, srv.Root(), &source, dagql.Selector{
+		Field: "moduleSource",
+		Args: []dagql.NamedInput{
+			{Name: "refString", Value: dagql.String(compatWorkspace.ProjectRoot)},
+			{Name: "disableFindUp", Value: dagql.Boolean(true)},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("load legacy module source: %w", err)
+	}
+
+	sourceSchema := &moduleSourceSchema{}
+	generatedCode, err := sourceSchema.runSDKCodegen(ctx, source)
+	if err != nil {
+		var missingImpl ErrSDKCodegenNotImplemented
+		if errors.As(err, &missingImpl) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	entries := make([]string, 0, len(generatedCode.VCSIgnoredPaths))
+	for _, ignore := range generatedCode.VCSIgnoredPaths {
+		if ignoresGeneratedPath(ignore, generatedCode.VCSGeneratedPaths) {
+			entries = append(entries, "/"+strings.TrimPrefix(ignore, "/"))
+		}
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	projectRoot, err := workspaceMigrationProjectRootRelPath(ws, compatWorkspace.ProjectRoot)
+	if err != nil {
+		return nil, err
+	}
+	sourcePath := compatWorkspace.Config.Source
+	if sourcePath != "" && !filepath.IsLocal(sourcePath) {
+		return nil, fmt.Errorf("module source path %q escapes its project", sourcePath)
+	}
+
+	return &workspaceMigrationGitignoreCleanup{
+		Path:    filepath.Join(projectRoot, sourcePath, ".gitignore"),
+		Entries: entries,
 	}, nil
 }
 
@@ -615,6 +713,10 @@ func (s *workspaceSchema) workspaceMigrationChangeset(
 	if err != nil {
 		return nil, err
 	}
+	updatedDir, err = applyWorkspaceMigrationGitignoreCleanups(ctx, updatedDir, plans.GitignoreCleanups)
+	if err != nil {
+		return nil, err
+	}
 	updatedDir, err = applyWorkspaceMigrationWorkspacePlans(ctx, ws, updatedDir, plans.WorkspacePlans)
 	if err != nil {
 		return nil, err
@@ -639,6 +741,62 @@ func (s *workspaceSchema) workspaceMigrationChangeset(
 		return nil, fmt.Errorf("migration changeset: %w", err)
 	}
 	return changes.Self(), nil
+}
+
+func applyWorkspaceMigrationGitignoreCleanups(
+	ctx context.Context,
+	dir dagql.ObjectResult[*core.Directory],
+	cleanups []workspaceMigrationGitignoreCleanup,
+) (dagql.ObjectResult[*core.Directory], error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dir, err
+	}
+	for _, cleanup := range cleanups {
+		stat, err := dir.Self().Stat(ctx, dir, srv, cleanup.Path, true)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return dir, fmt.Errorf("stat legacy gitignore %q: %w", cleanup.Path, err)
+		}
+
+		contents, err := core.DirectoryReadFile(ctx, dir, cleanup.Path)
+		if err != nil {
+			return dir, fmt.Errorf("read legacy gitignore %q: %w", cleanup.Path, err)
+		}
+		updatedContents := removeWorkspaceMigrationGitignoreEntries(contents, cleanup.Entries)
+		if bytes.Equal(contents, updatedContents) {
+			continue
+		}
+
+		dir, err = workspaceMigrationSelectDirectory(ctx, dir, "withNewFile", []dagql.NamedInput{
+			{Name: "path", Value: dagql.NewString(path.Clean(filepath.ToSlash(cleanup.Path)))},
+			{Name: "contents", Value: dagql.String(updatedContents)},
+			{Name: "permissions", Value: dagql.Int(stat.Permissions)},
+		})
+		if err != nil {
+			return dir, fmt.Errorf("rewrite legacy gitignore %q: %w", cleanup.Path, err)
+		}
+	}
+	return dir, nil
+}
+
+func removeWorkspaceMigrationGitignoreEntries(contents []byte, entries []string) []byte {
+	remove := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		remove[entry] = struct{}{}
+	}
+
+	updated := make([]byte, 0, len(contents))
+	for _, line := range bytes.SplitAfter(contents, []byte("\n")) {
+		value := strings.TrimSuffix(strings.TrimSuffix(string(line), "\n"), "\r")
+		if _, ok := remove[value]; ok {
+			continue
+		}
+		updated = append(updated, line...)
+	}
+	return updated
 }
 
 func applyWorkspaceMigrationLegacyLockMoves(

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -177,6 +177,11 @@ func (s *workspaceSchema) workspaceMigrationGitignoreCleanups(
 		if compatWorkspace == nil || compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil {
 			continue
 		}
+		// A module left in legacy format keeps runtime codegen, so its
+		// generated-code ignore rules must stay.
+		if workspaceMigrationLeavesModuleLegacy(compatWorkspace) {
+			continue
+		}
 		cleanup, err := s.workspaceMigrationGitignoreCleanup(ctx, srv, ws, compatWorkspace)
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf(

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -758,17 +758,18 @@ func applyWorkspaceMigrationGitignoreCleanups(
 		return dir, err
 	}
 	for _, cleanup := range cleanups {
-		stat, err := dir.Self().Stat(ctx, dir, srv, cleanup.Path, true)
+		cleanupPath := path.Clean(filepath.ToSlash(cleanup.Path))
+		stat, err := dir.Self().Stat(ctx, dir, srv, cleanupPath, true)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
 		if err != nil {
-			return dir, fmt.Errorf("stat legacy gitignore %q: %w", cleanup.Path, err)
+			return dir, fmt.Errorf("stat legacy gitignore %q: %w", cleanupPath, err)
 		}
 
-		contents, err := core.DirectoryReadFile(ctx, dir, cleanup.Path)
+		contents, err := core.DirectoryReadFile(ctx, dir, cleanupPath)
 		if err != nil {
-			return dir, fmt.Errorf("read legacy gitignore %q: %w", cleanup.Path, err)
+			return dir, fmt.Errorf("read legacy gitignore %q: %w", cleanupPath, err)
 		}
 		updatedContents := removeWorkspaceMigrationGitignoreEntries(contents, cleanup.Entries)
 		if bytes.Equal(contents, updatedContents) {
@@ -776,12 +777,12 @@ func applyWorkspaceMigrationGitignoreCleanups(
 		}
 
 		dir, err = workspaceMigrationSelectDirectory(ctx, dir, "withNewFile", []dagql.NamedInput{
-			{Name: "path", Value: dagql.NewString(path.Clean(filepath.ToSlash(cleanup.Path)))},
+			{Name: "path", Value: dagql.NewString(cleanupPath)},
 			{Name: "contents", Value: dagql.String(updatedContents)},
 			{Name: "permissions", Value: dagql.Int(stat.Permissions)},
 		})
 		if err != nil {
-			return dir, fmt.Errorf("rewrite legacy gitignore %q: %w", cleanup.Path, err)
+			return dir, fmt.Errorf("rewrite legacy gitignore %q: %w", cleanupPath, err)
 		}
 	}
 	return dir, nil

--- a/core/schema/workspace_migrate_module_config.go
+++ b/core/schema/workspace_migrate_module_config.go
@@ -31,7 +31,7 @@ func workspaceMigrationModuleConfigConversions(
 			// when its source is a non-root subdir (a normal toolchain would
 			// otherwise be treated as workspace-shaped). Only a genuine nested
 			// workspace (its own toolchains/blueprint) is left as legacy.
-			if workspace.HasOwnWorkspaceSemantics(compatWorkspace.Config) {
+			if workspaceMigrationLeavesModuleLegacy(compatWorkspace) {
 				continue
 			}
 		} else {
@@ -60,6 +60,15 @@ func workspaceMigrationModuleConfigConversions(
 		return nil, nil
 	}
 	return conversions, nil
+}
+
+// workspaceMigrationLeavesModuleLegacy reports whether migration leaves this
+// module's config in legacy format: a discovered nested workspace (own
+// toolchains/blueprint) is neither converted in place nor routed through
+// PlanMigration.
+func workspaceMigrationLeavesModuleLegacy(compatWorkspace *workspace.CompatWorkspace) bool {
+	return compatWorkspace.DiscoveredLocalModule &&
+		workspace.HasOwnWorkspaceSemantics(compatWorkspace.Config)
 }
 
 func legacyModuleConfigAsCurrent(cfg *modules.ModuleConfig) ([]byte, error) {


### PR DESCRIPTION
### What was broken

Legacy SDK codegen ignores generated files because they used to be recreated at runtime. After `dagger setup`, trusted runtimes expect those files to be committed instead.

That leaves migrated modules in a loop: `dagger generate` writes the files, source loading filters them out, and the runtime asks the user to generate them again.

### What this does

During migration, setup removes the legacy `.gitignore` entries that describe generated code. It only removes exact, root-anchored lines in the format Dagger wrote, so user rules and non-generated SDK ignores such as `/.env` stay in place.

The implementation asks the module's configured SDK for `VCSGeneratedPaths` and `VCSIgnoredPaths`, then removes the overlap. The legacy config only identifies the SDK; it does not contain these paths. Using the SDK keeps the migration correct for the configured SDK version and for custom SDKs, without teaching core about Go, Python, or TypeScript filenames.

This can load and run SDK codegen once during setup. That is a deliberate one-time migration cost: the work runs in Dagger's DAG and benefits from caching. If the SDK cannot be inspected, setup records a migration warning and continues with the config migration.

### Testing

The first commit reproduces the full transition: legacy Go codegen writes its generated files and ignore rules, setup migrates the module, and the trusted module must still load.

Run the focused test with:

```shell
dagger call engine-dev test --pkg=./core/integration --run='^TestWorkspaceMigration/TestWorkspaceMigrateGeneratedCodeGitignore$'
```

Also verified with:

```shell
go test ./core/schema ./core/workspace
dagger call engine-dev test --pkg=./core/integration --run='^TestWorkspaceMigration$'
```

All 38 workspace-migration integration tests pass.

Fixes #13717
