### PR TITLE
fix: scope `dagger setup` migration to the selected project

### DIFF
--- a/.changes/unreleased/Changed-20260730-120000.yaml
+++ b/.changes/unreleased/Changed-20260730-120000.yaml
@@ -1,0 +1,23 @@
+kind: Changed
+body: |
+  `dagger setup` now does much less during a 1.0 migration, especially for
+  repos that are just dagger modules:
+  - Migration only touches the root `dagger.json` (found up from the current
+    directory) and the local dependencies/toolchains it references. Unreferenced
+    modules — including ones under `.dagger/modules/` — are left alone.
+  - The migrated `dagger-module.toml` is written exactly where the legacy
+    `dagger.json` was — with its `source` and dependency paths preserved as-is
+    — instead of being synthesized under `.dagger/modules/<name>/`. Installs
+    that reference the module by path keep resolving to the config file.
+  - A repo that *is* a dagger module (root `dagger.json` with its source at the
+    root) converts its config in place and gets a minimal `dagger.toml` that
+    only pins its SDK runtime; the module is not installed into the workspace
+    and no `entrypoint = true` is set.
+  - Setup no longer combines migration with module recommendations: applying a
+    migration ends the run, and recommendations appear on the next
+    `dagger setup` once the workspace is current. Declining the migration
+    falls through to recommendations as before.
+time: 2026-07-30T12:00:00Z
+custom:
+  Author: kpenfound
+  PR: 13810

--- a/.changes/unreleased/Changed-20260730-120000.yaml
+++ b/.changes/unreleased/Changed-20260730-120000.yaml
@@ -17,6 +17,15 @@ body: |
     migration ends the run, and recommendations appear on the next
     `dagger setup` once the workspace is current. Declining the migration
     falls through to recommendations as before.
+  - Running `dagger setup` from a module subdirectory (a `dagger.json` below
+    the repository root) migrates just that module: `dagger.json` becomes
+    `dagger-module.toml` in place and no workspace is created. Module
+    recommendations are skipped in this case.
+  - Nested `dagger.toml` files are never created. A subdirectory `dagger.json`
+    with toolchains has them installed into a `dagger.toml` at the repository
+    root (local sources rebased); the module itself is not installed. A
+    subdirectory `dagger.json` with a `blueprint` is left as legacy with a
+    warning.
 time: 2026-07-30T12:00:00Z
 custom:
   Author: kpenfound

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -709,21 +709,24 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, configOut, `[modules.myapp]`)
-		require.Contains(t, configOut, `source = ".dagger/modules/myapp"`)
+		require.Contains(t, configOut, strings.Join([]string{
+			"[modules.myapp]",
+			`source = "."`,
+		}, "\n"))
 		require.Contains(t, configOut, `entrypoint = true`)
 
-		moduleOut, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		moduleOut, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, moduleOut, `name = "myapp"`)
-		require.Contains(t, moduleOut, `source = "../../../ci"`)
+		require.Contains(t, moduleOut, `source = "ci"`,
+			"the source path is preserved as-is: the config replaces dagger.json at the same location")
 
 		out, err := ctr.With(compatDaggerCall("greet")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "hello from migrated compat", strings.TrimSpace(out))
 	})
 
-	t.Run("migrate creates root parent workspace for sdk-only root-source modules", func(ctx context.Context, t *testctx.T) {
+	t.Run("migrate converts sdk-only root-source modules in place with a minimal workspace config", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		ctr := legacySDKOnlyGoSource(t, c, "hello from sdk-only root").
 			With(compatDaggerExec("setup", "--auto-apply"))
@@ -734,16 +737,21 @@ func (WorkspaceCompatSuite) TestCompatMigration(ctx context.Context, t *testctx.
 		out, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 
-		_, err = ctr.WithExec([]string{"test", "-f", "dagger.json"}).Sync(ctx)
-		require.NoError(t, err, "sdk-only dagger.json should remain in place")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "sdk-only dagger.json should be converted in place")
+
+		_, err = ctr.WithExec([]string{"test", "-f", "dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "module config should be converted in place at the root")
 
 		_, err = ctr.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
-		require.NoError(t, err, "root parent workspace config should be created")
+		require.NoError(t, err, "minimal workspace config should be created")
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, configOut, `[modules.dagger-go-sdk]`)
 		require.Contains(t, configOut, `source = "github.com/dagger/go-sdk"`)
+		require.NotContains(t, configOut, `[modules.myapp]`,
+			"a repo that is just a dagger module is not installed into the workspace")
 
 		reportOut, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)
 		require.NoError(t, err)

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -828,9 +828,16 @@ func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.C
 }`).
 		With(compatDaggerExec("setup", "--auto-apply"))
 
-	configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
+	// The selected config sits in a subdirectory of the repo, so its
+	// toolchains hoist into a dagger.toml at the repo root (never a nested
+	// one), with local sources rebased.
+	_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.toml"}).Sync(ctx)
+	require.NoError(t, err, "no nested workspace config in the app directory")
+	configOut, err := ctr.WithExec([]string{"cat", "/work/dagger.toml"}).Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, configOut, "[modules.hello-with-generators]")
+	require.Contains(t, configOut, `source = "./modules/hello-with-generators"`,
+		"the toolchain's local source is rebased to the repo root")
 	require.Contains(t, configOut, `generate.skip = ["generate-other-files", "other-generators:*"]`)
 
 	listOut, err := ctr.With(compatDaggerExec("generate", "-l")).CombinedOutput(ctx)
@@ -845,6 +852,8 @@ func (WorkspaceCompatSuite) TestCompatMigrationToolchainSkipFields(ctx context.C
 	require.Contains(t, runOut, "hello-with-generators:generate-files")
 	require.NotContains(t, runOut, "hello-with-generators:generate-other-files")
 
+	// Generated changes still apply relative to where the command runs; only
+	// the workspace config location moved to the repo root.
 	exists, err := runCtr.Exists(ctx, "foo")
 	require.NoError(t, err)
 	require.True(t, exists)
@@ -883,9 +892,16 @@ func (WorkspaceCompatSuite) TestCompatMigrationPortMappings(ctx context.Context,
 }`).
 		With(compatDaggerExec("setup", "--auto-apply"))
 
-	configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
+	// The subdirectory config's toolchains (and their port mappings) hoist
+	// into a dagger.toml at the repo root — nested workspace configs are
+	// never created.
+	_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.toml"}).Sync(ctx)
+	require.NoError(t, err, "no nested workspace config in the app directory")
+	configOut, err := ctr.WithExec([]string{"cat", "/work/dagger.toml"}).Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, configOut, "[modules.hello-with-services]")
+	require.Contains(t, configOut, `source = "./modules/hello-with-services"`,
+		"the toolchain's local source is rebased to the repo root")
 	require.Contains(t, configOut, `up.skip = ["redis", "infra:database"]`)
 	require.Contains(t, configOut, "[ports.3000]")
 	require.Contains(t, configOut, `backendService = "hello-with-services:web"`)

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -75,7 +75,7 @@ type Myapp {
 		require.NoError(t, err)
 		require.Contains(t, out, `"isEmpty": false`)
 		require.Contains(t, out, `"path": "dagger.toml"`)
-		require.Contains(t, out, `"path": ".dagger/modules/myapp/dagger-module.toml"`)
+		require.Contains(t, out, `"path": "dagger-module.toml"`)
 
 		_, err = preview.WithExec([]string{"test", "-f", "dagger.json"}).Sync(ctx)
 		require.NoError(t, err, "preview should leave the legacy config on disk")
@@ -83,7 +83,7 @@ type Myapp {
 		_, err = preview.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
 		require.Error(t, err, "preview should not write workspace config")
 
-		_, err = preview.WithExec([]string{"test", "-f", ".dagger/modules/myapp/dagger-module.toml"}).Sync(ctx)
+		_, err = preview.WithExec([]string{"test", "-f", "dagger-module.toml"}).Sync(ctx)
 		require.Error(t, err, "preview should not write migrated module config")
 	})
 
@@ -108,13 +108,17 @@ type Myapp {
 		_, err := ctr.WithExec([]string{"test", "-d", "ci"}).Sync(ctx)
 		require.NoError(t, err, "source directory should remain available after migration")
 
-		djson, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		djson, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, djson, `name = "myapp"`)
+		require.Contains(t, djson, `source = "ci"`)
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, configOut, ".dagger/modules/myapp")
+		require.Contains(t, configOut, strings.Join([]string{
+			"[modules.myapp]",
+			`source = "."`,
+		}, "\n"))
 
 		out, err := ctr.With(daggerCall("greet")).Stdout(ctx)
 		require.NoError(t, err)
@@ -194,7 +198,7 @@ func (m *Nested) Message() string {
 // TestWorkspaceMigrateOutcomes should cover the main result classes of a
 // migration.
 func (WorkspaceMigrationSuite) TestWorkspaceMigrateOutcomes(ctx context.Context, t *testctx.T) {
-	t.Run("non-local source stays in place behind moved config", func(ctx context.Context, t *testctx.T) {
+	t.Run("module config replaces dagger.json in place", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
 		ctr := legacyWorkspaceBase(t, c, `{
@@ -214,12 +218,17 @@ type Myapp {
 		_, err := ctr.WithExec([]string{"test", "-f", "ci/main.dang"}).Sync(ctx)
 		require.NoError(t, err, "source file should remain in its original directory")
 
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/myapp/main.dang"}).Sync(ctx)
-		require.Error(t, err, "source file should not be copied to the migrated module config directory")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/modules"}).Sync(ctx)
+		require.NoError(t, err, "migration must not synthesize configs under .dagger/modules")
 
-		djson, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "ci/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "the module config must not move into the source directory: installs by path point at the dagger.json location")
+
+		djson, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, djson, `source = "../../../ci"`)
+		require.Contains(t, djson, `name = "myapp"`)
+		require.Contains(t, djson, `source = "ci"`,
+			"the source path is preserved as-is")
 
 		out, err := ctr.With(daggerCall("greet")).Stdout(ctx)
 		require.NoError(t, err)
@@ -228,12 +237,16 @@ type Myapp {
 
 	t.Run("sdk-only config migrates before install", func(ctx context.Context, t *testctx.T) {
 		// The allowed path for an SDK-only dagger.json is explicit migration
-		// first, then workspace mutation. Migration creates the parent native
-		// workspace config and preserves the root module, so a later `dagger
-		// install` can safely add dependencies to dagger.toml.
+		// first, then workspace mutation. Migration converts the module config
+		// in place and creates a minimal workspace config pinning only the SDK
+		// runtime, so a later `dagger install` can safely add dependencies to
+		// dagger.toml.
 		c := connect(ctx, t)
 		ctr := legacySDKOnlyGoSource(t, c, "hello from root source").
 			With(legacyDangModule("dep", "dep", "Dep", "hello from dep")).
+			// The converted module keeps working only with its generated code
+			// committed (current-format modules have no runtime codegen).
+			With(materializeModuleFiles(".")).
 			With(daggerExec("setup", "--auto-apply"))
 
 		out, err := ctr.CombinedOutput(ctx)
@@ -244,16 +257,22 @@ type Myapp {
 		_, err = ctr.WithExec([]string{"test", "-f", "main.go"}).Sync(ctx)
 		require.NoError(t, err, "source file should remain at root")
 
-		_, err = ctr.WithExec([]string{"test", "-f", "dagger.json"}).Sync(ctx)
-		require.NoError(t, err, "legacy dagger.json should remain in place")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "legacy dagger.json should be converted in place")
+
+		_, err = ctr.WithExec([]string{"test", "-f", "dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "module config should be converted in place at the root")
 
 		_, err = ctr.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
-		require.NoError(t, err, "root parent workspace config should be created")
+		require.NoError(t, err, "minimal workspace config should be created")
 
 		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, configOut, `[modules.dagger-go-sdk]`)
 		require.Contains(t, configOut, `source = "github.com/dagger/go-sdk"`)
+		require.NotContains(t, configOut, `[modules.myapp]`,
+			"a repo that is just a dagger module is not installed into the workspace")
+		require.NotContains(t, configOut, "entrypoint")
 
 		reportOut, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -276,7 +295,9 @@ type Myapp {
 		require.Contains(t, configOut, `source = "dep"`)
 	})
 
-	t.Run("plain module in default dot dagger modules directory migrates", func(ctx context.Context, t *testctx.T) {
+	t.Run("unreferenced module in default dot dagger modules directory is not touched", func(ctx context.Context, t *testctx.T) {
+		// Migration no longer crawls the repo (not even .dagger/modules): only
+		// the selected root config and the local modules it references migrate.
 		c := connect(ctx, t)
 		ctr := legacyWorkspaceBase(t, c, `{
   "name": "myapp",
@@ -297,13 +318,11 @@ type Myapp {
 		out, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 
-		cfgOut, err := ctr.WithExec([]string{"cat", ".dagger/modules/project/dagger-module.toml"}).Stdout(ctx)
-		require.NoError(t, err)
-		require.Contains(t, cfgOut, `name = "project"`)
-		require.Contains(t, cfgOut, `[runtime]`)
+		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/project/dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "an unreferenced module keeps its legacy config")
 
-		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/modules/project/dagger.json"}).Sync(ctx)
-		require.NoError(t, err, "legacy project-local module config should be removed after conversion")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/modules/project/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "an unreferenced module is not converted")
 	})
 
 	t.Run("toolchains are marked with legacy default path", func(ctx context.Context, t *testctx.T) {
@@ -377,15 +396,17 @@ type Myapp {
 		_, err := ctr.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
 		require.NoError(t, err)
 
-		djson, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		djson, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, djson, `source = "../.."`)
+		require.Contains(t, djson, `name = "myapp"`)
+		require.Contains(t, djson, `source = ".dagger"`,
+			"the source path is preserved as-is")
 
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/myapp/main.dang"}).Sync(ctx)
-		require.Error(t, err, "source file should not be copied to the migrated module config directory")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "the module config must not move into the source directory")
 
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/myapp/go.mod"}).Sync(ctx)
-		require.Error(t, err, "source metadata should not be copied to the migrated module config directory")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/modules/myapp"}).Sync(ctx)
+		require.NoError(t, err, "migration must not synthesize configs under .dagger/modules")
 
 		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/main.dang"}).Sync(ctx)
 		require.NoError(t, err, "source file should remain in place")
@@ -471,10 +492,10 @@ type Myapp {
 		_, err = ctr.WithExec([]string{"test", "!", "-e", "libs/foo/dagger.json"}).Sync(ctx)
 		require.NoError(t, err, "legacy dependency config should be removed after in-place conversion")
 
-		mainCfg, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		mainCfg, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, mainCfg, "../../../libs/foo",
-			"main module's dependency reference is rebased to the still-in-place converted dependency")
+		require.Contains(t, mainCfg, `"./libs/foo"`,
+			"main module's dependency reference is preserved as-is: the config did not move")
 
 		// The converted dependency's runtime is installed and pinned in the
 		// workspace.
@@ -523,39 +544,36 @@ type Myapp {
 		}
 	})
 
-	t.Run("nested workspace plan resolves its SDK installs", func(ctx context.Context, t *testctx.T) {
+	t.Run("discovered dependency SDK installs resolve to real refs", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		// A globbed .dagger/modules/tool config that itself must-migrate (its
-		// source is a non-root subdir) becomes its OWN workspace plan, with its
-		// own dagger.toml — separate from the top-level workspace the setup
-		// command runs in. Its SDK install (and any it owns for discovered deps)
-		// must still be resolved to a real ref, even though it lives in a config
-		// the current-workspace fixup pass doesn't read. The tool uses `php`,
-		// whose sdks.json ref (github.com/dagger/php-sdk) differs from the
-		// engine-side runtime mapping, so this also pins that the CLI registry —
-		// what `dagger sdk install` uses — wins for these nested configs.
+		// A discovered local dependency's runtime is recorded in the migrated
+		// workspace config by bare short name and must be resolved to a real
+		// ref. The tool uses `php`, whose sdks.json ref
+		// (github.com/dagger/php-sdk) differs from the engine-side runtime
+		// mapping, so this also pins that the CLI registry — what `dagger sdk
+		// install` uses — wins.
 		ctr := legacyWorkspaceBase(t, c, `{
   "name": "myapp",
   "sdk": {"source": "dang"},
-  "source": "ci"
+  "source": "ci",
+  "dependencies": [{"name": "tool", "source": "./tool"}]
 }`, func(ctr *dagger.Container) *dagger.Container {
 			return ctr.
 				WithNewFile("ci/main.dang", "\ntype Myapp {\n  pub greet: String! { \"hi\" }\n}\n").
-				WithNewFile(".dagger/modules/tool/dagger.json", `{"name":"tool","sdk":{"source":"php"},"source":"src","dependencies":[{"name":"helper","source":"./helper"}]}`).
-				WithNewFile(".dagger/modules/tool/src/index.php", "<?php\n").
-				With(legacyDangModule(".dagger/modules/tool/helper", "helper", "Helper", "help"))
+				WithNewFile("tool/dagger.json", `{"name":"tool","sdk":{"source":"php"},"source":"src"}`).
+				WithNewFile("tool/src/index.php", "<?php\n")
 		}).With(daggerExec("setup", "--auto-apply"))
 
 		out, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 
-		nested, err := ctr.WithExec([]string{"cat", ".dagger/modules/tool/dagger.toml"}).Stdout(ctx)
+		wsOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		// The tool's own runtime resolves to its sdks.json ref (CLI registry),
-		// and the discovered helper's dang runtime resolves too.
-		require.Contains(t, nested, `source = "github.com/dagger/php-sdk"`, nested)
-		require.Contains(t, nested, `source = "github.com/dagger/dang-sdk"`, nested)
-		require.NotContains(t, nested, `source = "php"`, nested)
+		// The root module's dang runtime and the discovered tool's php runtime
+		// both resolve to their sdks.json refs.
+		require.Contains(t, wsOut, `source = "github.com/dagger/php-sdk"`, wsOut)
+		require.Contains(t, wsOut, `source = "github.com/dagger/dang-sdk"`, wsOut)
+		require.NotContains(t, wsOut, `source = "php"`, wsOut)
 	})
 
 	t.Run("pre-existing nested workspace config is left untouched", func(ctx context.Context, t *testctx.T) {
@@ -817,7 +835,7 @@ type Dep1 {
 			require.NoError(t, err)
 			require.Contains(t, stdout+stderr, "prepare migration diff")
 			require.Contains(t, stdout+stderr, "workspace configuration: dagger.toml")
-			require.Contains(t, stdout+stderr, "move module: dagger.json -> .dagger/modules/myapp/dagger-module.toml")
+			require.Contains(t, stdout+stderr, "move module: dagger.json -> dagger-module.toml")
 			require.NotContains(t, stdout+stderr, "Migrated to workspace format")
 		})
 	})
@@ -963,12 +981,14 @@ type Inner {
 		require.Contains(t, nestedConfigOut, `[modules.inner]`)
 		require.NotContains(t, nestedConfigOut, `[modules.outer]`)
 
-		_, err = ctr.WithExec([]string{"test", "!", "-e", "../.dagger/modules/outer/dagger-module.toml"}).Sync(ctx)
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "../dagger-module.toml"}).Sync(ctx)
 		require.NoError(t, err, "outer migrated module config should not be created")
 
-		djson, err := ctr.WithExec([]string{"cat", ".dagger/modules/inner/dagger-module.toml"}).Stdout(ctx)
+		djson, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Contains(t, djson, `source = "../../../src"`)
+		require.Contains(t, djson, `name = "inner"`)
+		require.Contains(t, djson, `source = "src"`,
+			"the source path is preserved as-is")
 	})
 
 	t.Run("does not migrate unrelated child config from root", func(ctx context.Context, t *testctx.T) {
@@ -999,7 +1019,10 @@ type Api {
 		require.NoError(t, err, "child legacy config should stay in place")
 	})
 
-	t.Run("plain modules in default dot dagger modules directory create parent workspace", func(ctx context.Context, t *testctx.T) {
+	t.Run("modules in default dot dagger modules directory are not crawled", func(ctx context.Context, t *testctx.T) {
+		// Migration only follows the selected root config and its local
+		// references; with no root dagger.json, modules sitting under
+		// .dagger/modules are left exactly as they are.
 		ctr := workspaceBase(t, c).
 			WithNewFile(".dagger/modules/videostitch/dagger.json", `{
   "name": "videostitch",
@@ -1020,43 +1043,20 @@ type Videostitch struct{}
 
 		output, err := ctr.CombinedOutput(ctx)
 		require.NoError(t, err, output)
-		// The per-module "requires explicit loading" warnings are recorded in the
-		// on-disk migration report (asserted below), not printed to setup stdout.
 
-		_, err = ctr.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
-		require.NoError(t, err, "root parent workspace config should be created")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.toml"}).Sync(ctx)
+		require.NoError(t, err, "no workspace config should be created")
 
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/videostitch/dagger.json"}).Sync(ctx)
-		require.Error(t, err, "legacy plain module config should be converted")
+		for _, mod := range []string{"videostitch", "clipper"} {
+			_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/" + mod + "/dagger.json"}).Sync(ctx)
+			require.NoError(t, err, "unreferenced module %s keeps its legacy config", mod)
 
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/videostitch/dagger-module.toml"}).Sync(ctx)
-		require.NoError(t, err, "plain module config should be converted")
+			_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/modules/" + mod + "/dagger-module.toml"}).Sync(ctx)
+			require.NoError(t, err, "unreferenced module %s is not converted", mod)
+		}
 
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/clipper/dagger.json"}).Sync(ctx)
-		require.Error(t, err, "legacy plain module config should be converted")
-
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/clipper/dagger-module.toml"}).Sync(ctx)
-		require.NoError(t, err, "plain module config should be converted")
-
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/videostitch/dagger.toml"}).Sync(ctx)
-		require.Error(t, err, "plain module should not get its own workspace config")
-
-		_, err = ctr.WithExec([]string{"test", "-f", ".dagger/modules/clipper/dagger.toml"}).Sync(ctx)
-		require.Error(t, err, "plain module should not get its own workspace config")
-
-		configOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
-		require.NoError(t, err)
-		require.Contains(t, configOut, `[modules.dagger-go-sdk]`)
-		require.Contains(t, configOut, `source = "github.com/dagger/go-sdk"`)
-		require.Contains(t, configOut, `[modules.dagger-typescript-sdk]`)
-		require.Contains(t, configOut, `source = "github.com/dagger/typescript-sdk"`)
-
-		reportOut, err := ctr.WithExec([]string{"cat", ".dagger/migration-report.md"}).Stdout(ctx)
-		require.NoError(t, err)
-		require.Contains(t, reportOut, "## .dagger/modules/videostitch requires explicit loading")
-		require.Contains(t, reportOut, "**This works**: `dagger -m .dagger/modules/videostitch call --help`")
-		require.Contains(t, reportOut, "**This no longer works**: `cd .dagger/modules/videostitch; dagger call --help`")
-		require.Contains(t, reportOut, "## .dagger/modules/clipper requires explicit loading")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/migration-report.md"}).Sync(ctx)
+		require.NoError(t, err, "no migration report should be written")
 	})
 }
 
@@ -1154,16 +1154,16 @@ type Myapp {
   }
 }
 `).
-				WithNewFile(".dagger/modules/myapp/dagger-module.toml", `name = "some-other-module"
+				WithNewFile("dagger-module.toml", `name = "some-other-module"
 `)
 		})
 
 		out, err := ctr.With(daggerExecFail("setup", "--auto-apply")).CombinedOutput(ctx)
 		require.NoError(t, err)
-		require.Contains(t, out, `migration target ".dagger/modules/myapp/dagger-module.toml" already exists`)
+		require.Contains(t, out, `migration target "dagger-module.toml" already exists`)
 		require.Contains(t, out, "refusing to overwrite")
 
-		conflictOut, err := ctr.WithExec([]string{"cat", ".dagger/modules/myapp/dagger-module.toml"}).Stdout(ctx)
+		conflictOut, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, conflictOut, `name = "some-other-module"`)
 

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -934,6 +934,10 @@ func (WorkspaceMigrationSuite) TestWorkspaceMigrateScope(ctx context.Context, t 
 	c := connect(ctx, t)
 
 	t.Run("migrates selected nested config without touching outer config", func(ctx context.Context, t *testctx.T) {
+		// The main expected subdirectory case: a nested dagger.json whose
+		// module source is in a subdirectory migrates module-only — the config
+		// converts to dagger-module.toml in place, and no dagger.toml is
+		// created anywhere (nested workspace configs are never written).
 		ctr := workspaceBase(t, c).
 			WithNewFile("dagger.json", `{
   "name": "outer",
@@ -964,22 +968,21 @@ type Inner {
 			WithWorkdir("/work/nested").
 			With(daggerExec("setup", "--auto-apply"))
 
-		_, err := ctr.WithExec([]string{"test", "-f", "dagger.toml"}).Sync(ctx)
-		require.NoError(t, err, "nested compat workspace should be migrated")
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "Migrated the module in place; no workspace config was created.")
+
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.toml"}).Sync(ctx)
+		require.NoError(t, err, "migration should not write a nested workspace config")
 
 		_, err = ctr.WithExec([]string{"test", "-f", "../dagger.json"}).Sync(ctx)
 		require.NoError(t, err, "outer legacy config should not be migrated from the nested run")
 
-		_, err = ctr.WithExec([]string{"test", "-f", "../dagger.toml"}).Sync(ctx)
-		require.Error(t, err, "migration should not write root workspace config")
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "../dagger.toml"}).Sync(ctx)
+		require.NoError(t, err, "migration should not write root workspace config")
 
-		_, err = ctr.WithExec([]string{"test", "-f", "dagger.json"}).Sync(ctx)
-		require.Error(t, err, "nested legacy config should be removed")
-
-		nestedConfigOut, err := ctr.WithExec([]string{"cat", "dagger.toml"}).Stdout(ctx)
-		require.NoError(t, err)
-		require.Contains(t, nestedConfigOut, `[modules.inner]`)
-		require.NotContains(t, nestedConfigOut, `[modules.outer]`)
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "nested legacy config should be removed")
 
 		_, err = ctr.WithExec([]string{"test", "!", "-e", "../dagger-module.toml"}).Sync(ctx)
 		require.NoError(t, err, "outer migrated module config should not be created")
@@ -989,6 +992,137 @@ type Inner {
 		require.Contains(t, djson, `name = "inner"`)
 		require.Contains(t, djson, `source = "src"`,
 			"the source path is preserved as-is")
+	})
+
+	t.Run("plain module in a subdirectory migrates module only", func(ctx context.Context, t *testctx.T) {
+		// Setup run from a subdirectory that is a dagger module migrates just
+		// that module from v0 to v1: dagger.json converts to dagger-module.toml
+		// in place (its local dependencies too), no workspace config is created
+		// anywhere, and module recommendations are skipped.
+		ctr := workspaceBase(t, c).
+			WithNewFile("tools/hello/dagger.json", `{"name":"hello","sdk":{"source":"dang"},"dependencies":[{"name":"dep","source":"./dep"}]}`).
+			WithNewFile("tools/hello/main.dang", `
+type Hello {
+  pub greet: String! {
+    "hello from subdirectory module"
+  }
+}
+`).
+			With(legacyDangModule("tools/hello/dep", "dep", "Dep", "hello from dep")).
+			WithExec([]string{"git", "add", "."}).
+			WithExec([]string{"git", "commit", "-m", "initial"}).
+			WithWorkdir("/work/tools/hello").
+			With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "Migrated the module in place; no workspace config was created.")
+		require.NotContains(t, out, "Step 3: Recommended modules")
+		require.NotContains(t, out, "Run `dagger setup` again")
+
+		for _, dir := range []string{".", "dep"} {
+			_, err = ctr.WithExec([]string{"test", "-f", dir + "/dagger-module.toml"}).Sync(ctx)
+			require.NoError(t, err, "%s should be converted in place", dir)
+			_, err = ctr.WithExec([]string{"test", "!", "-e", dir + "/dagger.json"}).Sync(ctx)
+			require.NoError(t, err, "%s legacy config should be removed", dir)
+		}
+
+		for _, cfg := range []string{"dagger.toml", "dep/dagger.toml", "../../dagger.toml"} {
+			_, err = ctr.WithExec([]string{"test", "!", "-e", cfg}).Sync(ctx)
+			require.NoError(t, err, "no workspace config should be created at %s", cfg)
+		}
+		_, err = ctr.WithExec([]string{"test", "!", "-e", ".dagger/migration-report.md"}).Sync(ctx)
+		require.NoError(t, err, "module-only migration writes no migration report")
+
+		// The converted module config still names its sdk, so it loads without
+		// any workspace.
+		callOut, err := ctr.With(daggerCallAt(".", "greet")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from subdirectory module", strings.TrimSpace(callOut))
+	})
+
+	t.Run("subdirectory toolchains hoist into the repo-root workspace", func(ctx context.Context, t *testctx.T) {
+		// Nested dagger.toml files are never created: a subdirectory config
+		// with toolchains installs them into a dagger.toml at the repo root
+		// (local sources rebased), while the module config converts in place
+		// and the module itself is not installed into the workspace.
+		ctr := workspaceBase(t, c).
+			WithNewFile("tools/hello/dagger.json", `{
+  "name": "hello",
+  "sdk": {"source": "dang"},
+  "toolchains": [{"name": "tc", "source": "./toolchain"}]
+}`).
+			WithNewFile("tools/hello/main.dang", `
+type Hello {
+  pub greet: String! {
+    "hello from subdirectory module"
+  }
+}
+`).
+			With(legacyDangModule("tools/hello/toolchain", "tc", "Tc", "hello from toolchain")).
+			WithExec([]string{"git", "add", "."}).
+			WithExec([]string{"git", "commit", "-m", "initial"}).
+			WithWorkdir("/work/tools/hello").
+			With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.toml"}).Sync(ctx)
+		require.NoError(t, err, "no nested workspace config should be created in the module directory")
+
+		wsOut, err := ctr.WithExec([]string{"cat", "/work/dagger.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, wsOut, `[modules.tc]`)
+		require.Contains(t, wsOut, `source = "./tools/hello/toolchain"`,
+			"local toolchain sources are rebased to the repo root")
+		require.NotContains(t, wsOut, `[modules.hello]`,
+			"the subdirectory module is not installed into the repo-wide workspace")
+		// The module's runtime is pinned in the hoisted root workspace and
+		// resolved to its real ref by the setup SDK fixup pass.
+		require.Contains(t, wsOut, `[modules.dagger-dang-sdk]`)
+		require.Contains(t, wsOut, `source = "github.com/dagger/dang-sdk"`)
+
+		mjson, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, mjson, `name = "hello"`)
+		_, err = ctr.WithExec([]string{"test", "!", "-e", "dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "legacy config should be removed after in-place conversion")
+
+		_, err = ctr.WithExec([]string{"test", "-f", "toolchain/dagger-module.toml"}).Sync(ctx)
+		require.NoError(t, err, "the local toolchain converts in place")
+
+		reportOut, err := ctr.WithExec([]string{"cat", "/work/.dagger/migration-report.md"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, reportOut, "## tools/hello requires explicit loading")
+	})
+
+	t.Run("subdirectory blueprint config is left legacy with a warning", func(ctx context.Context, t *testctx.T) {
+		// A blueprint needs a workspace config, and hoisting an entrypoint to
+		// the repo root would change repo-wide behavior — the config is left
+		// as legacy, and setup explains the skip instead of claiming there is
+		// nothing to migrate.
+		ctr := workspaceBase(t, c).
+			WithNewFile("tools/hello/dagger.json", `{
+  "name": "hello",
+  "blueprint": {"name": "bp", "source": "github.com/dagger/dagger/modules/wolfi@main"}
+}`).
+			WithExec([]string{"git", "add", "."}).
+			WithExec([]string{"git", "commit", "-m", "initial"}).
+			WithWorkdir("/work/tools/hello").
+			With(daggerExec("setup", "--auto-apply"))
+
+		out, err := ctr.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "Skipped: skipped migrating tools/hello/dagger.json: it defines a blueprint")
+		require.NotContains(t, out, "Step 3: Recommended modules")
+
+		_, err = ctr.WithExec([]string{"test", "-f", "dagger.json"}).Sync(ctx)
+		require.NoError(t, err, "the blueprint config stays legacy")
+		for _, cfg := range []string{"dagger.toml", "dagger-module.toml", "/work/dagger.toml"} {
+			_, err = ctr.WithExec([]string{"test", "!", "-e", cfg}).Sync(ctx)
+			require.NoError(t, err, "nothing should be written for a skipped blueprint config (%s)", cfg)
+		}
 	})
 
 	t.Run("does not migrate unrelated child config from root", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -93,16 +93,52 @@ func (s *workspaceSchema) migrate(
 	if err != nil {
 		return nil, err
 	}
+
+	// A subdirectory config with a blueprint is left as legacy: a blueprint
+	// needs a workspace config, nested dagger.toml files are not created, and
+	// hoisting an entrypoint to the repo root would change repo-wide behavior.
+	// Surface the skip as a warning-only step so setup can explain the no-op.
+	if selected := workspaceMigrationSelectedCompatWorkspace(compatWorkspaces); selected != nil &&
+		selected.Config != nil && selected.Config.Blueprint != nil {
+		rel, err := workspaceMigrationProjectRootRelPath(ws, selected.ProjectRoot)
+		if err != nil {
+			return nil, err
+		}
+		if rel != "." {
+			return &core.WorkspaceMigration{
+				Changes: emptyChanges,
+				Steps: []*core.WorkspaceMigrationStep{
+					{
+						Code:        "legacy-dagger-json",
+						Description: "Migration skipped",
+						Warnings: []string{fmt.Sprintf(
+							"skipped migrating %s: it defines a blueprint, which needs a workspace config, and migration does not create nested dagger.toml files; the config was left as legacy",
+							workspaceMigrationDisplayPath(filepath.Join(rel, workspace.LegacyModuleConfigFileName)),
+						)},
+						Changes: emptyChanges,
+					},
+				},
+			}, nil
+		}
+	}
+
 	plans := make([]*workspace.MigrationPlan, 0, len(compatWorkspaces))
 	for _, compatWorkspace := range compatWorkspaces {
 		// Discovered local modules are converted in place; never route them
 		// through PlanMigration, which would move and delete their dagger.json
 		// and break the reference that pointed at them.
-		if !compatWorkspace.MustMigrateToWorkspaceConfig() || compatWorkspace.DiscoveredLocalModule {
+		if compatWorkspace.DiscoveredLocalModule {
+			continue
+		}
+		routesThroughPlan, err := workspaceMigrationRoutesThroughPlan(ws, compatWorkspace)
+		if err != nil {
+			return nil, err
+		}
+		if !routesThroughPlan {
 			continue
 		}
 
-		plan, err := s.prepareWorkspaceMigrationPlan(ctx, compatWorkspace)
+		plan, err := s.prepareWorkspaceMigrationPlan(ctx, ws, compatWorkspace)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +149,7 @@ func (s *workspaceSchema) migrate(
 	if err != nil {
 		return nil, err
 	}
-	moduleConfigConversions, err := workspaceMigrationModuleConfigConversions(compatWorkspaces)
+	moduleConfigConversions, err := workspaceMigrationModuleConfigConversions(ws, compatWorkspaces)
 	if err != nil {
 		return nil, err
 	}
@@ -261,14 +297,49 @@ func (s *workspaceSchema) workspaceMigrationGitignoreCleanup(
 
 func (s *workspaceSchema) prepareWorkspaceMigrationPlan(
 	ctx context.Context,
+	ws *core.Workspace,
 	compatWorkspace *workspace.CompatWorkspace,
 ) (*workspace.MigrationPlan, error) {
-	plan, err := workspace.PlanMigration(compatWorkspace)
+	plan, err := workspace.PlanMigration(compatWorkspace, ws.HostPath())
 	if err != nil {
 		return nil, err
 	}
 	recordWorkspaceMigrationModuleSpans(ctx, compatWorkspace.Modules)
 	return plan, nil
+}
+
+// workspaceMigrationSelectedCompatWorkspace returns the compat workspace for
+// the selected legacy config — the one found up from cwd, as opposed to the
+// modules discovered through its local references.
+func workspaceMigrationSelectedCompatWorkspace(compatWorkspaces []*workspace.CompatWorkspace) *workspace.CompatWorkspace {
+	for _, compatWorkspace := range compatWorkspaces {
+		if compatWorkspace != nil && !compatWorkspace.DiscoveredLocalModule {
+			return compatWorkspace
+		}
+	}
+	return nil
+}
+
+// workspaceMigrationRoutesThroughPlan reports whether a selected legacy config
+// is handled by PlanMigration — which writes a workspace config — rather than
+// by in-place module conversion alone. A config at the workspace root plans
+// whenever it carries workspace semantics; a subdirectory config plans only
+// when it has toolchains to hoist into the workspace-root dagger.toml. A
+// subdirectory config that must migrate merely because its source is in a
+// subdirectory is the plain "migrate this one module" case: it converts in
+// place and creates no workspace.
+func workspaceMigrationRoutesThroughPlan(ws *core.Workspace, compatWorkspace *workspace.CompatWorkspace) (bool, error) {
+	if !compatWorkspace.MustMigrateToWorkspaceConfig() {
+		return false, nil
+	}
+	rel, err := workspaceMigrationProjectRootRelPath(ws, compatWorkspace.ProjectRoot)
+	if err != nil {
+		return false, err
+	}
+	if rel == "." {
+		return true, nil
+	}
+	return compatWorkspace.Config != nil && len(compatWorkspace.Config.Toolchains) > 0, nil
 }
 
 func (s *workspaceSchema) workspaceMigrationCompatWorkspaces(
@@ -792,7 +863,7 @@ func applyWorkspaceMigrationWorkspacePlan(
 	plan *workspace.MigrationPlan,
 ) (dagql.ObjectResult[*core.Directory], error) {
 	if len(plan.MigratedModuleConfigData) > 0 {
-		migratedModuleConfigPath, err := workspaceMigrationRootPath(ws, plan, plan.MigratedModuleConfigPath)
+		migratedModuleConfigPath, err := workspaceMigrationModuleRootPath(ws, plan, plan.MigratedModuleConfigPath)
 		if err != nil {
 			return dir, err
 		}
@@ -822,7 +893,7 @@ func applyWorkspaceMigrationWorkspacePlan(
 		}
 	}
 
-	legacyConfigPath, err := workspaceMigrationRootPath(ws, plan, workspace.LegacyModuleConfigFileName)
+	legacyConfigPath, err := workspaceMigrationModuleRootPath(ws, plan, workspace.LegacyModuleConfigFileName)
 	if err != nil {
 		return dir, err
 	}
@@ -920,6 +991,15 @@ func workspaceMigrationRootTargetPaths(ws *core.Workspace, plans workspaceMigrat
 	}
 
 	for _, plan := range plans.WorkspacePlans {
+		if len(plan.MigratedModuleConfigData) > 0 {
+			rootPath, err := workspaceMigrationModuleRootPath(ws, plan, plan.MigratedModuleConfigPath)
+			if err != nil {
+				return nil, err
+			}
+			if err := addPath(rootPath); err != nil {
+				return nil, err
+			}
+		}
 		for _, targetPath := range workspaceMigrationTargetPaths(plan) {
 			rootPath, err := workspaceMigrationRootPath(ws, plan, targetPath)
 			if err != nil {
@@ -1037,6 +1117,11 @@ func workspaceMigrationLegacyLockProjectRoots(plans workspaceMigrationPlanBundle
 	}
 	for _, plan := range plans.WorkspacePlans {
 		addProject(plan.ProjectRoot)
+		if plan.ModuleProjectRoot != "" {
+			// A hoisted plan's legacy lockfile lives next to the legacy
+			// dagger.json, not at the workspace root the plan writes to.
+			addProject(plan.ModuleProjectRoot)
+		}
 	}
 	for _, plan := range plans.ParentPlans {
 		addProject(plan.ProjectRoot)
@@ -1054,6 +1139,21 @@ func workspaceMigrationRootPath(ws *core.Workspace, plan *workspace.MigrationPla
 	return workspaceMigrationRootPathForProject(ws, plan.ProjectRoot, relPath)
 }
 
+// workspaceMigrationModuleRootPath resolves a path against the plan's module
+// project root — where the legacy dagger.json lives and its converted module
+// config lands. For a hoisted subdirectory project this differs from the
+// plan's ProjectRoot (the workspace root, where dagger.toml lands).
+func workspaceMigrationModuleRootPath(ws *core.Workspace, plan *workspace.MigrationPlan, relPath string) (string, error) {
+	if plan == nil {
+		return "", fmt.Errorf("migration plan is unavailable")
+	}
+	moduleRoot := plan.ModuleProjectRoot
+	if moduleRoot == "" {
+		moduleRoot = plan.ProjectRoot
+	}
+	return workspaceMigrationRootPathForProject(ws, moduleRoot, relPath)
+}
+
 func workspaceMigrationRootPathForProject(ws *core.Workspace, projectRoot string, relPath string) (string, error) {
 	projectRootPath, err := workspaceMigrationProjectRootRelPath(ws, projectRoot)
 	if err != nil {
@@ -1065,11 +1165,12 @@ func workspaceMigrationRootPathForProject(ws *core.Workspace, projectRoot string
 	return filepath.Join(projectRootPath, relPath), nil
 }
 
+// workspaceMigrationTargetPaths returns the plan's target paths that resolve
+// against its ProjectRoot. The migrated module config is deliberately absent:
+// it resolves against the module project root (see
+// workspaceMigrationModuleRootPath), which differs for hoisted plans.
 func workspaceMigrationTargetPaths(plan *workspace.MigrationPlan) []string {
-	paths := make([]string, 0, 3)
-	if len(plan.MigratedModuleConfigData) > 0 {
-		paths = append(paths, plan.MigratedModuleConfigPath)
-	}
+	paths := make([]string, 0, 2)
 	paths = append(paths, workspace.ConfigFileName)
 	if len(plan.MigrationReportData) > 0 {
 		paths = append(paths, plan.MigrationReportPath)

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -215,6 +215,15 @@ func (s *workspaceSchema) workspaceMigrationGitignoreCleanup(
 		return nil, fmt.Errorf("load legacy module source: %w", err)
 	}
 
+	// The load above resolves whatever module config lives at the project
+	// root. If it isn't the legacy SDK module being migrated — e.g. a stray
+	// dagger-module.toml already sits at the migration target, which target
+	// validation will reject with a proper error — there is no legacy codegen
+	// to inspect, and running it would panic on the missing SDK.
+	if source.Self() == nil || source.Self().SDK == nil || source.Self().SDKImpl == nil {
+		return nil, nil
+	}
+
 	sourceSchema := &moduleSourceSchema{}
 	generatedCode, err := sourceSchema.runSDKCodegen(ctx, source)
 	if err != nil {
@@ -302,12 +311,6 @@ func (s *workspaceSchema) workspaceMigrationCompatWorkspaces(
 
 	compatWorkspaces := make([]*workspace.CompatWorkspace, 0, len(configPaths))
 	for _, cp := range configPaths {
-		// A locally-referenced module may legitimately live under a hidden
-		// directory (e.g. ./.internal/foo); only filter hidden paths for the
-		// selected/glob discovery set, not for explicit dependency references.
-		if !cp.DiscoveredLocalModule && workspaceMigrationHiddenPath(cp.Path) {
-			continue
-		}
 		configPath := filepath.Join(ws.HostPath(), filepath.FromSlash(cp.Path))
 		configDir := filepath.Dir(configPath)
 		hasWorkspaceConfig, err := workspaceMigrationHasExplicitConfigAncestor(workspaceCtx, statFS, ws.HostPath(), configDir)
@@ -337,8 +340,9 @@ func (s *workspaceSchema) workspaceMigrationCompatWorkspaces(
 	return compatWorkspaces, discoveryWarnings, nil
 }
 
-// workspaceMigrationConfigPath is a legacy config discovered for migration,
-// tagged with whether it was reached by following a local module reference.
+// workspaceMigrationConfigPath is a legacy config selected for migration,
+// tagged with whether it was reached by following a local module reference
+// from the selected root config (rather than being the selection itself).
 type workspaceMigrationConfigPath struct {
 	Path                  string
 	DiscoveredLocalModule bool
@@ -349,61 +353,33 @@ func workspaceMigrationLegacyConfigPaths(
 	rootDir dagql.ObjectResult[*core.Directory],
 	ws *core.Workspace,
 ) ([]workspaceMigrationConfigPath, []string, error) {
-	// Migration is intentionally scoped to the selected legacy project plus
-	// its conventional project-local module directory. A repo may contain
-	// unrelated dagger.json files in testdata, examples, or nested projects;
-	// those should only migrate when the user runs migration from that project.
+	// Migration is intentionally scoped to the selected legacy project: the
+	// dagger.json found up from cwd plus the local dependencies and toolchains
+	// it references, transitively. A repo may contain unrelated dagger.json
+	// files — testdata, examples, sibling modules, nested projects — and those
+	// are never touched; they only migrate when migration runs from their own
+	// directory.
 	selectedConfig, selected, err := workspaceMigrationSelectedLegacyConfigPath(ctx, rootDir, ws)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	projectRoot := workspaceMigrationCleanRelPath(ws.Cwd)
-	if selected {
-		projectRoot = path.Dir(selectedConfig)
-		if projectRoot == "." {
-			projectRoot = ""
-		}
+	if !selected || workspaceMigrationHiddenPath(selectedConfig) {
+		return nil, nil, nil
 	}
 
-	initial := make([]string, 0, 1)
-	if selected {
-		initial = append(initial, selectedConfig)
+	projectRoot := path.Dir(selectedConfig)
+	if projectRoot == "." {
+		projectRoot = ""
 	}
 
-	moduleConfigPattern := path.Join(projectRoot, workspace.LockDirName, "modules", "**", workspace.LegacyModuleConfigFileName)
-	modulePaths, err := rootDir.Self().Glob(ctx, rootDir, moduleConfigPattern)
-	if err != nil {
-		return nil, nil, fmt.Errorf("find legacy module configs under %s: %w", path.Join(projectRoot, workspace.LockDirName, "modules"), err)
-	}
-	initial = append(initial, modulePaths...)
-	initial = workspaceMigrationUniqueSortedPaths(initial)
-
-	// Seed the dependency walk from the configs that will actually be migrated,
-	// dropping hidden .dagger/modules/** glob hits (e.g. a scratch dir): an
-	// ignored hidden config must not be read, nor drag its own local deps into
-	// migration. Hidden modules reached from a non-hidden explicit reference are
-	// still discovered by the walk itself.
-	seeds := make([]string, 0, len(initial))
-	for _, p := range initial {
-		if workspaceMigrationHiddenPath(p) {
-			continue
-		}
-		seeds = append(seeds, p)
-	}
-	discovered, warnings, err := workspaceMigrationDiscoverLocalModules(ctx, rootDir, projectRoot, seeds)
+	discovered, warnings, err := workspaceMigrationDiscoverLocalModules(ctx, rootDir, projectRoot, []string{selectedConfig})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Selected/glob origin wins over a discovered origin: a config that is both a
-	// .dagger/modules/** hit and locally referenced keeps its existing handling.
-	result := make([]workspaceMigrationConfigPath, 0, len(initial)+len(discovered))
-	seen := make(map[string]struct{}, len(initial)+len(discovered))
-	for _, p := range initial {
-		result = append(result, workspaceMigrationConfigPath{Path: p})
-		seen[path.Clean(p)] = struct{}{}
-	}
+	result := make([]workspaceMigrationConfigPath, 0, 1+len(discovered))
+	result = append(result, workspaceMigrationConfigPath{Path: selectedConfig})
+	seen := map[string]struct{}{path.Clean(selectedConfig): {}}
 	for _, p := range discovered {
 		if _, ok := seen[path.Clean(p)]; ok {
 			continue
@@ -1342,25 +1318,4 @@ func workspaceMigrationPlanBundleWarnings(plans workspaceMigrationPlanBundle) []
 		}
 	}
 	return warnings
-}
-
-func workspaceConfigUsesMigratedModuleSources(cfg *workspace.Config, configDir string) bool {
-	if cfg == nil {
-		return false
-	}
-
-	migratedModulesDir := filepath.Clean(filepath.Join(workspace.LockDirName, "modules"))
-	for _, entry := range cfg.Modules {
-		resolvedSource := workspace.ResolveModuleEntrySource(configDir, entry.Source)
-		if filepath.IsAbs(resolvedSource) {
-			continue
-		}
-		resolvedSource = filepath.Clean(resolvedSource)
-		if resolvedSource == migratedModulesDir ||
-			strings.HasPrefix(resolvedSource, migratedModulesDir+string(filepath.Separator)) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/core/schema/workspace_migrate_module_config.go
+++ b/core/schema/workspace_migrate_module_config.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 )
@@ -13,6 +14,7 @@ type workspaceMigrationModuleConfigConversion struct {
 }
 
 func workspaceMigrationModuleConfigConversions(
+	ws *core.Workspace,
 	compatWorkspaces []*workspace.CompatWorkspace,
 ) ([]workspaceMigrationModuleConfigConversion, error) {
 	// This is filename-format migration, not workspace compat projection:
@@ -32,15 +34,22 @@ func workspaceMigrationModuleConfigConversions(
 			if workspaceMigrationLeavesModuleLegacy(compatWorkspace) {
 				continue
 			}
-		} else if compatWorkspace.MustMigrateToWorkspaceConfig() {
-			// PlanMigration writes this config's dagger-module.toml alongside
-			// its dagger.toml.
-			continue
+		} else {
+			routesThroughPlan, err := workspaceMigrationRoutesThroughPlan(ws, compatWorkspace)
+			if err != nil {
+				return nil, err
+			}
+			if routesThroughPlan {
+				// PlanMigration writes this config's dagger-module.toml
+				// itself (in place, at the module's own project root).
+				continue
+			}
 		}
 		// Reaching here non-discovered means the selected config is a plain
-		// SDK module with its source at the project root — the "repo is just
-		// a dagger module" shape. It converts in place; the minimal workspace
-		// config pinning its runtime comes from the parent-plan flow.
+		// SDK module — either the "repo is just a dagger module" shape (source
+		// at the workspace root, runtime pinned via the parent-plan flow) or a
+		// module in a subdirectory (module-only migration: converted in place
+		// with no workspace created).
 		if compatWorkspace.ProjectRoot == "" {
 			return nil, fmt.Errorf("legacy module config project root is required")
 		}

--- a/core/schema/workspace_migrate_module_config.go
+++ b/core/schema/workspace_migrate_module_config.go
@@ -2,8 +2,6 @@ package schema
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
@@ -34,14 +32,15 @@ func workspaceMigrationModuleConfigConversions(
 			if workspaceMigrationLeavesModuleLegacy(compatWorkspace) {
 				continue
 			}
-		} else {
-			if compatWorkspace.MustMigrateToWorkspaceConfig() {
-				continue
-			}
-			if compatWorkspace.Config.SDK != nil && !workspaceMigrationProjectRootInDefaultModules(compatWorkspace.ProjectRoot) {
-				continue
-			}
+		} else if compatWorkspace.MustMigrateToWorkspaceConfig() {
+			// PlanMigration writes this config's dagger-module.toml alongside
+			// its dagger.toml.
+			continue
 		}
+		// Reaching here non-discovered means the selected config is a plain
+		// SDK module with its source at the project root — the "repo is just
+		// a dagger module" shape. It converts in place; the minimal workspace
+		// config pinning its runtime comes from the parent-plan flow.
 		if compatWorkspace.ProjectRoot == "" {
 			return nil, fmt.Errorf("legacy module config project root is required")
 		}
@@ -82,14 +81,4 @@ func legacyModuleConfigAsCurrent(cfg *modules.ModuleConfig) ([]byte, error) {
 	return modules.MarshalModuleConfigForFormat(&modules.ModuleConfigWithUserFields{
 		ModuleConfig: cloned,
 	}, modules.ConfigFormatCurrent)
-}
-
-func workspaceMigrationProjectRootInDefaultModules(projectRoot string) bool {
-	parts := strings.Split(filepath.ToSlash(filepath.Clean(projectRoot)), "/")
-	for i := 0; i+2 < len(parts); i++ {
-		if parts[i] == workspace.LockDirName && parts[i+1] == "modules" && parts[i+2] != "" {
-			return true
-		}
-	}
-	return false
 }

--- a/core/schema/workspace_migrate_parent.go
+++ b/core/schema/workspace_migrate_parent.go
@@ -66,19 +66,44 @@ func workspaceMigrationParentAssignments(
 		if compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil {
 			continue
 		}
-		// A project-style layout (source in a subdirectory) installs the module
-		// into its own migrated workspace config with its SDK recorded as-sdk;
-		// there is no separate runtime pin to hoist and no explicit-loading
-		// warning. Only the "repo is just a dagger module" shape — source at
-		// the project root — flows through here, whether or not toolchains
-		// force a workspace plan of its own.
+		rel, err := workspaceMigrationProjectRootRelPath(ws, compatWorkspace.ProjectRoot)
+		if err != nil {
+			return nil, err
+		}
+		if rel != "." {
+			// The selected config sits below the workspace root ("setup from a
+			// module subdirectory"). Its module is never installed into a
+			// workspace, so nothing records its SDK as-sdk on its behalf:
+			//   - with toolchains, those hoist into the workspace-root
+			//     dagger.toml, and the runtime pin plus explicit-loading
+			//     warning land on that hoisted plan;
+			//   - without toolchains, this is the module-only migration: the
+			//     config converts in place, no workspace is created, and there
+			//     is no runtime pin and no warning. The converted
+			//     dagger-module.toml still names its sdk, so the module stays
+			//     loadable on its own.
+			if len(compatWorkspace.Config.Toolchains) == 0 {
+				continue
+			}
+			assignments = append(assignments, workspaceMigrationParentAssignment{
+				CompatWorkspace:   compatWorkspace,
+				ParentProjectRoot: ws.HostPath(),
+			})
+			continue
+		}
+		// A project-style layout at the workspace root (source in a
+		// subdirectory) installs the module into its own migrated workspace
+		// config with its SDK recorded as-sdk; there is no separate runtime
+		// pin to hoist and no explicit-loading warning. Only the "repo is just
+		// a dagger module" shape — source at the project root — flows through
+		// here, whether or not toolchains force a workspace plan of its own.
 		if compatWorkspace.MustMigrateToWorkspaceConfig() && !workspace.ModuleSourceAtRoot(compatWorkspace.Config) {
 			continue
 		}
 		// The runtime pin and warning land at the module's own project root:
 		// either its planned dagger.toml (toolchains case) or a minimal parent
-		// config synthesized there. Never at the workspace/git root — a module
-		// repo must not grow a repo-root workspace claiming sibling modules.
+		// config synthesized there. Never above it — a module repo must not
+		// grow a workspace claiming sibling modules.
 		assignments = append(assignments, workspaceMigrationParentAssignment{
 			CompatWorkspace:   compatWorkspace,
 			ParentProjectRoot: compatWorkspace.ProjectRoot,
@@ -296,9 +321,12 @@ func workspaceMigrationInstallDiscoveredModuleSDKs(
 			return nil, err
 		}
 		if owner == "" {
-			// Every discovered module descends from a config that is itself
-			// migrated into a workspace, so a planned owner is expected.
-			return nil, fmt.Errorf("no migrated workspace owns discovered module %q", compatWorkspace.ProjectRoot)
+			// A module-only migration — setup run from a module subdirectory —
+			// plans no workspace config at all, so a discovered dependency has
+			// no config to record its SDK in. Its converted dagger-module.toml
+			// still names its sdk; the install happens when a workspace later
+			// claims these modules.
+			continue
 		}
 		modulePath, err := filepath.Rel(owner, compatWorkspace.ProjectRoot)
 		if err != nil {

--- a/core/schema/workspace_migrate_parent.go
+++ b/core/schema/workspace_migrate_parent.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/core"
-	coresdk "github.com/dagger/dagger/core/sdk"
 	"github.com/dagger/dagger/core/workspace"
 )
 
@@ -31,7 +30,7 @@ func workspaceMigrationParentPlansForPlainModules(
 	compatWorkspaces []*workspace.CompatWorkspace,
 	workspacePlans []*workspace.MigrationPlan,
 ) ([]workspaceMigrationParentPlan, error) {
-	assignments, err := workspaceMigrationParentAssignments(ws, compatWorkspaces, workspacePlans)
+	assignments, err := workspaceMigrationParentAssignments(ws, compatWorkspaces)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +47,6 @@ func workspaceMigrationParentPlansForPlainModules(
 func workspaceMigrationParentAssignments(
 	ws *core.Workspace,
 	compatWorkspaces []*workspace.CompatWorkspace,
-	workspacePlans []*workspace.MigrationPlan,
 ) ([]workspaceMigrationParentAssignment, error) {
 	if ws == nil || ws.HostPath() == "" {
 		return nil, fmt.Errorf("workspace host path is required")
@@ -56,7 +54,7 @@ func workspaceMigrationParentAssignments(
 
 	assignments := make([]workspaceMigrationParentAssignment, 0, len(compatWorkspaces))
 	for _, compatWorkspace := range compatWorkspaces {
-		if compatWorkspace == nil || compatWorkspace.MustMigrateToWorkspaceConfig() {
+		if compatWorkspace == nil {
 			continue
 		}
 		// A discovered local dependency/toolchain target is loaded through its
@@ -68,16 +66,22 @@ func workspaceMigrationParentAssignments(
 		if compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil {
 			continue
 		}
-		parentRoot, err := workspaceMigrationNearestPlannedParent(compatWorkspace.ProjectRoot, workspacePlans)
-		if err != nil {
-			return nil, err
+		// A project-style layout (source in a subdirectory) installs the module
+		// into its own migrated workspace config with its SDK recorded as-sdk;
+		// there is no separate runtime pin to hoist and no explicit-loading
+		// warning. Only the "repo is just a dagger module" shape — source at
+		// the project root — flows through here, whether or not toolchains
+		// force a workspace plan of its own.
+		if compatWorkspace.MustMigrateToWorkspaceConfig() && !workspace.ModuleSourceAtRoot(compatWorkspace.Config) {
+			continue
 		}
-		if parentRoot == "" {
-			parentRoot = ws.HostPath()
-		}
+		// The runtime pin and warning land at the module's own project root:
+		// either its planned dagger.toml (toolchains case) or a minimal parent
+		// config synthesized there. Never at the workspace/git root — a module
+		// repo must not grow a repo-root workspace claiming sibling modules.
 		assignments = append(assignments, workspaceMigrationParentAssignment{
 			CompatWorkspace:   compatWorkspace,
-			ParentProjectRoot: parentRoot,
+			ParentProjectRoot: compatWorkspace.ProjectRoot,
 		})
 	}
 	return assignments, nil
@@ -119,29 +123,6 @@ func workspaceMigrationParentPlans(
 		})
 	}
 	return parentPlans, nil
-}
-
-func workspaceMigrationNearestPlannedParent(projectRoot string, plans []*workspace.MigrationPlan) (string, error) {
-	if projectRoot == "" {
-		return "", fmt.Errorf("module project root is required")
-	}
-	var nearest string
-	for _, plan := range plans {
-		if plan == nil || plan.ProjectRoot == "" {
-			continue
-		}
-		contains, err := workspaceMigrationPathContains(plan.ProjectRoot, projectRoot)
-		if err != nil {
-			return "", fmt.Errorf("planned parent path: %w", err)
-		}
-		if !contains {
-			continue
-		}
-		if nearest == "" || len(filepath.Clean(plan.ProjectRoot)) > len(filepath.Clean(nearest)) {
-			nearest = plan.ProjectRoot
-		}
-	}
-	return nearest, nil
 }
 
 func workspaceMigrationPlannedProjectRoots(plans []*workspace.MigrationPlan) map[string]struct{} {
@@ -240,40 +221,46 @@ func workspaceMigrationInstallParentSDKModules(
 	parentPlans []workspaceMigrationParentPlan,
 	assignments []workspaceMigrationParentAssignment,
 ) ([]workspaceMigrationParentPlan, error) {
-	// NOTE(workspace-migrate): These SDK modules are written to the parent
+	// NOTE(workspace-migrate): These SDK installs are written to the parent
 	// workspace configs without refreshing lock entries during migration. Future
 	// workspace commands can resolve them through the normal lock refresh path.
-	modulesByParent := map[string][]coresdk.WorkspaceModule{}
+	//
+	// The install is recorded through the same as-sdk mechanism as every other
+	// migrated runtime (short name, resolved to its real ref by the setup SDK
+	// fixup pass), so a discovered local module sharing the runtime reuses the
+	// same entry — one SDK install serves every module in the repo.
+	sdksByParent := map[string][]string{}
 	for _, assignment := range assignments {
-		mod, ok, err := workspaceMigrationSDKModule(assignment.CompatWorkspace)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
+		cfg := assignment.CompatWorkspace.Config
+		if cfg == nil || cfg.SDK == nil || cfg.SDK.Source == "" {
 			continue
 		}
 		parentRoot := assignment.ParentProjectRoot
-		modulesByParent[parentRoot] = append(modulesByParent[parentRoot], mod)
+		sdksByParent[parentRoot] = append(sdksByParent[parentRoot], cfg.SDK.Source)
 	}
-	if len(modulesByParent) == 0 {
+	if len(sdksByParent) == 0 {
 		return parentPlans, nil
 	}
 
 	targets := newWorkspaceMigrationConfigTargets(workspacePlans, parentPlans)
 
-	parentRoots := make([]string, 0, len(modulesByParent))
-	for parentRoot := range modulesByParent {
+	parentRoots := make([]string, 0, len(sdksByParent))
+	for parentRoot := range sdksByParent {
 		parentRoots = append(parentRoots, parentRoot)
 	}
 	sort.Strings(parentRoots)
 
 	for _, parentRoot := range parentRoots {
-		mods := workspaceMigrationDedupSDKModules(modulesByParent[parentRoot])
-		if len(mods) == 0 {
-			continue
-		}
+		sources := sdksByParent[parentRoot]
 		if err := targets.update(parentRoot, func(data []byte) ([]byte, error) {
-			return workspaceMigrationConfigWithSDKModules(data, mods)
+			cfg, err := workspace.ParseConfig(data)
+			if err != nil {
+				return nil, err
+			}
+			for _, source := range sources {
+				workspace.AddMigratedSDKInstall(cfg, source)
+			}
+			return workspace.UpdateConfigBytes(data, cfg)
 		}); err != nil {
 			return nil, fmt.Errorf("install SDK modules at %s: %w", parentRoot, err)
 		}
@@ -336,96 +323,6 @@ func workspaceMigrationConfigWithMigratedModuleSDK(configData []byte, sdkSource,
 	}
 	workspace.AddMigratedModuleSDK(cfg, sdkSource, modulePath)
 	return workspace.UpdateConfigBytes(configData, cfg)
-}
-
-func workspaceMigrationSDKModule(compatWorkspace *workspace.CompatWorkspace) (coresdk.WorkspaceModule, bool, error) {
-	if compatWorkspace == nil || compatWorkspace.Config == nil || compatWorkspace.Config.SDK == nil {
-		return coresdk.WorkspaceModule{}, false, nil
-	}
-	return coresdk.WorkspaceModuleForRuntime(compatWorkspace.Config.SDK.Source)
-}
-
-func workspaceMigrationDedupSDKModules(mods []coresdk.WorkspaceModule) []coresdk.WorkspaceModule {
-	if len(mods) == 0 {
-		return nil
-	}
-	seen := map[coresdk.WorkspaceModule]struct{}{}
-	deduped := make([]coresdk.WorkspaceModule, 0, len(mods))
-	for _, mod := range mods {
-		if mod.Name == "" || mod.Source == "" {
-			continue
-		}
-		if _, ok := seen[mod]; ok {
-			continue
-		}
-		seen[mod] = struct{}{}
-		deduped = append(deduped, mod)
-	}
-	sort.Slice(deduped, func(i, j int) bool {
-		if deduped[i].Name == deduped[j].Name {
-			return deduped[i].Source < deduped[j].Source
-		}
-		return deduped[i].Name < deduped[j].Name
-	})
-	return deduped
-}
-
-func workspaceMigrationConfigWithSDKModules(
-	configData []byte,
-	mods []coresdk.WorkspaceModule,
-) ([]byte, error) {
-	cfg, err := workspace.ParseConfig(configData)
-	if err != nil {
-		return nil, err
-	}
-
-	changed := false
-	if cfg.Modules == nil {
-		cfg.Modules = map[string]workspace.ModuleEntry{}
-	}
-	for _, mod := range mods {
-		if workspaceMigrationInstallSDKModule(cfg.Modules, mod) {
-			changed = true
-		}
-	}
-	if !changed {
-		return configData, nil
-	}
-
-	return workspace.UpdateConfigBytes(configData, cfg)
-}
-
-func workspaceMigrationInstallSDKModule(
-	modules map[string]workspace.ModuleEntry,
-	mod coresdk.WorkspaceModule,
-) bool {
-	for _, entry := range modules {
-		if entry.Source == mod.Source {
-			return false
-		}
-	}
-
-	name := mod.Name
-	if existing, ok := modules[name]; ok && existing.Source != mod.Source {
-		name = workspaceMigrationUniqueSDKModuleName(modules, name)
-	}
-	modules[name] = workspace.ModuleEntry{
-		Source: mod.Source,
-	}
-	return true
-}
-
-func workspaceMigrationUniqueSDKModuleName(modules map[string]workspace.ModuleEntry, base string) string {
-	candidate := base + "-runtime"
-	if _, exists := modules[candidate]; !exists {
-		return candidate
-	}
-	for i := 2; ; i++ {
-		candidate = fmt.Sprintf("%s-runtime-%d", base, i)
-		if _, exists := modules[candidate]; !exists {
-			return candidate
-		}
-	}
 }
 
 func workspaceMigrationWarnExplicitModuleLoading(

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -341,7 +341,10 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 	ws := &core.Workspace{}
 	ws.SetHostPath(root)
 
-	t.Run("plain module in a subdirectory creates parent at its own root with SDK module", func(t *testing.T) {
+	t.Run("plain module in a subdirectory gets no parent workspace", func(t *testing.T) {
+		// Setup run from a module subdirectory migrates just the module: the
+		// config converts in place and no workspace is created anywhere — no
+		// runtime pin, no explicit-loading warning, no migration report.
 		plain := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video"), `{
   "name": "video",
   "sdk": {"source": "go"}
@@ -349,25 +352,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 
 		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{plain}, nil)
 		require.NoError(t, err)
-		require.Len(t, plans, 1)
-		// The parent lands at the module's own project root, never the
-		// workspace/git root: a module repo must not grow a repo-root
-		// workspace claiming sibling modules.
-		require.Equal(t, filepath.Join(root, "modules", "video"), plans[0].ProjectRoot)
-		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
-		require.NoError(t, err)
-		// The runtime is recorded as an as-sdk install by short name; setup's
-		// SDK fixup pass resolves it to its real ref.
-		sdk := cfg.Modules["dagger-go-sdk"]
-		require.Equal(t, "go", sdk.Source)
-		require.NotNil(t, sdk.AsSDK)
-		require.Equal(t, []string{
-			"modules/video requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m modules/video ...`.",
-		}, plans[0].Warnings)
-		require.Equal(t, filepath.Join(workspace.LockDirName, "migration-report.md"), plans[0].MigrationReportPath)
-		require.Contains(t, string(plans[0].MigrationReportData), "## modules/video requires explicit loading")
-		require.Contains(t, string(plans[0].MigrationReportData), "**This works**: `dagger -m modules/video call --help`")
-		require.Contains(t, string(plans[0].MigrationReportData), "**This no longer works**: `cd modules/video; dagger call --help`")
+		require.Empty(t, plans)
 	})
 
 	t.Run("plain root module creates root parent with SDK module", func(t *testing.T) {
@@ -394,18 +379,18 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Contains(t, string(plans[0].MigrationReportData), "**This no longer works**: `dagger call --help`")
 	})
 
-	t.Run("module repo with its own workspace plan installs SDK in that plan", func(t *testing.T) {
-		// A must-migrate config (toolchains) whose source is at the project
-		// root is the "repo is just a dagger module" shape: its SDK runtime is
-		// pinned as a plain install in its own planned dagger.toml, and the
-		// explicit-loading warning lands on that plan.
+	t.Run("subdirectory toolchains config installs SDK in the hoisted root plan", func(t *testing.T) {
+		// A subdirectory config with toolchains hoists them into a dagger.toml
+		// planned at the workspace root; its SDK runtime pin and the
+		// explicit-loading warning land on that hoisted plan.
 		moduleRepo := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
   "name": "api",
   "sdk": {"source": "go"},
   "toolchains": [{"name": "tc", "source": "./tc"}]
 }`)
 		migrated := &workspace.MigrationPlan{
-			ProjectRoot:         filepath.Join(root, "services", "api"),
+			ProjectRoot:         root,
+			ModuleProjectRoot:   filepath.Join(root, "services", "api"),
 			WorkspaceConfigData: []byte(initialWorkspaceConfig),
 		}
 
@@ -424,17 +409,18 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Contains(t, string(migrated.MigrationReportData), "## services/api requires explicit loading")
 	})
 
-	t.Run("project-style module is not assigned a runtime pin", func(t *testing.T) {
-		// A must-migrate config with its source in a subdirectory installs the
-		// module into its own migrated workspace config with the SDK recorded
-		// as-sdk; the parent-plan flow must leave it alone entirely.
-		project := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
+	t.Run("project-style module at the root is not assigned a runtime pin", func(t *testing.T) {
+		// A must-migrate config at the workspace root with its source in a
+		// subdirectory installs the module into its own migrated workspace
+		// config with the SDK recorded as-sdk; the parent-plan flow must leave
+		// it alone entirely.
+		project := testRuntimeCompatWorkspace(t, root, `{
   "name": "api",
   "sdk": {"source": "go"},
   "source": "src"
 }`)
 		migrated := &workspace.MigrationPlan{
-			ProjectRoot:         filepath.Join(root, "services", "api"),
+			ProjectRoot:         root,
 			WorkspaceConfigData: []byte(initialWorkspaceConfig),
 		}
 
@@ -447,27 +433,42 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Empty(t, workspaceMigrationWarnings(migrated))
 	})
 
-	t.Run("plain modules each get a parent at their own root", func(t *testing.T) {
-		video := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video"), `{
-  "name": "video",
-  "sdk": {"source": "go"}
-}`)
-		audio := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "audio"), `{
-  "name": "audio",
-  "sdk": {"source": "go"}
+	t.Run("subdirectory module without toolchains gets no runtime pin", func(t *testing.T) {
+		// A subdirectory config that must migrate only because its source is
+		// in a subdirectory is the module-only case: no workspace is planned
+		// anywhere, so there is no runtime pin and no warning.
+		project := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
+  "name": "api",
+  "sdk": {"source": "go"},
+  "source": "src"
 }`)
 
-		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{video, audio}, nil)
+		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{project}, nil)
 		require.NoError(t, err)
-		require.Len(t, plans, 2)
-		for _, plan := range plans {
-			cfg, err := workspace.ParseConfig(plan.WorkspaceConfigData)
-			require.NoError(t, err)
-			require.Len(t, cfg.Modules, 1)
-			sdk := cfg.Modules["dagger-go-sdk"]
-			require.Equal(t, "go", sdk.Source)
-			require.NotNil(t, sdk.AsSDK)
-		}
+		require.Empty(t, plans)
+	})
+
+	t.Run("subdirectory module-only migration leaves discovered dependency SDKs unrecorded", func(t *testing.T) {
+		// With no workspace planned anywhere, a discovered local dependency has
+		// no config to record its SDK in; the install is skipped rather than
+		// failing the migration.
+		plain := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video"), `{
+  "name": "video",
+  "sdk": {"source": "go"},
+  "dependencies": [{"name": "dep", "source": "./dep"}]
+}`)
+		dep := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video", "dep"), `{
+  "name": "dep",
+  "sdk": {"source": "go"}
+}`)
+		dep.DiscoveredLocalModule = true
+
+		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{plain, dep}, nil)
+		require.NoError(t, err)
+		require.Empty(t, plans)
+		plans, err = workspaceMigrationInstallDiscoveredModuleSDKs(nil, plans, []*workspace.CompatWorkspace{plain, dep})
+		require.NoError(t, err)
+		require.Empty(t, plans)
 	})
 
 	t.Run("parent SDK module name conflicts get a stable alternate name", func(t *testing.T) {
@@ -477,7 +478,8 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
   "toolchains": [{"name": "tc", "source": "./tc"}]
 }`)
 		migrated := &workspace.MigrationPlan{
-			ProjectRoot: filepath.Join(root, "services", "api"),
+			ProjectRoot:       root,
+			ModuleProjectRoot: filepath.Join(root, "services", "api"),
 			WorkspaceConfigData: []byte(`[modules.dagger-go-sdk]
 source = "github.com/acme/custom-go-sdk"
 `),
@@ -494,9 +496,9 @@ source = "github.com/acme/custom-go-sdk"
 	})
 
 	t.Run("module repo runtime pin and discovered dependency share one SDK install", func(t *testing.T) {
-		// One SDK install serves every module in the repo: the module-repo
+		// One SDK install serves every module in the repo: the hoisted
 		// runtime pin and a discovered local dependency using the same runtime
-		// must collapse into a single [modules.<sdk>] entry.
+		// must collapse into a single [modules.<sdk>] entry in the root plan.
 		moduleRepo := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
   "name": "api",
   "sdk": {"source": "go"},
@@ -508,7 +510,8 @@ source = "github.com/acme/custom-go-sdk"
 }`)
 		dep.DiscoveredLocalModule = true
 		migrated := &workspace.MigrationPlan{
-			ProjectRoot:         filepath.Join(root, "services", "api"),
+			ProjectRoot:         root,
+			ModuleProjectRoot:   filepath.Join(root, "services", "api"),
 			WorkspaceConfigData: []byte(initialWorkspaceConfig),
 		}
 
@@ -525,7 +528,7 @@ source = "github.com/acme/custom-go-sdk"
 		require.Equal(t, "go", sdk.Source)
 		require.NotNil(t, sdk.AsSDK)
 		require.Len(t, sdk.AsSDK.Modules, 1)
-		require.Equal(t, filepath.Join("libs", "dep"), filepath.FromSlash(sdk.AsSDK.Modules[0].Path))
+		require.Equal(t, filepath.Join("services", "api", "libs", "dep"), filepath.FromSlash(sdk.AsSDK.Modules[0].Path))
 	})
 }
 
@@ -555,14 +558,16 @@ func TestWorkspaceMigrationModuleConfigConversions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, noSDKPlain)
 
-	conversions, err := workspaceMigrationModuleConfigConversions([]*workspace.CompatWorkspace{
+	ws := &core.Workspace{}
+	ws.SetHostPath(root)
+	conversions, err := workspaceMigrationModuleConfigConversions(ws, []*workspace.CompatWorkspace{
 		plain,
 		rootSDKOnly,
 		workspaceConfig,
 		noSDKPlain,
 	})
 	require.NoError(t, err)
-	require.Len(t, conversions, 3, "everything except the workspace-shaped config converts in place")
+	require.Len(t, conversions, 4, "every selected shape without toolchains converts in place, including a subdirectory config with a source subdir")
 	require.Equal(t, filepath.Join(root, ".dagger", "modules", "video"), conversions[0].ProjectRoot)
 	cfg, err := modules.ParseModuleConfigForFilename(conversions[0].ConfigData, workspace.ModuleConfigFileName)
 	require.NoError(t, err)
@@ -580,8 +585,17 @@ func TestWorkspaceMigrationModuleConfigConversions(t *testing.T) {
 	require.Equal(t, "app", cfg.Name)
 	require.Equal(t, "go", cfg.SDK.Source)
 
-	require.Equal(t, filepath.Join(root, "modules", "data"), conversions[2].ProjectRoot)
+	// A subdirectory config that must migrate only because its source is in a
+	// subdirectory is the plain "migrate this one module" case: it converts in
+	// place with its source preserved, and no workspace is created for it.
+	require.Equal(t, filepath.Join(root, "services", "api"), conversions[2].ProjectRoot)
 	cfg, err = modules.ParseModuleConfigForFilename(conversions[2].ConfigData, workspace.ModuleConfigFileName)
+	require.NoError(t, err)
+	require.Equal(t, "api", cfg.Name)
+	require.Equal(t, "src", cfg.Source)
+
+	require.Equal(t, filepath.Join(root, "modules", "data"), conversions[3].ProjectRoot)
+	cfg, err = modules.ParseModuleConfigForFilename(conversions[3].ConfigData, workspace.ModuleConfigFileName)
 	require.NoError(t, err)
 	require.Equal(t, "data", cfg.Name)
 	require.Nil(t, cfg.SDK)
@@ -639,7 +653,9 @@ func TestWorkspaceMigrationDiscoveredLocalModuleConversions(t *testing.T) {
 }`)
 	nested.DiscoveredLocalModule = true
 
-	conversions, err := workspaceMigrationModuleConfigConversions([]*workspace.CompatWorkspace{toolchain, nested})
+	ws := &core.Workspace{}
+	ws.SetHostPath(root)
+	conversions, err := workspaceMigrationModuleConfigConversions(ws, []*workspace.CompatWorkspace{toolchain, nested})
 	require.NoError(t, err)
 	require.Len(t, conversions, 1, "the normal toolchain converts; the nested workspace is left as legacy")
 	require.Equal(t, filepath.Join(root, "toolchain"), conversions[0].ProjectRoot)

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -323,17 +323,6 @@ func TestWorkspaceMigrationWarningsKeepsGapWarningsAggregated(t *testing.T) {
 	}, workspaceMigrationWarnings(plan))
 }
 
-func TestWorkspaceConfigUsesMigratedModuleSourcesResolvesFromConfigDir(t *testing.T) {
-	cfg := &workspace.Config{
-		Modules: map[string]workspace.ModuleEntry{
-			"api": {Source: filepath.Join(workspace.LockDirName, "modules", "api")},
-		},
-	}
-
-	require.True(t, workspaceConfigUsesMigratedModuleSources(cfg, "."))
-	require.False(t, workspaceConfigUsesMigratedModuleSources(cfg, workspace.LockDirName))
-}
-
 func TestWorkspaceMigrationRootPath(t *testing.T) {
 	root := filepath.Join(string(filepath.Separator), "repo")
 	ws := &core.Workspace{}
@@ -352,7 +341,7 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 	ws := &core.Workspace{}
 	ws.SetHostPath(root)
 
-	t.Run("plain module outside migrated workspaces creates root parent with SDK module", func(t *testing.T) {
+	t.Run("plain module in a subdirectory creates parent at its own root with SDK module", func(t *testing.T) {
 		plain := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video"), `{
   "name": "video",
   "sdk": {"source": "go"}
@@ -361,10 +350,17 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{plain}, nil)
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
-		require.Equal(t, root, plans[0].ProjectRoot)
+		// The parent lands at the module's own project root, never the
+		// workspace/git root: a module repo must not grow a repo-root
+		// workspace claiming sibling modules.
+		require.Equal(t, filepath.Join(root, "modules", "video"), plans[0].ProjectRoot)
 		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
+		// The runtime is recorded as an as-sdk install by short name; setup's
+		// SDK fixup pass resolves it to its real ref.
+		sdk := cfg.Modules["dagger-go-sdk"]
+		require.Equal(t, "go", sdk.Source)
+		require.NotNil(t, sdk.AsSDK)
 		require.Equal(t, []string{
 			"modules/video requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m modules/video ...`.",
 		}, plans[0].Warnings)
@@ -386,7 +382,9 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Equal(t, root, plans[0].ProjectRoot)
 		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
+		sdk := cfg.Modules["dagger-go-sdk"]
+		require.Equal(t, "go", sdk.Source)
+		require.NotNil(t, sdk.AsSDK)
 		require.Equal(t, []string{
 			"Root module requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m . ...`.",
 		}, plans[0].Warnings)
@@ -396,46 +394,60 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 		require.Contains(t, string(plans[0].MigrationReportData), "**This no longer works**: `dagger call --help`")
 	})
 
-	t.Run("plain module under migrated workspace installs SDK in migrated workspace", func(t *testing.T) {
-		plain := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api", "modules", "video"), `{
-  "name": "video",
-  "sdk": {"source": "go"}
+	t.Run("module repo with its own workspace plan installs SDK in that plan", func(t *testing.T) {
+		// A must-migrate config (toolchains) whose source is at the project
+		// root is the "repo is just a dagger module" shape: its SDK runtime is
+		// pinned as a plain install in its own planned dagger.toml, and the
+		// explicit-loading warning lands on that plan.
+		moduleRepo := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
+  "name": "api",
+  "sdk": {"source": "go"},
+  "toolchains": [{"name": "tc", "source": "./tc"}]
 }`)
 		migrated := &workspace.MigrationPlan{
 			ProjectRoot:         filepath.Join(root, "services", "api"),
 			WorkspaceConfigData: []byte(initialWorkspaceConfig),
 		}
 
-		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{plain}, []*workspace.MigrationPlan{migrated})
+		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{moduleRepo}, []*workspace.MigrationPlan{migrated})
 		require.NoError(t, err)
 		require.Empty(t, plans)
 		cfg, err := workspace.ParseConfig(migrated.WorkspaceConfigData)
 		require.NoError(t, err)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
+		sdk := cfg.Modules["dagger-go-sdk"]
+		require.Equal(t, "go", sdk.Source)
+		require.NotNil(t, sdk.AsSDK)
 		require.Equal(t, []string{
-			"services/api/modules/video requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m services/api/modules/video ...`.",
+			"services/api requires explicit loading. If your scripts rely on implicit loading, change them to `dagger -m services/api ...`.",
 		}, workspaceMigrationWarnings(migrated))
 		require.Equal(t, filepath.Join(workspace.LockDirName, "migration-report.md"), migrated.MigrationReportPath)
-		require.Contains(t, string(migrated.MigrationReportData), "## services/api/modules/video requires explicit loading")
+		require.Contains(t, string(migrated.MigrationReportData), "## services/api requires explicit loading")
 	})
 
-	t.Run("plain module beside migrated workspace creates root parent", func(t *testing.T) {
-		plain := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video"), `{
-  "name": "video",
-  "sdk": {"source": "go"}
+	t.Run("project-style module is not assigned a runtime pin", func(t *testing.T) {
+		// A must-migrate config with its source in a subdirectory installs the
+		// module into its own migrated workspace config with the SDK recorded
+		// as-sdk; the parent-plan flow must leave it alone entirely.
+		project := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
+  "name": "api",
+  "sdk": {"source": "go"},
+  "source": "src"
 }`)
 		migrated := &workspace.MigrationPlan{
 			ProjectRoot:         filepath.Join(root, "services", "api"),
 			WorkspaceConfigData: []byte(initialWorkspaceConfig),
 		}
 
-		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{plain}, []*workspace.MigrationPlan{migrated})
+		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{project}, []*workspace.MigrationPlan{migrated})
 		require.NoError(t, err)
-		require.Len(t, plans, 1)
-		require.Equal(t, root, plans[0].ProjectRoot)
+		require.Empty(t, plans)
+		cfg, err := workspace.ParseConfig(migrated.WorkspaceConfigData)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Modules)
+		require.Empty(t, workspaceMigrationWarnings(migrated))
 	})
 
-	t.Run("parent SDK modules are deduped", func(t *testing.T) {
+	t.Run("plain modules each get a parent at their own root", func(t *testing.T) {
 		video := testRuntimeCompatWorkspace(t, filepath.Join(root, "modules", "video"), `{
   "name": "video",
   "sdk": {"source": "go"}
@@ -447,17 +459,22 @@ func TestWorkspaceMigrationParentPlans(t *testing.T) {
 
 		plans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{video, audio}, nil)
 		require.NoError(t, err)
-		require.Len(t, plans, 1)
-		cfg, err := workspace.ParseConfig(plans[0].WorkspaceConfigData)
-		require.NoError(t, err)
-		require.Len(t, cfg.Modules, 1)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk"].Source)
+		require.Len(t, plans, 2)
+		for _, plan := range plans {
+			cfg, err := workspace.ParseConfig(plan.WorkspaceConfigData)
+			require.NoError(t, err)
+			require.Len(t, cfg.Modules, 1)
+			sdk := cfg.Modules["dagger-go-sdk"]
+			require.Equal(t, "go", sdk.Source)
+			require.NotNil(t, sdk.AsSDK)
+		}
 	})
 
 	t.Run("parent SDK module name conflicts get a stable alternate name", func(t *testing.T) {
-		plain := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api", "modules", "video"), `{
-  "name": "video",
-  "sdk": {"source": "go"}
+		moduleRepo := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
+  "name": "api",
+  "sdk": {"source": "go"},
+  "toolchains": [{"name": "tc", "source": "./tc"}]
 }`)
 		migrated := &workspace.MigrationPlan{
 			ProjectRoot: filepath.Join(root, "services", "api"),
@@ -466,12 +483,49 @@ source = "github.com/acme/custom-go-sdk"
 `),
 		}
 
-		_, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{plain}, []*workspace.MigrationPlan{migrated})
+		_, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{moduleRepo}, []*workspace.MigrationPlan{migrated})
 		require.NoError(t, err)
 		cfg, err := workspace.ParseConfig(migrated.WorkspaceConfigData)
 		require.NoError(t, err)
 		require.Equal(t, "github.com/acme/custom-go-sdk", cfg.Modules["dagger-go-sdk"].Source)
-		require.Equal(t, "github.com/dagger/go-sdk", cfg.Modules["dagger-go-sdk-runtime"].Source)
+		sdk := cfg.Modules["dagger-go-sdk-2"]
+		require.Equal(t, "go", sdk.Source)
+		require.NotNil(t, sdk.AsSDK)
+	})
+
+	t.Run("module repo runtime pin and discovered dependency share one SDK install", func(t *testing.T) {
+		// One SDK install serves every module in the repo: the module-repo
+		// runtime pin and a discovered local dependency using the same runtime
+		// must collapse into a single [modules.<sdk>] entry.
+		moduleRepo := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api"), `{
+  "name": "api",
+  "sdk": {"source": "go"},
+  "toolchains": [{"name": "tc", "source": "./tc"}]
+}`)
+		dep := testRuntimeCompatWorkspace(t, filepath.Join(root, "services", "api", "libs", "dep"), `{
+  "name": "dep",
+  "sdk": {"source": "go"}
+}`)
+		dep.DiscoveredLocalModule = true
+		migrated := &workspace.MigrationPlan{
+			ProjectRoot:         filepath.Join(root, "services", "api"),
+			WorkspaceConfigData: []byte(initialWorkspaceConfig),
+		}
+
+		parentPlans, err := workspaceMigrationParentPlansForPlainModules(ws, []*workspace.CompatWorkspace{moduleRepo, dep}, []*workspace.MigrationPlan{migrated})
+		require.NoError(t, err)
+		parentPlans, err = workspaceMigrationInstallDiscoveredModuleSDKs([]*workspace.MigrationPlan{migrated}, parentPlans, []*workspace.CompatWorkspace{moduleRepo, dep})
+		require.NoError(t, err)
+		require.Empty(t, parentPlans)
+
+		cfg, err := workspace.ParseConfig(migrated.WorkspaceConfigData)
+		require.NoError(t, err)
+		require.Len(t, cfg.Modules, 1, "one SDK install serves every module in the repo")
+		sdk := cfg.Modules["dagger-go-sdk"]
+		require.Equal(t, "go", sdk.Source)
+		require.NotNil(t, sdk.AsSDK)
+		require.Len(t, sdk.AsSDK.Modules, 1)
+		require.Equal(t, filepath.Join("libs", "dep"), filepath.FromSlash(sdk.AsSDK.Modules[0].Path))
 	})
 }
 
@@ -508,7 +562,7 @@ func TestWorkspaceMigrationModuleConfigConversions(t *testing.T) {
 		noSDKPlain,
 	})
 	require.NoError(t, err)
-	require.Len(t, conversions, 2)
+	require.Len(t, conversions, 3, "everything except the workspace-shaped config converts in place")
 	require.Equal(t, filepath.Join(root, ".dagger", "modules", "video"), conversions[0].ProjectRoot)
 	cfg, err := modules.ParseModuleConfigForFilename(conversions[0].ConfigData, workspace.ModuleConfigFileName)
 	require.NoError(t, err)
@@ -518,8 +572,16 @@ func TestWorkspaceMigrationModuleConfigConversions(t *testing.T) {
 	require.Equal(t, "sha256:abc", cfg.Dependencies[0].Pin)
 	require.Equal(t, "./local", cfg.Dependencies[1].Source)
 
-	require.Equal(t, filepath.Join(root, "modules", "data"), conversions[1].ProjectRoot)
+	// A root sdk-only config is the "repo is just a dagger module" shape and
+	// converts in place rather than being left as legacy.
+	require.Equal(t, root, conversions[1].ProjectRoot)
 	cfg, err = modules.ParseModuleConfigForFilename(conversions[1].ConfigData, workspace.ModuleConfigFileName)
+	require.NoError(t, err)
+	require.Equal(t, "app", cfg.Name)
+	require.Equal(t, "go", cfg.SDK.Source)
+
+	require.Equal(t, filepath.Join(root, "modules", "data"), conversions[2].ProjectRoot)
+	cfg, err = modules.ParseModuleConfigForFilename(conversions[2].ConfigData, workspace.ModuleConfigFileName)
 	require.NoError(t, err)
 	require.Equal(t, "data", cfg.Name)
 	require.Nil(t, cfg.SDK)

--- a/core/workspace/legacy.go
+++ b/core/workspace/legacy.go
@@ -38,9 +38,9 @@ type CompatWorkspace struct {
 
 	// DiscoveredLocalModule marks a compat workspace that was reached by
 	// following a local toolchain/dependency reference from another migrated
-	// config (rather than being the selected project or a .dagger/modules
-	// glob hit). Such a module is converted in place regardless of a non-root
-	// source, and is never routed to PlanMigration or a parent plan.
+	// config (rather than being the selected project). Such a module is
+	// converted in place regardless of a non-root source, and is never routed
+	// to PlanMigration or a parent plan.
 	DiscoveredLocalModule bool
 }
 
@@ -174,11 +174,16 @@ func buildCompatWorkspace(cfg *modules.ModuleConfig, configPath string) *CompatW
 	}
 
 	if cfg.SDK != nil && cfg.Name != "" {
+		// The entry source points at the module config's directory: migration
+		// replaces dagger.json with dagger-module.toml at the same location
+		// (the project root, alongside dagger.toml) rather than synthesizing
+		// a config under .dagger/modules/<name> or moving it into the source
+		// directory — installs by path must keep resolving to the config.
 		compatWorkspace.MainModule = &CompatMainModule{
 			Name:       cfg.Name,
 			ConfigName: cfg.Name,
 			Entry: ModuleEntry{
-				Source:     filepath.Join(LockDirName, "modules", cfg.Name),
+				Source:     ".",
 				Entrypoint: cfg.Blueprint == nil,
 			},
 		}
@@ -295,7 +300,16 @@ func mustMigrateToWorkspaceConfig(cfg *modules.ModuleConfig) bool {
 	if cfg.Blueprint != nil || len(cfg.Toolchains) > 0 {
 		return true
 	}
-	return cfg.SDK != nil && cfg.Source != "" && cfg.Source != "."
+	return cfg.SDK != nil && !ModuleSourceAtRoot(cfg)
+}
+
+// ModuleSourceAtRoot reports whether a legacy module config's source lives in
+// the config's own directory — the "repo is just a dagger module" shape, as
+// opposed to a module tucked into a subdirectory of a project repo. Migration
+// treats such a module as the repo itself: its config converts in place and it
+// is neither installed into the workspace nor given an entrypoint.
+func ModuleSourceAtRoot(cfg *modules.ModuleConfig) bool {
+	return cfg == nil || cfg.Source == "" || filepath.Clean(cfg.Source) == "."
 }
 
 // ParseLegacyBlueprint parses a legacy dagger.json and extracts its blueprint.

--- a/core/workspace/legacy_test.go
+++ b/core/workspace/legacy_test.go
@@ -131,7 +131,7 @@ func TestParseCompatWorkspace(t *testing.T) {
 	require.NotNil(t, compat.MainModule)
 	require.Equal(t, "app", compat.MainModule.Name)
 	require.Equal(t, ModuleEntry{
-		Source:     ".dagger/modules/app",
+		Source:     ".",
 		Entrypoint: true,
 	}, compat.MainModule.Entry)
 	require.Len(t, compat.Modules, 1)
@@ -158,7 +158,7 @@ func TestParseRuntimeCompatWorkspace(t *testing.T) {
 	require.NotNil(t, compat.MainModule)
 	require.Equal(t, "app", compat.MainModule.Name)
 	require.Equal(t, ModuleEntry{
-		Source:     ".dagger/modules/app",
+		Source:     ".",
 		Entrypoint: true,
 	}, compat.MainModule.Entry)
 	require.Empty(t, compat.Modules)

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -136,7 +137,15 @@ func IsLocalRef(source, pin string) bool {
 // MigrationPlan is the pure filesystem plan for migrating a legacy
 // dagger.json project to workspace format.
 type MigrationPlan struct {
-	ProjectRoot              string
+	// ProjectRoot is where the workspace config (dagger.toml) and migration
+	// report land.
+	ProjectRoot string
+	// ModuleProjectRoot is where the legacy dagger.json lives: the migrated
+	// dagger-module.toml replaces it there and the legacy file is removed
+	// there. It equals ProjectRoot except for a hoisted subdirectory project,
+	// whose workspace fields migrate to the workspace root while the module
+	// config stays in place.
+	ModuleProjectRoot        string
 	Warnings                 []string
 	MigrationGapCount        int
 	MigrationReportPath      string
@@ -147,8 +156,13 @@ type MigrationPlan struct {
 }
 
 // PlanMigration computes the pure filesystem plan for migrating a compat
-// workspace into workspace format.
-func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
+// workspace into workspace format. workspaceRoot is the workspace boundary:
+// when the legacy config lives below it, the plan is "hoisted" — nested
+// dagger.toml files are never created, so the config's workspace fields
+// (toolchains) are installed into a dagger.toml at the workspace root with
+// their local sources rebased, while the module config still converts in
+// place at its own directory and the module itself is not installed.
+func PlanMigration(compatWorkspace *CompatWorkspace, workspaceRoot string) (*MigrationPlan, error) {
 	if compatWorkspace == nil || compatWorkspace.Config == nil {
 		return nil, fmt.Errorf("compat workspace is required")
 	}
@@ -158,16 +172,40 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 	if compatWorkspace.ConfigPath == "" {
 		return nil, fmt.Errorf("compat workspace config path is required")
 	}
+	if workspaceRoot == "" {
+		workspaceRoot = compatWorkspace.ProjectRoot
+	}
 
 	cfg := compatWorkspace.Config
 	if !mustMigrateToWorkspaceConfig(cfg) {
 		return nil, fmt.Errorf("dagger.json does not require workspace config migration")
 	}
+
+	moduleRoot := compatWorkspace.ProjectRoot
+	hoistRel, err := filepath.Rel(filepath.Clean(workspaceRoot), filepath.Clean(moduleRoot))
+	if err != nil {
+		return nil, fmt.Errorf("project root %q relative to workspace root %q: %w", moduleRoot, workspaceRoot, err)
+	}
+	hoistRel = filepath.ToSlash(hoistRel)
+	if hoistRel == ".." || strings.HasPrefix(hoistRel, "../") {
+		return nil, fmt.Errorf("project root %q escapes workspace root %q", moduleRoot, workspaceRoot)
+	}
+	hoisted := hoistRel != "."
+	if hoisted && cfg.Blueprint != nil {
+		// A subdirectory blueprint config is left as legacy by the caller;
+		// hoisting a blueprint would change the repo-wide entrypoint.
+		return nil, fmt.Errorf("subdirectory config with a blueprint cannot be hoisted to the workspace root")
+	}
+
 	hasSDK := cfg.SDK != nil && cfg.SDK.Source != ""
 	sourceAtRoot := ModuleSourceAtRoot(cfg)
 
 	plan := &MigrationPlan{
-		ProjectRoot: compatWorkspace.ProjectRoot,
+		ProjectRoot:       workspaceRoot,
+		ModuleProjectRoot: moduleRoot,
+	}
+	if !hoisted {
+		plan.ProjectRoot = moduleRoot
 	}
 
 	// The module config replaces dagger.json at the exact same location:
@@ -190,12 +228,20 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 	}
 
 	wsCfg := compatWorkspace.WorkspaceConfig()
+	if hoisted {
+		// The toolchain installs move from the subdirectory config into the
+		// workspace-root dagger.toml, so their local sources must be
+		// re-expressed relative to the workspace root.
+		rebaseHoistedModuleSources(wsCfg, hoistRel)
+	}
 	mainModule := compatWorkspace.MainModule
-	if !hasSDK || sourceAtRoot {
+	if !hasSDK || sourceAtRoot || hoisted {
 		// A module whose source is the project root IS the repo, not a module
 		// owned by a surrounding project: it is not installed into the
 		// workspace and gets no entrypoint. Its SDK runtime is pinned
 		// separately (as a plain module install) by the migration caller.
+		// A hoisted subdirectory module is likewise never installed into the
+		// repo-wide workspace — only its toolchains are.
 		mainModule = nil
 	}
 	if mainModule != nil {
@@ -223,6 +269,20 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 	}
 
 	return plan, nil
+}
+
+// rebaseHoistedModuleSources rewrites local module install sources so refs
+// that were relative to a subdirectory legacy config resolve from the
+// workspace root, where the hoisted dagger.toml lives. Remote refs pass
+// through untouched.
+func rebaseHoistedModuleSources(wsCfg *Config, rel string) {
+	for name, entry := range wsCfg.Modules {
+		if !IsLocalRef(entry.Source, "") {
+			continue
+		}
+		entry.Source = "./" + path.Join(rel, filepath.ToSlash(entry.Source))
+		wsCfg.Modules[name] = entry
+	}
 }
 
 func renderMigrationWorkspaceConfig(cfg *Config, mainModule *CompatMainModule) ([]byte, error) {

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -48,8 +48,30 @@ func migrationSDKInstallName(sdkRef string) string {
 // created, matching how the root module's SDK is recorded. This keeps every
 // locally-defined module's runtime installed and pinned in the workspace.
 func AddMigratedModuleSDK(wsCfg *Config, sdkSource, modulePath string) {
-	if wsCfg == nil || sdkSource == "" {
+	sdkName := ensureMigratedSDKInstall(wsCfg, sdkSource)
+	if sdkName == "" {
 		return
+	}
+	entry := wsCfg.Modules[sdkName]
+	entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: modulePath})
+	wsCfg.Modules[sdkName] = entry
+}
+
+// AddMigratedSDKInstall records a workspace SDK install for sdkSource without
+// registering a managed module — the "repo is just a dagger module" pin, where
+// the one install is expected to serve every module in the repo. It reuses an
+// existing as-sdk install for the same runtime source, so a later
+// AddMigratedModuleSDK for the same runtime lands on the same entry instead of
+// installing the SDK twice.
+func AddMigratedSDKInstall(wsCfg *Config, sdkSource string) {
+	ensureMigratedSDKInstall(wsCfg, sdkSource)
+}
+
+// ensureMigratedSDKInstall finds or creates the as-sdk install entry for
+// sdkSource and returns its install name ("" if there is nothing to record).
+func ensureMigratedSDKInstall(wsCfg *Config, sdkSource string) string {
+	if wsCfg == nil || sdkSource == "" {
+		return ""
 	}
 	if wsCfg.Modules == nil {
 		wsCfg.Modules = map[string]ModuleEntry{}
@@ -59,9 +81,7 @@ func AddMigratedModuleSDK(wsCfg *Config, sdkSource, modulePath string) {
 	// runtime is not installed twice under different names.
 	for name, entry := range wsCfg.Modules {
 		if entry.AsSDK != nil && entry.Source == sdkSource {
-			entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: modulePath})
-			wsCfg.Modules[name] = entry
-			return
+			return name
 		}
 	}
 
@@ -82,8 +102,8 @@ func AddMigratedModuleSDK(wsCfg *Config, sdkSource, modulePath string) {
 	if entry.AsSDK == nil {
 		entry.AsSDK = &ModuleAsSDK{}
 	}
-	entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: modulePath})
 	wsCfg.Modules[sdkName] = entry
+	return sdkName
 }
 
 // uniqueModuleName returns base if free, otherwise base with a numeric suffix,
@@ -144,21 +164,23 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 		return nil, fmt.Errorf("dagger.json does not require workspace config migration")
 	}
 	hasSDK := cfg.SDK != nil && cfg.SDK.Source != ""
-	needsProjectModuleMigration := hasSDK
+	sourceAtRoot := ModuleSourceAtRoot(cfg)
 
 	plan := &MigrationPlan{
 		ProjectRoot: compatWorkspace.ProjectRoot,
 	}
 
-	if needsProjectModuleMigration {
-		modulePath := filepath.Join("modules", cfg.Name)
-		moduleDir := filepath.Join(LockDirName, modulePath)
-		newModuleConfig, err := buildMigratedModuleConfig(cfg, moduleDir)
+	// The module config replaces dagger.json at the exact same location:
+	// other repos may install this module by path, and that path must keep
+	// resolving to the module config file. Nothing moves and no paths are
+	// rebased.
+	if hasSDK {
+		newModuleConfig, err := buildMigratedModuleConfig(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("building migrated module config: %w", err)
 		}
 		plan.MigratedModuleConfigData = newModuleConfig
-		plan.MigratedModuleConfigPath = filepath.Join(moduleDir, ModuleConfigFileName)
+		plan.MigratedModuleConfigPath = ModuleConfigFileName
 	}
 
 	warnings := analyzeCustomizations(cfg.Toolchains)
@@ -168,21 +190,28 @@ func PlanMigration(compatWorkspace *CompatWorkspace) (*MigrationPlan, error) {
 	}
 
 	wsCfg := compatWorkspace.WorkspaceConfig()
-	if needsProjectModuleMigration && compatWorkspace.MainModule != nil {
-		wsCfg.Modules[cfg.Name] = compatWorkspace.MainModule.Entry
+	mainModule := compatWorkspace.MainModule
+	if !hasSDK || sourceAtRoot {
+		// A module whose source is the project root IS the repo, not a module
+		// owned by a surrounding project: it is not installed into the
+		// workspace and gets no entrypoint. Its SDK runtime is pinned
+		// separately (as a plain module install) by the migration caller.
+		mainModule = nil
 	}
+	if mainModule != nil {
+		wsCfg.Modules[cfg.Name] = mainModule.Entry
 
-	// Surface the legacy module's SDK ref as a workspace module installed
-	// AS an SDK, with the migrated module recorded under the SDK's as-sdk
-	// authoring list. Legacy dagger.json carried the SDK inline on the
-	// module; new dagger.toml records every install (regular module or SDK)
-	// under [modules.*], with the SDK-role data nested in
-	// [modules.<sdk>.as-sdk.*]. This is the file-format catch-up for the
-	// runtime/SDK split.
-	if hasSDK {
-		AddMigratedModuleSDK(wsCfg, cfg.SDK.Source, filepath.Join(LockDirName, "modules", cfg.Name))
+		// Surface the legacy module's SDK ref as a workspace module installed
+		// AS an SDK, with the migrated module recorded under the SDK's as-sdk
+		// authoring list. Legacy dagger.json carried the SDK inline on the
+		// module; new dagger.toml records every install (regular module or
+		// SDK) under [modules.*], with the SDK-role data nested in
+		// [modules.<sdk>.as-sdk.*]. This is the file-format catch-up for the
+		// runtime/SDK split. The module path is the module config's directory
+		// — the project root, where dagger-module.toml replaced dagger.json.
+		AddMigratedModuleSDK(wsCfg, cfg.SDK.Source, ".")
 	}
-	workspaceConfigData, err := renderMigrationWorkspaceConfig(wsCfg, compatWorkspace.MainModule)
+	workspaceConfigData, err := renderMigrationWorkspaceConfig(wsCfg, mainModule)
 	if err != nil {
 		return nil, fmt.Errorf("serializing workspace config: %w", err)
 	}
@@ -218,17 +247,22 @@ func renderMigrationWorkspaceConfig(cfg *Config, mainModule *CompatMainModule) (
 	return UpdateConfigBytes(seeded, cfg)
 }
 
-// buildMigratedModuleConfig creates the cleaned-up dagger-module.toml for the migrated
-// module. newModuleDir is relative to the project root.
-func buildMigratedModuleConfig(cfg *modules.ModuleConfig, newModuleDir string) ([]byte, error) {
-	source, err := migratedModuleRelPath(newModuleDir, cfg.Source)
-	if err != nil {
-		return nil, fmt.Errorf("rebasing source path: %w", err)
+// buildMigratedModuleConfig creates the cleaned-up dagger-module.toml that
+// replaces dagger.json at the same location. The config does not move, so
+// source, dependency, and include paths are preserved as-is; only the
+// workspace-level fields (toolchains, blueprint, customizations) are dropped —
+// those migrate into dagger.toml instead.
+func buildMigratedModuleConfig(cfg *modules.ModuleConfig) ([]byte, error) {
+	if cfg.Source != "" && filepath.IsAbs(cfg.Source) {
+		return nil, fmt.Errorf("source path %q is absolute", cfg.Source)
 	}
-
-	rootPrefix, err := migratedModuleRootPrefix(newModuleDir)
-	if err != nil {
-		return nil, fmt.Errorf("rebasing project root: %w", err)
+	source := cfg.Source
+	if source != "" {
+		source = filepath.ToSlash(filepath.Clean(source))
+	}
+	if source == "." {
+		// An empty source means "here", matching configs authored natively.
+		source = ""
 	}
 
 	deps := make([]*modules.ModuleConfigDependency, 0, len(cfg.Dependencies))
@@ -236,32 +270,14 @@ func buildMigratedModuleConfig(cfg *modules.ModuleConfig, newModuleDir string) (
 		if dep == nil {
 			continue
 		}
-
-		depSource := dep.Source
-		if IsLocalRef(dep.Source, dep.Pin) {
-			depSource, err = migratedModuleRelPath(newModuleDir, dep.Source)
-			if err != nil {
-				return nil, fmt.Errorf("rebasing dependency %q source path: %w", dep.Name, err)
-			}
-		}
-
 		deps = append(deps, &modules.ModuleConfigDependency{
 			Name:             dep.Name,
-			Source:           depSource,
+			Source:           dep.Source,
 			Pin:              dep.Pin,
 			Customizations:   cloneCustomizations(dep.Customizations),
 			IgnoreChecks:     append([]string(nil), dep.IgnoreChecks...),
 			IgnoreGenerators: append([]string(nil), dep.IgnoreGenerators...),
 		})
-	}
-
-	includes := make([]string, 0, len(cfg.Include))
-	for _, inc := range cfg.Include {
-		if strings.HasPrefix(inc, "!") {
-			includes = append(includes, "!"+rootPrefix+inc[1:])
-		} else {
-			includes = append(includes, rootPrefix+inc)
-		}
 	}
 
 	newCfg := modules.ModuleConfig{
@@ -270,7 +286,7 @@ func buildMigratedModuleConfig(cfg *modules.ModuleConfig, newModuleDir string) (
 		SDK:                           cfg.SDK,
 		Source:                        source,
 		Dependencies:                  deps,
-		Include:                       includes,
+		Include:                       append([]string(nil), cfg.Include...),
 		Codegen:                       cfg.Codegen,
 		Clients:                       cfg.Clients,
 		DisableDefaultFunctionCaching: cfg.DisableDefaultFunctionCaching,
@@ -283,32 +299,6 @@ func buildMigratedModuleConfig(cfg *modules.ModuleConfig, newModuleDir string) (
 		return nil, err
 	}
 	return out, nil
-}
-
-func migratedModuleRelPath(newModuleDir, source string) (string, error) {
-	if source == "" {
-		source = "."
-	}
-	if filepath.IsAbs(source) {
-		return "", fmt.Errorf("source path %q is absolute", source)
-	}
-
-	rel, err := filepath.Rel(newModuleDir, filepath.Clean(source))
-	if err != nil {
-		return "", err
-	}
-	return filepath.ToSlash(rel), nil
-}
-
-func migratedModuleRootPrefix(newModuleDir string) (string, error) {
-	rootRel, err := migratedModuleRelPath(newModuleDir, ".")
-	if err != nil {
-		return "", err
-	}
-	if rootRel == "." {
-		return "", nil
-	}
-	return rootRel + "/", nil
 }
 
 type migrationWarning struct {

--- a/core/workspace/migrate_test.go
+++ b/core/workspace/migrate_test.go
@@ -38,11 +38,13 @@ func TestPlanMigrationPreservesDependencyPinsInModuleConfig(t *testing.T) {
   ]
 }`)
 
+	require.Equal(t, ModuleConfigFileName, plan.MigratedModuleConfigPath,
+		"the module config replaces dagger.json at the same location")
 	cfg, err := modules.ParseModuleConfigForFilename(plan.MigratedModuleConfigData, ModuleConfigFileName)
 	require.NoError(t, err)
 	require.Equal(t, "myapp", cfg.Name)
 	require.Equal(t, "go", cfg.SDK.Source)
-	require.Equal(t, "../../../src", cfg.Source)
+	require.Equal(t, "src", cfg.Source, "the source path is preserved as-is")
 	require.Len(t, cfg.Dependencies, 1)
 	require.Equal(t, "dep", cfg.Dependencies[0].Name)
 	require.Equal(t, "github.com/acme/dep@main", cfg.Dependencies[0].Source)
@@ -103,20 +105,27 @@ func TestPlanMigrationWritesMigrationReportForGaps(t *testing.T) {
 	require.Contains(t, reportData, `"function": [`)
 }
 
-func TestPlanMigrationRebasesMainModuleSource(t *testing.T) {
+// TestPlanMigrationConvertsModuleConfigInPlace verifies the migrated
+// dagger-module.toml replaces dagger.json at the exact same location, with the
+// source path preserved as-is: other repos may install this module by path,
+// and that path must keep resolving to the module config file. Only a module
+// whose source lives in a subdirectory (a project-style layout) is installed
+// into the workspace with an entrypoint.
+func TestPlanMigrationConvertsModuleConfigInPlace(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name   string
-		source string
-		want   string
+		name       string
+		source     string
+		wantSource string
+		installed  bool
 	}{
-		{name: "empty", source: "", want: "../../.."},
-		{name: "root", source: ".", want: "../../.."},
-		{name: "subdir", source: "ci", want: "../../../ci"},
-		{name: "nested subdir", source: "src/mod", want: "../../../src/mod"},
-		{name: "dot dagger", source: ".dagger", want: "../.."},
-		{name: "clean dot dagger", source: "./.dagger/", want: "../.."},
+		{name: "empty", source: "", wantSource: "."},
+		{name: "root", source: ".", wantSource: "."},
+		{name: "subdir", source: "ci", wantSource: "ci", installed: true},
+		{name: "nested subdir", source: "src/mod", wantSource: "src/mod", installed: true},
+		{name: "dot dagger", source: ".dagger", wantSource: ".dagger", installed: true},
+		{name: "clean dot dagger", source: "./.dagger/", wantSource: ".dagger", installed: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -130,11 +139,49 @@ func TestPlanMigrationRebasesMainModuleSource(t *testing.T) {
   ]
 }`, tc.source))
 
+			require.Equal(t, ModuleConfigFileName, plan.MigratedModuleConfigPath,
+				"the module config replaces dagger.json at the same location")
 			cfg, err := modules.ParseModuleConfigForFilename(plan.MigratedModuleConfigData, ModuleConfigFileName)
 			require.NoError(t, err)
-			require.Equal(t, tc.want, cfg.Source)
+			require.Equal(t, "myapp", cfg.Name)
+			// Parsing normalizes an omitted source to ".".
+			require.Equal(t, tc.wantSource, cfg.Source)
+
+			wsCfg, err := ParseConfig(plan.WorkspaceConfigData)
+			require.NoError(t, err)
+			entry, installed := wsCfg.Modules["myapp"]
+			require.Equal(t, tc.installed, installed,
+				"a module whose source is the project root is the repo itself and must not be installed")
+			if tc.installed {
+				require.Equal(t, ".", entry.Source,
+					"the entry points at the module config's directory")
+				require.True(t, entry.Entrypoint)
+			}
 		})
 	}
+}
+
+// TestPlanMigrationModuleRepoSkipsSDKInstall verifies the "repo is just a
+// dagger module" shape (source at the project root) records no as-sdk install
+// for the root module: the runtime pin is a plain install added by the
+// migration caller, and the module gets no entrypoint.
+func TestPlanMigrationModuleRepoSkipsSDKInstall(t *testing.T) {
+	t.Parallel()
+
+	plan := testMigrationPlan(t, "repo", `{
+  "name": "myapp",
+  "sdk": {"source": "go"},
+  "source": ".",
+  "toolchains": [
+    {"name": "tools", "source": "./tools"}
+  ]
+}`)
+
+	require.Equal(t, ModuleConfigFileName, plan.MigratedModuleConfigPath)
+	configData := string(plan.WorkspaceConfigData)
+	require.NotContains(t, configData, "[modules.myapp]")
+	require.NotContains(t, configData, "as-sdk")
+	require.Contains(t, configData, "[modules.tools]")
 }
 
 func TestPlanMigrationRejectsAbsoluteMainModuleSource(t *testing.T) {
@@ -156,7 +203,7 @@ func TestPlanMigrationWritesMainModuleFirst(t *testing.T) {
 	plan := testMigrationPlan(t, "repo", `{
   "name": "myapp",
   "sdk": {"source": "go"},
-  "source": ".",
+  "source": "src",
   "toolchains": [
     {"name": "toolchain", "source": "./toolchain"}
   ],
@@ -195,7 +242,7 @@ func TestPlanMigrationWritesAsSDK(t *testing.T) {
 	require.Contains(t, configData, "[modules.dagger-go-sdk]")
 	require.Contains(t, configData, `source = "go"`)
 	require.Contains(t, configData, "[[modules.dagger-go-sdk.as-sdk.modules]]")
-	require.Contains(t, configData, `path = ".dagger/modules/myapp"`)
+	require.Contains(t, configData, `path = "."`)
 }
 
 func TestMigrationSDKInstallName(t *testing.T) {

--- a/core/workspace/migrate_test.go
+++ b/core/workspace/migrate_test.go
@@ -193,7 +193,7 @@ func TestPlanMigrationRejectsAbsoluteMainModuleSource(t *testing.T) {
   "source": "/tmp"
 }`)
 
-	_, err := PlanMigration(compat)
+	_, err := PlanMigration(compat, compat.ProjectRoot)
 	require.ErrorContains(t, err, `source path "/tmp" is absolute`)
 }
 
@@ -356,6 +356,58 @@ func TestPlanMigrationAllowsDifferentPinnedWorkspaceRefs(t *testing.T) {
 	require.Contains(t, configData, `source = "github.com/acme/toolchain@2222222"`)
 }
 
+// TestPlanMigrationHoistsSubdirectoryToolchains covers a legacy config in a
+// subdirectory of the workspace: nested dagger.toml files are never created,
+// so its toolchains install into a dagger.toml at the workspace root with
+// local sources rebased, while the module config converts in place at the
+// subdirectory and the module itself is not installed.
+func TestPlanMigrationHoistsSubdirectoryToolchains(t *testing.T) {
+	t.Parallel()
+
+	root := "repo"
+	compat := testCompatWorkspace(t, filepath.Join(root, "tools", "hello"), `{
+  "name": "hello",
+  "sdk": {"source": "go"},
+  "source": "src",
+  "toolchains": [
+    {"name": "tc", "source": "./toolchain"},
+    {"name": "remote", "source": "github.com/acme/tool@main", "pin": "1111111"}
+  ]
+}`)
+
+	plan, err := PlanMigration(compat, root)
+	require.NoError(t, err)
+
+	require.Equal(t, root, plan.ProjectRoot,
+		"the workspace config lands at the workspace root, never nested")
+	require.Equal(t, filepath.Join(root, "tools", "hello"), plan.ModuleProjectRoot,
+		"the module config stays at the legacy config's own directory")
+	require.Equal(t, ModuleConfigFileName, plan.MigratedModuleConfigPath)
+
+	wsCfg, err := ParseConfig(plan.WorkspaceConfigData)
+	require.NoError(t, err)
+	require.Equal(t, "./tools/hello/toolchain", wsCfg.Modules["tc"].Source,
+		"local toolchain sources are rebased to the workspace root")
+	require.Equal(t, "github.com/acme/tool@1111111", wsCfg.Modules["remote"].Source,
+		"remote toolchain refs pass through untouched")
+	_, installed := wsCfg.Modules["hello"]
+	require.False(t, installed,
+		"a hoisted subdirectory module is not installed into the repo-wide workspace")
+}
+
+func TestPlanMigrationRefusesToHoistSubdirectoryBlueprint(t *testing.T) {
+	t.Parallel()
+
+	compat := testCompatWorkspace(t, filepath.Join("repo", "tools", "hello"), `{
+  "name": "hello",
+  "sdk": {"source": "go"},
+  "blueprint": {"name": "bp", "source": "github.com/acme/bp@main"}
+}`)
+
+	_, err := PlanMigration(compat, "repo")
+	require.ErrorContains(t, err, "blueprint cannot be hoisted")
+}
+
 func TestPlanMigrationRejectsConfigWithoutWorkspaceConfigMigration(t *testing.T) {
 	t.Parallel()
 
@@ -365,14 +417,14 @@ func TestPlanMigrationRejectsConfigWithoutWorkspaceConfigMigration(t *testing.T)
 	}`))
 	require.NoError(t, err)
 
-	_, err = PlanMigration(buildCompatWorkspace(cfg, filepath.Join("repo", LegacyModuleConfigFileName)))
+	_, err = PlanMigration(buildCompatWorkspace(cfg, filepath.Join("repo", LegacyModuleConfigFileName)), "repo")
 	require.ErrorContains(t, err, "dagger.json does not require workspace config migration")
 }
 
 func testMigrationPlan(t *testing.T, projectRoot, cfg string) *MigrationPlan {
 	t.Helper()
 
-	plan, err := PlanMigration(testCompatWorkspace(t, projectRoot, cfg))
+	plan, err := PlanMigration(testCompatWorkspace(t, projectRoot, cfg), projectRoot)
 	require.NoError(t, err)
 	return plan
 }

--- a/docs/current_docs/adopting/workspace-setup.mdx
+++ b/docs/current_docs/adopting/workspace-setup.mdx
@@ -83,7 +83,7 @@ If your project already uses a legacy `dagger.json`, run `dagger setup` — its 
 dagger setup
 ```
 
-This writes `dagger.toml` from your existing configuration. When a migration applies, setup stops there — run `dagger setup` again afterward to see module recommendations for the migrated workspace. See [Upgrade to Workspaces](../reference/upgrade-to-workspaces.mdx) for details.
+This writes `dagger.toml` from your existing configuration. When a migration applies, setup stops there — run `dagger setup` again afterward to see module recommendations for the migrated workspace. Running setup from a module subdirectory (a `dagger.json` below the repository root) migrates just that module to `dagger-module.toml` without creating a workspace. See [Upgrade to Workspaces](../reference/upgrade-to-workspaces.mdx) for details.
 
 ## What's next
 

--- a/docs/current_docs/adopting/workspace-setup.mdx
+++ b/docs/current_docs/adopting/workspace-setup.mdx
@@ -83,7 +83,7 @@ If your project already uses a legacy `dagger.json`, run `dagger setup` — its 
 dagger setup
 ```
 
-This writes `dagger.toml` from your existing configuration. See [Upgrade to Workspaces](../reference/upgrade-to-workspaces.mdx) for details.
+This writes `dagger.toml` from your existing configuration. When a migration applies, setup stops there — run `dagger setup` again afterward to see module recommendations for the migrated workspace. See [Upgrade to Workspaces](../reference/upgrade-to-workspaces.mdx) for details.
 
 ## What's next
 

--- a/docs/current_docs/getting-started/quickstart.mdx
+++ b/docs/current_docs/getting-started/quickstart.mdx
@@ -38,7 +38,7 @@ git checkout -b add-dagger-checks
 
 ## Setup your workspace
 
-`dagger setup` walks through a few prompts: logging in to Dagger Cloud, migrating any legacy configuration (not needed here), and installing recommended modules based on a scan of your project.
+`dagger setup` walks through a few prompts: logging in to Dagger Cloud, then — since this project has no legacy Dagger configuration to migrate — installing recommended modules based on a scan of your project.
 
 ```shell
 dagger setup

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2577,13 +2577,16 @@ Ensure Dagger is properly set up and operational in the workspace
 
 Ensure Dagger is properly set up and operational in the workspace.
 
-Walks through three steps, each prompted independently:
+Starts with a Cloud login prompt, then takes one of two paths:
 
-  1. Cloud login        — authenticate with Dagger Cloud.
-  2. Workspace migrate  — convert any legacy dagger.json projects to
-                          the current workspace format.
-  3. Recommended modules — suggest modules to install based on files
-                           present in the workspace.
+  • Workspace migrate    — if a legacy dagger.json project is detected,
+                           convert it to the current workspace format.
+  • Recommended modules  — otherwise, suggest modules to install based
+                           on files present in the workspace.
+
+Migration and recommendations never run together: after applying a
+migration, run setup again to see recommendations for the migrated
+workspace. Declining the migration falls through to recommendations.
 
 Idempotent: safe to run anytime. No-ops what's already in good shape.
 Each step can be skipped at the prompt. With --auto-apply, all steps

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2588,6 +2588,13 @@ Migration and recommendations never run together: after applying a
 migration, run setup again to see recommendations for the migrated
 workspace. Declining the migration falls through to recommendations.
 
+Run from a module subdirectory (a dagger.json below the repository
+root), the migrate step converts just that module to dagger-module.toml:
+no workspace is created and module recommendations are skipped. If that
+config lists toolchains, they are installed into a dagger.toml at the
+repository root — never a nested one. A subdirectory config with a
+blueprint is left as legacy with a warning.
+
 Idempotent: safe to run anytime. No-ops what's already in good shape.
 Each step can be skipped at the prompt. With --auto-apply, all steps
 are applied without prompting. In non-interactive mode (no TTY) the

--- a/docs/current_docs/reference/upgrade-to-workspaces.mdx
+++ b/docs/current_docs/reference/upgrade-to-workspaces.mdx
@@ -45,7 +45,13 @@ No. Backwards compatibility will infer a workspace from your existing `dagger.js
 dagger setup
 ```
 
-`dagger setup` walks through three steps with per-step prompts; the middle step converts workspace fields from legacy `dagger.json` into `dagger.toml`, and converts plain module-shaped `dagger.json` files to `dagger-module.toml`. If anything needs manual attention, it creates `.dagger/migration-report.md` with instructions.
+`dagger setup` prompts before each step. Its migration step converts workspace fields from your legacy `dagger.json` into `dagger.toml`, and converts module-shaped `dagger.json` files to `dagger-module.toml` in place — module files are never moved, and only the root `dagger.json` plus the local dependencies and toolchains it references are touched. If anything needs manual attention, it creates `.dagger/migration-report.md` with instructions.
+
+A few migration behaviors worth knowing:
+
+- If your repo *is* a dagger module — the root `dagger.json` describes a module whose source lives at the repo root — migration converts the config in place and writes a minimal `dagger.toml` that only pins the module's SDK. The module is not installed into the workspace, so load it explicitly: `dagger -m . call --help`.
+- Modules now commit their generated code (e.g. `dagger.gen.go`) instead of regenerating it at runtime. Migration removes the legacy `.gitignore` rules that ignored those files — after migrating, run `dagger generate` and commit the output.
+- Applying a migration ends the setup run; run `dagger setup` again to see module recommendations for the migrated workspace.
 
 ## What happened to module-management commands?
 

--- a/docs/current_docs/reference/upgrade-to-workspaces.mdx
+++ b/docs/current_docs/reference/upgrade-to-workspaces.mdx
@@ -50,6 +50,8 @@ dagger setup
 A few migration behaviors worth knowing:
 
 - If your repo *is* a dagger module — the root `dagger.json` describes a module whose source lives at the repo root — migration converts the config in place and writes a minimal `dagger.toml` that only pins the module's SDK. The module is not installed into the workspace, so load it explicitly: `dagger -m . call --help`.
+- Running `dagger setup` from a module subdirectory — a `dagger.json` below the repository root — migrates just that module: `dagger.json` becomes `dagger-module.toml` in place (along with any local dependencies it references) and no workspace is created. Module recommendations are skipped in this case.
+- Nested `dagger.toml` files are never created. If a subdirectory `dagger.json` lists toolchains, migration installs them into a `dagger.toml` at the repository root, with local source paths rebased; the module itself is not installed into that workspace. A subdirectory `dagger.json` with a `blueprint` is left as legacy with a warning.
 - Modules now commit their generated code (e.g. `dagger.gen.go`) instead of regenerating it at runtime. Migration removes the legacy `.gitignore` rules that ignored those files — after migrating, run `dagger generate` and commit the output.
 - Applying a migration ends the setup run; run `dagger setup` again to see module recommendations for the migrated workspace.
 

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -42,6 +42,13 @@ Migration and recommendations never run together: after applying a
 migration, run setup again to see recommendations for the migrated
 workspace. Declining the migration falls through to recommendations.
 
+Run from a module subdirectory (a dagger.json below the repository
+root), the migrate step converts just that module to dagger-module.toml:
+no workspace is created and module recommendations are skipped. If that
+config lists toolchains, they are installed into a dagger.toml at the
+repository root — never a nested one. A subdirectory config with a
+blueprint is left as legacy with a warning.
+
 Idempotent: safe to run anytime. No-ops what's already in good shape.
 Each step can be skipped at the prompt. With --auto-apply, all steps
 are applied without prompting. In non-interactive mode (no TTY) the
@@ -72,6 +79,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			recs            []recommendation
 			install         bool
 			migrated        bool
+			moduleOnly      bool
 			migratedConfigs []string
 		)
 		if err := func() error {
@@ -81,7 +89,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			}
 			defer closeSess()
 			dag := sess.Dagger()
-			migrated, migratedConfigs, err = setupStepMigrate(ctx, cmd, dag)
+			migrated, moduleOnly, migratedConfigs, err = setupStepMigrate(ctx, cmd, dag)
 			if err != nil {
 				return fmt.Errorf("step 2 (migrate): %w", err)
 			}
@@ -92,6 +100,13 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 				// `dagger setup`. A declined migration falls through — the
 				// user opted to keep the workspace as-is, so recommendations
 				// still run.
+				return nil
+			}
+			if moduleOnly {
+				// Setup ran from a module subdirectory: the migration converts
+				// just that module and creates no workspace. Recommendations
+				// are workspace-scoped and would create one, so they never run
+				// here — even when the migration was declined.
 				return nil
 			}
 			recs, install, err = planRecommend(ctx, cmd, dag)
@@ -106,8 +121,10 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 		// Session 2: a fresh session re-detects the workspace migrated in
 		// session 1 as native. Resolve any SDK that migration recorded by short
 		// name to its real ref (sdks.json), then install accepted recommendations.
+		// A module-only migration writes no dagger.toml, so there is nothing to
+		// resolve or install and no second session to open.
 		needInstall := install && len(recs) > 0
-		if migrated || needInstall {
+		if (migrated && !moduleOnly) || needInstall {
 			sess, closeSess, err := connect(ctx)
 			if err != nil {
 				return err
@@ -129,7 +146,11 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 		}
 
 		if migrated {
-			fmt.Fprintln(out, "\nRun `dagger setup` again to see recommended modules for the migrated workspace.")
+			if moduleOnly {
+				fmt.Fprintln(out, "\nMigrated the module in place; no workspace config was created.")
+			} else {
+				fmt.Fprintln(out, "\nRun `dagger setup` again to see recommended modules for the migrated workspace.")
+			}
 		}
 		fmt.Fprintln(out, "\nSetup complete.")
 		return nil
@@ -185,7 +206,13 @@ const emptyWorkspaceSetupHint = `  No workspace loaded here yet — nothing to m
 // session should resolve SDKs migration may have recorded by short name) and
 // the workspace-root-relative paths of the dagger.toml configs it wrote — the
 // exact set the SDK resolution pass must scope itself to.
-func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (applied bool, configs []string, _ error) {
+//
+// moduleOnly reports a migration that writes no dagger.toml at all: setup ran
+// from a module subdirectory, so only the module config converts (dagger.json
+// -> dagger-module.toml) and no workspace is created. It is reported whether
+// or not the migration was applied, so the caller can skip workspace-scoped
+// recommendations either way.
+func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (applied bool, moduleOnly bool, configs []string, _ error) {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "\nStep 2: Workspace migration")
 
@@ -195,18 +222,34 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 
 	changesID, err := changes.ID(ctx)
 	if err != nil {
-		return false, nil, fmt.Errorf("compute migration: %w", err)
+		return false, false, nil, fmt.Errorf("compute migration: %w", err)
 	}
 	changes = dagger.Ref[*dagger.Changeset](dag, changesID)
 
 	isEmpty, err := changes.IsEmpty(ctx)
 	if err != nil {
-		return false, nil, fmt.Errorf("check migration: %w", err)
+		return false, false, nil, fmt.Errorf("check migration: %w", err)
 	}
 	if isEmpty {
+		// An empty changeset can still carry warning-only steps: a legacy
+		// config migration skipped by design (e.g. a subdirectory dagger.json
+		// with a blueprint is left as legacy). Surface those instead of "No
+		// migration needed", and skip workspace-scoped recommendations — the
+		// selected legacy config sits in a module subdirectory.
+		skipWarnings, err := migrationStepWarnings(ctx, migration)
+		if err != nil {
+			return false, false, nil, fmt.Errorf("check migration warnings: %w", err)
+		}
+		if len(skipWarnings) > 0 {
+			for _, warning := range skipWarnings {
+				fmt.Fprintf(out, "  Skipped: %s\n", warning)
+			}
+			return false, true, nil, nil
+		}
+
 		configFile, err := ws.ConfigFile(ctx)
 		if err != nil {
-			return false, nil, fmt.Errorf("check workspace config: %w", err)
+			return false, false, nil, fmt.Errorf("check workspace config: %w", err)
 		}
 		if configFile == "" {
 			// Nothing to migrate and no workspace config yet — don't seed an empty
@@ -214,30 +257,50 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 			if !silent {
 				fmt.Fprint(out, emptyWorkspaceSetupHint)
 			}
-			return false, nil, nil
+			return false, false, nil, nil
 		}
 		fmt.Fprintln(out, "  No migration needed.")
-		return false, nil, nil
+		return false, false, nil, nil
 	}
 
 	configs, err = migratedConfigPaths(ctx, changes)
 	if err != nil {
-		return false, nil, err
+		return false, false, nil, err
 	}
+	moduleOnly = len(configs) == 0
 
 	// handleWorkspaceResponse owns the apply prompt via a huh form when
 	// autoApply is false — we don't run our own confirm() here, otherwise
 	// the user would face two prompts back-to-back for the same action.
 	applied, err = handleWorkspaceResponse(ctx, dag, ws.WithChanges(changes), autoApply)
 	if err != nil {
-		return false, nil, err
+		return false, false, nil, err
 	}
 	if !applied {
 		// The user declined: the legacy config is left in place, so there is
 		// nothing to resolve and the migrated config files were never written.
-		return false, nil, nil
+		return false, moduleOnly, nil, nil
 	}
-	return true, configs, nil
+	return true, moduleOnly, configs, nil
+}
+
+// migrationStepWarnings collects the warnings attached to the migration's
+// steps. With an empty changeset these are the only signal a legacy config was
+// deliberately skipped rather than absent.
+func migrationStepWarnings(ctx context.Context, migration *dagger.WorkspaceMigration) ([]string, error) {
+	steps, err := migration.Steps(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var warnings []string
+	for _, step := range steps {
+		stepWarnings, err := step.Warnings(ctx)
+		if err != nil {
+			return nil, err
+		}
+		warnings = append(warnings, stepWarnings...)
+	}
+	return warnings, nil
 }
 
 // migratedConfigPaths returns the workspace-root-relative paths of the

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -23,20 +23,24 @@ import (
 )
 
 // setupCmd is the idempotent "ensure environment works" doctor verb.
-// Walks through three optional steps, each with a confirmation prompt:
-// (1) Cloud login, (2) workspace migration, (3) recommended modules.
+// Walks through optional steps, each with a confirmation prompt:
+// (1) Cloud login, then EITHER (2) workspace migration when the workspace
+// is legacy, OR (3) recommended modules when it is already current.
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Ensure Dagger is properly set up and operational in the workspace",
 	Long: `Ensure Dagger is properly set up and operational in the workspace.
 
-Walks through three steps, each prompted independently:
+Starts with a Cloud login prompt, then takes one of two paths:
 
-  1. Cloud login        — authenticate with Dagger Cloud.
-  2. Workspace migrate  — convert any legacy dagger.json projects to
-                          the current workspace format.
-  3. Recommended modules — suggest modules to install based on files
-                           present in the workspace.
+  • Workspace migrate    — if a legacy dagger.json project is detected,
+                           convert it to the current workspace format.
+  • Recommended modules  — otherwise, suggest modules to install based
+                           on files present in the workspace.
+
+Migration and recommendations never run together: after applying a
+migration, run setup again to see recommendations for the migrated
+workspace. Declining the migration falls through to recommendations.
 
 Idempotent: safe to run anytime. No-ops what's already in good shape.
 Each step can be skipped at the prompt. With --auto-apply, all steps
@@ -61,7 +65,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 	// and cached for a session's lifetime, so install must not reuse the
 	// migrate session or it would still see the legacy dagger.json.
 	return withSetupSessions(cmd.Context(), func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) error {
-		// Session 1: migrate (apply form) + recommend (compute + install
+		// Session 1: migrate (apply form) or recommend (compute + install
 		// confirm form). The migrate write lands here; the session is closed
 		// before the install session opens so the workspace lock is released.
 		var (
@@ -80,6 +84,15 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			migrated, migratedConfigs, err = setupStepMigrate(ctx, cmd, dag)
 			if err != nil {
 				return fmt.Errorf("step 2 (migrate): %w", err)
+			}
+			if migrated {
+				// Migration and recommendations are alternative paths: piling
+				// recommended modules onto a freshly migrated workspace adds
+				// confusion, not value. Recommendations appear on the next
+				// `dagger setup`. A declined migration falls through — the
+				// user opted to keep the workspace as-is, so recommendations
+				// still run.
+				return nil
 			}
 			recs, install, err = planRecommend(ctx, cmd, dag)
 			if err != nil {
@@ -115,6 +128,9 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			}
 		}
 
+		if migrated {
+			fmt.Fprintln(out, "\nRun `dagger setup` again to see recommended modules for the migrated workspace.")
+		}
 		fmt.Fprintln(out, "\nSetup complete.")
 		return nil
 	})
@@ -164,11 +180,12 @@ const emptyWorkspaceSetupHint = `  No workspace loaded here yet — nothing to m
         dagger module init <sdk> <name>
 `
 
-// setupStepMigrate reports whether a migration was needed (and thus a fresh
+// setupStepMigrate reports whether a migration was applied (which routes setup
+// down the migration path instead of recommendations, and means a fresh
 // session should resolve SDKs migration may have recorded by short name) and
 // the workspace-root-relative paths of the dagger.toml configs it wrote — the
 // exact set the SDK resolution pass must scope itself to.
-func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (bool, []string, error) {
+func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (applied bool, configs []string, _ error) {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "\nStep 2: Workspace migration")
 
@@ -203,7 +220,7 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 		return false, nil, nil
 	}
 
-	configs, err := migratedConfigPaths(ctx, changes)
+	configs, err = migratedConfigPaths(ctx, changes)
 	if err != nil {
 		return false, nil, err
 	}
@@ -211,7 +228,7 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 	// handleWorkspaceResponse owns the apply prompt via a huh form when
 	// autoApply is false — we don't run our own confirm() here, otherwise
 	// the user would face two prompts back-to-back for the same action.
-	applied, err := handleWorkspaceResponse(ctx, dag, ws.WithChanges(changes), autoApply)
+	applied, err = handleWorkspaceResponse(ctx, dag, ws.WithChanges(changes), autoApply)
 	if err != nil {
 		return false, nil, err
 	}


### PR DESCRIPTION
Fixes #13756

`dagger setup` was doing too much during 1.0 migration, especially for repos that are just dagger modules and not modules living inside a project repo. This implements the plan from https://github.com/dagger/dagger/issues/13756#issuecomment-5135156385:

## Changes

- **No more repo crawling.** Migration only touches the selected `dagger.json` (found up from cwd) plus the local dependencies and toolchains it references, transitively. Unreferenced modules — including ones under `.dagger/modules/` — are left exactly as they are.
- **`dagger-module.toml` replaces `dagger.json` at the exact same location.** The `source`, dependency, and include paths are preserved as-is — other repos may install the module by path, and that path must keep resolving to the module config file. Nothing is synthesized under `.dagger/modules/<name>/` and no paths are rebased. Project-style repos (root `dagger.json` with source in a subdirectory) install the module in `dagger.toml` as `[modules.<name>] source = "."` with `entrypoint = true`.
- **"Repo is just a dagger module" detection.** A root `dagger.json` whose source is at the root converts its config in place and gets a minimal `dagger.toml` that only pins the SDK runtime. The module is not installed into the workspace and gets no `entrypoint = true`.
- **One SDK install per runtime.** The module-repo runtime pin uses the same as-sdk install mechanism as every other migrated SDK (matching what `dagger sdk install` writes), so a discovered local module sharing the runtime reuses the entry — one SDK install serves every module in the repo.
- **Setup branches between migration and recommendations.** Applying a migration ends the run, with recommendations appearing on the next `dagger setup`. Declining the migration falls through to recommendations.

## Setup from a module subdirectory

Running `dagger setup` from a subdirectory that is a dagger module (a `dagger.json` below the repository root) migrates just that module from v0 to v1 instead of creating a workspace:

- **Module-only migration.** A plain module config — including the main expected case, a module with its source in a subdirectory — converts to `dagger-module.toml` in place (local dependencies too). No `dagger.toml` is created anywhere and module recommendations are skipped, whether the migration is applied or declined. The converted config still names its SDK, so the module stays loadable with `dagger -m`.
- **Nested `dagger.toml` files are never created.** A subdirectory config with toolchains has them installed into a `dagger.toml` at the repository root, with local sources rebased (`../shared-tool` seen from `modules/app` becomes `./modules/shared-tool`) and its runtime pinned there via the shared as-sdk install. The module itself is not installed into that workspace.
- **A subdirectory config with a `blueprint` is left as legacy.** Migration returns a warning-only step and setup surfaces the skip ("Skipped: ... it defines a blueprint ...") instead of claiming there is nothing to migrate — hoisting an entrypoint would change repo-wide behavior.

Docs (`upgrade-to-workspaces`, `workspace-setup`, quickstart, and the generated CLI reference) are updated to match, including a note that migration removes the legacy `.gitignore` rules for generated code so `dagger generate` output can be committed.

## Tests

- Unit: `core/workspace`, `core/schema`, `internal/cmd/dagger`, including tests pinning the single-SDK-install guarantee, the hoisted subdirectory plan, and the module-only route.
- Integration: `TestWorkspaceMigration`, `TestWorkspaceCompat` — 151 passed against a dev engine, with new subtests for the plain-module, toolchain-hoist, and blueprint-skip subdirectory cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
