### PR TITLE
sdk/go: add explicit marshal/unmarshal seam (IDClient, MarshalJSON, UnmarshalJSON)

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -244,7 +244,10 @@ func mainSrc(checkVersionCompatibility func(string) bool) string {
 
 	// A lot of the "work" actually happens when we're marshalling the return
 	// value, which entails getting object IDs, which happens in MarshalJSON,
-	// which has no ctx argument, so we use this lovely global variable.
+	// which has no ctx argument. The explicit call sites below use
+	// dagger.MarshalJSON/dagger.UnmarshalJSON to scope that state to each
+	// operation; this call remains so that user code that marshals Dagger
+	// objects directly (e.g. via json.Marshal) keeps working.
 	setMarshalContext(ctx)
 
 	fnCall := dag.CurrentFunctionCall()
@@ -290,7 +293,7 @@ func mainSrc(checkVersionCompatibility func(string) bool) string {
 	if err != nil {
 		return err
 	}
-	resultBytes, err := json.Marshal(result)
+	resultBytes, err := dagger.MarshalJSON(ctx, result)
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
@@ -610,7 +613,7 @@ func (ps *parseState) fillObjectFunctionCase(
 	parentVarName := "parent"
 	statements = append(statements,
 		Var().Id(parentVarName).Id(objName),
-		Err().Op("=").Qual("json", "Unmarshal").Call(Id(parentJSONVar), Op("&").Id(parentVarName)),
+		Err().Op("=").Qual("dagger", "UnmarshalJSON").Call(Id("dag"), Id(parentJSONVar), Op("&").Id(parentVarName)),
 		checkErrStatement("failed to unmarshal parent object"),
 	)
 
@@ -664,7 +667,8 @@ func (ps *parseState) fillObjectFunctionCase(
 
 		statements = append(statements,
 			If(Id(inputArgsVar).Index(Lit(spec.name)).Op("!=").Nil()).Block(
-				Err().Op("=").Qual("json", "Unmarshal").Call(
+				Err().Op("=").Qual("dagger", "UnmarshalJSON").Call(
+					Id("dag"),
 					Index().Byte().Parens(Id(inputArgsVar).Index(Lit(spec.name))),
 					Op("&").Add(target),
 				),

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -34,11 +35,65 @@ func Tracer() trace.Tracer {
 // reassigned at runtime after the span is initialized
 var marshalCtx = context.Background()
 
+// marshalMu serializes swaps of the package-level marshaling state
+// (marshalCtx{{ if IsModuleCode }} and dag{{ end }}) performed by MarshalJSON{{ if IsModuleCode }} and UnmarshalJSON{{ end }}.
+var marshalMu sync.Mutex
+
 {{ if IsModuleCode }}
 // SetMarshalContext is a hack that lets us set the ctx to use for
 // MarshalJSON implementations that get an object's ID.
+//
+// Deprecated: use MarshalJSON, which scopes the context to a single
+// marshaling operation instead of mutating package-level state.
 func SetMarshalContext(ctx context.Context) {
 	marshalCtx = ctx
+}
+{{ end }}
+
+// IDClient is the minimal client surface needed to reconstruct Dagger
+// objects from their IDs. *Client implements it.
+type IDClient interface {
+	// QueryBuilder returns the root query builder, bound to the client's
+	// underlying GraphQL client.
+	QueryBuilder() *querybuilder.Selection
+	// GraphQLClient returns the underlying graphql.Client.
+	GraphQLClient() graphql.Client
+}
+
+// MarshalJSON serializes v to JSON, resolving any Dagger objects it contains
+// to their IDs using the given ctx.
+//
+// Prefer this over calling json.Marshal directly on values containing Dagger
+// objects: their MarshalJSON implementations must query the API to resolve
+// IDs, and this function makes the context used for those queries explicit.
+func MarshalJSON(ctx context.Context, v any) ([]byte, error) {
+	marshalMu.Lock()
+	defer marshalMu.Unlock()
+	prevCtx := marshalCtx
+	marshalCtx = ctx
+	defer func() { marshalCtx = prevCtx }()
+	return json.Marshal(v)
+}
+
+{{ if IsModuleCode }}
+// UnmarshalJSON deserializes JSON data into v, reconstructing any Dagger
+// objects it contains from their IDs using the given client.
+//
+// Prefer this over calling json.Unmarshal directly on data containing Dagger
+// object IDs: their UnmarshalJSON implementations need a client to
+// reconstruct objects, and this function makes that client explicit.
+func UnmarshalJSON(c IDClient, data []byte, v any) error {
+	marshalMu.Lock()
+	defer marshalMu.Unlock()
+	prevDag := dag
+	dag = &Client{
+		Query: &Query{
+			query: c.QueryBuilder(),
+		},
+		client: c.GraphQLClient(),
+	}
+	defer func() { dag = prevDag }()
+	return json.Unmarshal(data, v)
 }
 {{ end }}
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -22,6 +24,35 @@ func Tracer() trace.Tracer {
 
 // reassigned at runtime after the span is initialized
 var marshalCtx = context.Background()
+
+// marshalMu serializes swaps of the package-level marshaling state
+// (marshalCtx) performed by MarshalJSON.
+var marshalMu sync.Mutex
+
+// IDClient is the minimal client surface needed to reconstruct Dagger
+// objects from their IDs. *Client implements it.
+type IDClient interface {
+	// QueryBuilder returns the root query builder, bound to the client's
+	// underlying GraphQL client.
+	QueryBuilder() *querybuilder.Selection
+	// GraphQLClient returns the underlying graphql.Client.
+	GraphQLClient() graphql.Client
+}
+
+// MarshalJSON serializes v to JSON, resolving any Dagger objects it contains
+// to their IDs using the given ctx.
+//
+// Prefer this over calling json.Marshal directly on values containing Dagger
+// objects: their MarshalJSON implementations must query the API to resolve
+// IDs, and this function makes the context used for those queries explicit.
+func MarshalJSON(ctx context.Context, v any) ([]byte, error) {
+	marshalMu.Lock()
+	defer marshalMu.Unlock()
+	prevCtx := marshalCtx
+	marshalCtx = ctx
+	defer func() { marshalCtx = prevCtx }()
+	return json.Marshal(v)
+}
 
 // assertNotNil panic if the given value is nil.
 // This function is used to validate that input with pointer type are not nil.


### PR DESCRIPTION
## What

Adds an explicit marshal/unmarshal seam to the Go SDK and generated module code, in all codegen modes (library, module, standalone client):

- **`IDClient`** — the minimal client surface needed to reconstruct Dagger objects from their IDs (`QueryBuilder()`, `GraphQLClient()`). `*Client` already implements it in all three modes; no generated code changes were needed for that.
- **`MarshalJSON(ctx, v)`** — marshals `v`, scoping the ID-resolution context to this single call (mutex-guarded swap of `marshalCtx`).
- **`UnmarshalJSON(c, data, v)`** (module mode) — unmarshals `data`, reconstructing objects through the given client (mutex-guarded swap of `dag`).

The generated module dispatch now expresses its dependencies explicitly: parent state and input args unmarshal via `dagger.UnmarshalJSON(dag, ...)`, and function results marshal via `dagger.MarshalJSON(ctx, ...)`.

`SetMarshalContext` remains (deprecated) so user code that calls `json.Marshal` directly on Dagger objects keeps working with the dispatch context; it can be dropped once the per-type `UnmarshalJSON` methods go away.

## Why

Generated code currently relies on package-level globals (`marshalCtx`, `dag`) set once per dispatch via `SetMarshalContext`. This couples core types to module-specific global state, and is one of the blockers for sharing core types via `dagger.io/dagger` instead of regenerating them under `internal/dagger` in every module (see the [Go codegen v2 proposal](https://gist.github.com/TomChv/86d8b19468642153eb8f003e1023b876), related: #11417, #11547).

With this seam in place, the globals can later be removed (e.g. via json/v2 marshalers — see the stacked follow-up PR) without touching generated call sites again.

## Behavior

Unchanged. The helpers swap the same globals the per-type methods read today; wire behavior is identical.

## Test plan

- `sdk/go` builds; regenerated `sdk/go/dagger.gen.go` matches template output.
- Module-mode output (all dispatch call sites + helpers) compiles against a generated-module fixture.
- `go run ./cmd/codegen generate-library` produces output whose static section is byte-identical to the committed `sdk/go/dagger.gen.go`.
- Needs a maintainer/CI pass for: `dagger generate` round-trip on a real module and the integration suite (module codegen requires an engine connection).

## Notes for reviewers

- The `IDClient` methods reuse the already-exported `QueryBuilder()`/`GraphQLClient()` accessors, so the interface is satisfied by embedding — any future wrapper client type gets it for free.
- Part 1 of a stack; part 2 adds json/v2 `Marshalers`/`Unmarshalers` on top of `IDClient`.
