### PR TITLE
sdk/php: harden CLI PATH fallback

### DIFF
--- a/sdk/php/src/Connection/ProcessSessionConnection.php
+++ b/sdk/php/src/Connection/ProcessSessionConnection.php
@@ -191,6 +191,16 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
                 'dagger CLI not found in PATH',
             );
         }
+        if (!self::isAbsolutePath($binPath)) {
+            throw new CliFallbackFailed(
+                $downloadError,
+                new RuntimeException(sprintf(
+                    'cannot run dagger executable found relative to the current directory: %s',
+                    $binPath,
+                )),
+                'dagger CLI not found in PATH',
+            );
+        }
 
         $warning = sprintf(
             'CLI version %s is unavailable; using %s from PATH (version compatibility is not guaranteed).',
@@ -198,7 +208,10 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
             $binPath,
         );
         if ($this->logger instanceof NullLogger) {
-            fwrite($this->warningOutput(), $warning . PHP_EOL);
+            $output = $this->warningOutput();
+            if (is_resource($output)) {
+                fwrite($output, $warning . PHP_EOL);
+            }
         } else {
             $this->logger->warning($warning);
         }
@@ -206,9 +219,18 @@ class ProcessSessionConnection extends Connection implements LoggerAwareInterfac
         return $binPath;
     }
 
-    /** @return resource */
+    /** @return resource|false */
     protected function warningOutput()
     {
-        return STDERR;
+        // STDERR is only defined under the CLI SAPI; web SAPIs (fpm, mod_php)
+        // need an explicit stream.
+        return defined('STDERR') ? STDERR : fopen('php://stderr', 'w');
+    }
+
+    private static function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || 1 === preg_match('#^[A-Za-z]:[/\\\\]#', $path);
     }
 }

--- a/sdk/php/tests/Unit/Connection/CliFallbackTest.php
+++ b/sdk/php/tests/Unit/Connection/CliFallbackTest.php
@@ -193,6 +193,27 @@ final class CliFallbackTest extends TestCase
     }
 
     #[Test]
+    public function itRefusesADaggerCliFoundRelativeToTheCurrentDirectory(): void
+    {
+        $this->createDaggerExecutable();
+        $previousCwd = getcwd();
+        self::assertNotFalse($previousCwd);
+        chdir($this->tempDir);
+        putenv('PATH=bin');
+        $downloadError = new CliReleaseUnavailable('download failed');
+
+        try {
+            $error = $this->catchError(fn() => $this->newConnection()->fallbackToLocalCli($downloadError));
+        } finally {
+            chdir($previousCwd);
+        }
+
+        self::assertInstanceOf(CliFallbackFailed::class, $error);
+        self::assertSame($downloadError, $error->getDownloadError());
+        self::assertStringContainsString('relative to the current directory', (string) $error);
+    }
+
+    #[Test]
     public function itPreservesDownloadAndSessionErrorsWhenTheFallbackFailsToStart(): void
     {
         $binPath = $this->createDaggerExecutable();


### PR DESCRIPTION
### What was broken

Two failure modes in the CLI PATH fallback added in e1b1bb01f (used when the pinned CLI release can't be downloaded).

**1. Web apps crashed on the fallback warning.** PHP only defines the `STDERR` constant under the CLI SAPI. The fallback warning (default logger) wrote to it unconditionally, so under php-fpm, Apache or `php -S`, the fallback died right when it was about to work:

```
Fatal error: Uncaught Error: Undefined constant "STDERR"
  in src/Connection/ProcessSessionConnection.php:212
```

**2. The fallback could execute `./dagger` from the current directory.** Symfony's `ExecutableFinder` returns relative candidates when PATH contains `.` or a relative entry. Running the SDK inside an untrusted checkout that ships a file named `dagger` would execute that file. Go refuses this since 1.19 (`exec.LookPath` returns `ErrDot`), and the TypeScript SDK throws explicitly.

### The fix

- Warning: use `STDERR` when defined, otherwise `fopen('php://stderr')`; if no stream can be opened, skip the warning — it is never fatal.
- Relative candidates: refuse them with the same error TypeScript uses, keeping the original download error attached like every other failure path:

```
cannot run dagger executable found relative to the current directory: ./dagger
```

### Repro

The STDERR crash, verified before/after under the web SAPI (needs any `dagger` on PATH so the fallback reaches the warning):

```shell
cd sdk/php && composer install
cat > /tmp/repro.php <<'EOF'
<?php
require getenv('SDK_DIR') . '/vendor/autoload.php';
$conn = new \Dagger\Connection\ProcessSessionConnection(getcwd(), false, new \Dagger\Connection\CliDownloader());
$bin = $conn->fallbackToLocalCli(new \Dagger\Exception\CliReleaseUnavailable('release unavailable'));
echo "fallback ok: $bin";
EOF
SDK_DIR=$PWD php -S 127.0.0.1:8080 /tmp/repro.php &
curl -s 127.0.0.1:8080
# before: Fatal error: Uncaught Error: Undefined constant "STDERR" ... ProcessSessionConnection.php:212
# after:  fallback ok: /usr/local/bin/dagger
#         (server stderr: CLI version 1.0.0-beta.8 is unavailable; using /usr/local/bin/dagger from PATH ...)
```

The relative-path mechanism in isolation — this is the value the fallback fed to `Process` before:

```shell
mkdir -p /tmp/evil && printf '#!/bin/sh\necho pwned\n' > /tmp/evil/dagger && chmod +x /tmp/evil/dagger
cd /tmp/evil
PATH=. php -r 'require "'$OLDPWD'/vendor/autoload.php";
  var_dump((new Symfony\Component\Process\ExecutableFinder())->find("dagger"));'
# string(8) "./dagger"   <- executed before this PR; rejected now
```

### Testing

```shell
cd sdk/php && vendor/bin/phpunit tests/Unit/Connection/CliFallbackTest.php
# OK (12 tests, 35 assertions)
```

New test `itRefusesADaggerCliFoundRelativeToTheCurrentDirectory`: a fake `dagger` reachable only through a relative PATH entry is rejected. The existing fallback tests keep proving the absolute-path case works and pin the warning text (they override `warningOutput()`, so they're unaffected by its new default).