### PR TITLE
PHP client lib: if downloading CLI fails, fall back to PATH

### DIFF
--- a/sdk/php/src/Connection/CliDownloader.php
+++ b/sdk/php/src/Connection/CliDownloader.php
@@ -2,6 +2,7 @@
 
 namespace Dagger\Connection;
 
+use Dagger\Exception\CliReleaseUnavailable;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -78,7 +79,7 @@ class CliDownloader implements LoggerAwareInterface
         return 'windows' === $this->getOs();
     }
 
-    private function getDefaultCliArchiveName(string $version): string
+    protected function getDefaultCliArchiveName(string $version): string
     {
         $ext = $this->isWindows() ? 'zip' : 'tar.gz';
 
@@ -117,28 +118,54 @@ class CliDownloader implements LoggerAwareInterface
         }
     }
 
-    private function getExpectedChecksum(string $daggerVersion, string $archiveName): ?string
+    private function getExpectedChecksum(string $daggerVersion, string $archiveName): string
     {
-        $checksumMapUrl = "https://dl.dagger.io/dagger/releases/{$daggerVersion}/checksums.txt";
-        $checksumMapContent = file_get_contents($checksumMapUrl);
+        $checksumMapUrl = $this->getChecksumsUrl($daggerVersion);
+        [$checksumMapContent, $statusCode] = $this->fetchUrl($checksumMapUrl);
+        if (null !== $statusCode && $statusCode >= 400) {
+            $message = "Failed to download checksums from {$checksumMapUrl}: HTTP {$statusCode}";
+            if ($this->isCliReleaseUnavailable($statusCode)) {
+                throw new CliReleaseUnavailable($message);
+            }
 
-        $checksumArray = explode("\n", trim($checksumMapContent));
-        $checksumMap = [];
-
-        foreach ($checksumArray as $checksumLine) {
-            [$v, $k] = preg_split("/\s+/", $checksumLine, 2);
-            $checksumMap[$k] = $v;
+            throw new RuntimeException($message);
+        }
+        if (false === $checksumMapContent) {
+            throw new RuntimeException("Failed to download checksums from {$checksumMapUrl}");
         }
 
-        return $checksumMap[$archiveName] ?? null;
+        foreach (explode("\n", trim($checksumMapContent)) as $checksumLine) {
+            $parts = preg_split('/\s+/', trim($checksumLine), 2);
+            if (false === $parts || 2 !== count($parts)) {
+                throw new RuntimeException("Malformed checksum data from {$checksumMapUrl}");
+            }
+
+            [$checksum, $filename] = $parts;
+            if ($filename === $archiveName) {
+                if (1 !== preg_match('/^[a-f0-9]{64}$/i', $checksum)) {
+                    throw new RuntimeException("Malformed checksum data from {$checksumMapUrl}");
+                }
+
+                return $checksum;
+            }
+        }
+
+        throw new RuntimeException("Could not find checksum for {$archiveName}");
     }
 
     private function extractCli(string $archiveName, string $daggerVersion, string $tmpBinFile): string
     {
         $tmpArchiveFile = $this->getCacheDir() . DIRECTORY_SEPARATOR . $archiveName;
-        $archiveUrl = "https://dl.dagger.io/dagger/releases/{$daggerVersion}/{$archiveName}";
+        $archiveUrl = $this->getArchiveUrl($daggerVersion, $archiveName);
         $this->logger->info("Downloading dagger {$daggerVersion} from {$archiveUrl}");
-        file_put_contents($tmpArchiveFile, file_get_contents($archiveUrl));
+        [$archiveContent, $statusCode] = $this->fetchUrl($archiveUrl);
+        if (null !== $statusCode && $statusCode >= 400) {
+            throw new RuntimeException("Failed to download Dagger CLI archive from {$archiveUrl}: HTTP {$statusCode}");
+        }
+        if (false === $archiveContent) {
+            throw new RuntimeException("Failed to download Dagger CLI archive from {$archiveUrl}");
+        }
+        file_put_contents($tmpArchiveFile, $archiveContent);
 
         if ($this->isWindows()) {
             throw new RuntimeException('Not implemented');
@@ -151,5 +178,43 @@ class CliDownloader implements LoggerAwareInterface
         unlink($tmpArchiveFile);
 
         return $archiveHash;
+    }
+
+    private function getChecksumsUrl(string $daggerVersion): string
+    {
+        return "https://dl.dagger.io/dagger/releases/{$daggerVersion}/checksums.txt";
+    }
+
+    private function getArchiveUrl(string $daggerVersion, string $archiveName): string
+    {
+        return "https://dl.dagger.io/dagger/releases/{$daggerVersion}/{$archiveName}";
+    }
+
+    /** @return array{string|false, int|null} */
+    protected function fetchUrl(string $url): array
+    {
+        $context = stream_context_create([
+            'http' => [
+                'ignore_errors' => true,
+            ],
+        ]);
+        $http_response_header = [];
+        $content = @file_get_contents($url, false, $context);
+        $responseHeaders = $http_response_header;
+        $statusCode = null;
+
+        foreach ($responseHeaders as $header) {
+            if (1 === preg_match('/^HTTP\/\S+\s+(\d{3})\b/i', $header, $matches)) {
+                $statusCode = (int) $matches[1];
+            }
+        }
+
+        return [$content, $statusCode];
+    }
+
+    private function isCliReleaseUnavailable(int $statusCode): bool
+    {
+        // dl.dagger.io returns 403 for missing S3 objects.
+        return 403 === $statusCode || 404 === $statusCode;
     }
 }

--- a/sdk/php/src/Connection/ProcessSessionConnection.php
+++ b/sdk/php/src/Connection/ProcessSessionConnection.php
@@ -3,13 +3,17 @@
 namespace Dagger\Connection;
 
 use Dagger\Connection;
+use Dagger\Exception\CliFallbackFailed;
+use Dagger\Exception\CliReleaseUnavailable;
 use GraphQL\Client;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\InputStream;
+use Throwable;
 
 /**
  * @deprecated
@@ -35,7 +39,25 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
             return $this->client;
         }
 
-        $cliBinPath = $this->getCliPath();
+        [$cliBinPath, $downloadError] = $this->getCliPath();
+
+        try {
+            return $this->startCliSession($cliBinPath);
+        } catch (Throwable $sessionError) {
+            if (null !== $downloadError) {
+                throw new CliFallbackFailed(
+                    $downloadError,
+                    $sessionError,
+                    sprintf('failed to use CLI from PATH "%s"', $cliBinPath),
+                );
+            }
+
+            throw $sessionError;
+        }
+    }
+
+    protected function startCliSession(string $cliBinPath): Client
+    {
         $sdkVersion = Provisioning::getSdkVersion();
 
         $sessionInformation = null;
@@ -137,13 +159,56 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
         $this->close();
     }
 
-    private function getCliPath(): string
+    /** @return array{string, CliReleaseUnavailable|null} */
+    private function getCliPath(): array
     {
         $cliBinPath = getenv('_EXPERIMENTAL_DAGGER_CLI_BIN');
-        if (false === $cliBinPath) {
-            $cliBinPath = $this->cliDownloader->download();
+        if (false !== $cliBinPath) {
+            return [$cliBinPath, null];
         }
 
-        return $cliBinPath;
+        try {
+            return [$this->cliDownloader->download(), null];
+        } catch (CliReleaseUnavailable $downloadError) {
+            return [$this->fallbackToLocalCli($downloadError), $downloadError];
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function fallbackToLocalCli(Throwable $downloadError): string
+    {
+        if (!$downloadError instanceof CliReleaseUnavailable) {
+            throw $downloadError;
+        }
+
+        $binPath = (new ExecutableFinder())->find('dagger');
+        if (null === $binPath) {
+            throw new CliFallbackFailed(
+                $downloadError,
+                new RuntimeException('dagger executable was not found'),
+                'dagger CLI not found in PATH',
+            );
+        }
+
+        $warning = sprintf(
+            'CLI version %s is unavailable; using %s from PATH (version compatibility is not guaranteed).',
+            Provisioning::getCliVersion(),
+            $binPath,
+        );
+        if ($this->logger instanceof NullLogger) {
+            fwrite($this->warningOutput(), $warning . PHP_EOL);
+        } else {
+            $this->logger->warning($warning);
+        }
+
+        return $binPath;
+    }
+
+    /** @return resource */
+    protected function warningOutput()
+    {
+        return STDERR;
     }
 }

--- a/sdk/php/src/Connection/Provisioning.php
+++ b/sdk/php/src/Connection/Provisioning.php
@@ -9,7 +9,7 @@ final class Provisioning
 {
     public static function getCliVersion(): string
     {
-        return require_once 'version.php';
+        return require __DIR__ . '/version.php';
     }
 
     public static function getSdkVersion(): string

--- a/sdk/php/src/Exception/CliFallbackFailed.php
+++ b/sdk/php/src/Exception/CliFallbackFailed.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Dagger\Exception;
+
+use RuntimeException;
+use Throwable;
+
+final class CliFallbackFailed extends RuntimeException
+{
+    public function __construct(
+        private readonly CliReleaseUnavailable $downloadError,
+        private readonly Throwable $fallbackError,
+        string $context,
+    ) {
+        parent::__construct(
+            sprintf(
+                "%s\n%s: %s",
+                $downloadError->getMessage(),
+                $context,
+                $fallbackError->getMessage(),
+            ),
+            previous: $fallbackError,
+        );
+    }
+
+    public function getDownloadError(): CliReleaseUnavailable
+    {
+        return $this->downloadError;
+    }
+
+    public function getFallbackError(): Throwable
+    {
+        return $this->fallbackError;
+    }
+}

--- a/sdk/php/src/Exception/CliReleaseUnavailable.php
+++ b/sdk/php/src/Exception/CliReleaseUnavailable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Dagger\Exception;
+
+use RuntimeException;
+
+final class CliReleaseUnavailable extends RuntimeException
+{
+}

--- a/sdk/php/tests/Unit/Connection/CliFallbackTest.php
+++ b/sdk/php/tests/Unit/Connection/CliFallbackTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Dagger\Tests\Unit\Connection;
+
+use Dagger\Connection\CliDownloader;
+use Dagger\Connection\ProcessSessionConnection;
+use Dagger\Connection\Provisioning;
+use Dagger\Exception\CliFallbackFailed;
+use Dagger\Exception\CliReleaseUnavailable;
+use GraphQL\Client;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use RuntimeException;
+use Stringable;
+use Throwable;
+
+#[Group('unit')]
+final class CliFallbackTest extends TestCase
+{
+    private string $tempDir;
+    private string|false $previousCacheHome;
+    private string|false $previousCliBin;
+    private string|false $previousPath;
+    private string|false $previousPathExt;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'dagger-php-test-' . bin2hex(random_bytes(8));
+        mkdir($this->tempDir);
+
+        $this->previousCacheHome = getenv('XDG_CACHE_HOME');
+        $this->previousCliBin = getenv('_EXPERIMENTAL_DAGGER_CLI_BIN');
+        $this->previousPath = getenv('PATH');
+        $this->previousPathExt = getenv('PATHEXT');
+        putenv("XDG_CACHE_HOME={$this->tempDir}");
+        putenv('_EXPERIMENTAL_DAGGER_CLI_BIN');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreEnv('XDG_CACHE_HOME', $this->previousCacheHome);
+        $this->restoreEnv('_EXPERIMENTAL_DAGGER_CLI_BIN', $this->previousCliBin);
+        $this->restoreEnv('PATH', $this->previousPath);
+        $this->restoreEnv('PATHEXT', $this->previousPathExt);
+        $this->removeDirectory($this->tempDir);
+    }
+
+    #[Test]
+    #[DataProvider('unavailableStatusCodes')]
+    public function itMarksMissingChecksumMetadataAsUnavailable(int $statusCode): void
+    {
+        $downloader = new FakeCliDownloader([
+            ['', $statusCode],
+        ]);
+
+        $error = $this->catchError(fn() => $downloader->download('unreleased'));
+
+        self::assertInstanceOf(CliReleaseUnavailable::class, $error);
+        self::assertStringContainsString("HTTP {$statusCode}", $error->getMessage());
+    }
+
+    #[Test]
+    #[DataProvider('unavailableStatusCodes')]
+    public function itDoesNotMarkMissingArchivesAsUnavailable(int $statusCode): void
+    {
+        // Missing checksums mean the release is absent; a missing archive may be a
+        // partial or broken release, so it must remain fatal.
+        $downloader = new FakeCliDownloader([]);
+        $archiveName = $downloader->archiveName('unreleased');
+        $downloader->setResponses([
+            [str_repeat('0', 64) . "  {$archiveName}\n", 200],
+            ['', $statusCode],
+        ]);
+
+        $error = $this->catchError(fn() => $downloader->download('unreleased'));
+
+        self::assertNotInstanceOf(CliReleaseUnavailable::class, $error);
+        self::assertStringContainsString("HTTP {$statusCode}", $error->getMessage());
+    }
+
+    #[Test]
+    public function itValidatesChecksumMetadataBeforeDownloadingTheArchive(): void
+    {
+        $downloader = new FakeCliDownloader([
+            [str_repeat('0', 64) . "  another-archive.tar.gz\n", 200],
+            new RuntimeException('archive should not be downloaded'),
+        ]);
+
+        $error = $this->catchError(fn() => $downloader->download('unreleased'));
+
+        self::assertNotInstanceOf(CliReleaseUnavailable::class, $error);
+        self::assertStringContainsString('Could not find checksum', $error->getMessage());
+    }
+
+    #[Test]
+    public function itDoesNotMarkOtherChecksumHttpErrorsAsUnavailable(): void
+    {
+        $downloader = new FakeCliDownloader([
+            ['', 500],
+        ]);
+
+        $error = $this->catchError(fn() => $downloader->download('unreleased'));
+
+        self::assertNotInstanceOf(CliReleaseUnavailable::class, $error);
+        self::assertStringContainsString('HTTP 500', $error->getMessage());
+    }
+
+    #[Test]
+    public function itDoesNotFallBackForUnrelatedDownloadErrors(): void
+    {
+        $transportError = new RuntimeException('transport failed');
+        $downloader = new FakeCliDownloader([$transportError]);
+        $downloadError = $this->catchError(fn() => $downloader->download('unreleased'));
+        $connection = $this->newConnection();
+
+        $fallbackError = $this->catchError(fn() => $connection->fallbackToLocalCli($downloadError));
+
+        self::assertSame($transportError, $downloadError);
+        self::assertSame($downloadError, $fallbackError);
+    }
+
+    #[Test]
+    public function itUsesTheDaggerCliInPathAndWarns(): void
+    {
+        $binPath = $this->createDaggerExecutable();
+        $downloadError = new CliReleaseUnavailable('download failed');
+        $logger = new CollectingLogger();
+        $connection = $this->newConnection();
+        $connection->setLogger($logger);
+        $cliVersion = Provisioning::getCliVersion();
+
+        $actual = $connection->fallbackToLocalCli($downloadError);
+
+        self::assertSame($binPath, $actual);
+        self::assertSame([
+            [
+                LogLevel::WARNING,
+                sprintf(
+                    'CLI version %s is unavailable; using %s from PATH (version compatibility is not guaranteed).',
+                    $cliVersion,
+                    $binPath,
+                ),
+            ],
+        ], $logger->records);
+    }
+
+    #[Test]
+    public function itWarnsOnStderrWithTheDefaultLogger(): void
+    {
+        $binPath = $this->createDaggerExecutable();
+        $downloadError = new CliReleaseUnavailable('download failed');
+        $connection = new CapturingWarningProcessSessionConnection(
+            $this->tempDir,
+            false,
+            new CliDownloader(),
+        );
+
+        $actual = $connection->fallbackToLocalCli($downloadError);
+
+        self::assertSame($binPath, $actual);
+        self::assertSame(
+            sprintf(
+                'CLI version %s is unavailable; using %s from PATH (version compatibility is not guaranteed).%s',
+                Provisioning::getCliVersion(),
+                $binPath,
+                PHP_EOL,
+            ),
+            $connection->warning(),
+        );
+    }
+
+    #[Test]
+    public function itPreservesDownloadAndPathErrorsWhenNoCliIsFound(): void
+    {
+        $emptyPath = $this->tempDir . DIRECTORY_SEPARATOR . 'empty';
+        mkdir($emptyPath);
+        putenv("PATH={$emptyPath}");
+        $downloadError = new CliReleaseUnavailable('download failed');
+
+        $error = $this->catchError(fn() => $this->newConnection()->fallbackToLocalCli($downloadError));
+
+        self::assertInstanceOf(CliFallbackFailed::class, $error);
+        self::assertSame($downloadError, $error->getDownloadError());
+        self::assertSame($error->getFallbackError(), $error->getPrevious());
+        self::assertInstanceOf(RuntimeException::class, $error->getFallbackError());
+        self::assertSame('dagger executable was not found', $error->getFallbackError()->getMessage());
+        self::assertStringContainsString('download failed', (string) $error);
+        self::assertStringContainsString('dagger executable was not found', (string) $error);
+    }
+
+    #[Test]
+    public function itPreservesDownloadAndSessionErrorsWhenTheFallbackFailsToStart(): void
+    {
+        $binPath = $this->createDaggerExecutable();
+        $sessionError = new RuntimeException('session failed');
+        $downloader = new FakeCliDownloader([
+            ['', 403],
+        ]);
+        $connection = new FailingProcessSessionConnection(
+            $this->tempDir,
+            false,
+            $downloader,
+            $sessionError,
+        );
+        $connection->setLogger(new CollectingLogger());
+
+        $error = $this->catchError(fn() => $connection->connect());
+
+        self::assertInstanceOf(CliFallbackFailed::class, $error);
+        self::assertInstanceOf(CliReleaseUnavailable::class, $error->getDownloadError());
+        self::assertSame($sessionError, $error->getFallbackError());
+        self::assertSame($sessionError, $error->getPrevious());
+        self::assertStringContainsString('Failed to download checksums', (string) $error);
+        self::assertStringContainsString("failed to use CLI from PATH \"{$binPath}\": session failed", (string) $error);
+    }
+
+    /** @return array<string, array{int}> */
+    public static function unavailableStatusCodes(): array
+    {
+        return [
+            '403 Forbidden' => [403],
+            '404 Not Found' => [404],
+        ];
+    }
+
+    private function newConnection(): ProcessSessionConnection
+    {
+        return new ProcessSessionConnection($this->tempDir, false, new CliDownloader());
+    }
+
+    private function createDaggerExecutable(): string
+    {
+        $binDir = $this->tempDir . DIRECTORY_SEPARATOR . 'bin';
+        mkdir($binDir);
+        $isWindows = '\\' === DIRECTORY_SEPARATOR;
+        $binPath = $binDir . DIRECTORY_SEPARATOR . ($isWindows ? 'dagger.bat' : 'dagger');
+        file_put_contents($binPath, $isWindows ? "@exit /b 1\r\n" : "#!/bin/sh\nexit 1\n");
+        chmod($binPath, 0700);
+        putenv("PATH={$binDir}");
+        if ($isWindows) {
+            putenv('PATHEXT=.BAT');
+        }
+
+        return $binPath;
+    }
+
+    private function catchError(callable $operation): Throwable
+    {
+        try {
+            $operation();
+        } catch (Throwable $error) {
+            return $error;
+        }
+
+        self::fail('Expected operation to fail');
+    }
+
+    private function restoreEnv(string $name, string|false $value): void
+    {
+        putenv(false === $value ? $name : "{$name}={$value}");
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+        rmdir($directory);
+    }
+}
+
+final class FakeCliDownloader extends CliDownloader
+{
+    /** @param list<array{string|false, int|null}|Throwable> $responses */
+    public function __construct(private array $responses)
+    {
+        parent::__construct();
+    }
+
+    /** @param list<array{string|false, int|null}|Throwable> $responses */
+    public function setResponses(array $responses): void
+    {
+        $this->responses = $responses;
+    }
+
+    public function archiveName(string $version): string
+    {
+        return $this->getDefaultCliArchiveName($version);
+    }
+
+    /** @return array{string|false, int|null} */
+    protected function fetchUrl(string $url): array
+    {
+        $response = array_shift($this->responses);
+        if ($response instanceof Throwable) {
+            throw $response;
+        }
+        if (null === $response) {
+            throw new RuntimeException("Unexpected request for {$url}");
+        }
+
+        return $response;
+    }
+}
+
+final class FailingProcessSessionConnection extends ProcessSessionConnection
+{
+    public function __construct(
+        string $workDir,
+        bool $loadWorkspaceModules,
+        CliDownloader $cliDownloader,
+        private readonly Throwable $sessionError,
+    ) {
+        parent::__construct($workDir, $loadWorkspaceModules, $cliDownloader);
+    }
+
+    protected function startCliSession(string $cliBinPath): Client
+    {
+        throw $this->sessionError;
+    }
+}
+
+final class CapturingWarningProcessSessionConnection extends ProcessSessionConnection
+{
+    /** @var resource */
+    private $warningStream;
+
+    public function __construct(
+        string $workDir,
+        bool $loadWorkspaceModules,
+        CliDownloader $cliDownloader,
+    ) {
+        $stream = fopen('php://memory', 'w+');
+        if (false === $stream) {
+            throw new RuntimeException('Could not create warning stream');
+        }
+        $this->warningStream = $stream;
+        parent::__construct($workDir, $loadWorkspaceModules, $cliDownloader);
+    }
+
+    public function warning(): string
+    {
+        rewind($this->warningStream);
+        $warning = stream_get_contents($this->warningStream);
+        if (false === $warning) {
+            throw new RuntimeException('Could not read warning stream');
+        }
+
+        return $warning;
+    }
+
+    /** @return resource */
+    protected function warningOutput()
+    {
+        return $this->warningStream;
+    }
+}
+
+final class CollectingLogger extends AbstractLogger
+{
+    /** @var list<array{mixed, string}> */
+    public array $records = [];
+
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        $this->records[] = [$level, (string) $message];
+    }
+}


### PR DESCRIPTION
Implement the PHP part of #13766, to fix CLI bootstrap in unreleased libs.

When the release server returns 403 or 404, fall back to `dagger` from `PATH` and emit a compatibility warning. Other download failures remain fatal.

Part of #13766.