### PR TITLE
core: stop staged local dep generation recursion

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -490,6 +490,97 @@ func (m *Consumer) SyncGenerators(ctx context.Context, workspace *dagger.Workspa
 	require.NotContains(t, out, "result *core.Changeset is detached")
 }
 
+// TestGenerateLocalDependenciesTerminatesOnRootDep locks in that
+// ModuleSource.generateLocalDependencies terminates when a module's local
+// dependency closure leads back to a dependency that is currently being
+// generated one level up.
+//
+// The shape (mirroring the go-sdk workspace, where this recursed forever): the
+// workspace root module is managed as-sdk by an SDK module whose generator —
+// like the real SDK management modules — stages every visible module's local
+// dependency closure before generating it, and a nested module depends on the
+// workspace root. Staging the nested module's closure generates the root via
+// that SDK generator, whose own staging pass walks the nested module again;
+// since the root dependency is recorded in the staged workspace's
+// StagedGeneration set, the nested walk must skip it instead of recursing
+// through the generator with a fresh workspace ID per round.
+func (GeneratorsSuite) TestGenerateLocalDependenciesTerminatesOnRootDep(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := goGitBase(t, c).
+		WithNewFile("dagger.toml", `[modules.root-mod]
+source = "."
+
+[modules.nested]
+source = ".dagger/modules/nested"
+
+[modules.fanout-sdk]
+source = ".dagger/modules/fanout-sdk"
+
+[modules.fanout-sdk.as-sdk]
+
+[[modules.fanout-sdk.as-sdk.modules]]
+path = "."
+`).
+		WithNewFile("dagger.json", `{
+  "name": "root-mod",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`).
+		WithNewFile(".dagger/modules/nested/dagger.json", `{
+  "name": "nested",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "dependencies": [
+    { "name": "root-mod", "source": "../../.." }
+  ],
+  "source": "."
+}`).
+		WithNewFile(".dagger/modules/fanout-sdk/dagger.json", `{
+  "name": "fanout-sdk",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`).
+		WithNewFile(".dagger/modules/fanout-sdk/main.go", `package main
+
+import (
+	"context"
+
+	"dagger/fanout-sdk/internal/dagger"
+)
+
+type FanoutSdk struct{}
+
+// Mimic an SDK-wide generator: stage each visible module's local dependency
+// closure, then emit a marker changeset.
+// +generate
+func (m *FanoutSdk) Generate(ctx context.Context, ws *dagger.Workspace) (*dagger.Changeset, error) {
+	for _, path := range []string{".", ".dagger/modules/nested"} {
+		_, err := ws.ModuleSource(path).GenerateLocalDependencies(ws).Sync(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dag.Directory().WithNewFile("fanout-generated", "ok").Changes(dag.Directory()), nil
+}
+`)
+
+	// Bound the run so a regression fails instead of hanging: pre-fix this
+	// recursed with a fresh workspace per round until the client disconnected.
+	ctr := base.WithExec(
+		[]string{"timeout", "300", "dagger", "generate", "fanout-sdk", "-y", "--progress=plain"},
+		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+	)
+	out, err := ctr.CombinedOutput(ctx)
+	require.NoError(t, err, out)
+
+	generated, err := ctr.File("fanout-generated").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ok", generated)
+}
+
 // TestWorkspaceGenerateNarrowsToRequestedModule locks in that
 // `dagger generate <module>` only loads the named generator's module. The
 // workspace generators resolver loads modules on demand from its include

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3053,8 +3053,13 @@ func (s *moduleSourceSchema) moduleSourceGeneratedContextChangeset(
 // exactly that closure staged. The staged workspace records the dependency in
 // its StagedGeneration set (via __withGeneratedLocalDependencies), so the SDK
 // generator's own nested generateLocalDependencies call for that module
-// short-circuits instead of re-walking. Without the memoization and the mark,
-// generation fans out once per path through the dependency DAG.
+// short-circuits instead of re-walking. Nested walks for other modules also
+// skip any dependency the workspace already marks as staged: the marked
+// dependency's generator run is what invoked them, so re-staging it would
+// recurse through that generator forever (see the depPaths loop below).
+// Without the memoization and the marks, generation fans out once per path
+// through the dependency DAG — or diverges entirely when a module beneath a
+// dependency depends on that same dependency.
 //
 // Results accumulate by overlaying each changeset onto the workspace root
 // directory — never by patch-based changeset merging — so overlapping content
@@ -3140,7 +3145,17 @@ func (s *moduleSourceSchema) moduleSourceGenerateLocalDependencies(
 		return res, fmt.Errorf("read workspace SDK ownership: %w", err)
 	}
 
-	// Direct local dependencies, deduplicated, in declaration order.
+	// Direct local dependencies, deduplicated, in declaration order. A
+	// dependency the workspace already records in StagedGeneration is skipped
+	// outright: this workspace was built by this very field while generating
+	// that dependency, and the walk reaching it again means the dependency's
+	// own SDK generator regenerates modules beneath it whose closures lead
+	// back to the dependency (e.g. the dependency is the workspace root, so
+	// every module — including this receiver — sits beneath it). Re-staging
+	// it can never converge — its fresh codegen is being produced by the
+	// in-flight generator run one level up — and each re-entry would rebuild
+	// the staged workspace with a longer ID, so neither the memoized recursion
+	// nor the receiver short-circuit above ever terminates it.
 	var depPaths []string
 	seenDeps := make(map[string]bool)
 	for _, dep := range src.Self().Dependencies {
@@ -3152,6 +3167,9 @@ func (s *moduleSourceSchema) moduleSourceGenerateLocalDependencies(
 			continue
 		}
 		seenDeps[p] = true
+		if slices.Contains(workspace.Self().StagedGeneration, cleanWorkspaceRelPath(p)) {
+			continue
+		}
 		depPaths = append(depPaths, p)
 	}
 	slog.ExtraDebug("generateLocalDependencies walk",

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3077,7 +3077,14 @@ func (s *moduleSourceSchema) moduleSourceGenerateLocalDependencies(
 		Workspace dagql.ID[*core.Workspace]
 	},
 ) (res dagql.ObjectResult[*core.Changeset], rerr error) {
-	ctx, span := core.Tracer(ctx).Start(ctx, "generate local dependencies", telemetry.Reveal())
+	// Dir-kind sources (e.g. loaded through Workspace.moduleSource, as the
+	// recursion below does) have no ref string; identify them by their
+	// workspace-relative source root instead.
+	srcDesc := srcInst.Self().AsString()
+	if srcDesc == "" {
+		srcDesc = cleanWorkspaceRelPath(srcInst.Self().SourceRootSubpath)
+	}
+	ctx, span := core.Tracer(ctx).Start(ctx, "generate local dependencies for "+srcDesc)
 	defer telemetry.EndWithCause(span, &rerr)
 
 	dag, err := core.CurrentDagqlServer(ctx)


### PR DESCRIPTION
## Problem

#13771 made local dependency generation linear by memoizing the walk per (dependency path, workspace) and marking staged workspaces (`StagedGeneration`) so a dependency's SDK generator short-circuits its own nested `generateLocalDependencies` call. Both guards key on the *receiver* module — and neither terminates the walk when a **different** module's closure leads back to a dependency that is currently being generated one level up.

The go-sdk workspace hits exactly that shape (Dagger Cloud trace `084a5c4289bfff01a3d8050c48bbc0ef`, org `dagger-dogfood`):

- the workspace root module `.` is managed as-sdk by `dang-sdk`, and
- `e2e` (`.dagger/modules/e2e`) declares a local dependency on `../../..` — the workspace root.

Staging `e2e`'s closure generates dependency `.` by running the dang SDK's generator, which — like every SDK management module — regenerates *all* modules beneath its cwd. The dependency being the workspace root puts `e2e` beneath it, so the generator's nested walk for `e2e` re-stages `.`, re-running the generator. Each round rebuilds the staged workspace (`withWorkdir` + `__withGeneratedLocalDependencies`) with a longer ID, so the memoization key never repeats: the recorded trace shows 90 rounds with 90 distinct workspace digests, every call `cache.outcome: executed`, rounds slowing from 1.4s to 3.5s+ as the ID chain grows, until the run was killed at ~10 minutes. Reproduced locally against a dev engine: 136 rounds in a 240s timeout, 137 distinct workspace digests.

The receiver short-circuit can't help (`e2e` is never the module being staged, so it is never marked), and `localDepCycle` can't either (the dependency graph is acyclic — the cycle runs through the SDK-generate fan-out, not dependency edges).

## Fix

Skip dependencies the workspace already records in `StagedGeneration` during the direct-dependency walk. A marked dependency's generator run is what invoked the walk: its transitive closure is already overlaid on this very workspace, and its fresh codegen cannot exist yet from inside its own generation — re-staging it can never converge. The nested module generates against the dependency's committed bindings instead, and picks up fresh ones at the top level of the walk, where the dependency's generator output *is* staged.

Deep-staging durability from #13771 is preserved: a module beneath a dependency still stages every *other* dependency in its closure — only the one currently being generated one level up is skipped.

## Verification (dev engine)

- New integration test `TestGenerators/TestGenerateLocalDependenciesTerminatesOnRootDep` reconstructs the topology hermetically (an as-sdk module managing the workspace root + a nested module depending on the root + an SDK-style generator that stages every visible module's closure before generating). Pre-fix it recurses exactly like the real workspace — still looping thousands of spans deep when the engine was killed minutes in; post-fix it passes in 17s.
- Manual repro (scratch copy of the go-sdk workspace): pre-fix `dagger generate -y` looped 136 rounds inside a 240s timeout; post-fix it completes with **2** staging rounds and **2** distinct workspace digests in the captured telemetry, converging to "no changes to apply" on the already-generated repo.
- `go test ./core/schema/ ./core/workspace/...` pass.

## Telemetry

A follow-up commit names each `generateLocalDependencies` span after its receiver (`generate local dependencies for <ref>`, falling back to the workspace-relative source root for dir-kind sources, which have no ref string) and drops the span's `Reveal` — the per-dependency `generate local dependency: <path>` span remains the user-facing progress line. Diagnosing this bug from the recorded trace required decoding call IDs to tell which module each nested walk belonged to; now it's in the span name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
