### PR TITLE
Python client lib: if downloading CLI fails, fall back to PATH

### DIFF
--- a/sdk/python/src/dagger/provisioning/_download.py
+++ b/sdk/python/src/dagger/provisioning/_download.py
@@ -22,7 +22,7 @@ import platformdirs
 
 from dagger._engine._version import CLI_VERSION
 
-from ._exceptions import DownloadError
+from ._exceptions import CLIReleaseUnavailableError, DownloadError
 from ._progress import Progress
 
 logger = logging.getLogger(__name__)
@@ -188,12 +188,13 @@ class Downloader:
 
     def _download(self, path: Path) -> Path:
         logger.debug("Downloading dagger CLI from %s to %s", self.archive_url, path)
-        self.progress.update_sync("Downloading dagger CLI")
         try:
             expected_hash = self.expected_checksum()
         except httpx.HTTPError as e:
             msg = f"Failed to download checksums from {self.checksum_url}: {e}"
             raise DownloadError(msg) from e
+
+        self.progress.update_sync("Downloading dagger CLI")
 
         with TempFile(f"temp-{self.CLI_BIN_PREFIX}", self.cache_dir) as tmp_bin:
             try:
@@ -216,13 +217,24 @@ class Downloader:
     def expected_checksum(self) -> str:
         archive_name = self.archive_name
         with httpx.stream("GET", self.checksum_url, follow_redirects=True) as r:
-            r.raise_for_status()
+            try:
+                r.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                if self.is_cli_release_unavailable(e.response.status_code):
+                    msg = f"Failed to download checksums from {self.checksum_url}: {e}"
+                    raise CLIReleaseUnavailableError(msg) from e
+                raise
             for line in r.iter_lines():
                 checksum, filename = line.split()
                 if filename == archive_name:
                     return checksum
         msg = "Could not find checksum for archive"
         raise DownloadError(msg)
+
+    @staticmethod
+    def is_cli_release_unavailable(status_code: int) -> bool:
+        # dl.dagger.io returns 403 for missing S3 objects.
+        return status_code in (httpx.codes.FORBIDDEN, httpx.codes.NOT_FOUND)
 
     def extract_cli_archive(self, dest: IO[bytes]) -> str:
         """

--- a/sdk/python/src/dagger/provisioning/_engine.py
+++ b/sdk/python/src/dagger/provisioning/_engine.py
@@ -1,11 +1,16 @@
 import contextlib
 import logging
 import os
+import shutil
+import sys
 import typing
+from typing import TextIO
 
+from exceptiongroup import ExceptionGroup
 from typing_extensions import Self
 
 import dagger
+from dagger._engine._version import CLI_VERSION
 from dagger.client._session import (
     BaseConnection,
     ConnectConfig,
@@ -16,7 +21,7 @@ from dagger.client._session import (
 
 from ._config import Config
 from ._download import Downloader
-from ._exceptions import ProvisionError
+from ._exceptions import CLIReleaseUnavailableError, ProvisionError
 from ._progress import Progress
 from ._session import start_cli_session
 
@@ -33,6 +38,28 @@ async def provision_engine(cfg: Config):
         logger.debug("Provisioning engine")
         yield await Engine(cfg, stack).provision()
         logger.debug("Closing engine provisioning")
+
+
+def fallback_to_local_cli(
+    download_error: Exception,
+    log_output: TextIO | None = None,
+) -> str:
+    if not isinstance(download_error, CLIReleaseUnavailableError):
+        raise download_error
+
+    bin_path = shutil.which("dagger")
+    if bin_path is None:
+        path_error = FileNotFoundError("dagger executable was not found")
+        msg = f"{download_error}\ndagger CLI not found in PATH: {path_error}"
+        raise ExceptionGroup(msg, [download_error, path_error]) from path_error
+
+    warning_output = log_output if log_output is not None else sys.stderr
+    print(
+        f"CLI version {CLI_VERSION} is unavailable; using {bin_path} from PATH "
+        "(version compatibility is not guaranteed).",
+        file=warning_output,
+    )
+    return bin_path
 
 
 class Engine:
@@ -63,12 +90,26 @@ class Engine:
             # Only start progress if we are provisioning, not on active sessions
             # like `dagger run`.
             await self.progress.start("Provisioning engine")
-            cli_bin = await self.get_cli()
+            download_error = None
+            try:
+                cli_bin = await self.get_cli()
+            except CLIReleaseUnavailableError as e:
+                download_error = e
+                cli_bin = fallback_to_local_cli(e, self.cfg.log_output)
 
             await self.progress.update("Creating new Engine session")
-            connect_params = await self.stack.enter_async_context(
-                start_cli_session(self.cfg, cli_bin)
-            )
+            try:
+                connect_params = await self.stack.enter_async_context(
+                    start_cli_session(self.cfg, cli_bin)
+                )
+            except Exception as e:
+                if download_error is not None:
+                    msg = (
+                        f"{download_error}\nfailed to use CLI from PATH "
+                        f"{cli_bin!r}: {e}"
+                    )
+                    raise ExceptionGroup(msg, [download_error, e]) from e
+                raise
 
         self.connect_params = connect_params
         self.connect_config = ConnectConfig(

--- a/sdk/python/src/dagger/provisioning/_exceptions.py
+++ b/sdk/python/src/dagger/provisioning/_exceptions.py
@@ -12,6 +12,10 @@ class DownloadError(ProvisionError):
         return f"Failed to download the Dagger CLI: {super().__str__()}"
 
 
+class CLIReleaseUnavailableError(DownloadError):
+    """The requested Dagger CLI release is unavailable."""
+
+
 class SessionError(ProvisionError):
     """Error while starting an engine session."""
 

--- a/sdk/python/tests/provisioning/test_cli_fallback.py
+++ b/sdk/python/tests/provisioning/test_cli_fallback.py
@@ -1,0 +1,126 @@
+import contextlib
+import io
+import os
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from exceptiongroup import ExceptionGroup
+from pytest_httpx import HTTPXMock
+
+import dagger
+from dagger.provisioning import _engine as engine
+from dagger.provisioning._download import Downloader
+from dagger.provisioning._exceptions import (
+    CLIReleaseUnavailableError,
+    DownloadError,
+    SessionError,
+)
+
+
+def test_fallback_to_local_cli(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    bin_name = "dagger.exe" if os.name == "nt" else "dagger"
+    bin_path = tmp_path / bin_name
+    bin_path.touch(mode=0o700)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    download_error = CLIReleaseUnavailableError("download failed")
+    logs = io.StringIO()
+
+    actual = engine.fallback_to_local_cli(download_error, logs)
+
+    assert actual == str(bin_path)
+    assert logs.getvalue() == (
+        f"CLI version {engine.CLI_VERSION} is unavailable; using {bin_path} from PATH "
+        "(version compatibility is not guaranteed).\n"
+    )
+
+
+def test_no_fallback_to_local_cli_for_other_errors():
+    download_error = DownloadError("download failed")
+
+    with pytest.raises(DownloadError) as exc_info:
+        engine.fallback_to_local_cli(download_error)
+
+    assert exc_info.value is download_error
+
+
+def test_fallback_preserves_download_and_path_errors(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    download_error = CLIReleaseUnavailableError("download failed")
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        engine.fallback_to_local_cli(download_error)
+
+    assert exc_info.value.exceptions[0] is download_error
+    assert isinstance(exc_info.value.exceptions[1], FileNotFoundError)
+    assert exc_info.value.__cause__ is exc_info.value.exceptions[1]
+    assert "Failed to download the Dagger CLI" in str(exc_info.value)
+    assert "dagger executable was not found" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("status_code", [403, 404])
+def test_checksum_marks_release_unavailable(
+    status_code: int,
+    httpx_mock: HTTPXMock,
+):
+    downloader = Downloader(version="unreleased")
+    httpx_mock.add_response(url=downloader.checksum_url, status_code=status_code)
+
+    with pytest.raises(CLIReleaseUnavailableError):
+        downloader.expected_checksum()
+
+
+@pytest.mark.parametrize("status_code", [403, 404])
+def test_missing_archive_does_not_mark_release_unavailable(
+    status_code: int,
+    httpx_mock: HTTPXMock,
+):
+    # Missing checksums mean the release is absent; a missing archive may be a
+    # partial or broken release, so it must remain fatal.
+    downloader = Downloader(version="unreleased")
+    httpx_mock.add_response(url=downloader.archive_url, status_code=status_code)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        downloader.extract_cli_archive(io.BytesIO())
+
+    assert not isinstance(exc_info.value, CLIReleaseUnavailableError)
+
+
+@pytest.mark.anyio
+async def test_fallback_session_error_preserves_download_error(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    bin_name = "dagger.exe" if os.name == "nt" else "dagger"
+    bin_path = tmp_path / bin_name
+    bin_path.touch(mode=0o700)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    download_error = CLIReleaseUnavailableError("download failed")
+    session_error = SessionError("session failed")
+    stack = contextlib.AsyncExitStack()
+    instance = engine.Engine(dagger.Config(log_output=io.StringIO()), stack)
+    instance.progress = AsyncMock()
+    monkeypatch.setattr(instance, "get_cli", AsyncMock(side_effect=download_error))
+
+    @contextlib.asynccontextmanager
+    async def fail_to_start_cli_session(*_):
+        raise session_error
+        yield
+
+    monkeypatch.setattr(engine, "start_cli_session", fail_to_start_cli_session)
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await instance.provision()
+
+    assert exc_info.value.exceptions == (download_error, session_error)
+    assert exc_info.value.__cause__ is session_error
+    assert "Failed to download the Dagger CLI" in str(exc_info.value)
+    assert "Failed to start Dagger engine session" in str(exc_info.value)


### PR DESCRIPTION
Implement the Python part of #13766, to fix CLI bootstrap in unreleased libs.

When the release server returns 403 or 404, fall back to `dagger` from `PATH` and emit a compatibility warning. Other download failures remain fatal.

Part of #13766.
