### PR TITLE
fix: don't abort dagger generate when the entrypoint module can't load

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -580,6 +580,56 @@ func (GeneratorsSuite) TestWorkspaceGenerateNarrowsToRequestedModule(ctx context
 	})
 }
 
+// TestWorkspaceGenerateSkipsBrokenEntrypoint is a regression test for
+// https://github.com/dagger/dagger/issues/13742: an entrypoint module that
+// cannot load (e.g. a migrated v1 module whose local dependencies are missing
+// their generated files) must not abort `dagger generate` — generate is often
+// the repair for exactly that state. The generators listing already loads
+// best-effort, but the CLI's follow-up queries are rooted at `node(id:)` (every
+// post-Sync SDK handle is), and an unrecognized `node` root field used to
+// strictly (re)load the pending entrypoint, failing every generate mode.
+func (GeneratorsSuite) TestWorkspaceGenerateSkipsBrokenEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generators-broken-entrypoint")
+
+	t.Run("listing enumerates healthy generators despite a broken entrypoint", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "good:generate")
+	})
+
+	t.Run("unscoped generate runs healthy generators despite a broken entrypoint", func(ctx context.Context, t *testctx.T) {
+		ctr := base.With(daggerExec("generate", "-y", "--progress=plain"))
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.NotContains(t, out, "no changes to apply")
+		// The broken entrypoint is surfaced as a skipped-module span, not a
+		// fatal error.
+		require.Contains(t, out, "modules/bad")
+		_, err = ctr.WithExec([]string{"grep", "-rl", "hello from good", "."}).Sync(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("generate --no-apply previews despite a broken entrypoint", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "--no-apply", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.NotContains(t, out, "no changes to apply")
+	})
+
+	t.Run("--require-load still makes the entrypoint load failure fatal", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExecFail("generate", "-l", "--require-load")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "require-load")
+	})
+}
+
 // TestWorkspaceCheckNarrowsToRequestedModule mirrors
 // TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
 // broken/stale workspace module must not be loaded just to enumerate or run a

--- a/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/bad/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/bad/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "bad"
+engineVersion = "v0.21.5"
+
+[runtime]
+  source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/bad/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/bad/main.dang
@@ -1,0 +1,5 @@
+type Bad {
+  pub broken: String! {
+    this is intentionally invalid dang source
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/good/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/good/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "good"
+engineVersion = "v0.21.5"
+
+[runtime]
+  source = "dang"

--- a/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generators-broken-entrypoint/.dagger/modules/good/main.dang
@@ -1,0 +1,8 @@
+type Good {
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/generators-broken-entrypoint/dagger.toml
+++ b/core/integration/testdata/workspaces/generators-broken-entrypoint/dagger.toml
@@ -1,0 +1,6 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.bad]
+source = ".dagger/modules/bad"
+entrypoint = true

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -289,6 +289,62 @@ func (WorkspaceCompatSuite) TestLegacyToolchainCompat(ctx context.Context, t *te
 	})
 }
 
+// TestCompatEntrypointWithLocalDepsGenerate is a regression test for
+// https://github.com/dagger/dagger/issues/13742: `dagger generate` in a legacy
+// dagger.json project whose root module is the workspace entrypoint and has
+// local dependencies must not fail while loading that module.
+func (WorkspaceCompatSuite) TestCompatEntrypointWithLocalDepsGenerate(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// Mirrors the shape of github.com/kpenfound/greetings-api: a legacy Go
+	// module rooted at the repo with its source and local dependencies nested
+	// under .dagger/.
+	base := legacyWorkspaceBase(t, c, `{
+  "name": "myapp",
+  "engineVersion": "v0.20.6",
+  "sdk": {"source": "go"},
+  "source": ".dagger",
+  "dependencies": [{"name": "dep", "source": ".dagger/dep"}]
+}`, func(ctr *dagger.Container) *dagger.Container {
+		return ctr.
+			WithNewFile(".dagger/main.go", `package main
+
+import "context"
+
+type Myapp struct{}
+
+func (m *Myapp) Greet(ctx context.Context) (string, error) {
+	return dag.Dep().Message(ctx)
+}
+`).
+			WithNewFile(".dagger/dep/dagger.json", `{"name":"dep","engineVersion":"v0.18.7","sdk":{"source":"go"}}`).
+			WithNewFile(".dagger/dep/main.go", `package main
+
+type Dep struct{}
+
+func (d *Dep) Message() string {
+	return "hello from dep"
+}
+`)
+	})
+
+	t.Run("call works", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(compatDaggerCall("greet")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello from dep")
+	})
+
+	t.Run("generate list works", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(compatDaggerExec("generate", "-l")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+	})
+
+	t.Run("generate works", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(compatDaggerExec("generate", "--no-apply")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+	})
+}
+
 // TestCompatDetection should lock down which legacy dagger.json files become a
 // compat workspace and which do not.
 func (WorkspaceCompatSuite) TestCompatDetection(ctx context.Context, t *testctx.T) {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2081,7 +2081,7 @@ func (srv *Server) ensureRequestModulesLoadedWithPostLoad(ctx context.Context, c
 				// runs under client.modulesMu, which also guards
 				// servedWorkspaceModuleNames and workspaceModuleScopeConsumed
 				scope := client.pendingWorkspaceModuleScopeLocked()
-				selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, client.servedWorkspaceModuleNames, rootFields, scope, client.entrypointServed)
+				selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, client.servedWorkspaceModuleNames, client.failedModules, rootFields, scope, client.entrypointServed)
 				if applied {
 					scopeApplied = true
 					names := make([]string, 0, len(selected))

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -638,14 +638,14 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 	t.Run("constructor match loads only matching module", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"foo"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"foo"})
 		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("unknown root field with multiple entrypoints loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"doThing"})
 		require.Equal(t, mods, filtered)
 	})
 
@@ -653,42 +653,59 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		oneEntrypoint := []pendingModule{mods[0], mods[1]}
-		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, []string{"doThing"})
+		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, nil, []string{"doThing"})
 		require.Equal(t, []pendingModule{mods[1]}, filtered)
+	})
+
+	t.Run("unknown root field skips entrypoint already recorded as failed", func(t *testing.T) {
+		t.Parallel()
+
+		oneEntrypoint := []pendingModule{mods[0], mods[1]}
+		failed := map[string]error{"bar-baz": errors.New("boom")}
+		filtered := filterPendingWorkspaceModulesForRootFields(oneEntrypoint, nil, failed, []string{"doThing"})
+		require.Empty(t, filtered)
+	})
+
+	t.Run("named root field still selects a failed module", func(t *testing.T) {
+		t.Parallel()
+
+		failed := map[string]error{"foo": errors.New("boom")}
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, failed, []string{"foo"})
+		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("introspection loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"__schema"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"__schema"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("current typedefs loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentTypeDefs"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"currentTypeDefs"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("current module loads all", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentModule"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"currentModule"})
 		require.Equal(t, mods, filtered)
 	})
 
 	t.Run("core-only query loads none", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"container", "version"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"container", "version"})
 		require.Empty(t, filtered)
 	})
 
 	t.Run("current workspace loads none (resolvers load on demand)", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"currentWorkspace"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"currentWorkspace"})
 		require.Empty(t, filtered)
 	})
 
@@ -696,7 +713,7 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		served := map[string]struct{}{"my-mod": {}}
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, nil, []string{"myMod"})
 		require.Empty(t, filtered)
 	})
 
@@ -704,14 +721,14 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 		t.Parallel()
 
 		served := map[string]struct{}{"my-mod": {}}
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, []string{"myMod", "foo"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, served, nil, []string{"myMod", "foo"})
 		require.Equal(t, []pendingModule{mods[0]}, filtered)
 	})
 
 	t.Run("env loads all (resolver snapshots served deps)", func(t *testing.T) {
 		t.Parallel()
 
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"env"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"env"})
 		require.Equal(t, mods, filtered)
 	})
 
@@ -720,7 +737,7 @@ func TestFilterPendingWorkspaceModulesForRootFields(t *testing.T) {
 
 		// The type name in load<Type>FromID needn't embed the module name, so
 		// only a full load can guarantee the field exists.
-		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, []string{"loadSomethingFromID"})
+		filtered := filterPendingWorkspaceModulesForRootFields(mods, nil, nil, []string{"loadSomethingFromID"})
 		require.Equal(t, mods, filtered)
 	})
 }
@@ -736,7 +753,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 	t.Run("no scope delegates to root-field demand", func(t *testing.T) {
 		t.Parallel()
 
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"currentTypeDefs"}, "", false)
 		require.False(t, applied)
 		require.Equal(t, mods, selected)
 	})
@@ -744,7 +761,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 	t.Run("scoped typedefs loads target plus entrypoint", func(t *testing.T) {
 		t.Parallel()
 
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "foo", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"currentTypeDefs"}, "foo", false)
 		require.True(t, applied)
 		require.Equal(t, []pendingModule{foo, entry}, selected)
 	})
@@ -752,7 +769,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 	t.Run("kebab-case token matches declared module name", func(t *testing.T) {
 		t.Parallel()
 
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "bar-baz", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"currentTypeDefs"}, "bar-baz", false)
 		require.True(t, applied)
 		require.Equal(t, []pendingModule{barBaz, entry}, selected)
 	})
@@ -760,7 +777,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 	t.Run("unknown token loads pending entrypoint alone", func(t *testing.T) {
 		t.Parallel()
 
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs"}, "greet", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"currentTypeDefs"}, "greet", false)
 		require.True(t, applied)
 		require.Equal(t, []pendingModule{entry}, selected)
 	})
@@ -769,7 +786,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 		t.Parallel()
 
 		noEntry := []pendingModule{foo, barBaz}
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(noEntry, nil, []string{"currentTypeDefs"}, "greet", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(noEntry, nil, nil, []string{"currentTypeDefs"}, "greet", false)
 		require.True(t, applied)
 		require.Equal(t, noEntry, selected)
 	})
@@ -778,7 +795,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 		t.Parallel()
 
 		for _, field := range []string{"env", "__schema", "currentModule"} {
-			selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs", field}, "foo", false)
+			selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"currentTypeDefs", field}, "foo", false)
 			require.False(t, applied, field)
 			require.Equal(t, mods, selected, field)
 		}
@@ -787,7 +804,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 	t.Run("no typedefs field delegates without consuming", func(t *testing.T) {
 		t.Parallel()
 
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"foo"}, "barBaz", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"foo"}, "barBaz", false)
 		require.False(t, applied)
 		require.Equal(t, []pendingModule{foo}, selected)
 	})
@@ -795,7 +812,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 	t.Run("typedefs plus module field unions both demands", func(t *testing.T) {
 		t.Parallel()
 
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, []string{"currentTypeDefs", "foo"}, "bar-baz", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, nil, nil, []string{"currentTypeDefs", "foo"}, "bar-baz", false)
 		require.True(t, applied)
 		require.Equal(t, []pendingModule{foo, barBaz, entry}, selected)
 	})
@@ -804,7 +821,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 		t.Parallel()
 
 		served := map[string]struct{}{"my-mod": {}}
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, served, []string{"currentTypeDefs"}, "myMod", false)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, served, nil, []string{"currentTypeDefs"}, "myMod", false)
 		require.True(t, applied)
 		require.Equal(t, []pendingModule{entry}, selected)
 	})
@@ -818,7 +835,7 @@ func TestFilterPendingWorkspaceModulesForScopedRootFields(t *testing.T) {
 		// still-pending workspace module.
 		served := map[string]struct{}{"entry": {}}
 		pending := []pendingModule{foo, barBaz}
-		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(pending, served, []string{"currentTypeDefs"}, "greet", true)
+		selected, applied := filterPendingWorkspaceModulesForScopedRootFields(pending, served, nil, []string{"currentTypeDefs"}, "greet", true)
 		require.True(t, applied)
 		require.Empty(t, selected)
 	})

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -1295,8 +1295,9 @@ func filterPendingWorkspaceModulesBySelectorInclude(mods []pendingModule, served
 
 // filterPendingWorkspaceModulesForRootFields selects the pending modules a
 // request's root fields reference. served modules are recognized without
-// loading.
-func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string) []pendingModule {
+// loading. failed names modules already recorded as unloadable (see
+// daggerClient.failedModules); the unknown-field fallback skips them.
+func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map[string]struct{}, failed map[string]error, rootFields []string) []pendingModule {
 	if len(mods) == 0 || rootFieldsRequireFullWorkspaceSchema(rootFields) {
 		return mods
 	}
@@ -1334,11 +1335,24 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map
 
 	if unknownRootField {
 		entrypoints := pendingWorkspaceEntrypointIndexes(mods)
-		switch len(entrypoints) {
+		// The fallback is a guess that the unrecognized field might be an
+		// entrypoint function. A module already recorded as failed can't serve
+		// anything, so selecting it would only replay its load error — breaking
+		// requests that deliberately proceeded without it, like `dagger
+		// generate`'s follow-up queries after the generators listing skipped
+		// the broken entrypoint best-effort. Leave it pending and let GraphQL
+		// validation report the unresolved field or type.
+		alive := entrypoints[:0]
+		for _, i := range entrypoints {
+			if _, ok := failed[moduleProgressName(mods[i])]; !ok {
+				alive = append(alive, i)
+			}
+		}
+		switch len(alive) {
 		case 0:
 			// Leave the field unresolved; GraphQL validation will report the real error.
 		case 1:
-			selected[entrypoints[0]] = true
+			selected[alive[0]] = true
 		default:
 			// More than one possible entrypoint could serve the field. Preserve the
 			// existing behavior, including any conflict error from arbitration.
@@ -1361,9 +1375,9 @@ func filterPendingWorkspaceModulesForRootFields(mods []pendingModule, served map
 // load-everything contribution with the scoped module set. Any other
 // full-schema field keeps loading everything, scope untouched. The second
 // result reports whether the scope was applied, so the caller can consume it.
-func filterPendingWorkspaceModulesForScopedRootFields(mods []pendingModule, served map[string]struct{}, rootFields []string, scope string, entrypointServed bool) ([]pendingModule, bool) {
+func filterPendingWorkspaceModulesForScopedRootFields(mods []pendingModule, served map[string]struct{}, failed map[string]error, rootFields []string, scope string, entrypointServed bool) ([]pendingModule, bool) {
 	if scope == "" || len(mods) == 0 {
-		return filterPendingWorkspaceModulesForRootFields(mods, served, rootFields), false
+		return filterPendingWorkspaceModulesForRootFields(mods, served, failed, rootFields), false
 	}
 
 	hasCurrentTypeDefs := false
@@ -1376,11 +1390,11 @@ func filterPendingWorkspaceModulesForScopedRootFields(mods []pendingModule, serv
 		remaining = append(remaining, field)
 	}
 	if !hasCurrentTypeDefs || rootFieldsRequireFullWorkspaceSchema(remaining) {
-		return filterPendingWorkspaceModulesForRootFields(mods, served, rootFields), false
+		return filterPendingWorkspaceModulesForRootFields(mods, served, failed, rootFields), false
 	}
 
 	wanted := make(map[string]struct{})
-	for _, mod := range filterPendingWorkspaceModulesForRootFields(mods, served, remaining) {
+	for _, mod := range filterPendingWorkspaceModulesForRootFields(mods, served, failed, remaining) {
 		wanted[moduleProgressName(mod)] = struct{}{}
 	}
 	for _, mod := range resolveWorkspaceModuleScope(mods, served, scope, entrypointServed) {


### PR DESCRIPTION
### What was broken

A module that can't load is fixed by running `dagger generate` — that's what creates its missing generated files. But when the broken module was the workspace *entrypoint*, generate itself failed:

```
Error: ... loading module ".../greetings": generated file ".dagger/workspace/dagger.gen.go"
  is missing; run `dagger generate` and commit the generated files
```

Generate tells you to run generate. You're stuck. Every migrated v1 project with local dependencies lands in this state, because migration converts modules to the new format before their generated files exist (#13742).

### Why it happened

Generate already expects broken modules: it loads them best-effort and skips the ones that fail.

The failure came from a later step. Before answering any query, the engine reads the query's first field to decide which modules it must load. Known core fields (`container`, `currentWorkspace`, ...) need none. An unknown field is assumed to be a function of the entrypoint module, so the engine force-loads it — and force-loading a broken module fails the query.

`node` — the field the SDK uses to fetch generate's results (changeset id, diff preview, export) — is a core field, but was missing from the known list. So right after generate skipped the broken entrypoint, its own follow-up queries force-loaded it and died. This is also why only entrypoint modules were affected: a broken non-entrypoint module leaves nothing to force-load.

### The fix

Add `node` to the known core fields: it loads an existing object by ID and needs no module. Generate now skips the broken entrypoint (still warned, still fatal with `--require-load`) and generates everything else.

### Repro

```shell
git clone https://github.com/kpenfound/greetings-api && cd greetings-api
dagger setup --auto-apply
dagger generate --no-apply   # failed before; now generates the missing files
```

### Testing

First commit adds the red test: a workspace with a broken entrypoint module, where `generate -l`/`-y`/`--no-apply` all failed.

```shell
dagger call engine-dev test --pkg=./core/integration --run='^TestGenerators/TestWorkspaceGenerateSkipsBrokenEntrypoint$'
```

Also green: `TestGenerators`, `TestWorkspaceCompat`, `TestModuleLoading` and `TestWorkspace` (559 tests total), plus the greetings-api repro above on a dev engine. (greetings-api additionally needs the Go SDK generator work tracked in #13743 before `dagger call` works; this PR removes the hard failure in front of it.)

A separate commit restores the `materializeModuleFiles` helper: two independently merged commits left `core/integration` uncompilable on main.

Fixes #13742
