### PR TITLE
fix: reopen snapshot ref for no-op withChanges

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -2824,7 +2824,19 @@ func (dir *Directory) WithChanges(ctx context.Context, parent dagql.ObjectResult
 			dir.Snapshot.setValue(scratchSnapshot)
 			return nil
 		}
-		dir.Snapshot.setValue(currentSnapshot)
+		// Reopen rather than sharing the parent's ref instance: each cached
+		// Directory value owns its snapshot handle and releases it when its
+		// cache entry is collected, so sharing one instance would let this
+		// result's collection invalidate the parent's still-cached snapshot.
+		query, err := CurrentQuery(ctx)
+		if err != nil {
+			return err
+		}
+		reopened, err := query.SnapshotManager().GetBySnapshotID(ctx, currentSnapshot.SnapshotID(), bkcache.NoUpdateLastUsed)
+		if err != nil {
+			return err
+		}
+		dir.Snapshot.setValue(reopened)
 		return nil
 	}
 

--- a/core/integration/changeset_test.go
+++ b/core/integration/changeset_test.go
@@ -10,8 +10,10 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/testutil"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -848,6 +850,68 @@ func (s ChangesetSuite) TestWithChanges(ctx context.Context, t *testctx.T) {
 		return dest.WithChanges(source)
 	}, false)
 	s.testWithChangesSymlinks(t)
+}
+
+// Regression test for a snapshot use-after-release: Directory.withChanges with
+// an empty changeset used to store the parent's snapshot ref instance on the
+// derived directory instead of opening its own handle. Once the derived cache
+// entry was collected (session close plus cache prune), releasing its snapshot
+// handle invalidated the parent's still-cached snapshot, and every later use
+// of the parent from any session failed with "invalid immutable ref". A
+// dedicated nested engine is used because the repro requires an unrestricted
+// prune of the engine-wide cache.
+func (ChangesetSuite) TestWithChangesEmptyChangesetKeepsParentSnapshot(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	engineSvc, err := c.Host().Tunnel(devEngineContainerAsService(devEngineContainer(c))).Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { engineSvc.Stop(ctx) })
+	endpoint, err := engineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{Scheme: "tcp"})
+	require.NoError(t, err)
+
+	keeper, err := dagger.Connect(ctx,
+		dagger.WithRunnerHost(endpoint),
+		dagger.WithLogOutput(testutil.NewTWriter(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() { keeper.Close() })
+
+	parentOf := func(cl *dagger.Client) *dagger.Directory {
+		return cl.Directory().WithNewFile("marker.txt", "shared parent")
+	}
+
+	// keeper takes shared ownership of the parent's cache entry so it outlives
+	// the second session below.
+	_, err = parentOf(keeper).Sync(ctx)
+	require.NoError(t, err)
+
+	// A second session derives a directory from the same parent by applying an
+	// empty changeset, evaluates it, and disconnects.
+	poisoner, err := dagger.Connect(ctx,
+		dagger.WithRunnerHost(endpoint),
+		dagger.WithLogOutput(testutil.NewTWriter(t)))
+	require.NoError(t, err)
+	_, err = parentOf(poisoner).WithChanges(poisoner.Changeset()).Sync(ctx)
+	require.NoError(t, err)
+	require.NoError(t, poisoner.Close())
+
+	// The closed session's cache refs release asynchronously, and the derived
+	// entry is only collected once a prune removes its persisted edge. Keep
+	// pruning and re-mounting the parent long enough to cover both; with the
+	// shared-handle bug the glob fails with "invalid immutable ref" as soon as
+	// the derived entry is collected.
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		require.NoError(t, keeper.Engine().LocalCache().Prune(ctx))
+		// Vary the pattern so each call is a fresh (uncached) evaluation that
+		// has to mount the parent snapshot.
+		pattern := fmt.Sprintf("*%d*", time.Now().UnixNano())
+		_, err := parentOf(keeper).Glob(ctx, pattern)
+		require.NoError(t, err)
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func (s ChangesetSuite) TestChangesAsPatch(ctx context.Context, t *testctx.T) {


### PR DESCRIPTION
## Problem

Once an empty changeset is applied anywhere on an engine, the engine can enter a state where every use of the parent directory — from any session — fails with `invalid immutable ref 0x...: invalid` until the engine restarts. In practice the poisoned parent is often the shared scratch directory (`Query.directory`), since SDK generators build outputs as `dag.directory().withChanges(cs)` and workspace staging overlays apply changesets onto the workspace root, both frequently with empty changesets. First observed as `dagger generate` failing repeatedly, with even a bare `dagger core directory entries` failing on the same engine.

## Root cause

`Directory.WithChanges` has a fast path for an empty changeset that stored the parent's snapshot ref *instance* on the derived directory (`dir.Snapshot.setValue(currentSnapshot)`), introduced in #13342. Every cached `Directory` value owns its snapshot handle and releases it in `Directory.OnRelease` when its dagql cache entry is collected. Because the derived result shared the parent's handle, collecting the derived entry — e.g. disk-pressure GC pruning its persisted edge after its creating session closed — released the handle out from under the parent's still-cached, still-owned entry. Every subsequent mount of the parent then failed the `released` check in `immutableRef.Mount`.

Instrumented runs showed the signature clearly: one real release of the shared handle from `gc → Prune → removePersistedEdge → collect → Directory.OnRelease`, followed by dozens of no-op re-releases of the same pointer as other empty-`withChanges` derivatives of the same parent were collected. Before #13342 even no-op merges went through `SnapshotManager.Merge`, which returns a fresh handle in all paths, so no sharing occurred.

## Fix

The empty-changeset path now reopens its own handle via `SnapshotManager().GetBySnapshotID(...)`, the same convention `subdirectory`, `diff`, and the container rootfs clone helper already follow. An audit of every other `Snapshot.setValue` site in `core/` found no other instance-sharing violation.

## Testing

New regression test `TestChangeset/TestWithChangesEmptyChangesetKeepsParentSnapshot`: two sessions against a nested dev engine — one holds the parent entry, the other applies an empty changeset and disconnects — then a prune loop re-mounts the parent. Verified both ways: it fails with `invalid immutable ref` on the unfixed code and passes with the fix. Also validated end to end on a dev engine: repeated `dagger generate` runs across sessions plus explicit prunes no longer reproduce the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
