### PR TITLE
core: fall back to engine commit for remote runtimes

### DIFF
--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -15,6 +15,10 @@ import (
 	telemetry "github.com/dagger/otel-go"
 )
 
+// ErrModuleVersionNotFound indicates that a requested module version does not
+// match any tag in its Git repository.
+var ErrModuleVersionNotFound = errors.New("module version not found")
+
 // FastModuleSourceKindCheck performs a quick heuristic check to determine
 // whether a module ref string refers to a local path or a git source.
 // Returns "" if the kind cannot be determined without further inspection.
@@ -226,5 +230,5 @@ func matchVersion(versions []string, match, subPath string) (string, error) {
 			return v, nil
 		}
 	}
-	return "", fmt.Errorf("unable to find version %s", match)
+	return "", fmt.Errorf("%w: %s", ErrModuleVersionNotFound, match)
 }

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -24,7 +24,7 @@ func TestMatchVersion(t *testing.T) {
 	require.Equal(t, "path/v1.0.1", match3)
 
 	_, err = matchVersion(vers, "v2.0.1", "/")
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrModuleVersionNotFound)
 
 	_, err = matchVersion([]string{"hello/v0.3.0"}, "v0.3.0", "/hello")
 	require.NoError(t, err)

--- a/core/sdk/loader.go
+++ b/core/sdk/loader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/distconsts"
+	iversion "github.com/dagger/dagger/internal/version"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/opencontainers/go-digest"
 )
@@ -146,11 +147,46 @@ func (l *Loader) namedSDK(
 		if !ok {
 			return nil, errUnknownBuiltinSDK
 		}
-		return l.SDKForModule(ctx, root, &core.SDKConfig{
+		sdkConfig := &core.SDKConfig{
 			Source:       sdkMod.Source,
 			Config:       sdk.Config,
 			Experimental: sdk.Experimental,
-		}, nil)
+		}
+		loaded, tagErr := l.externalSDKForModule(ctx, root, sdkConfig, nil)
+		if tagErr == nil {
+			return loaded, nil
+		}
+
+		// A bare remote builtin normally resolves at engine.Tag. On main,
+		// VERSION already names the next release before its Git tag exists.
+		// Retry at the exact engine source commit, which is always available
+		// for provenance-stamped builds. Explicit user refs remain authoritative.
+		// TODO(https://github.com/dagger/dagger/issues/13755): Since these
+		// runtimes live in this repository, should bare refs always resolve from
+		// the engine commit instead of pulling by tag first?
+		_, _, hasExplicitVersion := strings.Cut(sdk.Source, "@")
+		if hasExplicitVersion ||
+			!errors.Is(tagErr, core.ErrModuleVersionNotFound) ||
+			iversion.Commit == "" {
+			return nil, tagErr
+		}
+		commitMod, ok := workspaceModuleForBuiltinSDK(sdkNamedParsed, "@"+iversion.Commit)
+		if !ok {
+			return nil, errUnknownBuiltinSDK
+		}
+		sdkConfig.Source = commitMod.Source
+		loaded, commitErr := l.externalSDKForModule(ctx, root, sdkConfig, nil)
+		if commitErr != nil {
+			return nil, fmt.Errorf(
+				"failed to load SDK %q from %q: %w; fallback to engine commit %q failed: %w",
+				sdk.Source,
+				sdkMod.Source,
+				tagErr,
+				iversion.Commit,
+				commitErr,
+			)
+		}
+		return loaded, nil
 	}
 
 	return nil, errUnknownBuiltinSDK


### PR DESCRIPTION
## Summary

- retry bare Java, PHP, and Elixir runtime references at the engine source commit when the engine version tag cannot be resolved
- preserve explicit user-provided runtime refs without fallback
- report both the tag resolution failure and commit fallback failure
- reference #13755 and leave a TODO about resolving these in-repository runtimes directly by commit

## Why

Development builds from `main` advertise the next release version before that release tag exists. Bare remote runtime names therefore expand to a non-existent tag even though the matching runtime source exists at the engine commit.

## Impact

Java, PHP, and Elixir runtimes can load from unreleased development engine builds while released builds continue to resolve their normal version tags.

## Validation

- `gofmt -w core/sdk/loader.go`
- `git diff --check`
- static review only; tests were intentionally not run
