### PR TITLE
fix: validate local dependency SDK dispatch

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3270,7 +3270,18 @@ func sdkOwnersByModulePathFromConfig(cfg *workspace.Config) (map[string]string, 
 			continue
 		}
 		for _, managed := range entry.AsSDK.Modules {
-			owners[cleanWorkspaceRelPath(managed.Path)] = name
+			path := cleanWorkspaceRelPath(managed.Path)
+			if existing, ok := owners[path]; ok && existing != name {
+				sdkNames := []string{existing, name}
+				slices.Sort(sdkNames)
+				return nil, fmt.Errorf(
+					"module path %q is managed by multiple SDKs: %q and %q",
+					path,
+					sdkNames[0],
+					sdkNames[1],
+				)
+			}
+			owners[path] = name
 		}
 	}
 	return owners, nil

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3096,15 +3096,22 @@ func (s *moduleSourceSchema) generateOneLocalDependency(
 	// Scope generation to the owning SDK's generator (include) and hand it the
 	// dep-scoped workspace (withWorkspace). filterGeneratorsByInclude matches the
 	// bare module name, exactly like `dagger generate <sdk-name>`.
-	var depChanges dagql.ObjectResult[*core.Changeset]
-	if err := dag.Select(ctx, workspace, &depChanges,
-		dagql.Selector{
-			Field: "generators",
-			Args: []dagql.NamedInput{
-				{Name: "include", Value: dagql.Opt(dagql.ArrayInput[dagql.String]{dagql.String(owner)})},
-				{Name: "withWorkspace", Value: dagql.Opt(dagql.NewID[*core.Workspace](wsDID))},
-			},
+	var generators dagql.ObjectResult[*core.GeneratorGroup]
+	if err := dag.Select(ctx, workspace, &generators, dagql.Selector{
+		Field: "generators",
+		Args: []dagql.NamedInput{
+			{Name: "include", Value: dagql.Opt(dagql.ArrayInput[dagql.String]{dagql.String(owner)})},
+			{Name: "withWorkspace", Value: dagql.Opt(dagql.NewID[*core.Workspace](wsDID))},
 		},
+	}); err != nil {
+		return dagql.ObjectResult[*core.Changeset]{}, err
+	}
+	if err := validateDependencyGeneratorGroup(owner, depPath, generators.Self()); err != nil {
+		return dagql.ObjectResult[*core.Changeset]{}, err
+	}
+
+	var depChanges dagql.ObjectResult[*core.Changeset]
+	if err := dag.Select(ctx, generators, &depChanges,
 		dagql.Selector{Field: "run"},
 		dagql.Selector{Field: "changes"},
 	); err != nil {
@@ -3119,6 +3126,10 @@ func (s *moduleSourceSchema) generateOneLocalDependency(
 		return dagql.ObjectResult[*core.Changeset]{}, fmt.Errorf("reroot changeset under %q: %w", depPath, err)
 	}
 	return depChanges, nil
+}
+
+func validateDependencyGeneratorGroup(string, string, *core.GeneratorGroup) error {
+	return nil
 }
 
 // rerootChangesetUnder returns changes with every path prefixed by dir, turning
@@ -3235,6 +3246,10 @@ func sdkOwnersByModulePath(ctx context.Context, ws *core.Workspace) (map[string]
 	if err != nil {
 		return nil, err
 	}
+	return sdkOwnersByModulePathFromConfig(cfg)
+}
+
+func sdkOwnersByModulePathFromConfig(cfg *workspace.Config) (map[string]string, error) {
 	owners := map[string]string{}
 	for name, entry := range cfg.Modules {
 		if entry.AsSDK == nil {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3128,7 +3128,21 @@ func (s *moduleSourceSchema) generateOneLocalDependency(
 	return depChanges, nil
 }
 
-func validateDependencyGeneratorGroup(string, string, *core.GeneratorGroup) error {
+func validateDependencyGeneratorGroup(owner, depPath string, generators *core.GeneratorGroup) error {
+	if len(generators.LoadFailures) > 0 {
+		return fmt.Errorf(
+			"load owning SDK %q generators: %s",
+			owner,
+			strings.Join(generators.LoadFailures, "; "),
+		)
+	}
+	if len(generators.Generators) == 0 {
+		return fmt.Errorf(
+			"owning SDK %q exposes no generators for dependency %q",
+			owner,
+			depPath,
+		)
+	}
 	return nil
 }
 

--- a/core/schema/modulesource_test.go
+++ b/core/schema/modulesource_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
@@ -234,5 +235,76 @@ func TestLocalDepClosureLeafFirst(t *testing.T) {
 
 	t.Run("no local deps yields empty", func(t *testing.T) {
 		require.Empty(t, localDepClosureLeafFirst(mk("a", local)))
+	})
+}
+
+func TestValidateDependencyGeneratorGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects SDK load failures", func(t *testing.T) {
+		err := validateDependencyGeneratorGroup("go-sdk", "modules/dep", &core.GeneratorGroup{
+			LoadFailures: []string{"failed to load go-sdk", "missing dependency"},
+		})
+		require.EqualError(t, err, `load owning SDK "go-sdk" generators: failed to load go-sdk; missing dependency`)
+	})
+
+	t.Run("rejects an empty generator group", func(t *testing.T) {
+		err := validateDependencyGeneratorGroup("go-sdk", "modules/dep", &core.GeneratorGroup{})
+		require.EqualError(t, err, `owning SDK "go-sdk" exposes no generators for dependency "modules/dep"`)
+	})
+
+	t.Run("accepts a populated generator group", func(t *testing.T) {
+		err := validateDependencyGeneratorGroup("go-sdk", "modules/dep", &core.GeneratorGroup{
+			Generators: []*core.Generator{{}},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestSDKOwnersByModulePathFromConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maps normalized module paths", func(t *testing.T) {
+		owners, err := sdkOwnersByModulePathFromConfig(&workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"go-sdk": {
+					AsSDK: &workspace.ModuleAsSDK{
+						Modules: []workspace.SDKManagedModule{
+							{Path: "./modules/go"},
+							{Path: "modules/go"},
+						},
+					},
+				},
+				"typescript-sdk": {
+					AsSDK: &workspace.ModuleAsSDK{
+						Modules: []workspace.SDKManagedModule{{Path: "modules/typescript"}},
+					},
+				},
+				"plain-module": {},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"modules/go":         "go-sdk",
+			"modules/typescript": "typescript-sdk",
+		}, owners)
+	})
+
+	t.Run("rejects paths managed by multiple SDKs", func(t *testing.T) {
+		_, err := sdkOwnersByModulePathFromConfig(&workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"go-sdk": {
+					AsSDK: &workspace.ModuleAsSDK{
+						Modules: []workspace.SDKManagedModule{{Path: "./modules/shared"}},
+					},
+				},
+				"typescript-sdk": {
+					AsSDK: &workspace.ModuleAsSDK{
+						Modules: []workspace.SDKManagedModule{{Path: "modules/shared"}},
+					},
+				},
+			},
+		})
+		require.EqualError(t, err, `module path "modules/shared" is managed by multiple SDKs: "go-sdk" and "typescript-sdk"`)
 	})
 }


### PR DESCRIPTION
## Summary

- materialize and validate the owning SDK's generator group before running local dependency generation
- surface SDK load failures and reject an owning SDK that exposes no matching generators
- reject workspace module paths claimed by more than one SDK

## Issues

Local dependency generation previously selected `workspace.generators(...).run.changes` as one chain. Workspace generator discovery tolerates module load failures, so a failed or unmatched owning SDK could produce an empty generator group. Running that group returned an empty changeset, silently leaving the dependency ungenerated instead of reporting why its SDK could not run.

SDK ownership was also collected into a map by iterating the workspace's module map. When two SDK entries claimed the same normalized module path, the later map entry overwrote the earlier one. Since Go map iteration order is unspecified, the selected owner was nondeterministic.

This change validates the selected generator group before execution and reports load failures or missing generators. It also detects conflicting ownership declarations and returns a stable error naming both SDKs.

## Validation

- `go test ./core/schema`
