### PR TITLE
Java client lib: if downloading CLI fails, fall back to PATH

### DIFF
--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIDownloader.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIDownloader.java
@@ -1,7 +1,7 @@
 package io.dagger.client.engineconn;
 
 import java.io.*;
-import java.net.URL;
+import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +37,7 @@ class CLIDownloader {
   }
 
   public CLIDownloader() {
-    this(url -> new URL(url).openStream());
+    this(FileFetcher::fetchURL);
   }
 
   public String downloadCLI(String version) throws IOException {
@@ -93,11 +93,22 @@ class CLIDownloader {
     return String.format("dagger_v%s_%s_%s.%s", version, getOS(), getArch(), ext);
   }
 
-  private Map<String, String> fetchChecksumMap(String version) throws IOException {
+  Map<String, String> fetchChecksumMap(String version) throws IOException {
     Map<String, String> checksums = new HashMap<>();
     String checksumMapURL =
         String.format("https://dl.dagger.io/dagger/releases/%s/checksums.txt", version);
-    try (BufferedInputStream in = new BufferedInputStream(fetcher.fetch(checksumMapURL))) {
+    try (FileFetcher.Response response = fetcher.fetch(checksumMapURL)) {
+      if (response.statusCode() != HttpURLConnection.HTTP_OK) {
+        String message =
+            String.format(
+                "Failed to download checksums from %s: %s", checksumMapURL, response.status());
+        if (isCLIReleaseUnavailable(response.statusCode())) {
+          throw new CLIReleaseUnavailableException(message);
+        }
+        throw new IOException(message);
+      }
+
+      BufferedInputStream in = new BufferedInputStream(response.body());
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       byte[] dataBuffer = new byte[1024];
       int bytesRead;
@@ -115,7 +126,7 @@ class CLIDownloader {
     }
   }
 
-  private String extractCLI(String archiveName, String version, Path dest) throws IOException {
+  String extractCLI(String archiveName, String version, Path dest) throws IOException {
     String cliArchiveURL =
         String.format("https://dl.dagger.io/dagger/releases/%s/%s", version, archiveName);
     LOG.info("Downloading Dagger CLI from " + cliArchiveURL);
@@ -126,8 +137,14 @@ class CLIDownloader {
       throw new IOException("Could not instantiate SHA-256 digester", nsae);
     }
     LOG.info("Extracting archive...");
-    try (InputStream in =
-        new BufferedInputStream(new DigestInputStream(fetcher.fetch(cliArchiveURL), sha256))) {
+    try (FileFetcher.Response response = fetcher.fetch(cliArchiveURL)) {
+      if (response.statusCode() != HttpURLConnection.HTTP_OK) {
+        throw new IOException(
+            String.format(
+                "Failed to download CLI archive from %s: %s", cliArchiveURL, response.status()));
+      }
+
+      InputStream in = new BufferedInputStream(new DigestInputStream(response.body(), sha256));
       if (isWindows()) {
         extractZip(in, dest);
       } else {
@@ -136,6 +153,12 @@ class CLIDownloader {
       byte[] checksum = sha256.digest();
       return HexFormat.of().formatHex(checksum);
     }
+  }
+
+  private static boolean isCLIReleaseUnavailable(int statusCode) {
+    // dl.dagger.io returns 403 for missing S3 objects.
+    return statusCode == HttpURLConnection.HTTP_FORBIDDEN
+        || statusCode == HttpURLConnection.HTTP_NOT_FOUND;
   }
 
   private void extractZip(InputStream in, Path dest) throws IOException {

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIPathResolver.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIPathResolver.java
@@ -1,0 +1,82 @@
+package io.dagger.client.engineconn;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+class CLIPathResolver {
+
+  String findDaggerCLI() throws IOException {
+    String path = System.getenv("PATH");
+    if (path == null) {
+      throw new IOException("PATH is not set");
+    }
+
+    for (String candidate : daggerCLIPathCandidates(isWindows(), path, System.getenv("PATHEXT"))) {
+      Path candidatePath = Path.of(candidate);
+      if (!Files.isRegularFile(candidatePath) || !Files.isExecutable(candidatePath)) {
+        continue;
+      }
+      if (!candidatePath.isAbsolute()) {
+        throw new IOException(
+            "cannot run dagger executable found relative to the current directory: " + candidate);
+      }
+      return candidatePath.toString();
+    }
+
+    throw new IOException("dagger executable was not found");
+  }
+
+  List<String> daggerCLIPathCandidates(boolean windows, String path, String pathExt) {
+    String delimiter = windows ? ";" : ":";
+    List<String> extensions = windows ? windowsExecutableExtensions(pathExt) : List.of("");
+    List<String> candidates = new ArrayList<>();
+
+    for (String directory : path.split(delimiter, -1)) {
+      if (windows) {
+        // Match PowerShell and Go's exec.LookPath behavior.
+        if (directory.isEmpty()) {
+          continue;
+        }
+        if (directory.length() >= 2 && directory.startsWith("\"") && directory.endsWith("\"")) {
+          directory = directory.substring(1, directory.length() - 1);
+        }
+      } else if (directory.isEmpty()) {
+        // Match Unix shell semantics.
+        directory = ".";
+      }
+
+      for (String extension : extensions) {
+        candidates.add(join(directory, "dagger" + extension, windows));
+      }
+    }
+    return candidates;
+  }
+
+  private List<String> windowsExecutableExtensions(String pathExt) {
+    String value = pathExt == null || pathExt.isEmpty() ? ".COM;.EXE;.BAT;.CMD" : pathExt;
+    List<String> extensions = new ArrayList<>();
+    for (String extension : value.toLowerCase(Locale.ROOT).split(";")) {
+      if (extension.isEmpty()) {
+        continue;
+      }
+      extensions.add(extension.startsWith(".") ? extension : "." + extension);
+    }
+    return extensions;
+  }
+
+  private String join(String directory, String fileName, boolean windows) {
+    String separator = windows ? "\\" : "/";
+    while (directory.endsWith("/") || directory.endsWith("\\")) {
+      directory = directory.substring(0, directory.length() - 1);
+    }
+    return directory.isEmpty() ? separator + fileName : directory + separator + fileName;
+  }
+
+  private boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+  }
+}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIReleaseUnavailableException.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIReleaseUnavailableException.java
@@ -1,0 +1,10 @@
+package io.dagger.client.engineconn;
+
+import java.io.IOException;
+
+class CLIReleaseUnavailableException extends IOException {
+
+  CLIReleaseUnavailableException(String message) {
+    super(message);
+  }
+}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIRunner.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/CLIRunner.java
@@ -6,8 +6,10 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,20 +24,67 @@ class CLIRunner implements Runnable {
   private boolean failed = false;
   private ExecutorService executorService;
   private final CLIDownloader cliDownloader;
+  private final CLIPathResolver cliPathResolver;
+  private final Consumer<String> warningOutput;
+  private IOException downloadError;
+  private String fallbackCLIPath;
+  private Throwable sessionError;
 
   public CLIRunner(String workingDir, boolean loadWorkspaceModules, CLIDownloader cliDownloader)
       throws IOException {
+    this(
+        workingDir,
+        loadWorkspaceModules,
+        cliDownloader,
+        new CLIPathResolver(),
+        System.err::println);
+  }
+
+  CLIRunner(
+      String workingDir,
+      boolean loadWorkspaceModules,
+      CLIDownloader cliDownloader,
+      CLIPathResolver cliPathResolver,
+      Consumer<String> warningOutput) {
     this.workingDir = workingDir;
     this.loadWorkspaceModules = loadWorkspaceModules;
     this.cliDownloader = cliDownloader;
+    this.cliPathResolver = cliPathResolver;
+    this.warningOutput = warningOutput;
   }
 
-  private String getCLIPath() throws IOException {
+  String getCLIPath() throws IOException {
     String cliBinPath = System.getenv("_EXPERIMENTAL_DAGGER_CLI_BIN");
     if (cliBinPath == null) {
-      cliBinPath = cliDownloader.downloadCLI();
+      try {
+        cliBinPath = cliDownloader.downloadCLI();
+      } catch (IOException error) {
+        cliBinPath = fallbackToLocalCLI(error);
+      }
     }
     LOG.info("Found dagger CLI: " + cliBinPath);
+    return cliBinPath;
+  }
+
+  String fallbackToLocalCLI(IOException error) throws IOException {
+    if (!(error instanceof CLIReleaseUnavailableException)) {
+      throw error;
+    }
+
+    String cliBinPath;
+    try {
+      cliBinPath = cliPathResolver.findDaggerCLI();
+    } catch (IOException pathError) {
+      throw combineErrors(
+          error, "dagger CLI not found in PATH: " + pathError.getMessage(), pathError);
+    }
+
+    downloadError = error;
+    fallbackCLIPath = cliBinPath;
+    warningOutput.accept(
+        String.format(
+            "CLI version %s is unavailable; using %s from PATH (version compatibility is not guaranteed).",
+            Provisioning.getCLIVersion(), cliBinPath));
     return cliBinPath;
   }
 
@@ -43,6 +92,13 @@ class CLIRunner implements Runnable {
     while (params == null) {
       try {
         if (failed) {
+          if (downloadError != null) {
+            Throwable error =
+                sessionError == null
+                    ? new IOException("Could not connect to Dagger engine")
+                    : sessionError;
+            throw fallbackSessionError(fallbackCLIPath, error);
+          }
           throw new IOException("Could not connect to Dagger engine");
         }
         wait();
@@ -52,7 +108,8 @@ class CLIRunner implements Runnable {
     return params;
   }
 
-  private synchronized void setFailed() {
+  synchronized void setFailed(Throwable error) {
+    this.sessionError = error;
     this.failed = true;
     notifyAll();
   }
@@ -77,41 +134,69 @@ class CLIRunner implements Runnable {
     if (loadWorkspaceModules) {
       command.add("--load-workspace-modules");
     }
-    this.process =
-        FluentProcess.start(
-                command.get(0), command.subList(1, command.size()).toArray(new String[0]))
-            .withAllowedExitCodes(137);
+    try {
+      this.process = startProcess(command);
+    } catch (IOException sessionError) {
+      if (downloadError != null) {
+        throw fallbackSessionError(command.get(0), sessionError);
+      }
+      throw sessionError;
+    } catch (RuntimeException sessionError) {
+      if (downloadError != null) {
+        throw fallbackSessionError(command.get(0), sessionError);
+      }
+      throw sessionError;
+    }
     LOG.debug("Opening session: {}", process.toString());
     executorService = Executors.newSingleThreadExecutor(r -> new Thread(r, "dagger-runner"));
     executorService.execute(this);
   }
 
+  FluentProcess startProcess(List<String> command) throws IOException {
+    return FluentProcess.start(
+            command.get(0), command.subList(1, command.size()).toArray(new String[0]))
+        .withAllowedExitCodes(137);
+  }
+
   @Override
   public void run() {
     try {
-      process
-          .streamOutputLines()
-          .forEach(
-              line -> {
-                if (line.isStdout() && line.line().contains("session_token")) {
-                  try (JsonReader reader = Json.createReader(new StringReader(line.line()))) {
-                    JsonObject obj = reader.readObject();
-                    int port = obj.getInt("port");
-                    String sessionToken = obj.getString("session_token");
-                    setParams(new ConnectParams(port, sessionToken));
-                  }
-                } else {
-                  LOG.info(line.line());
-                }
-              });
+      streamSessionOutput();
     } catch (RuntimeException e) {
       if (!(e.getCause() instanceof IOException
           && "Stream closed".equals(e.getCause().getMessage()))) {
         LOG.error(e.getMessage(), e);
-        setFailed();
+        setFailed(e);
         throw e;
       }
+    } finally {
+      setFailedIfNoParams(
+          new IOException("CLI session ended before connection parameters were received"));
     }
+  }
+
+  private synchronized void setFailedIfNoParams(Throwable error) {
+    if (params == null && !failed) {
+      setFailed(error);
+    }
+  }
+
+  void streamSessionOutput() {
+    process
+        .streamOutputLines()
+        .forEach(
+            line -> {
+              if (line.isStdout() && line.line().contains("session_token")) {
+                try (JsonReader reader = Json.createReader(new StringReader(line.line()))) {
+                  JsonObject obj = reader.readObject();
+                  int port = obj.getInt("port");
+                  String sessionToken = obj.getString("session_token");
+                  setParams(new ConnectParams(port, sessionToken));
+                }
+              } else {
+                LOG.info(line.line());
+              }
+            });
   }
 
   public void shutdown() {
@@ -121,5 +206,20 @@ class CLIRunner implements Runnable {
     if (process != null) {
       process.close();
     }
+  }
+
+  private static IOException combineErrors(
+      IOException originalError, String message, Throwable followupError) {
+    IOException combined =
+        new IOException(originalError.getMessage() + "\n" + message, originalError);
+    combined.addSuppressed(followupError);
+    return combined;
+  }
+
+  private IOException fallbackSessionError(String cliPath, Throwable error) {
+    return combineErrors(
+        downloadError,
+        String.format("failed to use CLI from PATH \"%s\": %s", cliPath, error.getMessage()),
+        error);
   }
 }

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/FileFetcher.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/FileFetcher.java
@@ -2,9 +2,91 @@ package io.dagger.client.engineconn;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 @FunctionalInterface
 interface FileFetcher {
 
-  InputStream fetch(String url) throws IOException;
+  Response fetch(String url) throws IOException;
+
+  static Response fetchURL(String url) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    return fetchConnection(connection);
+  }
+
+  static Response fetchConnection(HttpURLConnection connection) throws IOException {
+    InputStream body = null;
+    try {
+      connection.setInstanceFollowRedirects(true);
+      int statusCode = connection.getResponseCode();
+      String statusMessage = connection.getResponseMessage();
+      body =
+          statusCode == HttpURLConnection.HTTP_OK
+              ? connection.getInputStream()
+              : connection.getErrorStream();
+      if (body == null) {
+        body = InputStream.nullInputStream();
+      }
+      return new Response(statusCode, statusMessage, body, connection);
+    } catch (IOException | RuntimeException error) {
+      if (body != null) {
+        try {
+          body.close();
+        } catch (IOException closeError) {
+          error.addSuppressed(closeError);
+        }
+      }
+      try {
+        connection.disconnect();
+      } catch (RuntimeException disconnectError) {
+        error.addSuppressed(disconnectError);
+      }
+      throw error;
+    }
+  }
+
+  final class Response implements AutoCloseable {
+    private final int statusCode;
+    private final String statusMessage;
+    private final InputStream body;
+    private final HttpURLConnection connection;
+
+    Response(int statusCode, String statusMessage, InputStream body) {
+      this(statusCode, statusMessage, body, null);
+    }
+
+    private Response(
+        int statusCode, String statusMessage, InputStream body, HttpURLConnection connection) {
+      this.statusCode = statusCode;
+      this.statusMessage = statusMessage;
+      this.body = body;
+      this.connection = connection;
+    }
+
+    int statusCode() {
+      return statusCode;
+    }
+
+    String status() {
+      return statusMessage == null || statusMessage.isBlank()
+          ? Integer.toString(statusCode)
+          : statusCode + " " + statusMessage;
+    }
+
+    InputStream body() {
+      return body;
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        body.close();
+      } finally {
+        if (connection != null) {
+          connection.disconnect();
+        }
+      }
+    }
+  }
 }

--- a/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/CLIProvisioningTest.java
+++ b/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/CLIProvisioningTest.java
@@ -1,0 +1,483 @@
+package io.dagger.client.engineconn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ongres.process.FluentProcess;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+
+@ExtendWith(SystemStubsExtension.class)
+class CLIProvisioningTest {
+
+  @SystemStub private EnvironmentVariables environmentVariables;
+  @SystemStub private SystemErr systemErr;
+  @TempDir private Path tempDir;
+
+  @BeforeEach
+  void clearCLIOverride() {
+    environmentVariables.set("_EXPERIMENTAL_DAGGER_CLI_BIN", null);
+  }
+
+  @Test
+  void checksumMarksReleaseUnavailable() {
+    for (int statusCode :
+        new int[] {HttpURLConnection.HTTP_FORBIDDEN, HttpURLConnection.HTTP_NOT_FOUND}) {
+      CLIDownloader downloader = new CLIDownloader(fetcherReturning(statusCode));
+
+      IOException error =
+          catchThrowableOfType(() -> downloader.fetchChecksumMap("unreleased"), IOException.class);
+
+      assertThat(error)
+          .isInstanceOf(CLIReleaseUnavailableException.class)
+          .hasMessageContaining(Integer.toString(statusCode));
+    }
+  }
+
+  @Test
+  void followsRedirectAndClassifiesFinalChecksumStatus() throws Exception {
+    AtomicInteger finalStatus = new AtomicInteger();
+    AtomicInteger redirectRequests = new AtomicInteger();
+    AtomicInteger checksumRequests = new AtomicInteger();
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+        "/redirect",
+        exchange -> {
+          redirectRequests.incrementAndGet();
+          exchange.getResponseHeaders().add("Location", "/checksums");
+          exchange.sendResponseHeaders(HttpURLConnection.HTTP_MOVED_TEMP, -1);
+          exchange.close();
+        });
+    server.createContext(
+        "/checksums",
+        exchange -> {
+          checksumRequests.incrementAndGet();
+          exchange.sendResponseHeaders(finalStatus.get(), -1);
+          exchange.close();
+        });
+    server.start();
+
+    try {
+      String redirectURL =
+          String.format("http://127.0.0.1:%d/redirect", server.getAddress().getPort());
+      for (int statusCode :
+          new int[] {HttpURLConnection.HTTP_FORBIDDEN, HttpURLConnection.HTTP_NOT_FOUND}) {
+        finalStatus.set(statusCode);
+        CLIDownloader downloader = new CLIDownloader(ignored -> FileFetcher.fetchURL(redirectURL));
+
+        IOException error =
+            catchThrowableOfType(
+                () -> downloader.fetchChecksumMap("unreleased"), IOException.class);
+
+        assertThat(error)
+            .isInstanceOf(CLIReleaseUnavailableException.class)
+            .hasMessageContaining(Integer.toString(statusCode));
+      }
+      assertThat(redirectRequests).hasValue(2);
+      assertThat(checksumRequests).hasValue(2);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void responseCloseClosesBodyAndDisconnects() throws Exception {
+    TrackingHttpURLConnection connection =
+        new TrackingHttpURLConnection(HttpURLConnection.HTTP_OK, null);
+
+    try (FileFetcher.Response response = FileFetcher.fetchConnection(connection)) {
+      assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    }
+
+    assertThat(connection.body.closed).isTrue();
+    assertThat(connection.disconnected).isTrue();
+  }
+
+  @Test
+  void responseSetupFailureDisconnects() throws Exception {
+    IOException setupError = new IOException("response failed");
+    TrackingHttpURLConnection connection = new TrackingHttpURLConnection(0, setupError);
+
+    IOException error =
+        catchThrowableOfType(() -> FileFetcher.fetchConnection(connection), IOException.class);
+
+    assertThat(error).isSameAs(setupError);
+    assertThat(connection.disconnected).isTrue();
+  }
+
+  @Test
+  void otherChecksumErrorsDoNotMarkReleaseUnavailable() {
+    CLIDownloader downloader =
+        new CLIDownloader(fetcherReturning(HttpURLConnection.HTTP_INTERNAL_ERROR));
+
+    IOException error =
+        catchThrowableOfType(() -> downloader.fetchChecksumMap("unreleased"), IOException.class);
+
+    assertThat(error)
+        .isNotInstanceOf(CLIReleaseUnavailableException.class)
+        .hasMessageContaining("500");
+  }
+
+  @Test
+  void unavailableChecksumStopsBeforeArchiveDownload() {
+    List<String> fetchedURLs = new ArrayList<>();
+    String version = "unreleased-" + UUID.randomUUID();
+    CLIDownloader downloader =
+        new CLIDownloader(
+            url -> {
+              fetchedURLs.add(url);
+              return response(HttpURLConnection.HTTP_NOT_FOUND);
+            });
+
+    IOException error =
+        catchThrowableOfType(() -> downloader.downloadCLI(version), IOException.class);
+
+    assertThat(error).isInstanceOf(CLIReleaseUnavailableException.class);
+    assertThat(fetchedURLs)
+        .containsExactly(
+            String.format("https://dl.dagger.io/dagger/releases/%s/checksums.txt", version));
+  }
+
+  @Test
+  void missingArchiveDoesNotMarkReleaseUnavailable() {
+    // Missing checksums mean the release is absent; a missing archive may be a
+    // partial or broken release, so it must remain fatal.
+    for (int statusCode :
+        new int[] {HttpURLConnection.HTTP_FORBIDDEN, HttpURLConnection.HTTP_NOT_FOUND}) {
+      CLIDownloader downloader = new CLIDownloader(fetcherReturning(statusCode));
+
+      IOException error =
+          catchThrowableOfType(
+              () ->
+                  downloader.extractCLI("archive.tar.gz", "unreleased", tempDir.resolve("dagger")),
+              IOException.class);
+
+      assertThat(error)
+          .isNotInstanceOf(CLIReleaseUnavailableException.class)
+          .hasMessageContaining(Integer.toString(statusCode));
+    }
+  }
+
+  @Test
+  void usesDaggerCLIInPathAndWarns() throws Exception {
+    String binName = isWindows() ? "dagger.exe" : "dagger";
+    Path binPath = Files.createFile(tempDir.resolve(binName));
+    assertThat(binPath.toFile().setExecutable(true)).isTrue();
+    environmentVariables.set("PATH", tempDir.toString());
+    if (isWindows()) {
+      environmentVariables.set("PATHEXT", ".EXE");
+    }
+
+    CLIReleaseUnavailableException downloadError =
+        new CLIReleaseUnavailableException("download failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    when(downloader.downloadCLI()).thenThrow(downloadError);
+    CLIRunner runner = new CLIRunner(".", false, downloader);
+
+    String actual = runner.getCLIPath();
+
+    assertThat(actual).isEqualTo(binPath.toString());
+    assertThat(systemErr.getText())
+        .startsWith(
+            String.format(
+                    "CLI version %s is unavailable; using %s from PATH (version compatibility is not guaranteed).",
+                    Provisioning.getCLIVersion(), binPath)
+                + System.lineSeparator());
+  }
+
+  @Test
+  void unrelatedDownloadErrorDoesNotFallback() throws Exception {
+    IOException downloadError = new IOException("download failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    when(downloader.downloadCLI()).thenThrow(downloadError);
+    CLIPathResolver resolver = mock(CLIPathResolver.class);
+    CLIRunner runner = runner(downloader, resolver, new ArrayList<>());
+
+    IOException error = catchThrowableOfType(runner::getCLIPath, IOException.class);
+
+    assertThat(error).isSameAs(downloadError);
+    verify(resolver, never()).findDaggerCLI();
+  }
+
+  @Test
+  void preservesDownloadAndPathErrorsWhenNoCLIIsFound() throws Exception {
+    environmentVariables.set("PATH", tempDir.toString());
+    CLIReleaseUnavailableException downloadError =
+        new CLIReleaseUnavailableException("download failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    when(downloader.downloadCLI()).thenThrow(downloadError);
+    CLIRunner runner = runner(downloader, new CLIPathResolver(), new ArrayList<>());
+
+    IOException error = catchThrowableOfType(runner::getCLIPath, IOException.class);
+
+    assertThat(error)
+        .hasMessageContaining("download failed")
+        .hasMessageContaining("dagger executable was not found");
+    assertThat(error.getCause()).isSameAs(downloadError);
+    assertThat(error.getSuppressed()).hasSize(1);
+    assertThat(error.getSuppressed()[0])
+        .isInstanceOf(IOException.class)
+        .hasMessage("dagger executable was not found");
+  }
+
+  @Test
+  void preservesDownloadAndSessionErrorsWhenFallbackHandshakeFails() throws Exception {
+    CLIReleaseUnavailableException downloadError =
+        new CLIReleaseUnavailableException("download failed");
+    RuntimeException sessionError = new RuntimeException("session failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    CLIPathResolver resolver = mock(CLIPathResolver.class);
+    when(resolver.findDaggerCLI()).thenReturn("/usr/local/bin/dagger");
+    CLIRunner runner =
+        new CLIRunner(".", false, downloader, resolver, warning -> {}) {
+          @Override
+          void streamSessionOutput() {
+            throw sessionError;
+          }
+        };
+    runner.fallbackToLocalCLI(downloadError);
+
+    RuntimeException runError = catchThrowableOfType(runner::run, RuntimeException.class);
+
+    IOException error = catchThrowableOfType(runner::getConnectionParams, IOException.class);
+
+    assertThat(runError).isSameAs(sessionError);
+    assertThat(error)
+        .hasMessageContaining("download failed")
+        .hasMessageContaining("session failed");
+    assertThat(error.getCause()).isSameAs(downloadError);
+    assertThat(error.getSuppressed()).containsExactly(sessionError);
+  }
+
+  @Test
+  void preservesDownloadErrorWhenFallbackEndsBeforeHandshake() throws Exception {
+    CLIReleaseUnavailableException downloadError =
+        new CLIReleaseUnavailableException("download failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    CLIPathResolver resolver = mock(CLIPathResolver.class);
+    when(resolver.findDaggerCLI()).thenReturn("/usr/local/bin/dagger");
+    CLIRunner runner =
+        new CLIRunner(".", false, downloader, resolver, warning -> {}) {
+          @Override
+          void streamSessionOutput() {}
+        };
+    runner.fallbackToLocalCLI(downloadError);
+
+    runner.run();
+
+    IOException error =
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(1),
+            () -> catchThrowableOfType(runner::getConnectionParams, IOException.class));
+
+    assertThat(error)
+        .hasMessageContaining("download failed")
+        .hasMessageContaining("CLI session ended before connection parameters were received");
+    assertThat(error.getCause()).isSameAs(downloadError);
+    assertThat(error.getSuppressed())
+        .singleElement()
+        .isInstanceOf(IOException.class)
+        .hasMessage("CLI session ended before connection parameters were received");
+  }
+
+  @Test
+  void preservesDownloadErrorWhenFallbackStreamClosesBeforeHandshake() throws Exception {
+    CLIReleaseUnavailableException downloadError =
+        new CLIReleaseUnavailableException("download failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    CLIPathResolver resolver = mock(CLIPathResolver.class);
+    when(resolver.findDaggerCLI()).thenReturn("/usr/local/bin/dagger");
+    CLIRunner runner =
+        new CLIRunner(".", false, downloader, resolver, warning -> {}) {
+          @Override
+          void streamSessionOutput() {
+            throw new RuntimeException(new IOException("Stream closed"));
+          }
+        };
+    runner.fallbackToLocalCLI(downloadError);
+
+    runner.run();
+
+    IOException error =
+        assertTimeoutPreemptively(
+            Duration.ofSeconds(1),
+            () -> catchThrowableOfType(runner::getConnectionParams, IOException.class));
+
+    assertThat(error)
+        .hasMessageContaining("download failed")
+        .hasMessageContaining("CLI session ended before connection parameters were received");
+    assertThat(error.getCause()).isSameAs(downloadError);
+    assertThat(error.getSuppressed())
+        .singleElement()
+        .isInstanceOf(IOException.class)
+        .hasMessage("CLI session ended before connection parameters were received");
+  }
+
+  @Test
+  void preservesDownloadAndSessionErrorsWhenFallbackProcessStartFails() throws Exception {
+    CLIReleaseUnavailableException downloadError =
+        new CLIReleaseUnavailableException("download failed");
+    IOException sessionError = new IOException("session failed");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    when(downloader.downloadCLI()).thenThrow(downloadError);
+    CLIPathResolver resolver = mock(CLIPathResolver.class);
+    when(resolver.findDaggerCLI()).thenReturn("/usr/local/bin/dagger");
+    CLIRunner runner =
+        new CLIRunner(".", false, downloader, resolver, warning -> {}) {
+          @Override
+          FluentProcess startProcess(List<String> command) throws IOException {
+            throw sessionError;
+          }
+        };
+
+    IOException error = catchThrowableOfType(runner::start, IOException.class);
+
+    assertThat(error)
+        .hasMessageContaining("download failed")
+        .hasMessageContaining("session failed");
+    assertThat(error.getCause()).isSameAs(downloadError);
+    assertThat(error.getSuppressed()).containsExactly(sessionError);
+  }
+
+  @Test
+  void explicitCLIOverrideKeepsPriority() throws Exception {
+    environmentVariables.set("_EXPERIMENTAL_DAGGER_CLI_BIN", "/explicit/dagger");
+    CLIDownloader downloader = mock(CLIDownloader.class);
+    CLIRunner runner = runner(downloader, new CLIPathResolver(), new ArrayList<>());
+
+    assertThat(runner.getCLIPath()).isEqualTo("/explicit/dagger");
+    verify(downloader, never()).downloadCLI();
+  }
+
+  @Test
+  void normalizesWindowsPathAndPathExt() {
+    List<String> candidates =
+        new CLIPathResolver()
+            .daggerCLIPathCandidates(true, "C:\\bin;;\"D:\\other bin\"", "EXE;;.CMD;");
+
+    assertThat(candidates)
+        .containsExactly(
+            "C:\\bin\\dagger.exe",
+            "C:\\bin\\dagger.cmd",
+            "D:\\other bin\\dagger.exe",
+            "D:\\other bin\\dagger.cmd");
+  }
+
+  @Test
+  void usesDefaultWindowsExecutableExtensionsWhenPathExtIsEmpty() {
+    List<String> candidates = new CLIPathResolver().daggerCLIPathCandidates(true, "C:\\bin", "");
+
+    assertThat(candidates)
+        .containsExactly(
+            "C:\\bin\\dagger.com",
+            "C:\\bin\\dagger.exe",
+            "C:\\bin\\dagger.bat",
+            "C:\\bin\\dagger.cmd");
+  }
+
+  private FileFetcher fetcherReturning(int statusCode) {
+    return url -> response(statusCode);
+  }
+
+  private FileFetcher.Response response(int statusCode) {
+    return new FileFetcher.Response(
+        statusCode, "test status", new ByteArrayInputStream(new byte[0]));
+  }
+
+  private CLIRunner runner(
+      CLIDownloader downloader, CLIPathResolver resolver, List<String> warnings) {
+    return new CLIRunner(".", false, downloader, resolver, warnings::add);
+  }
+
+  private boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase().contains("win");
+  }
+
+  private static class TrackingHttpURLConnection extends HttpURLConnection {
+    private final int responseCode;
+    private final IOException responseError;
+    private final TrackingInputStream body = new TrackingInputStream();
+    private boolean disconnected;
+
+    TrackingHttpURLConnection(int responseCode, IOException responseError) throws Exception {
+      super(new URL("http://example.test"));
+      this.responseCode = responseCode;
+      this.responseError = responseError;
+    }
+
+    @Override
+    public int getResponseCode() throws IOException {
+      if (responseError != null) {
+        throw responseError;
+      }
+      return responseCode;
+    }
+
+    @Override
+    public String getResponseMessage() {
+      return "test status";
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return body;
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return body;
+    }
+
+    @Override
+    public void disconnect() {
+      disconnected = true;
+    }
+
+    @Override
+    public boolean usingProxy() {
+      return false;
+    }
+
+    @Override
+    public void connect() {}
+  }
+
+  private static class TrackingInputStream extends ByteArrayInputStream {
+    private boolean closed;
+
+    TrackingInputStream() {
+      super(new byte[0]);
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      super.close();
+    }
+  }
+}


### PR DESCRIPTION
Implement the Java part of #13766, to fix CLI bootstrap in unreleased libs.

When the release server returns 403 or 404, fall back to `dagger` from `PATH` and emit a compatibility warning. Other download failures remain fatal.

Part of #13766.