### PR TITLE
Resolve cmd:// secrets relative to the workspace root, not the CLI's CWD

### DIFF
--- a/engine/client/secretprovider/cmd.go
+++ b/engine/client/secretprovider/cmd.go
@@ -8,14 +8,22 @@ import (
 )
 
 func cmdProvider(ctx context.Context, cmd string) ([]byte, error) {
-	var stdoutBytes []byte
-	var err error
+	var c *exec.Cmd
 	if runtime.GOOS == "windows" {
-		stdoutBytes, err = exec.CommandContext(ctx, "cmd.exe", "/C", cmd).Output()
+		c = exec.CommandContext(ctx, "cmd.exe", "/C", cmd)
 	} else {
 		// #nosec G204
-		stdoutBytes, err = exec.CommandContext(ctx, "sh", "-c", cmd).Output()
+		c = exec.CommandContext(ctx, "sh", "-c", cmd)
 	}
+	// Run relative to the workspace root (the dagger.json directory) rather
+	// than inheriting the CLI's own CWD, so relative paths in cmd:// values
+	// (e.g. a script checked into the repo) resolve consistently regardless
+	// of which subdirectory `dagger` was invoked from. Empty when no
+	// dagger.json was found, which preserves today's fallback behavior
+	// (inherit the process's own CWD).
+	c.Dir = workspaceRootFromContext(ctx)
+
+	stdoutBytes, err := c.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run secret command %q: %w", cmd, err)
 	}

--- a/engine/client/secretprovider/cmd_test.go
+++ b/engine/client/secretprovider/cmd_test.go
@@ -1,0 +1,89 @@
+package secretprovider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdProviderResolvesRelativeToWorkspaceRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell script")
+	}
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "dagger.json"), []byte(`{}`), 0o644))
+
+	scriptPath := filepath.Join(root, "scripts", "print-secret.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf hunter2"), 0o755))
+
+	// Invoke from a subdirectory of the workspace, with a cmd:// value
+	// written relative to the workspace root - this is exactly the case
+	// that fails without cmd.Dir set.
+	subdir := filepath.Join(root, "some", "module", "dir")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	ctx := withWorkspaceRoot(t.Context(), root)
+	out, err := cmdProvider(ctx, "scripts/print-secret.sh")
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", string(out))
+}
+
+func TestCmdProviderFallsBackToProcessCWDWithoutWorkspace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell script")
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "print-secret.sh"), []byte("#!/bin/sh\nprintf hunter2"), 0o755))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer func() { require.NoError(t, os.Chdir(wd)) }()
+
+	// No workspace root in context (as if no dagger.json was found) - must
+	// still behave like before this change: relative to the process CWD.
+	out, err := cmdProvider(context.Background(), "./print-secret.sh")
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", string(out))
+}
+
+func TestFindWorkspaceRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "dagger.json"), []byte(`{}`), 0o644))
+
+	subdir := filepath.Join(root, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(subdir))
+	defer func() { require.NoError(t, os.Chdir(wd)) }()
+
+	got := findWorkspaceRoot()
+	// Resolve symlinks on both sides (e.g. /tmp -> /private/tmp on macOS).
+	wantResolved, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	gotResolved, err := filepath.EvalSymlinks(got)
+	require.NoError(t, err)
+	require.Equal(t, wantResolved, gotResolved)
+}
+
+func TestFindWorkspaceRootNoneFound(t *testing.T) {
+	dir := t.TempDir()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer func() { require.NoError(t, os.Chdir(wd)) }()
+
+	// t.TempDir() is under the OS temp dir, which shouldn't itself contain
+	// a dagger.json anywhere above it.
+	require.Empty(t, findWorkspaceRoot())
+}

--- a/engine/client/secretprovider/context.go
+++ b/engine/client/secretprovider/context.go
@@ -1,0 +1,22 @@
+package secretprovider
+
+import "context"
+
+type workspaceRootKey struct{}
+
+// withWorkspaceRoot attaches the client's workspace root (the directory
+// containing dagger.json, if any) to ctx, for providers that need to resolve
+// paths consistently regardless of the client's current working directory.
+func withWorkspaceRoot(ctx context.Context, root string) context.Context {
+	if root == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, workspaceRootKey{}, root)
+}
+
+// workspaceRootFromContext returns the workspace root attached by
+// withWorkspaceRoot, or "" if none was set.
+func workspaceRootFromContext(ctx context.Context) string {
+	root, _ := ctx.Value(workspaceRootKey{}).(string)
+	return root
+}

--- a/engine/client/secretprovider/secretprovider.go
+++ b/engine/client/secretprovider/secretprovider.go
@@ -46,10 +46,17 @@ func ResolverForID(id string) (SecretResolver, string, error) {
 	return resolver, pathWithQuery, nil
 }
 
-type SecretProvider struct{}
+type SecretProvider struct {
+	// workspaceRoot is the directory containing this client's dagger.json,
+	// if any. Resolved once at construction time, since it doesn't change
+	// over the lifetime of a client. See findWorkspaceRoot for why this is
+	// determined independently rather than reusing the engine's own
+	// workspace resolution.
+	workspaceRoot string
+}
 
 func NewSecretProvider() SecretProvider {
-	return SecretProvider{}
+	return SecretProvider{workspaceRoot: findWorkspaceRoot()}
 }
 
 func (sp SecretProvider) Register(server *grpc.Server) {
@@ -62,6 +69,7 @@ func (sp SecretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretRe
 		return nil, err
 	}
 
+	ctx = withWorkspaceRoot(ctx, sp.workspaceRoot)
 	plaintext, err := resolver(ctx, u)
 	if err != nil {
 		if errors.Is(err, secrets.ErrNotFound) {

--- a/engine/client/secretprovider/workspace.go
+++ b/engine/client/secretprovider/workspace.go
@@ -1,0 +1,36 @@
+package secretprovider
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// findWorkspaceRoot walks up from the current working directory looking for
+// a dagger.json, so that relative cmd:// secret paths resolve consistently
+// regardless of which subdirectory `dagger` was invoked from.
+//
+// This mirrors (independently, client-side) the workspace-root resolution
+// the engine already does server-side for module source paths declared in
+// dagger.json - see engine/server/session_workspaces.go. It's duplicated
+// here rather than shared because that resolution walks the *client's*
+// filesystem through an RPC-backed StatFS abstraction, which isn't
+// available yet at the point the client sets up its local secret provider.
+//
+// Returns "" if no dagger.json is found (e.g. dagger invoked outside of
+// any workspace), in which case cmd:// falls back to today's behavior.
+func findWorkspaceRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "dagger.json")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Problem

`cmdProvider` (`engine/client/secretprovider/cmd.go`) runs `sh -c <cmd>` with
no `Dir` set, so a relative path in a `cmd://` secret URI resolves against
whatever directory the `dagger` CLI happens to be invoked from - not the
workspace root where `dagger.json` and `.env` live.

Example: a `.env` at the workspace root with

```
MY_TOKEN=cmd://"scripts/get-token.sh"?cacheKey=token
```

only resolves correctly when `dagger` is invoked from the workspace root.
Invoking from a module's own source directory, or from CI running with a
different working directory, fails with something like:

```
failed to run secret command "scripts/get-token.sh": exit status 127
```

This is the same class of bug fixed in #12934 for module source paths
declared in `dagger.json` (resolved relative to the config dir, not CWD) -
`cmd://` secret resolution wasn't covered by that fix.

## Fix

Resolve the workspace root client-side (walk up from the CWD looking for
`dagger.json`, mirroring `git rev-parse --show-toplevel`'s approach for
`.git`) and thread it through `GetSecret` via `context.Context` so
`cmdProvider` can set `cmd.Dir`. This is a small, self-contained,
client-side lookup rather than reusing the engine's own workspace
resolution (`engine/server/session_workspaces.go`), which walks the
client's filesystem through an RPC-backed `StatFS` abstraction that isn't
available yet at the point the client constructs its local secret
provider - see the comment in `workspace.go` for the reasoning. Happy to
change approach if maintainers prefer plumbing the already-resolved
workspace root down from session setup instead.

Falls back to today's behavior (inherit the process's own CWD) when no
`dagger.json` is found above the CWD.

## Changes

- `engine/client/secretprovider/workspace.go` (new): `findWorkspaceRoot()`.
- `engine/client/secretprovider/context.go` (new): context plumbing for the
  resolved root.
- `engine/client/secretprovider/secretprovider.go`: resolve the workspace
  root once at `NewSecretProvider()` time, attach it to `ctx` in
  `GetSecret`.
- `engine/client/secretprovider/cmd.go`: set `cmd.Dir` from context.
- `engine/client/secretprovider/cmd_test.go` (new): covers the
  workspace-relative resolution, the CWD fallback when no workspace is
  found, and `findWorkspaceRoot` itself.

## Open questions for review

- Should this reuse/share logic with the engine-side workspace resolution
  instead of a separate client-side walk-up, even at the cost of an extra
  round-trip before the secret provider is usable?
- Marking as draft to get a read on approach before polishing further
  (e.g. Windows path handling wasn't specifically exercised beyond the
  existing `runtime.GOOS` branch).