### PR TITLE
perf: make generate-all performant

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -25,7 +25,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"go.opentelemetry.io/otel/log"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func NewChangeset(ctx context.Context, before, after dagql.ObjectResult[*Directory]) (*Changeset, error) {
@@ -618,7 +617,6 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 		return nil, err
 	}
 
-	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
 	defer stdio.Close()
 

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -23,11 +23,11 @@ import (
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 	bkclient "github.com/dagger/dagger/internal/buildkit/client"
+	"github.com/dagger/dagger/util/parallel"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"go.opentelemetry.io/otel/log"
-	"golang.org/x/sync/errgroup"
 )
 
 func NewChangeset(ctx context.Context, before, after dagql.ObjectResult[*Directory]) (*Changeset, error) {
@@ -1052,6 +1052,21 @@ func (ch *Changeset) WithChangeset(
 	return newChangesetFromMerge(ctx, before, afterDir)
 }
 
+// maxParallelChangesets bounds how many changesets are worked on at once.
+// Each job mounts both of a changeset's snapshots and walks them, so this is
+// I/O bound work holding real resources for its duration, not something to fan
+// out one goroutine per changeset over.
+const maxParallelChangesets = 8
+
+// changesetJobs returns a job pool for per-changeset work, capped so that a
+// merge of many changesets doesn't mount all of them at once.
+func changesetJobs() parallel.Jobs {
+	return parallel.New().
+		WithContextualTracer(true).
+		WithInternal(true).
+		WithLimit(maxParallelChangesets)
+}
+
 // WithChangesets merges multiple changesets into this one using git's octopus merge strategy.
 // The onConflictStrategy determines how conflicts are handled:
 //   - FailEarlyOnConflicts: fail before merge if file-level conflicts are detected
@@ -1061,27 +1076,31 @@ func (ch *Changeset) WithChangesets(
 	others []*Changeset,
 	onConflictStrategy WithChangesetsMergeConflict,
 ) (*Changeset, error) {
-	// Before wasting any effort, remove any changesets that are empty
+	// Before wasting any effort, remove any changesets that are empty.
+	//
+	// This asks ComputePaths rather than IsEmpty: every surviving changeset
+	// needs its paths computed anyway and ComputePaths memoizes, whereas
+	// IsEmpty would mount and walk both trees all over again for each one. It
+	// also counts directory-only changes, which IsEmpty deliberately ignores
+	// the way `git diff --quiet` does.
 	filtered := make([]*Changeset, len(others))
-	eg := new(errgroup.Group)
+	jobs := changesetJobs()
 	for i, other := range others {
-		eg.Go(func() error {
-			isEmpty, err := other.IsEmpty(ctx)
+		jobs = jobs.WithJob(fmt.Sprintf("changeset %d paths", i), func(ctx context.Context) error {
+			paths, err := other.ComputePaths(ctx)
 			if err != nil {
-				return err
+				return fmt.Errorf("compute paths for changeset %d: %w", i, err)
 			}
-			if !isEmpty {
+			if !changesetPathsEmpty(paths) {
 				filtered[i] = other
 			}
 			return nil
 		})
 	}
-	if err := eg.Wait(); err != nil {
+	if err := jobs.Run(ctx); err != nil {
 		return nil, err
 	}
-	filtered = slices.DeleteFunc(filtered, func(cs *Changeset) bool { return cs == nil })
-
-	others = filtered
+	others = slices.DeleteFunc(filtered, func(cs *Changeset) bool { return cs == nil })
 
 	if len(others) == 0 {
 		return ch, nil
@@ -1113,18 +1132,29 @@ func (ch *Changeset) WithChangesets(
 		return nil, err
 	}
 
-	ourPatch, err := enginetel.TaskRet(ctx, "self asPatch", ch.AsPatch)
-	if err != nil {
-		return nil, fmt.Errorf("get our patch: %w", err)
-	}
-
+	// Each patch is an independent mount-and-diff, so take them all at once.
+	var ourPatch *File
 	otherPatches := make([]*File, len(others))
-	for i, other := range others {
-		patch, err := enginetel.TaskRet(ctx, "other asPatch", other.AsPatch)
+	patchJobs := changesetJobs().WithJob("self asPatch", func(ctx context.Context) error {
+		patch, err := ch.AsPatch(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("get patch for changeset %d: %w", i, err)
+			return fmt.Errorf("get our patch: %w", err)
 		}
-		otherPatches[i] = patch
+		ourPatch = patch
+		return nil
+	})
+	for i, other := range others {
+		patchJobs = patchJobs.WithJob(fmt.Sprintf("changeset %d asPatch", i), func(ctx context.Context) error {
+			patch, err := other.AsPatch(ctx)
+			if err != nil {
+				return fmt.Errorf("get patch for changeset %d: %w", i, err)
+			}
+			otherPatches[i] = patch
+			return nil
+		})
+	}
+	if err := patchJobs.Run(ctx); err != nil {
+		return nil, err
 	}
 
 	afterDir, err := enginetel.TaskRet(ctx, "octopus merge", func(ctx context.Context) (*Directory, error) {
@@ -1263,9 +1293,9 @@ func checkAllPairwiseConflicts(ctx context.Context, ch *Changeset, others []*Cha
 	}
 
 	otherPaths := make([]*ChangesetPaths, len(others))
-	eg := new(errgroup.Group)
+	jobs := changesetJobs()
 	for i, other := range others {
-		eg.Go(func() error {
+		jobs = jobs.WithJob(fmt.Sprintf("changeset %d paths", i), func(ctx context.Context) error {
 			paths, err := other.ComputePaths(ctx)
 			if err != nil {
 				return fmt.Errorf("compute paths for changeset %d: %w", i, err)
@@ -1274,7 +1304,7 @@ func checkAllPairwiseConflicts(ctx context.Context, ch *Changeset, others []*Cha
 			return nil
 		})
 	}
-	if err := eg.Wait(); err != nil {
+	if err := jobs.Run(ctx); err != nil {
 		return err
 	}
 

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,11 +21,13 @@ import (
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/slog"
 	bkcache "github.com/dagger/dagger/engine/snapshots"
+	enginetel "github.com/dagger/dagger/engine/telemetry"
 	bkclient "github.com/dagger/dagger/internal/buildkit/client"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"go.opentelemetry.io/otel/log"
+	"golang.org/x/sync/errgroup"
 )
 
 func NewChangeset(ctx context.Context, before, after dagql.ObjectResult[*Directory]) (*Changeset, error) {
@@ -153,7 +156,15 @@ func (*DiffStat) DecodePersistedObject(_ context.Context, _ *dagql.Server, _ uin
 // metadata and git diffs.
 func (ch *Changeset) ComputePaths(ctx context.Context) (*ChangesetPaths, error) {
 	ch.pathsOnce.Do(func() {
-		ch.cachedPaths, ch.pathsErr = ch.computePathsOnce(ctx)
+		enginetel.Task(ctx, "computing paths", func(ctx context.Context) error {
+			ch.cachedPaths, ch.pathsErr = ch.computePathsOnce(ctx)
+			out := telemetry.SpanStdio(ctx, InstrumentationLibrary).Stdout
+			fmt.Fprintln(out, "added:", ch.cachedPaths.Added)
+			fmt.Fprintln(out, "removed:", ch.cachedPaths.Removed)
+			fmt.Fprintln(out, "modified:", ch.cachedPaths.Modified)
+			fmt.Fprintln(out, "renamed:", ch.cachedPaths.Renamed)
+			return ch.pathsErr
+		})
 	})
 	return ch.cachedPaths, ch.pathsErr
 }
@@ -617,9 +628,6 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 		return nil, err
 	}
 
-	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
-	defer stdio.Close()
-
 	newRef, err := query.SnapshotManager().New(ctx, nil,
 		bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
 		bkcache.WithDescription("Changeset.asPatch"))
@@ -634,6 +642,19 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Determine the changed paths so we only diff things that actually changed,
+	// rather than the entire tree
+	paths, err := ch.ComputePaths(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compute paths: %w", err)
+	}
+	var pathSpecs []string
+	pathSpecs = append(pathSpecs, paths.Added...)
+	pathSpecs = append(pathSpecs, paths.Removed...)
+	pathSpecs = append(pathSpecs, paths.Modified...)
+	pathSpecs = append(pathSpecs, slices.Sorted(maps.Keys(paths.Renamed))...)
+
 	err = MountRef(ctx, beforeRef, func(before string, _ *mount.Mount) error {
 		beforeDir, err := containerdfs.RootPath(before, beforeSelector)
 		if err != nil {
@@ -670,16 +691,28 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 				}
 				defer patchFile.Close()
 
+				if len(pathSpecs) == 0 {
+					// No paths actually changed (no-op Changeset) - just return early rather than
+					// computing an expensive no-op diff.
+					return nil
+				}
+
 				// --no-renames: with --no-prefix, git strips the a/ b/ mount dirs
 				// from the ---/+++ lines but not from rename from/to lines, so a
 				// rename entry makes the patch unapplyable ("inconsistent old
 				// filename"). Emitting renames as delete+add avoids the mismatch;
 				// with --binary the result is identical.
-				cmd := exec.CommandContext(ctx, "git", "diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b")
-				cmd.Dir = root
-				cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
-				cmd.Stderr = stdio.Stderr
-				if err := cmd.Run(); err != nil {
+				args := []string{"diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b"}
+				args = append(args, pathSpecs...)
+				if err := enginetel.Task(ctx, strings.Join(args, " "), func(context.Context) error {
+					stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
+					defer stdio.Close()
+					cmd := exec.CommandContext(ctx, "git", args...)
+					cmd.Dir = root
+					cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
+					cmd.Stderr = stdio.Stderr
+					return cmd.Run()
+				}); err != nil {
 					var exitErr *exec.ExitError
 					// Check if it's exit code 1, which is expected for git diff when files differ
 					if errors.As(err, &exitErr) && exitErr.ExitCode() != 1 {
@@ -966,6 +999,28 @@ func (ch *Changeset) WithChangesets(
 	others []*Changeset,
 	onConflictStrategy WithChangesetsMergeConflict,
 ) (*Changeset, error) {
+	// Before wasting any effort, remove any changesets that are empty
+	filtered := make([]*Changeset, len(others))
+	eg := new(errgroup.Group)
+	for i, other := range others {
+		eg.Go(func() error {
+			isEmpty, err := other.IsEmpty(ctx)
+			if err != nil {
+				return err
+			}
+			if !isEmpty {
+				filtered[i] = other
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	filtered = slices.DeleteFunc(filtered, func(cs *Changeset) bool { return cs == nil })
+
+	others = filtered
+
 	if len(others) == 0 {
 		return ch, nil
 	}
@@ -982,36 +1037,44 @@ func (ch *Changeset) WithChangesets(
 		return ch.WithChangeset(ctx, others[0], twoWayStrategy)
 	}
 
-	err := checkAllPairwiseConflicts(ctx, ch, others)
+	err := enginetel.Task(ctx, "checking pairwise conflicts", func(ctx context.Context) error {
+		return checkAllPairwiseConflicts(ctx, ch, others)
+	})
 	if err != nil && onConflictStrategy == FailEarlyOnConflicts {
 		return nil, err
 	}
 
-	before, err := mergeBeforeDirectories(ctx, ch, others...)
+	before, err := enginetel.TaskRet(ctx, "merging before directories", func(ctx context.Context) (dagql.ObjectResult[*Directory], error) {
+		return mergeBeforeDirectories(ctx, ch, others...)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	ourPatch, err := ch.AsPatch(ctx)
+	ourPatch, err := enginetel.TaskRet(ctx, "self asPatch", ch.AsPatch)
 	if err != nil {
 		return nil, fmt.Errorf("get our patch: %w", err)
 	}
 
 	otherPatches := make([]*File, len(others))
 	for i, other := range others {
-		patch, err := other.AsPatch(ctx)
+		patch, err := enginetel.TaskRet(ctx, "other asPatch", other.AsPatch)
 		if err != nil {
 			return nil, fmt.Errorf("get patch for changeset %d: %w", i, err)
 		}
 		otherPatches[i] = patch
 	}
 
-	afterDir, err := gitOctopusMergeWithPatches(ctx, before, ourPatch, otherPatches)
+	afterDir, err := enginetel.TaskRet(ctx, "octopus merge", func(ctx context.Context) (*Directory, error) {
+		return gitOctopusMergeWithPatches(ctx, before, ourPatch, otherPatches)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	return newChangesetFromMerge(ctx, before, afterDir)
+	return enginetel.TaskRet(ctx, "new changeset from merge", func(ctx context.Context) (*Changeset, error) {
+		return newChangesetFromMerge(ctx, before, afterDir)
+	})
 }
 
 // mergeBeforeDirectories merges the "before" directories from all changesets,
@@ -1036,20 +1099,22 @@ func mergeBeforeDirectories(ctx context.Context, ch *Changeset, others ...*Chang
 	// paths that A and B disagree on.
 	var lastDigest digest.Digest
 	appendBefore := func(before dagql.ObjectResult[*Directory]) error {
-		dgst, err := before.ContentPreferredDigest(ctx)
-		if err != nil {
-			return fmt.Errorf("before content-preferred digest: %w", err)
-		}
-		if dgst == lastDigest {
+		return enginetel.Task(ctx, "append before", func(ctx context.Context) error {
+			dgst, err := before.ContentPreferredDigest(ctx)
+			if err != nil {
+				return fmt.Errorf("before content-preferred digest: %w", err)
+			}
+			if dgst == lastDigest {
+				return nil
+			}
+			id, err := before.ID()
+			if err != nil {
+				return fmt.Errorf("before ID: %w", err)
+			}
+			lastDigest = dgst
+			selectors = append(selectors, withDirectorySelector(id))
 			return nil
-		}
-		id, err := before.ID()
-		if err != nil {
-			return fmt.Errorf("before ID: %w", err)
-		}
-		lastDigest = dgst
-		selectors = append(selectors, withDirectorySelector(id))
-		return nil
+		})
 	}
 
 	if err := appendBefore(ch.Before); err != nil {
@@ -1132,12 +1197,19 @@ func checkAllPairwiseConflicts(ctx context.Context, ch *Changeset, others []*Cha
 	}
 
 	otherPaths := make([]*ChangesetPaths, len(others))
+	eg := new(errgroup.Group)
 	for i, other := range others {
-		paths, err := other.ComputePaths(ctx)
-		if err != nil {
-			return fmt.Errorf("compute paths for changeset %d: %w", i, err)
-		}
-		otherPaths[i] = paths
+		eg.Go(func() error {
+			paths, err := other.ComputePaths(ctx)
+			if err != nil {
+				return fmt.Errorf("compute paths for changeset %d: %w", i, err)
+			}
+			otherPaths[i] = paths
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
 	}
 
 	for i, paths := range otherPaths {
@@ -1282,10 +1354,14 @@ func gitOctopusMergeWithPatches(
 	otherPatches []*File,
 ) (*Directory, error) {
 	return withGitMergeWorkspace(ctx, base, "Changeset.withChangesets git octopus merge", func(workDir string) error {
-		if err := initGitRepo(ctx, workDir); err != nil {
+		if err := enginetel.Task(ctx, "init git", func(ctx context.Context) error {
+			return initGitRepo(ctx, workDir)
+		}); err != nil {
 			return err
 		}
-		if err := createBranchWithPatchFile(ctx, workDir, "ours", ourPatch); err != nil {
+		if err := enginetel.Task(ctx, "create branch for ours", func(ctx context.Context) error {
+			return createBranchWithPatchFile(ctx, workDir, "ours", ourPatch)
+		}); err != nil {
 			return err
 		}
 
@@ -1293,19 +1369,25 @@ func gitOctopusMergeWithPatches(
 		for i, patch := range otherPatches {
 			branchName := fmt.Sprintf("branch_%d", i)
 			branchNames[i] = branchName
-			if err := createBranchWithPatchFile(ctx, workDir, branchName, patch, "HEAD~1"); err != nil {
+			if err := enginetel.Task(ctx, "create branch "+branchName, func(ctx context.Context) error {
+				return createBranchWithPatchFile(ctx, workDir, branchName, patch, "HEAD~1")
+			}); err != nil {
 				return err
 			}
 		}
 
-		if err := runGit(ctx, workDir, "checkout", "ours"); err != nil {
+		if err := enginetel.Task(ctx, "checkout ours", func(ctx context.Context) error {
+			return runGit(ctx, workDir, "checkout", "ours")
+		}); err != nil {
 			return err
 		}
 
 		mergeArgs := []string{"merge", "--no-edit", "--no-commit"}
 		mergeArgs = append(mergeArgs, branchNames...)
 
-		if err := runGit(ctx, workDir, mergeArgs...); err != nil {
+		if err := enginetel.Task(ctx, "git merge", func(ctx context.Context) error {
+			return runGit(ctx, workDir, mergeArgs...)
+		}); err != nil {
 			return err
 		}
 

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -200,6 +200,58 @@ func (ch *Changeset) computePathsOnce(ctx context.Context) (*ChangesetPaths, err
 		return nil, err
 	}
 	return result, nil
+}
+
+// maxGitPathSpecBytes bounds the pathspecs appended to a git diff. They only
+// narrow work that would otherwise be correct anyway, and argv has a hard size
+// limit, so the list gets collapsed or dropped rather than allowed to grow
+// until exec fails.
+const maxGitPathSpecBytes = 128 << 10
+
+// gitDiffPathSpecs returns pathspecs limiting a diff to the paths that
+// actually changed. Renamed paths need no entry of their own: ChangesetPaths
+// records them under both their old and new names, in Removed and Added.
+//
+// An empty result means "diff everything". Too many paths to pass are first
+// collapsed to their parent directories, which still match everything beneath
+// them, and given up on entirely once even those don't fit.
+func gitDiffPathSpecs(paths *ChangesetPaths) []string {
+	specs := slices.Concat(paths.Added, paths.Removed, paths.Modified)
+	for pathSpecsSize(specs) > maxGitPathSpecBytes {
+		specs = collapsePathSpecsToParents(specs)
+		if len(specs) == 0 {
+			return nil
+		}
+	}
+	return specs
+}
+
+func pathSpecsSize(specs []string) int {
+	var size int
+	for _, spec := range specs {
+		size += len(spec) + 1 // NUL terminator in argv
+	}
+	return size
+}
+
+// collapsePathSpecsToParents replaces each pathspec with its parent directory,
+// which matches everything the original did and then some. Returns nil once
+// any entry sits at the tree root, since its parent is the whole tree.
+func collapsePathSpecsToParents(specs []string) []string {
+	seen := make(map[string]struct{}, len(specs))
+	collapsed := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		parent := path.Dir(path.Clean(spec))
+		if parent == "." || parent == "/" {
+			return nil
+		}
+		if _, ok := seen[parent]; ok {
+			continue
+		}
+		seen[parent] = struct{}{}
+		collapsed = append(collapsed, parent)
+	}
+	return collapsed
 }
 
 func computeChangesetPaths(ctx context.Context, beforeDir, afterDir string) (*ChangesetPaths, error) {
@@ -657,11 +709,8 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compute paths: %w", err)
 	}
-	var pathSpecs []string
-	pathSpecs = append(pathSpecs, paths.Added...)
-	pathSpecs = append(pathSpecs, paths.Removed...)
-	pathSpecs = append(pathSpecs, paths.Modified...)
-	pathSpecs = append(pathSpecs, slices.Sorted(maps.Keys(paths.Renamed))...)
+	noChanges := changesetPathsEmpty(paths)
+	pathSpecs := gitDiffPathSpecs(paths)
 
 	err = MountRef(ctx, beforeRef, func(before string, _ *mount.Mount) error {
 		beforeDir, err := containerdfs.RootPath(before, beforeSelector)
@@ -699,7 +748,7 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 				}
 				defer patchFile.Close()
 
-				if len(pathSpecs) == 0 {
+				if noChanges {
 					// No paths actually changed (no-op Changeset) - just return early rather than
 					// computing an expensive no-op diff.
 					return nil
@@ -711,10 +760,18 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 				// filename"). Emitting renames as delete+add avoids the mismatch;
 				// with --binary the result is identical.
 				args := []string{"diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b"}
-				args = append(args, pathSpecs...)
-				fmt.Fprint(stdio.Stdout, "running git", args)
+				if len(pathSpecs) > 0 {
+					// -- so a path starting with - isn't parsed as a flag, and
+					// GIT_LITERAL_PATHSPECS below so one starting with : isn't
+					// parsed as pathspec magic. Either would otherwise fail the
+					// diff or silently drop the path from the patch.
+					args = append(args, "--")
+					args = append(args, pathSpecs...)
+				}
+				fmt.Fprintln(stdio.Stdout, "running git", strings.Join(args, " "))
 				cmd := exec.CommandContext(ctx, "git", args...)
 				cmd.Dir = root
+				cmd.Env = append(os.Environ(), "GIT_LITERAL_PATHSPECS=1")
 				cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
 				cmd.Stderr = stdio.Stderr
 				if err := cmd.Run(); err != nil {

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -22,6 +22,7 @@ import (
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 	bkclient "github.com/dagger/dagger/internal/buildkit/client"
 	telemetry "github.com/dagger/otel-go"
+	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/trace"
@@ -1026,17 +1027,40 @@ func mergeBeforeDirectories(ctx context.Context, ch *Changeset, others ...*Chang
 	selectors := []dagql.Selector{
 		{Field: "directory"},
 	}
-	beforeID, err := ch.Before.ID()
-	if err != nil {
-		return dagql.ObjectResult[*Directory]{}, fmt.Errorf("before ID: %w", err)
-	}
-	selectors = append(selectors, withDirectorySelector(beforeID))
-	for _, other := range others {
-		otherBeforeID, err := other.Before.ID()
+	// Changesets merged together are normally diffs taken against a common
+	// base, so their before directories are usually the same directory
+	// repeated. Merging a directory onto itself is a no-op, but each merge
+	// still walks the whole tree, so folding in N identical copies costs N
+	// full-tree copies to produce what the first one already produced.
+	//
+	// Only consecutive repeats are collapsed. Dropping every repeat would
+	// reorder a sequence like A, B, A, where the trailing A is what decides
+	// paths that A and B disagree on.
+	var lastDigest digest.Digest
+	appendBefore := func(before dagql.ObjectResult[*Directory]) error {
+		dgst, err := before.ContentPreferredDigest(ctx)
 		if err != nil {
-			return dagql.ObjectResult[*Directory]{}, fmt.Errorf("other before ID: %w", err)
+			return fmt.Errorf("before content-preferred digest: %w", err)
 		}
-		selectors = append(selectors, withDirectorySelector(otherBeforeID))
+		if dgst == lastDigest {
+			return nil
+		}
+		id, err := before.ID()
+		if err != nil {
+			return fmt.Errorf("before ID: %w", err)
+		}
+		lastDigest = dgst
+		selectors = append(selectors, withDirectorySelector(id))
+		return nil
+	}
+
+	if err := appendBefore(ch.Before); err != nil {
+		return dagql.ObjectResult[*Directory]{}, err
+	}
+	for _, other := range others {
+		if err := appendBefore(other.Before); err != nil {
+			return dagql.ObjectResult[*Directory]{}, err
+		}
 	}
 
 	selectors = append(selectors, dagql.Selector{

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -156,14 +156,19 @@ func (*DiffStat) DecodePersistedObject(_ context.Context, _ *dagql.Server, _ uin
 // metadata and git diffs.
 func (ch *Changeset) ComputePaths(ctx context.Context) (*ChangesetPaths, error) {
 	ch.pathsOnce.Do(func() {
-		enginetel.Task(ctx, "computing paths", func(ctx context.Context) error {
+		_ = enginetel.Task(ctx, "computing paths", func(ctx context.Context) error {
 			ch.cachedPaths, ch.pathsErr = ch.computePathsOnce(ctx)
-			out := telemetry.SpanStdio(ctx, InstrumentationLibrary).Stdout
-			fmt.Fprintln(out, "added:", ch.cachedPaths.Added)
-			fmt.Fprintln(out, "removed:", ch.cachedPaths.Removed)
-			fmt.Fprintln(out, "modified:", ch.cachedPaths.Modified)
-			fmt.Fprintln(out, "renamed:", ch.cachedPaths.Renamed)
-			return ch.pathsErr
+			if ch.pathsErr != nil {
+				// nothing to report; cachedPaths is nil on error
+				return ch.pathsErr
+			}
+			stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+			defer stdio.Close()
+			fmt.Fprintln(stdio.Stdout, "added:", ch.cachedPaths.Added)
+			fmt.Fprintln(stdio.Stdout, "removed:", ch.cachedPaths.Removed)
+			fmt.Fprintln(stdio.Stdout, "modified:", ch.cachedPaths.Modified)
+			fmt.Fprintln(stdio.Stdout, "renamed:", ch.cachedPaths.Renamed)
+			return nil
 		})
 	})
 	return ch.cachedPaths, ch.pathsErr
@@ -628,6 +633,9 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 		return nil, err
 	}
 
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
+	defer stdio.Close()
+
 	newRef, err := query.SnapshotManager().New(ctx, nil,
 		bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
 		bkcache.WithDescription("Changeset.asPatch"))
@@ -704,15 +712,12 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 				// with --binary the result is identical.
 				args := []string{"diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b"}
 				args = append(args, pathSpecs...)
-				if err := enginetel.Task(ctx, strings.Join(args, " "), func(context.Context) error {
-					stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
-					defer stdio.Close()
-					cmd := exec.CommandContext(ctx, "git", args...)
-					cmd.Dir = root
-					cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
-					cmd.Stderr = stdio.Stderr
-					return cmd.Run()
-				}); err != nil {
+				fmt.Fprint(stdio.Stdout, "running git", args)
+				cmd := exec.CommandContext(ctx, "git", args...)
+				cmd.Dir = root
+				cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
+				cmd.Stderr = stdio.Stderr
+				if err := cmd.Run(); err != nil {
 					var exitErr *exec.ExitError
 					// Check if it's exit code 1, which is expected for git diff when files differ
 					if errors.As(err, &exitErr) && exitErr.ExitCode() != 1 {

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -1097,21 +1097,25 @@ func mergeBeforeDirectories(ctx context.Context, ch *Changeset, others ...*Chang
 	// Only consecutive repeats are collapsed. Dropping every repeat would
 	// reorder a sequence like A, B, A, where the trailing A is what decides
 	// paths that A and B disagree on.
+	// haveLast rather than comparing against the zero digest: an empty digest
+	// would otherwise read as a repeat of nothing and drop the first before
+	// directory, silently changing the merge base.
 	var lastDigest digest.Digest
+	var haveLast bool
 	appendBefore := func(before dagql.ObjectResult[*Directory]) error {
 		return enginetel.Task(ctx, "append before", func(ctx context.Context) error {
 			dgst, err := before.ContentPreferredDigest(ctx)
 			if err != nil {
 				return fmt.Errorf("before content-preferred digest: %w", err)
 			}
-			if dgst == lastDigest {
+			if haveLast && dgst == lastDigest {
 				return nil
 			}
 			id, err := before.ID()
 			if err != nil {
 				return fmt.Errorf("before ID: %w", err)
 			}
-			lastDigest = dgst
+			lastDigest, haveLast = dgst, true
 			selectors = append(selectors, withDirectorySelector(id))
 			return nil
 		})

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -685,9 +685,6 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 		return nil, err
 	}
 
-	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
-	defer stdio.Close()
-
 	newRef, err := query.SnapshotManager().New(ctx, nil,
 		bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
 		bkcache.WithDescription("Changeset.asPatch"))
@@ -768,23 +765,32 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 					args = append(args, "--")
 					args = append(args, pathSpecs...)
 				}
-				fmt.Fprintln(stdio.Stdout, "running git", strings.Join(args, " "))
-				cmd := exec.CommandContext(ctx, "git", args...)
-				cmd.Dir = root
-				cmd.Env = append(os.Environ(), "GIT_LITERAL_PATHSPECS=1")
-				cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
-				cmd.Stderr = stdio.Stderr
-				if err := cmd.Run(); err != nil {
-					var exitErr *exec.ExitError
-					// Check if it's exit code 1, which is expected for git diff when files differ
-					if errors.As(err, &exitErr) && exitErr.ExitCode() != 1 {
+				return enginetel.Task(ctx, "git diff", func(ctx context.Context) error {
+					stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
+					defer stdio.Close()
+					// The span is named for the command rather than the whole
+					// argv, which the pathspecs make unbounded; log those.
+					fmt.Fprintln(stdio.Stdout, "running git", strings.Join(args, " "))
+					cmd := exec.CommandContext(ctx, "git", args...)
+					cmd.Dir = root
+					cmd.Env = append(os.Environ(), "GIT_LITERAL_PATHSPECS=1")
+					cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
+					cmd.Stderr = stdio.Stderr
+					if err := cmd.Run(); err != nil {
+						var exitErr *exec.ExitError
+						// Exit code 1 just means the trees differ, which is the
+						// whole point; returning it would end the span in error
+						// for every patch that isn't empty.
+						if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+							return nil
+						}
 						// NB: we could technically populate an ExecError here, but that
 						// feels like it leaks implementation details; "exit status 128" isn't
 						// exactly clear
 						return fmt.Errorf("failed to generate patch: %w", err)
 					}
-				}
-				return nil
+					return nil
+				})
 			})
 		}, mountRefAsReadOnly)
 	}, mountRefAsReadOnly)

--- a/core/directory.go
+++ b/core/directory.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dagger/dagger/util/patternmatcher"
 	"github.com/dustin/go-humanize"
 	"github.com/vektah/gqlparser/v2/ast"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
@@ -1621,7 +1620,6 @@ func (dir *Directory) applyPatchToSnapshot(ctx context.Context, parentRef bkcach
 		return nil, err
 	}
 
-	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
 	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
 	defer stdio.Close()
 
@@ -1797,8 +1795,6 @@ func (dir *Directory) Search(ctx context.Context, self dagql.ObjectResult[*Direc
 	if err != nil {
 		return nil, err
 	}
-
-	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
 
 	results := []*SearchResult{}
 	err = MountRef(ctx, ref, func(root string, _ *mount.Mount) error {

--- a/core/file.go
+++ b/core/file.go
@@ -24,7 +24,6 @@ import (
 	bkclient "github.com/dagger/dagger/internal/buildkit/client"
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/engineutil"
@@ -825,8 +824,6 @@ func (file *File) Search(ctx context.Context, self dagql.ObjectResult[*File], op
 		return nil, err
 	}
 
-	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
-
 	results := []*SearchResult{}
 	err = MountRef(ctx, ref, func(root string, _ *mount.Mount) error {
 		resolvedDir, err := containerdfs.RootPath(root, filepath.Dir(filePath))
@@ -848,8 +845,6 @@ func (file *File) Search(ctx context.Context, self dagql.ObjectResult[*File], op
 
 //nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
 func (file *File) WithReplaced(ctx context.Context, parent dagql.ObjectResult[*File], searchStr, replacementStr string, firstFrom *int, all bool) error {
-	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
-
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return err

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -1177,10 +1177,20 @@ func runningInsideModule(ctx context.Context) (bool, error) {
 func (src *ModuleSource) outerEnvFile(ctx context.Context) (*EnvFile, string, error) {
 	// The outer env file is the caller's own .env, found by walking their host.
 	// Module code has no host session, so this lookup can only block until the
-	// context deadline; and resolving it through the caller's client instead
-	// would hand a module the caller's .env for any module source it can
-	// synthesize. innerEnvFile already refuses non-local sources "for safety" —
-	// this is the same restriction from the other direction.
+	// context deadline.
+	//
+	// This only reaches dir- and git-kind sources: LoadUserDefaults swaps in the
+	// non-module parent's client metadata for local sources before getting here,
+	// so those still resolve against the caller's host as they always have.
+	// Extending that to dir/git would be a wider grant — it would hand a module
+	// the caller's .env for any module source it can synthesize — so they get an
+	// empty one instead. innerEnvFile already refuses non-local sources "for
+	// safety"; this is the same restriction from the other direction.
+	//
+	// core/schema/git.go runs the same check for host git credentials and pairs
+	// it with an IsModuleDependencyResolution escape hatch. There is nothing to
+	// escape to here: findUp from a nested client only ever timed out, so there
+	// is no working behavior to preserve.
 	inModule, err := runningInsideModule(ctx)
 	if err != nil {
 		return nil, "", err

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -1155,7 +1155,40 @@ func (src *ModuleSource) innerEnvFile(ctx context.Context) (*EnvFile, string, er
 	return envFile, envFilePath, nil
 }
 
+// runningInsideModule reports whether the caller is module code rather than a
+// client that owns a host session, by comparing the current client against the
+// nearest non-module ancestor.
+func runningInsideModule(ctx context.Context) (bool, error) {
+	current, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return false, err
+	}
+	parent, err := query.NonModuleParentClientMetadata(ctx)
+	if err != nil {
+		return false, err
+	}
+	return current.ClientID != parent.ClientID, nil
+}
+
 func (src *ModuleSource) outerEnvFile(ctx context.Context) (*EnvFile, string, error) {
+	// The outer env file is the caller's own .env, found by walking their host.
+	// Module code has no host session, so this lookup can only block until the
+	// context deadline; and resolving it through the caller's client instead
+	// would hand a module the caller's .env for any module source it can
+	// synthesize. innerEnvFile already refuses non-local sources "for safety" —
+	// this is the same restriction from the other direction.
+	inModule, err := runningInsideModule(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	if inModule {
+		return &EnvFile{}, "", nil
+	}
+
 	dag, err := CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, "", err

--- a/engine/telemetry/task.go
+++ b/engine/telemetry/task.go
@@ -1,0 +1,24 @@
+package telemetry
+
+import (
+	"context"
+
+	dagtel "github.com/dagger/otel-go"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Task(ctx context.Context, name string, fn func(context.Context) error) (rerr error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().
+		Tracer("dagger.io/engine/telemetry").
+		Start(ctx, name, dagtel.Internal())
+	defer dagtel.EndWithCause(span, &rerr)
+	return fn(ctx)
+}
+
+func TaskRet[T any](ctx context.Context, name string, fn func(context.Context) (T, error)) (ret T, rerr error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().
+		Tracer("dagger.io/engine/telemetry").
+		Start(ctx, name, dagtel.Internal())
+	defer dagtel.EndWithCause(span, &rerr)
+	return fn(ctx)
+}

--- a/toolchains/cli-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/cli-dev/internal/dagger/dagger.gen.go
@@ -2467,6 +2467,69 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	return convert(response), nil
 }
 
+// ContainerLayerOpts contains options for Container.Layer
+type ContainerLayerOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Returns the image layer or configuration blob with the given digest as a File.
+func (r *Container) Layer(id string, opts ...ContainerLayerOpts) *File {
+	q := r.query.Select("layer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+	q = q.Arg("id", id)
+
+	return &File{
+		query: q,
+	}
+}
+
+// ContainerManifestOpts contains options for Container.Manifest
+type ContainerManifestOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Computes and returns the manifest for this container as a File.
+func (r *Container) Manifest(opts ...ContainerManifestOpts) *File {
+	q := r.query.Select("manifest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.query.Select("mounts")

--- a/toolchains/docs-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/docs-dev/internal/dagger/dagger.gen.go
@@ -2467,6 +2467,69 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	return convert(response), nil
 }
 
+// ContainerLayerOpts contains options for Container.Layer
+type ContainerLayerOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Returns the image layer or configuration blob with the given digest as a File.
+func (r *Container) Layer(id string, opts ...ContainerLayerOpts) *File {
+	q := r.query.Select("layer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+	q = q.Arg("id", id)
+
+	return &File{
+		query: q,
+	}
+}
+
+// ContainerManifestOpts contains options for Container.Manifest
+type ContainerManifestOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Computes and returns the manifest for this container as a File.
+func (r *Container) Manifest(opts ...ContainerManifestOpts) *File {
+	q := r.query.Select("manifest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.query.Select("mounts")

--- a/toolchains/engine-dev/internal/dagger/dagger.gen.go
+++ b/toolchains/engine-dev/internal/dagger/dagger.gen.go
@@ -2467,6 +2467,69 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	return convert(response), nil
 }
 
+// ContainerLayerOpts contains options for Container.Layer
+type ContainerLayerOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Returns the image layer or configuration blob with the given digest as a File.
+func (r *Container) Layer(id string, opts ...ContainerLayerOpts) *File {
+	q := r.query.Select("layer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+	q = q.Arg("id", id)
+
+	return &File{
+		query: q,
+	}
+}
+
+// ContainerManifestOpts contains options for Container.Manifest
+type ContainerManifestOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Computes and returns the manifest for this container as a File.
+func (r *Container) Manifest(opts ...ContainerManifestOpts) *File {
+	q := r.query.Select("manifest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.query.Select("mounts")

--- a/toolchains/go/internal/dagger/dagger.gen.go
+++ b/toolchains/go/internal/dagger/dagger.gen.go
@@ -2467,6 +2467,69 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	return convert(response), nil
 }
 
+// ContainerLayerOpts contains options for Container.Layer
+type ContainerLayerOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Returns the image layer or configuration blob with the given digest as a File.
+func (r *Container) Layer(id string, opts ...ContainerLayerOpts) *File {
+	q := r.query.Select("layer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+	q = q.Arg("id", id)
+
+	return &File{
+		query: q,
+	}
+}
+
+// ContainerManifestOpts contains options for Container.Manifest
+type ContainerManifestOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Computes and returns the manifest for this container as a File.
+func (r *Container) Manifest(opts ...ContainerManifestOpts) *File {
+	q := r.query.Select("manifest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.query.Select("mounts")

--- a/toolchains/release/internal/dagger/dagger.gen.go
+++ b/toolchains/release/internal/dagger/dagger.gen.go
@@ -2467,6 +2467,69 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	return convert(response), nil
 }
 
+// ContainerLayerOpts contains options for Container.Layer
+type ContainerLayerOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Returns the image layer or configuration blob with the given digest as a File.
+func (r *Container) Layer(id string, opts ...ContainerLayerOpts) *File {
+	q := r.query.Select("layer")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+	q = q.Arg("id", id)
+
+	return &File{
+		query: q,
+	}
+}
+
+// ContainerManifestOpts contains options for Container.Manifest
+type ContainerManifestOpts struct {
+	// Force each layer of the image to use the specified compression algorithm.
+	//
+	// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
+	ForcedCompression ImageLayerCompression
+	// Media types to use for image layers. Defaults to OCI.
+	//
+	// Default: OCIMediaTypes
+	MediaTypes ImageMediaTypes
+}
+
+// Computes and returns the manifest for this container as a File.
+func (r *Container) Manifest(opts ...ContainerManifestOpts) *File {
+	q := r.query.Select("manifest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `forcedCompression` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
+			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
+		}
+	}
+
+	return &File{
+		query: q,
+	}
+}
+
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.query.Select("mounts")

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -93,7 +93,7 @@ func (c *Copier) copy(ctx context.Context, src *source, matcher *matcher, srcPat
 		return err
 	}
 	if opts.CopyDirContents && root.Info.IsDir() {
-		if err := c.dest.removeForReplace(destPath, root.Info, opts); err != nil {
+		if _, err := c.dest.removeForReplace(destPath, root.Info, opts); err != nil {
 			return err
 		}
 		if _, _, err := c.dest.ensureDir(destPath, &root, opts, false); err != nil {
@@ -198,7 +198,7 @@ func (c *Copier) copyEntry(
 			if err := c.ensurePending(pending, opts); err != nil {
 				return err
 			}
-			if err := c.dest.removeForReplace(destPath, ent.Info, opts); err != nil {
+			if _, err := c.dest.removeForReplace(destPath, ent.Info, opts); err != nil {
 				return err
 			}
 			rel, _, err := c.dest.ensureDir(destPath, &ent, opts, true)
@@ -252,12 +252,17 @@ func (c *Copier) ensurePending(pending []pendingDir, opts CopyOptions) error {
 }
 
 func (c *Copier) copyNode(ent sourceEntry, destPath string, opts CopyOptions) error {
-	if err := c.dest.removeForReplace(destPath, ent.Info, opts); err != nil {
-		return err
-	}
-	realPath, err := c.dest.realPath(destPath)
+	// removeForReplace already resolves the write-root path when it removes
+	// something; reuse it rather than resolving the same path twice.
+	realPath, err := c.dest.removeForReplace(destPath, ent.Info, opts)
 	if err != nil {
 		return err
+	}
+	if realPath == "" {
+		realPath, err = c.dest.realPath(destPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	mode := ent.Info.Mode()

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -93,18 +93,20 @@ func (c *Copier) copy(ctx context.Context, src *source, matcher *matcher, srcPat
 		return err
 	}
 	if opts.CopyDirContents && root.Info.IsDir() {
-		if _, err := c.dest.removeForReplace(destPath, root.Info, opts); err != nil {
+		if _, err := c.dest.removeForReplace(destPath, resolvedParent{}, root.Info, opts); err != nil {
 			return err
 		}
-		if _, _, err := c.dest.ensureDir(destPath, &root, opts, false); err != nil {
+		rel, _, err := c.dest.ensureDir(destPath, &root, opts, false)
+		if err != nil {
 			return err
 		}
 		entries, err := src.readDir("")
 		if err != nil {
 			return err
 		}
+		parent := resolvedParent{rel: rel, ok: true}
 		for _, ent := range entries {
-			if err := c.copyEntry(ctx, src, matcher, ent, filepath.Join(destPath, filepath.Base(ent.Rel)), opts, matchState{}, nil); err != nil {
+			if err := c.copyEntry(ctx, src, matcher, ent, filepath.Join(destPath, filepath.Base(ent.Rel)), opts, matchState{}, nil, parent); err != nil {
 				return err
 			}
 		}
@@ -123,7 +125,7 @@ func (c *Copier) copy(ctx context.Context, src *source, matcher *matcher, srcPat
 	} else if destExists && destInfo.IsDir() {
 		destPath = filepath.Join(destPath, filepath.Base(src.baseView))
 	}
-	return c.copyEntry(ctx, src, matcher, root, destPath, opts, matchState{}, nil)
+	return c.copyEntry(ctx, src, matcher, root, destPath, opts, matchState{}, nil, resolvedParent{})
 }
 
 func (c *Copier) copyFile(ctx context.Context, src *source, srcPath, destPath string, opts CopyOptions) error {
@@ -157,7 +159,7 @@ func (c *Copier) copyFile(ctx context.Context, src *source, srcPath, destPath st
 		RealPath: src.baseReal,
 		Info:     src.baseInfo,
 	}
-	return c.copyNode(ent, destPath, opts)
+	return c.copyNode(ent, destPath, resolvedParent{}, opts)
 }
 
 func (c *Copier) copyEntry(
@@ -169,6 +171,7 @@ func (c *Copier) copyEntry(
 	opts CopyOptions,
 	parentState matchState,
 	pending []pendingDir,
+	parent resolvedParent,
 ) error {
 	select {
 	case <-ctx.Done():
@@ -193,18 +196,20 @@ func (c *Copier) copyEntry(
 
 	if ent.Info.IsDir() {
 		childPending := pending
+		childParent := resolvedParent{}
 		var realDirPath string
 		if include {
 			if err := c.ensurePending(pending, opts); err != nil {
 				return err
 			}
-			if _, err := c.dest.removeForReplace(destPath, ent.Info, opts); err != nil {
+			if _, err := c.dest.removeForReplace(destPath, parent, ent.Info, opts); err != nil {
 				return err
 			}
 			rel, _, err := c.dest.ensureDir(destPath, &ent, opts, true)
 			if err != nil {
 				return err
 			}
+			childParent = resolvedParent{rel: rel, ok: true}
 			realDirPath = filepath.Join(c.dest.writeRoot, rel)
 		} else {
 			childPending = append(childPending, pendingDir{entry: ent, destPath: destPath})
@@ -223,7 +228,7 @@ func (c *Copier) copyEntry(
 		}
 		for _, child := range children {
 			childDest := filepath.Join(destPath, filepath.Base(child.Rel))
-			if err := c.copyEntry(ctx, src, matcher, child, childDest, opts, state, childPending); err != nil {
+			if err := c.copyEntry(ctx, src, matcher, child, childDest, opts, state, childPending, childParent); err != nil {
 				return err
 			}
 		}
@@ -239,7 +244,7 @@ func (c *Copier) copyEntry(
 	if err := c.ensurePending(pending, opts); err != nil {
 		return err
 	}
-	return c.copyNode(ent, destPath, opts)
+	return c.copyNode(ent, destPath, parent, opts)
 }
 
 func (c *Copier) ensurePending(pending []pendingDir, opts CopyOptions) error {
@@ -251,15 +256,15 @@ func (c *Copier) ensurePending(pending []pendingDir, opts CopyOptions) error {
 	return nil
 }
 
-func (c *Copier) copyNode(ent sourceEntry, destPath string, opts CopyOptions) error {
+func (c *Copier) copyNode(ent sourceEntry, destPath string, parent resolvedParent, opts CopyOptions) error {
 	// removeForReplace already resolves the write-root path when it removes
 	// something; reuse it rather than resolving the same path twice.
-	realPath, err := c.dest.removeForReplace(destPath, ent.Info, opts)
+	realPath, err := c.dest.removeForReplace(destPath, parent, ent.Info, opts)
 	if err != nil {
 		return err
 	}
 	if realPath == "" {
-		realPath, err = c.dest.realPath(destPath)
+		realPath, err = c.dest.realPathIn(destPath, parent)
 		if err != nil {
 			return err
 		}

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -274,14 +274,14 @@ func (c *Copier) copyNode(ent sourceEntry, destPath string, opts CopyOptions) er
 		if err != nil {
 			return err
 		}
-		if err := os.RemoveAll(realPath); err != nil {
+		if err := c.dest.removeAll(realPath, !opts.ReplaceExisting); err != nil {
 			return err
 		}
 		if err := os.Symlink(target, realPath); err != nil {
 			return err
 		}
 	case mode&os.ModeDevice != 0, mode&os.ModeNamedPipe != 0, mode&os.ModeSocket != 0:
-		if err := os.RemoveAll(realPath); err != nil {
+		if err := c.dest.removeAll(realPath, !opts.ReplaceExisting); err != nil {
 			return err
 		}
 		if err := mknod(realPath, ent.Info); err != nil {
@@ -302,7 +302,7 @@ func (c *Copier) copyRegular(ent sourceEntry, realPath string, opts CopyOptions)
 	if !opts.DisableHardlinks {
 		ino = statInode(st)
 		if linkSrc, ok := c.dest.sourceLinks[ino]; ok {
-			if err := os.RemoveAll(realPath); err != nil {
+			if err := c.dest.removeAll(realPath, !opts.ReplaceExisting); err != nil {
 				return err
 			}
 			if err := os.Link(linkSrc, realPath); err != nil && !isHardlinkFallback(err) {
@@ -314,7 +314,7 @@ func (c *Copier) copyRegular(ent sourceEntry, realPath string, opts CopyOptions)
 	}
 
 	if !opts.DisableHardlinks && !opts.DisableSourceHardlinks && opts.Chown == nil && opts.Mode == nil {
-		if err := os.RemoveAll(realPath); err != nil {
+		if err := c.dest.removeAll(realPath, !opts.ReplaceExisting); err != nil {
 			return err
 		}
 		if err := os.Link(ent.RealPath, realPath); err == nil {

--- a/util/layercopy/copy_linux_bench_test.go
+++ b/util/layercopy/copy_linux_bench_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package layercopy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildBenchTree writes a tree approximating a source repository: a fixed
+// branching factor down to the given depth, with filesPerDir regular files at
+// every level. Depth matters as much as file count here, because destination
+// path resolution walks from the root for each entry.
+func buildBenchTree(tb testing.TB, root string, depth, branch, filesPerDir int) int {
+	tb.Helper()
+	files := 0
+	var build func(dir string, d int)
+	build = func(dir string, d int) {
+		require.NoError(tb, os.MkdirAll(dir, 0o755))
+		for i := range filesPerDir {
+			p := filepath.Join(dir, fmt.Sprintf("file%d.txt", i))
+			require.NoError(tb, os.WriteFile(p, []byte("contents"), 0o644))
+			files++
+		}
+		if d == 0 {
+			return
+		}
+		for i := range branch {
+			build(filepath.Join(dir, fmt.Sprintf("dir%d", i)), d-1)
+		}
+	}
+	build(root, depth)
+	return files
+}
+
+// BenchmarkCopyDirectoryOntoExisting mirrors the engine's hot path: repeated
+// Directory.withDirectory merges of the same large source tree onto a
+// destination that already contains it, i.e. CopyDirContents+ReplaceExisting
+// where every entry already exists at the destination.
+func BenchmarkCopyDirectoryOntoExisting(b *testing.B) {
+	root := b.TempDir()
+	srcRoot := filepath.Join(root, "src")
+	dstRoot := filepath.Join(root, "dst")
+	files := buildBenchTree(b, srcRoot, 6, 2, 16)
+	require.NoError(b, os.Mkdir(dstRoot, 0o755))
+
+	opts := CopyOptions{CopyDirContents: true, ReplaceExisting: true}
+	ctx := context.Background()
+
+	// Seed the destination so every measured iteration takes the
+	// ReplaceExisting path, as it does for the second and later merges.
+	seed, err := NewCopier(Mount{Root: dstRoot})
+	require.NoError(b, err)
+	require.NoError(b, seed.Copy(ctx, Mount{Root: srcRoot}, "/", "/", opts))
+	require.NoError(b, seed.Close())
+
+	b.ReportMetric(float64(files), "files")
+	for b.Loop() {
+		copier, err := NewCopier(Mount{Root: dstRoot})
+		require.NoError(b, err)
+		require.NoError(b, copier.Copy(ctx, Mount{Root: srcRoot}, "/", "/", opts))
+		require.NoError(b, copier.Close())
+	}
+}

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -442,3 +442,47 @@ func requireOpaqueDir(t *testing.T, path string) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{'y'}, val)
 }
+
+// TestMaterializeDeepOverlayAncestors covers materializing several levels of
+// pre-existing view directories into an empty upper in one step. Ancestors are
+// resolved once and then created parent-first; creating them in any other
+// order fails because the parent does not exist yet.
+func TestMaterializeDeepOverlayAncestors(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	srcRoot := filepath.Join(root, "src")
+	viewRoot := filepath.Join(root, "view")
+	upperRoot := filepath.Join(root, "upper")
+	require.NoError(t, os.Mkdir(srcRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcRoot, "leaf.txt"), []byte("leaf"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(viewRoot, "a", "b", "c", "d"), 0o755))
+	require.NoError(t, os.Mkdir(upperRoot, 0o755))
+
+	copier, err := NewCopier(Mount{
+		Root: viewRoot,
+		Mount: &mount.Mount{
+			Type:    "overlay",
+			Options: []string{"upperdir=" + upperRoot},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, copier.Close())
+	})
+
+	err = copier.Copy(context.Background(), Mount{Root: srcRoot}, "/", "/a/b/c/d", CopyOptions{
+		CopyDirContents: true,
+		ReplaceExisting: true,
+	})
+	require.NoError(t, err)
+
+	for _, dir := range []string{"a", "a/b", "a/b/c", "a/b/c/d"} {
+		info, err := os.Lstat(filepath.Join(upperRoot, dir))
+		require.NoErrorf(t, err, "ancestor %q was not materialized", dir)
+		require.True(t, info.IsDir())
+	}
+	got, err := os.ReadFile(filepath.Join(upperRoot, "a", "b", "c", "d", "leaf.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "leaf", string(got))
+}

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -387,10 +387,11 @@ func TestRemoveForReplaceDirectoryOverOverlayLowerFileMarksOpaque(t *testing.T) 
 	srcInfo, err := os.Stat(filepath.Join(srcRoot, "node"))
 	require.NoError(t, err)
 
-	err = dst.removeForReplace("/node", srcInfo, CopyOptions{
+	realPath, err := dst.removeForReplace("/node", srcInfo, CopyOptions{
 		ReplaceExisting: true,
 	})
 	require.NoError(t, err)
+	require.Equal(t, filepath.Join(upperRoot, "node"), realPath)
 
 	info, err := os.Stat(filepath.Join(upperRoot, "node"))
 	require.NoError(t, err)

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -233,7 +233,7 @@ func TestCopyEntryMissingSourceAfterFilter(t *testing.T) {
 			ViewPath: "/src/gone.txt",
 			RealPath: "/src/gone.txt",
 			StatErr:  missingErr,
-		}, "/dst/gone.txt", CopyOptions{}, matchState{}, nil)
+		}, "/dst/gone.txt", CopyOptions{}, matchState{}, nil, resolvedParent{})
 		require.NoError(t, err)
 	})
 
@@ -250,7 +250,7 @@ func TestCopyEntryMissingSourceAfterFilter(t *testing.T) {
 			ViewPath: "/src/gone.txt",
 			RealPath: "/src/gone.txt",
 			StatErr:  missingErr,
-		}, "/dst/gone.txt", CopyOptions{}, matchState{}, nil)
+		}, "/dst/gone.txt", CopyOptions{}, matchState{}, nil, resolvedParent{})
 		require.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
@@ -387,7 +387,7 @@ func TestRemoveForReplaceDirectoryOverOverlayLowerFileMarksOpaque(t *testing.T) 
 	srcInfo, err := os.Stat(filepath.Join(srcRoot, "node"))
 	require.NoError(t, err)
 
-	realPath, err := dst.removeForReplace("/node", srcInfo, CopyOptions{
+	realPath, err := dst.removeForReplace("/node", resolvedParent{}, srcInfo, CopyOptions{
 		ReplaceExisting: true,
 	})
 	require.NoError(t, err)

--- a/util/layercopy/dest_linux.go
+++ b/util/layercopy/dest_linux.go
@@ -37,6 +37,11 @@ type destination struct {
 	// subtree stop re-stat'ing every ancestor. It holds an invariant relied on
 	// when walking ancestors: if a path is present, so are all of its parents.
 	// Directory removals drop the whole set; file removals cannot invalidate it.
+	//
+	// This assumes the write root is only mutated through the Copier for its
+	// lifetime. Callers that reach around it — core/directory.go's withChanges
+	// removes changeset paths with a plain RemoveAll — must do so before the
+	// first copy, while the set is still empty.
 	materializedDirs map[string]struct{}
 }
 

--- a/util/layercopy/dest_linux.go
+++ b/util/layercopy/dest_linux.go
@@ -350,6 +350,48 @@ func (d *destination) removeAll(realPath string, mayBeDir bool) error {
 	return nil
 }
 
+// resolvedParent carries the destination directory an entry is being copied
+// into, once it has already been resolved and materialized. Entries inside it
+// then need no resolution of their own: their parent is known to be
+// symlink-free, so only their final component can still be a symlink. ok is
+// false when the parent is not known yet, and paths are resolved from the
+// destination root as before.
+type resolvedParent struct {
+	rel string
+	ok  bool
+}
+
+// realPathIn returns the write-root path for destPath, using a known parent
+// directory when there is one. realPath resolves only the parent and appends
+// the final component, so this is the same answer without the walk.
+func (d *destination) realPathIn(destPath string, parent resolvedParent) (string, error) {
+	if !parent.ok {
+		return d.realPath(destPath)
+	}
+	base := filepath.Base(cleanContainerPath(destPath))
+	return filepath.Join(d.writeRoot, parent.rel, base), nil
+}
+
+// statViewIn stats destPath in the view, using a known parent directory when
+// there is one. Only the final component can still be a symlink there, so an
+// lstat settles the common case and the bounded resolution below is only
+// needed when it turns out to be one.
+func (d *destination) statViewIn(destPath string, parent resolvedParent) (os.FileInfo, bool, error) {
+	if parent.ok {
+		base := filepath.Base(cleanContainerPath(destPath))
+		info, err := os.Lstat(filepath.Join(d.viewRoot, parent.rel, base))
+		switch {
+		case err == nil && info.Mode()&os.ModeSymlink == 0:
+			return info, true, nil
+		case err != nil && (os.IsNotExist(err) || isNotDir(err)):
+			return nil, false, nil
+		case err != nil:
+			return nil, false, err
+		}
+	}
+	return d.statView(destPath)
+}
+
 func (d *destination) realPath(destPath string) (string, error) {
 	destPath = cleanContainerPath(destPath)
 	parentRel, err := d.ensureParent(destPath)
@@ -382,12 +424,12 @@ func (d *destination) statView(destPath string) (os.FileInfo, bool, error) {
 // returns the resolved write-root path whenever it had to resolve one, so that
 // callers needing the same path can reuse it instead of resolving it a second
 // time. An empty string means nothing was resolved and nothing was removed.
-func (d *destination) removeForReplace(destPath string, srcInfo os.FileInfo, opts CopyOptions) (string, error) {
+func (d *destination) removeForReplace(destPath string, parent resolvedParent, srcInfo os.FileInfo, opts CopyOptions) (string, error) {
 	if !opts.ReplaceExisting {
 		return "", nil
 	}
 
-	destInfo, exists, err := d.statView(destPath)
+	destInfo, exists, err := d.statViewIn(destPath, parent)
 	if err != nil || !exists {
 		return "", err
 	}
@@ -395,7 +437,7 @@ func (d *destination) removeForReplace(destPath string, srcInfo os.FileInfo, opt
 		return "", nil
 	}
 
-	realPath, err := d.realPath(destPath)
+	realPath, err := d.realPathIn(destPath, parent)
 	if err != nil {
 		return "", err
 	}

--- a/util/layercopy/dest_linux.go
+++ b/util/layercopy/dest_linux.go
@@ -319,35 +319,39 @@ func (d *destination) statView(destPath string) (os.FileInfo, bool, error) {
 	return nil, false, err
 }
 
-func (d *destination) removeForReplace(destPath string, srcInfo os.FileInfo, opts CopyOptions) error {
+// removeForReplace clears a destination path that is about to be replaced. It
+// returns the resolved write-root path whenever it had to resolve one, so that
+// callers needing the same path can reuse it instead of resolving it a second
+// time. An empty string means nothing was resolved and nothing was removed.
+func (d *destination) removeForReplace(destPath string, srcInfo os.FileInfo, opts CopyOptions) (string, error) {
 	if !opts.ReplaceExisting {
-		return nil
+		return "", nil
 	}
 
 	destInfo, exists, err := d.statView(destPath)
 	if err != nil || !exists {
-		return err
+		return "", err
 	}
 	if srcInfo.IsDir() && destInfo.IsDir() {
-		return nil
+		return "", nil
 	}
 
 	realPath, err := d.realPath(destPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := os.RemoveAll(realPath); err != nil {
-		return err
+		return "", err
 	}
 	if d.overlay && srcInfo.IsDir() && !destInfo.IsDir() {
 		if err := os.Mkdir(realPath, srcInfo.Mode().Perm()); err != nil && !os.IsExist(err) {
-			return err
+			return "", err
 		}
 		if err := d.markOpaque(realPath); err != nil {
-			return err
+			return "", err
 		}
 	}
-	return nil
+	return realPath, nil
 }
 
 func (d *destination) applyMetadataPath(dstPath string, src *sourceEntry, opts CopyOptions) error {

--- a/util/layercopy/dest_linux.go
+++ b/util/layercopy/dest_linux.go
@@ -31,6 +31,13 @@ type destination struct {
 
 	sourceLinks map[inode]string
 	crossLinks  map[inode]struct{}
+
+	// materializedDirs records resolved relative paths already known to exist
+	// as directories in the write root, so repeated copies into the same
+	// subtree stop re-stat'ing every ancestor. It holds an invariant relied on
+	// when walking ancestors: if a path is present, so are all of its parents.
+	// Directory removals drop the whole set; file removals cannot invalidate it.
+	materializedDirs map[string]struct{}
 }
 
 func newDestination(m Mount) (*destination, error) {
@@ -39,10 +46,11 @@ func newDestination(m Mount) (*destination, error) {
 	}
 
 	d := &destination{
-		viewRoot:    m.Root,
-		writeRoot:   m.Root,
-		sourceLinks: map[inode]string{},
-		crossLinks:  map[inode]struct{}{},
+		viewRoot:         m.Root,
+		writeRoot:        m.Root,
+		sourceLinks:      map[inode]string{},
+		crossLinks:       map[inode]struct{}{},
+		materializedDirs: map[string]struct{}{},
 	}
 	if m.Mount == nil {
 		return d, nil
@@ -83,7 +91,7 @@ func (d *destination) mkdir(destPath string, opts CopyOptions) error {
 			if err != nil {
 				return err
 			}
-			if err := os.RemoveAll(realPath); err != nil {
+			if err := d.removeAll(realPath, false); err != nil {
 				return err
 			}
 			if d.overlay {
@@ -160,12 +168,10 @@ func (d *destination) ensureExistingDir(destPath string, src *sourceEntry, opts 
 		return "", false, err
 	}
 	rel = cleanRel(rel)
-	// Recurse on the parent of the resolved path, not destPath, to handle
-	// symlinks on dest paths.
-	if parent := filepath.Dir(cleanContainerPath(rel)); parent != "/" && parent != "." {
-		if _, _, err := d.ensureDir(parent, nil, CopyOptions{}, false); err != nil {
-			return "", false, err
-		}
+	// Materialize the ancestors of the resolved path, not of destPath, to
+	// handle symlinks on dest paths.
+	if err := d.materializeAncestors(rel); err != nil {
+		return "", false, err
 	}
 	realPath, materialized, err := d.materializeExistingDir(rel, viewPath)
 	if err != nil {
@@ -230,6 +236,7 @@ func (d *destination) createDir(destPath string, src *sourceEntry, opts CopyOpti
 	if err := d.applyMetadataPath(realPath, src, opts); err != nil {
 		return "", false, err
 	}
+	d.markMaterialized(cleanRel(rel))
 	return rel, true, nil
 }
 
@@ -244,7 +251,7 @@ func (d *destination) replaceCreateDir(realPath string, mode os.FileMode, opts C
 	if info.IsDir() {
 		return nil
 	}
-	if err := os.RemoveAll(realPath); err != nil {
+	if err := d.removeAll(realPath, false); err != nil {
 		return err
 	}
 	if err := os.Mkdir(realPath, mode); err != nil && !os.IsExist(err) {
@@ -267,12 +274,44 @@ func mkdirMode(src *sourceEntry, opts CopyOptions) os.FileMode {
 	return mode
 }
 
+// materializeAncestors ensures every ancestor of rel exists in the write root.
+//
+// rel is produced by rootPath, so every component of it is already resolved:
+// none of its ancestors can be a symlink and none of them need resolving
+// again. Walking them directly avoids re-resolving the whole path from the
+// destination root once per level, which made ensuring a directory cost work
+// quadratic in its depth. The walk stops at the first ancestor known to be
+// materialized, since everything above it must be materialized too.
+func (d *destination) materializeAncestors(rel string) error {
+	var ancestors []string
+	for p := filepath.Dir(cleanContainerPath(rel)); p != "/" && p != "."; p = filepath.Dir(p) {
+		ancRel := cleanRel(p)
+		if _, ok := d.materializedDirs[ancRel]; ok {
+			break
+		}
+		ancestors = append(ancestors, ancRel)
+	}
+	// Materialize top-down so each parent exists before its child, preserving
+	// the materializedDirs invariant.
+	slices.Reverse(ancestors)
+	for _, ancRel := range ancestors {
+		if _, _, err := d.materializeExistingDir(ancRel, filepath.Join(d.viewRoot, ancRel)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (d *destination) materializeExistingDir(rel, viewPath string) (string, bool, error) {
 	realPath := filepath.Join(d.writeRoot, rel)
+	if _, ok := d.materializedDirs[rel]; ok {
+		return realPath, false, nil
+	}
 	if info, err := os.Lstat(realPath); err == nil {
 		if !info.IsDir() {
 			return "", false, fmt.Errorf("destination upper path %q exists and is not a directory", realPath)
 		}
+		d.markMaterialized(rel)
 		return realPath, false, nil
 	} else if !os.IsNotExist(err) {
 		return "", false, err
@@ -288,7 +327,27 @@ func (d *destination) materializeExistingDir(rel, viewPath string) (string, bool
 	if err := copyMetadata(realPath, viewPath, info, nil, nil, false, nil, false); err != nil {
 		return "", false, err
 	}
+	d.markMaterialized(rel)
 	return realPath, true, nil
+}
+
+func (d *destination) markMaterialized(rel string) {
+	if rel != "" {
+		d.materializedDirs[rel] = struct{}{}
+	}
+}
+
+// removeAll removes a path from the write root. mayBeDir reports whether the
+// caller cannot rule out that the path is a directory; removing a directory
+// invalidates the materialized set, whereas removing a file never can.
+func (d *destination) removeAll(realPath string, mayBeDir bool) error {
+	if err := os.RemoveAll(realPath); err != nil {
+		return err
+	}
+	if mayBeDir {
+		clear(d.materializedDirs)
+	}
+	return nil
 }
 
 func (d *destination) realPath(destPath string) (string, error) {
@@ -340,7 +399,7 @@ func (d *destination) removeForReplace(destPath string, srcInfo os.FileInfo, opt
 	if err != nil {
 		return "", err
 	}
-	if err := os.RemoveAll(realPath); err != nil {
+	if err := d.removeAll(realPath, destInfo.IsDir()); err != nil {
 		return "", err
 	}
 	if d.overlay && srcInfo.IsDir() && !destInfo.IsDir() {

--- a/util/parallel/parallel.go
+++ b/util/parallel/parallel.go
@@ -11,8 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func New() parallelJobs {
-	return parallelJobs{
+func New() Jobs {
+	return Jobs{
 		Tracing:  true, // Enable tracing by default
 		Internal: false,
 		Reveal:   false, // this used to be 'true', but it caused too many "hiding noisy spans" in web trace view
@@ -27,7 +27,9 @@ func Run(ctx context.Context, name string, fn JobFunc) error {
 	return New().WithJob(name, fn).Run(ctx)
 }
 
-type parallelJobs struct {
+// Jobs is a set of jobs to run together, built up with the With methods and
+// executed by Run.
+type Jobs struct {
 	Jobs     []Job
 	Limit    *int
 	Internal bool
@@ -65,55 +67,55 @@ type Job struct {
 
 type JobFunc func(context.Context) error
 
-func (p parallelJobs) WithTracing(tracing bool) parallelJobs {
+func (p Jobs) WithTracing(tracing bool) Jobs {
 	p = p.Clone()
 	p.Tracing = tracing
 	return p
 }
 
-func (p parallelJobs) WithInternal(internal bool) parallelJobs {
+func (p Jobs) WithInternal(internal bool) Jobs {
 	p = p.Clone()
 	p.Internal = internal
 	return p
 }
 
-func (p parallelJobs) WithReveal(reveal bool) parallelJobs {
+func (p Jobs) WithReveal(reveal bool) Jobs {
 	p = p.Clone()
 	p.Reveal = reveal
 	return p
 }
 
-func (p parallelJobs) WithContextualTracer(contextualTracer bool) parallelJobs {
+func (p Jobs) WithContextualTracer(contextualTracer bool) Jobs {
 	p = p.Clone()
 	p.ContextualTracer = contextualTracer
 	return p
 }
 
-func (p parallelJobs) WithRollupSpans(rollupSpans bool) parallelJobs {
+func (p Jobs) WithRollupSpans(rollupSpans bool) Jobs {
 	p = p.Clone()
 	p.RollupSpans = rollupSpans
 	return p
 }
 
-func (p parallelJobs) WithRollupLogs(rollupLogs bool) parallelJobs {
+func (p Jobs) WithRollupLogs(rollupLogs bool) Jobs {
 	p = p.Clone()
 	p.RollupLogs = rollupLogs
 	return p
 }
 
-func (p parallelJobs) WithFailFast(failFast bool) parallelJobs {
+func (p Jobs) WithFailFast(failFast bool) Jobs {
 	p = p.Clone()
 	p.FailFast = failFast
 	return p
 }
 
-func (p parallelJobs) WithJob(name string, fn JobFunc, attributes ...attribute.KeyValue) parallelJobs {
+func (p Jobs) WithJob(name string, fn JobFunc, attributes ...attribute.KeyValue) Jobs {
 	p = p.Clone()
 	p.Jobs = append(p.Jobs, Job{name, fn, attributes, p.Internal, p.Reveal, p.ContextualTracer, p.RollupLogs, p.RollupSpans, p.Tracing})
 	return p
 }
 
-func (p parallelJobs) Clone() parallelJobs {
+func (p Jobs) Clone() Jobs {
 	cp := p
 	cp.Jobs = slices.Clone(cp.Jobs)
 	return cp
@@ -173,13 +175,13 @@ func (job Job) Run(ctx context.Context) error {
 	return job.Runner(ctx)()
 }
 
-func (p parallelJobs) WithLimit(limit int) parallelJobs {
+func (p Jobs) WithLimit(limit int) Jobs {
 	p = p.Clone()
 	p.Limit = &limit
 	return p
 }
 
-func (p parallelJobs) Run(ctx context.Context) error {
+func (p Jobs) Run(ctx context.Context) error {
 	if p.FailFast {
 		return p.runFailFast(ctx)
 	}
@@ -193,7 +195,7 @@ func (p parallelJobs) Run(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func (p parallelJobs) runFailFast(ctx context.Context) error {
+func (p Jobs) runFailFast(ctx context.Context) error {
 	eg := pool.New().WithContext(ctx).WithCancelOnError().WithFirstError()
 	if p.Limit != nil {
 		eg = eg.WithMaxGoroutines(*p.Limit)
@@ -206,7 +208,7 @@ func (p parallelJobs) runFailFast(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func (p parallelJobs) RunSerial(ctx context.Context) error {
+func (p Jobs) RunSerial(ctx context.Context) error {
 	for _, job := range p.Jobs {
 		if err := job.Run(ctx); err != nil {
 			return err


### PR DESCRIPTION
Engine-side changes needed before `generate-all` can be performant across a workspace with many modules. Split out from the 1.0 conversion work so it can be deployed first.

The three groups below are independent, and they are **not** equally load-bearing — please read the caveat on the `layercopy` group before reviewing it.

## `modulesource`: `outerEnvFile` from module code

This one is the point of the PR. It is motivated entirely by https://github.com/dagger/polyfill/pull/6, which deletes 1023 lines by asking the engine for a module's generated-context changeset directly instead of round-tripping it through a nested privileged Go helper. That polyfill change is blocked on this commit.

`innerEnvFile` refuses non-local sources "for safety", but `outerEnvFile` had no such guard and unconditionally reached for `host.findUp(".env")`. Module code has no host session, so loading a dir-kind module source from inside a module blocked until the context deadline and then failed with `failed to get requester session: context deadline exceeded`. `Workspace.moduleSource` produces dir-kind sources, which made that whole API unreachable from module code — and it is the API that lets an SDK module generate without shelling out to a nested session.

`outerEnvFile` now returns empty when the caller is module code. Resolving it through the caller's client instead would also have worked, but that would hand a module the caller's `.env` for any module source it can synthesize.

**This is the change most worth careful review.** It changes when user defaults get loaded, and it is the only one here whose behavior isn't pinned by an existing test.

## `changeset`: repeated `before` directories

Merging changesets first unions their `before` directories, one `withDirectory` per changeset. Changesets merged together are normally diffs taken against a common base, so those directories are usually the same directory repeated — merging one onto itself changes nothing but still walks the whole tree. A merge of N changesets paid N full-tree copies to produce what the first one already produced. This showed up directly in traces of `generate-all` as a run of identical `withDirectory(path: "", source: Host.directory(...))` calls, one per module.

Consecutive repeats are now collapsed, comparing content-preferred digests the same way changeset path computation already does. Only consecutive repeats are dropped: removing every repeat would reorder a sequence like `A, B, A`, where the trailing `A` is what decides paths that `A` and `B` disagree on.

## `layercopy`: destination path resolution — and a caveat

**These were tried first and had little to no effect on real `generate-all` performance. Happy to drop them from this PR if we'd rather not carry them.**

They came out of a CPU profile showing `Directory.withDirectory` at over half of engine CPU, with 88% of syscall time in `lstat`. The optimizations do what they claim in isolation, but a profile taken after deploying them showed total engine CPU down only ~27%, with the real cost sitting elsewhere — which is what led to the two changes above. They stand on their own as a large reduction in per-entry copy cost, and `withDirectory` is hot for plenty besides generation, but they are not what makes `generate-all` fast.

Three commits, each measured against a new benchmark reproducing the shape the engine hits — a deep source tree copied onto a destination that already contains it, with `CopyDirContents` and `ReplaceExisting` set.

- `copyNode` resolved the write-root path twice per entry, once inside `removeForReplace` and again immediately after. The first result is now returned and reused.
- Ensuring a directory resolved its path from the destination root and then recursed on the parent, which resolved from the root again. Resolution `lstat`s every component, so ensuring one directory cost work quadratic in its depth, and every copied entry ensured its parent. The recursion was never necessary: the relative path being recursed on comes out of `rootPath`, so it is already fully resolved and none of its ancestors can be a symlink.
- Copying walks depth-first, so by the time an entry is copied its destination directory has just been resolved. That result was thrown away and every entry resolved its own destination from the root again. It is now threaded down into the entries inside it.

On the benchmark (2032 files, six levels deep):

| | ms/op | allocs/op | bytes/op |
|---|---|---|---|
| before | 113.0 | 1,283,717 | 79.9 MB |
| after | 17.5 | 62,493 | 5.89 MB |

`lstat` calls over a fixed workload drop from 201,160 to 11,196.

## Testing

- `util/layercopy` unit tests pass, including two added cases: materializing several levels of pre-existing overlay directories in one step (parent-first ordering), and the existing symlinked-destination-directory case, which covers the new resolved-parent fast path's symlink fallback.
- `TestChangeset` integration suite passes in full, covering both callers of `mergeBeforeDirectories` — the two-way `WithChangeset` and the N-way `WithChangesets`.

## Not measured

The benchmark and syscall numbers above are real and reproducible. The end-to-end effect on a large `generate-all` run is **not** measured here — that needs https://github.com/dagger/polyfill/pull/6 and the corresponding dang-sdk change deployed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
