### PR TITLE
set dagger commit to a beta.8 version with the publish fixes

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -18,7 +18,12 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v1.0.0-beta.7"
+    default: ""
+    required: false
+
+  version:
+    description: "Dagger commit to run against"
+    default: "352dd3d22652b02383ff655a7c20dc41821d3fe4"
     required: false
 
   dev-engine:
@@ -49,6 +54,8 @@ runs:
       shell: bash
       env:
         DAGGER_VERSION: "${{ inputs.version }}"
+      env:
+        DAGGER_COMMIT: "${{ inputs.commit }}"
       run: |
         if [[ -x "$(command -v dagger)" ]]; then
           echo "::group::Checking dagger"


### PR DESCRIPTION
includes this fix: https://github.com/dagger/dagger/commit/00cb7d3a0e8d1eb6ec672aa504db14e52a9d1e21 which prevents the publish from failing