### PR TITLE
test: restore materializeModuleFiles helper

### DIFF
--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -29,6 +29,12 @@ func TestWorkspaceMigration(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(WorkspaceMigrationSuite{})
 }
 
+// materializeModuleFiles runs codegen and exports the module's generated
+// files into the container: TOML modules don't regenerate at runtime.
+func materializeModuleFiles(refString string) dagger.WithContainerFunc {
+	return daggerQuery(`{moduleSource(refString:%q){generatedContextDirectory{export(path:".")}}}`, refString)
+}
+
 // TestWorkspaceMigratePreviewAndApply should cover the main CLI lifecycle:
 // preview via the workspace `migrate` API (non-mutating) and apply via
 // `dagger setup --auto-apply`.


### PR DESCRIPTION
### What was broken

`core/integration` no longer compiles on main:

```
core/integration/workspace_migration_test.go:131:9: undefined: materializeModuleFiles
```

Two PRs raced: db4e39b74 removed the `materializeModuleFiles` helper as unused (it was, on that branch), while 2e61e4171f independently added a usage of it. Each branch was green on its own; merged together they left a usage with no definition, so every check that compiles the integration tests fails on any branch based on current main.

CI evidence: `golang:lint-all` on #13761 fails with exactly this error — [trace 5ee68a99f7311ebb25fc816b2026d2f9](https://dagger.cloud/dagger/traces/5ee68a99f7311ebb25fc816b2026d2f9) (`dagger trace 5ee68a99f7311ebb25fc816b2026d2f9`).

### What this does

Restores the helper, unchanged.

Extracted from #13774 so main gets green without waiting on that review.
