### PR TITLE
engine-dev: fix comment formatting lint on main

### DIFF
--- a/toolchains/engine-dev/main.go
+++ b/toolchains/engine-dev/main.go
@@ -460,12 +460,12 @@ var targets = []struct {
 		Platforms: []dagger.Platform{"linux/amd64", "linux/arm64"},
 	},
 	// comment out nvidia variant for the moment to fix publish steps
-	//{
-	//Name:       "wolfi with nvidia variant",
-	//Tag:        "%s-gpu",
-	//Platforms:  []dagger.Platform{"linux/amd64"},
-	//GPUSupport: true,
-	//},
+	// {
+	// 	Name:       "wolfi with nvidia variant",
+	// 	Tag:        "%s-gpu",
+	// 	Platforms:  []dagger.Platform{"linux/amd64"},
+	// 	GPUSupport: true,
+	// },
 }
 
 type targetResult struct {


### PR DESCRIPTION
`golang:lint-all` fails on every branch based on current main: gocritic (`commentFormatting`) rejects the `//`-without-space style of the commented-out nvidia variant from b16582775 (#13746).

Verified by running `dagger check "golang:lint-all"` locally: green with this change, red without.

cc @marcosnils