### PR TITLE
TypeScript client lib: if downloading CLI fails, fall back to PATH

### DIFF
--- a/sdk/typescript/src/provisioning/bin.spec.ts
+++ b/sdk/typescript/src/provisioning/bin.spec.ts
@@ -1,0 +1,183 @@
+import assert from "assert"
+import * as fs from "fs"
+import * as http from "http"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import { type AddressInfo } from "net"
+import * as os from "os"
+import * as path from "path"
+import { PassThrough } from "stream"
+
+import { _overrideCLIChecksumsURL, _overrideCLIURL, Bin } from "./bin.js"
+
+describe("CLI provisioning", function () {
+  let engineConn: Bin
+  let tempDir: string
+  let previousCacheHome: string | undefined
+  let previousPath: string | undefined
+  let server: http.Server | undefined
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dagger-test-"))
+    previousCacheHome = process.env.XDG_CACHE_HOME
+    previousPath = process.env.PATH
+    process.env.XDG_CACHE_HOME = path.join(tempDir, "cache")
+    engineConn = new Bin(undefined, "unreleased")
+  })
+
+  afterEach(async () => {
+    _overrideCLIURL("")
+    _overrideCLIChecksumsURL("")
+    restoreEnv("XDG_CACHE_HOME", previousCacheHome)
+    restoreEnv("PATH", previousPath)
+    fs.rmSync(tempDir, { recursive: true })
+
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close((error) => (error ? reject(error) : resolve()))
+      })
+      server = undefined
+    }
+  })
+
+  describe("fallbackToLocalCLI", function () {
+    it("uses the dagger CLI in PATH", async function () {
+      await overrideChecksumsResponse(403)
+      const binDir = path.join(tempDir, "bin")
+      fs.mkdirSync(binDir)
+      const binPath = path.join(
+        binDir,
+        os.platform() === "win32" ? "dagger.exe" : "dagger",
+      )
+      fs.writeFileSync(binPath, "", { mode: 0o700 })
+      process.env.PATH = binDir
+
+      const downloadError = await getError(engineConn["downloadCLI"]())
+      const logs = new PassThrough()
+
+      const actual = engineConn["fallbackToLocalCLI"](downloadError, logs)
+
+      assert.equal(actual, binPath)
+      assert.match(logs.read().toString(), /compatibility is not guaranteed/)
+    })
+
+    it("returns other download errors", function () {
+      const downloadError = new Error("download failed")
+
+      assert.throws(
+        () => engineConn["fallbackToLocalCLI"](downloadError),
+        (error) => error === downloadError,
+      )
+    })
+
+    it("preserves download and PATH errors when no CLI is found", async function () {
+      await overrideChecksumsResponse(403)
+      process.env.PATH = tempDir
+
+      const downloadError = await getError(engineConn["downloadCLI"]())
+
+      assert.throws(
+        () => engineConn["fallbackToLocalCLI"](downloadError),
+        (error) => {
+          assert(error instanceof AggregateError)
+          assert.match(error.message, /failed to download dagger cli binary/)
+          assert.match(error.message, /dagger executable was not found/)
+          return true
+        },
+      )
+    })
+  })
+
+  describe("release availability", function () {
+    // Missing checksums mean the release is absent; a missing archive may be a
+    // partial or broken release, so it must remain fatal.
+    for (const status of [403, 404]) {
+      it(`marks checksums returning ${status} as unavailable`, async function () {
+        await overrideChecksumsResponse(status)
+
+        const error = await getError(engineConn["checksumMap"]())
+
+        assert(engineConn["hasCLIReleaseUnavailableError"](error))
+      })
+    }
+
+    it("does not mark a missing archive as unavailable", async function () {
+      const baseURL = await startServer(404)
+      _overrideCLIURL(`${baseURL}/archive.tar.gz`)
+
+      const error = await getError(
+        engineConn["extractArchive"](tempDir, engineConn["normalizedOS"]()),
+      )
+
+      assert(!engineConn["hasCLIReleaseUnavailableError"](error))
+    })
+  })
+
+  describe("Windows PATH resolution", function () {
+    // Match Go's exec.LookPath and PowerShell: skip empty PATH entries and
+    // normalize PATHEXT before searching.
+    it("normalizes PATH and PATHEXT", function () {
+      const candidates = engineConn["daggerCLIPathCandidates"](
+        "windows",
+        String.raw`C:\bin;;"D:\other bin"`,
+        "EXE;;.CMD;",
+      )
+
+      assert.deepEqual(candidates, [
+        String.raw`C:\bin\dagger.exe`,
+        String.raw`C:\bin\dagger.cmd`,
+        String.raw`D:\other bin\dagger.exe`,
+        String.raw`D:\other bin\dagger.cmd`,
+      ])
+    })
+
+    it("uses default executable extensions when PATHEXT is empty", function () {
+      const candidates = engineConn["daggerCLIPathCandidates"](
+        "windows",
+        String.raw`C:\bin`,
+        "",
+      )
+
+      assert.deepEqual(candidates, [
+        String.raw`C:\bin\dagger.com`,
+        String.raw`C:\bin\dagger.exe`,
+        String.raw`C:\bin\dagger.bat`,
+        String.raw`C:\bin\dagger.cmd`,
+      ])
+    })
+  })
+
+  async function overrideChecksumsResponse(status: number): Promise<void> {
+    const baseURL = await startServer(status)
+    _overrideCLIChecksumsURL(`${baseURL}/checksums.txt`)
+  }
+
+  async function startServer(status: number): Promise<string> {
+    server = http.createServer((_req, res) => {
+      res.writeHead(status)
+      res.end()
+    })
+    await new Promise<void>((resolve) => {
+      server?.listen(0, "127.0.0.1", resolve).unref()
+    })
+    const addr = server.address() as AddressInfo
+    return `http://${addr.address}:${addr.port}`
+  }
+})
+
+async function getError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise
+  } catch (error) {
+    assert(error instanceof Error)
+    return error
+  }
+  throw new Error("expected operation to fail")
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/sdk/typescript/src/provisioning/bin.ts
+++ b/sdk/typescript/src/provisioning/bin.ts
@@ -25,6 +25,13 @@ let OVERRIDE_CLI_URL: string = ""
 let OVERRIDE_CHECKSUMS_URL: string = ""
 const CLI_HOST = "dl.dagger.io"
 
+class CLIReleaseUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "CLIReleaseUnavailableError"
+  }
+}
+
 export type ExecaChildProcess = ResultPromise<{
   stdio: "pipe"
   reject: true
@@ -58,22 +65,35 @@ export class Bin implements EngineConn {
   }
 
   async Connect(opts: ConnectOpts): Promise<GraphQLClient> {
+    let downloadError: Error | undefined
+
     if (!this.binPath) {
-      if (opts.LogOutput) {
-        opts.LogOutput.write("Downloading CLI... ")
-      }
-
-      this.binPath = await this.downloadCLI()
-
-      if (opts.LogOutput) {
-        opts.LogOutput.write("OK!\n")
+      try {
+        this.binPath = await this.downloadCLI(opts.LogOutput)
+      } catch (e) {
+        downloadError = e instanceof Error ? e : new Error(String(e))
+        this.binPath = this.fallbackToLocalCLI(downloadError, opts.LogOutput)
       }
     }
 
-    return this.runEngineSession(this.binPath, opts)
+    try {
+      return await this.runEngineSession(this.binPath, opts)
+    } catch (e) {
+      if (downloadError) {
+        const sessionError = e instanceof Error ? e : new Error(String(e))
+        throw new AggregateError(
+          [downloadError, sessionError],
+          `${downloadError.message}\nfailed to use CLI from PATH "${this.binPath}": ${sessionError.message}`,
+          { cause: e },
+        )
+      }
+      throw e
+    }
   }
 
-  private async downloadCLI(): Promise<string> {
+  private async downloadCLI(
+    logOutput?: NodeJS.WritableStream,
+  ): Promise<string> {
     if (!this.cliVersion) {
       throw new Error("cliVersion is not set")
     }
@@ -91,12 +111,17 @@ export class Bin implements EngineConn {
     )
 
     try {
+      const expectedChecksum = await this.expectedChecksum()
+
+      if (logOutput) {
+        logOutput.write("Downloading CLI... ")
+      }
+
       // download an archive and use appropriate extraction depending on platforms (zip on windows, tar.gz on other platforms)
       const actualChecksum: string = await this.extractArchive(
         tmpBinDownloadDir,
         this.normalizedOS(),
       )
-      const expectedChecksum = await this.expectedChecksum()
       if (actualChecksum !== expectedChecksum) {
         throw new Error(
           `checksum mismatch: expected ${expectedChecksum}, got ${actualChecksum}`,
@@ -105,6 +130,10 @@ export class Bin implements EngineConn {
       fs.chmodSync(tmpBinPath, 0o700)
       fs.renameSync(tmpBinPath, binPath)
       fs.rmSync(tmpBinDownloadDir, { recursive: true })
+
+      if (logOutput) {
+        logOutput.write("OK!\n")
+      }
     } catch (e) {
       fs.rmSync(tmpBinDownloadDir, { recursive: true })
       throw new InitEngineSessionBinaryError(
@@ -137,6 +166,127 @@ export class Bin implements EngineConn {
     }
 
     return binPath
+  }
+
+  private fallbackToLocalCLI(
+    downloadError: Error,
+    logOutput?: NodeJS.WritableStream,
+  ): string {
+    if (!this.hasCLIReleaseUnavailableError(downloadError)) {
+      throw downloadError
+    }
+
+    let binPath: string
+    try {
+      binPath = this.findDaggerCLI()
+    } catch (e) {
+      const pathError = e instanceof Error ? e : new Error(String(e))
+      throw new AggregateError(
+        [downloadError, pathError],
+        `${downloadError.message}\ndagger CLI not found in PATH: ${pathError.message}`,
+        { cause: e },
+      )
+    }
+
+    const warningOutput = logOutput ?? process.stderr
+    warningOutput.write(
+      `CLI version ${this.cliVersion} is unavailable; using ${binPath} from PATH (version compatibility is not guaranteed).\n`,
+    )
+    return binPath
+  }
+
+  private hasCLIReleaseUnavailableError(error: Error): boolean {
+    const seen = new Set<Error>()
+    let current: Error | undefined = error
+
+    while (current && !seen.has(current)) {
+      if (current instanceof CLIReleaseUnavailableError) {
+        return true
+      }
+      seen.add(current)
+      current = current.cause instanceof Error ? current.cause : undefined
+    }
+    return false
+  }
+
+  private findDaggerCLI(): string {
+    const pathEnv = process.env.PATH
+    if (!pathEnv) {
+      throw new Error("PATH is not set")
+    }
+
+    const platform = this.normalizedOS()
+    const pathImplementation = platform === "windows" ? path.win32 : path.posix
+    for (const candidate of this.daggerCLIPathCandidates(
+      platform,
+      pathEnv,
+      process.env.PATHEXT,
+    )) {
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK)
+        if (!fs.statSync(candidate).isFile()) {
+          continue
+        }
+      } catch {
+        // Continue searching PATH.
+        continue
+      }
+      if (!pathImplementation.isAbsolute(candidate)) {
+        throw new Error(
+          `cannot run dagger executable found relative to the current directory: ${candidate}`,
+        )
+      }
+      return candidate
+    }
+
+    throw new Error("dagger executable was not found")
+  }
+
+  private daggerCLIPathCandidates(
+    platform: string,
+    pathEnv: string,
+    pathExt: string | undefined,
+  ): string[] {
+    const windows = platform === "windows"
+    const pathImplementation = windows ? path.win32 : path.posix
+    const extensions = windows
+      ? this.windowsExecutableExtensions(pathExt)
+      : [""]
+    const candidates: string[] = []
+
+    for (let directory of pathEnv.split(pathImplementation.delimiter)) {
+      if (windows) {
+        // Match PowerShell and Go's exec.LookPath behavior.
+        if (directory === "") {
+          continue
+        }
+        directory = directory.replace(/^"(.*)"$/, "$1")
+      } else if (directory === "") {
+        // Match Unix shell semantics.
+        directory = "."
+      }
+
+      for (const extension of extensions) {
+        candidates.push(
+          pathImplementation.join(
+            directory,
+            `${this.DAGGER_CLI_BIN_PREFIX}${extension}`,
+          ),
+        )
+      }
+    }
+    return candidates
+  }
+
+  private windowsExecutableExtensions(pathExt: string | undefined): string[] {
+    const value = pathExt || ".COM;.EXE;.BAT;.CMD"
+    return value
+      .toLowerCase()
+      .split(";")
+      .filter((extension) => extension !== "")
+      .map((extension) =>
+        extension.startsWith(".") ? extension : `.${extension}`,
+      )
   }
 
   /**
@@ -375,9 +525,11 @@ export class Bin implements EngineConn {
     // download checksums.txt
     const checksums = await fetch(this.cliChecksumURL())
     if (!checksums.ok) {
-      throw new Error(
-        `failed to download checksums.txt from ${this.cliChecksumURL()}`,
-      )
+      const message = `failed to download checksums.txt from ${this.cliChecksumURL()}: ${checksums.status} ${checksums.statusText}`
+      if (this.isCLIReleaseUnavailable(checksums.status)) {
+        throw new CLIReleaseUnavailableError(message)
+      }
+      throw new Error(message)
     }
     const checksumsText = await checksums.text()
     // iterate over lines filling in map of filename -> checksum
@@ -387,6 +539,11 @@ export class Bin implements EngineConn {
       checksumMap.set(filename, checksum)
     }
     return checksumMap
+  }
+
+  private isCLIReleaseUnavailable(status: number): boolean {
+    // dl.dagger.io returns 403 for missing S3 objects.
+    return status === 403 || status === 404
   }
 
   private async expectedChecksum(): Promise<string> {


### PR DESCRIPTION
Implement the TypeScript part of #13766, to fix CLI bootstrap in unreleased libs.

When the release server returns 403 or 404, fall back to `dagger` from `PATH` and emit a compatibility warning. Other download failures remain fatal.

Part of #13766.
