### PR TITLE
core: merge changesets by content, not patches

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -1507,6 +1507,17 @@ var gitEphemeralConfig = []string{
 	"-c", "maintenance.autoDetach=false",
 	"-c", "gc.auto=0",
 	"-c", "gc.autoDetach=false",
+	// Snapshots share file contents via hardlinks, so a file's ctime, inode
+	// and device can all change out from under us (e.g. when a concurrent
+	// snapshot hardlinks the same inode) without the content changing.
+	//
+	// Left alone, git sees these as stat-dirty entries, and `git merge`'s
+	// internal `git stash create` fails with a bewildering "fatal: stash
+	// failed".
+	//
+	// 'minimal' compares only mtime + size, which is all we can trust here.
+	"-c", "core.checkStat=minimal",
+	"-c", "core.trustctime=false",
 }
 
 func runGit(ctx context.Context, dir string, args ...string) error {

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 	"go.opentelemetry.io/otel/log"
+	"golang.org/x/sys/unix"
 )
 
 func NewChangeset(ctx context.Context, before, after dagql.ObjectResult[*Directory]) (*Changeset, error) {
@@ -1453,7 +1454,34 @@ func (ws *gitMergeWorkspace) applyContent(ctx context.Context, content *changese
 		}
 	}
 
-	return mkdirChangesetAddedDirs(ctx, copier, ws.dir, content.paths)
+	if err := mkdirChangesetAddedDirs(ctx, copier, ws.dir, content.paths); err != nil {
+		return err
+	}
+	return ws.touchAppliedPaths(content.paths)
+}
+
+// touchAppliedPaths bumps the mtime of every path the changeset wrote so git
+// can see the change. Snapshot contents carry normalized timestamps and the
+// copier preserves them, so a same-size edit can leave a file's mtime and
+// size both identical to the index entry; with core.checkStat=minimal (see
+// gitEphemeralConfig) git add would then skip re-hashing it and silently
+// drop the change from the branch commit.
+func (ws *gitMergeWorkspace) touchAppliedPaths(paths *ChangesetPaths) error {
+	for _, p := range slices.Concat(paths.Added, paths.Modified) {
+		if strings.HasSuffix(p, "/") {
+			// Directories are untracked by git; only file stat data matters.
+			continue
+		}
+		full, err := RootPathWithoutFinalSymlink(ws.root, path.Join(ws.dir, p))
+		if err != nil {
+			return err
+		}
+		err = unix.UtimesNanoAt(unix.AT_FDCWD, full, nil, unix.AT_SYMLINK_NOFOLLOW)
+		if err != nil && !errors.Is(err, unix.ENOENT) {
+			return fmt.Errorf("touch %s: %w", p, err)
+		}
+	}
+	return nil
 }
 
 // withGitMergeWorkspace sets up a workspace for git merge operations, runs the provided

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -23,6 +23,7 @@ import (
 	bkcache "github.com/dagger/dagger/engine/snapshots"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 	bkclient "github.com/dagger/dagger/internal/buildkit/client"
+	"github.com/dagger/dagger/util/layercopy"
 	"github.com/dagger/dagger/util/parallel"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/opencontainers/go-digest"
@@ -1035,19 +1036,18 @@ func (ch *Changeset) WithChangeset(
 		return nil, err
 	}
 
-	ourPatch, err := ch.AsPatch(ctx)
+	ourContent, err := ch.content(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("generate our patch: %w", err)
+		return nil, fmt.Errorf("materialize our changes: %w", err)
 	}
-	theirPatch, err := other.AsPatch(ctx)
+	theirContent, err := other.content(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("generate their patch: %w", err)
+		return nil, fmt.Errorf("materialize their changes: %w", err)
 	}
 
-	afterDir, err := gitMergeWithPatches(ctx,
+	afterDir, err := gitMergeChangesets(ctx,
 		before,
-		ourPatch, theirPatch,
-		ourPaths.AllRemoved, theirPaths.AllRemoved,
+		ourContent, theirContent,
 		conflicts,
 		onConflictStrategy,
 	)
@@ -1138,33 +1138,34 @@ func (ch *Changeset) WithChangesets(
 		return nil, err
 	}
 
-	// Each patch is an independent mount-and-diff, so take them all at once.
-	var ourPatch *File
-	otherPatches := make([]*File, len(others))
-	patchJobs := changesetJobs().WithJob("self asPatch", func(ctx context.Context) error {
-		patch, err := ch.AsPatch(ctx)
+	// Each diff is an independent snapshot-diff materialization, so take them
+	// all at once.
+	var ourContent *changesetContent
+	otherContents := make([]*changesetContent, len(others))
+	contentJobs := changesetJobs().WithJob("self changes", func(ctx context.Context) error {
+		content, err := ch.content(ctx)
 		if err != nil {
-			return fmt.Errorf("get our patch: %w", err)
+			return fmt.Errorf("materialize our changes: %w", err)
 		}
-		ourPatch = patch
+		ourContent = content
 		return nil
 	})
 	for i, other := range others {
-		patchJobs = patchJobs.WithJob(fmt.Sprintf("changeset %d asPatch", i), func(ctx context.Context) error {
-			patch, err := other.AsPatch(ctx)
+		contentJobs = contentJobs.WithJob(fmt.Sprintf("changeset %d changes", i), func(ctx context.Context) error {
+			content, err := other.content(ctx)
 			if err != nil {
-				return fmt.Errorf("get patch for changeset %d: %w", i, err)
+				return fmt.Errorf("materialize changes for changeset %d: %w", i, err)
 			}
-			otherPatches[i] = patch
+			otherContents[i] = content
 			return nil
 		})
 	}
-	if err := patchJobs.Run(ctx); err != nil {
+	if err := contentJobs.Run(ctx); err != nil {
 		return nil, err
 	}
 
 	afterDir, err := enginetel.TaskRet(ctx, "octopus merge", func(ctx context.Context) (*Directory, error) {
-		return gitOctopusMergeWithPatches(ctx, before, ourPatch, otherPatches)
+		return gitOctopusMergeChangesets(ctx, before, ourContent, otherContents)
 	})
 	if err != nil {
 		return nil, err
@@ -1333,9 +1334,131 @@ func checkAllPairwiseConflicts(ctx context.Context, ch *Changeset, others []*Cha
 	return nil
 }
 
+// changesetContent is a changeset reduced to its file-level content: a diff
+// directory holding its added and modified files, plus the computed paths
+// describing removals and empty added directories. Unlike a patch, this
+// content can be applied onto any base — content the base already contains
+// overlays as a no-op instead of double-applying or failing a hunk.
+type changesetContent struct {
+	// diff is the materialized Before.diff(After) directory — the same
+	// content Directory.WithChanges and Changeset.Export apply. Zero when the
+	// changeset adds and modifies nothing.
+	diff  dagql.ObjectResult[*Directory]
+	paths *ChangesetPaths
+}
+
+// content reduces the changeset to its file-level content, independent of its
+// before directory.
+func (ch *Changeset) content(ctx context.Context) (*changesetContent, error) {
+	paths, err := ch.ComputePaths(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compute paths: %w", err)
+	}
+	content := &changesetContent{paths: paths}
+	if len(paths.Added) == 0 && len(paths.Modified) == 0 {
+		// Nothing to overlay; removals are carried by paths alone.
+		return content, nil
+	}
+
+	srv, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	afterID, err := ch.After.ID()
+	if err != nil {
+		return nil, fmt.Errorf("after ID: %w", err)
+	}
+	var diffDir dagql.ObjectResult[*Directory]
+	if err := srv.Select(ctx, ch.Before, &diffDir,
+		dagql.Selector{
+			Field: "diff",
+			Args: []dagql.NamedInput{
+				{Name: "other", Value: dagql.NewID[*Directory](afterID)},
+			},
+		},
+	); err != nil {
+		return nil, fmt.Errorf("compute changes diff directory: %w", err)
+	}
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := cache.Evaluate(ctx, diffDir); err != nil {
+		return nil, fmt.Errorf("evaluate changes diff directory: %w", err)
+	}
+	content.diff = diffDir
+	return content, nil
+}
+
+// gitMergeWorkspace is a mounted scratch copy of the merge base that git
+// branches are built in.
+type gitMergeWorkspace struct {
+	root    string // mounted snapshot root
+	dir     string // base directory selector within root
+	workDir string // absolute path of dir under root; where git runs
+}
+
+// applyContent applies a changeset's file-level content to the work tree:
+// removed paths are deleted, the diff directory is overlaid, and empty added
+// directories are recreated (the diff snapshot does not carry them). This
+// mirrors Directory.WithChanges' application of the same content.
+func (ws *gitMergeWorkspace) applyContent(ctx context.Context, content *changesetContent) error {
+	if err := removeChangesetPaths(ws.root, ws.dir, content.paths.Removed); err != nil {
+		return fmt.Errorf("remove paths: %w", err)
+	}
+
+	// The copier must write through the mounted view, not the snapshot's
+	// upperdir: git runs inside the mount and has to see every file this
+	// writes, and modifying an overlay's layers behind a live mount leaves
+	// the view incoherent (git add sees names it cannot stat). So no Mount is
+	// passed here, unlike Directory.WithChanges, which never reads back
+	// through the mount before committing.
+	copier, err := layercopy.NewCopier(layercopy.Mount{Root: ws.root})
+	if err != nil {
+		return err
+	}
+	defer copier.Close()
+
+	if content.diff.Self() != nil {
+		diffRef, err := content.diff.Self().Snapshot.GetOrEval(ctx, content.diff.Result)
+		if err != nil {
+			return fmt.Errorf("diff snapshot: %w", err)
+		}
+		diffPath, err := content.diff.Self().Dir.GetOrEval(ctx, content.diff.Result)
+		if err != nil {
+			return fmt.Errorf("diff path: %w", err)
+		}
+		if diffPath == "" {
+			diffPath = "/"
+		}
+		if diffRef != nil {
+			err = MountRef(ctx, diffRef, func(srcRoot string, srcMnt *mount.Mount) error {
+				return copier.Copy(ctx,
+					layercopy.Mount{Root: srcRoot, Mount: srcMnt},
+					diffPath,
+					ws.dir,
+					layercopy.CopyOptions{
+						CopyDirContents: true,
+						ReplaceExisting: true,
+						// Linking from the diff snapshot into the mounted
+						// work tree crosses devices, so every attempt would
+						// just fail into the copy fallback.
+						DisableSourceHardlinks: true,
+					},
+				)
+			}, mountRefAsReadOnly)
+			if err != nil {
+				return fmt.Errorf("copy changed paths: %w", err)
+			}
+		}
+	}
+
+	return mkdirChangesetAddedDirs(ctx, copier, ws.dir, content.paths)
+}
+
 // withGitMergeWorkspace sets up a workspace for git merge operations, runs the provided
 // function, then commits and returns the resulting directory.
-func withGitMergeWorkspace(ctx context.Context, base dagql.ObjectResult[*Directory], description string, fn func(workDir string) error) (*Directory, error) {
+func withGitMergeWorkspace(ctx context.Context, base dagql.ObjectResult[*Directory], description string, fn func(ws *gitMergeWorkspace) error) (*Directory, error) {
 	cache, err := dagql.EngineCache(ctx)
 	if err != nil {
 		return nil, err
@@ -1370,7 +1493,11 @@ func withGitMergeWorkspace(ctx context.Context, base dagql.ObjectResult[*Directo
 		if err != nil {
 			return err
 		}
-		return fn(workDir)
+		return fn(&gitMergeWorkspace{
+			root:    root,
+			dir:     baseSelector,
+			workDir: workDir,
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -1391,25 +1518,24 @@ func withGitMergeWorkspace(ctx context.Context, base dagql.ObjectResult[*Directo
 	return dir, nil
 }
 
-func gitMergeWithPatches(
+func gitMergeChangesets(
 	ctx context.Context,
 	base dagql.ObjectResult[*Directory],
-	ourPatch, theirPatch *File,
-	ourRemoved, theirRemoved []string,
+	ours, theirs *changesetContent,
 	conflicts Conflicts,
 	strategy WithChangesetMergeConflict,
 ) (*Directory, error) {
-	return withGitMergeWorkspace(ctx, base, "Changeset.withChangeset git merge", func(workDir string) error {
-		if err := initGitRepo(ctx, workDir); err != nil {
+	return withGitMergeWorkspace(ctx, base, "Changeset.withChangeset git merge", func(ws *gitMergeWorkspace) error {
+		if err := initGitRepo(ctx, ws.workDir); err != nil {
 			return err
 		}
-		if err := createBranchWithPatchFile(ctx, workDir, "ours", ourPatch); err != nil {
+		if err := createBranchWithContent(ctx, ws, "ours", ours); err != nil {
 			return err
 		}
-		if err := createBranchWithPatchFile(ctx, workDir, "theirs", theirPatch, "HEAD~1"); err != nil {
+		if err := createBranchWithContent(ctx, ws, "theirs", theirs, "HEAD~1"); err != nil {
 			return err
 		}
-		if err := runGit(ctx, workDir, "checkout", "ours"); err != nil {
+		if err := runGit(ctx, ws.workDir, "checkout", "ours"); err != nil {
 			return err
 		}
 
@@ -1422,7 +1548,7 @@ func gitMergeWithPatches(
 		}
 		mergeArgs = append(mergeArgs, "theirs")
 
-		mergeErr := runGit(ctx, workDir, mergeArgs...)
+		mergeErr := runGit(ctx, ws.workDir, mergeArgs...)
 
 		switch strategy {
 		case FailOnConflict:
@@ -1432,7 +1558,7 @@ func gitMergeWithPatches(
 		case LeaveConflictMarkers, PreferOursOnConflict, PreferTheirsOnConflict:
 			modifyDeleteConflicts := conflicts.ModifyDeletePaths()
 			if len(modifyDeleteConflicts) > 0 {
-				if err := resolveModifyDeleteConflicts(ctx, workDir, modifyDeleteConflicts, strategy, ourRemoved, theirRemoved); err != nil {
+				if err := resolveModifyDeleteConflicts(ctx, ws.workDir, modifyDeleteConflicts, strategy, ours.paths.AllRemoved, theirs.paths.AllRemoved); err != nil {
 					return err
 				}
 			}
@@ -1442,44 +1568,44 @@ func gitMergeWithPatches(
 			}
 		}
 
-		if err := os.RemoveAll(filepath.Join(workDir, ".git")); err != nil {
+		if err := os.RemoveAll(filepath.Join(ws.workDir, ".git")); err != nil {
 			return fmt.Errorf("remove temporary merge git repository: %w", err)
 		}
 		return nil
 	})
 }
 
-func gitOctopusMergeWithPatches(
+func gitOctopusMergeChangesets(
 	ctx context.Context,
 	base dagql.ObjectResult[*Directory],
-	ourPatch *File,
-	otherPatches []*File,
+	ourContent *changesetContent,
+	otherContents []*changesetContent,
 ) (*Directory, error) {
-	return withGitMergeWorkspace(ctx, base, "Changeset.withChangesets git octopus merge", func(workDir string) error {
+	return withGitMergeWorkspace(ctx, base, "Changeset.withChangesets git octopus merge", func(ws *gitMergeWorkspace) error {
 		if err := enginetel.Task(ctx, "init git", func(ctx context.Context) error {
-			return initGitRepo(ctx, workDir)
+			return initGitRepo(ctx, ws.workDir)
 		}); err != nil {
 			return err
 		}
 		if err := enginetel.Task(ctx, "create branch for ours", func(ctx context.Context) error {
-			return createBranchWithPatchFile(ctx, workDir, "ours", ourPatch)
+			return createBranchWithContent(ctx, ws, "ours", ourContent)
 		}); err != nil {
 			return err
 		}
 
-		branchNames := make([]string, len(otherPatches))
-		for i, patch := range otherPatches {
+		branchNames := make([]string, len(otherContents))
+		for i, content := range otherContents {
 			branchName := fmt.Sprintf("branch_%d", i)
 			branchNames[i] = branchName
 			if err := enginetel.Task(ctx, "create branch "+branchName, func(ctx context.Context) error {
-				return createBranchWithPatchFile(ctx, workDir, branchName, patch, "HEAD~1")
+				return createBranchWithContent(ctx, ws, branchName, content, "HEAD~1")
 			}); err != nil {
 				return err
 			}
 		}
 
 		if err := enginetel.Task(ctx, "checkout ours", func(ctx context.Context) error {
-			return runGit(ctx, workDir, "checkout", "ours")
+			return runGit(ctx, ws.workDir, "checkout", "ours")
 		}); err != nil {
 			return err
 		}
@@ -1488,12 +1614,12 @@ func gitOctopusMergeWithPatches(
 		mergeArgs = append(mergeArgs, branchNames...)
 
 		if err := enginetel.Task(ctx, "git merge", func(ctx context.Context) error {
-			return runGit(ctx, workDir, mergeArgs...)
+			return runGit(ctx, ws.workDir, mergeArgs...)
 		}); err != nil {
 			return err
 		}
 
-		if err := os.RemoveAll(filepath.Join(workDir, ".git")); err != nil {
+		if err := os.RemoveAll(filepath.Join(ws.workDir, ".git")); err != nil {
 			return fmt.Errorf("remove temporary octopus merge git repository: %w", err)
 		}
 		return nil
@@ -1541,60 +1667,6 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 	return nil
 }
 
-// gitApplyPatchFromFile streams the patch to avoid loading it entirely into memory.
-func gitApplyPatchFromFile(ctx context.Context, dir string, patch *File) error {
-	if patch == nil {
-		return nil
-	}
-
-	patchRef, _ := patch.Snapshot.Peek()
-	if patchRef == nil {
-		return fmt.Errorf("evaluate patch ref: nil")
-	}
-	patchPathSelector, _ := patch.File.Peek()
-
-	return MountRef(ctx, patchRef, func(patchMount string, _ *mount.Mount) error {
-		patchPath, err := containerdfs.RootPath(patchMount, patchPathSelector)
-		if err != nil {
-			return err
-		}
-
-		// Check if patch file is empty
-		info, err := os.Stat(patchPath)
-		if err != nil {
-			return fmt.Errorf("stat patch file: %w", err)
-		}
-		if info.Size() == 0 {
-			return nil
-		}
-
-		tempPatch := filepath.Join(dir, ".dagger-patch")
-		srcFile, err := os.Open(patchPath)
-		if err != nil {
-			return fmt.Errorf("open patch file: %w", err)
-		}
-		defer srcFile.Close()
-
-		dstFile, err := os.Create(tempPatch)
-		if err != nil {
-			return fmt.Errorf("create temp patch file: %w", err)
-		}
-
-		if _, err := io.Copy(dstFile, srcFile); err != nil {
-			dstFile.Close()
-			os.Remove(tempPatch)
-			return fmt.Errorf("copy patch file: %w", err)
-		}
-		if err := dstFile.Close(); err != nil {
-			os.Remove(tempPatch)
-			return fmt.Errorf("close temp patch file: %w", err)
-		}
-
-		defer os.Remove(tempPatch)
-		return runGit(ctx, dir, "apply", "--allow-empty", tempPatch)
-	}, mountRefAsReadOnly)
-}
-
 func initGitRepo(ctx context.Context, dir string) error {
 	if err := runGit(ctx, dir, "init"); err != nil {
 		return err
@@ -1605,25 +1677,25 @@ func initGitRepo(ctx context.Context, dir string) error {
 	return runGit(ctx, dir, "commit", "--allow-empty", "-m", "base")
 }
 
-func createBranchWithPatchFile(ctx context.Context, dir string, branchName string, patch *File, startPoint ...string) error {
+// createBranchWithContent creates branchName from startPoint (default: the
+// current HEAD) and populates it with the changeset's file-level content.
+func createBranchWithContent(ctx context.Context, ws *gitMergeWorkspace, branchName string, content *changesetContent, startPoint ...string) error {
 	checkoutArgs := []string{"checkout", "-b", branchName}
 	if len(startPoint) > 0 {
 		checkoutArgs = append(checkoutArgs, startPoint[0])
 	}
-	if err := runGit(ctx, dir, checkoutArgs...); err != nil {
+	if err := runGit(ctx, ws.workDir, checkoutArgs...); err != nil {
 		return err
 	}
-	if patch != nil {
-		if err := gitApplyPatchFromFile(ctx, dir, patch); err != nil {
-			return fmt.Errorf("apply %s patch: %w", branchName, err)
-		}
+	if err := ws.applyContent(ctx, content); err != nil {
+		return fmt.Errorf("apply %s changes: %w", branchName, err)
 	}
 	// Always commit (even if empty) to ensure consistent commit structure
 	// This is needed so that HEAD~1 references work correctly
-	if err := runGit(ctx, dir, "add", "-A"); err != nil {
+	if err := runGit(ctx, ws.workDir, "add", "-A"); err != nil {
 		return err
 	}
-	if err := runGit(ctx, dir, "commit", "--allow-empty", "-m", branchName); err != nil {
+	if err := runGit(ctx, ws.workDir, "commit", "--allow-empty", "-m", branchName); err != nil {
 		return err
 	}
 	return nil

--- a/core/integration/changeset_test.go
+++ b/core/integration/changeset_test.go
@@ -7,6 +7,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"testing"
 
 	"dagger.io/dagger"
@@ -2052,5 +2054,67 @@ func (ChangesetSuite) TestWithChangesets(ctx context.Context, t *testctx.T) {
 			require.NoError(t, err)
 			require.Equal(t, fmt.Sprintf("content from changeset %d", i), content)
 		}
+	})
+}
+
+// Changesets that modify different regions of the same file must all survive
+// a merge. Merge branches are populated with full-file content, but git
+// re-derives line-level hunks against the merge base, so the content overlay
+// must not coarsen merging to whole-file granularity.
+func (ChangesetSuite) TestSameFileRegionMerge(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line%d", i+1)
+	}
+	base := c.Directory().WithNewFile("f.txt", strings.Join(lines, "\n")+"\n")
+
+	withLine := func(in []string, n int, text string) []string {
+		out := slices.Clone(in)
+		out[n-1] = text
+		return out
+	}
+	fileContent := func(in []string) string {
+		return strings.Join(in, "\n") + "\n"
+	}
+	edit := func(n int, text string) *dagger.Changeset {
+		return base.
+			WithNewFile("f.txt", fileContent(withLine(lines, n, text))).
+			Changes(base)
+	}
+
+	top := edit(1, "TOP-EDIT")
+	mid := edit(15, "MID-EDIT")
+	bot := edit(30, "BOT-EDIT")
+
+	t.Run("two-way", func(ctx context.Context, t *testctx.T) {
+		merged, err := top.WithChangeset(mid).Sync(ctx)
+		require.NoError(t, err)
+		content, err := merged.After().File("f.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t,
+			fileContent(withLine(withLine(lines, 1, "TOP-EDIT"), 15, "MID-EDIT")),
+			content)
+	})
+
+	t.Run("octopus", func(ctx context.Context, t *testctx.T) {
+		merged, err := c.Changeset().
+			WithChangesets([]*dagger.Changeset{top, mid, bot}).
+			Sync(ctx)
+		require.NoError(t, err)
+		content, err := merged.After().File("f.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t,
+			fileContent(withLine(withLine(withLine(lines, 1, "TOP-EDIT"), 15, "MID-EDIT"), 30, "BOT-EDIT")),
+			content)
+	})
+
+	// Overlapping edits still conflict; only separate regions compose. (Where
+	// exactly nearby-but-disjoint edits stop composing is git's merge
+	// heuristics, deliberately not pinned here.)
+	t.Run("overlapping edits conflict", func(ctx context.Context, t *testctx.T) {
+		_, err := edit(10, "A-EDIT").WithChangeset(edit(10, "B-EDIT")).Sync(ctx)
+		require.Error(t, err)
 	})
 }

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -4,6 +4,7 @@ package layercopy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -341,7 +342,8 @@ func (c *Copier) copyRegular(ent sourceEntry, realPath string, opts CopyOptions)
 }
 
 func isHardlinkFallback(err error) bool {
-	return err != nil && (os.IsExist(err) || err == unix.EXDEV || err == unix.EMLINK || err == syscall.EXDEV || err == syscall.EMLINK)
+	// os.Link wraps the errno in *os.LinkError, so unwrap rather than compare.
+	return err != nil && (os.IsExist(err) || errors.Is(err, unix.EXDEV) || errors.Is(err, unix.EMLINK))
 }
 
 func copyFileContent(dstPath, srcPath string) error {


### PR DESCRIPTION
## Problem

`Changeset.withChangeset[s]` built each merge branch by `git apply`ing the changeset's patch onto a union of every input's before directory. That silently assumes all inputs share a common base. When the befores diverge — e.g. generate staging a shared dependency's codegen into each dependent's workspace — the union base already contains one side's post-state, so insertion hunks re-apply at an offset (generated code is repetitive enough for `git apply` to match context past an existing copy, duplicating code) and modification hunks fail outright with `error: patch failed`. This is what forced the go SDK's rebase workaround (dagger/go-sdk@89edf83): manufacturing a common base at the callsite, in the wrong layer. A changeset *is* its file-level diff — `withChangeset` shouldn't require callers to curate bases.

Complements #13771, which made the staging-side accumulation merge-free; this octopus merge was the last patch-based consumer.

## Fix

**core: ignore ctime when merging changesets** — snapshots share file contents via hardlinks, so a file's ctime, inode, and device can change under a live merge workspace without the content changing. Git sees stat-dirty entries and `git merge`'s internal `git stash create` fails with a bewildering `fatal: stash failed`. The ephemeral merge repos now run with `core.checkStat=minimal` and `core.trustctime=false`.

**fix(layercopy): unwrap hardlink fallback errors** — `os.Link` wraps errnos in `*os.LinkError`, so the EXDEV/EMLINK comparisons never matched and the content-copy fallback was dead code. Nobody hit this while every copy targeted the snapshot filesystem itself, but copying into a mounted view (a different superblock) trips it immediately.

**fix(core): merge changesets by content** — each merge branch is now built from the changeset's file-level content instead of a patch: materialize `Before.diff(After)` (the same content `Directory.withChanges` and `Changeset.export` already apply), delete the removed paths, overlay the diff onto the checked-out base, recreate empty added directories, and commit. Content the base already contains becomes a no-op, so inputs no longer need a common base, while genuinely common-base inputs produce the same branches the patches did. The merge step itself is unchanged: git re-derives line-level hunks against the merge base, so same-file edits in different regions still compose textually and overlapping edits still conflict per the `onConflict` strategy. `asPatch` stays (API-visible); the patch-apply plumbing is deleted.

Two constraints baked into the implementation: the copier writes through the mounted view rather than the snapshot upperdir (git must see the files it stages; mutating an overlay's layers behind a live mount leaves the view incoherent), and source hardlinks are disabled (they always cross superblocks into the view).

**fix(core): touch merge-applied paths so git sees them** — snapshot contents carry normalized timestamps and the copier preserves them, so a same-size edit leaves a file's mtime and size identical to its index entry. With `core.checkStat=minimal`, `git add` skipped re-hashing such files and silently dropped the edit from the branch commit; the worktree still carried the content, so the last-applied changeset's version leaked into the merge result and modify/modify conflicts "merged" cleanly, clobbering one side. Every applied path's mtime is bumped after the overlay. Adds `TestSameFileRegionMerge`, pinning that same-file different-region edits compose in both two-way and octopus merges and that overlapping edits still conflict — the case that caught this.

## Compatibility

No API changes. For changesets sharing a common base, branch content is identical to the patch-applied result, so existing merges behave the same. Empty added directories now survive merges (patches couldn't represent them). Once this lands, the go SDK's rebase workaround can be reverted: generate output against the pre-workaround go-sdk is byte-identical to output with it.

## Verification (dagger repo, dev engine)

- Full `dagger generate dagger-go-sdk` against the pre-workaround go-sdk (dagger/go-sdk@0c04581): applies cleanly where it previously duplicated `AsVolume` bindings or failed hunks, output is byte-identical to the known-good regen, every toolchain compiles, and rerunning is a no-op.
- `TestChangeset` integration suite passes, including the new `TestSameFileRegionMerge` and all `TestChangesetMerge` / `TestWithChangesets` conflict flows.
- `go test ./core/schema ./core/workspace ./util/layercopy` pass; polyfill's e2e module-source checks (including the `generate-merge-check` disjointness pin) pass 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
