### PR TITLE
core: resolve bound services by their registered FQDN

### DIFF
--- a/.changes/unreleased/Fixed-20260727-193000.yaml
+++ b/.changes/unreleased/Fixed-20260727-193000.yaml
@@ -1,0 +1,14 @@
+kind: Fixed
+body: |
+  `Container.withServiceBinding` now works for a service whose custom hostname
+  was scoped to another module's DNS domain. A service created with
+  `withHostname` is namespaced into the domain of whichever module first starts
+  it, so a module that started its own service before handing it to a caller
+  left that caller's `withExec` failing at hosts-file setup with
+  `lookup <hostname> ... no such host`. Binding the service explicitly now
+  resolves it by the name it actually registered under. Reaching a module's
+  custom hostname by bare DNS remains scoped to that module.
+time: 2026-07-27T19:30:00Z
+custom:
+  Author: Zaba505
+  PR: 13751

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -2119,6 +2119,13 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 		}
 		defer detach()
 
+		// Same in-process pattern as ProfArgs above: the FQDN a bound service
+		// actually registered under is only known once it is running, which is
+		// after every execMD digest is computed. execMD is the same pointer the
+		// executor reads, so recording it here reaches the hosts-file setup
+		// without perturbing a cache key.
+		recordBoundServiceFQDNs(execMD, container.Services, runningSvcs)
+
 		execCtx := ctx
 		var cancelExec context.CancelCauseFunc
 		var serviceErrCh <-chan error

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -251,6 +251,35 @@ func (ServiceSuite) TestWithHostnameModuleScoping(ctx context.Context, t *testct
 	})
 }
 
+// A custom hostname is namespaced into the DNS domain of whichever module
+// starts the service, and the running instance is then shared session-wide by
+// content digest without that domain being part of its identity. A consumer in
+// another module therefore ends up holding a valid handle to a running service
+// whose only registered name it cannot resolve. Binding it explicitly still has
+// to work: unlike bare-hostname DNS (see TestWithHostnameModuleScoping), the
+// consumer was handed the service on purpose.
+func (ServiceSuite) TestWithHostnameServiceBindingAcrossModules(ctx context.Context, t *testctx.T) {
+	t.Run("service already started by the producing module", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		_, err := moduleFixture(t, c, "go/service-bind-hostname-cross").
+			With(withModuleFixture(t, c, "producer", "go/service-bind-hostname-producer")).
+			With(daggerCall("run")).
+			Sync(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("service first started by the binding itself", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		_, err := moduleFixture(t, c, "go/service-bind-hostname-cross").
+			With(withModuleFixture(t, c, "producer", "go/service-bind-hostname-producer")).
+			With(daggerCall("run-lazy")).
+			Sync(ctx)
+		require.NoError(t, err)
+	})
+}
+
 func (ServiceSuite) TestWithHostnameCircular(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/testdata/modules/go/service-bind-hostname-cross/dagger.json
+++ b/core/integration/testdata/modules/go/service-bind-hostname-cross/dagger.json
@@ -1,0 +1,13 @@
+{
+  "name": "consumer",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  },
+  "dependencies": [
+    {
+      "name": "producer",
+      "source": "producer"
+    }
+  ]
+}

--- a/core/integration/testdata/modules/go/service-bind-hostname-cross/main.go
+++ b/core/integration/testdata/modules/go/service-bind-hostname-cross/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"dagger/consumer/internal/dagger"
+)
+
+type Consumer struct{}
+
+// Run binds a service the producer module already started, and reaches it by
+// the hostname that module advertised. The service's custom hostname is scoped
+// to the producer's DNS domain, which this module never searches — binding it
+// explicitly has to work anyway.
+func (m *Consumer) Run(ctx context.Context) error {
+	reg := dag.Producer().Serve()
+
+	hostname, err := reg.Hostname(ctx)
+	if err != nil {
+		return err
+	}
+
+	return m.get(ctx, hostname, reg.Svc(), "hello from the started producer")
+}
+
+// RunLazy binds a service nothing has started yet, so this module's own binding
+// starts it.
+func (m *Consumer) RunLazy(ctx context.Context) error {
+	reg := dag.Producer().ServeLazy()
+
+	hostname, err := reg.Hostname(ctx)
+	if err != nil {
+		return err
+	}
+
+	return m.get(ctx, hostname, reg.Svc(), "hello from the lazy producer")
+}
+
+func (m *Consumer) get(ctx context.Context, hostname string, svc *dagger.Service, want string) error {
+	resp, err := dag.Container().
+		From("busybox:1.37.0").
+		WithEnvVariable("NOW", time.Now().String()).
+		WithServiceBinding(hostname, svc).
+		WithExec([]string{"wget", "-O-", "http://" + hostname}).
+		Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to reach bound service: %w", err)
+	}
+	if resp != want {
+		return fmt.Errorf("unexpected response: %q", resp)
+	}
+	return nil
+}

--- a/core/integration/testdata/modules/go/service-bind-hostname-producer/dagger.json
+++ b/core/integration/testdata/modules/go/service-bind-hostname-producer/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "producer",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  }
+}

--- a/core/integration/testdata/modules/go/service-bind-hostname-producer/main.go
+++ b/core/integration/testdata/modules/go/service-bind-hostname-producer/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+
+	"dagger/producer/internal/dagger"
+)
+
+type Producer struct{}
+
+// Registry models the shape a real module uses to hand a service to its
+// caller: a module object carrying the *dagger.Service on a declared field,
+// alongside the hostname that service advertises itself under.
+type Registry struct {
+	Svc      *dagger.Service
+	Hostname string
+}
+
+func (m *Producer) registry(hostname, greeting string) *Registry {
+	svc := dag.Container().
+		From("busybox:1.37.0").
+		WithWorkdir("/srv").
+		WithNewFile("index.html", greeting).
+		WithDefaultArgs([]string{"httpd", "-v", "-f"}).
+		WithExposedPort(80).
+		AsService().
+		WithHostname(hostname)
+
+	return &Registry{Svc: svc, Hostname: hostname}
+}
+
+// Serve returns a registry whose service this module has already started.
+// Starting module-side is what makes the service's custom hostname resolvable
+// only within this module's DNS domain, so the caller's later binding refers to
+// a running service it cannot reach through its own search domains.
+func (m *Producer) Serve(ctx context.Context) (*Registry, error) {
+	reg := m.registry("started-registry-host", "hello from the started producer")
+	if _, err := reg.Svc.Start(ctx); err != nil {
+		return nil, err
+	}
+	return reg, nil
+}
+
+// ServeLazy returns a registry without starting anything, so the caller's
+// binding is what starts the service. That ordering worked before the fix, and
+// is covered here to keep it working.
+func (m *Producer) ServeLazy() *Registry {
+	return m.registry("lazy-registry-host", "hello from the lazy producer")
+}

--- a/core/service.go
+++ b/core/service.go
@@ -607,6 +607,11 @@ func (svc *Service) startContainer(
 	}
 	cleanup.Add("detach deps", cleanups.Infallible(detachDeps))
 
+	// A service binding another module's custom-hostname service hits the same
+	// resolution problem its consumers do; see recordBoundServiceFQDNs. execMD
+	// is cloned above, so this never mutates shared state.
+	recordBoundServiceFQDNs(execMD, ctr.Services, runningDeps)
+
 	propagateDependencyExits := len(runningDeps) > 0 &&
 		running.Key.Kind != ServiceRuntimeInteractive &&
 		(opts.IO == nil || !opts.IO.Interactive)
@@ -1605,6 +1610,53 @@ type ServiceBinding struct {
 	Service  dagql.ObjectResult[*Service]
 	Hostname string
 	Aliases  AliasSet
+}
+
+// recordBoundServiceFQDNs notes, for each freshly started binding, the fully
+// qualified name the running service registered in DNS under, so the executor
+// can resolve it directly instead of re-deriving the bare hostname against the
+// consuming exec's search domains.
+//
+// A service with a custom hostname is namespaced into the domain of whichever
+// module happened to start it (see startContainer), and the running instance is
+// then shared session-wide by content digest without the domain forming part of
+// its identity. A consumer in another module therefore holds a perfectly valid
+// handle to a running service whose only registered name it cannot resolve.
+// Binding a service explicitly is a capability the consumer already has, so it
+// keeps working here; bare-hostname DNS stays namespaced as before.
+//
+// running is index-aligned with bindings, per Services.StartBindings.
+func recordBoundServiceFQDNs(
+	execMD *engineutil.ExecutionMetadata,
+	bindings ServiceBindings,
+	running []*RunningService,
+) {
+	if execMD == nil {
+		return
+	}
+	// Built locally and assigned once: callers may hand us a shallow clone of an
+	// ExecutionMetadata whose maps are still shared with the original.
+	fqdns := map[string]string{}
+	for i, bnd := range bindings {
+		if i >= len(running) {
+			break
+		}
+		svc := running[i]
+		if svc == nil || svc.Host == "" || svc.Host == bnd.Hostname {
+			continue
+		}
+		// Only services on the engine network get a name in the engine's DNS
+		// domain. A tunnel service reports a host-side dial address instead,
+		// which is meaningless inside the container and must keep resolving
+		// through the existing search-domain sweep.
+		if !strings.HasSuffix(svc.Host, network.DomainSuffix) {
+			continue
+		}
+		fqdns[bnd.Hostname] = svc.Host
+	}
+	if len(fqdns) > 0 {
+		execMD.HostAliasFQDNs = fqdns
+	}
 }
 
 func (bndp ServiceBindings) AttachDependencyResults(

--- a/core/service.go
+++ b/core/service.go
@@ -607,6 +607,11 @@ func (svc *Service) startContainer(
 	}
 	cleanup.Add("detach deps", cleanups.Infallible(detachDeps))
 
+	// A service binding another module's custom-hostname service hits the same
+	// resolution problem its consumers do; see recordBoundServiceFQDNs. execMD
+	// is cloned above, so this never mutates shared state.
+	recordBoundServiceFQDNs(execMD, ctr.Services, runningDeps)
+
 	propagateDependencyExits := len(runningDeps) > 0 &&
 		running.Key.Kind != ServiceRuntimeInteractive &&
 		(opts.IO == nil || !opts.IO.Interactive)
@@ -1604,6 +1609,53 @@ type ServiceBinding struct {
 	Service  dagql.ObjectResult[*Service]
 	Hostname string
 	Aliases  AliasSet
+}
+
+// recordBoundServiceFQDNs notes, for each freshly started binding, the fully
+// qualified name the running service registered in DNS under, so the executor
+// can resolve it directly instead of re-deriving the bare hostname against the
+// consuming exec's search domains.
+//
+// A service with a custom hostname is namespaced into the domain of whichever
+// module happened to start it (see startContainer), and the running instance is
+// then shared session-wide by content digest without the domain forming part of
+// its identity. A consumer in another module therefore holds a perfectly valid
+// handle to a running service whose only registered name it cannot resolve.
+// Binding a service explicitly is a capability the consumer already has, so it
+// keeps working here; bare-hostname DNS stays namespaced as before.
+//
+// running is index-aligned with bindings, per Services.StartBindings.
+func recordBoundServiceFQDNs(
+	execMD *engineutil.ExecutionMetadata,
+	bindings ServiceBindings,
+	running []*RunningService,
+) {
+	if execMD == nil {
+		return
+	}
+	// Built locally and assigned once: callers may hand us a shallow clone of an
+	// ExecutionMetadata whose maps are still shared with the original.
+	fqdns := map[string]string{}
+	for i, bnd := range bindings {
+		if i >= len(running) {
+			break
+		}
+		svc := running[i]
+		if svc == nil || svc.Host == "" || svc.Host == bnd.Hostname {
+			continue
+		}
+		// Only services on the engine network get a name in the engine's DNS
+		// domain. A tunnel service reports a host-side dial address instead,
+		// which is meaningless inside the container and must keep resolving
+		// through the existing search-domain sweep.
+		if !strings.HasSuffix(svc.Host, network.DomainSuffix) {
+			continue
+		}
+		fqdns[bnd.Hostname] = svc.Host
+	}
+	if len(fqdns) > 0 {
+		execMD.HostAliasFQDNs = fqdns
+	}
 }
 
 func (bndp ServiceBindings) AttachDependencyResults(

--- a/core/service_internal_test.go
+++ b/core/service_internal_test.go
@@ -1,0 +1,88 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordBoundServiceFQDNs(t *testing.T) {
+	t.Parallel()
+
+	const daggerFQDN = "svc-host.abc123.def456.dagger.local"
+
+	t.Run("records the name the running service registered under", func(t *testing.T) {
+		t.Parallel()
+
+		execMD := &engineutil.ExecutionMetadata{}
+		recordBoundServiceFQDNs(execMD,
+			ServiceBindings{{Hostname: "svc-host", Aliases: AliasSet{"svc-host"}}},
+			[]*RunningService{{Host: daggerFQDN}},
+		)
+		require.Equal(t, map[string]string{"svc-host": daggerFQDN}, execMD.HostAliasFQDNs)
+	})
+
+	t.Run("skips hosts outside the engine's DNS domain", func(t *testing.T) {
+		t.Parallel()
+
+		// A tunnel service reports a host-side dial address, which would be
+		// meaningless written into the container's hosts file.
+		execMD := &engineutil.ExecutionMetadata{}
+		recordBoundServiceFQDNs(execMD,
+			ServiceBindings{{Hostname: "tunnel-host"}},
+			[]*RunningService{{Host: "127.0.0.1"}},
+		)
+		require.Nil(t, execMD.HostAliasFQDNs)
+	})
+
+	t.Run("skips a host already equal to the bound hostname", func(t *testing.T) {
+		t.Parallel()
+
+		execMD := &engineutil.ExecutionMetadata{}
+		recordBoundServiceFQDNs(execMD,
+			ServiceBindings{{Hostname: daggerFQDN}},
+			[]*RunningService{{Host: daggerFQDN}},
+		)
+		require.Nil(t, execMD.HostAliasFQDNs)
+	})
+
+	t.Run("skips unstarted and missing entries", func(t *testing.T) {
+		t.Parallel()
+
+		execMD := &engineutil.ExecutionMetadata{}
+		recordBoundServiceFQDNs(execMD,
+			ServiceBindings{
+				{Hostname: "nil-svc"},
+				{Hostname: "empty-host"},
+				{Hostname: "past-the-end"},
+			},
+			[]*RunningService{nil, {Host: ""}},
+		)
+		require.Nil(t, execMD.HostAliasFQDNs)
+	})
+
+	t.Run("does not write through a map shared with a shallow clone", func(t *testing.T) {
+		t.Parallel()
+
+		shared := map[string]string{"pre-existing": "other.dagger.local"}
+		execMD := &engineutil.ExecutionMetadata{HostAliasFQDNs: shared}
+		recordBoundServiceFQDNs(execMD,
+			ServiceBindings{{Hostname: "svc-host"}},
+			[]*RunningService{{Host: daggerFQDN}},
+		)
+		require.Equal(t, map[string]string{"svc-host": daggerFQDN}, execMD.HostAliasFQDNs)
+		require.Equal(t, map[string]string{"pre-existing": "other.dagger.local"}, shared)
+	})
+
+	t.Run("tolerates absent metadata", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotPanics(t, func() {
+			recordBoundServiceFQDNs(nil,
+				ServiceBindings{{Hostname: "svc-host"}},
+				[]*RunningService{{Host: daggerFQDN}},
+			)
+		})
+	})
+}

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -103,6 +103,28 @@ type ExecutionMetadata struct {
 	// core->executor hand-off is an in-process pointer, so excluding it from
 	// JSON cannot drop it before use.
 	UserFacingSpanCtx trace.SpanContext `json:"-"`
+
+	// HostAliasFQDNs maps a HostAliases key (a bound service's advertised
+	// hostname) to the fully qualified name the running service actually
+	// registered in DNS under. A service with a custom hostname is namespaced
+	// into the domain of whichever module started it (core.Service.startContainer),
+	// and that FQDN is the only name the dnsname CNI plugin registers. The
+	// consuming exec only searches its own module domain plus the session
+	// domain, so re-deriving the name from the bare hostname fails outright
+	// whenever the service was first started by a different module. Recording
+	// the FQDN keeps an explicit WithServiceBinding working across that
+	// boundary without installing the producer's domain as a search domain,
+	// which would expose every other service scoped to it.
+	//
+	// Only entries for names in the engine's DNS domain are set; tunnel
+	// services report a host-side dial address instead and must keep resolving
+	// through the search-domain sweep in setupNetwork.
+	//
+	// json:"-" is load-bearing for the same reason as ProfArgs above: this
+	// run-time-only value must never perturb an exec cache key, and the
+	// core->executor hand-off is an in-process pointer, so excluding it from
+	// JSON cannot drop it before use.
+	HostAliasFQDNs map[string]string `json:"-"`
 }
 
 func (c *Client) Run(

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -306,12 +306,23 @@ func (c *Client) setupNetwork(ctx context.Context, state *execState) error {
 	for target, aliases := range state.execMD.HostAliases {
 		var ips []net.IP
 		var errs error
+		// The FQDN the running service actually registered under, when core
+		// knew it (see ExecutionMetadata.HostAliasFQDNs). It is tried first
+		// because a service scoped to another module's domain is unreachable
+		// via the search domains installed for this exec.
+		candidates := []string{}
+		if fqdn := state.execMD.HostAliasFQDNs[target]; fqdn != "" {
+			candidates = append(candidates, fqdn)
+		}
 		for _, domain := range append([]string{""}, extraSearchDomains...) {
 			qualified := target
 			if domain != "" {
 				qualified += "." + domain
 			}
+			candidates = append(candidates, qualified)
+		}
 
+		for _, qualified := range candidates {
 			var err error
 			ips, err = net.LookupIP(qualified)
 			if err == nil {

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -309,12 +309,23 @@ func (c *Client) setupNetwork(ctx context.Context, state *execState) error {
 	for target, aliases := range state.execMD.HostAliases {
 		var ips []net.IP
 		var errs error
+		// The FQDN the running service actually registered under, when core
+		// knew it (see ExecutionMetadata.HostAliasFQDNs). It is tried first
+		// because a service scoped to another module's domain is unreachable
+		// via the search domains installed for this exec.
+		candidates := []string{}
+		if fqdn := state.execMD.HostAliasFQDNs[target]; fqdn != "" {
+			candidates = append(candidates, fqdn)
+		}
 		for _, domain := range append([]string{""}, extraSearchDomains...) {
 			qualified := target
 			if domain != "" {
 				qualified += "." + domain
 			}
+			candidates = append(candidates, qualified)
+		}
 
+		for _, qualified := range candidates {
 			var err error
 			ips, err = net.LookupIP(qualified)
 			if err == nil {


### PR DESCRIPTION
Fixes #13750.

## The problem

`Container.withServiceBinding` fails at hosts-file setup — before the user's command runs — when the bound service has a custom hostname (`Service.withHostname`) and was first started by a **different module** than the one binding it:

```
lookup started-registry-host for hosts file: lookup started-registry-host on 10.87.0.1:53: no such host
  lookup started-registry-host.<modhash>.<sesshash>.dagger.local ... no such host
  lookup started-registry-host.<sesshash>.dagger.local ... no such host
```

Whichever module starts the service first owns its DNS domain, and the other participant can then never resolve it. A module that must talk to its own service before handing it to a caller (register a schema, seed a topic, run a migration) breaks the caller; keeping the service alive from the caller's side instead breaks the module. No ordering satisfies both, and no user-code workaround exists.

## Root cause

1. **A custom hostname is namespaced into the domain of whichever module starts the service.** `Service.startContainer` keys the domain off `query.ModuleParent(ctx)` — the *calling client*, not the module that authored the service. Nothing on `*Service` records ownership: `Container.asService` leaves `ModuleContext` zero and `withHostname` only sets `CustomHostname`.

2. **That FQDN is the only name registered.** It becomes the service container's hostname, is passed to CNI as `K8S_POD_NAME`, and the `dnsname` plugin writes a single `ip⇥FQDN` line into dnsmasq's `addn-hosts`. `cniprovider` never populates the declared `aliases` capability, so there are no CNAMEs and no second record. dnsmasq runs `local=/dagger.local/`, making anything else under that domain an authoritative NXDOMAIN.

3. **The consuming exec searches only its own module domain plus the session domain** (`core/container_exec.go`, `engine/engineutil/executor_spec.go`), resolving each binding from its **bare** hostname — exactly the three lookups in the error.

4. **`ServiceKey` has no domain component**, so a service already started by the producer is warm-joined verbatim; `svc.Start` never re-runs and the domain is never renegotiated.

The consumer therefore holds a valid handle to a *running* service whose only registered name it cannot resolve.

## The fix

Record the FQDN each bound service actually registered under once it is running, and try it first when building the container's hosts file, falling back to the existing bare + search-domain sweep.

Binding a service is an **explicit capability the consumer already holds** — it was handed the service deliberately — so it now works across the module boundary. Reaching a module's custom hostname by **bare DNS stays namespaced**: `TestWithHostnameModuleScoping`'s "is not reachable across modules" still passes. No search domain is installed for the producer's domain, so nothing else scoped to it is exposed — only the one bound IP reaches `/etc/hosts`.

The value is set at exec-run time on the same in-process `ExecutionMetadata` pointer the executor reads, following the existing `ProfArgs` / `UserFacingSpanCtx` precedent; `json:"-"` keeps it out of exec cache keys. Only names in the engine's DNS domain are recorded — a tunnel service reports a host-side dial address, which must not land in a container's hosts file.

## Open question for maintainers

`withHostname`'s per-module namespacing was deliberate (#8641), and `TestWithHostnameModuleScoping` asserts the bare-DNS half of it on purpose. That test never calls `withServiceBinding`, which is the gap this PR fills — I'm treating explicit binding as different in kind from ambient bare-hostname DNS, which is also consistent with services *without* a custom hostname (session domain) already working in exactly this shape (`TestContentAddressedModuleScoping`).

If you'd rather keep binding subject to namespacing, this becomes a feature request instead — there'd be no way for a producing module to publish a service its callers can reach, and `withHostname` stays unusable for services whose hostname must be baked into config before the container is built (`advertised.listeners`, virtual-host routing, TLS SANs). Happy to go that direction instead; see #13750.

## Test plan

Cross-module binding had **no** coverage before this: existing fixtures either pass the service as an argument (`service-content-addressed-cross`), carry it on a container rather than a module-object field (`runtime-service-reuse`), or never bind it at all (`service-ref-consumer`). The new fixture pair covers both orderings.

| | result |
|---|---|
| New test vs. **unfixed** engine | already-started ordering **fails** with the reported `no such host`; lazy ordering passes |
| New test **with** fix | both pass |
| `TestServices/(WithHostname*\|ContentAddressedModuleScoping\|HostnamesAreStable\|ServiceTunnelStartsOnceForDifferentClients)` | **17 passed**, 0 failures, 0 `no such host` |
| `go test ./core/ -run TestRecordBoundServiceFQDNs` | passes — tunnel-address guard, shared-map guard, nil handling |

```bash
dagger api call engine-dev test --pkg ./core/integration \
  --run='TestServices/TestWithHostnameServiceBindingAcrossModules'
```

### End-to-end against the original workload

Validated against the reporting workload — a Kafka module handing brokers and a standalone Confluent Schema Registry to a consumer container ([z5labs/devex#153](https://github.com/z5labs/devex/pull/153)), whose `run-against local` is documented in-tree as *"currently FAILS by design; once #147 lands it will run green."* Both runs used engines built from this same tree, differing only by the four fix files.

**With the fix** — `dagger call run-against local` passes, all 3 produced Avro records consumed through the full TLS produce→consume flow, zero errors, zero `no such host`:

```
{"offset":0,"partition":0,"schemaId":1,"topic":"t-f76b0d3629a2334b","value":{"message":"hello-...-0","sequence":0}}
{"offset":1,...,"sequence":1}
{"offset":2,...,"sequence":2}
```

**Without the fix** — same command, same tree:

```
! lookup broker-100-54cbbeac14 for hosts file: lookup broker-100-54cbbeac14 on 10.87.0.1:53: no such host
  lookup broker-100-54cbbeac14.usr1b4fqs442i.rs9jtdmr3d6pq.dagger.local on 10.87.0.1:53: no such host
  lookup broker-100-54cbbeac14.rs9jtdmr3d6pq.dagger.local on 10.87.0.1:53: no such host
```

The two domains searched are `ModuleDomain(ci)` and `SessionDomain` — neither is the kafka module's domain, where `RegisterSchema`/`Produce` had already started and registered those services. It surfaced the *broker* alias rather than `csr-…` here, which is the `HostAliases` map-iteration nondeterminism the original report described.

## Related surfaces — deliberately not touched

- `DNSConfig` (`core/git_remote.go`) installs only the session domain, so module-scoped services are invisible to the git / http / registry binding paths regardless of who started them.
- `ModuleParent` walks the client parent chain while the exec's `CurrentModule` does not, so a nested-exec client can start a service in module M's domain while its own execs get no module domain at all — same failure, no cross-module handoff needed.
- Declared module-object fields still persist raw handle strings (`core/object.go` returns `val` rather than the attached result) — the residue `d4cd0707` cleaned up for private fields. Not causal here; a dependency edge *is* recorded.

Happy to fold any of these in if you'd prefer them in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
