### PR TITLE
core: let container commands inherit workspaces

### DIFF
--- a/.changes/unreleased/Added-20260730-164222.yaml
+++ b/.changes/unreleased/Added-20260730-164222.yaml
@@ -1,0 +1,8 @@
+kind: Added
+body: |
+  Container commands can now grant nested Dagger clients access to a selected
+  `Workspace` with the `inheritWorkspace` argument.
+time: 2026-07-30T16:42:22+02:00
+custom:
+  Author: shykes
+  PR: 13789

--- a/core/container.go
+++ b/core/container.go
@@ -6991,6 +6991,10 @@ type ContainerAsServiceArgs struct {
 	// Provide the executed command access back to the Dagger API
 	ExperimentalPrivilegedNesting bool `default:"false"`
 
+	// Provide the executed command access back to the Dagger API with this
+	// workspace as the default for nested clients.
+	InheritWorkspace dagql.Optional[dagql.ID[*Workspace]]
+
 	// Grant the process all root capabilities
 	InsecureRootCapabilities bool `default:"false"`
 
@@ -7029,12 +7033,18 @@ func (container *Container) AsService(ctx context.Context, containerRes dagql.Ob
 		cmdargs = append(container.Config.Entrypoint, cmdargs...)
 	}
 
+	inheritedWorkspace, err := CaptureInheritedWorkspaceBinding(ctx, args.InheritWorkspace)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Service{
 		Container:                     containerRes,
 		Args:                          cmdargs,
 		ExperimentalPrivilegedNesting: args.ExperimentalPrivilegedNesting,
 		InsecureRootCapabilities:      args.InsecureRootCapabilities,
 		NoInit:                        args.NoInit,
+		InheritedWorkspace:            inheritedWorkspace,
 	}, nil
 }
 

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -68,6 +68,10 @@ type ContainerExecOpts struct {
 	// Provide the executed command access back to the Dagger API
 	ExperimentalPrivilegedNesting bool `default:"false"`
 
+	// Provide the executed command access back to the Dagger API with this
+	// workspace as the default for nested clients.
+	InheritWorkspace dagql.Optional[dagql.ID[*Workspace]]
+
 	// Grant the process all root capabilities
 	InsecureRootCapabilities bool `default:"false"`
 
@@ -95,6 +99,8 @@ type ContainerExecState struct {
 	ExecMD        *engineutil.ExecutionMetadata
 	ModuleContext dagql.ObjectResult[*Module]
 	FunctionCall  *FunctionCall
+
+	InheritedWorkspace *InheritedWorkspaceBinding
 }
 
 type ContainerExecLazy struct {
@@ -106,6 +112,10 @@ type persistedContainerExecLazy struct {
 	ModuleContextResultID          uint64                        `json:"moduleContextResultID,omitempty"`
 	Opts                           ContainerExecOpts             `json:"opts"`
 	ExecMD                         *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
+	InheritedWorkspaceResultID     uint64                        `json:"inheritedWorkspaceResultID,omitempty"`
+	InheritedWorkspaceBindingID    string                        `json:"inheritedWorkspaceBindingID,omitempty"`
+	InheritedWorkspaceEnv          string                        `json:"inheritedWorkspaceEnv,omitempty"`
+	InheritedWorkspaceEnvSet       bool                          `json:"inheritedWorkspaceEnvSet,omitempty"`
 	VolatileCacheHitParentResultID uint64                        `json:"volatileCacheHitParentResultID,omitempty"`
 	VolatileCacheHitVolatileEnv    []string                      `json:"volatileCacheHitVolatileEnv,omitempty"`
 }
@@ -150,6 +160,18 @@ func (lazy *ContainerExecLazy) AttachDependencies(ctx context.Context, attach fu
 		lazy.State.ModuleContext = moduleContext
 		deps = append(deps, moduleContext)
 	}
+	if binding := lazy.State.InheritedWorkspace; binding != nil && binding.Workspace.Self() != nil {
+		attached, err := attach(binding.Workspace)
+		if err != nil {
+			return nil, fmt.Errorf("attach container withExec inherited workspace: %w", err)
+		}
+		workspace, ok := attached.(dagql.ObjectResult[*Workspace])
+		if !ok {
+			return nil, fmt.Errorf("attach container withExec inherited workspace: expected %T, got %T", binding.Workspace, attached)
+		}
+		binding.Workspace = workspace
+		deps = append(deps, workspace)
+	}
 
 	return deps, nil
 }
@@ -172,11 +194,23 @@ func (lazy *ContainerExecLazy) EncodePersisted(ctx context.Context, cache dagql.
 			return nil, err
 		}
 	}
+	var inheritedWorkspaceResultID uint64
+	if binding := lazy.State.InheritedWorkspace; binding != nil && binding.Workspace.Self() != nil {
+		inheritedWorkspaceResultID, err = encodePersistedObjectRef(cache, binding.Workspace, "container withExec inherited workspace")
+		if err != nil {
+			return nil, err
+		}
+	}
+	binding := lazy.State.InheritedWorkspace
 	return json.Marshal(persistedContainerExecLazy{
-		ParentResultID:        parentID,
-		ModuleContextResultID: moduleContextID,
-		Opts:                  lazy.State.Opts,
-		ExecMD:                lazy.State.ExecMD,
+		ParentResultID:              parentID,
+		ModuleContextResultID:       moduleContextID,
+		Opts:                        lazy.State.Opts,
+		ExecMD:                      lazy.State.ExecMD,
+		InheritedWorkspaceResultID:  inheritedWorkspaceResultID,
+		InheritedWorkspaceBindingID: inheritedWorkspaceBindingID(binding),
+		InheritedWorkspaceEnv:       inheritedWorkspaceEnv(binding),
+		InheritedWorkspaceEnvSet:    binding != nil && binding.HasWorkspaceEnv,
 	})
 }
 
@@ -1186,13 +1220,19 @@ func (container *Container) WithExec(
 	moduleContext dagql.ObjectResult[*Module],
 	functionCall *FunctionCall,
 ) error {
+	inheritedWorkspace, err := CaptureInheritedWorkspaceBinding(ctx, opts.InheritWorkspace)
+	if err != nil {
+		return err
+	}
+	opts.InheritWorkspace = dagql.Optional[dagql.ID[*Workspace]]{}
 	state := &ContainerExecState{
-		LazyState:     NewLazyState(),
-		Parent:        parent,
-		Opts:          opts,
-		ExecMD:        execMD,
-		ModuleContext: moduleContext,
-		FunctionCall:  functionCall,
+		LazyState:          NewLazyState(),
+		Parent:             parent,
+		Opts:               opts,
+		ExecMD:             execMD,
+		ModuleContext:      moduleContext,
+		FunctionCall:       functionCall,
+		InheritedWorkspace: inheritedWorkspace,
 	}
 	container.Lazy = &ContainerExecLazy{State: state}
 	container.ImageRef = ""
@@ -2052,7 +2092,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 					rerr = err
 					return
 				}
-				if err := terminalContainer.TerminalExecError(ctx, callID, callDig, terminalContainerRes, execMD, &meta, rerr); err != nil {
+				if err := terminalContainer.TerminalExecError(ctx, callID, callDig, terminalContainerRes, state.InheritedWorkspace, execMD, &meta, rerr); err != nil {
 					rerr = err
 					return
 				}
@@ -2130,17 +2170,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			defer stopServiceMonitors()
 		}
 
-		var nestedClientMetadata *engine.ClientMetadata
-		if opts.ExperimentalPrivilegedNesting {
-			nestedClientMetadata = &engine.ClientMetadata{
-				ClientID:              identity.NewID(),
-				ClientVersion:         engine.Version,
-				SessionID:             clientMetadata.SessionID,
-				AllowedLLMModules:     slices.Clone(clientMetadata.AllowedLLMModules),
-				LockMode:              clientMetadata.LockMode,
-				UseRecipeIDsByDefault: execMD != nil && execMD.UseRecipeIDsByDefault,
-			}
-		}
+		nestedClientMetadata := nestedClientMetadataForExec(clientMetadata, execMD, opts.ExperimentalPrivilegedNesting, state.InheritedWorkspace)
 
 		procInfo := executor.ProcessInfo{Meta: meta}
 		if opts.Stdin != "" {
@@ -2156,6 +2186,10 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			if ok {
 				envContext = env
 			}
+		}
+		var workspaceContext dagql.ObjectResult[*Workspace]
+		if state.InheritedWorkspace != nil {
+			workspaceContext = state.InheritedWorkspace.Workspace
 		}
 
 		execErrCh := make(chan error, 1)
@@ -2175,6 +2209,7 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 				state.ModuleContext,
 				state.FunctionCall,
 				envContext,
+				workspaceContext,
 			)
 		}()
 
@@ -2279,12 +2314,26 @@ func decodePersistedContainerExecLazy(
 	if err != nil {
 		return err
 	}
+	inheritedWorkspace, err := loadPersistedObjectResultByResultID[*Workspace](ctx, dag, persisted.InheritedWorkspaceResultID, "container exec inherited workspace")
+	if err != nil {
+		return err
+	}
+	var inheritedBinding *InheritedWorkspaceBinding
+	if inheritedWorkspace.Self() != nil {
+		inheritedBinding = &InheritedWorkspaceBinding{
+			Workspace:       inheritedWorkspace,
+			BindingID:       persisted.InheritedWorkspaceBindingID,
+			WorkspaceEnv:    persisted.InheritedWorkspaceEnv,
+			HasWorkspaceEnv: persisted.InheritedWorkspaceEnvSet,
+		}
+	}
 	state := &ContainerExecState{
-		LazyState:     NewLazyState(),
-		Parent:        parent,
-		Opts:          persisted.Opts,
-		ExecMD:        persisted.ExecMD,
-		ModuleContext: moduleContext,
+		LazyState:          NewLazyState(),
+		Parent:             parent,
+		Opts:               persisted.Opts,
+		ExecMD:             persisted.ExecMD,
+		ModuleContext:      moduleContext,
+		InheritedWorkspace: inheritedBinding,
 	}
 	container.Lazy = &ContainerExecLazy{State: state}
 	container.ImageRef = ""

--- a/core/integration/testdata/modules/go/workspace-selection-nester/main.go
+++ b/core/integration/testdata/modules/go/workspace-selection-nester/main.go
@@ -7,7 +7,10 @@ import (
 	"dagger/nester/internal/dagger"
 )
 
-func New(greeting string) *Nester {
+func New(
+	// +default="default"
+	greeting string,
+) *Nester {
 	return &Nester{Message: greeting}
 }
 
@@ -19,16 +22,30 @@ func (m *Nester) Greeting() string {
 	return m.Message
 }
 
-func (m *Nester) NestedWorkspace(ctx context.Context, cli *dagger.File) (string, error) {
+func (m *Nester) NestedWorkspace(ctx context.Context, cli *dagger.File, inheritedWorkspace *dagger.Workspace) (string, error) {
 	return m.nested(ctx, cli, []string{"query"}, dagger.ContainerWithExecOpts{
-		ExperimentalPrivilegedNesting: true,
-		Stdin:                         "{currentWorkspace{cwd configFile}}",
+		InheritWorkspace: inheritedWorkspace,
+		Stdin:            "{currentWorkspace{cwd configFile}}",
 	})
 }
 
-func (m *Nester) NestedGreeting(ctx context.Context, cli *dagger.File) (string, error) {
+func (m *Nester) NestedGreeting(ctx context.Context, cli *dagger.File, inheritedWorkspace *dagger.Workspace) (string, error) {
 	return m.nested(ctx, cli, []string{"call", "greeting"}, dagger.ContainerWithExecOpts{
-		ExperimentalPrivilegedNesting: true,
+		InheritWorkspace: inheritedWorkspace,
+	})
+}
+
+func (m *Nester) NestedConfigRead(ctx context.Context, cli *dagger.File, inheritedWorkspace *dagger.Workspace) (string, error) {
+	return m.nested(ctx, cli, []string{"query"}, dagger.ContainerWithExecOpts{
+		InheritWorkspace: inheritedWorkspace,
+		Stdin:            `{currentWorkspace{configRead(key:"modules.nester.settings.greeting")}}`,
+	})
+}
+
+func (m *Nester) NestedExplicitWorkspace(ctx context.Context, cli *dagger.File, inheritedWorkspace *dagger.Workspace) (string, error) {
+	return m.nested(ctx, cli, []string{"-W", "/detected", "query"}, dagger.ContainerWithExecOpts{
+		InheritWorkspace: inheritedWorkspace,
+		Stdin:            "{currentWorkspace{cwd configFile}}",
 	})
 }
 
@@ -37,8 +54,9 @@ func (m *Nester) nested(ctx context.Context, cli *dagger.File, args []string, op
 	out, err := dag.Container().
 		From("alpine:3.22.1").
 		WithMountedFile("/bin/dagger", cli).
-		WithExec([]string{"mkdir", "-p", "/empty"}).
-		WithWorkdir("/empty").
+		WithExec([]string{"mkdir", "-p", "/empty", "/detected/.git"}).
+		WithNewFile("/detected/dagger.toml", "# explicitly selected nested workspace\n").
+		WithWorkdir("/detected").
 		WithExec(execArgs, opts).
 		Stdout(ctx)
 	if err != nil {

--- a/core/integration/testdata/workspace-inherit-sdk/main.go
+++ b/core/integration/testdata/workspace-inherit-sdk/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	contents, err := client.CurrentWorkspace().
+		File("marker.txt").
+		Contents(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(contents)
+}

--- a/core/integration/workspace_selection_test.go
+++ b/core/integration/workspace_selection_test.go
@@ -16,8 +16,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -82,6 +84,19 @@ func workspaceSelectionDangSource(typeName, fnName, result string) string {
 type ` + typeName + ` {
   pub ` + fnName + `: String! {
     "` + result + `"
+  }
+}
+`
+}
+
+func workspaceSelectionConfigurableDangSource(typeName, fieldName, defaultValue string) string {
+	return `
+type ` + typeName + ` {
+  pub ` + fieldName + `: String!
+
+  new(` + fieldName + `: String! = "` + defaultValue + `") {
+    self.` + fieldName + ` = ` + fieldName + `
+    self
   }
 }
 `
@@ -836,12 +851,7 @@ func (WorkspaceSelectionSuite) TestSelectedWorkspaceEnvOverlay(ctx context.Conte
 // workspace binding survives once a session is established and other clients
 // are created from it.
 func (WorkspaceSelectionSuite) TestDeclaredWorkspaceBindingPropagation(ctx context.Context, t *testctx.T) {
-	// TODO(#13054): Re-enable once container commands can explicitly inherit a
-	// workspace. The intended contract is command-scoped inheritance, not
-	// implicit inheritance from the module function that created the exec.
 	t.Run("nested clients inherit the declared workspace binding", func(ctx context.Context, t *testctx.T) {
-		t.Skip("TODO(#13054): waiting for command-scoped inheritWorkspace")
-
 		c := connect(ctx, t)
 		ctr := workspaceBase(t, c).
 			WithExec([]string{"mkdir", "-p", "/work/caller", "/work/selected"}).
@@ -865,9 +875,24 @@ greeting = "selected-ci"
 		require.JSONEq(t, `{"currentWorkspace":{"cwd":"/selected","configFile":"dagger.toml"}}`, out)
 	})
 
-	t.Run("nested clients inherit the declared workspace env overlay", func(ctx context.Context, t *testctx.T) {
-		t.Skip("TODO(#13054): waiting for command-scoped inheritWorkspace")
+	t.Run("nested explicit workspace beats inherited workspace", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := workspaceBase(t, c).
+			WithExec([]string{"mkdir", "-p", "/work/caller", "/work/selected"}).
+			WithWorkdir("/work/selected").
+			With(withModuleFixture(t, c, "/work/selected/.dagger/modules/nester", "go/workspace-selection-nester")).
+			WithNewFile("/work/selected/dagger.toml", `[modules.nester]
+source = ".dagger/modules/nester"
+entrypoint = true
+`).
+			WithWorkdir("/work/caller")
 
+		out, err := ctr.With(workspaceSelectionDaggerCall("-W", "../selected", "nested-explicit-workspace", "--cli", testCLIBinPath)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"cwd":"/","configFile":"dagger.toml"}}`, out)
+	})
+
+	t.Run("nested clients inherit the declared workspace env overlay", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		ctr := workspaceBase(t, c).
 			WithExec([]string{"mkdir", "-p", "/work/caller", "/work/selected"}).
@@ -889,5 +914,222 @@ greeting = "selected-ci"
 		out, err := ctr.With(workspaceSelectionDaggerCall("-W", "../selected", "--env", "ci", "nested-greeting", "--cli", testCLIBinPath)).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "selected-ci", strings.TrimSpace(out))
+
+		out, err = ctr.With(workspaceSelectionDaggerCall("-W", "../selected", "--env", "ci", "nested-config-read", "--cli", testCLIBinPath)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"configRead":"selected-ci"}}`, out)
 	})
+
+	t.Run("a parent SDK that did not load modules can supply them", func(ctx context.Context, t *testctx.T) {
+		root := t.TempDir()
+		initGitRepo(ctx, t, root)
+		moduleDir := filepath.Join(root, ".dagger", "modules", "greeter")
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "dagger.toml"), []byte(`[modules.greeter]
+source = ".dagger/modules/greeter"
+entrypoint = true
+
+[modules.greeter.settings]
+greeting = "top-level-sdk"
+`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "dagger.json"), []byte(`{"name":"greeter","sdk":{"source":"dang"}}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.dang"), []byte(workspaceSelectionConfigurableDangSource("Greeter", "greeting", "default")), 0o644))
+
+		c := connect(ctx, t, dagger.WithWorkspace(root))
+		out, err := c.Container().
+			From(alpineImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithExec([]string{"mkdir", "-p", "/empty"}).
+			WithWorkdir("/empty").
+			WithExec(
+				[]string{"dagger", "--progress=report", "call", "greeting"},
+				dagger.ContainerWithExecOpts{InheritWorkspace: c.CurrentWorkspace()},
+			).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "top-level-sdk", strings.TrimSpace(out))
+	})
+
+	t.Run("nested core queries do not load unrelated broken inherited modules", func(ctx context.Context, t *testctx.T) {
+		root := t.TempDir()
+		initGitRepo(ctx, t, root)
+		require.NoError(t, os.WriteFile(filepath.Join(root, "marker.txt"), []byte("caller workspace"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "dagger.toml"), []byte(`[modules.broken]
+source = ".dagger/modules/does-not-exist"
+`), 0o644))
+
+		c := connect(ctx, t, dagger.WithWorkspace(root))
+		out, err := c.Container().
+			From(alpineImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithExec([]string{"mkdir", "-p", "/detected/.git"}).
+			WithNewFile("/detected/dagger.toml", "# container-local workspace\n").
+			WithWorkdir("/detected").
+			WithExec(
+				[]string{"dagger", "--progress=report", "query"},
+				dagger.ContainerWithExecOpts{
+					InheritWorkspace: c.CurrentWorkspace(),
+					Stdin:            `{currentWorkspace{file(path:"marker.txt"){contents}}}`,
+				},
+			).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"file":{"contents":"caller workspace"}}}`, out)
+	})
+}
+
+func (WorkspaceSelectionSuite) TestInheritedWorkspaceExecutionPaths(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("Go SDK connection prefers the inherited workspace over container detection", func(ctx context.Context, t *testctx.T) {
+		const markerPath = "marker.txt"
+		const expected = "caller workspace"
+		root := newWorkspaceConfigWorkdir(ctx, t, "# caller workspace\n")
+		require.NoError(t, os.WriteFile(filepath.Join(root, markerPath), []byte(expected), 0o644))
+		c := connect(ctx, t, dagger.WithWorkspace(root))
+
+		repoPath, err := filepath.Abs("../..")
+		require.NoError(t, err)
+		code := c.Host().Directory(repoPath, dagger.HostDirectoryOpts{
+			Include: []string{
+				"core/integration/testdata/workspace-inherit-sdk/",
+				"sdk/go/",
+				"go.mod",
+				"go.sum",
+			},
+		})
+
+		out, err := c.Container().
+			From(golangImage).
+			With(goCache(c)).
+			WithDirectory("/src", code).
+			WithWorkdir("/src/core/integration/testdata/workspace-inherit-sdk").
+			WithNewFile("dagger.toml", "# container-local workspace\n").
+			WithNewFile(markerPath, "container workspace").
+			WithExec([]string{"mkdir", "-p", ".git"}).
+			WithExec(
+				[]string{"go", "run", "."},
+				dagger.ContainerWithExecOpts{InheritWorkspace: c.CurrentWorkspace()},
+			).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expected, out)
+	})
+
+	workspace := c.Directory().
+		WithNewFile("marker.txt", "service workspace").
+		AsWorkspace()
+	query := `{currentWorkspace{file(path:"marker.txt"){contents}}}`
+	serviceCmd := `printf '%s\n' '` + query + `' | dagger --progress=report query > /tmp/result && while true; do cat /tmp/result | nc -l -p 8080; done`
+	base := c.Container().
+		From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithExposedPort(8080)
+
+	readService := func(ctx context.Context, t *testctx.T, service *dagger.Service) string {
+		t.Helper()
+		out, err := c.Container().
+			From(alpineImage).
+			WithServiceBinding("workspace-svc", service).
+			WithExec([]string{"nc", "workspace-svc", "8080"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return out
+	}
+
+	t.Run("direct asService", func(ctx context.Context, t *testctx.T) {
+		service := base.AsService(dagger.ContainerAsServiceOpts{
+			Args:             []string{"sh", "-c", serviceCmd},
+			InheritWorkspace: workspace,
+		})
+		require.JSONEq(t, `{"currentWorkspace":{"file":{"contents":"service workspace"}}}`, readService(ctx, t, service))
+	})
+
+	t.Run("withExec to asService preserves the binding", func(ctx context.Context, t *testctx.T) {
+		service := base.
+			WithExec([]string{"true"}, dagger.ContainerWithExecOpts{InheritWorkspace: workspace}).
+			AsService(dagger.ContainerAsServiceOpts{Args: []string{"sh", "-c", serviceCmd}})
+		require.JSONEq(t, `{"currentWorkspace":{"file":{"contents":"service workspace"}}}`, readService(ctx, t, service))
+	})
+
+	t.Run("container up forwards the binding to its service command", func(ctx context.Context, t *testctx.T) {
+		resultCache := c.CacheVolume("workspace-up-" + identity.NewID())
+		upCmd := `printf '%s\n' '` + query + `' | dagger --progress=report query > /result/workspace.json && while true; do printf 'ready\n' | nc -l -p 8080; done`
+		upCtr := base.WithMountedCache("/result", resultCache)
+
+		upCtx, cancelUp := context.WithCancel(ctx)
+		upErr := make(chan error, 1)
+		go func() {
+			upErr <- upCtr.Up(upCtx, dagger.ContainerUpOpts{
+				Args:             []string{"sh", "-c", upCmd},
+				InheritWorkspace: workspace,
+				Random:           true,
+			})
+		}()
+
+		var result string
+		deadline := time.NewTimer(2 * time.Minute)
+		poll := time.NewTicker(time.Second)
+		defer deadline.Stop()
+		defer poll.Stop()
+		for result == "" {
+			select {
+			case err := <-upErr:
+				t.Fatalf("Container.up exited before its service became ready: %v", err)
+			case <-poll.C:
+				result, _ = c.Container().
+					From(alpineImage).
+					WithMountedCache("/result", resultCache).
+					WithEnvVariable("POLL", time.Now().String()).
+					WithExec([]string{"cat", "/result/workspace.json"}).
+					Stdout(ctx)
+			case <-deadline.C:
+				t.Fatal("Container.up service did not become ready")
+			}
+		}
+		require.JSONEq(t, `{"currentWorkspace":{"file":{"contents":"service workspace"}}}`, result)
+
+		cancelUp()
+		select {
+		case <-upErr:
+		case <-time.After(30 * time.Second):
+			t.Fatal("Container.up did not stop after cancellation")
+		}
+	})
+}
+
+func (WorkspaceSelectionSuite) TestInheritedArbitraryWorkspaceDoesNotLoadModules(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	workspace := workspaceSelectionSimpleWorkspaceDir(c, "greeter", "Greeter", "synthetic").
+		WithNewFile("marker.txt", "arbitrary workspace").
+		AsWorkspace()
+	base := c.Container().
+		From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithExec([]string{"mkdir", "-p", "/empty"}).
+		WithWorkdir("/empty")
+
+	out, err := base.
+		WithExec(
+			[]string{"dagger", "--progress=report", "query"},
+			dagger.ContainerWithExecOpts{
+				InheritWorkspace: workspace,
+				Stdin:            `{currentWorkspace{file(path:"marker.txt"){contents}}}`,
+			},
+		).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"currentWorkspace":{"file":{"contents":"arbitrary workspace"}}}`, out)
+
+	out, err = base.
+		WithExec(
+			[]string{"dagger", "--progress=report", "call", "identify"},
+			dagger.ContainerWithExecOpts{
+				InheritWorkspace: workspace,
+				Expect:           dagger.ReturnTypeFailure,
+			},
+		).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `unknown command "identify"`)
 }

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -70,6 +70,39 @@ func (b *SchemaBuilder) WithRoot(root *Query) *SchemaBuilder {
 	return cp
 }
 
+// Merge returns a builder containing both sets of modules while preserving
+// each module's install policy. The receiver wins name collisions.
+func (b *SchemaBuilder) Merge(other *SchemaBuilder) *SchemaBuilder {
+	cp := b.Clone()
+	if cp == nil {
+		return other.Clone()
+	}
+	if other == nil {
+		return cp
+	}
+	for _, entry := range other.entries {
+		if existing, ok := cp.Lookup(entry.mod.Name()); ok {
+			cp = cp.With(existing, entry.opts)
+			continue
+		}
+		cp = cp.With(entry.mod, entry.opts)
+	}
+	return cp
+}
+
+// WithoutEntrypoints returns a builder with every module installed as a
+// non-entrypoint while preserving its other install policy.
+func (b *SchemaBuilder) WithoutEntrypoints() *SchemaBuilder {
+	cp := b.Clone()
+	if cp == nil {
+		return nil
+	}
+	for i := range cp.entries {
+		cp.entries[i].opts.Entrypoint = false
+	}
+	return cp
+}
+
 func (b *SchemaBuilder) Prepend(mods ...Mod) *SchemaBuilder {
 	extra := make([]modDepEntry, len(mods))
 	for i, m := range mods {

--- a/core/query.go
+++ b/core/query.go
@@ -52,7 +52,7 @@ type SpecificClientAttachableConnOpts struct {
 // APIs from the server+session+client that are needed by core APIs
 type Server interface {
 	// Handle an HTTP request from a nested Dagger client.
-	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult)
+	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult, dagql.AnyObjectResult)
 
 	// Stitch in the given module to the list being served to the current client
 	ServeModule(ctx context.Context, mod dagql.ObjectResult[*Module], includeDependencies bool, entrypoint bool) error
@@ -86,6 +86,11 @@ type Server interface {
 
 	// The cached workspace result from ensureWorkspaceLoaded.
 	CurrentWorkspace(context.Context) (*Workspace, error)
+
+	// Capture a workspace result as trusted, execution-scoped context for a
+	// nested client. When the result is the current workspace of a live
+	// ancestor, the binding also carries its environment and module provenance.
+	CaptureInheritedWorkspaceBinding(context.Context, dagql.ObjectResult[*Workspace]) (*InheritedWorkspaceBinding, error)
 
 	// Load pending workspace modules on demand; include narrows to the modules
 	// its patterns name ("module" or "module:item"), empty or unrecognized

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -652,6 +652,13 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("expect").Doc(`Exit codes this command is allowed to exit with without error`),
 				dagql.Arg("experimentalPrivilegedNesting").Doc(
 					`Provides Dagger access to the executed command.`),
+				dagql.Arg("inheritWorkspace").
+					View(AfterVersion("v1.0.0-0")).
+					Doc(
+						`Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.`,
+						`When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.`,
+						`Only grant this access to trusted commands.`,
+					),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. Like --privileged in Docker`,
 					`DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.`),
@@ -949,6 +956,13 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("cmd").Doc(`If set, override the container's default terminal command and invoke these command arguments instead.`),
 				dagql.Arg("experimentalPrivilegedNesting").Doc(
 					`Provides Dagger access to the executed command.`),
+				dagql.Arg("inheritWorkspace").
+					View(AfterVersion("v1.0.0-0")).
+					Doc(
+						`Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.`,
+						`When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.`,
+						`Only grant this access to trusted commands.`,
+					),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
 				running a command with "sudo" or executing "docker run" with the
@@ -4520,6 +4534,13 @@ type containerTerminalArgs struct {
 	core.TerminalArgs
 }
 
+type containerTerminalLegacyArgs struct {
+	core.ExecTerminalArgs
+
+	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
+	InsecureRootCapabilities      dagql.Optional[dagql.Boolean] `default:"false"`
+}
+
 func (s *containerSchema) terminal(
 	ctx context.Context,
 	ctr dagql.ObjectResult[*core.Container],
@@ -4569,7 +4590,7 @@ func (s *containerSchema) terminal(
 func (s *containerSchema) terminalLegacy(
 	ctx context.Context,
 	ctr dagql.ObjectResult[*core.Container],
-	args containerTerminalArgs,
+	args containerTerminalLegacyArgs,
 ) (*core.TerminalLegacy, error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -296,6 +296,13 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 				dagql.Arg("cmd").Doc(`If set, override the container's default terminal command and invoke these command arguments instead.`),
 				dagql.Arg("experimentalPrivilegedNesting").Doc(
 					`Provides Dagger access to the executed command.`),
+				dagql.Arg("inheritWorkspace").
+					View(AfterVersion("v1.0.0-0")).
+					Doc(
+						`Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.`,
+						`When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.`,
+						`Only grant this access to trusted commands.`,
+					),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
 			running a command with "sudo" or executing "docker run" with the

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -48,6 +48,82 @@ func TestBaseSchemaAllowlist(t *testing.T) {
 			"`go test ./core/schema -run TestBaseSchemaAllowlist -update`.")
 }
 
+func TestInheritWorkspaceArgumentViews(t *testing.T) {
+	t.Parallel()
+
+	schemaForView := func(t *testing.T, view call.View) *codegenintrospection.Schema {
+		t.Helper()
+		ctx := context.Background()
+		cache, err := dagql.NewCache(ctx, "", nil, nil)
+		require.NoError(t, err)
+		ctx = dagql.ContextWithCache(ctx, cache)
+		ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+			ClientID:  "inherit-workspace-schema-client",
+			SessionID: "inherit-workspace-schema-session",
+		})
+		srv := &currentTypeDefsTestServer{}
+		root := core.NewRoot(srv)
+		coreSchemaBase, err := NewCoreSchemaBase(ctx, srv)
+		require.NoError(t, err)
+		dag, err := coreSchemaBase.Fork(ctx, root, view)
+		require.NoError(t, err)
+		data, err := getSchemaJSON(nil, nil, dag.View, dag)
+		require.NoError(t, err)
+		return decodeSchemaResponse(t, data).Schema
+	}
+
+	findArg := func(field *codegenintrospection.Field, name string) *codegenintrospection.InputValue {
+		if field == nil {
+			return nil
+		}
+		for _, arg := range field.Args {
+			if arg.Name == name {
+				return &arg
+			}
+		}
+		return nil
+	}
+
+	assertSurface := func(t *testing.T, schema *codegenintrospection.Schema, present bool) {
+		t.Helper()
+		for _, target := range []struct {
+			typeName  string
+			fieldName string
+		}{
+			{"Container", "withExec"},
+			{"Container", "asService"},
+			{"Container", "up"},
+			{"Container", "terminal"},
+			{"Directory", "terminal"},
+		} {
+			field := schemaField(schema.Types.Get(target.typeName), target.fieldName)
+			if !present && field == nil {
+				continue
+			}
+			require.NotNil(t, field, "%s.%s", target.typeName, target.fieldName)
+			arg := findArg(field, "inheritWorkspace")
+			if !present {
+				require.Nil(t, arg, "%s.%s", target.typeName, target.fieldName)
+				continue
+			}
+			require.NotNil(t, arg, "%s.%s", target.typeName, target.fieldName)
+			require.True(t, arg.TypeRef.ReferencesType("ID"))
+			require.Equal(t, "Workspace", arg.Directives.ExpectedType())
+		}
+
+		serviceTerminal := schemaField(schema.Types.Get("Service"), "terminal")
+		require.NotNil(t, serviceTerminal)
+		require.Nil(t, findArg(serviceTerminal, "inheritWorkspace"))
+	}
+
+	t.Run("v1", func(t *testing.T) {
+		assertSurface(t, schemaForView(t, "v1.0.0"), true)
+	})
+	t.Run("older view", func(t *testing.T) {
+		assertSurface(t, schemaForView(t, baseSchemaView()), false)
+	})
+}
+
 func TestSchemaJSONScrubbing(t *testing.T) {
 	ctx := context.Background()
 	baseCache, err := dagql.NewCache(ctx, "", nil, nil)

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -33,6 +33,13 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 					`If the container has an entrypoint, prepend it to the args.`),
 				dagql.Arg("experimentalPrivilegedNesting").Doc(
 					`Provides Dagger access to the executed command.`),
+				dagql.Arg("inheritWorkspace").
+					View(AfterVersion("v1.0.0-0")).
+					Doc(
+						`Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.`,
+						`When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.`,
+						`Only grant this access to trusted commands.`,
+					),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
 					running a command with "sudo" or executing "docker run" with the
@@ -76,6 +83,13 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 					`If the container has an entrypoint, prepend it to the args.`),
 				dagql.Arg("experimentalPrivilegedNesting").Doc(
 					`Provides Dagger access to the executed command.`),
+				dagql.Arg("inheritWorkspace").
+					View(AfterVersion("v1.0.0-0")).
+					Doc(
+						`Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.`,
+						`When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.`,
+						`Only grant this access to trusted commands.`,
+					),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
 					running a command with "sudo" or executing "docker run" with the
@@ -279,6 +293,18 @@ func (s *serviceSchema) containerAsServiceLegacy(ctx context.Context, parent dag
 }
 
 func (s *serviceSchema) containerAsService(ctx context.Context, parent dagql.ObjectResult[*core.Container], args core.ContainerAsServiceArgs) (*core.Service, error) {
+	var inheritedWorkspace *core.InheritedWorkspaceBinding
+	if !args.InheritWorkspace.Valid {
+		srv, err := core.CurrentDagqlServer(ctx)
+		if err != nil {
+			return nil, err
+		}
+		inheritedWorkspace, err = inheritedWorkspaceFromExecCall(ctx, srv, parent)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	cache, err := dagql.EngineCache(ctx)
 	if err != nil {
 		return nil, err
@@ -298,7 +324,53 @@ func (s *serviceSchema) containerAsService(ctx context.Context, parent dagql.Obj
 	}
 	args.Args = expandedArgs
 
-	return parent.Self().AsService(ctx, parent, args)
+	svc, err := parent.Self().AsService(ctx, parent, args)
+	if err != nil {
+		return nil, err
+	}
+	if svc.InheritedWorkspace == nil {
+		svc.InheritedWorkspace = inheritedWorkspace
+	}
+	return svc, nil
+}
+
+func inheritedWorkspaceFromExecCall(
+	ctx context.Context,
+	srv *dagql.Server,
+	parent dagql.ObjectResult[*core.Container],
+) (*core.InheritedWorkspaceBinding, error) {
+	var cur dagql.AnyObjectResult = parent
+	for cur != nil {
+		call, err := cur.ResultCall()
+		if err != nil {
+			return nil, err
+		}
+		receiver, err := cur.Receiver(ctx, srv)
+		if err != nil {
+			return nil, err
+		}
+		if call.Field == "withExec" {
+			ctr, ok := receiver.(dagql.ObjectResult[*core.Container])
+			if !ok {
+				return nil, fmt.Errorf("expected withExec receiver %T, got %T", ctr, receiver)
+			}
+			field, ok := ctr.ObjectType().FieldSpec(call.Field, call.View)
+			if !ok {
+				return nil, fmt.Errorf("could not find %s on %s", call.Field, ctr.Type().NamedType)
+			}
+			inputs, err := field.Args.InputsFromResultCallArgs(ctx, call.Args, call.View)
+			if err != nil {
+				return nil, err
+			}
+			var withExecArgs containerExecArgs
+			if err := field.Args.Decode(inputs, &withExecArgs, call.View); err != nil {
+				return nil, err
+			}
+			return core.CaptureInheritedWorkspaceBinding(ctx, withExecArgs.InheritWorkspace)
+		}
+		cur = receiver
+	}
+	return nil, nil
 }
 
 func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.ObjectResult[*core.Container], args struct {
@@ -327,6 +399,12 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.ObjectResult[
 		inputs = append(inputs, dagql.NamedInput{
 			Name:  "experimentalPrivilegedNesting",
 			Value: dagql.Boolean(true),
+		})
+	}
+	if args.InheritWorkspace.Valid {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "inheritWorkspace",
+			Value: args.InheritWorkspace,
 		})
 	}
 	if args.InsecureRootCapabilities {

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -58,6 +58,13 @@ func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []st
 	return nil, nil
 }
 
+func (s *currentTypeDefsTestServer) CaptureInheritedWorkspaceBinding(_ context.Context, workspace dagql.ObjectResult[*core.Workspace]) (*core.InheritedWorkspaceBinding, error) {
+	return &core.InheritedWorkspaceBinding{
+		Workspace: workspace,
+		BindingID: "test-workspace-binding",
+	}, nil
+}
+
 func (s *currentTypeDefsTestServer) CurrentServedDeps(context.Context) (*core.SchemaBuilder, error) {
 	return s.deps, nil
 }
@@ -97,7 +104,7 @@ func (s *currentTypeDefsTestServer) MuxEndpoint(context.Context, string, http.Ha
 	return nil
 }
 
-func (s *currentTypeDefsTestServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult) {
+func (s *currentTypeDefsTestServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult, dagql.AnyObjectResult) {
 }
 
 func (s *currentTypeDefsTestServer) Auth(context.Context) (*auth.RegistryAuthProvider, error) {

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -229,10 +229,23 @@ type workspaceConfigKeyArgs struct {
 
 func selectedWorkspaceEnv(ctx context.Context) (string, bool) {
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil || clientMetadata.WorkspaceEnv == nil || *clientMetadata.WorkspaceEnv == "" {
+	if err != nil {
 		return "", false
 	}
-	return *clientMetadata.WorkspaceEnv, true
+	if clientMetadata.WorkspaceEnv != nil {
+		if *clientMetadata.WorkspaceEnv == "" {
+			return "", false
+		}
+		return *clientMetadata.WorkspaceEnv, true
+	}
+	// The inherited env is effective only while the inherited workspace wins.
+	// An explicit workspace without --env selects that workspace's base config.
+	if clientMetadata.Workspace == nil &&
+		clientMetadata.InheritedWorkspaceEnvSet &&
+		clientMetadata.InheritedWorkspaceEnv != "" {
+		return clientMetadata.InheritedWorkspaceEnv, true
+	}
+	return "", false
 }
 
 func isExplicitEnvConfigKey(key string) bool {

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
 )
 
@@ -619,6 +620,70 @@ func TestEnvScopedConfigKeyQuotesDynamicSegments(t *testing.T) {
 	key, err := envScopedConfigKey(cfg, "review env", `modules."my.module".settings."some.key"`)
 	require.NoError(t, err)
 	require.Equal(t, `env."review env".modules."my.module".settings."some.key"`, key)
+}
+
+func TestSelectedWorkspaceEnv(t *testing.T) {
+	t.Parallel()
+
+	stringPtr := func(value string) *string { return &value }
+	tests := []struct {
+		name     string
+		metadata *engine.ClientMetadata
+		want     string
+		wantSet  bool
+	}{
+		{
+			name: "explicit env takes precedence",
+			metadata: &engine.ClientMetadata{
+				Workspace:                stringPtr("other-workspace"),
+				WorkspaceEnv:             stringPtr("explicit"),
+				InheritedWorkspaceEnv:    "inherited",
+				InheritedWorkspaceEnvSet: true,
+			},
+			want:    "explicit",
+			wantSet: true,
+		},
+		{
+			name: "inherited env applies with inherited workspace",
+			metadata: &engine.ClientMetadata{
+				InheritedWorkspaceEnv:    "inherited",
+				InheritedWorkspaceEnvSet: true,
+			},
+			want:    "inherited",
+			wantSet: true,
+		},
+		{
+			name: "explicit empty env suppresses inherited env",
+			metadata: &engine.ClientMetadata{
+				WorkspaceEnv:             stringPtr(""),
+				InheritedWorkspaceEnv:    "inherited",
+				InheritedWorkspaceEnvSet: true,
+			},
+		},
+		{
+			name: "explicit workspace suppresses inherited env",
+			metadata: &engine.ClientMetadata{
+				Workspace:                stringPtr("other-workspace"),
+				InheritedWorkspaceEnv:    "inherited",
+				InheritedWorkspaceEnvSet: true,
+			},
+		},
+		{
+			name:     "no env selected",
+			metadata: &engine.ClientMetadata{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := engine.ContextWithClientMetadata(context.Background(), test.metadata)
+			got, gotSet := selectedWorkspaceEnv(ctx)
+			require.Equal(t, test.wantSet, gotSet)
+			require.Equal(t, test.want, got)
+		})
+	}
 }
 
 func TestWorkspaceSettingConfigKeyQuotesDynamicSegments(t *testing.T) {

--- a/core/sdk/dang/shared/shared.go
+++ b/core/sdk/dang/shared/shared.go
@@ -51,7 +51,7 @@ func WithNestedClientServer(
 		ReadHeaderTimeout: 10 * time.Second,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			telemetry.Propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
-			query.ServeHTTPToNestedClient(resp, req, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, moduleContext, fnCall, envContext)
+			query.ServeHTTPToNestedClient(resp, req, nestedClientMetadata, callerClientID, hostServiceProxyToCaller, moduleContext, fnCall, envContext, nil)
 		}),
 	}
 	defer func() {

--- a/core/service.go
+++ b/core/service.go
@@ -59,6 +59,7 @@ type Service struct {
 	ExecMD                        *engineutil.ExecutionMetadata
 	ModuleContext                 dagql.ObjectResult[*Module]
 	ExecMeta                      *executor.Meta
+	InheritedWorkspace            *InheritedWorkspaceBinding
 
 	// TunnelUpstream is the service that this service is tunnelling to.
 	TunnelUpstream dagql.ObjectResult[*Service]
@@ -94,6 +95,10 @@ type persistedServicePayload struct {
 	ExecMD                        *engineutil.ExecutionMetadata `json:"execMD,omitempty"`
 	ModuleContextResultID         uint64                        `json:"moduleContextResultID,omitempty"`
 	ExecMeta                      *executor.Meta                `json:"execMeta,omitempty"`
+	InheritedWorkspaceResultID    uint64                        `json:"inheritedWorkspaceResultID,omitempty"`
+	InheritedWorkspaceBindingID   string                        `json:"inheritedWorkspaceBindingID,omitempty"`
+	InheritedWorkspaceEnv         string                        `json:"inheritedWorkspaceEnv,omitempty"`
+	InheritedWorkspaceEnvSet      bool                          `json:"inheritedWorkspaceEnvSet,omitempty"`
 	TunnelUpstreamResultID        uint64                        `json:"tunnelUpstreamResultID,omitempty"`
 	TunnelPorts                   []PortForward                 `json:"tunnelPorts,omitempty"`
 	HostSockets                   []persistedServiceHostSocket  `json:"hostSockets,omitempty"`
@@ -142,6 +147,15 @@ func (svc *Service) EncodePersistedObject(ctx context.Context, cache dagql.Persi
 			return dagql.PersistedObjectEncoding{}, err
 		}
 	}
+	if binding := svc.InheritedWorkspace; binding != nil && binding.Workspace.Self() != nil {
+		payload.InheritedWorkspaceResultID, err = encodePersistedObjectRef(cache, binding.Workspace, "service inherited workspace")
+		if err != nil {
+			return dagql.PersistedObjectEncoding{}, err
+		}
+		payload.InheritedWorkspaceBindingID = binding.BindingID
+		payload.InheritedWorkspaceEnv = binding.WorkspaceEnv
+		payload.InheritedWorkspaceEnvSet = binding.HasWorkspaceEnv
+	}
 	if svc.TunnelUpstream.Self() != nil {
 		payload.TunnelUpstreamResultID, err = encodePersistedObjectRef(cache, svc.TunnelUpstream, "service tunnel upstream")
 		if err != nil {
@@ -180,6 +194,10 @@ func (*Service) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ 
 	if err != nil {
 		return nil, err
 	}
+	inheritedWorkspace, err := loadPersistedObjectResultByResultID[*Workspace](ctx, dag, persisted.InheritedWorkspaceResultID, "service inherited workspace")
+	if err != nil {
+		return nil, err
+	}
 	tunnelUpstream, err := loadPersistedObjectResultByResultID[*Service](ctx, dag, persisted.TunnelUpstreamResultID, "service tunnel upstream")
 	if err != nil {
 		return nil, err
@@ -194,7 +212,7 @@ func (*Service) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ 
 			SourceClientID: sock.SourceClientID,
 		})
 	}
-	return &Service{
+	svc := &Service{
 		CustomHostname:                persisted.CustomHostname,
 		Container:                     container,
 		Args:                          slices.Clone(persisted.Args),
@@ -207,7 +225,16 @@ func (*Service) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ 
 		TunnelUpstream:                tunnelUpstream,
 		TunnelPorts:                   slices.Clone(persisted.TunnelPorts),
 		HostSockets:                   hostSockets,
-	}, nil
+	}
+	if inheritedWorkspace.Self() != nil {
+		svc.InheritedWorkspace = &InheritedWorkspaceBinding{
+			Workspace:       inheritedWorkspace,
+			BindingID:       persisted.InheritedWorkspaceBindingID,
+			WorkspaceEnv:    persisted.InheritedWorkspaceEnv,
+			HasWorkspaceEnv: persisted.InheritedWorkspaceEnvSet,
+		}
+	}
+	return svc, nil
 }
 
 func (svc *Service) AttachDependencyResults(
@@ -239,6 +266,18 @@ func (svc *Service) AttachDependencyResults(
 		}
 		svc.ModuleContext = moduleContext
 		owned = append(owned, moduleContext)
+	}
+	if binding := svc.InheritedWorkspace; binding != nil && binding.Workspace.Self() != nil {
+		attached, err := attach(binding.Workspace)
+		if err != nil {
+			return nil, fmt.Errorf("attach service inherited workspace: %w", err)
+		}
+		workspace, ok := attached.(dagql.ObjectResult[*Workspace])
+		if !ok {
+			return nil, fmt.Errorf("attach service inherited workspace: expected %T, got %T", binding.Workspace, attached)
+		}
+		binding.Workspace = workspace
+		owned = append(owned, workspace)
 	}
 	if svc.TunnelUpstream.Self() != nil {
 		upstream, err := attachServiceResult(attach, svc.TunnelUpstream, "attach service tunnel upstream")
@@ -296,6 +335,10 @@ func (svc *Service) Clone() *Service {
 	cp.Args = slices.Clone(cp.Args)
 	cp.TunnelPorts = slices.Clone(cp.TunnelPorts)
 	cp.HostSockets = slices.Clone(cp.HostSockets)
+	if svc.InheritedWorkspace != nil {
+		binding := *svc.InheritedWorkspace
+		cp.InheritedWorkspace = &binding
+	}
 	return &cp
 }
 
@@ -808,15 +851,10 @@ func (svc *Service) startContainer(
 	}
 	meta.Env = append(meta.Env, secretEnv...)
 
-	var nestedClientMetadata *engine.ClientMetadata
-	if svc.ExperimentalPrivilegedNesting {
-		nestedClientMetadata = &engine.ClientMetadata{
-			ClientID:          identity.NewID(),
-			ClientVersion:     engine.Version,
-			SessionID:         clientMetadata.SessionID,
-			AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
-			LockMode:          clientMetadata.LockMode,
-		}
+	nestedClientMetadata := nestedClientMetadataForExec(clientMetadata, execMD, svc.ExperimentalPrivilegedNesting, svc.InheritedWorkspace)
+	var workspaceContext dagql.ObjectResult[*Workspace]
+	if svc.InheritedWorkspace != nil {
+		workspaceContext = svc.InheritedWorkspace.Workspace
 	}
 
 	exited := make(chan struct{})
@@ -853,6 +891,7 @@ func (svc *Service) startContainer(
 			svc.ModuleContext,
 			nil,
 			dagql.ObjectResult[*Env]{},
+			workspaceContext,
 		)
 		runErr <- err
 	}()

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -49,7 +49,7 @@ type mockServer struct {
 	attachables    map[string]*grpc.ClientConn
 }
 
-func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult) {
+func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult, dagql.AnyObjectResult) {
 }
 
 func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*Module], includeDependencies bool, entrypoint bool) error {
@@ -127,6 +127,13 @@ func (ms *mockServer) SpecificClientMetadata(context.Context, string) (*engine.C
 
 func (ms *mockServer) CurrentWorkspace(context.Context) (*Workspace, error) {
 	return nil, nil
+}
+
+func (ms *mockServer) CaptureInheritedWorkspaceBinding(_ context.Context, workspace dagql.ObjectResult[*Workspace]) (*InheritedWorkspaceBinding, error) {
+	return &InheritedWorkspaceBinding{
+		Workspace: workspace,
+		BindingID: "mock-workspace-binding",
+	}, nil
 }
 
 func (ms *mockServer) SpecificClientAttachableConn(_ context.Context, clientID string, opts SpecificClientAttachableConnOpts) (*grpc.ClientConn, bool, error) {

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -121,6 +121,10 @@ type TerminalArgs struct {
 	// Provide dagger access to the executed command
 	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
 
+	// Provide dagger access to the executed command with this workspace as the
+	// default for nested clients.
+	InheritWorkspace dagql.Optional[dagql.ID[*Workspace]]
+
 	// Grant the process all root capabilities
 	InsecureRootCapabilities dagql.Optional[dagql.Boolean] `default:"false"`
 }
@@ -132,7 +136,7 @@ func (container *Container) Terminal(
 	containerRes dagql.ObjectResult[*Container],
 	args *TerminalArgs,
 ) error {
-	return container.terminal(ctx, selectedID, selectedDigest, containerRes, args, nil, nil, nil)
+	return container.terminal(ctx, selectedID, selectedDigest, containerRes, args, nil, nil, nil, nil)
 }
 
 func (container *Container) TerminalExecError(
@@ -140,11 +144,12 @@ func (container *Container) TerminalExecError(
 	selectedID *call.ID,
 	selectedDigest digest.Digest,
 	containerRes dagql.ObjectResult[*Container],
+	inheritedWorkspace *InheritedWorkspaceBinding,
 	execMD *engineutil.ExecutionMetadata,
 	execMeta *executor.Meta,
 	execErr error,
 ) error {
-	return container.terminal(ctx, selectedID, selectedDigest, containerRes, nil, execMD, execMeta, execErr)
+	return container.terminal(ctx, selectedID, selectedDigest, containerRes, nil, inheritedWorkspace, execMD, execMeta, execErr)
 }
 
 func (container *Container) terminal(
@@ -153,6 +158,7 @@ func (container *Container) terminal(
 	selectedDigest digest.Digest,
 	containerRes dagql.ObjectResult[*Container],
 	args *TerminalArgs,
+	inheritedWorkspace *InheritedWorkspaceBinding,
 	execMD *engineutil.ExecutionMetadata,
 	execMeta *executor.Meta,
 	execErr error,
@@ -215,13 +221,15 @@ func (container *Container) terminal(
 		svc, err = container.AsService(ctx, containerRes, ContainerAsServiceArgs{
 			Args:                          args.Cmd,
 			ExperimentalPrivilegedNesting: args.ExperimentalPrivilegedNesting.Value.Bool(),
+			InheritWorkspace:              args.InheritWorkspace,
 			InsecureRootCapabilities:      args.InsecureRootCapabilities.Value.Bool(),
 		})
 	} else {
 		svc = &Service{
-			Container: containerRes,
-			ExecMD:    execMD,
-			ExecMeta:  execMeta,
+			Container:          containerRes,
+			ExecMD:             execMD,
+			ExecMeta:           execMeta,
+			InheritedWorkspace: inheritedWorkspace,
 		}
 	}
 	if err != nil {

--- a/core/workspace_binding.go
+++ b/core/workspace_binding.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/dagger/dagger/internal/buildkit/identity"
+)
+
+// InheritedWorkspaceBinding is the trusted, execution-scoped workspace context
+// passed to a nested Dagger client.
+//
+// Workspace is retained as a real dependency so lazy execs and services can
+// derive a fresh session handle after persistence. The remaining fields
+// identify the live ancestor binding whose workspace module state may be
+// inherited.
+type InheritedWorkspaceBinding struct {
+	Workspace dagql.ObjectResult[*Workspace]
+
+	BindingID string
+
+	WorkspaceEnv    string
+	HasWorkspaceEnv bool
+}
+
+func inheritedWorkspaceBindingID(binding *InheritedWorkspaceBinding) string {
+	if binding == nil {
+		return ""
+	}
+	return binding.BindingID
+}
+
+func inheritedWorkspaceEnv(binding *InheritedWorkspaceBinding) string {
+	if binding == nil {
+		return ""
+	}
+	return binding.WorkspaceEnv
+}
+
+func CaptureInheritedWorkspaceBinding(
+	ctx context.Context,
+	input dagql.Optional[dagql.ID[*Workspace]],
+) (*InheritedWorkspaceBinding, error) {
+	if !input.Valid {
+		return nil, nil
+	}
+
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get Dagger server for inherited workspace: %w", err)
+	}
+	workspace, err := input.Value.Load(ctx, dag)
+	if err != nil {
+		return nil, fmt.Errorf("load inherited workspace: %w", err)
+	}
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get current query for inherited workspace: %w", err)
+	}
+	binding, err := query.Server.CaptureInheritedWorkspaceBinding(ctx, workspace)
+	if err != nil {
+		return nil, fmt.Errorf("capture inherited workspace binding: %w", err)
+	}
+	return binding, nil
+}
+
+func nestedClientMetadataForExec(
+	clientMetadata *engine.ClientMetadata,
+	execMD *engineutil.ExecutionMetadata,
+	experimentalPrivilegedNesting bool,
+	inheritedWorkspace *InheritedWorkspaceBinding,
+) *engine.ClientMetadata {
+	hasInheritedWorkspace := inheritedWorkspace != nil && inheritedWorkspace.Workspace.Self() != nil
+	if !experimentalPrivilegedNesting && !hasInheritedWorkspace {
+		return nil
+	}
+
+	nested := &engine.ClientMetadata{
+		ClientID:          identity.NewID(),
+		ClientVersion:     engine.Version,
+		SessionID:         clientMetadata.SessionID,
+		AllowedLLMModules: slices.Clone(clientMetadata.AllowedLLMModules),
+		LockMode:          clientMetadata.LockMode,
+	}
+	if execMD != nil {
+		nested.UseRecipeIDsByDefault = execMD.UseRecipeIDsByDefault
+	}
+	if inheritedWorkspace != nil {
+		nested.InheritedWorkspaceBindingID = inheritedWorkspace.BindingID
+		nested.InheritedWorkspaceEnv = inheritedWorkspace.WorkspaceEnv
+		nested.InheritedWorkspaceEnvSet = inheritedWorkspace.HasWorkspaceEnv
+	}
+	return nested
+}

--- a/core/workspace_binding_test.go
+++ b/core/workspace_binding_test.go
@@ -1,0 +1,165 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNestedClientMetadataForInheritedWorkspace(t *testing.T) {
+	t.Parallel()
+
+	dag, err := dagql.NewServer(t.Context(), &Workspace{})
+	require.NoError(t, err)
+	workspace, err := dagql.NewObjectResultForCall(
+		&Workspace{Address: "test://workspace"},
+		dag,
+		&dagql.ResultCall{SyntheticOp: "inherited-workspace"},
+	)
+	require.NoError(t, err)
+
+	clientMetadata := &engine.ClientMetadata{
+		SessionID:         "session",
+		AllowedLLMModules: []string{"llm"},
+		LockMode:          "frozen",
+	}
+	binding := &InheritedWorkspaceBinding{
+		Workspace:       workspace,
+		BindingID:       "binding",
+		WorkspaceEnv:    "ci",
+		HasWorkspaceEnv: true,
+	}
+
+	nested := nestedClientMetadataForExec(clientMetadata, nil, false, binding)
+	require.NotNil(t, nested)
+	require.Equal(t, "session", nested.SessionID)
+	require.Equal(t, []string{"llm"}, nested.AllowedLLMModules)
+	require.Equal(t, "frozen", nested.LockMode)
+	require.Equal(t, "binding", nested.InheritedWorkspaceBindingID)
+	require.Equal(t, "ci", nested.InheritedWorkspaceEnv)
+	require.True(t, nested.InheritedWorkspaceEnvSet)
+
+	require.NotNil(t, nestedClientMetadataForExec(clientMetadata, nil, true, nil))
+	require.Nil(t, nestedClientMetadataForExec(clientMetadata, nil, false, nil))
+}
+
+func TestInheritedWorkspacePersistence(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	ctx = dagql.ContextWithCache(ctx, cache)
+
+	query := &Query{Server: &cacheVolumeTestQueryServer{mockServer: &mockServer{}}}
+	srv := newCoreDagqlServerForTest(t, query)
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*Workspace]{}))
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*Container]{}))
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*Service]{}))
+
+	workspace := volumeTestCachedObjectResult(t, ctx, cache, srv, "workspace-session", "workspace", &Workspace{
+		Address: "test://inherited-workspace",
+	})
+	parent := volumeTestCachedObjectResult(t, ctx, cache, srv, "workspace-session", "parent", NewContainer(Platform(specs.Platform{
+		OS:           "linux",
+		Architecture: "amd64",
+	})))
+	parentResultID, err := cache.PersistedResultID(parent)
+	require.NoError(t, err)
+	binding := &InheritedWorkspaceBinding{
+		Workspace:       workspace,
+		BindingID:       "binding-id",
+		WorkspaceEnv:    "ci",
+		HasWorkspaceEnv: true,
+	}
+
+	t.Run("container exec lazy", func(t *testing.T) {
+		container := NewContainer(parent.Self().Platform)
+		container.Lazy = &ContainerExecLazy{State: &ContainerExecState{
+			LazyState:          NewLazyState(),
+			Parent:             parent,
+			Opts:               ContainerExecOpts{Args: []string{"true"}},
+			InheritedWorkspace: binding,
+		}}
+
+		encoded, err := container.EncodePersistedObject(ctx, cache)
+		require.NoError(t, err)
+		var payload persistedContainerPayload
+		require.NoError(t, json.Unmarshal(encoded.JSON, &payload))
+		var lazyPayload persistedContainerExecLazy
+		require.NoError(t, json.Unmarshal(payload.LazyJSON, &lazyPayload))
+		require.NotZero(t, lazyPayload.InheritedWorkspaceResultID)
+		require.Equal(t, "binding-id", lazyPayload.InheritedWorkspaceBindingID)
+		require.Equal(t, "ci", lazyPayload.InheritedWorkspaceEnv)
+		require.True(t, lazyPayload.InheritedWorkspaceEnvSet)
+
+		call := volumeTestCall("container-with-exec", container)
+		call.Field = "withExec"
+		decodedTyped, err := (&Container{}).DecodePersistedObject(ctx, srv, parentResultID, call, encoded.JSON)
+		require.NoError(t, err)
+		decoded := decodedTyped.(*Container)
+		lazy := decoded.Lazy.(*ContainerExecLazy)
+		require.Equal(t, "test://inherited-workspace", lazy.State.InheritedWorkspace.Workspace.Self().Address)
+		require.Equal(t, "binding-id", lazy.State.InheritedWorkspace.BindingID)
+		require.Equal(t, "ci", lazy.State.InheritedWorkspace.WorkspaceEnv)
+		require.True(t, lazy.State.InheritedWorkspace.HasWorkspaceEnv)
+	})
+
+	t.Run("service", func(t *testing.T) {
+		service := &Service{
+			Container:          parent,
+			Args:               []string{"true"},
+			InheritedWorkspace: binding,
+		}
+		encoded, err := service.EncodePersistedObject(ctx, cache)
+		require.NoError(t, err)
+		var payload persistedServicePayload
+		require.NoError(t, json.Unmarshal(encoded.JSON, &payload))
+		require.NotZero(t, payload.InheritedWorkspaceResultID)
+		require.Equal(t, "binding-id", payload.InheritedWorkspaceBindingID)
+		require.Equal(t, "ci", payload.InheritedWorkspaceEnv)
+		require.True(t, payload.InheritedWorkspaceEnvSet)
+
+		decodedTyped, err := (&Service{}).DecodePersistedObject(ctx, srv, 0, nil, encoded.JSON)
+		require.NoError(t, err)
+		decoded := decodedTyped.(*Service)
+		require.Equal(t, "test://inherited-workspace", decoded.InheritedWorkspace.Workspace.Self().Address)
+		require.Equal(t, "binding-id", decoded.InheritedWorkspace.BindingID)
+		require.Equal(t, "ci", decoded.InheritedWorkspace.WorkspaceEnv)
+		require.True(t, decoded.InheritedWorkspace.HasWorkspaceEnv)
+	})
+}
+
+func TestSchemaBuilderMergePrefersExistingModuleAndPromotesInstallPolicy(t *testing.T) {
+	t.Parallel()
+
+	dag, err := dagql.NewServer(t.Context(), &Module{})
+	require.NoError(t, err)
+	left, err := dagql.NewObjectResultForCall(
+		&Module{NameField: "greeter"},
+		dag,
+		&dagql.ResultCall{SyntheticOp: "left-greeter"},
+	)
+	require.NoError(t, err)
+	right, err := dagql.NewObjectResultForCall(
+		&Module{NameField: "greeter"},
+		dag,
+		&dagql.ResultCall{SyntheticOp: "right-greeter"},
+	)
+	require.NoError(t, err)
+
+	merged := NewSchemaBuilder(nil, nil).
+		With(NewUserMod(left), InstallOpts{SkipConstructor: true}).
+		Merge(NewSchemaBuilder(nil, nil).
+			With(NewUserMod(right), InstallOpts{Entrypoint: true}))
+
+	require.Len(t, merged.entries, 1)
+	require.Same(t, left.Self(), merged.entries[0].mod.ModuleResult().Self())
+	require.False(t, merged.entries[0].opts.SkipConstructor)
+	require.True(t, merged.entries[0].opts.Entrypoint)
+}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -479,6 +479,17 @@ type Container implements Exportable & Node & Syncer {
     experimentalPrivilegedNesting: Boolean = false
 
     """
+    Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+
+    When this is the caller's current workspace, its selected environment and
+    module commands are inherited. Other workspace values are available through
+    currentWorkspace, but do not provide module commands.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+
+    """
     Execute the command with all root capabilities. This is similar to running a
     command with "sudo" or executing "docker run" with the "--privileged" flag.
     Containerization does not provide any security guarantees when using this
@@ -938,6 +949,17 @@ type Container implements Exportable & Node & Syncer {
     experimentalPrivilegedNesting: Boolean = false
 
     """
+    Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+
+    When this is the caller's current workspace, its selected environment and
+    module commands are inherited. Other workspace values are available through
+    currentWorkspace, but do not provide module commands.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+
+    """
     Execute the command with all root capabilities. This is similar to running a
     command with "sudo" or executing "docker run" with the "--privileged" flag.
     Containerization does not provide any security guarantees when using this
@@ -975,6 +997,17 @@ type Container implements Exportable & Node & Syncer {
 
     """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+
+    When this is the caller's current workspace, its selected environment and
+    module commands are inherited. Other workspace values are available through
+    currentWorkspace, but do not provide module commands.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
 
     """
     Execute the command with all root capabilities. This is similar to running a
@@ -1210,6 +1243,17 @@ type Container implements Exportable & Node & Syncer {
 
     """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+
+    When this is the caller's current workspace, its selected environment and
+    module commands are inherited. Other workspace values are available through
+    currentWorkspace, but do not provide module commands.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
 
     """
     Execute the command with all root capabilities. Like --privileged in Docker
@@ -2264,6 +2308,17 @@ type Directory implements Exportable & Node & Syncer {
 
     """Provides Dagger access to the executed command."""
     experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+
+    When this is the caller's current workspace, its selected environment and
+    module commands are inherited. Other workspace values are available through
+    currentWorkspace, but do not provide module commands.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
 
     """
     Execute the command with all root capabilities. This is similar to running a

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -146,7 +146,7 @@
                     <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_asService">asService</a>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+                    <a href="#method_asService">asService</a>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         
                                             <p><p>Turn the container into a Service.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -476,7 +476,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_terminal">terminal</a>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+                    <a href="#method_terminal">terminal</a>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false)
         
                                             <p><p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -486,7 +486,7 @@
                     void
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_up">up</a>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+                    <a href="#method_up">up</a>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         
                                             <p><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -596,7 +596,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withExec">withExec</a>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+                    <a href="#method_withExec">withExec</a>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         
                                             <p><p>Execute a command in the container, and return a new snapshot of the container state after execution.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1080,7 +1080,7 @@
                     <h3 id="method_asService">
         <div class="location">at line 21</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
-    <strong>asService</strong>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+    <strong>asService</strong>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
     <div class="details">    
@@ -1107,6 +1107,11 @@
                     <tr>
                 <td>bool|null</td>
                 <td>$experimentalPrivilegedNesting</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null</td>
+                <td>$inheritWorkspace</td>
                 <td></td>
             </tr>
                     <tr>
@@ -1145,7 +1150,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asTarball">
-        <div class="location">at line 54</div>
+        <div class="location">at line 58</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>asTarball</strong>(array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -1197,7 +1202,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_combinedOutput">
-        <div class="location">at line 77</div>
+        <div class="location">at line 81</div>
         <code>                    string
     <strong>combinedOutput</strong>()
         </code>
@@ -1229,7 +1234,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_defaultArgs">
-        <div class="location">at line 86</div>
+        <div class="location">at line 90</div>
         <code>                    array
     <strong>defaultArgs</strong>()
         </code>
@@ -1261,7 +1266,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_directory">
-        <div class="location">at line 97</div>
+        <div class="location">at line 101</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>directory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -1308,7 +1313,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_dockerHealthcheck">
-        <div class="location">at line 110</div>
+        <div class="location">at line 114</div>
         <code>                    <a href="../Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a>
     <strong>dockerHealthcheck</strong>()
         </code>
@@ -1340,7 +1345,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_entrypoint">
-        <div class="location">at line 119</div>
+        <div class="location">at line 123</div>
         <code>                    array
     <strong>entrypoint</strong>()
         </code>
@@ -1372,7 +1377,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envVariable">
-        <div class="location">at line 128</div>
+        <div class="location">at line 132</div>
         <code>                    string
     <strong>envVariable</strong>(string $name)
         </code>
@@ -1414,7 +1419,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envVariables">
-        <div class="location">at line 138</div>
+        <div class="location">at line 142</div>
         <code>                    array
     <strong>envVariables</strong>()
         </code>
@@ -1446,7 +1451,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exists">
-        <div class="location">at line 147</div>
+        <div class="location">at line 151</div>
         <code>                    bool
     <strong>exists</strong>(string $path, <abbr title="Dagger\Dagger\ExistsType">ExistsType</abbr>|null $expectedType = null, bool|null $doNotFollowSymlinks = false, bool|null $expand = false)
         </code>
@@ -1503,7 +1508,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exitCode">
-        <div class="location">at line 172</div>
+        <div class="location">at line 176</div>
         <code>                    int
     <strong>exitCode</strong>()
         </code>
@@ -1535,7 +1540,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_experimentalWithAllGPUs">
-        <div class="location">at line 185</div>
+        <div class="location">at line 189</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>experimentalWithAllGPUs</strong>()
         </code>
@@ -1568,7 +1573,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_experimentalWithGPU">
-        <div class="location">at line 198</div>
+        <div class="location">at line 202</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>experimentalWithGPU</strong>(array $devices)
         </code>
@@ -1611,7 +1616,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_export">
-        <div class="location">at line 210</div>
+        <div class="location">at line 214</div>
         <code>                    string
     <strong>export</strong>(string $path, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, bool|null $expand = false)
         </code>
@@ -1673,7 +1678,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exportImage">
-        <div class="location">at line 237</div>
+        <div class="location">at line 241</div>
         <code>                    void
     <strong>exportImage</strong>(string $name, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -1730,7 +1735,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exposedPorts">
-        <div class="location">at line 262</div>
+        <div class="location">at line 266</div>
         <code>                    array
     <strong>exposedPorts</strong>()
         </code>
@@ -1762,7 +1767,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 273</div>
+        <div class="location">at line 277</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path, bool|null $expand = false)
         </code>
@@ -1809,7 +1814,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_from">
-        <div class="location">at line 286</div>
+        <div class="location">at line 290</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>from</strong>(string $address, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         </code>
@@ -1866,7 +1871,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 309</div>
+        <div class="location">at line 313</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1898,7 +1903,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_imageRef">
-        <div class="location">at line 318</div>
+        <div class="location">at line 322</div>
         <code>                    string
     <strong>imageRef</strong>()
         </code>
@@ -1930,7 +1935,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_import">
-        <div class="location">at line 327</div>
+        <div class="location">at line 331</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>import</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $tag = &#039;&#039;)
         </code>
@@ -1977,7 +1982,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_label">
-        <div class="location">at line 340</div>
+        <div class="location">at line 344</div>
         <code>                    string
     <strong>label</strong>(string $name)
         </code>
@@ -2019,7 +2024,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_labels">
-        <div class="location">at line 350</div>
+        <div class="location">at line 354</div>
         <code>                    array
     <strong>labels</strong>()
         </code>
@@ -2051,7 +2056,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_layer">
-        <div class="location">at line 359</div>
+        <div class="location">at line 363</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>layer</strong>(string $id, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2103,7 +2108,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_manifest">
-        <div class="location">at line 378</div>
+        <div class="location">at line 382</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>manifest</strong>(<abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2150,7 +2155,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_mounts">
-        <div class="location">at line 395</div>
+        <div class="location">at line 399</div>
         <code>                    array
     <strong>mounts</strong>()
         </code>
@@ -2182,7 +2187,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_platform">
-        <div class="location">at line 404</div>
+        <div class="location">at line 408</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>platform</strong>()
         </code>
@@ -2214,7 +2219,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_publish">
-        <div class="location">at line 415</div>
+        <div class="location">at line 419</div>
         <code>                    string
     <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         </code>
@@ -2286,7 +2291,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_rootfs">
-        <div class="location">at line 450</div>
+        <div class="location">at line 454</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>rootfs</strong>()
         </code>
@@ -2318,7 +2323,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stat">
-        <div class="location">at line 459</div>
+        <div class="location">at line 463</div>
         <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
@@ -2365,7 +2370,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stderr">
-        <div class="location">at line 474</div>
+        <div class="location">at line 478</div>
         <code>                    string
     <strong>stderr</strong>()
         </code>
@@ -2397,7 +2402,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stdout">
-        <div class="location">at line 485</div>
+        <div class="location">at line 489</div>
         <code>                    string
     <strong>stdout</strong>()
         </code>
@@ -2429,7 +2434,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 496</div>
+        <div class="location">at line 500</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -2461,9 +2466,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 506</div>
+        <div class="location">at line 510</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>terminal</strong>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+    <strong>terminal</strong>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
     <div class="details">    
@@ -2485,6 +2490,11 @@
                     <tr>
                 <td>bool|null</td>
                 <td>$experimentalPrivilegedNesting</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null</td>
+                <td>$inheritWorkspace</td>
                 <td></td>
             </tr>
                     <tr>
@@ -2513,9 +2523,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_up">
-        <div class="location">at line 529</div>
+        <div class="location">at line 537</div>
         <code>                    void
-    <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+    <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
     <div class="details">    
@@ -2555,6 +2565,11 @@
                 <td></td>
             </tr>
                     <tr>
+                <td><abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null</td>
+                <td>$inheritWorkspace</td>
+                <td></td>
+            </tr>
+                    <tr>
                 <td>bool|null</td>
                 <td>$insecureRootCapabilities</td>
                 <td></td>
@@ -2590,7 +2605,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_user">
-        <div class="location">at line 570</div>
+        <div class="location">at line 582</div>
         <code>                    string
     <strong>user</strong>()
         </code>
@@ -2622,7 +2637,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAnnotation">
-        <div class="location">at line 579</div>
+        <div class="location">at line 591</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withAnnotation</strong>(string $name, string $value)
         </code>
@@ -2669,7 +2684,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultArgs">
-        <div class="location">at line 590</div>
+        <div class="location">at line 602</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultArgs</strong>(array $args)
         </code>
@@ -2711,7 +2726,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultTerminalCmd">
-        <div class="location">at line 600</div>
+        <div class="location">at line 612</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2763,7 +2778,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 619</div>
+        <div class="location">at line 631</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false, int|null $permissions = null)
         </code>
@@ -2845,7 +2860,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDockerHealthcheck">
-        <div class="location">at line 660</div>
+        <div class="location">at line 672</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDockerHealthcheck</strong>(array $args, bool|null $shell = null, string|null $interval = null, string|null $timeout = null, string|null $startPeriod = null, string|null $startInterval = null, int|null $retries = null)
         </code>
@@ -2917,7 +2932,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEntrypoint">
-        <div class="location">at line 695</div>
+        <div class="location">at line 707</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
@@ -2964,7 +2979,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvFileVariables">
-        <div class="location">at line 708</div>
+        <div class="location">at line 720</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvFileVariables</strong>(<a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a> $source)
         </code>
@@ -3006,7 +3021,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvVariable">
-        <div class="location">at line 718</div>
+        <div class="location">at line 730</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
@@ -3058,7 +3073,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 732</div>
+        <div class="location">at line 744</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -3100,9 +3115,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExec">
-        <div class="location">at line 742</div>
+        <div class="location">at line 754</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+    <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
     <div class="details">    
@@ -3157,6 +3172,11 @@
                 <td></td>
             </tr>
                     <tr>
+                <td><abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null</td>
+                <td>$inheritWorkspace</td>
+                <td></td>
+            </tr>
+                    <tr>
                 <td>bool|null</td>
                 <td>$insecureRootCapabilities</td>
                 <td></td>
@@ -3192,7 +3212,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExposedPort">
-        <div class="location">at line 799</div>
+        <div class="location">at line 815</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
@@ -3257,7 +3277,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 822</div>
+        <div class="location">at line 838</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3324,7 +3344,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 851</div>
+        <div class="location">at line 867</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3391,7 +3411,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withLabel">
-        <div class="location">at line 880</div>
+        <div class="location">at line 896</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withLabel</strong>(string $name, string $value)
         </code>
@@ -3438,7 +3458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedCache">
-        <div class="location">at line 891</div>
+        <div class="location">at line 907</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedCache</strong>(string $path, <a href="../Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a> $cache, <abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3510,7 +3530,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 924</div>
+        <div class="location">at line 940</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3577,7 +3597,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 953</div>
+        <div class="location">at line 969</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3639,7 +3659,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedSecret">
-        <div class="location">at line 978</div>
+        <div class="location">at line 994</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedSecret</strong>(string $path, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, int|null $mode = 256, bool|null $expand = false)
         </code>
@@ -3706,7 +3726,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedTemp">
-        <div class="location">at line 1007</div>
+        <div class="location">at line 1023</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
@@ -3758,7 +3778,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedVolume">
-        <div class="location">at line 1023</div>
+        <div class="location">at line 1039</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedVolume</strong>(string $path, <a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a> $volume, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3815,7 +3835,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 1044</div>
+        <div class="location">at line 1060</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3882,7 +3902,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRegistryAuth">
-        <div class="location">at line 1073</div>
+        <div class="location">at line 1089</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRegistryAuth</strong>(string $address, string $username, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -3934,7 +3954,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRootfs">
-        <div class="location">at line 1085</div>
+        <div class="location">at line 1101</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRootfs</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $directory)
         </code>
@@ -3976,7 +3996,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretVariable">
-        <div class="location">at line 1095</div>
+        <div class="location">at line 1111</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSecretVariable</strong>(string $name, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -4023,7 +4043,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceBinding">
-        <div class="location">at line 1112</div>
+        <div class="location">at line 1128</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withServiceBinding</strong>(string $alias, <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a> $service)
         </code>
@@ -4072,7 +4092,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 1123</div>
+        <div class="location">at line 1139</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
@@ -4124,7 +4144,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUnixSocket">
-        <div class="location">at line 1137</div>
+        <div class="location">at line 1153</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUnixSocket</strong>(string $path, <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -4186,7 +4206,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUser">
-        <div class="location">at line 1162</div>
+        <div class="location">at line 1178</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUser</strong>(string $name)
         </code>
@@ -4228,7 +4248,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withVolatileVariable">
-        <div class="location">at line 1174</div>
+        <div class="location">at line 1190</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withVolatileVariable</strong>(string $name, string $value)
         </code>
@@ -4275,7 +4295,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 1185</div>
+        <div class="location">at line 1201</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4322,7 +4342,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 1198</div>
+        <div class="location">at line 1214</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
@@ -4364,7 +4384,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 1208</div>
+        <div class="location">at line 1224</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
@@ -4396,7 +4416,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 1217</div>
+        <div class="location">at line 1233</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4443,7 +4463,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDockerHealthcheck">
-        <div class="location">at line 1230</div>
+        <div class="location">at line 1246</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDockerHealthcheck</strong>()
         </code>
@@ -4475,7 +4495,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1239</div>
+        <div class="location">at line 1255</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
@@ -4517,7 +4537,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1251</div>
+        <div class="location">at line 1267</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
@@ -4559,7 +4579,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1261</div>
+        <div class="location">at line 1277</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
@@ -4606,7 +4626,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1274</div>
+        <div class="location">at line 1290</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4653,7 +4673,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1287</div>
+        <div class="location">at line 1303</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
@@ -4700,7 +4720,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1300</div>
+        <div class="location">at line 1316</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
@@ -4742,7 +4762,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1310</div>
+        <div class="location">at line 1326</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4789,7 +4809,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1323</div>
+        <div class="location">at line 1339</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
@@ -4831,7 +4851,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1333</div>
+        <div class="location">at line 1349</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
@@ -4873,7 +4893,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1343</div>
+        <div class="location">at line 1359</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4920,7 +4940,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1358</div>
+        <div class="location">at line 1374</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
@@ -4952,7 +4972,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutVolatileVariable">
-        <div class="location">at line 1367</div>
+        <div class="location">at line 1383</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutVolatileVariable</strong>(string $name)
         </code>
@@ -4994,7 +5014,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1379</div>
+        <div class="location">at line 1395</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
@@ -5026,7 +5046,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1388</div>
+        <div class="location">at line 1404</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -366,7 +366,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_terminal">terminal</a>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+                    <a href="#method_terminal">terminal</a>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false)
         
                                             <p><p>Opens an interactive terminal in new container with this directory mounted inside.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1604,7 +1604,7 @@
                     <h3 id="method_terminal">
         <div class="location">at line 337</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>terminal</strong>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+    <strong>terminal</strong>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, <abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $inheritWorkspace = null, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
     <div class="details">    
@@ -1634,6 +1634,11 @@
                 <td></td>
             </tr>
                     <tr>
+                <td><abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null</td>
+                <td>$inheritWorkspace</td>
+                <td></td>
+            </tr>
+                    <tr>
                 <td>bool|null</td>
                 <td>$insecureRootCapabilities</td>
                 <td></td>
@@ -1659,7 +1664,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 362</div>
+        <div class="location">at line 366</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withChanges</strong>(<a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a> $changes)
         </code>
@@ -1701,7 +1706,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 372</div>
+        <div class="location">at line 376</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false, string|null $owner = &#039;&#039;, int|null $permissions = null)
         </code>
@@ -1773,7 +1778,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 405</div>
+        <div class="location">at line 409</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -1815,7 +1820,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 415</div>
+        <div class="location">at line 419</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, int|null $permissions = null, string|null $owner = &#039;&#039;)
         </code>
@@ -1872,7 +1877,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 432</div>
+        <div class="location">at line 436</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null)
         </code>
@@ -1924,7 +1929,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 446</div>
+        <div class="location">at line 450</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewDirectory</strong>(string $path, int|null $permissions = 420)
         </code>
@@ -1971,7 +1976,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 459</div>
+        <div class="location">at line 463</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2023,7 +2028,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatch">
-        <div class="location">at line 473</div>
+        <div class="location">at line 477</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatch</strong>(string $patch)
         </code>
@@ -2065,7 +2070,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatchFile">
-        <div class="location">at line 483</div>
+        <div class="location">at line 487</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatchFile</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $patch)
         </code>
@@ -2107,7 +2112,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 493</div>
+        <div class="location">at line 497</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName)
         </code>
@@ -2154,7 +2159,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 504</div>
+        <div class="location">at line 508</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>
@@ -2196,7 +2201,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 514</div>
+        <div class="location">at line 518</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2238,7 +2243,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 524</div>
+        <div class="location">at line 528</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2280,7 +2285,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 534</div>
+        <div class="location">at line 538</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFiles</strong>(array $paths)
         </code>

--- a/engine/engineutil/client.go
+++ b/engine/engineutil/client.go
@@ -105,7 +105,7 @@ type Client struct {
 }
 
 type sessionHandler interface {
-	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult)
+	ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed, dagql.AnyObjectResult, dagql.AnyObjectResult)
 }
 
 func NewOpts(opts Opts) (*Opts, error) {

--- a/engine/engineutil/executor.go
+++ b/engine/engineutil/executor.go
@@ -120,6 +120,7 @@ func (c *Client) Run(
 	nestedClientModule dagql.AnyObjectResult,
 	nestedClientFunctionCall dagql.Typed,
 	nestedClientEnv dagql.AnyObjectResult,
+	nestedClientWorkspace dagql.AnyObjectResult,
 ) (rerr error) {
 	if id == "" {
 		id = randid.NewID()
@@ -143,6 +144,7 @@ func (c *Client) Run(
 		nestedClientModule,
 		nestedClientFunctionCall,
 		nestedClientEnv,
+		nestedClientWorkspace,
 	)
 
 	execIdent := state.id

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -125,6 +125,7 @@ type execState struct {
 	nestedClientModule       dagql.AnyObjectResult
 	nestedClientFunctionCall dagql.Typed
 	nestedClientEnv          dagql.AnyObjectResult
+	nestedClientWorkspace    dagql.AnyObjectResult
 
 	doneErr error
 	done    chan struct{}
@@ -144,6 +145,7 @@ func newExecState(
 	nestedClientModule dagql.AnyObjectResult,
 	nestedClientFunctionCall dagql.Typed,
 	nestedClientEnv dagql.AnyObjectResult,
+	nestedClientWorkspace dagql.AnyObjectResult,
 ) *execState {
 	execMDCopy := &ExecutionMetadata{}
 	if execMD != nil {
@@ -166,6 +168,7 @@ func newExecState(
 		nestedClientModule:       nestedClientModule,
 		nestedClientFunctionCall: nestedClientFunctionCall,
 		nestedClientEnv:          nestedClientEnv,
+		nestedClientWorkspace:    nestedClientWorkspace,
 		done:                     make(chan struct{}),
 	}
 }
@@ -1085,7 +1088,7 @@ func (c *Client) setupNestedClient(ctx context.Context, state *execState) (rerr 
 	httpSrv := &http.Server{
 		ReadHeaderTimeout: 10 * time.Second,
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			c.SessionHandler.ServeHTTPToNestedClient(resp, req, state.nestedClientMetadata, state.callerClientID, false, state.nestedClientModule, state.nestedClientFunctionCall, state.nestedClientEnv)
+			c.SessionHandler.ServeHTTPToNestedClient(resp, req, state.nestedClientMetadata, state.callerClientID, false, state.nestedClientModule, state.nestedClientFunctionCall, state.nestedClientEnv, state.nestedClientWorkspace)
 		}),
 		Protocols: protocols,
 	}

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -162,6 +162,13 @@ type ClientMetadata struct {
 	// nested-client state and must not be forwarded through client headers.
 	UseRecipeIDsByDefault bool `json:"-"`
 
+	// InheritedWorkspace* selects matching ancestor module state for a trusted
+	// workspace object passed in-process to a nested client. These fields are
+	// engine-internal and must never be accepted from client headers.
+	InheritedWorkspaceBindingID string `json:"-"`
+	InheritedWorkspaceEnv       string `json:"-"`
+	InheritedWorkspaceEnvSet    bool   `json:"-"`
+
 	// Profile enables engine wall-clock profiling (wcprof) for the duration
 	// of this client's work. Experimental; the recorded events are retrieved
 	// via the engine debug endpoints.

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -216,6 +216,9 @@ type daggerClient struct {
 	// the set of modules being served to this client, with per-module
 	// install policy (constructor vs type-only)
 	servedMods *core.SchemaBuilder
+	// Workspace-origin modules only. Kept separate so an inherited workspace
+	// cannot also inherit parent -m or explicitly served modules.
+	servedWorkspaceMods *core.SchemaBuilder
 	// the default deps that each client/module starts out with (currently just core)
 	defaultDeps *core.SchemaBuilder
 
@@ -225,6 +228,9 @@ type daggerClient struct {
 
 	// If the client is executing in an Env context, this is that Env.
 	env dagql.ObjectResult[*core.Env]
+	// Explicit workspace context inherited by the command that started this
+	// nested client.
+	inheritedWorkspace dagql.ObjectResult[*core.Workspace]
 
 	// engine utility job-related state/config
 	hostServiceProxyClientID string
@@ -259,6 +265,20 @@ type daggerClient struct {
 	// Cached workspace result from ensureWorkspaceLoaded.
 	workspace *core.Workspace
 
+	// Stable identity and environment for the loaded workspace binding.
+	workspaceBindingID string
+	workspaceEnv       string
+	workspaceEnvSet    bool
+	// workspaceModulesRequested lets an inherited child ask this client to
+	// gather workspace module state even when the client did not request that
+	// schema for itself.
+	workspaceModulesRequested atomic.Bool
+
+	// Serializes inherited demand, ancestor loading, and snapshot application.
+	// This preserves one-shot module scope and monotonic snapshots across
+	// concurrent requests.
+	inheritedWorkspaceModulesMu sync.Mutex
+
 	pendingModules      []pendingModule      // gathered in detectAndLoadWorkspaceWithRootfs
 	pendingExtraModules []engine.ExtraModule // populated from clientMD, can arrive late
 	modulesMu           sync.Mutex
@@ -271,6 +291,8 @@ type daggerClient struct {
 	entrypointServed bool
 	// resolved identities already served, for cross-batch deduplication
 	servedModuleKeys map[string]struct{}
+	// Resolved identities served specifically from workspace configuration.
+	servedWorkspaceModuleKeys map[string]struct{}
 	// served workspace module names, so demand filters recognize them without
 	// reloading
 	servedWorkspaceModuleNames map[string]struct{}
@@ -278,6 +300,7 @@ type daggerClient struct {
 	// scope is one-shot so later introspections load everything (guarded by
 	// modulesMu)
 	workspaceModuleScopeConsumed bool
+	workspaceEntrypointServed    bool
 	singleQueryMu                sync.Mutex
 	singleQueryServed            bool
 
@@ -778,6 +801,9 @@ type ClientInitOpts struct {
 
 	// If the client is executing in an Env context, this is that Env.
 	EnvContext dagql.ObjectResult[*core.Env]
+
+	// If the command explicitly inherited a workspace, this is that workspace.
+	InheritedWorkspace dagql.ObjectResult[*core.Workspace]
 }
 
 // requires that client.stateMu is held
@@ -886,6 +912,10 @@ func (srv *Server) initializeDaggerClient(
 			return fmt.Errorf("attach env context during client init: expected %T, got %T", opts.EnvContext, attached)
 		}
 		client.env = envInst
+	}
+
+	if err := initializeInheritedWorkspace(ctx, client, opts); err != nil {
+		return err
 	}
 
 	if opts.ModuleContext.Self() != nil {
@@ -1012,6 +1042,26 @@ func (srv *Server) initializeDaggerClient(
 	client.meterProvider = sdkmetric.NewMeterProvider(meterOpts...)
 
 	client.state = clientStateInitialized
+	return nil
+}
+
+func initializeInheritedWorkspace(ctx context.Context, client *daggerClient, opts *ClientInitOpts) error {
+	if opts.InheritedWorkspace.Self() == nil {
+		return nil
+	}
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get engine cache for inherited workspace: %w", err)
+	}
+	attached, err := cache.AttachResult(ctx, opts.SessionID, client.dag, opts.InheritedWorkspace)
+	if err != nil {
+		return fmt.Errorf("attach inherited workspace during client init: %w", err)
+	}
+	workspace, ok := attached.(dagql.ObjectResult[*core.Workspace])
+	if !ok {
+		return fmt.Errorf("attach inherited workspace during client init: expected %T, got %T", opts.InheritedWorkspace, attached)
+	}
+	client.inheritedWorkspace = workspace
 	return nil
 }
 
@@ -1447,6 +1497,7 @@ func (srv *Server) ServeHTTPToNestedClient(
 	moduleCtx dagql.AnyObjectResult,
 	functionCall dagql.Typed,
 	envCtx dagql.AnyObjectResult,
+	workspaceCtx dagql.AnyObjectResult,
 ) {
 	if nestedClientMetadata == nil {
 		http.Error(w, "nested client metadata is nil", http.StatusInternalServerError)
@@ -1488,6 +1539,18 @@ func (srv *Server) ServeHTTPToNestedClient(
 		}
 	}
 
+	var inheritedWorkspace dagql.ObjectResult[*core.Workspace]
+	if workspaceCtx != nil {
+		typed, ok := workspaceCtx.(dagql.ObjectResult[*core.Workspace])
+		if !ok {
+			http.Error(w, fmt.Sprintf("nested client workspace context is %T, not Workspace", workspaceCtx), http.StatusInternalServerError)
+			return
+		}
+		if typed.Self() != nil {
+			inheritedWorkspace = typed
+		}
+	}
+
 	var hostServiceProxyClientID string
 	if hostServiceProxyToCaller {
 		hostServiceProxyClientID = callerClientID
@@ -1500,6 +1563,7 @@ func (srv *Server) ServeHTTPToNestedClient(
 		ModuleContext:            moduleContext,
 		FunctionCall:             fnCall,
 		EnvContext:               envContext,
+		InheritedWorkspace:       inheritedWorkspace,
 	}).ServeHTTP(w, r)
 }
 
@@ -1920,27 +1984,43 @@ func (srv *Server) ensureRequestModulesLoaded(ctx context.Context, client *dagge
 // sensitive tests can observe the client immediately after module loading
 // returns, before any subsequent request finalization.
 func (srv *Server) ensureRequestModulesLoadedWithPostLoad(ctx context.Context, client *daggerClient, r *http.Request, postLoad func()) error {
+	mode, _ := workspaceBindingMode(client)
+	inheritWorkspaceModules := mode == workspaceBindingInherited && clientLoadsWorkspaceModules(client)
+
+	var rootFields []string
+	hasRootFields := false
+	if client.hasPendingWorkspaceModules() || inheritWorkspaceModules {
+		if ok, fields, err := dagql.PeekRootFields(r); err == nil && ok {
+			rootFields = fields
+			hasRootFields = true
+		}
+	}
+
+	if inheritWorkspaceModules {
+		if err := srv.inheritExplicitWorkspaceModules(ctx, client, rootFields, hasRootFields); err != nil {
+			return err
+		}
+	}
+
 	var filter func([]pendingModule) []pendingModule
 	scopeApplied := false
-	if client.hasPendingWorkspaceModules() {
-		if ok, rootFields, err := dagql.PeekRootFields(r); err == nil && ok {
-			filter = func(mods []pendingModule) []pendingModule {
-				// runs under client.modulesMu, which also guards
-				// servedWorkspaceModuleNames and workspaceModuleScopeConsumed
-				scope := client.pendingWorkspaceModuleScopeLocked()
-				selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, client.servedWorkspaceModuleNames, client.failedModules, rootFields, scope, client.entrypointServed)
-				if applied {
-					scopeApplied = true
-					names := make([]string, 0, len(selected))
-					for _, mod := range selected {
-						names = append(names, moduleProgressName(mod))
-					}
-					slog.Debug("narrowing workspace module load to client scope",
-						"scope", scope,
-						"modules", names)
+	if client.hasPendingWorkspaceModules() && hasRootFields {
+		filter = func(mods []pendingModule) []pendingModule {
+			// runs under client.modulesMu, which also guards
+			// servedWorkspaceModuleNames and workspaceModuleScopeConsumed
+			scope := client.pendingWorkspaceModuleScopeLocked()
+			selected, applied := filterPendingWorkspaceModulesForScopedRootFields(mods, client.servedWorkspaceModuleNames, client.failedModules, rootFields, scope, client.entrypointServed)
+			if applied {
+				scopeApplied = true
+				names := make([]string, 0, len(selected))
+				for _, mod := range selected {
+					names = append(names, moduleProgressName(mod))
 				}
-				return selected
+				slog.Debug("narrowing workspace module load to client scope",
+					"scope", scope,
+					"modules", names)
 			}
+			return selected
 		}
 	}
 	_, err := srv.ensureModulesLoadedModeWithSuccess(ctx, client, filter, false, func() {
@@ -2145,17 +2225,37 @@ func (srv *Server) ServeModule(ctx context.Context, mod dagql.ObjectResult[*core
 //
 // Not threadsafe: client.stateMu must be held when calling.
 func (srv *Server) serveModule(client *daggerClient, mod core.Mod, opts core.InstallOpts) error {
-	existing, ok := client.servedMods.Lookup(mod.Name())
+	builder, err := schemaBuilderWithModule(client.servedMods, client.dagqlRoot, mod, opts)
+	if err != nil {
+		return err
+	}
+	client.servedMods = builder
+	return nil
+}
+
+func (srv *Server) serveWorkspaceModule(client *daggerClient, mod core.Mod, opts core.InstallOpts) error {
+	builder, err := schemaBuilderWithModule(client.servedWorkspaceMods, client.dagqlRoot, mod, opts)
+	if err != nil {
+		return err
+	}
+	client.servedWorkspaceMods = builder
+	return nil
+}
+
+func schemaBuilderWithModule(builder *core.SchemaBuilder, root *core.Query, mod core.Mod, opts core.InstallOpts) (*core.SchemaBuilder, error) {
+	if builder == nil {
+		builder = core.NewSchemaBuilder(root, nil)
+	}
+	existing, ok := builder.Lookup(mod.Name())
 	if ok {
 		if !isSameModuleReference(existing.GetSource(), mod.GetSource()) {
-			return fmt.Errorf("module %s (source: %s | pin: %s) already exists with different source %s (pin: %s)",
+			return nil, fmt.Errorf("module %s (source: %s | pin: %s) already exists with different source %s (pin: %s)",
 				mod.Name(), mod.GetSource().AsString(), mod.GetSource().Pin(), existing.GetSource().AsString(), existing.GetSource().Pin(),
 			)
 		}
 	}
 	// With handles deduplication and promotion internally.
-	client.servedMods = client.servedMods.With(mod, opts)
-	return nil
+	return builder.With(mod, opts), nil
 }
 
 // Returns true if the module source a is the same as b or they come from the

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1677,6 +1677,139 @@ func TestEnsureWorkspaceLoadedKeepsExistingWorkspaceBinding(t *testing.T) {
 	require.Same(t, existing, child.workspace)
 }
 
+func TestInheritedWorkspaceCopiesMatchingAncestorModuleState(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	workspace := sessionTestWorkspaceResult(t)
+	bound := workspace.Self()
+	parentMod := sessionTestModuleResultWithSource(t, "greeter", "parent")
+	childMod := sessionTestModuleResultWithSource(t, "greeter", "child")
+	workspaceMods := core.NewSchemaBuilder(core.NewRoot(srv), nil).
+		With(core.NewUserMod(parentMod), core.InstallOpts{Entrypoint: true})
+	matching := &daggerClient{
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+		},
+		dagqlRoot:                 core.NewRoot(srv),
+		workspace:                 bound,
+		pendingWorkspaceLoad:      true,
+		workspaceLoaded:           true,
+		workspaceBindingID:        "matching-binding",
+		workspaceEnv:              "ci",
+		workspaceEnvSet:           true,
+		servedMods:                core.NewSchemaBuilder(core.NewRoot(srv), nil),
+		servedWorkspaceMods:       workspaceMods,
+		servedWorkspaceModuleKeys: map[string]struct{}{"workspace-module": {}},
+		workspaceEntrypointServed: true,
+		extraModulesLoaded:        true,
+		extraModulesErr:           errors.New("broken parent extra"),
+	}
+	carrier := &daggerClient{
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+		},
+		inheritedWorkspace: workspace,
+		workspace:          bound,
+		workspaceLoaded:    true,
+		workspaceBindingID: "matching-binding",
+		extraModulesLoaded: true,
+		extraModulesErr:    errors.New("broken carrier extra"),
+	}
+	child := &daggerClient{
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+		},
+		dagqlRoot: core.NewRoot(srv),
+		servedMods: core.NewSchemaBuilder(core.NewRoot(srv), nil).
+			With(core.NewUserMod(childMod), core.InstallOpts{Entrypoint: true}),
+		workspace:          bound,
+		workspaceBindingID: "matching-binding",
+		workspaceEnv:       "ci",
+		workspaceEnvSet:    true,
+		parents:            []*daggerClient{matching, carrier},
+	}
+
+	require.NoError(t, srv.inheritExplicitWorkspaceModules(context.Background(), child, nil, false))
+	require.NotNil(t, child.servedWorkspaceMods)
+	require.NotSame(t, workspaceMods, child.servedWorkspaceMods)
+	require.True(t, child.workspaceEntrypointServed)
+	require.True(t, child.entrypointServed)
+	require.Empty(t, child.servedModuleKeys)
+	got, ok := child.servedMods.Lookup("greeter")
+	require.True(t, ok)
+	require.Same(t, childMod.Self(), got.ModuleResult().Self(), "the child's explicit module must win a name collision")
+
+	secondParentMod := sessionTestModuleResultWithSource(t, "farewell", "parent")
+	matching.modulesMu.Lock()
+	matching.stateMu.Lock()
+	matching.servedWorkspaceMods = matching.servedWorkspaceMods.
+		With(core.NewUserMod(secondParentMod), core.InstallOpts{})
+	matching.servedWorkspaceModuleKeys["second-workspace-module"] = struct{}{}
+	matching.stateMu.Unlock()
+	matching.modulesMu.Unlock()
+
+	require.NoError(t, srv.inheritExplicitWorkspaceModules(context.Background(), child, nil, false))
+	require.Len(t, child.servedWorkspaceMods.Mods(), 2, "successive snapshots must be cumulative")
+}
+
+func TestInheritedWorkspaceWithoutMatchingAncestorKeepsCoreSchema(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	servedMods := core.NewSchemaBuilder(core.NewRoot(srv), nil)
+	child := &daggerClient{
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+		},
+		dagqlRoot:          core.NewRoot(srv),
+		servedMods:         servedMods,
+		workspace:          &core.Workspace{ClientID: "workspace-owner"},
+		workspaceBindingID: "missing-binding",
+	}
+
+	require.NoError(t, srv.inheritExplicitWorkspaceModules(context.Background(), child, nil, false))
+	require.Same(t, servedMods, child.servedMods)
+	require.Nil(t, child.servedWorkspaceMods)
+}
+
+func TestInheritedWorkspaceModuleFailureIsRetried(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	workspace := sessionTestWorkspaceResult(t)
+	parent := &daggerClient{
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+		},
+		dagqlRoot:                 core.NewRoot(srv),
+		servedMods:                core.NewSchemaBuilder(core.NewRoot(srv), nil),
+		servedWorkspaceMods:       core.NewSchemaBuilder(core.NewRoot(srv), nil),
+		workspace:                 workspace.Self(),
+		pendingWorkspaceLoad:      true,
+		workspaceLoaded:           true,
+		workspaceErr:              errors.New("transient workspace load"),
+		workspaceBindingID:        "binding",
+		workspaceEntrypointServed: true,
+	}
+	child := &daggerClient{
+		clientMetadata: &engine.ClientMetadata{
+			LoadWorkspaceModules:        true,
+			InheritedWorkspaceBindingID: "binding",
+		},
+		dagqlRoot:          core.NewRoot(srv),
+		servedMods:         core.NewSchemaBuilder(core.NewRoot(srv), nil),
+		inheritedWorkspace: workspace,
+		parents:            []*daggerClient{parent},
+	}
+
+	require.NoError(t, srv.loadInheritedWorkspaceBinding(child))
+	require.ErrorContains(t, srv.inheritExplicitWorkspaceModules(context.Background(), child, nil, false), "transient workspace load")
+
+	parent.workspaceErr = nil
+	require.NoError(t, srv.inheritExplicitWorkspaceModules(context.Background(), child, nil, false))
+}
+
 func TestResolveHostServiceCallerFallsBackToParentForSyntheticNestedClient(t *testing.T) {
 	t.Parallel()
 
@@ -1749,7 +1882,8 @@ func TestWorkspaceBindingMode(t *testing.T) {
 		t.Parallel()
 
 		client := &daggerClient{
-			pendingWorkspaceLoad: false,
+			pendingWorkspaceLoad: true,
+			inheritedWorkspace:   sessionTestWorkspaceResult(t),
 			clientMetadata: &engine.ClientMetadata{
 				Workspace: stringPtr("github.com/dagger/dagger@main"),
 			},
@@ -1758,6 +1892,20 @@ func TestWorkspaceBindingMode(t *testing.T) {
 		mode, workspaceRef := workspaceBindingMode(client)
 		require.Equal(t, workspaceBindingDeclared, mode)
 		require.Equal(t, "github.com/dagger/dagger@main", workspaceRef)
+	})
+
+	t.Run("inherited workspace takes precedence over host detection", func(t *testing.T) {
+		t.Parallel()
+
+		client := &daggerClient{
+			pendingWorkspaceLoad: true,
+			inheritedWorkspace:   sessionTestWorkspaceResult(t),
+			clientMetadata:       &engine.ClientMetadata{},
+		}
+
+		mode, workspaceRef := workspaceBindingMode(client)
+		require.Equal(t, workspaceBindingInherited, mode)
+		require.Empty(t, workspaceRef)
 	})
 
 	t.Run("non-module defaults to host detection", func(t *testing.T) {
@@ -1863,13 +2011,16 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			ExtraModules: []engine.ExtraModule{{
 				Ref: "github.com/dagger/base-extra",
 			}},
-			LoadWorkspaceModules:  true,
-			EagerRuntime:          true,
-			LockMode:              string(workspace.LockModeFrozen),
-			Workspace:             stringPtr("github.com/dagger/base@main"),
-			WorkspaceEnv:          stringPtr("parent-ci"),
-			WorkspaceModuleScope:  "parent-scope",
-			UseRecipeIDsByDefault: true,
+			LoadWorkspaceModules:        true,
+			EagerRuntime:                true,
+			LockMode:                    string(workspace.LockModeFrozen),
+			Workspace:                   stringPtr("github.com/dagger/base@main"),
+			WorkspaceEnv:                stringPtr("parent-ci"),
+			WorkspaceModuleScope:        "parent-scope",
+			UseRecipeIDsByDefault:       true,
+			InheritedWorkspaceBindingID: "trusted-binding",
+			InheritedWorkspaceEnv:       "trusted-ci",
+			InheritedWorkspaceEnvSet:    true,
 		}
 	}
 
@@ -1896,6 +2047,9 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 		require.Nil(t, md.WorkspaceEnv)
 		require.Empty(t, md.WorkspaceModuleScope)
 		require.True(t, md.UseRecipeIDsByDefault)
+		require.Equal(t, "trusted-binding", md.InheritedWorkspaceBindingID)
+		require.Equal(t, "trusted-ci", md.InheritedWorkspaceEnv)
+		require.True(t, md.InheritedWorkspaceEnvSet)
 
 		base.AllowedLLMModules[0] = "mutated"
 		require.Equal(t, []string{"parent"}, md.AllowedLLMModules)
@@ -1929,6 +2083,9 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			Workspace:                      &workspaceRef,
 			WorkspaceEnv:                   &workspaceEnv,
 			WorkspaceModuleScope:           "good-mod",
+			InheritedWorkspaceBindingID:    "forged-binding",
+			InheritedWorkspaceEnv:          "forged-env",
+			InheritedWorkspaceEnvSet:       true,
 		}
 
 		md := nestedClientMetadataForRequest(forwarded.AppendToHTTPHeaders(http.Header{}), baseMetadata())
@@ -1955,6 +2112,9 @@ func TestNestedClientMetadataForRequest(t *testing.T) {
 			Entrypoint: true,
 		}}, md.ExtraModules)
 		require.True(t, md.UseRecipeIDsByDefault)
+		require.Equal(t, "trusted-binding", md.InheritedWorkspaceBindingID)
+		require.Equal(t, "trusted-ci", md.InheritedWorkspaceEnv)
+		require.True(t, md.InheritedWorkspaceEnvSet)
 	})
 
 	t.Run("keeps parent lock mode when forwarded metadata omits it", func(t *testing.T) {
@@ -2268,6 +2428,10 @@ func stringPtr(v string) *string {
 }
 
 func sessionTestModuleResult(t *testing.T, name string) dagql.ObjectResult[*core.Module] {
+	return sessionTestModuleResultWithSource(t, name, name)
+}
+
+func sessionTestModuleResultWithSource(t *testing.T, name, source string) dagql.ObjectResult[*core.Module] {
 	t.Helper()
 
 	dag, err := dagql.NewServer(t.Context(), &core.Module{})
@@ -2275,7 +2439,21 @@ func sessionTestModuleResult(t *testing.T, name string) dagql.ObjectResult[*core
 	res, err := dagql.NewObjectResultForCall(
 		&core.Module{NameField: name},
 		dag,
-		&dagql.ResultCall{SyntheticOp: "session-test-module-" + name},
+		&dagql.ResultCall{SyntheticOp: "session-test-module-" + source},
+	)
+	require.NoError(t, err)
+	return res
+}
+
+func sessionTestWorkspaceResult(t *testing.T) dagql.ObjectResult[*core.Workspace] {
+	t.Helper()
+
+	dag, err := dagql.NewServer(t.Context(), &core.Workspace{})
+	require.NoError(t, err)
+	res, err := dagql.NewObjectResultForCall(
+		&core.Workspace{Address: "test://workspace"},
+		dag,
+		&dagql.ResultCall{SyntheticOp: "session-test-workspace"},
 	)
 	require.NoError(t, err)
 	return res

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/engine/telemetryattrs"
+	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/dagger/dagger/util/gitutil"
 	"github.com/dagger/dagger/util/parallel"
 )
@@ -45,12 +47,28 @@ func (srv *Server) invalidateClientWorkspace(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	client.inheritedWorkspaceModulesMu.Lock()
+	defer client.inheritedWorkspaceModulesMu.Unlock()
+
 	client.workspaceMu.Lock()
-	defer client.workspaceMu.Unlock()
 	client.workspaceLoaded = false
 	client.workspaceErr = nil
 	client.workspace = nil
+	client.workspaceBindingID = ""
+	client.workspaceEnv = ""
+	client.workspaceEnvSet = false
+	client.workspaceModulesRequested.Store(false)
 	client.pendingModules = nil
+	client.workspaceMu.Unlock()
+
+	client.modulesMu.Lock()
+	client.stateMu.Lock()
+	client.servedWorkspaceMods = nil
+	client.servedWorkspaceModuleKeys = nil
+	client.servedWorkspaceModuleNames = nil
+	client.workspaceEntrypointServed = false
+	client.stateMu.Unlock()
+	client.modulesMu.Unlock()
 	return nil
 }
 
@@ -64,6 +82,74 @@ func (srv *Server) CurrentWorkspace(ctx context.Context) (*core.Workspace, error
 		return nil, fmt.Errorf("%w: workspace not loaded", core.ErrNoCurrentWorkspace)
 	}
 	return client.workspace, nil
+}
+
+func (srv *Server) CaptureInheritedWorkspaceBinding(
+	ctx context.Context,
+	workspace dagql.ObjectResult[*core.Workspace],
+) (*core.InheritedWorkspaceBinding, error) {
+	if workspace.Self() == nil {
+		return nil, fmt.Errorf("workspace is nil")
+	}
+	client, err := srv.clientFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := append(slices.Clone(client.parents), client)
+	var fallback *core.InheritedWorkspaceBinding
+	for i := len(candidates) - 1; i >= 0; i-- {
+		candidate := candidates[i]
+		if err := srv.ensureWorkspaceLoaded(workspaceClientContext(ctx, candidate), candidate); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+			// Provenance is optional: an arbitrary Workspace is still valid for
+			// currentWorkspace even when an unrelated client binding cannot load.
+			continue
+		}
+		candidate.workspaceMu.Lock()
+		if candidate.workspace != workspace.Self() {
+			candidate.workspaceMu.Unlock()
+			continue
+		}
+		if candidate.workspaceBindingID == "" {
+			candidate.workspaceBindingID = identity.NewID()
+		}
+		binding := &core.InheritedWorkspaceBinding{
+			Workspace:       workspace,
+			BindingID:       candidate.workspaceBindingID,
+			WorkspaceEnv:    candidate.workspaceEnv,
+			HasWorkspaceEnv: candidate.workspaceEnvSet,
+		}
+		candidate.workspaceMu.Unlock()
+		if clientLoadsWorkspaceModules(candidate) {
+			return binding, nil
+		}
+		if fallback == nil {
+			fallback = binding
+		}
+	}
+
+	if fallback != nil {
+		return fallback, nil
+	}
+	return &core.InheritedWorkspaceBinding{
+		Workspace: workspace,
+	}, nil
+}
+
+func workspaceClientContext(ctx context.Context, client *daggerClient) context.Context {
+	if client == nil {
+		return ctx
+	}
+	if client.clientMetadata != nil {
+		ctx = engine.ContextWithClientMetadata(ctx, client.clientMetadata)
+	}
+	if client.dagqlRoot != nil {
+		ctx = core.ContextWithQuery(ctx, client.dagqlRoot)
+	}
+	return ctx
 }
 
 func canonicalModuleReference(src *core.ModuleSource) string {
@@ -92,6 +178,9 @@ func (srv *Server) ensureWorkspaceLoaded(ctx context.Context, client *daggerClie
 	if mode == workspaceBindingInherit {
 		return srv.inheritWorkspaceBinding(ctx, client)
 	}
+	if mode == workspaceBindingInherited {
+		return srv.loadInheritedWorkspaceBinding(client)
+	}
 
 	client.workspaceMu.Lock()
 	defer client.workspaceMu.Unlock()
@@ -117,6 +206,11 @@ func (srv *Server) ensureWorkspaceLoaded(ctx context.Context, client *daggerClie
 	}
 	if err != nil {
 		client.workspaceErr = err
+	} else if client.workspace != nil {
+		if client.workspaceBindingID == "" {
+			client.workspaceBindingID = identity.NewID()
+		}
+		client.workspaceEnv, client.workspaceEnvSet = workspaceEnvFromClientMetadata(client.clientMetadata)
 	}
 
 	client.workspaceLoaded = true
@@ -127,20 +221,79 @@ type workspaceBindingModeType string
 
 const (
 	workspaceBindingDeclared   workspaceBindingModeType = "declared"
+	workspaceBindingInherited  workspaceBindingModeType = "inherited"
 	workspaceBindingDetectHost workspaceBindingModeType = "detect_host"
 	workspaceBindingInherit    workspaceBindingModeType = "inherit"
 )
 
 // workspaceBindingMode resolves binding behavior for the current client:
-// explicit workspace declaration, own host detection, or parent inheritance.
+// explicit workspace declaration, execution-scoped inherited workspace, own
+// host detection, or ordinary parent inheritance.
 func workspaceBindingMode(client *daggerClient) (workspaceBindingModeType, string) {
 	if workspaceRef, ok := workspaceRefFromClientMetadata(client.clientMetadata); ok {
 		return workspaceBindingDeclared, workspaceRef
+	}
+	if client.inheritedWorkspace.Self() != nil {
+		return workspaceBindingInherited, ""
 	}
 	if client.pendingWorkspaceLoad {
 		return workspaceBindingDetectHost, ""
 	}
 	return workspaceBindingInherit, ""
+}
+
+func clientLoadsWorkspaceModules(client *daggerClient) bool {
+	if client == nil {
+		return false
+	}
+	if client.workspaceModulesRequested.Load() {
+		return true
+	}
+	return client.clientMetadata != nil &&
+		client.clientMetadata.LoadWorkspaceModules &&
+		!client.clientMetadata.SkipWorkspaceModules
+}
+
+func (srv *Server) loadInheritedWorkspaceBinding(client *daggerClient) error {
+	client.workspaceMu.Lock()
+	if client.workspaceLoaded {
+		err := client.workspaceErr
+		client.workspaceMu.Unlock()
+		return err
+	}
+
+	if client.inheritedWorkspace.Self() == nil {
+		client.workspaceErr = fmt.Errorf("inherited workspace is nil")
+		client.workspaceLoaded = true
+		client.workspaceMu.Unlock()
+		return client.workspaceErr
+	}
+	client.workspace = client.inheritedWorkspace.Self()
+	if client.clientMetadata != nil {
+		client.workspaceBindingID = client.clientMetadata.InheritedWorkspaceBindingID
+		client.workspaceEnv = client.clientMetadata.InheritedWorkspaceEnv
+		client.workspaceEnvSet = client.clientMetadata.InheritedWorkspaceEnvSet
+		if requestedEnv, ok := workspaceEnvFromClientMetadata(client.clientMetadata); ok {
+			if !client.workspaceEnvSet || requestedEnv != client.workspaceEnv {
+				client.workspaceErr = fmt.Errorf(
+					"workspace env %q does not match inherited workspace env %q; explicitly select a workspace to change environments",
+					requestedEnv,
+					client.workspaceEnv,
+				)
+			}
+		}
+	}
+	if client.workspaceBindingID == "" {
+		client.workspaceBindingID = identity.NewID()
+	}
+	client.workspaceLoaded = true
+	err := client.workspaceErr
+	client.workspaceMu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // workspaceRefFromClientMetadata returns the explicitly declared workspace
@@ -192,12 +345,20 @@ func (srv *Server) inheritWorkspaceBinding(ctx context.Context, client *daggerCl
 		if isModuleRuntimeClient(client) && isModuleRuntimeClient(parent) {
 			return nil
 		}
+		// Ordinary inheritance preserves the active request context; workspace
+		// loading may depend on the child request's SDK-managed module state.
 		if err := srv.ensureWorkspaceLoaded(ctx, parent); err != nil {
 			return err
 		}
 
 		parent.workspaceMu.Lock()
+		if parent.workspace != nil && parent.workspaceBindingID == "" {
+			parent.workspaceBindingID = identity.NewID()
+		}
 		parentWorkspace := parent.workspace
+		parentBindingID := parent.workspaceBindingID
+		parentWorkspaceEnv := parent.workspaceEnv
+		parentWorkspaceEnvSet := parent.workspaceEnvSet
 		parent.workspaceMu.Unlock()
 		if parentWorkspace == nil {
 			continue
@@ -206,6 +367,9 @@ func (srv *Server) inheritWorkspaceBinding(ctx context.Context, client *daggerCl
 		client.workspaceMu.Lock()
 		if client.workspace == nil {
 			client.workspace = parentWorkspace
+			client.workspaceBindingID = parentBindingID
+			client.workspaceEnv = parentWorkspaceEnv
+			client.workspaceEnvSet = parentWorkspaceEnvSet
 		}
 		client.workspaceMu.Unlock()
 		return nil
@@ -629,10 +793,7 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	prebuiltSource core.WorkspaceSource,
 ) error {
 	clientMD := client.clientMetadata
-	loadModules := client.pendingWorkspaceLoad &&
-		clientMD != nil &&
-		clientMD.LoadWorkspaceModules &&
-		!clientMD.SkipWorkspaceModules
+	loadModules := client.pendingWorkspaceLoad && clientLoadsWorkspaceModules(client)
 	workspaceEnv, hasWorkspaceEnv := workspaceEnvFromClientMetadata(clientMD)
 
 	// --- Detect workspace (pure — no dagger.json knowledge) ---
@@ -949,6 +1110,26 @@ func (srv *Server) ensureModulesLoadedMode(ctx context.Context, client *daggerCl
 // load while modulesMu is still held. Callers use it for state transitions
 // that must be atomic with the load becoming visible to another request.
 func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool, onSuccessLocked func()) (loadFailures []string, rerr error) {
+	return srv.ensureModulesLoadedModeWithOptions(ctx, client, filter, bestEffort, true, onSuccessLocked)
+}
+
+func (srv *Server) ensureWorkspaceModulesLoadedMode(
+	ctx context.Context,
+	client *daggerClient,
+	filter func([]pendingModule) []pendingModule,
+	bestEffort bool,
+) (loadFailures []string, rerr error) {
+	return srv.ensureModulesLoadedModeWithOptions(ctx, client, filter, bestEffort, false, nil)
+}
+
+func (srv *Server) ensureModulesLoadedModeWithOptions(
+	ctx context.Context,
+	client *daggerClient,
+	filter func([]pendingModule) []pendingModule,
+	bestEffort bool,
+	loadExtraModules bool,
+	onSuccessLocked func(),
+) (loadFailures []string, rerr error) {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
 	defer func() {
@@ -957,8 +1138,10 @@ func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, clien
 		}
 	}()
 
-	if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
-		return nil, err
+	if loadExtraModules {
+		if err := srv.ensureExtraModulesLoadedLocked(ctx, client); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(client.pendingModules) == 0 {
@@ -1053,6 +1236,12 @@ func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, clien
 // ensureExtraModulesLoadedLocked loads -m modules. They are explicitly
 // requested, so they load eagerly with sticky failures (unlike on-demand
 // workspace modules). client.modulesMu must be held.
+func (srv *Server) ensureExtraModulesLoaded(ctx context.Context, client *daggerClient) error {
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+	return srv.ensureExtraModulesLoadedLocked(ctx, client)
+}
+
 func (srv *Server) ensureExtraModulesLoadedLocked(ctx context.Context, client *daggerClient) error {
 	if client.extraModulesLoaded {
 		return client.extraModulesErr
@@ -1610,34 +1799,241 @@ func (srv *Server) serveResolvedModuleLoadsLocked(client *daggerClient, loads []
 	for i := range loads {
 		load := resolved[i]
 		key := resolvedModuleLoadIdentity(load.primary)
-		if _, ok := client.servedModuleKeys[key]; ok {
-			continue
-		}
-		for _, related := range load.related {
-			if err := srv.serveModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: related.entrypoint}); err != nil {
-				return fmt.Errorf("error serving related module %s: %w", related.mod.Self().Name(), err)
-			}
-		}
-		if err := srv.serveModule(client, core.NewUserMod(load.primary), core.InstallOpts{Entrypoint: load.primaryEntrypoint}); err != nil {
-			return moduleLoadErr(loads[i], err)
-		}
-		// For the entrypoint module (the one the user targets via dagger call),
-		// also serve its direct dependencies so the client schema can resolve
-		// concrete types behind interfaces. This mirrors the includeDependencies
-		// behavior from `main`. Toolchain/non-entrypoint deps stay internal.
-		if load.primaryEntrypoint {
-			for _, dep := range load.primary.Self().Deps.Mods() {
-				if err := srv.serveModule(client, dep, core.InstallOpts{SkipConstructor: true}); err != nil {
-					return fmt.Errorf("error serving entrypoint dependency %s: %w", dep.Name(), err)
+		if _, alreadyServed := client.servedModuleKeys[key]; !alreadyServed {
+			for _, related := range load.related {
+				if err := srv.serveModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: related.entrypoint}); err != nil {
+					return fmt.Errorf("error serving related module %s: %w", related.mod.Self().Name(), err)
 				}
 			}
+			if err := srv.serveModule(client, core.NewUserMod(load.primary), core.InstallOpts{Entrypoint: load.primaryEntrypoint}); err != nil {
+				return moduleLoadErr(loads[i], err)
+			}
+			// For the entrypoint module (the one the user targets via dagger call),
+			// also serve its direct dependencies so the client schema can resolve
+			// concrete types behind interfaces. This mirrors the includeDependencies
+			// behavior from `main`. Toolchain/non-entrypoint deps stay internal.
+			if load.primaryEntrypoint {
+				for _, dep := range load.primary.Self().Deps.Mods() {
+					if err := srv.serveModule(client, dep, core.InstallOpts{SkipConstructor: true}); err != nil {
+						return fmt.Errorf("error serving entrypoint dependency %s: %w", dep.Name(), err)
+					}
+				}
+			}
+			if client.servedModuleKeys == nil {
+				client.servedModuleKeys = make(map[string]struct{})
+			}
+			client.servedModuleKeys[key] = struct{}{}
 		}
-		if client.servedModuleKeys == nil {
-			client.servedModuleKeys = make(map[string]struct{})
+
+		if loads[i].mod.Kind != moduleLoadKindAmbient {
+			continue
 		}
-		client.servedModuleKeys[key] = struct{}{}
+		if _, alreadyServed := client.servedWorkspaceModuleKeys[key]; alreadyServed {
+			continue
+		}
+		workspacePrimaryEntrypoint := loads[i].mod.Entrypoint
+		workspaceEntrypointServed := false
+		for _, related := range load.related {
+			relatedEntrypoint := loads[i].mod.Entrypoint && related.entrypoint
+			if relatedEntrypoint {
+				workspacePrimaryEntrypoint = false
+				workspaceEntrypointServed = true
+			}
+			if err := srv.serveWorkspaceModule(client, core.NewUserMod(related.mod), core.InstallOpts{Entrypoint: relatedEntrypoint}); err != nil {
+				return fmt.Errorf("error serving related workspace module %s: %w", related.mod.Self().Name(), err)
+			}
+		}
+		if err := srv.serveWorkspaceModule(client, core.NewUserMod(load.primary), core.InstallOpts{Entrypoint: workspacePrimaryEntrypoint}); err != nil {
+			return moduleLoadErr(loads[i], err)
+		}
+		if workspacePrimaryEntrypoint {
+			for _, dep := range load.primary.Self().Deps.Mods() {
+				if err := srv.serveWorkspaceModule(client, dep, core.InstallOpts{SkipConstructor: true}); err != nil {
+					return fmt.Errorf("error serving workspace entrypoint dependency %s: %w", dep.Name(), err)
+				}
+			}
+			workspaceEntrypointServed = true
+		}
+		client.workspaceEntrypointServed = client.workspaceEntrypointServed || workspaceEntrypointServed
+		if client.servedWorkspaceModuleKeys == nil {
+			client.servedWorkspaceModuleKeys = make(map[string]struct{})
+		}
+		client.servedWorkspaceModuleKeys[key] = struct{}{}
 	}
 
+	return nil
+}
+
+func (srv *Server) requestAncestorWorkspaceModules(ctx context.Context, client *daggerClient) (bool, error) {
+	mode, _ := workspaceBindingMode(client)
+	if mode == workspaceBindingInherit {
+		// Ordinary inheritance deliberately carries no module provenance. Keep
+		// walking to the ancestor that owns the binding.
+		return false, nil
+	}
+
+	// Forced gathering replaces pendingModules. Keep it atomic with normal
+	// request-driven module loads, which use the same mutex.
+	client.modulesMu.Lock()
+	defer client.modulesMu.Unlock()
+
+	client.workspaceModulesRequested.Store(true)
+	client.workspaceMu.Lock()
+	client.workspaceLoaded = false
+	client.workspaceErr = nil
+	client.workspace = nil
+	client.pendingModules = nil
+	client.workspaceMu.Unlock()
+
+	parentCtx := workspaceClientContext(ctx, client)
+	if err := srv.ensureWorkspaceLoaded(parentCtx, client); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (srv *Server) inheritExplicitWorkspaceModules(
+	ctx context.Context,
+	client *daggerClient,
+	rootFields []string,
+	filterByRootFields bool,
+) error {
+	client.inheritedWorkspaceModulesMu.Lock()
+	defer client.inheritedWorkspaceModulesMu.Unlock()
+
+	// Preserve the established precedence: this client's explicit -m modules
+	// load before inherited ambient workspace modules.
+	if err := srv.ensureExtraModulesLoaded(ctx, client); err != nil {
+		return err
+	}
+
+	var scope string
+	var childEntrypointServed bool
+	if filterByRootFields {
+		client.modulesMu.Lock()
+		scope = client.pendingWorkspaceModuleScopeLocked()
+		childEntrypointServed = client.entrypointServed
+		client.modulesMu.Unlock()
+	}
+
+	client.workspaceMu.Lock()
+	bindingID := client.workspaceBindingID
+	workspaceEnv := client.workspaceEnv
+	workspaceEnvSet := client.workspaceEnvSet
+	client.workspaceMu.Unlock()
+
+	for i := len(client.parents) - 1; i >= 0; i-- {
+		parent := client.parents[i]
+		parentCtx := workspaceClientContext(ctx, parent)
+		parentMode, _ := workspaceBindingMode(parent)
+		if parentMode == workspaceBindingInherit || parentMode == workspaceBindingInherited {
+			// The full ancestor chain is available on the child. Skip clients
+			// that only carry the binding and load from the client that owns its
+			// declared or detected module state.
+			continue
+		}
+
+		// Sibling inherited clients can force and filter the same owner's
+		// workspace modules concurrently. Serialize the owner's readiness,
+		// module load, and snapshot so their demands cannot reset or race each
+		// other.
+		parent.inheritedWorkspaceModulesMu.Lock()
+		if err := srv.ensureWorkspaceLoaded(parentCtx, parent); err != nil {
+			parent.inheritedWorkspaceModulesMu.Unlock()
+			return err
+		}
+		parent.workspaceMu.Lock()
+		matches := parent.workspaceBindingID == bindingID &&
+			parent.workspaceEnv == workspaceEnv &&
+			parent.workspaceEnvSet == workspaceEnvSet
+		parent.workspaceMu.Unlock()
+		parentMode, _ = workspaceBindingMode(parent)
+		if !matches || parentMode == workspaceBindingInherit || parentMode == workspaceBindingInherited {
+			parent.inheritedWorkspaceModulesMu.Unlock()
+			continue
+		}
+		if !clientLoadsWorkspaceModules(parent) {
+			ready, err := srv.requestAncestorWorkspaceModules(ctx, parent)
+			if err != nil {
+				parent.inheritedWorkspaceModulesMu.Unlock()
+				return err
+			}
+			if !ready {
+				parent.inheritedWorkspaceModulesMu.Unlock()
+				continue
+			}
+		}
+		scopeApplied := false
+		var filter func([]pendingModule) []pendingModule
+		if filterByRootFields {
+			filter = func(mods []pendingModule) []pendingModule {
+				selected, applied := filterPendingWorkspaceModulesForScopedRootFields(
+					mods,
+					parent.servedWorkspaceModuleNames,
+					parent.failedModules,
+					rootFields,
+					scope,
+					childEntrypointServed,
+				)
+				scopeApplied = applied
+				return selected
+			}
+		}
+		if _, err := srv.ensureWorkspaceModulesLoadedMode(parentCtx, parent, filter, false); err != nil {
+			parent.inheritedWorkspaceModulesMu.Unlock()
+			return err
+		}
+
+		parent.modulesMu.Lock()
+		parent.stateMu.RLock()
+		workspaceMods := parent.servedWorkspaceMods
+		if workspaceMods == nil {
+			workspaceMods = core.NewSchemaBuilder(parent.dagqlRoot, nil)
+		}
+		workspaceMods = workspaceMods.WithRoot(client.dagqlRoot)
+		failedModules := maps.Clone(parent.failedModules)
+		servedNames := maps.Clone(parent.servedWorkspaceModuleNames)
+		servedKeys := maps.Clone(parent.servedWorkspaceModuleKeys)
+		parentEntrypointServed := parent.workspaceEntrypointServed
+		parent.stateMu.RUnlock()
+		parent.modulesMu.Unlock()
+		parent.inheritedWorkspaceModulesMu.Unlock()
+
+		client.modulesMu.Lock()
+		client.stateMu.Lock()
+		aggregateWorkspaceMods := workspaceMods
+		if client.entrypointServed {
+			aggregateWorkspaceMods = aggregateWorkspaceMods.WithoutEntrypoints()
+		}
+		client.servedWorkspaceMods = client.servedWorkspaceMods.Merge(workspaceMods)
+		client.servedMods = client.servedMods.Merge(aggregateWorkspaceMods)
+		client.pendingModules = nil
+		if client.failedModules == nil {
+			client.failedModules = make(map[string]error)
+		}
+		maps.Copy(client.failedModules, failedModules)
+		if client.servedWorkspaceModuleNames == nil {
+			client.servedWorkspaceModuleNames = make(map[string]struct{})
+		}
+		maps.Copy(client.servedWorkspaceModuleNames, servedNames)
+		if client.servedWorkspaceModuleKeys == nil {
+			client.servedWorkspaceModuleKeys = make(map[string]struct{})
+		}
+		maps.Copy(client.servedWorkspaceModuleKeys, servedKeys)
+		client.workspaceEntrypointServed = client.workspaceEntrypointServed || parentEntrypointServed
+		client.entrypointServed = client.entrypointServed || parentEntrypointServed
+		if scopeApplied {
+			client.workspaceModuleScopeConsumed = true
+		}
+		client.stateMu.Unlock()
+		client.modulesMu.Unlock()
+		return nil
+	}
+
+	// Arbitrary Workspace values have no live ancestor module schema to copy.
+	// Keep serving the core schema: currentWorkspace and its filesystem APIs are
+	// still valid, and CLI clients request workspace modules even for core-only
+	// commands such as `dagger query`.
 	return nil
 }
 

--- a/hack/designs/container-workspace-inheritance.md
+++ b/hack/designs/container-workspace-inheritance.md
@@ -1,0 +1,352 @@
+# Container Workspace Inheritance
+
+## Status
+
+Proposed for [#13054](https://github.com/dagger/dagger/issues/13054).
+
+## Problem
+
+A Dagger client started inside a container detects its workspace from the
+container filesystem. That is usually correct, but it breaks commands that are
+meant to operate on the caller's workspace.
+
+For example, a Go test executed in a container may connect to Dagger and call
+`CurrentWorkspace`. Today that resolves from the test container's working
+directory, even when the outer client selected a different workspace.
+
+`experimentalPrivilegedNesting` grants the command access to the Dagger API, but
+does not say which workspace the nested client should use. Making every nested
+client inherit its parent implicitly is also incorrect: module runtimes must not
+gain ambient access to their callers' workspaces.
+
+A workspace binding is also more than a `Workspace` object. A client that loads
+workspace modules has a selected environment, pending module configuration, and
+a served module schema. Passing only the object can make `currentWorkspace`
+correct while `dagger call` still exposes the wrong modules or constructor
+defaults.
+
+## Solution
+
+Let a container command explicitly inherit a `Workspace` as the default for
+nested Dagger clients:
+
+```go
+testCtr.WithExec(
+    []string{"go", "test", "./..."},
+    dagger.ContainerWithExecOpts{
+        InheritWorkspace: dag.CurrentWorkspace(),
+    },
+)
+```
+
+`inheritWorkspace` is both a workspace binding and a grant of nested Dagger
+access. It is execution-scoped: it applies only to the command or service that
+receives the argument and is never ambient container state.
+
+When the argument is the caller's bound workspace, its effective environment
+and workspace module state are inherited with it.
+
+## API
+
+The schema uses the v1 global `ID` scalar with an expected type:
+
+```graphql
+extend type Container {
+  withExec(
+    # existing arguments omitted
+
+    """
+    Grant the command access to the Dagger API and use this workspace by
+    default for nested Dagger clients.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+  ): Container!
+
+  asService(
+    # existing arguments omitted
+
+    """
+    Grant the service command access to the Dagger API and use this workspace
+    by default for nested Dagger clients.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+  ): Service!
+
+  up(
+    # existing arguments omitted
+
+    """
+    Grant the service command access to the Dagger API and use this workspace
+    by default for nested Dagger clients.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+  ): Void
+
+  terminal(
+    # existing arguments omitted
+
+    """
+    Grant the terminal command access to the Dagger API and use this workspace
+    by default for nested Dagger clients.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+  ): Container!
+}
+
+extend type Directory {
+  terminal(
+    # existing arguments omitted
+
+    """
+    Grant the terminal command access to the Dagger API and use this workspace
+    by default for nested Dagger clients.
+
+    Only grant this access to trusted commands.
+    """
+    inheritWorkspace: ID @expectedType(name: "Workspace")
+  ): Directory!
+}
+```
+
+The arguments are gated after `v1.0.0-0`, matching the `Workspace` API. They do
+not appear in older schema views.
+
+### Convenience surfaces
+
+`Container.withExec` and `Container.asService` are the fundamental execution
+boundaries. The remaining fields include `inheritWorkspace` only when they
+define a new command.
+
+`Directory.terminal` includes the option because it creates a temporary
+container and defines its terminal command. There is no intermediate service on
+which the caller can select the binding, so omitting the option would prevent
+the convenience API from supporting workspace-aware interactive inspection.
+
+`Container.up` also includes the option. `Container.up` is shorthand for
+constructing a service with `Container.asService` and then calling `Service.up`;
+it intentionally accepts the same command-definition options as
+`Container.asService`. Forwarding `inheritWorkspace` preserves that established
+equivalence. The binding is captured while constructing the service and has the
+same lifetime and meaning as a binding passed directly to
+`Container.asService`.
+
+`Service.up` and `Service.terminal` do not include the option. They operate on
+an already-defined service, whose inherited workspace was selected when its
+command was defined. Adding the option at startup or attachment time would give
+it a different lifetime and meaning.
+
+## Workspace Selection
+
+A nested client selects its workspace in this order:
+
+| Priority | Source |
+| --- | --- |
+| 1 | Workspace explicitly declared by the nested client (`-W`, `--workspace`, or SDK connection options) |
+| 2 | `inheritWorkspace` on the command that started the client |
+| 3 | Detection from the nested client's own container filesystem |
+| 4 | Ordinary parent-client inheritance |
+
+An explicit nested workspace selection is complete: its workspace and
+environment are loaded normally and no inherited module state is reused.
+
+If `inheritWorkspace` is absent, behavior is unchanged.
+
+## Binding Contract
+
+Any `Workspace` value can be inherited for `currentWorkspace` and workspace
+APIs. This includes caller-local, remote, synthetic, and overlaid workspaces.
+
+Workspace module inheritance is narrower. A nested client can load modules from
+an inherited workspace when that value identifies a live ancestor workspace
+binding. This is the normal case:
+
+```go
+InheritWorkspace: dag.CurrentWorkspace()
+```
+
+The binding captures:
+
+- the retained `Workspace` result;
+- an opaque binding identity shared with the matching ancestor; and
+- the ancestor's selected workspace environment, if any.
+
+With no explicit nested environment, the nested client uses the captured
+environment and module state. A nested `--env` may name that same environment.
+Selecting a different environment requires an explicit workspace selection,
+for example `dagger -W /workspace --env prod ...`; that higher-priority binding
+uses the normal workspace loader.
+
+If an inherited value is not a live ancestor binding, the nested client still
+uses it for `currentWorkspace` and other core workspace APIs, but receives no
+workspace module schema from it. This distinction matters because CLI clients
+request workspace modules even for core-only operations such as
+`dagger query`. The engine does not silently detect modules from the container,
+reuse a different ancestor's schema, or attempt to reconstruct module
+configuration from an arbitrary workspace value.
+
+Generic module loading directly from an arbitrary `Workspace` object would
+require a separate workspace-source loader covering caller routing, remote
+roots, synthetic directories, overlays, lock state, compatibility workspaces,
+and environment application. That is not part of this change.
+
+## Nested Access
+
+`inheritWorkspace` enables the same nested Dagger connection that
+`experimentalPrivilegedNesting` enables. Supplying either argument is
+sufficient; supplying both is valid and creates one nested connection.
+
+This is intentionally stronger than mounting workspace files into the
+container. The nested client receives Dagger API access and can use the
+inherited `Workspace` according to its existing capabilities, including
+owner-routed host filesystem operations for a caller-local workspace.
+
+The inherited binding is trusted engine metadata. It is never read from the
+nested client's HTTP metadata, so a command without the public argument cannot
+forge inheritance. The nested client's own declared workspace and environment
+are still accepted from its request metadata and handled according to the
+precedence above.
+
+## Execution Lifetime
+
+At the schema boundary, the public ID is resolved to an internal inherited
+binding containing a `dagql.ObjectResult[*core.Workspace]`. The object result,
+not just its encoded handle, is retained as a dependency of the lazy execution:
+
+- `Container.withExec` retains the binding in `ContainerExecState`.
+- `Container.asService` and `Container.up` retain it in `Service`.
+- Converting a container whose most recent command inherited a workspace to a
+  service preserves that binding, unless `asService` selects a different one.
+- Terminal commands pass it to their temporary service.
+- The dependency graphs persist the workspace by result ID and reattach it when
+  loaded. The binding identity and selected environment are persisted alongside
+  that reference.
+
+Core passes the retained workspace result through the same typed in-process
+executor handoff used for module and environment context. The executor keeps it
+on the running exec state and passes it to the nested session handler, which
+type-checks it as `dagql.ObjectResult[*core.Workspace]` and reattaches it to the
+nested client's dagql server.
+
+The captured binding identity and environment travel separately in
+engine-internal `ClientMetadata` fields marked `json:"-"`. They are distinct
+from the public `Workspace` and `WorkspaceEnv` request fields. Binding selection
+consults them only when the typed inherited workspace wins, so an explicit
+nested workspace never accidentally receives the inherited environment.
+Nested request headers cannot set them.
+
+No encoded workspace handle is serialized or forwarded. After lazy container
+or service state is restored, the reattached workspace dependency itself
+crosses the executor boundary.
+
+A terminal opened synchronously for a failed exec reuses that exec's runtime
+metadata while its workspace dependency is still leased. This preserves the
+binding for the debugging command without making it container state.
+
+## Workspace Modules
+
+Each loaded workspace binding has a stable opaque identity for the life of the
+session. Ordinary inheritance and explicit command inheritance carry that
+identity; persisted inherited bindings retain it for matching after
+reattachment. The capture step uses exact object identity to recognize a
+Workspace value produced by a live ancestor; all matching after capture uses
+the opaque binding identity, never a Go pointer.
+
+When a nested client requests workspace modules, the engine finds the nearest
+ancestor with the same binding identity and selected environment. The ancestor
+gathers its workspace module configuration even if that client did not request
+a workspace schema for itself, then loads the subset demanded by the nested
+request. The engine clones the ancestor's workspace-specific served schema and
+entrypoint state, re-rooted on the nested client's `Query`.
+
+Loading completes against the ancestor because caller-local pending module refs
+belong to that client's filesystem session. The nested client receives the
+resolved workspace schema, not host paths that would resolve against its
+container.
+
+Only workspace-origin module state is inherited. Parent extra modules (`-m`),
+modules served explicitly through the API, and module-runtime context are not
+copied or loaded as a prerequisite. The nested client's own extra modules load
+first and keep their normal precedence over an ambient workspace entrypoint.
+
+This schema reuse runs only for an explicit inherited binding and therefore
+does not weaken the ordinary module-runtime inheritance boundary.
+
+## Execution Paths
+
+The binding is accepted by:
+
+- normal `Container.withExec`;
+- direct `Container.asService`;
+- `Container.up`;
+- `Container.terminal`;
+- `Directory.terminal`; and
+- a terminal opened for the failed `withExec` that carried the binding.
+
+No path stores inheritance as ambient `Container` configuration. The binding
+does follow the command when a container produced by
+`withExec(inheritWorkspace: ...)` is converted to a service with `asService`,
+as required for the conventional `withExec(...).asService()` service pattern.
+An explicit `inheritWorkspace` on `asService` wins.
+
+The implementation must use distinct schema argument structs, or explicitly
+gated arguments, so shared core structs cannot expose the argument on
+`Service.terminal` or on old API views by accident.
+
+## Caching
+
+The public workspace ID is part of the dagql call and must distinguish
+executions using different inherited bindings. The runtime handle is not part
+of serialized execution metadata.
+
+Otherwise, existing container caching semantics are unchanged. A host-backed
+workspace resolves live content when the command first executes, but the
+resulting `Container` is still an immutable, cacheable snapshot. Reusing the
+same workspace and container graph may reuse that snapshot. If Dagger later
+needs watch-like reruns, that should be an explicit cache/refresh control rather
+than a second, surprising meaning for `inheritWorkspace`.
+
+## Compatibility
+
+The arguments are optional. Their absence preserves current workspace
+detection, parent inheritance, module-runtime boundaries, module loading, and
+privileged nesting behavior.
+
+Older SDKs continue to call the existing fields without the argument. Older
+module schema views do not see it. Current SDK generation exposes an
+SDK-appropriate workspace object or ID option on the five command methods.
+
+## Behavioral guarantees
+
+The implementation guarantees:
+
+1. Declared workspace beats inherited workspace; inherited workspace beats
+   container detection and ordinary parent inheritance.
+2. A nested client cannot inject or replace the trusted inherited binding
+   through request metadata.
+3. `inheritWorkspace` alone enables nested Dagger access, and combining it with
+   `experimentalPrivilegedNesting` is redundant.
+4. `CurrentWorkspace` resolves a caller-provided local, remote, synthetic, or
+   overlaid workspace rather than the container filesystem.
+5. A matching ancestor's workspace modules, entrypoint, and selected
+   environment are available to a nested `dagger call`.
+6. Parent extra modules and module-runtime schema are not inherited.
+7. A different explicit nested workspace wins. A mismatched nested environment
+   fails clearly. An unmatched inherited value remains available to core
+   workspace APIs without exposing unrelated workspace modules.
+8. Direct service, `up`, container terminal, directory terminal, and exec-error
+   terminal paths preserve the binding.
+9. Lazy container and service persistence retain the workspace dependency and
+   derive a valid handle after restoration.
+10. Different inherited bindings do not share execution results; otherwise
+    existing `withExec` caching behavior is unchanged.
+11. Omitting the argument leaves existing behavior unchanged.
+12. Introspection proves the argument is present only on the five v1 command
+    fields, absent from older views, and absent from `Service.terminal`.

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -24,6 +24,7 @@ defmodule Dagger.Container do
           {:args, [String.t()]},
           {:use_entrypoint, boolean() | nil},
           {:experimental_privileged_nesting, boolean() | nil},
+          {:inherit_workspace, Dagger.Workspace.t() | nil},
           {:insecure_root_capabilities, boolean() | nil},
           {:expand, boolean() | nil},
           {:no_init, boolean() | nil}
@@ -37,6 +38,13 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg(
         "experimentalPrivilegedNesting",
         optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg(
+        "inheritWorkspace",
+        if(optional_args[:inherit_workspace],
+          do: Dagger.ID.id!(optional_args[:inherit_workspace]),
+          else: nil
+        )
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
@@ -644,6 +652,7 @@ defmodule Dagger.Container do
   @spec terminal(t(), [
           {:cmd, [String.t()]},
           {:experimental_privileged_nesting, boolean() | nil},
+          {:inherit_workspace, Dagger.Workspace.t() | nil},
           {:insecure_root_capabilities, boolean() | nil}
         ]) :: Dagger.Container.t()
   def terminal(%__MODULE__{} = container, optional_args \\ []) do
@@ -654,6 +663,13 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg(
         "experimentalPrivilegedNesting",
         optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg(
+        "inheritWorkspace",
+        if(optional_args[:inherit_workspace],
+          do: Dagger.ID.id!(optional_args[:inherit_workspace]),
+          else: nil
+        )
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
 
@@ -674,6 +690,7 @@ defmodule Dagger.Container do
           {:args, [String.t()]},
           {:use_entrypoint, boolean() | nil},
           {:experimental_privileged_nesting, boolean() | nil},
+          {:inherit_workspace, Dagger.Workspace.t() | nil},
           {:insecure_root_capabilities, boolean() | nil},
           {:expand, boolean() | nil},
           {:no_init, boolean() | nil}
@@ -689,6 +706,13 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg(
         "experimentalPrivilegedNesting",
         optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg(
+        "inheritWorkspace",
+        if(optional_args[:inherit_workspace],
+          do: Dagger.ID.id!(optional_args[:inherit_workspace]),
+          else: nil
+        )
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
@@ -905,6 +929,7 @@ defmodule Dagger.Container do
           {:redirect_stderr, String.t() | nil},
           {:expect, Dagger.ReturnType.t() | nil},
           {:experimental_privileged_nesting, boolean() | nil},
+          {:inherit_workspace, Dagger.Workspace.t() | nil},
           {:insecure_root_capabilities, boolean() | nil},
           {:expand, boolean() | nil},
           {:no_init, boolean() | nil}
@@ -923,6 +948,13 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg(
         "experimentalPrivilegedNesting",
         optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg(
+        "inheritWorkspace",
+        if(optional_args[:inherit_workspace],
+          do: Dagger.ID.id!(optional_args[:inherit_workspace]),
+          else: nil
+        )
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -412,6 +412,7 @@ defmodule Dagger.Directory do
           {:container, Dagger.Container.t() | nil},
           {:cmd, [String.t()]},
           {:experimental_privileged_nesting, boolean() | nil},
+          {:inherit_workspace, Dagger.Workspace.t() | nil},
           {:insecure_root_capabilities, boolean() | nil}
         ]) :: Dagger.Directory.t()
   def terminal(%__MODULE__{} = directory, optional_args \\ []) do
@@ -426,6 +427,13 @@ defmodule Dagger.Directory do
       |> QB.maybe_put_arg(
         "experimentalPrivilegedNesting",
         optional_args[:experimental_privileged_nesting]
+      )
+      |> QB.maybe_put_arg(
+        "inheritWorkspace",
+        if(optional_args[:inherit_workspace],
+          do: Dagger.ID.id!(optional_args[:inherit_workspace]),
+          else: nil
+        )
       )
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1781,6 +1781,12 @@ type ContainerAsServiceOpts struct {
 	UseEntrypoint bool
 	// Provides Dagger access to the executed command.
 	ExperimentalPrivilegedNesting bool
+	// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+	//
+	// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+	//
+	// Only grant this access to trusted commands.
+	InheritWorkspace *Workspace
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 	// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -1808,6 +1814,10 @@ func (r *Container) AsService(opts ...ContainerAsServiceOpts) *Service {
 		// `experimentalPrivilegedNesting` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
 			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `inheritWorkspace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InheritWorkspace) {
+			q = q.Arg("inheritWorkspace", opts[i].InheritWorkspace)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2619,6 +2629,12 @@ type ContainerTerminalOpts struct {
 	Cmd []string
 	// Provides Dagger access to the executed command.
 	ExperimentalPrivilegedNesting bool
+	// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+	//
+	// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+	//
+	// Only grant this access to trusted commands.
+	InheritWorkspace *Workspace
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 }
@@ -2634,6 +2650,10 @@ func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Container {
 		// `experimentalPrivilegedNesting` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
 			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `inheritWorkspace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InheritWorkspace) {
+			q = q.Arg("inheritWorkspace", opts[i].InheritWorkspace)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2662,6 +2682,12 @@ type ContainerUpOpts struct {
 	UseEntrypoint bool
 	// Provides Dagger access to the executed command.
 	ExperimentalPrivilegedNesting bool
+	// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+	//
+	// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+	//
+	// Only grant this access to trusted commands.
+	InheritWorkspace *Workspace
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 	// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -2700,6 +2726,10 @@ func (r *Container) Up(ctx context.Context, opts ...ContainerUpOpts) error {
 		// `experimentalPrivilegedNesting` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
 			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `inheritWorkspace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InheritWorkspace) {
+			q = q.Arg("inheritWorkspace", opts[i].InheritWorkspace)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2980,6 +3010,12 @@ type ContainerWithExecOpts struct {
 	Expect ReturnType
 	// Provides Dagger access to the executed command.
 	ExperimentalPrivilegedNesting bool
+	// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+	//
+	// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+	//
+	// Only grant this access to trusted commands.
+	InheritWorkspace *Workspace
 	// Execute the command with all root capabilities. Like --privileged in Docker
 	//
 	// DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.
@@ -3023,6 +3059,10 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 		// `experimentalPrivilegedNesting` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
 			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `inheritWorkspace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InheritWorkspace) {
+			q = q.Arg("inheritWorkspace", opts[i].InheritWorkspace)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -5194,6 +5234,12 @@ type DirectoryTerminalOpts struct {
 	Cmd []string
 	// Provides Dagger access to the executed command.
 	ExperimentalPrivilegedNesting bool
+	// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+	//
+	// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+	//
+	// Only grant this access to trusted commands.
+	InheritWorkspace *Workspace
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 }
@@ -5213,6 +5259,10 @@ func (r *Directory) Terminal(opts ...DirectoryTerminalOpts) *Directory {
 		// `experimentalPrivilegedNesting` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
 			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `inheritWorkspace` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InheritWorkspace) {
+			q = q.Arg("inheritWorkspace", opts[i].InheritWorkspace)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -22,6 +22,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         ?array $args = [],
         ?bool $useEntrypoint = false,
         ?bool $experimentalPrivilegedNesting = false,
+        ?Workspace $inheritWorkspace = null,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
         ?bool $noInit = false,
@@ -35,6 +36,9 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         }
         if (null !== $experimentalPrivilegedNesting) {
         $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $inheritWorkspace) {
+        $innerQueryBuilder->setArgument('inheritWorkspace', $inheritWorkspace);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -506,6 +510,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
     public function terminal(
         ?array $cmd = [],
         ?bool $experimentalPrivilegedNesting = false,
+        ?Workspace $inheritWorkspace = null,
         ?bool $insecureRootCapabilities = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
@@ -514,6 +519,9 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         }
         if (null !== $experimentalPrivilegedNesting) {
         $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $inheritWorkspace) {
+        $innerQueryBuilder->setArgument('inheritWorkspace', $inheritWorkspace);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -532,6 +540,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         ?array $args = [],
         ?bool $useEntrypoint = false,
         ?bool $experimentalPrivilegedNesting = false,
+        ?Workspace $inheritWorkspace = null,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
         ?bool $noInit = false,
@@ -551,6 +560,9 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         }
         if (null !== $experimentalPrivilegedNesting) {
         $leafQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $inheritWorkspace) {
+        $leafQueryBuilder->setArgument('inheritWorkspace', $inheritWorkspace);
         }
         if (null !== $insecureRootCapabilities) {
         $leafQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -748,6 +760,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         ?string $redirectStderr = '',
         ?ReturnType $expect = null,
         ?bool $experimentalPrivilegedNesting = false,
+        ?Workspace $inheritWorkspace = null,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
         ?bool $noInit = false,
@@ -774,6 +787,9 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         }
         if (null !== $experimentalPrivilegedNesting) {
         $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $inheritWorkspace) {
+        $innerQueryBuilder->setArgument('inheritWorkspace', $inheritWorkspace);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -338,6 +338,7 @@ class Directory extends Client\AbstractObject implements Client\IdAble, Exportab
         ?Container $container = null,
         ?array $cmd = [],
         ?bool $experimentalPrivilegedNesting = false,
+        ?Workspace $inheritWorkspace = null,
         ?bool $insecureRootCapabilities = false,
     ): Directory {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
@@ -349,6 +350,9 @@ class Directory extends Client\AbstractObject implements Client\IdAble, Exportab
         }
         if (null !== $experimentalPrivilegedNesting) {
         $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $inheritWorkspace) {
+        $innerQueryBuilder->setArgument('inheritWorkspace', $inheritWorkspace);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1729,6 +1729,7 @@ class Container(Type):
         args: list[str] | None = None,
         use_entrypoint: bool | None = False,
         experimental_privileged_nesting: bool | None = False,
+        inherit_workspace: "Workspace | None" = None,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
         no_init: bool | None = False,
@@ -1747,6 +1748,14 @@ class Container(Type):
             If the container has an entrypoint, prepend it to the args.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
+        inherit_workspace:
+            Provides Dagger access to the executed command and uses this
+            workspace by default for nested Dagger clients.
+            When this is the caller's current workspace, its selected
+            environment and module commands are inherited. Other workspace
+            values are available through currentWorkspace, but do not provide
+            module commands.
+            Only grant this access to trusted commands.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -1769,6 +1778,7 @@ class Container(Type):
             Arg(
                 "experimentalPrivilegedNesting", experimental_privileged_nesting, False
             ),
+            Arg("inheritWorkspace", inherit_workspace, None),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
             Arg("noInit", no_init, False),
@@ -2637,6 +2647,7 @@ class Container(Type):
         *,
         cmd: list[str] | None = None,
         experimental_privileged_nesting: bool | None = False,
+        inherit_workspace: "Workspace | None" = None,
         insecure_root_capabilities: bool | None = False,
     ) -> Self:
         """Opens an interactive terminal for this container using its configured
@@ -2650,6 +2661,14 @@ class Container(Type):
             invoke these command arguments instead.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
+        inherit_workspace:
+            Provides Dagger access to the executed command and uses this
+            workspace by default for nested Dagger clients.
+            When this is the caller's current workspace, its selected
+            environment and module commands are inherited. Other workspace
+            values are available through currentWorkspace, but do not provide
+            module commands.
+            Only grant this access to trusted commands.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -2662,6 +2681,7 @@ class Container(Type):
             Arg(
                 "experimentalPrivilegedNesting", experimental_privileged_nesting, False
             ),
+            Arg("inheritWorkspace", inherit_workspace, None),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("terminal", _args)
@@ -2675,6 +2695,7 @@ class Container(Type):
         args: list[str] | None = None,
         use_entrypoint: bool | None = False,
         experimental_privileged_nesting: bool | None = False,
+        inherit_workspace: "Workspace | None" = None,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
         no_init: bool | None = False,
@@ -2700,6 +2721,14 @@ class Container(Type):
             If the container has an entrypoint, prepend it to the args.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
+        inherit_workspace:
+            Provides Dagger access to the executed command and uses this
+            workspace by default for nested Dagger clients.
+            When this is the caller's current workspace, its selected
+            environment and module commands are inherited. Other workspace
+            values are available through currentWorkspace, but do not provide
+            module commands.
+            Only grant this access to trusted commands.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -2737,6 +2766,7 @@ class Container(Type):
             Arg(
                 "experimentalPrivilegedNesting", experimental_privileged_nesting, False
             ),
+            Arg("inheritWorkspace", inherit_workspace, None),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
             Arg("noInit", no_init, False),
@@ -3028,6 +3058,7 @@ class Container(Type):
         redirect_stderr: str | None = "",
         expect: ReturnType | None = ReturnType.SUCCESS,
         experimental_privileged_nesting: bool | None = False,
+        inherit_workspace: "Workspace | None" = None,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
         no_init: bool | None = False,
@@ -3063,6 +3094,14 @@ class Container(Type):
             Exit codes this command is allowed to exit with without error
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
+        inherit_workspace:
+            Provides Dagger access to the executed command and uses this
+            workspace by default for nested Dagger clients.
+            When this is the caller's current workspace, its selected
+            environment and module commands are inherited. Other workspace
+            values are available through currentWorkspace, but do not provide
+            module commands.
+            Only grant this access to trusted commands.
         insecure_root_capabilities:
             Execute the command with all root capabilities. Like --privileged
             in Docker
@@ -3090,6 +3129,7 @@ class Container(Type):
             Arg(
                 "experimentalPrivilegedNesting", experimental_privileged_nesting, False
             ),
+            Arg("inheritWorkspace", inherit_workspace, None),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
             Arg("noInit", no_init, False),
@@ -5164,6 +5204,7 @@ class Directory(Type):
         container: Container | None = None,
         cmd: list[str] | None = None,
         experimental_privileged_nesting: bool | None = False,
+        inherit_workspace: "Workspace | None" = None,
         insecure_root_capabilities: bool | None = False,
     ) -> Self:
         """Opens an interactive terminal in new container with this directory
@@ -5178,6 +5219,14 @@ class Directory(Type):
             invoke these command arguments instead.
         experimental_privileged_nesting:
             Provides Dagger access to the executed command.
+        inherit_workspace:
+            Provides Dagger access to the executed command and uses this
+            workspace by default for nested Dagger clients.
+            When this is the caller's current workspace, its selected
+            environment and module commands are inherited. Other workspace
+            values are available through currentWorkspace, but do not provide
+            module commands.
+            Only grant this access to trusted commands.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -5191,6 +5240,7 @@ class Directory(Type):
             Arg(
                 "experimentalPrivilegedNesting", experimental_privileged_nesting, False
             ),
+            Arg("inheritWorkspace", inherit_workspace, None),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("terminal", _args)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1576,6 +1576,11 @@ pub struct ContainerAsServiceOpts<'a> {
     /// Provides Dagger access to the executed command.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
+    /// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+    /// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+    /// Only grant this access to trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub inherit_workspace: Option<Id>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1739,6 +1744,11 @@ pub struct ContainerTerminalOpts<'a> {
     /// Provides Dagger access to the executed command.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
+    /// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+    /// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+    /// Only grant this access to trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub inherit_workspace: Option<Id>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1755,6 +1765,11 @@ pub struct ContainerUpOpts<'a> {
     /// Provides Dagger access to the executed command.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
+    /// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+    /// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+    /// Only grant this access to trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub inherit_workspace: Option<Id>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1851,6 +1866,11 @@ pub struct ContainerWithExecOpts<'a> {
     /// Provides Dagger access to the executed command.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
+    /// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+    /// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+    /// Only grant this access to trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub inherit_workspace: Option<Id>,
     /// Execute the command with all root capabilities. Like --privileged in Docker
     /// DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.
     #[builder(setter(into, strip_option), default)]
@@ -2151,6 +2171,9 @@ impl Container {
                 "experimentalPrivilegedNesting",
                 experimental_privileged_nesting,
             );
+        }
+        if let Some(inherit_workspace) = opts.inherit_workspace {
+            query = query.arg("inheritWorkspace", inherit_workspace);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -2850,6 +2873,9 @@ impl Container {
                 experimental_privileged_nesting,
             );
         }
+        if let Some(inherit_workspace) = opts.inherit_workspace {
+            query = query.arg("inheritWorkspace", inherit_workspace);
+        }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
@@ -2894,6 +2920,9 @@ impl Container {
                 "experimentalPrivilegedNesting",
                 experimental_privileged_nesting,
             );
+        }
+        if let Some(inherit_workspace) = opts.inherit_workspace {
+            query = query.arg("inheritWorkspace", inherit_workspace);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -3311,6 +3340,9 @@ impl Container {
                 "experimentalPrivilegedNesting",
                 experimental_privileged_nesting,
             );
+        }
+        if let Some(inherit_workspace) = opts.inherit_workspace {
+            query = query.arg("inheritWorkspace", inherit_workspace);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -5248,6 +5280,11 @@ pub struct DirectoryTerminalOpts<'a> {
     /// Provides Dagger access to the executed command.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
+    /// Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+    /// When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+    /// Only grant this access to trusted commands.
+    #[builder(setter(into, strip_option), default)]
+    pub inherit_workspace: Option<Id>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -5881,6 +5918,9 @@ impl Directory {
                 "experimentalPrivilegedNesting",
                 experimental_privileged_nesting,
             );
+        }
+        if let Some(inherit_workspace) = opts.inherit_workspace {
+            query = query.arg("inheritWorkspace", inherit_workspace);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -258,6 +258,15 @@ export type ContainerAsServiceOpts = {
   experimentalPrivilegedNesting?: boolean
 
   /**
+   * Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
+   */
+  inheritWorkspace?: Workspace
+
+  /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   insecureRootCapabilities?: boolean
@@ -497,6 +506,15 @@ export type ContainerTerminalOpts = {
   experimentalPrivilegedNesting?: boolean
 
   /**
+   * Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
+   */
+  inheritWorkspace?: Workspace
+
+  /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   insecureRootCapabilities?: boolean
@@ -531,6 +549,15 @@ export type ContainerUpOpts = {
    * Provides Dagger access to the executed command.
    */
   experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
+   */
+  inheritWorkspace?: Workspace
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -680,6 +707,15 @@ export type ContainerWithExecOpts = {
    * Provides Dagger access to the executed command.
    */
   experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
+   */
+  inheritWorkspace?: Workspace
 
   /**
    * Execute the command with all root capabilities. Like --privileged in Docker
@@ -1297,6 +1333,15 @@ export type DirectoryTerminalOpts = {
    * Provides Dagger access to the executed command.
    */
   experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
+   */
+  inheritWorkspace?: Workspace
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -4532,6 +4577,11 @@ export class Container extends BaseClient {
    * If empty, the container's default command is used.
    * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.inheritWorkspace Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
@@ -5112,6 +5162,11 @@ export class Container extends BaseClient {
    * Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.inheritWorkspace Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   terminal = (opts?: ContainerTerminalOpts): Container => {
@@ -5132,6 +5187,11 @@ export class Container extends BaseClient {
    * If empty, the container's default command is used.
    * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.inheritWorkspace Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
@@ -5298,6 +5358,11 @@ export class Container extends BaseClient {
    * @param opts.redirectStderr Redirect the command's standard error to a file in the container. Example: "./stderr.txt"
    * @param opts.expect Exit codes this command is allowed to exit with without error
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.inheritWorkspace Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. Like --privileged in Docker
    *
    * DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.
@@ -6717,6 +6782,11 @@ export class Directory extends BaseClient {
    * @param opts.container If set, override the default container used for the terminal.
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
    * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.inheritWorkspace Provides Dagger access to the executed command and uses this workspace by default for nested Dagger clients.
+   *
+   * When this is the caller's current workspace, its selected environment and module commands are inherited. Other workspace values are available through currentWorkspace, but do not provide module commands.
+   *
+   * Only grant this access to trusted commands.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   terminal = (opts?: DirectoryTerminalOpts): Directory => {


### PR DESCRIPTION
Closes #13054.

## Context

The execution and module-provenance contract is written down in [the design proposal](hack/designs/container-workspace-inheritance.md).

## Problem

A Dagger client started inside a container detects its workspace from the container filesystem. That is normally correct, but it breaks commands that are meant to operate on the workspace selected by their caller.

The concrete case is a Go test running in `Container.withExec`: when the test calls `dagger.Connect`, `CurrentWorkspace` resolves from the test container instead of the outer client. `experimentalPrivilegedNesting` grants Dagger API access, but does not carry a workspace binding.

Implicitly inheriting every parent workspace would be unsafe. Module runtimes must not gain ambient access to caller workspaces, and workspace modules also carry environment and schema state that cannot be reconstructed from an arbitrary `Workspace` object.

## Solution

Add an optional `inheritWorkspace` argument to the command-definition surfaces:

- `Container.withExec`
- `Container.asService`
- `Container.up`
- `Container.terminal`
- `Directory.terminal`

The argument grants the command nested Dagger access and installs the supplied workspace as its default. Explicit selection by the nested client still wins; otherwise the inherited binding wins over detection from the container filesystem. Omitting it preserves existing behavior.

The binding is command-scoped, retained as a typed DAG dependency, and persisted with lazy exec and service state. It survives the conventional `withExec(...).asService()` conversion and failed-exec terminal path without becoming ambient `Container` configuration.

When the value is a live ancestor workspace binding, the nested client also receives its selected environment and demand-loaded workspace module schema. Child `-m` modules keep precedence, parent extra modules and module-runtime schema remain isolated, and sibling requests synchronize module gathering without losing demand. Arbitrary or synthetic workspace values remain valid for `currentWorkspace` and core workspace APIs, but do not synthesize module commands.

`Container.up` is included because it defines the same service command as `Container.asService(...).up()` and already mirrors those command options. `Directory.terminal` is included because it creates the temporary container command itself. `Service.up` and `Service.terminal` remain unchanged because their service command has already been defined.

Official SDK clients and reference docs are regenerated from the resulting schema.