### PR TITLE
[backport-0.21] x-release: change phrasing to prevent users from thinking it runs from any build

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -440,7 +440,7 @@ func execXRelease(ctx context.Context) error {
 		return fmt.Errorf("download experimental release CLI: %w", err)
 	}
 
-	msg := fmt.Sprintf("running build from %s", ref)
+	msg := fmt.Sprintf("running dagger from %s", ref)
 	if release {
 		msg += fmt.Sprintf("; using release %s", engineRef)
 	} else if resolved {


### PR DESCRIPTION
Backports #13272 to the 0.21 release branch.

Updates the x-release status message from “running build” to “running dagger” so users do not interpret it as running from an arbitrary build.

Validation:
- `go test ./cmd/dagger -run ^TestXRelease`