### PR TITLE
dagql: release abandoned arbitrary cache results

### DIFF
--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -678,16 +678,13 @@ func HasPendingLazyEvaluation(res AnyResult) bool {
 	return lazyEvalFuncOfResult(res) != nil
 }
 
-func (c *Cache) trackSessionArbitrary(sessionID string, res ArbitraryCachedResult) {
+// trackSessionArbitraryLocked records a session owner while the result is
+// protected from concurrent detachment. The caller must hold c.callsMu.
+func (c *Cache) trackSessionArbitraryLocked(sessionID string, res *sharedArbitraryResult) {
 	if c == nil || sessionID == "" || res == nil {
 		return
 	}
-	shared, ok := res.(arbitraryResult)
-	if !ok || shared.shared == nil {
-		return
-	}
 
-	acquired := false
 	c.sessionMu.Lock()
 	if c.sessionArbitraryCallKeysBySession == nil {
 		c.sessionArbitraryCallKeysBySession = make(map[string]map[string]struct{})
@@ -695,17 +692,11 @@ func (c *Cache) trackSessionArbitrary(sessionID string, res ArbitraryCachedResul
 	if c.sessionArbitraryCallKeysBySession[sessionID] == nil {
 		c.sessionArbitraryCallKeysBySession[sessionID] = make(map[string]struct{})
 	}
-	if _, found := c.sessionArbitraryCallKeysBySession[sessionID][shared.shared.callKey]; !found {
-		c.sessionArbitraryCallKeysBySession[sessionID][shared.shared.callKey] = struct{}{}
-		acquired = true
+	if _, found := c.sessionArbitraryCallKeysBySession[sessionID][res.callKey]; !found {
+		c.sessionArbitraryCallKeysBySession[sessionID][res.callKey] = struct{}{}
+		res.ownerSessionCount++
 	}
 	c.sessionMu.Unlock()
-
-	if acquired {
-		c.callsMu.Lock()
-		shared.shared.ownerSessionCount++
-		c.callsMu.Unlock()
-	}
 }
 
 func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
@@ -765,15 +756,7 @@ func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
 			if res.ownerSessionCount < 0 {
 				res.ownerSessionCount = 0
 			}
-			if res.ownerSessionCount == 0 && res.waiters == 0 {
-				if existing := c.ongoingArbitraryCalls[callKey]; existing == res {
-					delete(c.ongoingArbitraryCalls, callKey)
-				}
-				if existing := c.completedArbitraryCalls[callKey]; existing == res {
-					delete(c.completedArbitraryCalls, callKey)
-				}
-				onRelease = res.onRelease
-			}
+			onRelease = c.detachUnownedArbitraryLocked(res)
 		}
 		c.callsMu.Unlock()
 		if onRelease != nil {

--- a/dagql/cache_arbitrary.go
+++ b/dagql/cache_arbitrary.go
@@ -2,7 +2,10 @@ package dagql
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/dagger/dagger/engine/slog"
 )
 
 func ArbitraryValueFunc(v any) func(context.Context) (any, error) {
@@ -80,12 +83,12 @@ func (c *Cache) GetOrInitArbitrary(
 	}
 
 	if res := c.completedArbitraryCalls[callKey]; res != nil {
-		c.callsMu.Unlock()
 		ret := arbitraryResult{
 			shared:   res,
 			hitCache: true,
 		}
-		c.trackSessionArbitrary(sessionID, ret)
+		c.trackSessionArbitraryLocked(sessionID, res)
+		c.callsMu.Unlock()
 		return ret, nil
 	}
 
@@ -109,11 +112,22 @@ func (c *Cache) GetOrInitArbitrary(
 	go func() {
 		defer close(res.waitCh)
 		val, err := fn(callCtx)
+
+		var onRelease OnReleaseFunc
+		c.callsMu.Lock()
 		res.err = err
 		if err == nil {
 			res.value = val
 			if onReleaser, ok := val.(OnReleaser); ok {
 				res.onRelease = onReleaser.OnRelease
+			}
+		}
+		onRelease = c.detachUnownedArbitraryLocked(res)
+		c.callsMu.Unlock()
+
+		if onRelease != nil {
+			if err := onRelease(context.WithoutCancel(ctx)); err != nil {
+				slog.Error("failed to release abandoned arbitrary cache result", "callKey", callKey, "err", err)
 			}
 		}
 	}()
@@ -146,13 +160,14 @@ func (c *Cache) waitArbitrary(ctx context.Context, sessionID string, res *shared
 	}
 
 	if err == nil {
-		delete(c.ongoingArbitraryCalls, res.callKey)
+		if existing := c.ongoingArbitraryCalls[res.callKey]; existing == res {
+			delete(c.ongoingArbitraryCalls, res.callKey)
+		}
 		if existing := c.completedArbitraryCalls[res.callKey]; existing != nil {
 			res = existing
 		} else {
 			c.completedArbitraryCalls[res.callKey] = res
 		}
-		c.callsMu.Unlock()
 
 		if isFirstCaller {
 			hitCache = false
@@ -161,19 +176,35 @@ func (c *Cache) waitArbitrary(ctx context.Context, sessionID string, res *shared
 			shared:   res,
 			hitCache: hitCache,
 		}
-		c.trackSessionArbitrary(sessionID, ret)
+		c.trackSessionArbitraryLocked(sessionID, res)
+		c.callsMu.Unlock()
 		return ret, nil
 	}
 
-	if res.ownerSessionCount == 0 && res.waiters == 0 {
-		if existing := c.ongoingArbitraryCalls[res.callKey]; existing == res {
-			delete(c.ongoingArbitraryCalls, res.callKey)
-		}
-		if existing := c.completedArbitraryCalls[res.callKey]; existing == res {
-			delete(c.completedArbitraryCalls, res.callKey)
-		}
-	}
-
+	onRelease := c.detachUnownedArbitraryLocked(res)
 	c.callsMu.Unlock()
+	if onRelease != nil {
+		err = errors.Join(err, onRelease(context.WithoutCancel(ctx)))
+	}
 	return nil, err
+}
+
+// detachUnownedArbitraryLocked removes res from the cache once it has no
+// waiters or session owners and transfers its cleanup callback to the caller.
+// The transfer clears res.onRelease so concurrent abandonment and session
+// release paths cannot invoke it twice. The caller must hold c.callsMu and run
+// the returned callback only after unlocking it.
+func (c *Cache) detachUnownedArbitraryLocked(res *sharedArbitraryResult) OnReleaseFunc {
+	if res == nil || res.ownerSessionCount != 0 || res.waiters != 0 {
+		return nil
+	}
+	if existing := c.ongoingArbitraryCalls[res.callKey]; existing == res {
+		delete(c.ongoingArbitraryCalls, res.callKey)
+	}
+	if existing := c.completedArbitraryCalls[res.callKey]; existing == res {
+		delete(c.completedArbitraryCalls, res.callKey)
+	}
+	onRelease := res.onRelease
+	res.onRelease = nil
+	return onRelease
 }

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -6823,6 +6823,95 @@ func TestCacheArbitraryConcurrent(t *testing.T) {
 	assert.Equal(t, 0, c.Size())
 }
 
+func TestCacheArbitraryAbandonedInitializationReleases(t *testing.T) {
+	t.Parallel()
+	ctx := cacheTestContext(t.Context())
+
+	cacheIface, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+
+	const (
+		key       = "arbitrary-abandoned-initialization"
+		sessionID = "test-session"
+	)
+	callerCtx, cancelCaller := context.WithCancel(ctx)
+	defer cancelCaller()
+
+	initStarted := make(chan struct{})
+	allowInitReturn := make(chan struct{})
+	initCause := make(chan error, 1)
+	var releaseCalls atomic.Int32
+
+	callerDone := make(chan error, 1)
+	go func() {
+		_, err := c.GetOrInitArbitrary(callerCtx, sessionID, key, func(callCtx context.Context) (any, error) {
+			close(initStarted)
+			<-allowInitReturn
+			initCause <- context.Cause(callCtx)
+			return cacheTestOpaqueValue{
+				value: "abandoned",
+				onRelease: func(context.Context) error {
+					releaseCalls.Add(1)
+					return nil
+				},
+			}, nil
+		})
+		callerDone <- err
+	}()
+
+	select {
+	case <-initStarted:
+	case <-t.Context().Done():
+		t.Fatal("initializer did not start")
+	}
+
+	c.callsMu.Lock()
+	abandoned := c.ongoingArbitraryCalls[key]
+	assert.Assert(t, abandoned != nil)
+	initDone := abandoned.waitCh
+	c.callsMu.Unlock()
+
+	// The initializer deliberately ignores its canceled context until the test
+	// allows it to return. First make the last waiter detach the unfinished entry.
+	cancelCaller()
+	select {
+	case err := <-callerDone:
+		assert.Assert(t, is.ErrorIs(err, context.Canceled))
+	case <-t.Context().Done():
+		t.Fatal("canceled caller did not return")
+	}
+
+	c.callsMu.Lock()
+	assert.Equal(t, 0, abandoned.waiters)
+	assert.Equal(t, 0, abandoned.ownerSessionCount)
+	assert.Assert(t, c.ongoingArbitraryCalls[key] != abandoned)
+	assert.Assert(t, c.completedArbitraryCalls[key] != abandoned)
+	c.callsMu.Unlock()
+	assert.Equal(t, 0, c.Size())
+
+	c.sessionMu.Lock()
+	_, tracked := c.sessionArbitraryCallKeysBySession[sessionID][key]
+	c.sessionMu.Unlock()
+	assert.Assert(t, !tracked)
+
+	// Now let the detached initializer successfully return an OnReleaser. Once
+	// waitCh closes, publication and abandonment cleanup must both be complete.
+	close(allowInitReturn)
+	select {
+	case <-initDone:
+	case <-t.Context().Done():
+		t.Fatal("initializer did not finish")
+	}
+	assert.Assert(t, is.ErrorIs(<-initCause, context.Canceled))
+	assert.Equal(t, int32(1), releaseCalls.Load())
+	assert.Equal(t, 0, c.Size())
+
+	// No session or cache path may retain a second claim on the abandoned value.
+	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+	assert.Equal(t, int32(1), releaseCalls.Load())
+}
+
 func TestCacheArbitraryRecursiveCall(t *testing.T) {
 	t.Parallel()
 	ctx := cacheTestContext(t.Context())

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -6842,6 +6842,8 @@ func TestCacheArbitraryAbandonedInitializationReleases(t *testing.T) {
 	allowInitReturn := make(chan struct{})
 	initCause := make(chan error, 1)
 	var releaseCalls atomic.Int32
+	var releaseCacheSize atomic.Int32
+	releaseCacheSize.Store(-1)
 
 	callerDone := make(chan error, 1)
 	go func() {
@@ -6852,6 +6854,7 @@ func TestCacheArbitraryAbandonedInitializationReleases(t *testing.T) {
 			return cacheTestOpaqueValue{
 				value: "abandoned",
 				onRelease: func(context.Context) error {
+					releaseCacheSize.Store(int32(c.Size()))
 					releaseCalls.Add(1)
 					return nil
 				},
@@ -6905,11 +6908,165 @@ func TestCacheArbitraryAbandonedInitializationReleases(t *testing.T) {
 	}
 	assert.Assert(t, is.ErrorIs(<-initCause, context.Canceled))
 	assert.Equal(t, int32(1), releaseCalls.Load())
+	assert.Equal(t, int32(0), releaseCacheSize.Load())
 	assert.Equal(t, 0, c.Size())
 
 	// No session or cache path may retain a second claim on the abandoned value.
 	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
 	assert.Equal(t, int32(1), releaseCalls.Load())
+}
+
+func TestCacheArbitraryAbandonedInitializationAllowsReentry(t *testing.T) {
+	t.Parallel()
+	ctx := cacheTestContext(t.Context())
+
+	cacheIface, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+
+	const key = "arbitrary-abandoned-reentry"
+	oldCallerCtx, cancelOldCaller := context.WithCancel(ctx)
+	defer cancelOldCaller()
+
+	oldInitStarted := make(chan struct{})
+	allowOldInitReturn := make(chan struct{})
+	var oldReleaseCalls atomic.Int32
+	var oldReleaseCacheSize atomic.Int32
+	oldReleaseCacheSize.Store(-1)
+
+	oldCallerDone := make(chan error, 1)
+	go func() {
+		_, err := c.GetOrInitArbitrary(oldCallerCtx, "old-session", key, func(context.Context) (any, error) {
+			close(oldInitStarted)
+			<-allowOldInitReturn
+			return cacheTestOpaqueValue{
+				value: "old",
+				onRelease: func(context.Context) error {
+					oldReleaseCacheSize.Store(int32(c.Size()))
+					oldReleaseCalls.Add(1)
+					return nil
+				},
+			}, nil
+		})
+		oldCallerDone <- err
+	}()
+
+	select {
+	case <-oldInitStarted:
+	case <-t.Context().Done():
+		t.Fatal("old initializer did not start")
+	}
+
+	c.callsMu.Lock()
+	oldEntry := c.ongoingArbitraryCalls[key]
+	assert.Assert(t, oldEntry != nil)
+	oldInitDone := oldEntry.waitCh
+	c.callsMu.Unlock()
+
+	cancelOldCaller()
+	select {
+	case err := <-oldCallerDone:
+		assert.Assert(t, is.ErrorIs(err, context.Canceled))
+	case <-t.Context().Done():
+		t.Fatal("old caller did not return")
+	}
+
+	var newReleaseCalls atomic.Int32
+	newRes, err := c.GetOrInitArbitrary(ctx, "new-session", key, func(context.Context) (any, error) {
+		return cacheTestOpaqueValue{
+			value: "new",
+			onRelease: func(context.Context) error {
+				newReleaseCalls.Add(1)
+				return nil
+			},
+		}, nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !newRes.HitCache())
+	assert.Equal(t, "new", newRes.Value().(cacheTestOpaqueValue).value)
+
+	c.callsMu.Lock()
+	newEntry := c.completedArbitraryCalls[key]
+	assert.Assert(t, newEntry != nil)
+	assert.Assert(t, newEntry != oldEntry)
+	assert.Equal(t, 1, newEntry.ownerSessionCount)
+	c.callsMu.Unlock()
+
+	close(allowOldInitReturn)
+	select {
+	case <-oldInitDone:
+	case <-t.Context().Done():
+		t.Fatal("old initializer did not finish")
+	}
+	assert.Equal(t, int32(1), oldReleaseCalls.Load())
+	assert.Equal(t, int32(1), oldReleaseCacheSize.Load())
+	assert.Equal(t, int32(0), newReleaseCalls.Load())
+	assert.Equal(t, 1, c.Size())
+
+	var replacementInitCalls atomic.Int32
+	hit, err := c.GetOrInitArbitrary(ctx, "new-session", key, func(context.Context) (any, error) {
+		replacementInitCalls.Add(1)
+		return "unexpected", nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, hit.HitCache())
+	assert.Equal(t, "new", hit.Value().(cacheTestOpaqueValue).value)
+	assert.Equal(t, int32(0), replacementInitCalls.Load())
+
+	assert.NilError(t, c.ReleaseSession(ctx, "old-session"))
+	assert.Equal(t, int32(1), oldReleaseCalls.Load())
+	assert.Equal(t, int32(0), newReleaseCalls.Load())
+	assert.Equal(t, 1, c.Size())
+
+	assert.NilError(t, c.ReleaseSession(ctx, "new-session"))
+	assert.Equal(t, int32(1), oldReleaseCalls.Load())
+	assert.Equal(t, int32(1), newReleaseCalls.Load())
+	assert.Equal(t, 0, c.Size())
+}
+
+func TestCacheArbitraryReleaseWaitsForAllSessionOwners(t *testing.T) {
+	t.Parallel()
+	ctx := cacheTestContext(t.Context())
+
+	cacheIface, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+
+	const key = "arbitrary-multiple-session-owners"
+	var releaseCalls atomic.Int32
+	_, err = c.GetOrInitArbitrary(ctx, "session-a", key, func(context.Context) (any, error) {
+		return cacheTestOpaqueValue{
+			value: "shared",
+			onRelease: func(context.Context) error {
+				releaseCalls.Add(1)
+				return nil
+			},
+		}, nil
+	})
+	assert.NilError(t, err)
+
+	var hitInitCalls atomic.Int32
+	hit, err := c.GetOrInitArbitrary(ctx, "session-b", key, func(context.Context) (any, error) {
+		hitInitCalls.Add(1)
+		return "unexpected", nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, hit.HitCache())
+	assert.Equal(t, int32(0), hitInitCalls.Load())
+
+	c.callsMu.Lock()
+	entry := c.completedArbitraryCalls[key]
+	assert.Assert(t, entry != nil)
+	assert.Equal(t, 2, entry.ownerSessionCount)
+	c.callsMu.Unlock()
+
+	assert.NilError(t, c.ReleaseSession(ctx, "session-a"))
+	assert.Equal(t, int32(0), releaseCalls.Load())
+	assert.Equal(t, 1, c.Size())
+
+	assert.NilError(t, c.ReleaseSession(ctx, "session-b"))
+	assert.Equal(t, int32(1), releaseCalls.Load())
+	assert.Equal(t, 0, c.Size())
 }
 
 func TestCacheArbitraryRecursiveCall(t *testing.T) {


### PR DESCRIPTION
## Summary

- release successful `GetOrInitArbitrary` values that finish after every waiter has abandoned the initialization
- serialize cleanup transfer with waiter and session ownership so `OnRelease` runs exactly once and outside cache locks
- add deterministic regression coverage for abandonment, replacement initialization, and multiple session owners

## Root cause

`GetOrInitArbitrary` runs its initializer in a goroutine. When the last waiter was canceled, the cancellation path removed the unfinished entry because it had no waiters or session owners.

If the initializer ignored or narrowly raced cancellation and then successfully returned an `OnReleaser`, the goroutine recorded its callback after the entry was already detached. No session owned the value, it was absent from both arbitrary-call maps, and arbitrary entries are neither persisted nor handled by cache pruning. Nothing could invoke `OnRelease`.

## Fix

An initialization with zero waiters and zero session owners is now treated as abandoned. If it subsequently succeeds, its cleanup callback is transferred under `callsMu`, cleared from the entry, and invoked immediately after unlocking. Clearing the callback during transfer provides the exact-once invariant across initializer completion, waiter cancellation, and session release.

Successful callers and cache hits now claim session ownership while detachment is excluded. Map removal is pointer-conditional, so an abandoned initializer finishing late cannot remove or release a replacement entry created for the same key.

The regression test controls the ordering with channels: it waits for initialization to begin, cancels the last waiter, proves the unfinished entry has been detached with no owner, and only then allows an `OnReleaser` value to return. Neighboring tests verify replacement initialization remains owned and cacheable, callbacks run outside `callsMu`, and cleanup waits for every session owner.

## Validation

- `dagger api call engine-dev test --pkg ./dagql --run='TestCacheArbitrary' --race`
- `dagger api call engine-dev test --pkg ./dagql`
