### PR TITLE
sdk/rust: error instead of hanging when session emits no connect params

### DIFF
--- a/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
@@ -146,15 +146,21 @@ impl InnerCliSession {
             loop {
                 tokio::select! {
                     line = stdout_bufr.next_line() => {
-                        if let Ok(Some(line)) = line {
-                            if let Ok(conn) = serde_json::from_str::<ConnectParams>(&line) {
-                                sender.send(conn).await.unwrap();
-                                continue;
-                            }
+                        match line {
+                            Ok(Some(line)) => {
+                                if let Ok(conn) = serde_json::from_str::<ConnectParams>(&line) {
+                                    sender.send(conn).await.unwrap();
+                                    continue;
+                                }
 
-                            if let Some(logger) = &logger {
-                                logger.stdout(&line).unwrap();
+                                if let Some(logger) = &logger {
+                                    logger.stdout(&line).unwrap();
+                                }
                             }
+                            // EOF or read error: the process is gone, so stop
+                            // reading; dropping the sender lets get_conn fail
+                            // instead of waiting forever.
+                            _ => break,
                         }
                     },
                     _ = rx.recv() => {
@@ -175,10 +181,13 @@ impl InnerCliSession {
             loop {
                 tokio::select! {
                     line = stderr_bufr.next_line() => {
-                        if let Ok(Some(line)) = line {
-                            if let Some(logger) = &logger {
-                                logger.stderr(&line).unwrap();
+                        match line {
+                            Ok(Some(line)) => {
+                                if let Some(logger) = &logger {
+                                    logger.stderr(&line).unwrap();
+                                }
                             }
+                            _ => break,
                         }
                     },
                     _ = rx.recv() => {

--- a/sdk/rust/crates/dagger-sdk/src/core/engine.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/engine.rs
@@ -297,7 +297,10 @@ mod tests {
         .await
         .expect("a session exiting without connect params must error, not hang");
 
-        let error = result.unwrap_err();
+        let error = match result {
+            Ok(_) => panic!("expected fallback session to fail"),
+            Err(error) => error,
+        };
         assert!(format!("{error:#}").contains("could not receive ok signal"));
     }
 

--- a/sdk/rust/crates/dagger-sdk/src/core/engine.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/engine.rs
@@ -137,14 +137,9 @@ fn fallback_to_local_cli(
         bin_path.display()
     );
     if let Some(logger) = logger {
-        if let Err(fallback_error) = logger.stderr(&warning) {
-            return Err(CliPathFallbackError {
-                download_error,
-                fallback_context: "failed to emit CLI compatibility warning".into(),
-                fallback_error,
-            }
-            .into());
-        }
+        // A failed warning write shouldn't turn a usable fallback into an
+        // error; go/python/typescript ignore it too.
+        let _ = logger.stderr(&warning);
     } else {
         eprintln!("{warning}");
     }
@@ -272,6 +267,38 @@ mod tests {
         assert!(rendered.contains("CLI release unavailable"));
         assert!(rendered.contains("https://example.test/checksums.txt"));
         assert!(rendered.contains(&format!("failed to use CLI from PATH {bin_path:?}")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fallback_session_exiting_without_params_errors_instead_of_hanging() {
+        let temp_dir = TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("dagger");
+        let mut file = File::create(&bin_path).unwrap();
+        file.write_all(b"#!/bin/sh\nexit 1\n").unwrap();
+        let mut permissions = file.metadata().unwrap().permissions();
+        permissions.set_mode(0o700);
+        file.set_permissions(permissions).unwrap();
+        drop(file);
+
+        let _path_lock = path_lock();
+        let _path = PathGuard::set(temp_dir.path());
+        let logger: DynLogger = Arc::new(TestLogger::default());
+        let cfg = Config::builder().logger(logger).build();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            Engine::new().connect_provisioned_cli(
+                &cfg,
+                "unreleased",
+                Err(unavailable_download_error()),
+            ),
+        )
+        .await
+        .expect("a session exiting without connect params must error, not hang");
+
+        let error = result.unwrap_err();
+        assert!(format!("{error:#}").contains("could not receive ok signal"));
     }
 
     fn unavailable_download_error() -> DaggerError {


### PR DESCRIPTION
### What was broken

Since 3af634875, when the pinned CLI release can't be downloaded, the SDK falls back to whatever `dagger` is on PATH. If that binary exits without printing connect params — an old CLI printing usage, or an unrelated binary that happens to be named `dagger` — `connect()` hung forever, spinning a read loop at 100% CPU. Go, Python and TypeScript return an error in the same situation.

### Why it happened

After spawning `dagger session`, `get_conn` reads the child's stdout until a JSON line with the connect params appears. The read loop treated EOF as "try again", not "the process is gone", so it re-polled forever and the channel never resolved. That was harmless while the SDK only ever spawned a CLI it had just downloaded — that binary always prints params. The PATH fallback made "binary exits silently" a reachable case.

### The fix

Break the read loops on EOF or read error. The channel sender drops, `recv()` returns `None`, and the pre-existing error surfaces — no new error path:

```
could not receive ok signal from dagger-engine
```

wrapped with the original download error, so the user sees both why the download failed and why the fallback binary didn't work.

Also a drive-by alignment: a failed write of the compatibility warning no longer aborts an otherwise working fallback (Go/Python/TypeScript ignore that error too).

### Repro

The new test runs the real connect path against a fake `dagger` that exits silently. To see the bug, run it with the fix reverted — same test, old reader loop:

```shell
cd sdk/rust
git checkout origin/main -- crates/dagger-sdk/src/core/cli_session.rs
cargo test -p dagger-sdk fallback_session_exiting_without_params
# fails after its 30s guard: "a session exiting without connect params must error, not hang"

git checkout HEAD -- crates/dagger-sdk/src/core/cli_session.rs
cargo test -p dagger-sdk fallback_session_exiting_without_params
# passes immediately with the error above
```

Real-world equivalent: an old `dagger` on PATH plus a pinned SDK version with no published release (e.g. building against an unreleased tag).

### Testing

New test `fallback_session_exiting_without_params_errors_instead_of_hanging`, guarded by a 30s timeout so a regression fails CI instead of hanging it. `rust-sdk:test` runs the suite in CI:

```shell
cd sdk/rust && cargo test -p dagger-sdk
```