### PR TITLE
Elixir client lib: if downloading CLI fails, fall back to PATH

### DIFF
--- a/sdk/elixir/lib/dagger/core/engine/downloader.ex
+++ b/sdk/elixir/lib/dagger/core/engine/downloader.ex
@@ -7,17 +7,24 @@ defmodule Dagger.Core.Engine.Downloader do
   @doc false
   def download(cli_version, opts \\ []) do
     cli_host = opts[:cli_host] || @dagger_default_cli_host
-    cache_dir = :filename.basedir(:user_cache, "dagger")
+    cache_dir = opts[:cache_dir] || :filename.basedir(:user_cache, "dagger")
     {os, _} = target()
     bin_name = dagger_bin_name(cli_version, os)
     cache_bin_path = Path.join([cache_dir, bin_name])
+    archive_name = default_cli_archive_name(target(), cli_version)
+
+    archive_url =
+      opts[:archive_url] || cli_archive_url(cli_host, cli_version, archive_name)
+
+    checksums_url = opts[:checksums_url] || checksum_url(cli_host, cli_version)
     perm = 0o700
 
     with :ok <- File.mkdir_p(cache_dir),
          :ok <- File.chmod(cache_dir, perm),
          {:error, :enoent} <- File.stat(cache_bin_path),
          temp_bin_path = Path.join([cache_dir, "temp-" <> bin_name]),
-         :ok <- extract_cli(cli_host, cli_version, temp_bin_path),
+         {:ok, expected_checksum} <- expected_checksum(checksums_url, archive_name),
+         :ok <- extract_cli(archive_url, expected_checksum, temp_bin_path),
          :ok <- File.chmod(temp_bin_path, perm),
          :ok <- File.rename(temp_bin_path, cache_bin_path) do
       {:ok, cache_bin_path}
@@ -27,24 +34,32 @@ defmodule Dagger.Core.Engine.Downloader do
     end
   end
 
-  defp extract_cli(cli_host, cli_version, bin_path) do
-    with {:ok, {{_, 200, _}, headers, response}} <-
-           :httpc.request(cli_archive_url(cli_host, cli_version)),
-         :ok <- verify_checksum(response, cli_host, cli_version),
-         {:ok, files} <-
-           extract(
-             response,
-             List.keyfind!(headers, ~c"content-type", 0)
-             |> elem(1)
-             |> to_string()
-           ) do
-      {_, dagger_bin} =
-        Enum.find(files, fn {filename, _bin} ->
-          {os, _} = target()
-          filename == dagger_bin_in_archive(os)
-        end)
+  @doc false
+  def extract_cli(archive_url, expected_checksum, bin_path) do
+    case :httpc.request(archive_url) do
+      {:ok, {{_, 200, _}, headers, response}} ->
+        with :ok <- verify_checksum(response, expected_checksum),
+             {:ok, files} <-
+               extract(
+                 response,
+                 List.keyfind!(headers, ~c"content-type", 0)
+                 |> elem(1)
+                 |> to_string()
+               ) do
+          {_, dagger_bin} =
+            Enum.find(files, fn {filename, _bin} ->
+              {os, _} = target()
+              filename == dagger_bin_in_archive(os)
+            end)
 
-      File.write(bin_path, dagger_bin)
+          File.write(bin_path, dagger_bin)
+        end
+
+      {:ok, {{_, status, _}, _, _}} ->
+        {:error, {:failed_to_download_cli, archive_url, {:http_status, status}}}
+
+      {:error, reason} ->
+        {:error, {:failed_to_download_cli, archive_url, reason}}
     end
   end
 
@@ -56,58 +71,62 @@ defmodule Dagger.Core.Engine.Downloader do
     :zip.extract(IO.iodata_to_binary(archive), [:memory])
   end
 
-  defp verify_checksum(response, cli_host, cli_version) do
+  defp verify_checksum(response, expected_checksum) do
     calculated_checksum = :crypto.hash(:sha256, response) |> Base.encode16(case: :lower)
 
-    case expected_checksum(cli_host, cli_version) do
-      {:ok, expected_checksum} ->
-        if :crypto.hash_equals(calculated_checksum, expected_checksum) do
-          :ok
-        else
-          {:error, "checksum mismatch: expected #{expected_checksum}, got #{calculated_checksum}"}
-        end
-
-      error ->
-        error
-    end
-  end
-
-  defp expected_checksum(cli_host, cli_version) do
-    archive_name = default_cli_archive_name(target(), cli_version)
-
-    {:ok, checksum_map} = checksum_map(cli_host, cli_version)
-
-    expected_value =
-      Enum.find_value(checksum_map, fn {key, value} ->
-        if to_string(key) == archive_name, do: value
-      end)
-
-    if is_nil(expected_value) do
-      {:error, "expected value find error"}
+    if :crypto.hash_equals(calculated_checksum, expected_checksum) do
+      :ok
     else
-      {:ok, expected_value}
+      {:error, "checksum mismatch: expected #{expected_checksum}, got #{calculated_checksum}"}
     end
   end
 
-  defp checksum_map(cli_host, cli_version) do
+  defp expected_checksum(checksums_url, archive_name) do
+    with {:ok, checksum_map} <- checksum_map(checksums_url) do
+      expected_value =
+        Enum.find_value(checksum_map, fn {key, value} ->
+          if to_string(key) == archive_name, do: value
+        end)
+
+      if is_nil(expected_value) do
+        {:error, "expected value find error"}
+      else
+        {:ok, expected_value}
+      end
+    end
+  end
+
+  @doc false
+  def checksum_map(checksums_url) do
     try do
-      with {:ok, {{_, 200, _}, _, response}} <-
-             :httpc.request(checksum_url(cli_host, cli_version)) do
-        checksum_map =
-          response
-          |> to_string()
-          |> String.split("\n", trim: true)
-          |> Enum.map(&String.split/1)
-          |> Enum.map(fn
-            [hash, file] ->
-              {file, hash}
+      case :httpc.request(checksums_url) do
+        {:ok, {{_, 200, _}, _, response}} ->
+          checksum_map =
+            response
+            |> to_string()
+            |> String.split("\n", trim: true)
+            |> Enum.map(&String.split/1)
+            |> Enum.map(fn
+              [hash, file] ->
+                {file, hash}
 
-            list ->
-              raise "Invalid checksum line: #{length(list)}"
-          end)
-          |> Enum.into(%{})
+              list ->
+                raise "Invalid checksum line: #{length(list)}"
+            end)
+            |> Enum.into(%{})
 
-        {:ok, checksum_map}
+          {:ok, checksum_map}
+
+        {:ok, {{_, status, _}, _, _}} when status in [403, 404] ->
+          {:error,
+           {:cli_release_unavailable,
+            {:failed_to_download_checksums, checksums_url, {:http_status, status}}}}
+
+        {:ok, {{_, status, _}, _, _}} ->
+          {:error, {:failed_to_download_checksums, checksums_url, {:http_status, status}}}
+
+        {:error, reason} ->
+          {:error, {:failed_to_download_checksums, checksums_url, reason}}
       end
     rescue
       reason in RuntimeError -> {:error, reason}
@@ -121,8 +140,7 @@ defmodule Dagger.Core.Engine.Downloader do
     "https://#{cli_host}/dagger/releases/#{cli_version}/checksums.txt"
   end
 
-  defp cli_archive_url(cli_host, cli_version) do
-    archive_name = default_cli_archive_name(target(), cli_version)
+  defp cli_archive_url(cli_host, cli_version, archive_name) do
     "https://#{cli_host}/dagger/releases/#{cli_version}/#{archive_name}"
   end
 

--- a/sdk/elixir/lib/dagger/core/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/core/engine_conn.ex
@@ -54,24 +54,90 @@ defmodule Dagger.Core.EngineConn do
 
   @doc false
   def from_remote_cli(opts) do
-    case Downloader.download(Dagger.Core.Version.engine_version()) do
+    from_remote_cli(opts, Downloader, &start_cli_session/2)
+  end
+
+  @doc false
+  def from_remote_cli(opts, downloader) do
+    from_remote_cli(opts, downloader, &start_cli_session/2)
+  end
+
+  @doc false
+  def from_remote_cli(opts, downloader, start_session) do
+    cli_version = Dagger.Core.Version.engine_version()
+
+    case downloader.download(cli_version) do
       {:ok, bin_path} ->
-        start_cli_session(bin_path, opts)
+        start_session.(bin_path, opts)
+
+      {:error, {:cli_release_unavailable, _} = download_error} ->
+        with {:ok, bin_path} <-
+               fallback_to_local_cli(download_error, cli_version, opts[:log_output] || :stderr) do
+          case start_session.(bin_path, opts) do
+            {:ok, _conn} = result ->
+              result
+
+            session_error ->
+              {:error,
+               {:cli_fallback_failed, download_error,
+                {:failed_to_use_cli_from_path, bin_path, session_error}}}
+          end
+        end
 
       error ->
         error
     end
   end
 
+  @doc false
+  def fallback_to_local_cli(download_error, cli_version, log_output \\ :stderr)
+
+  def fallback_to_local_cli(
+        {:cli_release_unavailable, _} = download_error,
+        cli_version,
+        log_output
+      ) do
+    case System.find_executable("dagger") do
+      bin_path when is_binary(bin_path) ->
+        IO.puts(
+          log_output,
+          "CLI version #{cli_version} is unavailable; using #{bin_path} from PATH " <>
+            "(version compatibility is not guaranteed)."
+        )
+
+        {:ok, bin_path}
+
+      nil ->
+        path_error =
+          {:dagger_cli_not_found, "dagger CLI not found in PATH", :no_executable}
+
+        {:error, {:cli_fallback_failed, download_error, path_error}}
+    end
+  end
+
+  def fallback_to_local_cli(download_error, _cli_version, _log_output) do
+    {:error, download_error}
+  end
+
   defp start_cli_session(bin_path, opts) do
     connect_timeout = opts[:connect_timeout]
-    session_pid = spawn_link(Dagger.Session, :start, [bin_path, self(), opts])
+
+    {session_pid, monitor_ref} =
+      spawn_monitor(Dagger.Session, :start, [bin_path, self(), opts])
 
     receive do
       {^session_pid, %{"port" => port, "session_token" => token}} ->
+        Process.link(session_pid)
+        Process.demonitor(monitor_ref, [:flush])
         {:ok, %__MODULE__{port: port, token: token, session_pid: session_pid}}
+
+      {:DOWN, ^monitor_ref, :process, ^session_pid, reason} ->
+        {:error, {:session_start_failed, reason}}
     after
-      connect_timeout -> {:error, :session_timeout}
+      connect_timeout ->
+        Process.exit(session_pid, :kill)
+        Process.demonitor(monitor_ref, [:flush])
+        {:error, :session_timeout}
     end
   end
 

--- a/sdk/elixir/test/dagger/core/engine_cli_fallback_test.exs
+++ b/sdk/elixir/test/dagger/core/engine_cli_fallback_test.exs
@@ -1,0 +1,244 @@
+defmodule Dagger.Core.EngineCLIFallbackTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :tmp_dir
+
+  alias Dagger.Core.Engine.Downloader
+  alias Dagger.Core.EngineConn
+
+  defmodule UnavailableDownloader do
+    def download(_cli_version) do
+      {:error,
+       {:cli_release_unavailable,
+        {:failed_to_download_checksums, "https://example.test/checksums.txt", {:http_status, 403}}}}
+    end
+  end
+
+  defmodule ProcessDownloader do
+    def download(_cli_version) do
+      {:ok, Process.get(:downloaded_cli_path)}
+    end
+  end
+
+  setup do
+    path = System.get_env("PATH")
+
+    on_exit(fn ->
+      if path do
+        System.put_env("PATH", path)
+      else
+        System.delete_env("PATH")
+      end
+    end)
+
+    :ok
+  end
+
+  describe "release availability" do
+    # Missing checksums mean the release is absent; a missing archive may be a
+    # partial or broken release, so it must remain fatal.
+    for status <- [403, 404] do
+      test "marks checksums returning #{status} as unavailable" do
+        status = unquote(status)
+        url = start_server(status)
+
+        assert {:error,
+                {:cli_release_unavailable,
+                 {:failed_to_download_checksums, ^url, {:http_status, ^status}}}} =
+                 Downloader.checksum_map(url)
+      end
+
+      test "does not mark an archive returning #{status} as unavailable", %{tmp_dir: tmp_dir} do
+        status = unquote(status)
+        url = start_server(status)
+
+        assert {:error, {:failed_to_download_cli, ^url, {:http_status, ^status}}} =
+                 Downloader.extract_cli(url, "unused", Path.join(tmp_dir, "dagger"))
+      end
+    end
+
+    test "checks release availability before downloading the archive", %{tmp_dir: tmp_dir} do
+      checksums_url = start_server(500)
+
+      assert {:error, {:failed_to_download_checksums, ^checksums_url, {:http_status, 500}}} =
+               Downloader.download("unreleased",
+                 cache_dir: tmp_dir,
+                 checksums_url: checksums_url,
+                 archive_url: "not a valid URL"
+               )
+    end
+  end
+
+  describe "fallback to the local CLI" do
+    test "uses the dagger CLI in PATH and emits a compatibility warning", %{tmp_dir: tmp_dir} do
+      bin_path = create_dagger_executable(tmp_dir)
+      System.put_env("PATH", tmp_dir)
+      {:ok, logs} = StringIO.open("")
+
+      download_error = cli_release_unavailable_error()
+
+      assert {:ok, ^bin_path} =
+               EngineConn.fallback_to_local_cli(download_error, "unreleased", logs)
+
+      assert {_input, output} = StringIO.contents(logs)
+
+      assert output ==
+               "CLI version unreleased is unavailable; using #{bin_path} from PATH " <>
+                 "(version compatibility is not guaranteed).\n"
+    end
+
+    test "returns unrelated download errors without falling back", %{tmp_dir: tmp_dir} do
+      _bin_path = create_dagger_executable(tmp_dir)
+      System.put_env("PATH", tmp_dir)
+      download_error = {:failed_to_download_checksums, "checksums.txt", {:http_status, 500}}
+
+      assert {:error, ^download_error} =
+               EngineConn.fallback_to_local_cli(download_error, "unreleased")
+    end
+
+    test "preserves the download and PATH errors when no CLI is found", %{tmp_dir: tmp_dir} do
+      System.put_env("PATH", tmp_dir)
+      download_error = cli_release_unavailable_error()
+
+      assert {:error,
+              {:cli_fallback_failed, ^download_error,
+               {:dagger_cli_not_found, "dagger CLI not found in PATH", :no_executable}}} =
+               result =
+               EngineConn.fallback_to_local_cli(download_error, "unreleased")
+
+      rendered = inspect(result)
+      assert rendered =~ "cli_release_unavailable"
+      assert rendered =~ "dagger CLI not found in PATH"
+    end
+
+    test "preserves the download and fallback session errors", %{tmp_dir: tmp_dir} do
+      bin_path = create_dagger_executable(tmp_dir)
+      System.put_env("PATH", tmp_dir)
+      {:ok, logs} = StringIO.open("")
+      download_error = cli_release_unavailable_error()
+      session_error = {:error, {:session_start_failed, :boom}}
+      start_session = fn ^bin_path, _opts -> session_error end
+
+      assert {:error,
+              {:cli_fallback_failed, ^download_error,
+               {:failed_to_use_cli_from_path, ^bin_path, ^session_error}}} =
+               result =
+               EngineConn.from_remote_cli(
+                 [log_output: logs],
+                 UnavailableDownloader,
+                 start_session
+               )
+
+      rendered = inspect(result)
+      assert rendered =~ "cli_release_unavailable"
+      assert rendered =~ "session_start_failed"
+    end
+  end
+
+  describe "session startup lifecycle" do
+    test "returns a visible error when the session process fails before the handshake", %{
+      tmp_dir: tmp_dir
+    } do
+      missing_bin_path = Path.join(tmp_dir, "missing-dagger")
+      Process.put(:downloaded_cli_path, missing_bin_path)
+      on_exit(fn -> Process.delete(:downloaded_cli_path) end)
+
+      assert {:error, {:session_start_failed, reason}} =
+               EngineConn.from_remote_cli(
+                 [connect_timeout: 1_000, log_output: :stderr],
+                 ProcessDownloader
+               )
+
+      assert inspect(reason) =~ "enoent"
+    end
+
+    test "links the session process after a successful handshake", %{tmp_dir: tmp_dir} do
+      bin_path = create_session_executable(tmp_dir)
+      test_pid = self()
+      {:ok, logs} = StringIO.open("")
+
+      {caller_pid, caller_ref} =
+        spawn_monitor(fn ->
+          Process.put(:downloaded_cli_path, bin_path)
+
+          {:ok, conn} =
+            EngineConn.from_remote_cli(
+              [connect_timeout: 1_000, log_output: logs],
+              ProcessDownloader
+            )
+
+          send(test_pid, {:session_started, self(), conn.session_pid})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:session_started, ^caller_pid, session_pid}, 1_000
+      Process.exit(session_pid, :kill)
+      assert_receive {:DOWN, ^caller_ref, :process, ^caller_pid, :killed}, 1_000
+    end
+  end
+
+  defp cli_release_unavailable_error do
+    {:cli_release_unavailable,
+     {:failed_to_download_checksums, "https://example.test/checksums.txt", {:http_status, 403}}}
+  end
+
+  defp create_dagger_executable(tmp_dir) do
+    bin_name = if match?({:win32, _}, :os.type()), do: "dagger.exe", else: "dagger"
+    bin_path = Path.join(tmp_dir, bin_name)
+    File.write!(bin_path, "")
+    File.chmod!(bin_path, 0o700)
+    bin_path
+  end
+
+  defp create_session_executable(tmp_dir) do
+    bin_path = Path.join(tmp_dir, "fake-dagger")
+
+    File.write!(
+      bin_path,
+      "#!/bin/sh\n" <>
+        "echo '{\"port\":1234,\"session_token\":\"token\"}'\n" <>
+        "while :; do sleep 60; done\n"
+    )
+
+    File.chmod!(bin_path, 0o700)
+    bin_path
+  end
+
+  defp start_server(status, body \\ "") do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [
+        :binary,
+        packet: :raw,
+        active: false,
+        reuseaddr: true,
+        ip: {127, 0, 0, 1}
+      ])
+
+    {:ok, {{127, 0, 0, 1}, port}} = :inet.sockname(listen_socket)
+
+    server_pid =
+      spawn(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen_socket)
+        {:ok, _request} = :gen_tcp.recv(socket, 0, 5_000)
+
+        response =
+          "HTTP/1.1 #{status} Test\r\n" <>
+            "content-length: #{byte_size(body)}\r\n" <>
+            "content-type: application/octet-stream\r\n" <>
+            "connection: close\r\n\r\n" <> body
+
+        :ok = :gen_tcp.send(socket, response)
+        :gen_tcp.close(socket)
+      end)
+
+    on_exit(fn ->
+      :gen_tcp.close(listen_socket)
+
+      if Process.alive?(server_pid) do
+        Process.exit(server_pid, :kill)
+      end
+    end)
+
+    "http://127.0.0.1:#{port}"
+  end
+end


### PR DESCRIPTION
Implement the Elixir part of #13766, to fix CLI bootstrap in unreleased libs.

When the release server returns 403 or 404, fall back to `dagger` from `PATH` and emit a compatibility warning. Other download failures remain fatal.

Part of #13766.