### PR TITLE
ci: drop obsolete SkipWorkspaceModules workaround from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,8 +179,6 @@ jobs:
       - uses: docker/setup-qemu-action@v3
 
       - uses: actions/checkout@v4
-      - name: "FIXME: SkipWorkspaceModules workaround"
-        run: rm dagger.json # FIXME: general workaround that does the equivalent of SkipWorkspaceModules(). See #12932, #12933
 
       - uses: actions/setup-go@v5
         with:
@@ -336,7 +334,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Set CLI Test URL"
         run: |
-          rm dagger.json # FIXME: general workaround that does the equivalent of SkipWorkspaceModules(). See #12932, #12933
           if [ ${{ github.event_name }} == 'push' ]; then
             BASE_URL="https://${{ vars.RELEASE_FQDN }}/dagger"
             if [ $GITHUB_REF_NAME == 'main' ]; then
@@ -439,7 +436,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Set CLI Test URL"
         run: |
-          rm dagger.json # FIXME: general workaround that does the equivalent of SkipWorkspaceModules(). See #12932, #12933
           if [ ${{ github.event_name }} == 'push' ]; then
             BASE_URL="https://${{ vars.RELEASE_FQDN }}/dagger"
             if [ $GITHUB_REF_NAME == 'main' ]; then


### PR DESCRIPTION
## What

Delete the `rm dagger.json` workaround from the Test SDK Provision jobs in `.github/workflows/publish.yml` (the macos step and the two linux x86_64 occurrences), instead of updating it for the new config file name.

## Why

Main has been red since 52d61b4ad migrated the workspace config from `dagger.json` to `dagger.toml`: the workaround step now fails on every main push —

```
rm: cannot remove 'dagger.json': No such file or directory
##[error]Process completed with exit code 1.
```

e.g. https://github.com/dagger/dagger/actions/runs/30651953715 and every main push since.

The workaround itself is obsolete:

- It was added in #12933 (early April) because Python/TypeScript SDK sessions auto-loaded the repo's workspace modules during provision tests.
- One week later, c41d6707d (#12983) made workspace module loading **opt-in**: `dagger session` only loads workspace modules when `--load-workspace-modules` is passed, and no SDK passes it during provisioning.
- Evidence it's safe: the python and TypeScript **arm64** provision jobs never had the workaround, run the same module-load tests, and pass green today with the workspace config present in the checkout.

Note: the Publish workflow only triggers on main/tag pushes, so this proves itself on the first push to main after merge.