### PR TITLE
feat: run generate after module init and api client init

### DIFF
--- a/core/integration/command_hints_test.go
+++ b/core/integration/command_hints_test.go
@@ -46,8 +46,9 @@ func (CommandHintsSuite) TestEmptySetupHint(ctx context.Context, t *testctx.T) {
 
 // TestSDKInstallAndClientInitHints verifies that `dagger sdk install go` prints
 // a hint for each capability the go SDK has (it authors both modules and
-// clients), and that `dagger api client init` points the user at
-// `dagger generate` once the client is scaffolded.
+// clients), and that `dagger api client init` no longer points the user at
+// `dagger generate`: it runs the SDK's generators itself, so the bindings are
+// already there (dagger/dagger#13714).
 func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t *testctx.T) {
 	workdir := t.TempDir()
 	initGitRepo(ctx, t, workdir)
@@ -65,7 +66,8 @@ func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t
 
 	clientOut, err := hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "api", "client", "init", "go", "./myclient", ".dagger/modules/myapp")
 	require.NoError(t, err, "%s", string(clientOut))
-	require.Contains(t, string(clientOut), "dagger generate")
+	require.NotContains(t, string(clientOut), "dagger generate",
+		"client init generates the bindings, so it must not send the user to `dagger generate`")
 }
 
 // TestUninstalledSDKInitHint verifies that `dagger module init <sdk> <name>`

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -427,6 +427,240 @@ func (m *ClientGeneratorFixture) GenerateClients(ctx context.Context, ws *dagger
 	require.Contains(t, two, "client-generator-fixture")
 }
 
+// initGeneratorFixture is an SDK module supporting `module init` / `client init`
+// alongside cwd-anchored generators, mirroring how the real SDKs discover work
+// (go-sdk's `modules(ws)`, typescript-sdk's `generateAllClient`): each generator
+// emits a marker for the modules or clients its workspace entry manages at or
+// below the workspace cwd. Paths in a returned changeset are cwd-relative, which
+// is what lets the engine re-root a cwd-scoped run.
+//
+// The workspace it manages always holds one pre-existing module and one
+// pre-existing client, so anything generated outside the initialized path shows
+// up as a stray marker.
+func initGeneratorFixture(t testing.TB, c *dagger.Client) *dagger.Container {
+	return goGitBase(t, c).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", testCLIBinPath).
+		With(nonNestedDevEngine(c)).
+		WithNewFile("dagger.toml", `[modules.init-fixture]
+source = ".dagger/init-fixture"
+
+[modules.init-fixture.as-sdk]
+name = "fixture"
+
+[[modules.init-fixture.as-sdk.modules]]
+path = "existing/mod"
+
+[[modules.init-fixture.as-sdk.clients]]
+path = "existing/client"
+module = ".dagger/init-fixture"
+`).
+		WithNewFile(".dagger/init-fixture/dagger.json", `{
+  "name": "init-fixture",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`).
+		WithNewFile(".dagger/init-fixture/main.go", `package main
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"dagger/init-fixture/internal/dagger"
+)
+
+type InitFixture struct{}
+
+// InitModule scaffolds the SDK-owned files for a new module.
+func (m *InitFixture) InitModule(ctx context.Context, ws *dagger.Workspace, name string, path string) (*dagger.Changeset, error) {
+	return dag.Directory().WithNewFile(path+"/scaffold.txt", name+"\n").Changes(dag.Directory()), nil
+}
+
+// InitClient scaffolds the SDK-owned files for a new client.
+func (m *InitFixture) InitClient(ctx context.Context, ws *dagger.Workspace, path string, module string) (*dagger.Changeset, error) {
+	return dag.Directory().WithNewFile(path+"/scaffold.txt", module+"\n").Changes(dag.Directory()), nil
+}
+
+// +generate
+func (m *InitFixture) GenerateModules(ctx context.Context, ws *dagger.Workspace) (*dagger.Changeset, error) {
+	cwd, err := workspaceCwd(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	modules, err := dag.CurrentModule().AsSDK(dagger.CurrentModuleAsSDKOpts{Workspace: ws}).Modules(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	generated := dag.Directory()
+	for _, mod := range modules {
+		modPath, err := mod.Path(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rel, ok := relativeToCwd(cwd, modPath)
+		if !ok {
+			continue
+		}
+		generated = generated.WithNewFile(path.Join(rel, "generated-module.txt"), modPath+"\n")
+	}
+	return generated.Changes(dag.Directory()), nil
+}
+
+// +generate
+func (m *InitFixture) GenerateClients(ctx context.Context, ws *dagger.Workspace) (*dagger.Changeset, error) {
+	cwd, err := workspaceCwd(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	clients, err := dag.CurrentModule().AsSDK(dagger.CurrentModuleAsSDKOpts{Workspace: ws}).Clients(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	generated := dag.Directory()
+	for _, client := range clients {
+		clientPath, err := client.Path(ctx)
+		if err != nil {
+			return nil, err
+		}
+		module, err := client.Module(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rel, ok := relativeToCwd(cwd, clientPath)
+		if !ok {
+			continue
+		}
+		generated = generated.WithNewFile(path.Join(rel, "generated-client.txt"), module+"\n")
+	}
+	return generated.Changes(dag.Directory()), nil
+}
+
+func workspaceCwd(ctx context.Context, ws *dagger.Workspace) (string, error) {
+	cwd, err := ws.Cwd(ctx)
+	if err != nil {
+		return "", err
+	}
+	return normalizeWorkspacePath(cwd), nil
+}
+
+func normalizeWorkspacePath(p string) string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return "."
+	}
+	return path.Clean(trimmed)
+}
+
+// relativeToCwd reports target relative to cwd, and whether it is at or below
+// it. A returned changeset can only carry paths under the caller's location, so
+// anything outside is skipped.
+func relativeToCwd(cwd, target string) (string, bool) {
+	target = normalizeWorkspacePath(target)
+	if cwd == "." {
+		return target, true
+	}
+	if target == cwd {
+		return ".", true
+	}
+	if strings.HasPrefix(target, cwd+"/") {
+		return strings.TrimPrefix(target, cwd+"/"), true
+	}
+	return "", false
+}
+`)
+}
+
+// TestModuleInitGeneratesForNewModuleOnly covers the `dagger module init` half
+// of dagger/dagger#13714: init runs the owning SDK's generators for what it just
+// created, so the module is usable without a separate `dagger generate`, and
+// nothing else in the workspace is touched.
+func (GeneratorsSuite) TestModuleInitGeneratesForNewModuleOnly(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixture(t, c)
+
+	t.Run("generates the new module", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec("module", "init", "fixture", "newmod", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		// The SDK's scaffold and the engine's module config both landed...
+		scaffold, err := initialized.File(".dagger/modules/newmod/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "newmod\n", scaffold)
+		_, err = initialized.File(".dagger/modules/newmod/dagger-module.toml").Contents(ctx)
+		require.NoError(t, err)
+
+		// ...and so did the generator output, in the same apply.
+		generated, err := initialized.File(".dagger/modules/newmod/generated-module.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ".dagger/modules/newmod\n", generated)
+
+		// The pre-existing module and client sit outside the new module's cwd,
+		// so the scoped run never reached them.
+		for _, stray := range []string{"existing/mod/generated-module.txt", "existing/client/generated-client.txt"} {
+			exists, err := initialized.Exists(ctx, stray)
+			require.NoError(t, err)
+			require.False(t, exists, "generation must not escape the initialized module: %s", stray)
+		}
+	})
+
+	t.Run("--no-generate scaffolds without generating", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec("module", "init", "fixture", "newmod", "--no-generate", "--auto-apply"))
+
+		scaffold, err := initialized.File(".dagger/modules/newmod/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "newmod\n", scaffold)
+
+		exists, err := initialized.Exists(ctx, ".dagger/modules/newmod/generated-module.txt")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+}
+
+// TestAPIClientInitGeneratesForNewClientOnly covers the `dagger api client init`
+// half of dagger/dagger#13714.
+func (GeneratorsSuite) TestAPIClientInitGeneratesForNewClientOnly(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixture(t, c)
+
+	t.Run("generates the new client", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"api", "client", "init", "fixture", "clients/one", ".dagger/init-fixture", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		scaffold, err := initialized.File("clients/one/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ".dagger/init-fixture\n", scaffold)
+
+		generated, err := initialized.File("clients/one/generated-client.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ".dagger/init-fixture\n", generated)
+
+		for _, stray := range []string{"existing/mod/generated-module.txt", "existing/client/generated-client.txt"} {
+			exists, err := initialized.Exists(ctx, stray)
+			require.NoError(t, err)
+			require.False(t, exists, "generation must not escape the initialized client: %s", stray)
+		}
+	})
+
+	t.Run("--no-generate scaffolds without generating", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"api", "client", "init", "fixture", "clients/one", ".dagger/init-fixture", "--no-generate", "--auto-apply"))
+
+		scaffold, err := initialized.File("clients/one/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ".dagger/init-fixture\n", scaffold)
+
+		exists, err := initialized.Exists(ctx, "clients/one/generated-client.txt")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+}
+
 func (GeneratorsSuite) TestGeneratorGroupChangesSyncWithNestedSDKCodegen(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -576,6 +576,15 @@ func (sdk *persistedModuleSourceLazySDK) AsRuntimeTarget() (RuntimeTarget, bool)
 	return persistedModuleSourceLazyRuntimeTarget{sdk: sdk}, true
 }
 
+// AsModule reports no module. Every other capability is a behavior this wrapper
+// can defer behind a recorded flag; a module result is a value, so handing one
+// back would mean loading the SDK eagerly and defeating the laziness. Callers
+// that need the SDK's own module (workspace init's scoped generation) hold a
+// freshly loaded SDK, never a rehydrated one.
+func (sdk *persistedModuleSourceLazySDK) AsModule() (dagql.ObjectResult[*Module], bool) {
+	return dagql.ObjectResult[*Module]{}, false
+}
+
 type persistedModuleSourceLazyRuntime struct {
 	sdk *persistedModuleSourceLazySDK
 }

--- a/core/modulesource_test.go
+++ b/core/modulesource_test.go
@@ -53,6 +53,10 @@ func (sdk *moduleSourceAttachTestSDK) AsClientInitializer() (ClientInitializer, 
 	return nil, false
 }
 
+func (sdk *moduleSourceAttachTestSDK) AsModule() (dagql.ObjectResult[*Module], bool) {
+	return dagql.ObjectResult[*Module]{}, false
+}
+
 func (sdk *moduleSourceAttachTestSDK) AsRuntimeTarget() (RuntimeTarget, bool) {
 	return nil, false
 }

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -159,6 +159,12 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("module").Doc("Workspace-root-relative path of the module whose generated local dependencies these are."),
 				dagql.Arg("changes").Doc("The staged dependency codegen to apply."),
 			),
+		dagql.NodeFunc("__sdkGenerators", s.sdkGenerators).
+			Doc("(Internal-only) The generators exposed by an SDK installed in this workspace.",
+				"Built straight from the SDK's own module, so it demands no workspace module loading: an init flow can generate for what it just created without pulling in the rest of the workspace.").
+			Args(
+				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name whose generators to collect."),
+			),
 		dagql.NodeFunc("withWorkdir", s.withWorkdir).
 			View(AfterVersion("v1.0.0-0")).
 			Doc("Return this workspace with its working directory pointed at the given workspace-relative path.").
@@ -198,7 +204,8 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withInitModule", s.withInitModule).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a new module initialized.").
+			Doc("Return this workspace with a new module initialized.",
+				"The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.").
 			Args(
 				dagql.Arg("name").Doc("Name of the new module."),
 				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name to use."),
@@ -207,16 +214,19 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("include").Doc("Additional include patterns for the module."),
 				dagql.Arg("args").Doc("SDK-specific init arguments."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
+				dagql.Arg("noGenerate").Doc("Skip running the SDK's generators for the new module."),
 			),
 		dagql.NodeFunc("withInitClient", s.withInitClient).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a generated API client initialized.").
+			Doc("Return this workspace with a generated API client initialized.",
+				"The SDK's generators run for the new client, so the returned workspace carries its generated bindings.").
 			Args(
 				dagql.Arg("path").Doc("Workspace-relative output directory for the generated client."),
 				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name to use."),
 				dagql.Arg("module").Doc("Workspace-relative path or canonical ref for the module the client binds to."),
 				dagql.Arg("args").Doc("SDK-specific init arguments."),
 				dagql.Arg("here").Doc("Write to the workspace config directory at the workspace cwd."),
+				dagql.Arg("noGenerate").Doc("Skip running the SDK's generators for the new client."),
 			),
 		dagql.NodeFunc("withConfigValue", s.withConfigValue).
 			View(AfterVersion("v1.0.0-0")).

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -413,7 +413,7 @@ func (s *workspaceSchema) withInitModule(
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceInitModuleArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	changes, err := s.initModuleChanges(
+	changes, scope, err := s.initModuleChanges(
 		workspaceInstallContextWithLockMode(ctx, workspace.LockModeDisabled),
 		parent,
 		args,
@@ -421,7 +421,14 @@ func (s *workspaceSchema) withInitModule(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.workspaceWithChangeset(ctx, parent, changes)
+	updated, err := s.workspaceWithChangeset(ctx, parent, changes)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if args.NoGenerate {
+		return updated, nil
+	}
+	return s.withScopedGeneration(ctx, updated, scope)
 }
 
 func (s *workspaceSchema) withInitClient(
@@ -429,7 +436,7 @@ func (s *workspaceSchema) withInitClient(
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceInitClientArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	changes, err := s.initClientChanges(
+	changes, scope, err := s.initClientChanges(
 		workspaceInstallContextWithLockMode(ctx, workspace.LockModeDisabled),
 		parent,
 		args,
@@ -437,7 +444,180 @@ func (s *workspaceSchema) withInitClient(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.workspaceWithChangeset(ctx, parent, changes)
+	updated, err := s.workspaceWithChangeset(ctx, parent, changes)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if args.NoGenerate {
+		return updated, nil
+	}
+	return s.withScopedGeneration(ctx, updated, scope)
+}
+
+// initScope identifies what an init just created: the workspace-root-relative
+// path of the new module or client, and the module entry name of the SDK that
+// owns it.
+type initScope struct {
+	sdk  string
+	path string
+}
+
+// sdkGenerators collects the generators an installed SDK exposes, reading them
+// off the SDK's own module.
+//
+// Workspace.generators answers the same question for the workspace as a whole,
+// but sources its modules from the ones the client loaded, so asking it for a
+// single SDK means demanding workspace module loading. This loads the one SDK
+// named and nothing else — the same load init already performs to scaffold with.
+func (s *workspaceSchema) sdkGenerators(
+	ctx context.Context,
+	parentResult dagql.ObjectResult[*core.Workspace],
+	args struct {
+		SDK string
+	},
+) (*core.GeneratorGroup, error) {
+	parent := parentResult.Self()
+	staged, err := s.loadWorkspaceConfigForOverlay(ctx, parent, workspaceConfigMustExist, false)
+	if err != nil {
+		return nil, err
+	}
+	sdkName, _, sdkRef, err := installedSDKSource(staged.Config, args.SDK)
+	if err != nil {
+		return nil, err
+	}
+	loaded, err := s.loadWorkspaceSDK(ctx, parent, staged.ConfigDir, sdkRef)
+	if err != nil {
+		return nil, fmt.Errorf("load SDK %q: %w", sdkName, err)
+	}
+	mod, ok := loaded.AsModule()
+	if !ok {
+		// A builtin SDK is a packaged binary, not a module, so it has no
+		// generator functions to expose.
+		return &core.GeneratorGroup{}, nil
+	}
+	mod, err = moduleUnderWorkspaceName(ctx, mod, sdkName)
+	if err != nil {
+		return nil, fmt.Errorf("load SDK %q as %q: %w", sdkRef, sdkName, err)
+	}
+
+	gg, err := core.NewGeneratorGroup(ctx, mod, nil)
+	if err != nil {
+		return nil, fmt.Errorf("generators from SDK %q: %w", sdkName, err)
+	}
+	// Name the tree after the workspace entry, so generator paths read the same
+	// as they do under `dagger generate <sdk>`.
+	reparentWorkspaceTreeRoot(gg.Node, sdkName)
+	// Bind the receiver, exactly as Workspace.generators does, so the generators
+	// run against this workspace — overlay edits and cwd included — instead of
+	// the session's frozen current workspace.
+	gg.BoundWorkspace = parentResult
+	return gg, nil
+}
+
+// moduleUnderWorkspaceName reloads mod under the name its workspace entry gives
+// it, matching how workspace module loading installs it.
+//
+// The name is load-bearing, not cosmetic: currentModule.asSDK — which every SDK
+// generator calls to find the modules and clients it manages — matches the
+// running module's name against the dagger.toml entries. An SDK loaded from its
+// ref carries its own name ("go-sdk"), so without this it fails to match its
+// entry ("dagger-go-sdk") and reports that it is not installed as an SDK.
+func moduleUnderWorkspaceName(
+	ctx context.Context,
+	mod dagql.ObjectResult[*core.Module],
+	name string,
+) (dagql.ObjectResult[*core.Module], error) {
+	if mod.Self().Name() == name {
+		return mod, nil
+	}
+	src := mod.Self().Source
+	if !src.Valid {
+		return mod, fmt.Errorf("module has no source")
+	}
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return mod, err
+	}
+	var renamed dagql.ObjectResult[*core.Module]
+	if err := dag.Select(ctx, src.Value, &renamed,
+		dagql.Selector{
+			Field: "withName",
+			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(name)}},
+		},
+		dagql.Selector{Field: "asModule"},
+	); err != nil {
+		return mod, err
+	}
+	return renamed, nil
+}
+
+// withScopedGeneration runs the owning SDK's generators against updated with
+// scope.path as the workspace cwd, and folds their output back into it — so an
+// init returns a single changeset carrying both the scaffold and the generated
+// code it needs to be loadable.
+//
+// Scoping is by cwd, not by generator selection: every SDK's @generate is
+// anchored at the workspace cwd (it generates the module it's in plus the ones
+// beneath, and only the clients under that path), so pointing it at what was
+// just created is what keeps the rest of the workspace untouched. This is the
+// same mechanism ModuleSource.generateLocalDependencies uses per dependency.
+//
+// The generators come from __sdkGenerators, which reads them off the SDK's own
+// module, rather than from Workspace.generators, which resolves them out of the
+// client's loaded workspace modules. Init already loads the SDK to scaffold
+// with, so the former needs nothing else; the latter would make init demand
+// workspace module loading for a set it only ever filters back down to this one
+// SDK.
+func (s *workspaceSchema) withScopedGeneration(
+	ctx context.Context,
+	updated dagql.ObjectResult[*core.Workspace],
+	scope initScope,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+
+	// Nothing to stage: what was just created has no already-generated local
+	// dependency closure to carry in.
+	scoped, err := scopedStagedWorkspace(ctx, dag, updated, scope.path, dagql.ObjectResult[*core.Changeset]{})
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("scope workspace to %q: %w", scope.path, err)
+	}
+
+	// Resolved on the scoped workspace, because the group binds to its receiver:
+	// that is what carries both the post-init overlay — where the entry init just
+	// recorded in dagger.toml lives, without which the generator would not see the
+	// new module or client — and the cwd that scopes it.
+	var generators dagql.ObjectResult[*core.GeneratorGroup]
+	if err := dag.Select(ctx, scoped, &generators, dagql.Selector{
+		Field: "__sdkGenerators",
+		Args: []dagql.NamedInput{
+			{Name: "sdk", Value: dagql.String(scope.sdk)},
+		},
+	}); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if len(generators.Self().Generators) == 0 {
+		// An SDK that exposes no generator has nothing to contribute; the
+		// config and scaffold init planned still stand.
+		return updated, nil
+	}
+
+	var generated dagql.ObjectResult[*core.Changeset]
+	if err := dag.Select(ctx, generators, &generated,
+		dagql.Selector{Field: "run"},
+		dagql.Selector{Field: "changes"},
+	); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	// Generation ran with scope.path as cwd, so its changeset is rooted there.
+	// Re-root it to the workspace root so it overlays in the right place.
+	generated, err = rerootChangesetUnder(ctx, dag, generated, scope.path)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("reroot changeset under %q: %w", scope.path, err)
+	}
+	return s.workspaceWithChangeset(ctx, updated, generated)
 }
 
 func (s *workspaceSchema) withUpdatedLock(

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -15,57 +15,62 @@ import (
 )
 
 type workspaceInitClientArgs struct {
-	Path   string
-	SDK    string
-	Module string
-	Args   core.JSON `default:""`
-	Here   bool      `default:"false"`
+	Path       string
+	SDK        string
+	Module     string
+	Args       core.JSON `default:""`
+	Here       bool      `default:"false"`
+	NoGenerate bool      `default:"false"`
 }
 
+// initClientChanges stages the workspace config edit recording the new client
+// plus whatever the SDK's initClient scaffolds. The returned initScope names
+// what was created, so the caller can generate for exactly it (see
+// workspaceSchema.withScopedGeneration).
 func (s *workspaceSchema) initClientChanges(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceInitClientArgs,
-) (res dagql.ObjectResult[*core.Changeset], _ error) {
+) (res dagql.ObjectResult[*core.Changeset], scope initScope, _ error) {
 	ws := parent.Self()
 	lockMode := ""
 	if clientMetadata, err := engine.ClientMetadataFromContext(ctx); err == nil {
 		lockMode = clientMetadata.LockMode
 	}
 	if args.Path == "" {
-		return res, fmt.Errorf("client path is required")
+		return res, scope, fmt.Errorf("client path is required")
 	}
 	if args.SDK == "" {
-		return res, fmt.Errorf("SDK name is required")
+		return res, scope, fmt.Errorf("SDK name is required")
 	}
 	if args.Module == "" {
-		return res, fmt.Errorf("module ref is required")
+		return res, scope, fmt.Errorf("module ref is required")
 	}
 
 	clientPath, err := cleanWorkspaceClientPath(args.Path)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(ws, args.Module)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	staged, err := s.loadWorkspaceConfigForOverlay(ctx, ws, workspaceConfigMustExist, args.Here)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	cfg := staged.Config
 	sdkName, sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	workspaceCtx := ctx
 	if ws.ClientID != "" {
 		workspaceCtx, err = s.withWorkspaceClientContext(ctx, ws)
 		if err != nil {
-			return res, fmt.Errorf("workspace client context: %w", err)
+			return res, scope, fmt.Errorf("workspace client context: %w", err)
 		}
 	}
 	if lockMode != "" {
@@ -75,7 +80,7 @@ func (s *workspaceSchema) initClientChanges(
 
 	targetModule, err := s.resolveClientTargetModule(workspaceCtx, ws, moduleLoadRef, "")
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	modulePin := targetModule.Self().Pin()
 
@@ -90,49 +95,64 @@ func (s *workspaceSchema) initClientChanges(
 
 	newConfigBytes, err := workspace.UpdateConfigBytes(staged.Data, cfg)
 	if err != nil {
-		return res, fmt.Errorf("update workspace config: %w", err)
+		return res, scope, fmt.Errorf("update workspace config: %w", err)
 	}
 
 	configRelPath := staged.ConfigFile
 	baseDir, err := s.workspaceOverlayRootfs(ctx, ws)
 	if err != nil {
-		return res, fmt.Errorf("resolve workspace rootfs: %w", err)
+		return res, scope, fmt.Errorf("resolve workspace rootfs: %w", err)
 	}
 
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return res, fmt.Errorf("dagql server: %w", err)
+		return res, scope, fmt.Errorf("dagql server: %w", err)
 	}
 
 	updatedDir := baseDir
 	updatedDir, err = workspaceWithFile(ctx, dag, updatedDir, configRelPath, newConfigBytes)
 	if err != nil {
-		return res, fmt.Errorf("stage workspace config update: %w", err)
+		return res, scope, fmt.Errorf("stage workspace config update: %w", err)
 	}
 
 	engineChanges, err := workspaceMigrationChanges(ctx, updatedDir, baseDir)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	sdkArgs, err := coresdk.DecodeInitArgs(args.Args)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	loadedSDK, err := s.loadWorkspaceSDK(ctx, ws, staged.ConfigDir, sdkRef)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	clientInitializer, ok := loadedSDK.AsClientInitializer()
 	if !ok {
-		return res, fmt.Errorf("%q does not support client init", args.SDK)
+		return res, scope, fmt.Errorf("%q does not support client init", args.SDK)
 	}
 	sdkChanges, err := clientInitializer.InitClient(ctx, parent, clientPath, moduleRef, sdkArgs)
 	if err != nil {
-		return res, fmt.Errorf("sdk client init: %w", err)
+		return res, scope, fmt.Errorf("sdk client init: %w", err)
 	}
 
-	return mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
+	res, err = mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
+	if err != nil {
+		return res, scope, err
+	}
+
+	// Create the client directory, even when the SDK's initClient scaffolds
+	// nothing into it (the Go SDK stages an empty changeset). Generation runs
+	// with this path as the workspace cwd, and a cwd that exists in neither the
+	// overlay nor the host cannot be resolved — "stat <path>: no such file or
+	// directory". Module init gets this for free from the dagger-module.toml the
+	// engine writes; a client has no engine-owned file of its own.
+	res, err = changesetWithDirectoryMode(ctx, res, clientPath, 0o755)
+	if err != nil {
+		return res, scope, err
+	}
+	return res, initScope{sdk: sdkName, path: clientPath}, nil
 }
 
 func (s *workspaceSchema) resolveClientTargetModule(

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -15,13 +15,14 @@ import (
 )
 
 type workspaceInitModuleArgs struct {
-	Name    string
-	SDK     string
-	Path    string    `default:""`
-	Source  string    `default:""`
-	Include []string  `default:"[]"`
-	Args    core.JSON `default:""`
-	Here    bool      `default:"false"`
+	Name       string
+	SDK        string
+	Path       string    `default:""`
+	Source     string    `default:""`
+	Include    []string  `default:"[]"`
+	Args       core.JSON `default:""`
+	Here       bool      `default:"false"`
+	NoGenerate bool      `default:"false"`
 }
 
 // initModuleChanges builds the workspace edits required to create a new module
@@ -41,18 +42,21 @@ type workspaceInitModuleArgs struct {
 // Every change is staged into one Changeset and returned. No filesystem write
 // happens inside this function.
 //
+// The returned initScope names what was created, so the caller can generate for
+// exactly it (see workspaceSchema.withScopedGeneration).
+//
 //nolint:gocyclo // inherently branchy orchestration (validate args, resolve SDK, plan changes)
 func (s *workspaceSchema) initModuleChanges(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceInitModuleArgs,
-) (res dagql.ObjectResult[*core.Changeset], _ error) {
+) (res dagql.ObjectResult[*core.Changeset], scope initScope, _ error) {
 	ws := parent.Self()
 	if args.Name == "" {
-		return res, fmt.Errorf("module name is required")
+		return res, scope, fmt.Errorf("module name is required")
 	}
 	if args.SDK == "" {
-		return res, fmt.Errorf("SDK name is required")
+		return res, scope, fmt.Errorf("SDK name is required")
 	}
 
 	// Resolve the workspace-relative path for the new module. Empty = default
@@ -64,27 +68,27 @@ func (s *workspaceSchema) initModuleChanges(
 	}
 	relPath = filepath.Clean(relPath)
 	if filepath.IsAbs(relPath) {
-		return res, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
+		return res, scope, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
 	}
 	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
-		return res, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
+		return res, scope, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
 	}
 
 	staged, err := s.loadWorkspaceConfigForOverlay(ctx, ws, workspaceConfigMustExist, args.Here)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	cfg := staged.Config
 	sdkName, sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	// Reject name conflicts in installed modules and reject path conflicts
 	// across any SDK's authored modules. Two SDKs claiming the same path is
 	// a corruption we shouldn't silently extend.
 	if _, exists := cfg.Modules[args.Name]; exists {
-		return res, fmt.Errorf("module %q is already installed in this workspace", args.Name)
+		return res, scope, fmt.Errorf("module %q is already installed in this workspace", args.Name)
 	}
 	for installedName, installed := range cfg.Modules {
 		if installed.AsSDK == nil {
@@ -92,7 +96,7 @@ func (s *workspaceSchema) initModuleChanges(
 		}
 		for _, m := range installed.AsSDK.Modules {
 			if filepath.Clean(m.Path) == relPath {
-				return res, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", relPath, installedName)
+				return res, scope, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", relPath, installedName)
 			}
 		}
 	}
@@ -102,23 +106,23 @@ func (s *workspaceSchema) initModuleChanges(
 
 	loadedSDK, err := s.loadWorkspaceSDK(ctx, ws, staged.ConfigDir, sdkRef)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	// By default the SDK module is also the runtime. SDKs that split authoring
 	// from execution advertise RuntimeTarget and provide the runtime ref.
 	defaultRuntimeRef, err := moduleEntrySourceWithPinRelativeTo(staged.ConfigDir, relPath, sdkEntry)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	runtimeRef := defaultRuntimeRef
 	if target, ok := loadedSDK.AsRuntimeTarget(); ok {
 		runtimeRef, err = target.TargetRuntime(ctx)
 		if err != nil {
-			return res, fmt.Errorf("resolve SDK target runtime: %w", err)
+			return res, scope, fmt.Errorf("resolve SDK target runtime: %w", err)
 		}
 		if runtimeRef == "" {
-			return res, fmt.Errorf("SDK target runtime is empty")
+			return res, scope, fmt.Errorf("SDK target runtime is empty")
 		}
 	}
 
@@ -129,7 +133,7 @@ func (s *workspaceSchema) initModuleChanges(
 	// Render new dagger.toml bytes through the format-preserving editor.
 	newConfigBytes, err := workspace.UpdateConfigBytes(staged.Data, cfg)
 	if err != nil {
-		return res, fmt.Errorf("update workspace config: %w", err)
+		return res, scope, fmt.Errorf("update workspace config: %w", err)
 	}
 
 	// Generate the new module's config file (dagger-module.toml) ONLY. The
@@ -145,45 +149,45 @@ func (s *workspaceSchema) initModuleChanges(
 	// diff is computed at the end.
 	baseDir, err := s.workspaceOverlayRootfs(ctx, ws)
 	if err != nil {
-		return res, fmt.Errorf("resolve workspace rootfs: %w", err)
+		return res, scope, fmt.Errorf("resolve workspace rootfs: %w", err)
 	}
 	moduleDiff, err := s.workspaceModuleInitConfigDiff(ctx, baseDir, args, relPath, runtimeRef)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	configRelPath := staged.ConfigFile
 
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return res, fmt.Errorf("dagql server: %w", err)
+		return res, scope, fmt.Errorf("dagql server: %w", err)
 	}
 
 	updatedDir := baseDir
 	updatedDir, err = workspaceWithFile(ctx, dag, updatedDir, configRelPath, newConfigBytes)
 	if err != nil {
-		return res, fmt.Errorf("stage workspace config update: %w", err)
+		return res, scope, fmt.Errorf("stage workspace config update: %w", err)
 	}
 	updatedDir, err = workspaceWithDirectoryOverlay(ctx, dag, updatedDir, moduleDiff)
 	if err != nil {
-		return res, fmt.Errorf("stage module generated context: %w", err)
+		return res, scope, fmt.Errorf("stage module generated context: %w", err)
 	}
 
 	engineChanges, err := workspaceMigrationChanges(ctx, updatedDir, baseDir)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	sdkArgs, err := coresdk.DecodeInitArgs(args.Args)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 	moduleInitializer, ok := loadedSDK.AsModuleInitializer()
 	if !ok {
-		return res, fmt.Errorf("%q does not support module init", args.SDK)
+		return res, scope, fmt.Errorf("%q does not support module init", args.SDK)
 	}
 	sdkChanges, err := moduleInitializer.InitModule(ctx, parent, args.Name, relPath, sdkArgs)
 	if err != nil {
-		return res, fmt.Errorf("sdk module init: %w", err)
+		return res, scope, fmt.Errorf("sdk module init: %w", err)
 	}
 
 	// Enforce the ownership split: the SDK's initModule must not touch the
@@ -191,12 +195,12 @@ func (s *workspaceSchema) initModuleChanges(
 	// error instead of a cryptic "added in both changesets" from the merge
 	// below (or, worse, an SDK silently clobbering config the engine wrote).
 	if err := validateSDKInitChangesetOwnership(ctx, args.SDK, sdkChanges, configRelPath, relPath); err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	merged, err := mergeWorkspaceInitChangeset(ctx, engineChanges, sdkChanges)
 	if err != nil {
-		return res, err
+		return res, scope, err
 	}
 
 	// Changesets are merged through Git, which does not track directory modes.
@@ -204,7 +208,11 @@ func (s *workspaceSchema) initModuleChanges(
 	// umask instead of retaining the mode staged by the engine or SDK. Normalize
 	// only the module root here: it is owned by module init, while directories
 	// below it remain owned by the SDK and keep their explicitly authored modes.
-	return changesetWithDirectoryMode(ctx, merged, relPath, 0o755)
+	res, err = changesetWithDirectoryMode(ctx, merged, relPath, 0o755)
+	if err != nil {
+		return res, scope, err
+	}
+	return res, initScope{sdk: sdkName, path: relPath}, nil
 }
 
 // changesetWithDirectoryMode returns changes with path's mode explicitly set

--- a/core/sdk.go
+++ b/core/sdk.go
@@ -427,6 +427,12 @@ type SDK interface {
 	// Transform the SDK into a RuntimeTarget if it implements it.
 	AsRuntimeTarget() (RuntimeTarget, bool)
 
+	// AsModule returns the Dagger module backing this SDK, for SDKs that are
+	// themselves modules. Callers use it to reach the SDK's own functions —
+	// notably its generators — without going through workspace module loading.
+	// Builtin SDKs are packaged binaries rather than modules and return false.
+	AsModule() (dagql.ObjectResult[*Module], bool)
+
 	// AttachDependencyResults attaches any cache-backed results embedded in the
 	// SDK implementation and returns the results the owning ModuleSource must
 	// retain.

--- a/core/sdk/dang_sdk.go
+++ b/core/sdk/dang_sdk.go
@@ -91,6 +91,12 @@ func (sdk *dangSDK) AsRuntimeTarget() (core.RuntimeTarget, bool) {
 	return nil, false
 }
 
+// AsModule reports no module: the Dang SDK is packaged into the engine rather
+// than loaded as a Dagger module, so it exposes no generator functions.
+func (sdk *dangSDK) AsModule() (dagql.ObjectResult[*core.Module], bool) {
+	return dagql.ObjectResult[*core.Module]{}, false
+}
+
 func (sdk *dangSDK) AttachDependencyResults(
 	context.Context,
 	func(dagql.AnyResult) (dagql.AnyResult, error),

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -92,6 +92,12 @@ func (sdk *goSDK) AsRuntimeTarget() (core.RuntimeTarget, bool) {
 	return nil, false
 }
 
+// AsModule reports no module: the Go SDK is a packaged codegen binary, not a
+// Dagger module, so it exposes no generator functions of its own.
+func (sdk *goSDK) AsModule() (dagql.ObjectResult[*core.Module], bool) {
+	return dagql.ObjectResult[*core.Module]{}, false
+}
+
 // AlwaysEnablesSelfCalls reports that the Go SDK always enables self calls:
 // generated bindings unconditionally include the module's own types, so
 // engine-side checks gated on SelfCallsEnabled (tolerating module types that

--- a/core/sdk/module.go
+++ b/core/sdk/module.go
@@ -310,6 +310,10 @@ func (sdk *module) AsClientInitializer() (core.ClientInitializer, bool) {
 	return &clientInitializerModule{mod: sdk, funcs: sdk.funcs}, true
 }
 
+func (sdk *module) AsModule() (dagql.ObjectResult[*core.Module], bool) {
+	return sdk.mod, true
+}
+
 func (sdk *module) AsRuntimeTarget() (core.RuntimeTarget, bool) {
 	if _, ok := sdk.funcs["targetRuntime"]; !ok {
 		return nil, false

--- a/docs/current_docs/extending/sdks/go.mdx
+++ b/docs/current_docs/extending/sdks/go.mdx
@@ -93,7 +93,7 @@ my-module/
 ```
 
 :::note
-`dagger module init` writes `dagger-module.toml` and `main.go` and updates the workspace config. After accepting those changes, run `dagger generate` once to create `go.mod`, `go.sum`, and the generated Go files shown above. Commit the generated Go files along with the rest of the module. Dagger needs the generated client to load the module, both from your local checkout and from a Git reference.
+`dagger module init` writes `dagger-module.toml` and `main.go`, updates the workspace config, and runs the Go SDK's generator for the new module — so `go.mod`, `go.sum`, and the generated Go files shown above are part of the same changeset. Commit the generated Go files along with the rest of the module. Dagger needs the generated client to load the module, both from your local checkout and from a Git reference. Pass `--no-generate` to scaffold without generating.
 :::
 
 The module config records the runtime separately from the SDK that authors it:
@@ -940,7 +940,7 @@ jobs:
 
 ## IDE setup, `go.mod` and `go.work`
 
-The first `dagger generate` creates a `go.mod` and `go.sum` inside your Dagger module. These files tell Go which dependencies the generated client needs. If the Dagger module lives inside a larger Go project, the additional `go.mod` can make an editor choose the wrong Go module for a file.
+`dagger module init` creates a `go.mod` and `go.sum` inside your Dagger module. These files tell Go which dependencies the generated client needs. If the Dagger module lives inside a larger Go project, the additional `go.mod` can make an editor choose the wrong Go module for a file.
 
 Two options:
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -237,6 +237,9 @@ SDK, plans the generated files and workspace config change, then returns a
 Changeset that the CLI previews and applies through the standard preview/apply
 flow.
 
+The SDK's generators run scoped to &lt;path&gt;, so the client's bindings come with
+it. Pass --no-generate to record and scaffold the client without them.
+
 ```
 dagger api client init <sdk> <path> <module>
 ```
@@ -245,6 +248,12 @@ dagger api client init <sdk> <path> <module>
 
 ```
 dagger api client init typescript ./lib/cli .dagger/modules/api
+```
+
+### Options
+
+```
+      --no-generate   Skip running the SDK's generators for the new client
 ```
 
 ### Options inherited from parent commands
@@ -2175,6 +2184,9 @@ What the engine does (atomically, in one Changeset):
      &lt;path&gt;.
   4. When --path is the default (.dagger/modules/&lt;name&gt;), also installs
      the new module as [modules.&lt;name&gt;] so it's callable here.
+  5. Runs the SDK's generators scoped to &lt;path&gt;, so the new module is
+     loadable without a separate 'dagger generate'. Pass --no-generate to
+     skip this.
 
 --path defaults to .dagger/modules/&lt;name&gt;. Custom paths skip the
 [modules.&lt;name&gt;] install (the user is managing workspace layout
@@ -2193,6 +2205,7 @@ dagger sdk install go && dagger module init go my-module
 ### Options
 
 ```
+      --no-generate   Skip running the SDK's generators for the new module
       --path string   Module path relative to the workspace root (default: .dagger/modules/<name>)
 ```
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5633,7 +5633,11 @@ type Workspace implements Node {
     here: Boolean = false
   ): Workspace!
 
-  """Return this workspace with a generated API client initialized."""
+  """
+  Return this workspace with a generated API client initialized.
+
+  The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
+  """
   withInitClient(
     """Workspace-relative output directory for the generated client."""
     path: String!
@@ -5651,9 +5655,16 @@ type Workspace implements Node {
 
     """Write to the workspace config directory at the workspace cwd."""
     here: Boolean = false
+
+    """Skip running the SDK's generators for the new client."""
+    noGenerate: Boolean = false
   ): Workspace!
 
-  """Return this workspace with a new module initialized."""
+  """
+  Return this workspace with a new module initialized.
+
+  The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
+  """
   withInitModule(
     """Name of the new module."""
     name: String!
@@ -5675,6 +5686,9 @@ type Workspace implements Node {
 
     """Write to the workspace config directory at the workspace cwd."""
     here: Boolean = false
+
+    """Skip running the SDK's generators for the new module."""
+    noGenerate: Boolean = false
   ): Workspace!
 
   """Return this workspace with a module installed in its config."""

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -406,7 +406,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+                    <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         
                                             <p><p>Return this workspace with a generated API client initialized.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -416,7 +416,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withInitModule">withInitModule</a>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+                    <a href="#method_withInitModule">withInitModule</a>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         
                                             <p><p>Return this workspace with a new module initialized.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1732,9 +1732,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 388</div>
+        <div class="location">at line 390</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+    <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
     </h3>
     <div class="details">    
@@ -1742,7 +1742,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a generated API client initialized.</p></p>                        
+                            <p><p>Return this workspace with a generated API client initialized.</p></p>                <p><p>The SDK's generators run for the new client, so the returned workspace carries its generated bindings.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1773,6 +1773,11 @@
                 <td>$here</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1794,9 +1799,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 411</div>
+        <div class="location">at line 419</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+    <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
     </h3>
     <div class="details">    
@@ -1804,7 +1809,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a new module initialized.</p></p>                        
+                            <p><p>Return this workspace with a new module initialized.</p></p>                <p><p>The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1845,6 +1850,11 @@
                 <td>$here</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1866,7 +1876,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 444</div>
+        <div class="location">at line 456</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -1918,7 +1928,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 460</div>
+        <div class="location">at line 472</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -1965,7 +1975,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 471</div>
+        <div class="location">at line 483</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2017,7 +2027,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 485</div>
+        <div class="location">at line 497</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2074,7 +2084,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 504</div>
+        <div class="location">at line 516</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2106,7 +2116,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 513</div>
+        <div class="location">at line 525</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2148,7 +2158,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 523</div>
+        <div class="location">at line 535</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2195,7 +2205,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 538</div>
+        <div class="location">at line 550</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2242,7 +2252,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 551</div>
+        <div class="location">at line 563</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2284,7 +2294,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 561</div>
+        <div class="location">at line 573</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2326,7 +2336,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 571</div>
+        <div class="location">at line 583</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2373,7 +2383,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 584</div>
+        <div class="location">at line 596</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	apiClientListJSON bool
+	apiClientListJSON       bool
+	apiClientInitNoGenerate bool
 )
 
 var apiClientCmd = &cobra.Command{
@@ -38,7 +39,10 @@ to add more choices.
 The engine resolves <sdk> from dagger.toml, validates that it is installed as an
 SDK, plans the generated files and workspace config change, then returns a
 Changeset that the CLI previews and applies through the standard preview/apply
-flow.`,
+flow.
+
+The SDK's generators run scoped to <path>, so the client's bindings come with
+it. Pass --no-generate to record and scaffold the client without them.`,
 	Example: "dagger api client init typescript ./lib/cli .dagger/modules/api",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -55,6 +59,7 @@ var apiClientListCmd = &cobra.Command{
 
 func init() {
 	apiClientListCmd.Flags().BoolVar(&apiClientListJSON, "json", false, "Output the client list in JSON format")
+	apiClientInitCmd.PersistentFlags().BoolVar(&apiClientInitNoGenerate, "no-generate", false, "Skip running the SDK's generators for the new client")
 
 	apiClientCmd.AddCommand(apiClientInitCmd, apiClientListCmd)
 }
@@ -69,30 +74,17 @@ func runAPIClientInitWithSDK(cmd *cobra.Command, sdkName, clientPath, moduleRef 
 		if err != nil {
 			return err
 		}
-		opts := dagger.WorkspaceWithInitClientOpts{}
+		opts := dagger.WorkspaceWithInitClientOpts{
+			NoGenerate: apiClientInitNoGenerate,
+		}
 		if sdkArgs != "" {
 			opts.Args = dagger.JSON(sdkArgs)
 		}
 		updated := dag.CurrentWorkspace().WithInitClient(clientPath, sdkName, moduleRef, opts)
-		applied, err := handleWorkspaceResponse(ctx, dag, updated, autoApply)
-		if err != nil {
-			return err
-		}
-		if applied && !silent {
-			fmt.Fprint(cmd.OutOrStdout(), clientInitGenerateHint)
-		}
-		return nil
+		_, err = handleWorkspaceResponse(ctx, dag, updated, autoApply)
+		return err
 	})
 }
-
-// clientInitGenerateHint points the user at the generate step: `api client
-// init` records and scaffolds the client, but its bindings are produced by
-// `dagger generate`.
-const clientInitGenerateHint = `
-  Client scaffolded. Generate its bindings with:
-
-      dagger generate
-`
 
 type apiClientListEntry struct {
 	SDK     string            `json:"sdk"`

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -121,7 +121,10 @@ func sdkRegistryRepoBase(repo string) string {
 
 // --- dagger module init ---
 
-var moduleInitPath string
+var (
+	moduleInitPath       string
+	moduleInitNoGenerate bool
+)
 
 var moduleInitCmd = &cobra.Command{
 	Use:   "init <sdk> <name>",
@@ -143,6 +146,9 @@ What the engine does (atomically, in one Changeset):
      <path>.
   4. When --path is the default (.dagger/modules/<name>), also installs
      the new module as [modules.<name>] so it's callable here.
+  5. Runs the SDK's generators scoped to <path>, so the new module is
+     loadable without a separate 'dagger generate'. Pass --no-generate to
+     skip this.
 
 --path defaults to .dagger/modules/<name>. Custom paths skip the
 [modules.<name>] install (the user is managing workspace layout
@@ -156,6 +162,7 @@ explicitly).`,
 
 func init() {
 	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Module path relative to the workspace root (default: .dagger/modules/<name>)")
+	moduleInitCmd.PersistentFlags().BoolVar(&moduleInitNoGenerate, "no-generate", false, "Skip running the SDK's generators for the new module")
 	moduleCmd.AddCommand(moduleInitCmd)
 }
 
@@ -170,7 +177,8 @@ func runModuleInitWithSDK(cmd *cobra.Command, sdkName, name string) error {
 			return err
 		}
 		opts := dagger.WorkspaceWithInitModuleOpts{
-			Path: moduleInitPath,
+			Path:       moduleInitPath,
+			NoGenerate: moduleInitNoGenerate,
 		}
 		if sdkArgs != "" {
 			opts.Args = dagger.JSON(sdkArgs)

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -482,10 +482,13 @@ defmodule Dagger.Workspace do
 
   @doc """
   Return this workspace with a generated API client initialized.
+
+  The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
   """
   @spec with_init_client(t(), String.t(), String.t(), String.t(), [
           {:args, Dagger.JSON.t() | nil},
-          {:here, boolean() | nil}
+          {:here, boolean() | nil},
+          {:no_generate, boolean() | nil}
         ]) :: Dagger.Workspace.t()
   def with_init_client(%__MODULE__{} = workspace, path, sdk, module, optional_args \\ []) do
     query_builder =
@@ -496,6 +499,7 @@ defmodule Dagger.Workspace do
       |> QB.put_arg("module", module)
       |> QB.maybe_put_arg("args", optional_args[:args])
       |> QB.maybe_put_arg("here", optional_args[:here])
+      |> QB.maybe_put_arg("noGenerate", optional_args[:no_generate])
 
     %Dagger.Workspace{
       query_builder: query_builder,
@@ -505,13 +509,16 @@ defmodule Dagger.Workspace do
 
   @doc """
   Return this workspace with a new module initialized.
+
+  The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
   """
   @spec with_init_module(t(), String.t(), String.t(), [
           {:path, String.t() | nil},
           {:source, String.t() | nil},
           {:include, [String.t()]},
           {:args, Dagger.JSON.t() | nil},
-          {:here, boolean() | nil}
+          {:here, boolean() | nil},
+          {:no_generate, boolean() | nil}
         ]) :: Dagger.Workspace.t()
   def with_init_module(%__MODULE__{} = workspace, name, sdk, optional_args \\ []) do
     query_builder =
@@ -524,6 +531,7 @@ defmodule Dagger.Workspace do
       |> QB.maybe_put_arg("include", optional_args[:include])
       |> QB.maybe_put_arg("args", optional_args[:args])
       |> QB.maybe_put_arg("here", optional_args[:here])
+      |> QB.maybe_put_arg("noGenerate", optional_args[:no_generate])
 
     %Dagger.Workspace{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -15656,9 +15656,13 @@ type WorkspaceWithInitClientOpts struct {
 	Args JSON
 	// Write to the workspace config directory at the workspace cwd.
 	Here bool
+	// Skip running the SDK's generators for the new client.
+	NoGenerate bool
 }
 
 // Return this workspace with a generated API client initialized.
+//
+// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
 func (r *Workspace) WithInitClient(path string, sdk string, module string, opts ...WorkspaceWithInitClientOpts) *Workspace {
 	q := r.query.Select("withInitClient")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -15669,6 +15673,10 @@ func (r *Workspace) WithInitClient(path string, sdk string, module string, opts 
 		// `here` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Here) {
 			q = q.Arg("here", opts[i].Here)
+		}
+		// `noGenerate` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoGenerate) {
+			q = q.Arg("noGenerate", opts[i].NoGenerate)
 		}
 	}
 	q = q.Arg("path", path)
@@ -15692,9 +15700,13 @@ type WorkspaceWithInitModuleOpts struct {
 	Args JSON
 	// Write to the workspace config directory at the workspace cwd.
 	Here bool
+	// Skip running the SDK's generators for the new module.
+	NoGenerate bool
 }
 
 // Return this workspace with a new module initialized.
+//
+// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
 func (r *Workspace) WithInitModule(name string, sdk string, opts ...WorkspaceWithInitModuleOpts) *Workspace {
 	q := r.query.Select("withInitModule")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -15717,6 +15729,10 @@ func (r *Workspace) WithInitModule(name string, sdk string, opts ...WorkspaceWit
 		// `here` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Here) {
 			q = q.Arg("here", opts[i].Here)
+		}
+		// `noGenerate` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoGenerate) {
+			q = q.Arg("noGenerate", opts[i].NoGenerate)
 		}
 	}
 	q = q.Arg("name", name)

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -384,6 +384,8 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
 
     /**
      * Return this workspace with a generated API client initialized.
+     *
+     * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
      */
     public function withInitClient(
         string $path,
@@ -391,6 +393,7 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
         string $module,
         ?Json $args = null,
         ?bool $here = false,
+        ?bool $noGenerate = false,
     ): Workspace {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withInitClient');
         $innerQueryBuilder->setArgument('path', $path);
@@ -402,11 +405,16 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
         if (null !== $here) {
         $innerQueryBuilder->setArgument('here', $here);
         }
+        if (null !== $noGenerate) {
+        $innerQueryBuilder->setArgument('noGenerate', $noGenerate);
+        }
         return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
      * Return this workspace with a new module initialized.
+     *
+     * The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
      */
     public function withInitModule(
         string $name,
@@ -416,6 +424,7 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
         ?array $include = [],
         ?Json $args = null,
         ?bool $here = false,
+        ?bool $noGenerate = false,
     ): Workspace {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withInitModule');
         $innerQueryBuilder->setArgument('name', $name);
@@ -434,6 +443,9 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
         }
         if (null !== $here) {
         $innerQueryBuilder->setArgument('here', $here);
+        }
+        if (null !== $noGenerate) {
+        $innerQueryBuilder->setArgument('noGenerate', $noGenerate);
         }
         return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -14794,8 +14794,12 @@ class Workspace(Type):
         *,
         args: JSON | None = None,
         here: bool | None = False,
+        no_generate: bool | None = False,
     ) -> Self:
         """Return this workspace with a generated API client initialized.
+
+        The SDK's generators run for the new client, so the returned workspace
+        carries its generated bindings.
 
         Parameters
         ----------
@@ -14810,6 +14814,8 @@ class Workspace(Type):
             SDK-specific init arguments.
         here:
             Write to the workspace config directory at the workspace cwd.
+        no_generate:
+            Skip running the SDK's generators for the new client.
         """
         _args = [
             Arg("path", path),
@@ -14817,6 +14823,7 @@ class Workspace(Type):
             Arg("module", module),
             Arg("args", args, None),
             Arg("here", here, False),
+            Arg("noGenerate", no_generate, False),
         ]
         _ctx = self._select("withInitClient", _args)
         return Workspace(_ctx)
@@ -14831,8 +14838,12 @@ class Workspace(Type):
         include: list[str] | None = None,
         args: JSON | None = None,
         here: bool | None = False,
+        no_generate: bool | None = False,
     ) -> Self:
         """Return this workspace with a new module initialized.
+
+        The SDK's generators run for the new module, so the returned workspace
+        carries the generated code it needs to be loadable.
 
         Parameters
         ----------
@@ -14850,6 +14861,8 @@ class Workspace(Type):
             SDK-specific init arguments.
         here:
             Write to the workspace config directory at the workspace cwd.
+        no_generate:
+            Skip running the SDK's generators for the new module.
         """
         _args = [
             Arg("name", name),
@@ -14859,6 +14872,7 @@ class Workspace(Type):
             Arg("include", [] if include is None else include, []),
             Arg("args", args, None),
             Arg("here", here, False),
+            Arg("noGenerate", no_generate, False),
         ]
         _ctx = self._select("withInitModule", _args)
         return Workspace(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -14378,6 +14378,9 @@ pub struct WorkspaceWithInitClientOpts {
     /// Write to the workspace config directory at the workspace cwd.
     #[builder(setter(into, strip_option), default)]
     pub here: Option<bool>,
+    /// Skip running the SDK's generators for the new client.
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceWithInitModuleOpts<'a> {
@@ -14390,6 +14393,9 @@ pub struct WorkspaceWithInitModuleOpts<'a> {
     /// Additional include patterns for the module.
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
+    /// Skip running the SDK's generators for the new module.
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
     /// Workspace-relative path for the new module.
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
@@ -15032,6 +15038,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a generated API client initialized.
+    /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
     /// # Arguments
     ///
@@ -15056,6 +15063,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a generated API client initialized.
+    /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
     /// # Arguments
     ///
@@ -15080,6 +15088,9 @@ impl Workspace {
         if let Some(here) = opts.here {
             query = query.arg("here", here);
         }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
+        }
         Workspace {
             proc: self.proc.clone(),
             selection: query,
@@ -15087,6 +15098,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a new module initialized.
+    /// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
     ///
     /// # Arguments
     ///
@@ -15104,6 +15116,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a new module initialized.
+    /// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
     ///
     /// # Arguments
     ///
@@ -15133,6 +15146,9 @@ impl Workspace {
         }
         if let Some(here) = opts.here {
             query = query.arg("here", here);
+        }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
         }
         Workspace {
             proc: self.proc.clone(),

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3193,6 +3193,11 @@ export type WorkspaceWithInitClientOpts = {
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
+
+  /**
+   * Skip running the SDK's generators for the new client.
+   */
+  noGenerate?: boolean
 }
 
 export type WorkspaceWithInitModuleOpts = {
@@ -3220,6 +3225,11 @@ export type WorkspaceWithInitModuleOpts = {
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
+
+  /**
+   * Skip running the SDK's generators for the new module.
+   */
+  noGenerate?: boolean
 }
 
 export type WorkspaceWithModuleOpts = {
@@ -14526,11 +14536,14 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a generated API client initialized.
+   *
+   * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
    * @param path Workspace-relative output directory for the generated client.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param module Workspace-relative path or canonical ref for the module the client binds to.
    * @param opts.args SDK-specific init arguments.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
+   * @param opts.noGenerate Skip running the SDK's generators for the new client.
    */
   withInitClient = (
     path: string,
@@ -14549,6 +14562,8 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a new module initialized.
+   *
+   * The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
    * @param name Name of the new module.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param opts.path Workspace-relative path for the new module.
@@ -14556,6 +14571,7 @@ export class Workspace extends BaseClient {
    * @param opts.include Additional include patterns for the module.
    * @param opts.args SDK-specific init arguments.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
+   * @param opts.noGenerate Skip running the SDK's generators for the new module.
    */
   withInitModule = (
     name: string,


### PR DESCRIPTION
Fixes #13714

## Problem

`dagger module init` scaffolds a module but leaves it ungenerated, so the next command fails with `generated file is missing; run 'dagger generate'`. `dagger api client init` printed a hint telling you to do the same thing by hand.

We couldn't just run generate on the user's behalf, because an unscoped `dagger generate` runs every generator in the workspace.

## Solution

Scope it by cwd. Every SDK's `@generate` is anchored at the workspace cwd — go-sdk's `modules(ws)` takes the enclosing module plus everything beneath it, typescript-sdk's `generateAllClient` filters clients by `inCwdScope` — so handing the generator a workspace pointed at the path init just created makes it generate that and nothing else. It's the same mechanism `ModuleSource.generateLocalDependencies` already uses to generate one dependency at a time.

`withInitModule`/`withInitClient` already hold the post-init overlay in memory, so `withScopedGeneration` chains onto it: `withWorkdir` to the new path, resolve the owning SDK's `generators` with that as the workspace override, run, and re-root the result back to the workspace root. Init and codegen come back as **one changeset** — one preview, one apply, and nothing lands on disk if you decline.

This adds no new codegen call site: it drives the same `GeneratorGroup` that `dagger generate` drives.

## Notes

- Both CLI commands switch from `SkipWorkspaceModules` to `LoadWorkspaceModules`. That's required — with modules skipped, `pendingModules` is empty and the generator group comes back empty. It isn't an eager cost: `currentWorkspace` demands nothing up front, so the only module loaded is the SDK named by the `include`.
- An SDK exposing no generator stays a no-op. A load failure on the SDK itself is fatal — it's the one module we can't silently skip.
- Generation failure fails the command and nothing is written, which is deliberate: a module whose codegen failed is unusable, and applying the scaffold behind a warning recreates exactly the half-initialized state this is meant to remove. `--no-generate` is the escape hatch.
- The arg is `noGenerate`, not `generate: Boolean! = true`, because the generated Go SDK drops zero-valued optional args — a `true`-defaulted bool could never carry `false` from the CLI. Same reason `Workspace.checks(noGenerate:)` is shaped that way.
- `dagger module init --path .` puts the cwd at the workspace root, so the SDK generates everything it manages. Inherent to cwd scoping, and the path was explicit.

## Test plan

- New fixture SDK in `generators_test.go` with `initModule`/`initClient` and two cwd-anchored generators, over a workspace that already holds a module and a client elsewhere. Asserts the new path is generated in the same apply **and** that the pre-existing ones stay unmarked — that second half is what catches a scoping regression. Plus `--no-generate` cases for both commands.
- `workspace_modules_test.go` checks end to end against the real dang SDK that a follow-up `dagger generate` finds nothing to do.