### PR TITLE
cli: keep --mod/--no-mod as deprecated aliases

### DIFF
--- a/.changes/unreleased/Deprecated-20260723-014900.yaml
+++ b/.changes/unreleased/Deprecated-20260723-014900.yaml
@@ -1,0 +1,7 @@
+kind: Deprecated
+body: |
+  The `--mod` and `--no-mod` flags are deprecated in favor of `--load-module` and `--no-load-module`. The old names keep working as hidden aliases so existing scripts and shebangs (e.g. `dagger shell --no-mod`) do not break, but they now print a notice pointing at the new name.
+time: 2026-07-23T01:49:00Z
+custom:
+  Author: vito
+  PR: 13721

--- a/internal/cmd/dagger/module.go
+++ b/internal/cmd/dagger/module.go
@@ -38,9 +38,17 @@ func addWorkspaceInstallFlags(cmd *cobra.Command) {
 // If optional is true, it also adds the --no-load-module flag and marks --load-module and --no-load-module as mutually exclusive.
 func moduleAddFlags(cmd *cobra.Command, flags *pflag.FlagSet, optional bool) {
 	flags.StringVarP(&moduleURL, "load-module", "m", "", "Use a one-off module (local path or git ref)")
+	// --mod is the pre-1.0 name for --load-module; keep it as a deprecated
+	// alias so existing scripts and shebangs don't break.
+	flags.StringVar(&moduleURL, "mod", "", "")
+	_ = flags.MarkDeprecated("mod", "use --load-module (-m) instead")
 	if optional {
 		flags.BoolVarP(&moduleNoURL, "no-load-module", "M", false, "Don't load any module for this command")
 		cmd.MarkFlagsMutuallyExclusive("load-module", "no-load-module")
+		// --no-mod is the pre-1.0 name for --no-load-module; keep it as a
+		// deprecated alias so existing scripts and shebangs don't break.
+		flags.BoolVar(&moduleNoURL, "no-mod", false, "")
+		_ = flags.MarkDeprecated("no-mod", "use --no-load-module (-M) instead")
 	}
 
 	var defaultAllowLLM []string


### PR DESCRIPTION
## What

The 1.0 workspace work renamed the module-loading flags:

- `--mod` → `--load-module`
- `--no-mod` → `--no-load-module`

The `-m` / `-M` shorthands were kept, but the old long names were removed, so anything spelling them out — user scripts, CI invocations, shebangs like `dagger shell --no-mod` — breaks on 1.0.

This restores `--mod` and `--no-mod` as **hidden, deprecated aliases** bound to the same variables. They keep working and print a one-line notice pointing at the new name, e.g.:

```
Flag --no-mod has been deprecated, use --no-load-module (-M) instead
```

They're hidden from `--help` so the canonical flags are the only ones advertised.

## Why

Don't break users (and our own `hack/build`) on the flag rename.

## Notes

- Single place to change: both aliases live in `moduleAddFlags`, so every command that exposes `--load-module` / `--no-load-module` gets the matching alias.
- Scope: aliased **both** renamed long flags (`--mod` and `--no-mod`) since they broke identically.
