### PR TITLE
dagql: recipe ID DAG dedupe, directive views

### DIFF
--- a/dagql/call_request_input.go
+++ b/dagql/call_request_input.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
+	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -59,15 +60,44 @@ func resultCallRefFromResult(ctx context.Context, res AnyResult) (*ResultCallRef
 	return &ResultCallRef{ResultID: uint64(shared.id), shared: shared}, nil
 }
 
-func resultCallRefFromIDInput(ctx context.Context, id *call.ID) (*ResultCallRef, error) {
+// recipeCallMemo deduplicates recipe-ID expansion within a single top-level
+// decode. Call IDs are content-addressed and acyclic, and a given digest always
+// denotes the exact same recipe, so the expanded *ResultCall for a digest can be
+// shared across every reference to it within one build: frames are treated as
+// frozen provenance (cloned/forked before any mutation), so sharing is safe and
+// collapses a heavily-shared ID DAG back into a DAG instead of unrolling it into
+// an exponentially larger tree. Without it, resuming a long agent/LLM session —
+// whose accumulated state is one big DAG with a base object referenced by a long
+// receiver chain and many args — expands to ~10^8 frames and tens of GB. The memo
+// is created fresh per top-level decode and used single-threaded down the
+// synchronous expansion, matching the plain visiting maps already threaded
+// through the digest helpers (e.g. recipeDigestWithVisiting).
+type recipeCallMemo map[digest.Digest]*ResultCall
+
+func resultCallRefFromIDInput(ctx context.Context, id *call.ID, memo recipeCallMemo) (*ResultCallRef, error) {
 	if id == nil {
 		return nil, fmt.Errorf("nil ID input")
 	}
+	if memo == nil {
+		memo = recipeCallMemo{}
+	}
 	if !id.IsHandle() {
-		frame, err := resultCallFromRecipeIDInput(ctx, id)
+		// A recipe (inline) ID inlines its entire sub-DAG. Without memoization a
+		// shared node (a base object reached via a long receiver chain and many
+		// args) is re-expanded once per path, unrolling the DAG into a tree. Expand
+		// each distinct recipe digest once and share the resulting frame.
+		dig := id.Digest()
+		if frame, ok := memo[dig]; ok {
+			if frame == nil {
+				return nil, nil
+			}
+			return &ResultCallRef{Call: frame}, nil
+		}
+		frame, err := resultCallFromRecipeIDInput(ctx, id, memo)
 		if err != nil {
 			return nil, err
 		}
+		memo[dig] = frame
 		if frame == nil {
 			return nil, nil
 		}
@@ -103,7 +133,7 @@ func resultCallRefFromIDInput(ctx context.Context, id *call.ID) (*ResultCallRef,
 	return &ResultCallRef{ResultID: uint64(shared.id), shared: shared}, nil
 }
 
-func resultCallFromRecipeIDInput(ctx context.Context, id *call.ID) (*ResultCall, error) {
+func resultCallFromRecipeIDInput(ctx context.Context, id *call.ID, memo recipeCallMemo) (*ResultCall, error) {
 	if id == nil {
 		return nil, nil
 	}
@@ -126,14 +156,14 @@ func resultCallFromRecipeIDInput(ctx context.Context, id *call.ID) (*ResultCall,
 	}
 
 	if receiver := id.Receiver(); receiver != nil {
-		receiverRef, err := resultCallRefFromIDInput(ctx, receiver)
+		receiverRef, err := resultCallRefFromIDInput(ctx, receiver, memo)
 		if err != nil {
 			return nil, fmt.Errorf("receiver: %w", err)
 		}
 		frame.Receiver = receiverRef
 	}
 	if mod := id.Module(); mod != nil {
-		modRef, err := resultCallRefFromIDInput(ctx, mod.ID())
+		modRef, err := resultCallRefFromIDInput(ctx, mod.ID(), memo)
 		if err != nil {
 			return nil, fmt.Errorf("module: %w", err)
 		}
@@ -145,14 +175,14 @@ func resultCallFromRecipeIDInput(ctx context.Context, id *call.ID) (*ResultCall,
 		}
 	}
 	for _, arg := range id.Args() {
-		converted, err := resultCallArgFromRecipeArgument(ctx, arg)
+		converted, err := resultCallArgFromRecipeArgument(ctx, arg, memo)
 		if err != nil {
 			return nil, fmt.Errorf("arg %q: %w", arg.Name(), err)
 		}
 		frame.Args = append(frame.Args, converted)
 	}
 	for _, input := range id.ImplicitInputs() {
-		converted, err := resultCallArgFromRecipeArgument(ctx, input)
+		converted, err := resultCallArgFromRecipeArgument(ctx, input, memo)
 		if err != nil {
 			return nil, fmt.Errorf("implicit input %q: %w", input.Name(), err)
 		}
@@ -161,11 +191,11 @@ func resultCallFromRecipeIDInput(ctx context.Context, id *call.ID) (*ResultCall,
 	return frame, nil
 }
 
-func resultCallArgFromRecipeArgument(ctx context.Context, arg *call.Argument) (*ResultCallArg, error) {
+func resultCallArgFromRecipeArgument(ctx context.Context, arg *call.Argument, memo recipeCallMemo) (*ResultCallArg, error) {
 	if arg == nil {
 		return nil, nil
 	}
-	value, err := resultCallLiteralFromRecipeLiteral(ctx, arg.Value())
+	value, err := resultCallLiteralFromRecipeLiteral(ctx, arg.Value(), memo)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +206,10 @@ func resultCallArgFromRecipeArgument(ctx context.Context, arg *call.Argument) (*
 	}, nil
 }
 
-//nolint:dupl // symmetric with resultCallLiteralFromCallLiteral; the two differ in how structural input digests get resolved
-func resultCallLiteralFromRecipeLiteral(ctx context.Context, lit call.Literal) (*ResultCallLiteral, error) {
+// Symmetric with resultCallLiteralFromCallLiteral; the two differ in how
+// structural input digests get resolved, and in that this one threads a
+// recipeCallMemo.
+func resultCallLiteralFromRecipeLiteral(ctx context.Context, lit call.Literal, memo recipeCallMemo) (*ResultCallLiteral, error) {
 	switch v := lit.(type) {
 	case nil:
 		return &ResultCallLiteral{Kind: ResultCallLiteralKindNull}, nil
@@ -200,7 +232,7 @@ func resultCallLiteralFromRecipeLiteral(ctx context.Context, lit call.Literal) (
 			DigestedStringDigest: v.Digest(),
 		}, nil
 	case *call.LiteralID:
-		ref, err := resultCallRefFromIDInput(ctx, v.Value())
+		ref, err := resultCallRefFromIDInput(ctx, v.Value(), memo)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +243,7 @@ func resultCallLiteralFromRecipeLiteral(ctx context.Context, lit call.Literal) (
 	case *call.LiteralList:
 		items := make([]*ResultCallLiteral, 0, v.Len())
 		for _, item := range v.Values() {
-			converted, err := resultCallLiteralFromRecipeLiteral(ctx, item)
+			converted, err := resultCallLiteralFromRecipeLiteral(ctx, item, memo)
 			if err != nil {
 				return nil, err
 			}
@@ -224,7 +256,7 @@ func resultCallLiteralFromRecipeLiteral(ctx context.Context, lit call.Literal) (
 	case *call.LiteralObject:
 		fields := make([]*ResultCallArg, 0, v.Len())
 		for _, field := range v.Args() {
-			converted, err := resultCallLiteralFromRecipeLiteral(ctx, field.Value())
+			converted, err := resultCallLiteralFromRecipeLiteral(ctx, field.Value(), memo)
 			if err != nil {
 				return nil, fmt.Errorf("field %q: %w", field.Name(), err)
 			}
@@ -267,7 +299,7 @@ func resultCallLiteralFromInput(ctx context.Context, input Input) (*ResultCallLi
 		if err != nil {
 			return nil, fmt.Errorf("ID input %T is invalid: %w", input, err)
 		}
-		ref, err := resultCallRefFromIDInput(ctx, id)
+		ref, err := resultCallRefFromIDInput(ctx, id, recipeCallMemo{})
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +351,8 @@ func resultCallLiteralFromInput(ctx context.Context, input Input) (*ResultCallLi
 	return resultCallLiteralFromCallLiteral(ctx, input.ToLiteral())
 }
 
-//nolint:dupl // symmetric with resultCallLiteralFromRecipeLiteral; the two differ in how structural input digests get resolved
+// Symmetric with resultCallLiteralFromRecipeLiteral; the two differ in how
+// structural input digests get resolved.
 func resultCallLiteralFromCallLiteral(ctx context.Context, lit call.Literal) (*ResultCallLiteral, error) {
 	switch v := lit.(type) {
 	case nil:
@@ -343,7 +376,7 @@ func resultCallLiteralFromCallLiteral(ctx context.Context, lit call.Literal) (*R
 			DigestedStringDigest: v.Digest(),
 		}, nil
 	case *call.LiteralID:
-		ref, err := resultCallRefFromIDInput(ctx, v.Value())
+		ref, err := resultCallRefFromIDInput(ctx, v.Value(), recipeCallMemo{})
 		if err != nil {
 			return nil, err
 		}

--- a/dagql/call_request_input_memo_test.go
+++ b/dagql/call_request_input_memo_test.go
@@ -1,0 +1,157 @@
+package dagql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// These tests pin the recipeCallMemo behavior added to resultCallRefFromIDInput:
+// a recipe (inline) ID DAG with shared sub-nodes must expand into a shared DAG,
+// not an unrolled tree. Before memoization, resuming a long agent/LLM session —
+// whose accumulated state references the same base object via a long receiver
+// chain and many args — expanded to ~10^8 ResultCall frames and tens of GB.
+
+var (
+	memoStrType = &ast.Type{NamedType: "String", NonNull: true}
+	memoObjType = &ast.Type{NamedType: "Obj", NonNull: true}
+)
+
+func refArg(t *testing.T, frame *ResultCall, name string) *ResultCall {
+	t.Helper()
+	for _, arg := range frame.Args {
+		if arg.Name != name {
+			continue
+		}
+		require.NotNil(t, arg.Value, "arg %q has nil value", name)
+		require.Equal(t, ResultCallLiteralKindResultRef, arg.Value.Kind, "arg %q", name)
+		require.NotNil(t, arg.Value.ResultRef, "arg %q has nil ref", name)
+		return arg.Value.ResultRef.Call
+	}
+	t.Fatalf("arg %q not found", name)
+	return nil
+}
+
+// A base object referenced by two distinct args of the same call must expand to
+// the exact same *ResultCall pointer — one expansion shared, not duplicated.
+func TestRecipeMemoDedupesSharedNode(t *testing.T) {
+	t.Parallel()
+
+	base := call.New().Append(memoStrType, "base")
+	top := call.New().Append(memoObjType, "combine",
+		call.WithArgs(
+			call.NewArgument("a", call.NewLiteralID(base), false),
+			call.NewArgument("b", call.NewLiteralID(base), false),
+		),
+	)
+
+	ref, err := resultCallRefFromIDInput(context.Background(), top, recipeCallMemo{})
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	require.NotNil(t, ref.Call)
+
+	a := refArg(t, ref.Call, "a")
+	b := refArg(t, ref.Call, "b")
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	require.Equal(t, "base", a.Field)
+	// The whole point: both references resolve to one shared frame.
+	require.Same(t, a, b, "shared base must expand to a single shared *ResultCall")
+}
+
+// Distinct bases must NOT be collapsed together — the memo keys on recipe digest,
+// so different recipes stay different frames.
+func TestRecipeMemoKeepsDistinctNodesDistinct(t *testing.T) {
+	t.Parallel()
+
+	baseA := call.New().Append(memoStrType, "baseA")
+	baseB := call.New().Append(memoStrType, "baseB")
+	top := call.New().Append(memoObjType, "combine",
+		call.WithArgs(
+			call.NewArgument("a", call.NewLiteralID(baseA), false),
+			call.NewArgument("b", call.NewLiteralID(baseB), false),
+		),
+	)
+
+	ref, err := resultCallRefFromIDInput(context.Background(), top, recipeCallMemo{})
+	require.NoError(t, err)
+
+	a := refArg(t, ref.Call, "a")
+	b := refArg(t, ref.Call, "b")
+	require.NotSame(t, a, b, "distinct recipes must not be deduplicated")
+	require.Equal(t, "baseA", a.Field)
+	require.Equal(t, "baseB", b.Field)
+}
+
+// The blowup scenario: a deep receiver chain where every level references the same
+// base. Without memoization the base is re-expanded once per level (and shared
+// sub-DAGs unroll super-linearly). With it, the base is a single shared frame
+// across all levels, so the retained frame is a DAG whose size is linear in the
+// number of distinct nodes.
+func TestRecipeMemoSharesAcrossReceiverChain(t *testing.T) {
+	t.Parallel()
+
+	const depth = 300
+	base := call.New().Append(memoStrType, "base")
+
+	var id *call.ID // call.New()
+	for i := range depth {
+		id = id.Append(memoObjType, fmt.Sprintf("step%d", i),
+			call.WithArgs(call.NewArgument("ref", call.NewLiteralID(base), false)),
+		)
+	}
+
+	ref, err := resultCallRefFromIDInput(context.Background(), id, recipeCallMemo{})
+	require.NoError(t, err)
+	require.NotNil(t, ref.Call)
+
+	// Walk the receiver chain, collecting each level's base ref and every distinct
+	// *ResultCall frame reachable.
+	distinct := map[*ResultCall]struct{}{}
+	var walk func(f *ResultCall)
+	walk = func(f *ResultCall) {
+		if f == nil {
+			return
+		}
+		if _, seen := distinct[f]; seen {
+			return
+		}
+		distinct[f] = struct{}{}
+		if f.Receiver != nil {
+			walk(f.Receiver.Call)
+		}
+		for _, arg := range f.Args {
+			if arg.Value != nil && arg.Value.ResultRef != nil {
+				walk(arg.Value.ResultRef.Call)
+			}
+		}
+	}
+	walk(ref.Call)
+
+	levels := 0
+	var firstBase *ResultCall
+	for f := ref.Call; f != nil; f = receiverFrame(f) {
+		levels++
+		got := refArg(t, f, "ref")
+		if firstBase == nil {
+			firstBase = got
+		}
+		require.Same(t, firstBase, got, "base must be shared at every chain level")
+	}
+	require.Equal(t, depth, levels)
+
+	// Linear, not exponential: depth chain frames + exactly one shared base.
+	require.Equal(t, depth+1, len(distinct),
+		"expected depth step frames + 1 shared base; a tree unroll would be far larger")
+}
+
+func receiverFrame(f *ResultCall) *ResultCall {
+	if f == nil || f.Receiver == nil {
+		return nil
+	}
+	return f.Receiver.Call
+}

--- a/dagql/dagql_test.go
+++ b/dagql/dagql_test.go
@@ -2775,17 +2775,27 @@ func TestViewsFilterNonObjectTypes(t *testing.T) {
 	class.Implements(iface)
 	srv.InstallObject(class)
 
+	srv.InstallDirective(dagql.DirectiveSpec{
+		Name:        "viewFilteredDirective",
+		Description: "future directive",
+		Locations: []dagql.DirectiveLocation{
+			dagql.DirectiveLocationFieldDefinition,
+		},
+	}.View(dagql.ExactView("future")))
+
 	oldSchema := srv.SchemaForView("old")
 	require.NotContains(t, oldSchema.Types, "ViewFilteredEnum")
 	require.NotContains(t, oldSchema.Types, "ViewFilteredInput")
 	require.NotContains(t, oldSchema.Types, "ViewFilteredInterface")
 	require.NotContains(t, oldSchema.Types["ViewFilteredInterfaceObject"].Interfaces, "ViewFilteredInterface")
+	require.NotContains(t, oldSchema.Directives, "viewFilteredDirective")
 
 	futureSchema := srv.SchemaForView("future")
 	require.Equal(t, ast.Enum, futureSchema.Types["ViewFilteredEnum"].Kind)
 	require.Equal(t, ast.InputObject, futureSchema.Types["ViewFilteredInput"].Kind)
 	require.Equal(t, ast.Interface, futureSchema.Types["ViewFilteredInterface"].Kind)
 	require.Contains(t, futureSchema.Types["ViewFilteredInterfaceObject"].Interfaces, "ViewFilteredInterface")
+	require.Contains(t, futureSchema.Directives, "viewFilteredDirective")
 }
 
 type CoolInt struct {

--- a/dagql/directives.go
+++ b/dagql/directives.go
@@ -12,6 +12,16 @@ type DirectiveSpec struct {
 	Args         InputSpecs          `field:"true"`
 	Locations    []DirectiveLocation `field:"true"`
 	IsRepeatable bool                `field:"true"`
+
+	// ViewFilter is a filter that specifies under which views this directive
+	// is visible.
+	ViewFilter ViewFilter
+}
+
+// View sets the ViewFilter under which this directive is visible.
+func (d DirectiveSpec) View(filter ViewFilter) DirectiveSpec {
+	d.ViewFilter = filter
+	return d
 }
 
 type DirectiveLocation string

--- a/dagql/result_call_frame.go
+++ b/dagql/result_call_frame.go
@@ -411,8 +411,30 @@ func (frame *ResultCall) RecipeID(ctx context.Context) (*call.ID, error) {
 	return frame.recipeID(ctx, c)
 }
 
+// recipeIDMemo deduplicates recipe-ID *reconstruction* (frame -> *call.ID) within
+// a single top-level rebuild — the inverse direction of recipeCallMemo. The
+// visiting map is only a cycle guard (it deletes each entry as it unwinds), so
+// without this a shared node reached via N paths rebuilds its entire *call.ID
+// subtree N times, unrolling the DAG into a tree (~2.6e8 objects / tens of GB on a
+// resumed agent/LLM session). call.IDs are immutable and content-addressed —
+// Append already shares receiver pointers and ToProto serializes to a
+// digest-keyed DAG — so reusing one *call.ID per shared node is safe and matches
+// the canonical form. Keyed by sharedResultID for by-ID refs (the dominant shared
+// case) and by *ResultCall identity for inline frames.
+type recipeIDMemo struct {
+	byResult map[sharedResultID]*call.ID
+	byFrame  map[*ResultCall]*call.ID
+}
+
+func newRecipeIDMemo() *recipeIDMemo {
+	return &recipeIDMemo{
+		byResult: map[sharedResultID]*call.ID{},
+		byFrame:  map[*ResultCall]*call.ID{},
+	}
+}
+
 func (frame *ResultCall) recipeID(ctx context.Context, c *Cache) (*call.ID, error) {
-	return frame.recipeIDWithVisiting(ctx, c, map[sharedResultID]struct{}{})
+	return frame.recipeIDWithVisiting(ctx, c, map[sharedResultID]struct{}{}, newRecipeIDMemo())
 }
 
 func (frame *ResultCall) CallPB(ctx context.Context) (*callpbv1.Call, error) {
@@ -1426,9 +1448,14 @@ func (c *Cache) resultCallByResultID(resultID sharedResultID) *ResultCall {
 	return res.loadResultCall()
 }
 
-func (frame *ResultCall) recipeIDWithVisiting(ctx context.Context, c *Cache, visiting map[sharedResultID]struct{}) (*call.ID, error) {
+func (frame *ResultCall) recipeIDWithVisiting(ctx context.Context, c *Cache, visiting map[sharedResultID]struct{}, memo *recipeIDMemo) (*call.ID, error) {
 	if frame == nil {
 		return nil, fmt.Errorf("rebuild recipe ID: nil frame")
+	}
+	if memo != nil {
+		if cached, ok := memo.byFrame[frame]; ok {
+			return cached, nil
+		}
 	}
 	field := frame.Field
 	if frame.Kind == ResultCallKindSynthetic {
@@ -1443,7 +1470,7 @@ func (frame *ResultCall) recipeIDWithVisiting(ctx context.Context, c *Cache, vis
 		mod        *call.Module
 	)
 	if frame.Receiver != nil {
-		id, err := frame.resolveRefRecipeID(ctx, c, frame.Receiver, visiting)
+		id, err := frame.resolveRefRecipeID(ctx, c, frame.Receiver, visiting, memo)
 		if err != nil {
 			return nil, fmt.Errorf("receiver: %w", err)
 		}
@@ -1453,18 +1480,18 @@ func (frame *ResultCall) recipeIDWithVisiting(ctx context.Context, c *Cache, vis
 		if frame.Module.ResultRef == nil {
 			return nil, fmt.Errorf("module: missing result ref")
 		}
-		modID, err := frame.resolveRefRecipeID(ctx, c, frame.Module.ResultRef, visiting)
+		modID, err := frame.resolveRefRecipeID(ctx, c, frame.Module.ResultRef, visiting, memo)
 		if err != nil {
 			return nil, fmt.Errorf("module: %w", err)
 		}
 		mod = call.NewModule(modID, frame.Module.Name, frame.Module.Ref, frame.Module.Pin)
 	}
 
-	args, err := frame.callArgs(ctx, c, frame.Args, visiting)
+	args, err := frame.callArgs(ctx, c, frame.Args, visiting, memo)
 	if err != nil {
 		return nil, fmt.Errorf("args: %w", err)
 	}
-	implicitInputs, err := frame.callArgs(ctx, c, frame.ImplicitInputs, visiting)
+	implicitInputs, err := frame.callArgs(ctx, c, frame.ImplicitInputs, visiting, memo)
 	if err != nil {
 		return nil, fmt.Errorf("implicit inputs: %w", err)
 	}
@@ -1489,20 +1516,28 @@ func (frame *ResultCall) recipeIDWithVisiting(ctx context.Context, c *Cache, vis
 		}
 		rebuilt = rebuilt.With(call.WithExtraDigest(extra))
 	}
+	if memo != nil {
+		memo.byFrame[frame] = rebuilt
+	}
 	return rebuilt, nil
 }
 
-func (frame *ResultCall) resolveRefRecipeID(ctx context.Context, c *Cache, ref *ResultCallRef, visiting map[sharedResultID]struct{}) (*call.ID, error) {
+func (frame *ResultCall) resolveRefRecipeID(ctx context.Context, c *Cache, ref *ResultCallRef, visiting map[sharedResultID]struct{}, memo *recipeIDMemo) (*call.ID, error) {
 	if err := ref.Validate(); err != nil {
 		return nil, err
 	}
 	if ref.Call != nil {
-		return ref.Call.recipeIDWithVisiting(ctx, c, visiting)
+		return ref.Call.recipeIDWithVisiting(ctx, c, visiting, memo)
 	}
 	if c == nil {
 		return nil, fmt.Errorf("cannot resolve result ref %d without cache", ref.ResultID)
 	}
 	refID := sharedResultID(ref.ResultID)
+	if memo != nil {
+		if cached, ok := memo.byResult[refID]; ok {
+			return cached, nil
+		}
+	}
 	refFrame := ref.loadSharedCall()
 	if refFrame == nil {
 		refFrame = c.resultCallByResultID(refID)
@@ -1516,7 +1551,14 @@ func (frame *ResultCall) resolveRefRecipeID(ctx context.Context, c *Cache, ref *
 	}
 	visiting[refID] = struct{}{}
 	defer delete(visiting, refID)
-	return refFrame.recipeIDWithVisiting(ctx, c, visiting)
+	id, err := refFrame.recipeIDWithVisiting(ctx, c, visiting, memo)
+	if err != nil {
+		return nil, err
+	}
+	if memo != nil {
+		memo.byResult[refID] = id
+	}
+	return id, nil
 }
 
 func (frame *ResultCall) callArgs(
@@ -1524,6 +1566,7 @@ func (frame *ResultCall) callArgs(
 	c *Cache,
 	frameArgs []*ResultCallArg,
 	visiting map[sharedResultID]struct{},
+	memo *recipeIDMemo,
 ) ([]*call.Argument, error) {
 	if len(frameArgs) == 0 {
 		return nil, nil
@@ -1533,7 +1576,7 @@ func (frame *ResultCall) callArgs(
 		if frameArg == nil || frameArg.Value == nil {
 			continue
 		}
-		lit, err := frame.callLiteral(ctx, c, frameArg.Value, visiting)
+		lit, err := frame.callLiteral(ctx, c, frameArg.Value, visiting, memo)
 		if err != nil {
 			return nil, err
 		}
@@ -1547,6 +1590,7 @@ func (frame *ResultCall) callLiteral(
 	c *Cache,
 	frameLit *ResultCallLiteral,
 	visiting map[sharedResultID]struct{},
+	memo *recipeIDMemo,
 ) (call.Literal, error) {
 	if frameLit == nil {
 		return nil, fmt.Errorf("missing literal")
@@ -1567,7 +1611,7 @@ func (frame *ResultCall) callLiteral(
 	case ResultCallLiteralKindDigestedString:
 		return call.NewLiteralDigestedString(frameLit.DigestedStringValue, frameLit.DigestedStringDigest), nil
 	case ResultCallLiteralKindResultRef:
-		id, err := frame.resolveRefRecipeID(ctx, c, frameLit.ResultRef, visiting)
+		id, err := frame.resolveRefRecipeID(ctx, c, frameLit.ResultRef, visiting, memo)
 		if err != nil {
 			return nil, err
 		}
@@ -1575,7 +1619,7 @@ func (frame *ResultCall) callLiteral(
 	case ResultCallLiteralKindList:
 		items := make([]call.Literal, 0, len(frameLit.ListItems))
 		for _, item := range frameLit.ListItems {
-			lit, err := frame.callLiteral(ctx, c, item, visiting)
+			lit, err := frame.callLiteral(ctx, c, item, visiting, memo)
 			if err != nil {
 				return nil, err
 			}
@@ -1588,7 +1632,7 @@ func (frame *ResultCall) callLiteral(
 			if field == nil || field.Value == nil {
 				continue
 			}
-			lit, err := frame.callLiteral(ctx, c, field.Value, visiting)
+			lit, err := frame.callLiteral(ctx, c, field.Value, visiting, memo)
 			if err != nil {
 				return nil, err
 			}

--- a/dagql/result_call_frame.go
+++ b/dagql/result_call_frame.go
@@ -76,12 +76,27 @@ type ResultCallModule struct {
 	Pin       string         `json:"pin,omitempty"`
 }
 
+// resultCallCloneMemo makes clone() DAG-preserving. Frames are stored as shared
+// DAGs (see recipeCallMemo), so a naive deep clone re-expands the shared sub-DAG
+// into a tree — one clone of a large shared frame exploded to ~3.3e8 objects and
+// ~28GB in a runaway. Keyed by the source *ResultCall (the only shared join
+// point; the Arg/Literal/Ref wrappers above each ResultCall are not themselves
+// shared), so each distinct source frame is cloned once and reused. The copy is
+// still fully independent of the original (distinct nodes); only sharing *within*
+// one clone is preserved, which is safe because frames are frozen provenance
+// (never mutated in place below the top-level spine).
+type resultCallCloneMemo = map[*ResultCall]*ResultCall
+
 func (mod *ResultCallModule) clone() *ResultCallModule {
+	return mod.cloneWith(resultCallCloneMemo{})
+}
+
+func (mod *ResultCallModule) cloneWith(memo resultCallCloneMemo) *ResultCallModule {
 	if mod == nil {
 		return nil
 	}
 	return &ResultCallModule{
-		ResultRef: mod.ResultRef.clone(),
+		ResultRef: mod.ResultRef.cloneWith(memo),
 		Name:      mod.Name,
 		Ref:       mod.Ref,
 		Pin:       mod.Pin,
@@ -94,14 +109,14 @@ type ResultCallArg struct {
 	Value       *ResultCallLiteral `json:"value,omitempty"`
 }
 
-func (arg *ResultCallArg) clone() *ResultCallArg {
+func (arg *ResultCallArg) cloneWith(memo resultCallCloneMemo) *ResultCallArg {
 	if arg == nil {
 		return nil
 	}
 	return &ResultCallArg{
 		Name:        arg.Name,
 		IsSensitive: arg.IsSensitive,
-		Value:       arg.Value.clone(),
+		Value:       arg.Value.cloneWith(memo),
 	}
 }
 
@@ -137,7 +152,7 @@ type ResultCallLiteral struct {
 	ObjectFields []*ResultCallArg     `json:"objectFields,omitempty"`
 }
 
-func (lit *ResultCallLiteral) clone() *ResultCallLiteral {
+func (lit *ResultCallLiteral) cloneWith(memo resultCallCloneMemo) *ResultCallLiteral {
 	if lit == nil {
 		return nil
 	}
@@ -150,18 +165,18 @@ func (lit *ResultCallLiteral) clone() *ResultCallLiteral {
 		EnumValue:            lit.EnumValue,
 		DigestedStringValue:  lit.DigestedStringValue,
 		DigestedStringDigest: lit.DigestedStringDigest,
-		ResultRef:            lit.ResultRef.clone(),
+		ResultRef:            lit.ResultRef.cloneWith(memo),
 	}
 	if len(lit.ListItems) > 0 {
 		cp.ListItems = make([]*ResultCallLiteral, 0, len(lit.ListItems))
 		for _, item := range lit.ListItems {
-			cp.ListItems = append(cp.ListItems, item.clone())
+			cp.ListItems = append(cp.ListItems, item.cloneWith(memo))
 		}
 	}
 	if len(lit.ObjectFields) > 0 {
 		cp.ObjectFields = make([]*ResultCallArg, 0, len(lit.ObjectFields))
 		for _, field := range lit.ObjectFields {
-			cp.ObjectFields = append(cp.ObjectFields, field.clone())
+			cp.ObjectFields = append(cp.ObjectFields, field.cloneWith(memo))
 		}
 	}
 	return cp
@@ -222,8 +237,15 @@ type ResultCallStructuralInputRef struct {
 }
 
 func (frame *ResultCall) clone() *ResultCall {
+	return frame.cloneWith(resultCallCloneMemo{})
+}
+
+func (frame *ResultCall) cloneWith(memo resultCallCloneMemo) *ResultCall {
 	if frame == nil {
 		return nil
+	}
+	if cp := memo[frame]; cp != nil {
+		return cp
 	}
 	cp := &ResultCall{
 		Kind:         frame.Kind,
@@ -234,20 +256,23 @@ func (frame *ResultCall) clone() *ResultCall {
 		Nth:          frame.Nth,
 		EffectIDs:    slices.Clone(frame.EffectIDs),
 		ExtraDigests: slices.Clone(frame.ExtraDigests),
-		Receiver:     frame.Receiver.clone(),
-		Module:       frame.Module.clone(),
 		ProfileSkip:  frame.ProfileSkip,
 	}
+	// Register before recursing so a shared (or, defensively, cyclic) sub-DAG
+	// resolves to this same clone instead of being re-expanded into a tree.
+	memo[frame] = cp
+	cp.Receiver = frame.Receiver.cloneWith(memo)
+	cp.Module = frame.Module.cloneWith(memo)
 	if len(frame.Args) > 0 {
 		cp.Args = make([]*ResultCallArg, 0, len(frame.Args))
 		for _, arg := range frame.Args {
-			cp.Args = append(cp.Args, arg.clone())
+			cp.Args = append(cp.Args, arg.cloneWith(memo))
 		}
 	}
 	if len(frame.ImplicitInputs) > 0 {
 		cp.ImplicitInputs = make([]*ResultCallArg, 0, len(frame.ImplicitInputs))
 		for _, arg := range frame.ImplicitInputs {
-			cp.ImplicitInputs = append(cp.ImplicitInputs, arg.clone())
+			cp.ImplicitInputs = append(cp.ImplicitInputs, arg.cloneWith(memo))
 		}
 	}
 	return cp
@@ -1010,13 +1035,13 @@ func (ref ResultCallStructuralInputRef) inputDigest(c *Cache) (digest.Digest, er
 	}
 }
 
-func (ref *ResultCallRef) clone() *ResultCallRef {
+func (ref *ResultCallRef) cloneWith(memo resultCallCloneMemo) *ResultCallRef {
 	if ref == nil {
 		return nil
 	}
 	return &ResultCallRef{
 		ResultID: ref.ResultID,
-		Call:     ref.Call.clone(),
+		Call:     ref.Call.cloneWith(memo),
 		shared:   ref.shared,
 	}
 }

--- a/dagql/result_call_frame_memo_test.go
+++ b/dagql/result_call_frame_memo_test.go
@@ -2,11 +2,30 @@ package dagql
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/stretchr/testify/require"
 )
+
+func collectFrames(f *ResultCall, seen map[*ResultCall]struct{}) {
+	if f == nil {
+		return
+	}
+	if _, ok := seen[f]; ok {
+		return
+	}
+	seen[f] = struct{}{}
+	if f.Receiver != nil {
+		collectFrames(f.Receiver.Call, seen)
+	}
+	for _, a := range f.Args {
+		if a.Value != nil && a.Value.ResultRef != nil {
+			collectFrames(a.Value.ResultRef.Call, seen)
+		}
+	}
+}
 
 // These tests pin the recipeIDMemo behavior added to recipeIDWithVisiting: the
 // reverse direction of recipeCallMemo. Rebuilding a *call.ID from a ResultCall
@@ -72,4 +91,88 @@ func TestRecipeIDMemoKeepsDistinctFramesDistinct(t *testing.T) {
 
 	byName := argIDsByName(t, id)
 	require.NotSame(t, byName["a"], byName["b"], "distinct frames must not be deduplicated")
+}
+
+// clone() must be DAG-preserving: a frame referenced via multiple paths must
+// clone to a single shared node, not be re-expanded into a tree. Before this,
+// cloning a large shared frame exploded to ~3.3e8 objects / ~28GB in a runaway.
+
+func TestCloneDedupesSharedFrame(t *testing.T) {
+	t.Parallel()
+
+	base := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "base"}
+	top := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(memoObjType),
+		Field: "combine",
+		Args:  []*ResultCallArg{inlineRefArg("a", base), inlineRefArg("b", base)},
+	}
+
+	cp := top.clone()
+	ca := cp.Args[0].Value.ResultRef.Call
+	cb := cp.Args[1].Value.ResultRef.Call
+	require.Same(t, ca, cb, "shared frame must clone to a single shared node")
+	require.NotSame(t, base, ca, "clone must be independent of the original")
+	require.Equal(t, "base", ca.Field)
+}
+
+func TestCloneKeepsDistinctFramesDistinct(t *testing.T) {
+	t.Parallel()
+
+	baseA := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "baseA"}
+	baseB := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "baseB"}
+	top := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(memoObjType),
+		Field: "combine",
+		Args:  []*ResultCallArg{inlineRefArg("a", baseA), inlineRefArg("b", baseB)},
+	}
+
+	cp := top.clone()
+	require.NotSame(t, cp.Args[0].Value.ResultRef.Call, cp.Args[1].Value.ResultRef.Call)
+}
+
+func TestCloneSharedDAGIsLinearAndIndependent(t *testing.T) {
+	t.Parallel()
+
+	const depth = 300
+	base := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "base"}
+	var frame *ResultCall
+	for i := range depth {
+		f := &ResultCall{
+			Kind:  ResultCallKindField,
+			Type:  NewResultCallType(memoObjType),
+			Field: fmt.Sprintf("step%d", i),
+			Args:  []*ResultCallArg{inlineRefArg("ref", base)},
+		}
+		if frame != nil {
+			f.Receiver = &ResultCallRef{Call: frame}
+		}
+		frame = f
+	}
+
+	orig := map[*ResultCall]struct{}{}
+	collectFrames(frame, orig)
+	require.Equal(t, depth+1, len(orig), "source DAG should be depth frames + 1 shared base")
+
+	cp := frame.clone()
+	cloned := map[*ResultCall]struct{}{}
+	collectFrames(cp, cloned)
+
+	// Linear, not exponential: a tree unroll would be vastly larger.
+	require.Equal(t, depth+1, len(cloned), "clone must stay a DAG, not unroll to a tree")
+	// Independent: no clone node may alias an original node.
+	for c := range cloned {
+		_, isOrig := orig[c]
+		require.False(t, isOrig, "clone must not alias original frames")
+	}
+	// Base stays shared at every level within the clone.
+	var firstBase *ResultCall
+	for f := cp; f != nil; f = receiverFrame(f) {
+		b := f.Args[0].Value.ResultRef.Call
+		if firstBase == nil {
+			firstBase = b
+		}
+		require.Same(t, firstBase, b, "base must be shared at every level of the clone")
+	}
 }

--- a/dagql/result_call_frame_memo_test.go
+++ b/dagql/result_call_frame_memo_test.go
@@ -1,0 +1,75 @@
+package dagql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the recipeIDMemo behavior added to recipeIDWithVisiting: the
+// reverse direction of recipeCallMemo. Rebuilding a *call.ID from a ResultCall
+// frame must keep shared nodes shared, else the DAG unrolls into a tree — the
+// second, symmetric blowup observed after engaging an LLM (~2.6e8 objects). These
+// exercise the inline (ref.Call) sharing path, which needs no cache.
+
+func inlineRefArg(name string, frame *ResultCall) *ResultCallArg {
+	return &ResultCallArg{
+		Name: name,
+		Value: &ResultCallLiteral{
+			Kind:      ResultCallLiteralKindResultRef,
+			ResultRef: &ResultCallRef{Call: frame},
+		},
+	}
+}
+
+func argIDsByName(t *testing.T, id *call.ID) map[string]*call.ID {
+	t.Helper()
+	out := map[string]*call.ID{}
+	for _, a := range id.Args() {
+		lit, ok := a.Value().(*call.LiteralID)
+		require.True(t, ok, "arg %q is not a LiteralID", a.Name())
+		out[a.Name()] = lit.Value()
+	}
+	return out
+}
+
+func TestRecipeIDMemoDedupesSharedInlineFrame(t *testing.T) {
+	t.Parallel()
+
+	base := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "base"}
+	top := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(memoObjType),
+		Field: "combine",
+		Args:  []*ResultCallArg{inlineRefArg("a", base), inlineRefArg("b", base)},
+	}
+
+	id, err := top.recipeID(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+
+	byName := argIDsByName(t, id)
+	require.Same(t, byName["a"], byName["b"],
+		"a shared inline frame must rebuild to a single shared *call.ID")
+}
+
+func TestRecipeIDMemoKeepsDistinctFramesDistinct(t *testing.T) {
+	t.Parallel()
+
+	baseA := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "baseA"}
+	baseB := &ResultCall{Kind: ResultCallKindField, Type: NewResultCallType(memoStrType), Field: "baseB"}
+	top := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(memoObjType),
+		Field: "combine",
+		Args:  []*ResultCallArg{inlineRefArg("a", baseA), inlineRefArg("b", baseB)},
+	}
+
+	id, err := top.recipeID(context.Background(), nil)
+	require.NoError(t, err)
+
+	byName := argIDsByName(t, id)
+	require.NotSame(t, byName["a"], byName["b"], "distinct frames must not be deduplicated")
+}

--- a/dagql/result_call_frame_test.go
+++ b/dagql/result_call_frame_test.go
@@ -383,7 +383,7 @@ func TestResultCallRefRecipeIDUsesLatestSharedFrame(t *testing.T) {
 
 	ref := &ResultCallRef{ResultID: uint64(shared.id), shared: shared}
 	caller := &ResultCall{}
-	id, err := caller.resolveRefRecipeID(ctx, c, ref, map[sharedResultID]struct{}{})
+	id, err := caller.resolveRefRecipeID(ctx, c, ref, map[sharedResultID]struct{}{}, newRecipeIDMemo())
 	require.NoError(t, err)
 	require.Equal(t, contentDigest, id.ContentDigest())
 

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -985,6 +985,9 @@ func (s *Server) SchemaForView(view call.View) *ast.Schema {
 		})
 		schema.Directives = map[string]*ast.DirectiveDefinition{}
 		sortutil.RangeSorted(s.directives, func(n string, d DirectiveSpec) {
+			if d.ViewFilter != nil && !d.ViewFilter.Contains(view) {
+				return
+			}
 			schema.Directives[n] = d.DirectiveDefinition(view)
 		})
 		h := xxh3.New()


### PR DESCRIPTION
Engine internals the agent work exposed, split out so they can be reviewed as ordinary dagql changes.

**Recipe ID DAG round-trip.** Recipe IDs round-tripped through `ResultCall` frames with no memoization in either direction, so a shared sub-DAG — a base object reached via a long receiver chain and referenced by many args — was rebuilt once per path, unrolling the DAG into a tree. Resuming a long agent session, whose accumulated state is one large heavily shared ID DAG, blew up to ~10^8 frames and tens of GB and OOMed the host; fixing expansion alone surfaced the same blowup on the reconstruction side at ~2.6e8 objects, and then again in `clone()` at ~3.3e8 objects. All three now memoize, keyed by recipe digest, `sharedResultID`/frame identity, and source frame respectively. IDs are content-addressed, immutable and acyclic, and frames are frozen provenance cloned before mutation, so sharing one node per distinct sub-ID is safe.

**Directive views.** `DirectiveSpec` gains a `ViewFilter`, honoured at install time, so a directive introduced for a new API surface no longer appears in the schema served to older clients — matching how fields and objects are already gated.
