### PR TITLE
fix: resolve workspace module names in module source lookup

### DIFF
--- a/core/integration/shell_test.go
+++ b/core/integration/shell_test.go
@@ -458,6 +458,47 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (ShellSuite) TestNoLoadModuleByName(ctx context.Context, t *testctx.T) {
+	// Regression test for https://github.com/dagger/dagger/issues/13728: with
+	// `dagger shell -M`, modules must be callable by their configured name, as
+	// in v0.2x, not only by their source path.
+
+	t.Run("workspace module by name", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := goGitBase(t, c).
+			With(withModuleFixture(t, c, ".dagger/modules/foo", "go/shell-load-another/foo")).
+			WithNewFile("dagger.toml", `[modules.foo]
+source = ".dagger/modules/foo"
+`).
+			With(daggerShellNoMod("foo | bar")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "foobar", out)
+	})
+
+	t.Run("workspace module by path", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := goGitBase(t, c).
+			With(withModuleFixture(t, c, ".dagger/modules/foo", "go/shell-load-another/foo")).
+			WithNewFile("dagger.toml", `[modules.foo]
+source = ".dagger/modules/foo"
+`).
+			With(daggerShellNoMod(".dagger/modules/foo | bar")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "foobar", out)
+	})
+
+	t.Run("legacy dependency by name", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := moduleFixture(t, c, "go/shell-module-lookup").
+			With(daggerShellNoMod("dep | version")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "dep function", out)
+	})
+}
+
 func (ShellSuite) TestLoadAnotherModule(ctx context.Context, t *testctx.T) {
 	t.Run("main object", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -405,6 +405,65 @@ func moduleConfigInDir(ctx context.Context, statFS core.StatFS, dir string) (fil
 	return "", false, nil
 }
 
+// workspaceModuleSourceByName resolves name as a module installed in the
+// workspace config (dagger.toml) of the workspace detected from the caller's
+// cwd. Returns found=false when there is no workspace config or no module
+// with that name.
+func (s *moduleSourceSchema) workspaceModuleSourceByName(
+	ctx context.Context,
+	query dagql.ObjectResult[*core.Query],
+	bk *engineutil.Client,
+	name string,
+	allowNotExists bool,
+) (inst dagql.Result[*core.ModuleSource], found bool, err error) {
+	cwd, err := bk.AbsPath(ctx, ".")
+	if err != nil {
+		return inst, false, fmt.Errorf("failed to get cwd: %w", err)
+	}
+	statFS := core.NewCallerStatFS(bk)
+	ws, err := workspace.Detect(ctx, func(ctx context.Context, path string) (string, bool, error) {
+		return core.StatFSExists(ctx, statFS, path)
+	}, cwd)
+	if err != nil {
+		return inst, false, fmt.Errorf("failed to detect workspace: %w", err)
+	}
+	if ws == nil || ws.ConfigFile == "" {
+		return inst, false, nil
+	}
+	configPath := filepath.Join(ws.Root, ws.ConfigFile)
+	contents, err := bk.ReadCallerHostFile(ctx, configPath)
+	if err != nil {
+		return inst, false, fmt.Errorf("failed to read workspace config file: %w", err)
+	}
+	cfg, err := workspace.ParseConfig(contents)
+	if err != nil {
+		return inst, false, fmt.Errorf("failed to parse workspace config: %w", err)
+	}
+	entry, ok := cfg.Modules[name]
+	if !ok || entry.Source == "" {
+		return inst, false, nil
+	}
+	if filepath.IsAbs(entry.Source) {
+		return inst, false, fmt.Errorf("workspace module %q source path %q is absolute", name, entry.Source)
+	}
+
+	source := workspace.ResolveModuleEntrySource(filepath.Dir(configPath), entry.Source)
+	parsedRef, err := core.ParseRefString(ctx, statFS, source, entry.Pin)
+	if err != nil {
+		return inst, false, fmt.Errorf("failed to parse workspace module ref string: %w", err)
+	}
+	switch parsedRef.Kind {
+	case core.ModuleSourceKindLocal:
+		inst, err = s.localModuleSource(ctx, query, bk, source, false, allowNotExists)
+		return inst, true, err
+	case core.ModuleSourceKindGit:
+		inst, err = s.gitModuleSource(ctx, query, parsedRef.Git, entry.Pin, false, false)
+		return inst, true, err
+	default:
+		return inst, false, fmt.Errorf("unsupported workspace module %q source kind %q", name, parsedRef.Kind)
+	}
+}
+
 //nolint:gocyclo
 func (s *moduleSourceSchema) localModuleSource(
 	ctx context.Context,
@@ -489,6 +548,16 @@ func (s *moduleSourceSchema) localModuleSource(
 					return s.gitModuleSource(ctx, query, parsedRef.Git, namedDep.Pin, false, false)
 				}
 			}
+		}
+
+		// similarly, check if it's the name of a module installed in the workspace
+		// config (dagger.toml) found-up from the cwd
+		inst, found, err := s.workspaceModuleSourceByName(ctx, query, bk, localPath, allowNotExists)
+		if err != nil {
+			return inst, err
+		}
+		if found {
+			return inst, nil
 		}
 	}
 


### PR DESCRIPTION
### What was broken

In v0.2x, `dagger shell -M` let you call any installed module by its name. In v1 that stopped working: name lookup still works for legacy `dagger.json` dependencies, but modules registered in a workspace's `dagger.toml` can only be called by their source path. With `[modules.foo]` in the workspace, `foo | bar` fails with `local path "foo" does not exist` while `.dagger/modules/foo | bar` works.

### What this does

Module ref resolution already handles names for legacy configs: when the given path doesn't exist on the host, it finds-up `dagger.json` and resolves the ref as a named dependency. This adds the same step for workspaces: after the legacy check, find-up `dagger.toml` from the caller's cwd and resolve the ref as a `[modules.<name>]` entry. Local sources load relative to the config directory; git sources keep the entry's pin.

The new lookup only runs when the path doesn't exist and find-up is enabled. Path-based loading, `--no-find-up` callers, and the "local path does not exist" error for unknown names are unchanged. Since the fix is in generic module source resolution, it also benefits anything else that loads modules by ref, not just the shell.

### Testing

The first commit reproduces the regression with three cases: workspace module by name (was red), workspace module by path, and legacy dependency by name (both already green).

```shell
dagger call engine-dev test --pkg=./core/integration --run='^TestShell/TestNoLoadModuleByName$'
```

Also verified the neighboring lookup suites:

```shell
dagger call engine-dev test --pkg=./core/integration --run='^TestShell/(TestModuleLookup|TestLoadAnotherModule|TestNoLoadModule|TestNotExists|TestDefaultToModule)$'
```

All 35 pass.

Fixes #13728
