### PR TITLE
engine: fix throttled registry uploads

### DIFF
--- a/engine/server/resolver/progress.go
+++ b/engine/server/resolver/progress.go
@@ -69,6 +69,17 @@ type progressWriter struct {
 	lastEmit time.Time
 }
 
+func (pw *progressWriter) Status() (content.Status, error) {
+	status, err := pw.Writer.Status()
+	if err != nil {
+		return content.Status{}, err
+	}
+	pw.mu.Lock()
+	pw.offset = status.Offset
+	pw.mu.Unlock()
+	return status, nil
+}
+
 func (pw *progressWriter) Write(p []byte) (int, error) {
 	n, err := pw.Writer.Write(p)
 	if n > 0 {

--- a/engine/server/resolver/push_test.go
+++ b/engine/server/resolver/push_test.go
@@ -27,6 +27,7 @@ func TestPushImageRetriesThrottledUpload(t *testing.T) {
 	img, store, expectedBlobs := newTestPushImage(t, ctx, 10)
 	registry := newThrottledPushRegistry(t, expectedBlobs)
 	t.Cleanup(registry.Close)
+	defer registry.releaseUploads()
 	registryHost := strings.TrimPrefix(registry.URL, "http://")
 
 	rslvr := New(Opts{
@@ -66,8 +67,13 @@ func TestPushImageRetriesThrottledUpload(t *testing.T) {
 	}()
 
 	select {
-	case <-registry.allUploadsStarted:
-	case <-time.After(250 * time.Millisecond):
+	case <-registry.uploadLimitReached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for concurrent uploads")
+	}
+	if rslvr.pushLimiter.TryAcquire(1) {
+		rslvr.pushLimiter.Release(1)
+		t.Fatal("registry uploads did not hold all limiter slots")
 	}
 	registry.releaseUploads()
 
@@ -79,6 +85,7 @@ func TestPushImageRetriesThrottledUpload(t *testing.T) {
 	}
 	require.NoError(t, registry.err())
 	require.Equal(t, 2, registry.throttledAttempts())
+	require.Equal(t, len(expectedBlobs), registry.firstUploadCount())
 	require.LessOrEqual(t, registry.maxConcurrentUploads(), maxConcurrentRegistryUploads)
 }
 
@@ -137,10 +144,10 @@ type throttledPushRegistry struct {
 
 	expectedBlobs map[digest.Digest][]byte
 
-	allUploadsStarted chan struct{}
-	uploadsReleased   chan struct{}
-	releaseOnce       sync.Once
-	allStartedOnce    sync.Once
+	uploadLimitReached chan struct{}
+	uploadsReleased    chan struct{}
+	releaseOnce        sync.Once
+	limitReachedOnce   sync.Once
 
 	mu                sync.Mutex
 	firstErr          error
@@ -156,10 +163,10 @@ func newThrottledPushRegistry(t *testing.T, expectedBlobs map[digest.Digest][]by
 	t.Helper()
 
 	registry := &throttledPushRegistry{
-		expectedBlobs:     expectedBlobs,
-		allUploadsStarted: make(chan struct{}),
-		uploadsReleased:   make(chan struct{}),
-		attempts:          map[digest.Digest]int{},
+		expectedBlobs:      expectedBlobs,
+		uploadLimitReached: make(chan struct{}),
+		uploadsReleased:    make(chan struct{}),
+		attempts:           map[digest.Digest]int{},
 	}
 	registry.Server = httptest.NewServer(http.HandlerFunc(registry.serveHTTP))
 	return registry
@@ -217,15 +224,15 @@ func (r *throttledPushRegistry) serveBlobUpload(w http.ResponseWriter, req *http
 	if r.activeUploads > r.maxActiveUploads {
 		r.maxActiveUploads = r.activeUploads
 	}
+	if r.activeUploads == maxConcurrentRegistryUploads {
+		r.limitReachedOnce.Do(func() {
+			close(r.uploadLimitReached)
+		})
+	}
 	r.attempts[dgst]++
 	attempt := r.attempts[dgst]
 	if attempt == 1 {
 		r.firstUploads++
-		if r.firstUploads == len(r.expectedBlobs) {
-			r.allStartedOnce.Do(func() {
-				close(r.allUploadsStarted)
-			})
-		}
 	}
 	if r.throttledDigest == "" {
 		r.throttledDigest = dgst
@@ -294,6 +301,12 @@ func (r *throttledPushRegistry) throttledAttempts() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.attempts[r.throttledDigest]
+}
+
+func (r *throttledPushRegistry) firstUploadCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.firstUploads
 }
 
 func (r *throttledPushRegistry) maxConcurrentUploads() int {

--- a/engine/server/resolver/push_test.go
+++ b/engine/server/resolver/push_test.go
@@ -1,0 +1,303 @@
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	localcontentstore "github.com/containerd/containerd/v2/plugins/content/local"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushImageRetriesThrottledUpload(t *testing.T) {
+	ctx := context.Background()
+	img, store, expectedBlobs := newTestPushImage(t, ctx, 10)
+	registry := newThrottledPushRegistry(t, expectedBlobs)
+	t.Cleanup(registry.Close)
+	registryHost := strings.TrimPrefix(registry.URL, "http://")
+
+	rslvr := New(Opts{
+		Hosts: func(domain string) ([]docker.RegistryHost, error) {
+			require.Equal(t, registryHost, domain)
+			return []docker.RegistryHost{
+				{
+					Client: registry.Client(),
+					Scheme: "http",
+					Host:   registryHost,
+					Path:   "/v2",
+					Capabilities: docker.HostCapabilityPull |
+						docker.HostCapabilityResolve |
+						docker.HostCapabilityPush,
+				},
+			}, nil
+		},
+		ContentStore: store,
+		LeaseManager: newTestLeaseManager(),
+	})
+	t.Cleanup(func() {
+		require.NoError(t, rslvr.Close())
+	})
+
+	pushDone := make(chan error, 1)
+	go func() {
+		pushDone <- rslvr.PushImage(
+			ctx,
+			img,
+			registryHost+"/dagger/test:latest",
+			PushOpts{
+				RegistryTransport: RegistryTransport{
+					Protocol: RegistryProtocolHTTP,
+				},
+			},
+		)
+	}()
+
+	select {
+	case <-registry.allUploadsStarted:
+	case <-time.After(250 * time.Millisecond):
+	}
+	registry.releaseUploads()
+
+	select {
+	case err := <-pushDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for image push")
+	}
+	require.NoError(t, registry.err())
+	require.Equal(t, 2, registry.throttledAttempts())
+	require.LessOrEqual(t, registry.maxConcurrentUploads(), maxConcurrentRegistryUploads)
+}
+
+func newTestPushImage(t *testing.T, ctx context.Context, layerCount int) (*PushedImage, content.Store, map[digest.Digest][]byte) {
+	t.Helper()
+
+	store, err := localcontentstore.NewLabeledStore(t.TempDir(), newTestContentLabelStore())
+	require.NoError(t, err)
+
+	expectedBlobs := make(map[digest.Digest][]byte, layerCount+1)
+	layers := make([]ocispecs.Descriptor, 0, layerCount)
+	for i := range layerCount {
+		payload := bytes.Repeat([]byte(fmt.Sprintf("layer-%02d-", i)), 16)
+		desc := testDescriptor(ocispecs.MediaTypeImageLayerGzip, payload)
+		layers = append(layers, desc)
+		expectedBlobs[desc.Digest] = payload
+		require.NoError(t, content.WriteBlob(ctx, store, fmt.Sprintf("seed-layer-%d", i), bytes.NewReader(payload), desc))
+	}
+
+	configBytes := []byte(`{"architecture":"amd64","os":"linux","config":{}}`)
+	configDesc := testDescriptor(ocispecs.MediaTypeImageConfig, configBytes)
+	expectedBlobs[configDesc.Digest] = configBytes
+	require.NoError(t, content.WriteBlob(ctx, store, "seed-config", bytes.NewReader(configBytes), configDesc))
+
+	manifestBytes, err := json.Marshal(ocispecs.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispecs.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    layers,
+	})
+	require.NoError(t, err)
+	manifestDesc := testDescriptor(ocispecs.MediaTypeImageManifest, manifestBytes)
+	manifestDesc.Platform = &ocispecs.Platform{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+	require.NoError(t, content.WriteBlob(ctx, store, "seed-manifest", bytes.NewReader(manifestBytes), manifestDesc))
+
+	indexBytes, err := json.Marshal(ocispecs.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispecs.MediaTypeImageIndex,
+		Manifests: []ocispecs.Descriptor{manifestDesc},
+	})
+	require.NoError(t, err)
+	rootDesc := testDescriptor(ocispecs.MediaTypeImageIndex, indexBytes)
+	require.NoError(t, content.WriteBlob(ctx, store, "seed-index", bytes.NewReader(indexBytes), rootDesc))
+
+	return &PushedImage{
+		RootDesc: rootDesc,
+		Provider: store,
+	}, store, expectedBlobs
+}
+
+type throttledPushRegistry struct {
+	*httptest.Server
+
+	expectedBlobs map[digest.Digest][]byte
+
+	allUploadsStarted chan struct{}
+	uploadsReleased   chan struct{}
+	releaseOnce       sync.Once
+	allStartedOnce    sync.Once
+
+	mu                sync.Mutex
+	firstErr          error
+	activeUploads     int
+	maxActiveUploads  int
+	firstUploads      int
+	throttledDigest   digest.Digest
+	attempts          map[digest.Digest]int
+	nextUploadSession int
+}
+
+func newThrottledPushRegistry(t *testing.T, expectedBlobs map[digest.Digest][]byte) *throttledPushRegistry {
+	t.Helper()
+
+	registry := &throttledPushRegistry{
+		expectedBlobs:     expectedBlobs,
+		allUploadsStarted: make(chan struct{}),
+		uploadsReleased:   make(chan struct{}),
+		attempts:          map[digest.Digest]int{},
+	}
+	registry.Server = httptest.NewServer(http.HandlerFunc(registry.serveHTTP))
+	return registry
+}
+
+func (r *throttledPushRegistry) serveHTTP(w http.ResponseWriter, req *http.Request) {
+	switch {
+	case req.URL.Path == "/v2/":
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		w.WriteHeader(http.StatusOK)
+
+	case req.Method == http.MethodHead &&
+		(strings.Contains(req.URL.Path, "/blobs/") || strings.Contains(req.URL.Path, "/manifests/")):
+		http.NotFound(w, req)
+
+	case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/blobs/uploads/"):
+		r.mu.Lock()
+		r.nextUploadSession++
+		uploadID := r.nextUploadSession
+		r.mu.Unlock()
+		w.Header().Set("Docker-Upload-UUID", fmt.Sprintf("upload-%d", uploadID))
+		w.Header().Set("Location", fmt.Sprintf("/v2/dagger/test/blobs/uploads/upload-%d", uploadID))
+		w.Header().Set("Range", "0-0")
+		w.WriteHeader(http.StatusAccepted)
+
+	case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/blobs/uploads/"):
+		r.serveBlobUpload(w, req)
+
+	case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/manifests/"):
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			r.recordError(fmt.Errorf("read manifest body: %w", err))
+			http.Error(w, "read manifest", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", digest.FromBytes(payload).String())
+		w.Header().Set("Location", req.URL.Path)
+		w.WriteHeader(http.StatusCreated)
+
+	default:
+		http.NotFound(w, req)
+	}
+}
+
+func (r *throttledPushRegistry) serveBlobUpload(w http.ResponseWriter, req *http.Request) {
+	dgst, err := digest.Parse(req.URL.Query().Get("digest"))
+	if err != nil {
+		r.recordError(fmt.Errorf("parse upload digest: %w", err))
+		http.Error(w, "invalid digest", http.StatusBadRequest)
+		return
+	}
+
+	r.mu.Lock()
+	r.activeUploads++
+	if r.activeUploads > r.maxActiveUploads {
+		r.maxActiveUploads = r.activeUploads
+	}
+	r.attempts[dgst]++
+	attempt := r.attempts[dgst]
+	if attempt == 1 {
+		r.firstUploads++
+		if r.firstUploads == len(r.expectedBlobs) {
+			r.allStartedOnce.Do(func() {
+				close(r.allUploadsStarted)
+			})
+		}
+	}
+	if r.throttledDigest == "" {
+		r.throttledDigest = dgst
+	}
+	throttled := r.throttledDigest == dgst
+	r.mu.Unlock()
+
+	defer func() {
+		r.mu.Lock()
+		r.activeUploads--
+		r.mu.Unlock()
+	}()
+
+	<-r.uploadsReleased
+
+	payload, err := io.ReadAll(req.Body)
+	if err != nil {
+		r.recordError(fmt.Errorf("read blob %s attempt %d: %w", dgst, attempt, err))
+		http.Error(w, "read blob", http.StatusInternalServerError)
+		return
+	}
+	expected, ok := r.expectedBlobs[dgst]
+	if !ok {
+		r.recordError(fmt.Errorf("unexpected blob %s", dgst))
+		http.Error(w, "unexpected blob", http.StatusBadRequest)
+		return
+	}
+	if !bytes.Equal(expected, payload) {
+		r.recordError(fmt.Errorf("blob %s attempt %d: expected %d bytes, got %d", dgst, attempt, len(expected), len(payload)))
+		http.Error(w, "invalid blob", http.StatusBadRequest)
+		return
+	}
+
+	if throttled && attempt == 1 {
+		w.Header().Set("Retry-After", "0")
+		http.Error(w, "retry upload", http.StatusTooManyRequests)
+		return
+	}
+
+	w.Header().Set("Docker-Content-Digest", dgst.String())
+	w.Header().Set("Location", req.URL.Path)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (r *throttledPushRegistry) releaseUploads() {
+	r.releaseOnce.Do(func() {
+		close(r.uploadsReleased)
+	})
+}
+
+func (r *throttledPushRegistry) recordError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.firstErr == nil {
+		r.firstErr = err
+	}
+}
+
+func (r *throttledPushRegistry) err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.firstErr
+}
+
+func (r *throttledPushRegistry) throttledAttempts() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.attempts[r.throttledDigest]
+}
+
+func (r *throttledPushRegistry) maxConcurrentUploads() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.maxActiveUploads
+}

--- a/engine/server/resolver/resolver.go
+++ b/engine/server/resolver/resolver.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"slices"
@@ -29,18 +30,22 @@ import (
 	"github.com/dagger/dagger/internal/buildkit/util/contentutil"
 	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/dagger/dagger/internal/buildkit/util/imageutil"
-	buildkitpush "github.com/dagger/dagger/internal/buildkit/util/push"
 	"github.com/dagger/dagger/internal/buildkit/util/tracing"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/distribution/reference"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 var ErrCredentialsNotFound = errors.New("registry credentials not found")
+
+// Keep registry pushes bounded to avoid overwhelming registries with one
+// request per image layer at once.
+const maxConcurrentRegistryUploads = 4
 
 type Credentials struct {
 	Username string
@@ -137,6 +142,7 @@ type Resolver struct {
 	auth         AuthSource
 	contentStore content.Store
 	leaseManager leases.Manager
+	pushLimiter  *semaphore.Weighted
 
 	resolveConfigG flightcontrol.Group[*resolveImageConfigResult]
 
@@ -151,6 +157,7 @@ func New(opts Opts) *Resolver {
 		auth:         opts.Auth,
 		contentStore: opts.ContentStore,
 		leaseManager: opts.LeaseManager,
+		pushLimiter:  semaphore.NewWeighted(maxConcurrentRegistryUploads),
 		hostCache:    map[string][]docker.RegistryHost{},
 	}
 }
@@ -623,16 +630,13 @@ func (r *Resolver) PushImage(ctx context.Context, img *PushedImage, ref string, 
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Hosts: r.pushRegistryHosts(opts.RegistryTransport, opts.Network),
 	})
-	pusher, err := buildkitpush.Pusher(ctx, resolver, ref)
+	pusher, err := resolver.Pusher(ctx, ref)
 	if err != nil {
 		return err
 	}
 
-	pushHandler := buildkitpush.Pusher
-	_ = pushHandler
-
 	pushUpdateSourceHandler, err := updateDistributionSourceHandler(r.contentStore, images.HandlerFunc(func(ctx context.Context, desc ocispecs.Descriptor) ([]ocispecs.Descriptor, error) {
-		_, err := limitedPushHandler(pusher, img.Provider)(ctx, desc)
+		_, err := pushHandler(pusher, img.Provider)(ctx, desc)
 		return nil, err
 	}), ref)
 	if err != nil {
@@ -663,7 +667,7 @@ func (r *Resolver) PushImage(ctx context.Context, img *PushedImage, ref string, 
 	}
 	rootDesc.MediaType = mediaType
 
-	if err := images.Dispatch(ctx, skipNonDistributableBlobs(images.Handlers(handlers...)), nil, rootDesc); err != nil {
+	if err := images.Dispatch(ctx, skipNonDistributableBlobs(images.Handlers(handlers...)), r.pushLimiter, rootDesc); err != nil {
 		return err
 	}
 
@@ -671,7 +675,7 @@ func (r *Resolver) PushImage(ctx context.Context, img *PushedImage, ref string, 
 	if err != nil {
 		return err
 	}
-	pushLeaf := limitedPushHandler(pusher, img.Provider)
+	pushLeaf := pushHandler(pusher, img.Provider)
 	for i := len(manifestStack) - 1; i >= 0; i-- {
 		if _, err := pushLeaf(ctx, manifestStack[i]); err != nil {
 			return err
@@ -1174,7 +1178,7 @@ func collectManifestStack(ctx context.Context, provider content.Provider, rootDe
 	return stack, nil
 }
 
-func limitedPushHandler(pusher remotes.Pusher, provider content.Provider) images.HandlerFunc {
+func pushHandler(pusher remotes.Pusher, provider content.Provider) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispecs.Descriptor) ([]ocispecs.Descriptor, error) {
 		cw, err := pusher.Push(ctx, desc)
 		if err != nil {
@@ -1192,11 +1196,11 @@ func limitedPushHandler(pusher remotes.Pusher, provider content.Provider) images
 		// stream upload progress per layer, attributed to the "pushing
 		// <ref>" span carried by ctx
 		w := wrapProgressWriter(ctx, cw, desc)
-		if err := content.Copy(ctx, w, content.NewReader(ra), desc.Size, desc.Digest); err != nil {
+		if err := content.Copy(ctx, w, io.NewSectionReader(ra, 0, desc.Size), desc.Size, desc.Digest); err != nil {
 			if errors.Is(err, cerrdefs.ErrAlreadyExists) {
 				return nil, nil
 			}
-			return nil, err
+			return nil, fmt.Errorf("push content %s (%d bytes): %w", desc.Digest, desc.Size, err)
 		}
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary

Registry image pushes could surface a misleading `short read: expected N bytes but got 0: unexpected EOF` after a registry throttled an upload with HTTP 429.

Containerd retries a throttled PUT by resetting its writer to offset zero and asking the caller to replay the request body. The resolver passed `content.Copy` a reader produced by `content.NewReader` over the local content store. That optimization returns a non-seekable reader, so once the first request consumed the body, the retry reused an exhausted stream and copied zero bytes.

This change:

- passes an explicit `io.SectionReader` so upload bodies can be rewound and replayed after a writer reset;
- shares a four-upload semaphore across registry pushes in the same resolver session, preventing concurrent image publications from creating an unbounded layer burst;
- synchronizes progress accounting with the writer offset after a reset;
- adds digest and size context to content-copy failures; and
- uses the containerd pusher directly, removing the resolver dependency on the BuildKit push helper.

Four is a conservative inherited low-single-digit default and an operational tuning point, not a proven universal optimum. The bound reduces avoidable registry pressure while retaining parallel uploads. This does not claim to eliminate registry throttling or add general transport retry and backoff policy.

## Regression test

The hermetic test uses an in-process OCI registry and the real containerd local content store. It:

1. holds four blob PUTs open to verify the shared concurrency bound;
2. fully consumes one upload body and responds with HTTP 429;
3. accepts the retry and verifies that the replayed bytes still match the expected digest; and
4. verifies that every expected blob was uploaded.

Without the rewindable reader, the test reproduces the zero-byte short-read failure. Without the limiter, it detects that the resolver semaphore is not governing the in-flight uploads.

## Validation

Run on Linux/amd64:

- `dagger api call engine-dev test --pkg ./engine/server/resolver --run='^TestPushImageRetriesThrottledUpload$'`
- `go test -count=1 ./engine/server/resolver`
- `go test -race -count=1 -run '^TestPushImageRetriesThrottledUpload$' ./engine/server/resolver`
- `go test -count=10 -run '^TestPushImageRetriesThrottledUpload$' ./engine/server/resolver`
- `go vet ./engine/server/resolver`
- `git diff --check`
