### PR TITLE
cli: avoid retaining telemetry in silent sessions

### DIFF
--- a/.changes/unreleased/Fixed-20260729-043546.yaml
+++ b/.changes/unreleased/Fixed-20260729-043546.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Silent SDK sessions no longer retain frontend telemetry in memory while Cloud
+  and OTLP export remain enabled. `DAGGER_SILENT` is now honored as the
+  equivalent of `--silent`.
+time: 2026-07-29T04:35:46Z
+custom:
+  Author: sipsma
+  PR: 13762

--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -38,6 +38,57 @@ func (ClientSuite) TestClose(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 }
 
+func (ClientSuite) TestSilentSessionExportsTelemetryToCloud(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	devEngine := devEngineContainerAsService(devEngineContainer(c))
+
+	thisRepoPath, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	code := c.Host().Directory(thisRepoPath, dagger.HostDirectoryOpts{
+		Include: []string{
+			"core/integration/testdata/telemetry/",
+			"core/integration/testdata/basic-container/",
+			"sdk/go/",
+			"go.mod",
+			"go.sum",
+		},
+	})
+
+	eventsVol := c.CacheVolume("dagger-silent-session-events-" + identity.NewID())
+	base := c.Container().
+		From(golangImage).
+		WithExec([]string{"apk", "add", "git"}).
+		With(goCache(c)).
+		WithMountedDirectory("/src", code).
+		WithWorkdir("/src")
+
+	fakeCloud := base.
+		WithMountedCache("/events", eventsVol).
+		WithDefaultArgs([]string{"go", "run", "./core/integration/testdata/telemetry/"}).
+		WithExposedPort(8080).
+		AsService()
+
+	eventsID := identity.NewID()
+	_, err = base.
+		WithServiceBinding("dev-engine", devEngine).
+		WithServiceBinding("cloud", fakeCloud).
+		WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://dev-engine:1234").
+		WithEnvVariable("DAGGER_CLOUD_URL", "http://cloud:8080/"+eventsID).
+		WithEnvVariable("DAGGER_CLOUD_TOKEN", "test").
+		WithEnvVariable("DAGGER_SILENT", "true").
+		WithExec([]string{"go", "run", "./core/integration/testdata/basic-container/"}).
+		Sync(ctx)
+	require.NoError(t, err, "silent SDK session handshake, query, and close must succeed")
+
+	_, err = base.
+		WithMountedCache("/events", eventsVol).
+		WithExec([]string{"grep", "-F", "Container.withExec", fmt.Sprintf("/events/%s/v1/traces.json.names", eventsID)}).
+		Sync(ctx)
+	require.NoError(t, err, "relayed engine spans must still reach the independent Cloud exporter")
+}
+
 func (ClientSuite) TestMultiSameTrace(ctx context.Context, t *testctx.T) {
 	rootCtx, span := otel.Tracer("dagger").Start(ctx, "root")
 	defer span.End()

--- a/core/integration/testdata/telemetry/main.go
+++ b/core/integration/testdata/telemetry/main.go
@@ -8,6 +8,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/protobuf/proto"
 )
 
 func main() {
@@ -28,9 +32,31 @@ func main() {
 		}
 		defer eventsF.Close()
 
-		_, err = io.Copy(eventsF, r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
+		}
+		if _, err := eventsF.Write(body); err != nil {
+			panic(err)
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/v1/traces") {
+			var req coltracepb.ExportTraceServiceRequest
+			if err := proto.Unmarshal(body, &req); err != nil {
+				panic(err)
+			}
+			namesF, err := os.OpenFile(eventsFp+".names", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+			if err != nil {
+				panic(err)
+			}
+			defer namesF.Close()
+			for _, resourceSpans := range req.ResourceSpans {
+				for _, scopeSpans := range resourceSpans.ScopeSpans {
+					for _, span := range scopeSpans.Spans {
+						fmt.Fprintln(namesF, span.Name)
+					}
+				}
+			}
 		}
 
 		w.WriteHeader(http.StatusCreated)

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -78,6 +78,17 @@ func runnerHostForEngineVersion(version string) string {
 
 type runClientCallback func(context.Context, *client.Client) error
 
+type disableFrontendTelemetryKey struct{}
+
+func withoutFrontendTelemetry(ctx context.Context) context.Context {
+	return context.WithValue(ctx, disableFrontendTelemetryKey{}, true)
+}
+
+func frontendTelemetryDisabled(ctx context.Context) bool {
+	disabled, _ := ctx.Value(disableFrontendTelemetryKey{}).(bool)
+	return disabled
+}
+
 func withEngine(
 	ctx context.Context,
 	params client.Params,
@@ -310,16 +321,23 @@ var skipSharedTelemetryExporters bool
 // Such sessions render to a discard frontend and have no reason to export to
 // Cloud, so they simply skip the shared exporters.
 func engineTelemetryConfig(ctx context.Context) telemetry.Config {
+	return engineTelemetryConfigWithCloud(ctx, enginetel.ConfiguredCloudExporters)
+}
+
+type configuredCloudExportersFunc func(context.Context) (sdktrace.SpanExporter, sdklog.Exporter, sdkmetric.Exporter, bool)
+
+func engineTelemetryConfigWithCloud(ctx context.Context, configuredCloudExporters configuredCloudExportersFunc) telemetry.Config {
 	cfg := telemetry.Config{
 		Detect:   !skipSharedTelemetryExporters,
 		Resource: Resource(ctx),
-
-		LiveTraceExporters:  []sdktrace.SpanExporter{Frontend.SpanExporter()},
-		LiveLogExporters:    []sdklog.Exporter{Frontend.LogExporter()},
-		LiveMetricExporters: []sdkmetric.Exporter{Frontend.MetricExporter()},
+	}
+	if !frontendTelemetryDisabled(ctx) {
+		cfg.LiveTraceExporters = append(cfg.LiveTraceExporters, Frontend.SpanExporter())
+		cfg.LiveLogExporters = append(cfg.LiveLogExporters, Frontend.LogExporter())
+		cfg.LiveMetricExporters = append(cfg.LiveMetricExporters, Frontend.MetricExporter())
 	}
 	if !skipSharedTelemetryExporters {
-		if spans, logs, metrics, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
+		if spans, logs, metrics, ok := configuredCloudExporters(ctx); ok {
 			// Wrap the Cloud span exporter in a LARGE-queue live processor instead of
 			// letting telemetry.Init wrap it with the default 2048-slot BSP, so the
 			// CLI→Cloud hop does not silently drop spans on a big burst — a cold engine

--- a/internal/cmd/dagger/engine_test.go
+++ b/internal/cmd/dagger/engine_test.go
@@ -2,11 +2,155 @@ package daggercmd
 
 import (
 	"context"
-	"io"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/stretchr/testify/require"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
+
+type countingLogExporter struct {
+	exports atomic.Int64
+}
+
+func (e *countingLogExporter) Export(context.Context, []sdklog.Record) error {
+	e.exports.Add(1)
+	return nil
+}
+
+func (e *countingLogExporter) Shutdown(context.Context) error   { return nil }
+func (e *countingLogExporter) ForceFlush(context.Context) error { return nil }
+
+type countingMetricExporter struct {
+	exports atomic.Int64
+}
+
+func (e *countingMetricExporter) Export(context.Context, *metricdata.ResourceMetrics) error {
+	e.exports.Add(1)
+	return nil
+}
+
+func (e *countingMetricExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.DeltaTemporality
+}
+
+func (e *countingMetricExporter) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.AggregationDefault{}
+}
+
+func (e *countingMetricExporter) Shutdown(context.Context) error   { return nil }
+func (e *countingMetricExporter) ForceFlush(context.Context) error { return nil }
+
+func TestEngineTelemetryConfigDefaultsToFrontendAndCloud(t *testing.T) {
+	oldFrontend := Frontend
+	oldSkip := skipSharedTelemetryExporters
+	t.Cleanup(func() {
+		Frontend = oldFrontend
+		skipSharedTelemetryExporters = oldSkip
+	})
+	skipSharedTelemetryExporters = false
+
+	localSpans := tracetest.NewInMemoryExporter()
+	localLogs := new(countingLogExporter)
+	localMetrics := new(countingMetricExporter)
+	frontend := &idtui.FrontendMock{
+		SpanExporterFunc:   func() sdktrace.SpanExporter { return localSpans },
+		LogExporterFunc:    func() sdklog.Exporter { return localLogs },
+		MetricExporterFunc: func() sdkmetric.Exporter { return localMetrics },
+	}
+	Frontend = frontend
+
+	cloudSpans := tracetest.NewInMemoryExporter()
+	cloudLogs := new(countingLogExporter)
+	cloudMetrics := new(countingMetricExporter)
+	cfg := engineTelemetryConfigWithCloud(context.Background(), func(context.Context) (sdktrace.SpanExporter, sdklog.Exporter, sdkmetric.Exporter, bool) {
+		return cloudSpans, cloudLogs, cloudMetrics, true
+	})
+
+	require.True(t, cfg.Detect)
+	require.Len(t, frontend.SpanExporterCalls(), 1)
+	require.Len(t, frontend.LogExporterCalls(), 1)
+	require.Len(t, frontend.MetricExporterCalls(), 1)
+	require.Equal(t, []sdktrace.SpanExporter{localSpans}, cfg.LiveTraceExporters)
+	require.Equal(t, []sdklog.Exporter{localLogs, cloudLogs}, cfg.LiveLogExporters)
+	require.Equal(t, []sdkmetric.Exporter{localMetrics, cloudMetrics}, cfg.LiveMetricExporters)
+	require.Len(t, cfg.SpanProcessors, 1, "Cloud spans use their independent large-queue processor")
+	t.Cleanup(func() {
+		require.NoError(t, cfg.SpanProcessors[0].Shutdown(context.Background()))
+	})
+}
+
+func TestEngineTelemetryConfigWithoutFrontendStillExportsToCloud(t *testing.T) {
+	oldFrontend := Frontend
+	oldSkip := skipSharedTelemetryExporters
+	t.Cleanup(func() {
+		Frontend = oldFrontend
+		skipSharedTelemetryExporters = oldSkip
+	})
+	skipSharedTelemetryExporters = false
+
+	localSpans := tracetest.NewInMemoryExporter()
+	localLogs := new(countingLogExporter)
+	localMetrics := new(countingMetricExporter)
+	frontend := &idtui.FrontendMock{
+		SpanExporterFunc:   func() sdktrace.SpanExporter { return localSpans },
+		LogExporterFunc:    func() sdklog.Exporter { return localLogs },
+		MetricExporterFunc: func() sdkmetric.Exporter { return localMetrics },
+	}
+	Frontend = frontend
+
+	cloudSpans := tracetest.NewInMemoryExporter()
+	cloudLogs := new(countingLogExporter)
+	cloudMetrics := new(countingMetricExporter)
+	cfg := engineTelemetryConfigWithCloud(withoutFrontendTelemetry(context.Background()), func(context.Context) (sdktrace.SpanExporter, sdklog.Exporter, sdkmetric.Exporter, bool) {
+		return cloudSpans, cloudLogs, cloudMetrics, true
+	})
+
+	require.True(t, cfg.Detect)
+	require.Empty(t, frontend.SpanExporterCalls())
+	require.Empty(t, frontend.LogExporterCalls())
+	require.Empty(t, frontend.MetricExporterCalls())
+	require.Empty(t, cfg.LiveTraceExporters)
+	require.Equal(t, []sdklog.Exporter{cloudLogs}, cfg.LiveLogExporters)
+	require.Equal(t, []sdkmetric.Exporter{cloudMetrics}, cfg.LiveMetricExporters)
+	require.Len(t, cfg.SpanProcessors, 1)
+
+	snapshot := tracetest.SpanStub{
+		Name: "relayed engine span",
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    trace.TraceID{1},
+			SpanID:     trace.SpanID{1},
+			TraceFlags: trace.FlagsSampled,
+		}),
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}.Snapshot()
+	cfg.SpanProcessors[0].OnEnd(snapshot)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, cfg.SpanProcessors[0].ForceFlush(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, cfg.SpanProcessors[0].Shutdown(context.Background()))
+	})
+
+	require.NoError(t, cfg.LiveLogExporters[0].Export(ctx, nil))
+	require.NoError(t, cfg.LiveMetricExporters[0].Export(ctx, new(metricdata.ResourceMetrics)))
+
+	require.Len(t, cloudSpans.GetSpans(), 1)
+	require.Equal(t, int64(1), cloudLogs.exports.Load())
+	require.Equal(t, int64(1), cloudMetrics.exports.Load())
+	require.Empty(t, localSpans.GetSpans())
+	require.Zero(t, localLogs.exports.Load())
+	require.Zero(t, localMetrics.exports.Load())
+}
 
 // TestEngineTelemetryConfigSkipsSharedExporters guards the fix for the noisy
 // "HTTP exporter is shutdown" / "context canceled" telemetry warnings emitted by
@@ -17,7 +161,11 @@ import (
 func TestEngineTelemetryConfigSkipsSharedExporters(t *testing.T) {
 	oldFrontend := Frontend
 	oldSkip := skipSharedTelemetryExporters
-	Frontend = idtui.NewPlain(io.Discard)
+	Frontend = &idtui.FrontendMock{
+		SpanExporterFunc:   func() sdktrace.SpanExporter { return tracetest.NewInMemoryExporter() },
+		LogExporterFunc:    func() sdklog.Exporter { return new(countingLogExporter) },
+		MetricExporterFunc: func() sdkmetric.Exporter { return new(countingMetricExporter) },
+	}
 	t.Cleanup(func() {
 		Frontend = oldFrontend
 		skipSharedTelemetryExporters = oldSkip

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -58,7 +58,7 @@ var (
 	workspaceRef string
 	workspaceEnv string
 
-	silent                   bool
+	silent                   = silentFromEnv()
 	verbose                  int
 	quiet, _                 = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
 	reveal                   = os.Getenv("DAGGER_REVEAL") != ""
@@ -92,6 +92,12 @@ var (
 const daggerXReleaseEnv = "DAGGER_X_RELEASE"
 
 var githubCommitAPI = "https://api.github.com/repos/dagger/dagger/commits/"
+
+func silentFromEnv() bool {
+	// DAGGER_SILENT is the environment equivalent of --silent.
+	silent, _ := strconv.ParseBool(os.Getenv("DAGGER_SILENT"))
+	return silent
+}
 
 func init() {
 	// allow user explicitly setting progress via env, but default it to "auto"

--- a/internal/cmd/dagger/session.go
+++ b/internal/cmd/dagger/session.go
@@ -75,6 +75,12 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 	signal.Notify(make(chan os.Signal, 1), syscall.SIGPIPE)
 
 	ctx := cmd.Context()
+	if silent {
+		// SDK callers with no progress consumer use silent sessions. Keep the
+		// frontend lifecycle, but do not install its retaining dagui exporters;
+		// independent exporters such as Dagger Cloud remain configured.
+		ctx = withoutFrontendTelemetry(ctx)
+	}
 
 	sessionToken, err := uuid.NewRandom()
 	if err != nil {

--- a/internal/cmd/dagger/session_test.go
+++ b/internal/cmd/dagger/session_test.go
@@ -16,6 +16,26 @@ func TestSessionCmdWorkspaceFlag(t *testing.T) {
 	require.Equal(t, "W", flag.Shorthand)
 }
 
+func TestSilentFromEnv(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "unset", value: "", want: false},
+		{name: "true", value: "true", want: true},
+		{name: "one", value: "1", want: true},
+		{name: "false", value: "false", want: false},
+		{name: "zero", value: "0", want: false},
+		{name: "invalid", value: "not-a-bool", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("DAGGER_SILENT", test.value)
+			require.Equal(t, test.want, silentFromEnv())
+		})
+	}
+}
+
 // TestSessionClientParamsWorkspace verifies that the session command forwards
 // its explicit workspace selection into engine client params.
 func TestSessionClientParamsWorkspace(t *testing.T) {


### PR DESCRIPTION
## Summary

- honor `DAGGER_SILENT` as the environment equivalent of `--silent`
- omit frontend span, log, and metric exporters for silent `dagger session` processes before telemetry initialization
- keep Dagger Cloud and detected OTLP exporters enabled

## Motivation

Native CI workers can run 20 concurrent Go SDK clients, each of which starts a `dagger session` CLI child. The frontend in each child owns a `dagui.DB` that retains every relayed span, log, and metric for the session lifetime, even when progress output is silent and discarded.

In the observed 8 GiB worker OOMs, the worker process itself held about 172 MiB RSS while almost all remaining cgroup memory was held by the session children. Removing the frontend exporters in this mode prevents the unbounded frontend ownership path instead of hiding output or dropping retained data at shutdown.

## Semantics and tradeoffs

Default and non-session telemetry behavior is unchanged. Silent sessions still drain engine telemetry and export it to configured Cloud and OTLP destinations. They do not populate the local frontend database, so frontend-derived progress history is intentionally unavailable in the mode that already suppresses progress.

This change proves the ownership-path reduction but does not claim an exact RSS reduction without a representative production heap profile.

## Tests

- `go test ./internal/cmd/dagger -run="Test(EngineTelemetryConfig|SilentFromEnv)" -count=1`
- `go test -race ./internal/cmd/dagger -run="Test(EngineTelemetryConfig|SilentFromEnv)" -count=1`
- `dagger api call engine-dev test --pkg ./core/integration --run="TestClient/TestSilentSessionExportsTelemetryToCloud"` with isolated credentials and a local fake Cloud collector
- `dagger check "golang:lint"`
- `git diff --check`