### PR TITLE
Support user-level workspace config keyed by Git remote

### DIFF
--- a/core/integration/workspace_user_config_test.go
+++ b/core/integration/workspace_user_config_test.go
@@ -1,0 +1,330 @@
+package core
+
+// These tests cover user-level workspace configuration: personal overrides
+// kept outside the repository in the user's Dagger config file
+// (~/.config/dagger/config.toml, or $DAGGER_CONFIG), keyed by the workspace's
+// normalized Git remote. User-level values merge over the repository's
+// dagger.toml without modifying it, and may add personal environments.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+const userConfigWorkspaceFixture = `[modules.aws]
+source = "github.com/dagger/aws"
+
+[modules.aws.settings]
+profile = "shared"
+region = "us-east-1"
+
+[env.staging.modules.aws.settings]
+profile = "staging"
+`
+
+// newUserConfigWorkdir builds a git workspace with an origin remote and the
+// shared fixture config, plus a user-level config file outside the repo.
+// It returns the workdir and the user config path to pass via $DAGGER_CONFIG.
+func newUserConfigWorkdir(ctx context.Context, t *testctx.T, originURL, userConfigTOML string) (string, string) {
+	t.Helper()
+
+	workdir := newWorkspaceConfigWorkdir(ctx, t, userConfigWorkspaceFixture)
+	if originURL != "" {
+		gitCmd := exec.Command("git", "remote", "add", "origin", originURL)
+		gitCmd.Dir = workdir
+		gitOutput, err := gitCmd.CombinedOutput()
+		require.NoError(t, err, string(gitOutput))
+	}
+
+	userConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	if userConfigTOML != "" {
+		require.NoError(t, os.WriteFile(userConfigPath, []byte(userConfigTOML), 0o600))
+	}
+	return workdir, userConfigPath
+}
+
+// hostDaggerUserConfigExec runs the CLI with $DAGGER_CONFIG pointing at the
+// given user-level config path.
+func hostDaggerUserConfigExec(ctx context.Context, t *testctx.T, workdir, userConfigPath string, args ...string) ([]byte, error) {
+	t.Helper()
+
+	cmd := hostDaggerCommandRaw(ctx, t, workdir, append([]string{"--progress=report"}, args...)...)
+	cmd.Env = append(cmd.Env, "DAGGER_CONFIG="+userConfigPath)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("%s%s: %w", stdout.String(), stderr.String(), err)
+	}
+	return stdout.Bytes(), err
+}
+
+func (WorkspaceSuite) TestWorkspaceUserConfig(ctx context.Context, t *testctx.T) {
+	t.Run("user settings merge over repo config", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."github.com/acme/user-config-test".modules.aws.settings]
+profile = "alice-dev"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", strings.TrimSpace(string(out)))
+
+		// Keys the user did not override keep their repo values.
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
+
+		// The repository config file itself is never modified.
+		repoConfig, err := os.ReadFile(filepath.Join(workdir, "dagger.toml"))
+		require.NoError(t, err)
+		require.Equal(t, userConfigWorkspaceFixture, string(repoConfig))
+	})
+
+	t.Run("equivalent remote URL forms match", func(ctx context.Context, t *testctx.T) {
+		// Repo origin is scp-style ssh; the user config keys the same remote
+		// in https form with a .git suffix.
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."https://github.com/acme/user-config-test.git".modules.aws.settings]
+profile = "alice-dev"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("user config can add a personal env", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."github.com/acme/user-config-test".env.dev.modules.aws.settings]
+profile = "alice-dev"
+region = "us-west-2"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=dev", "workspace", "config", "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
+
+		// Without env selection, the user-added env is visible in the merged
+		// config view alongside the repo's own envs.
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config")
+		require.NoError(t, err)
+		require.Contains(t, string(out), "[env.dev.modules.aws.settings]")
+		require.Contains(t, string(out), "[env.staging.modules.aws.settings]")
+	})
+
+	t.Run("user env merges over repo env", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."github.com/acme/user-config-test".env.staging.modules.aws.settings]
+region = "eu-west-1"
+`)
+
+		// Repo env value survives; user env value layers on top.
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=staging", "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "staging", strings.TrimSpace(string(out)))
+
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=staging", "workspace", "config", "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "eu-west-1", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("overrides for other workspaces do not apply", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", `
+[workspaces."github.com/acme/other".modules.aws.settings]
+profile = "alice-dev"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "shared", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("workspace without a remote never matches", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t, "", `
+[workspaces."github.com/acme/user-config-test".modules.aws.settings]
+profile = "alice-dev"
+`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "shared", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("settings display includes user values", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+entrypoint = true
+
+[modules.aws.settings]
+region = "us-east-1"
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+		gitCmd := exec.Command("git", "remote", "add", "origin", "git@github.com:acme/user-config-test.git")
+		gitCmd.Dir = workdir
+		gitOutput, err := gitCmd.CombinedOutput()
+		require.NoError(t, err, string(gitOutput))
+
+		userConfigPath := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(userConfigPath, []byte(`
+[workspaces."github.com/acme/user-config-test".modules.aws.settings]
+region = "us-west-2"
+
+[workspaces."github.com/acme/user-config-test".env.dev.modules.aws.settings]
+region = "eu-west-1"
+`), 0o600))
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
+
+		// The selected env overlay still layers over the user-level value.
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=dev", "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "eu-west-1", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("missing user config file behaves as before", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", "")
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "shared", strings.TrimSpace(string(out)))
+	})
+}
+
+func (WorkspaceSuite) TestWorkspaceUserConfigWrites(ctx context.Context, t *testctx.T) {
+	t.Run("workspace config --global set, read back, unset", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", "")
+
+		_, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "-g", "modules.aws.settings.profile", "alice-dev")
+		require.NoError(t, err)
+
+		// The write landed in the user config file, keyed canonically, and the
+		// repository config is untouched.
+		userConfig, err := os.ReadFile(userConfigPath)
+		require.NoError(t, err)
+		require.Contains(t, string(userConfig), `github.com/acme/user-config-test`)
+		require.Contains(t, string(userConfig), `profile = "alice-dev"`)
+		repoConfig, err := os.ReadFile(filepath.Join(workdir, "dagger.toml"))
+		require.NoError(t, err)
+		require.Equal(t, userConfigWorkspaceFixture, string(repoConfig))
+
+		// Effective reads show the user-level value.
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", strings.TrimSpace(string(out)))
+
+		// Unset removes it and the effective value falls back to the repo's.
+		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "-g", "-u", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "shared", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("workspace config --global with --env targets a personal env", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", "")
+
+		_, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=dev", "workspace", "config", "-g", "modules.aws.settings.region", "us-west-2")
+		require.NoError(t, err)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=dev", "workspace", "config", "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
+
+		// Without the env selected, the base value still applies.
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
+	})
+
+	t.Run("workspace config --global rejects reads and non-settings keys", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t,
+			"git@github.com:acme/user-config-test.git", "")
+
+		_, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "-g", "modules.aws.settings.profile")
+		require.Error(t, err)
+		requireErrOut(t, err, "--global writes to user-level config")
+
+		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "-g", "modules.aws.source", "elsewhere")
+		require.Error(t, err)
+		requireErrOut(t, err, "cannot be stored in user-level config")
+	})
+
+	t.Run("workspace config --global requires a git remote", func(ctx context.Context, t *testctx.T) {
+		workdir, userConfigPath := newUserConfigWorkdir(ctx, t, "", "")
+
+		_, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "workspace", "config", "-g", "modules.aws.settings.profile", "alice-dev")
+		require.Error(t, err)
+		requireErrOut(t, err, "user-level config is keyed by the workspace's git remote")
+	})
+
+	t.Run("settings --global set, read back, unset", func(ctx context.Context, t *testctx.T) {
+		// [env.dev] exists in repo config: like repository-side env-scoped
+		// settings writes, --env with settings requires the env to exist
+		// (create one from scratch with `workspace config -g env.<name>...`).
+		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules.aws]
+source = "modules/aws"
+entrypoint = true
+
+[modules.aws.settings]
+region = "us-east-1"
+
+[env.dev]
+`, workspaceSettingsAWSModule("modules/aws", "aws"))
+		gitCmd := exec.Command("git", "remote", "add", "origin", "git@github.com:acme/user-config-test.git")
+		gitCmd.Dir = workdir
+		gitOutput, err := gitCmd.CombinedOutput()
+		require.NoError(t, err, string(gitOutput))
+		userConfigPath := filepath.Join(t.TempDir(), "config.toml")
+
+		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "-g", "aws", "region", "us-west-2")
+		require.NoError(t, err)
+
+		userConfig, err := os.ReadFile(userConfigPath)
+		require.NoError(t, err)
+		require.Contains(t, string(userConfig), `region = "us-west-2"`)
+
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
+
+		// --env scoping composes with --global.
+		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=dev", "settings", "-g", "aws", "region", "eu-west-1")
+		require.NoError(t, err)
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=dev", "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "eu-west-1", strings.TrimSpace(string(out)))
+
+		// Unset targets only the user-level value.
+		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "-g", "-u", "aws", "region")
+		require.NoError(t, err)
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "aws", "region")
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
+
+		// A read invocation with --global is rejected.
+		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "-g", "aws", "region")
+		require.Error(t, err)
+		requireErrOut(t, err, "--global stores a setting in user-level config")
+	})
+}

--- a/core/integration/workspace_user_config_test.go
+++ b/core/integration/workspace_user_config_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"dagger.io/dagger"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -326,5 +327,65 @@ region = "us-east-1"
 		_, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "settings", "-g", "aws", "region")
 		require.Error(t, err)
 		requireErrOut(t, err, "--global stores a setting in user-level config")
+	})
+}
+
+// TestWorkspaceUserConfigRemoteWorkspace covers user-level writes and reads
+// against a remote workspace selected with -W: the key derives from the
+// declared clone address (version dropped), the write lands in the caller's
+// user config file, and effective reads apply the overlay.
+func (WorkspaceSuite) TestWorkspaceUserConfigRemoteWorkspace(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	hostDir := t.TempDir()
+	writeWorkspaceSettingsModule(t, hostDir, workspaceSettingsAWSModule("modules/aws", "aws"))
+	writeWorkspaceConfigFile(t, hostDir, `[modules.aws]
+source = "modules/aws"
+entrypoint = true
+
+[modules.aws.settings]
+region = "us-east-1"
+`)
+	remoteRef := workspaceSelectionRemoteRef(ctx, t, c, c.Host().Directory(hostDir))
+
+	userConfigDaggerExec := func(ctr *dagger.Container, args ...string) *dagger.Container {
+		return ctr.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
+			UseEntrypoint:                 true,
+			ExperimentalPrivilegedNesting: true,
+		})
+	}
+
+	ctr := c.Container().From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithDirectory("/cfg", c.Directory()).
+		WithEnvVariable("DAGGER_CONFIG", "/cfg/config.toml").
+		WithWorkdir("/empty")
+
+	t.Run("workspace config --global writes for a remote workspace", func(ctx context.Context, t *testctx.T) {
+		written := userConfigDaggerExec(ctr, "-W", remoteRef, "workspace", "config", "-g", "modules.aws.settings.region", "us-west-2")
+
+		userConfig, err := written.File("/cfg/config.toml").Contents(ctx)
+		require.NoError(t, err)
+		// The entry is keyed by the normalized clone address, version dropped.
+		require.Contains(t, userConfig, `[workspaces."`)
+		require.Contains(t, userConfig, `/repo"`)
+		require.Contains(t, userConfig, `region = "us-west-2"`)
+
+		// Effective reads against the remote workspace apply the overlay.
+		out, err := userConfigDaggerExec(written, "-W", remoteRef, "workspace", "config", "modules.aws.settings.region").Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", strings.TrimSpace(out))
+	})
+
+	t.Run("settings --global writes for a remote workspace", func(ctx context.Context, t *testctx.T) {
+		written := userConfigDaggerExec(ctr, "-W", remoteRef, "settings", "-g", "aws", "region", "eu-west-1")
+
+		userConfig, err := written.File("/cfg/config.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, userConfig, `region = "eu-west-1"`)
+
+		out, err := userConfigDaggerExec(written, "-W", remoteRef, "settings", "aws", "region").Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "eu-west-1", strings.TrimSpace(out))
 	})
 }

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -185,18 +185,43 @@ func (s *workspaceSchema) configRead(
 		return dagql.String(result), nil
 	}
 
-	if envName, ok := selectedWorkspaceEnv(ctx); ok && !isExplicitEnvConfigKey(args.Key) {
+	envName, envSelected := selectedWorkspaceEnv(ctx)
+	overlay := parent.UserConfigOverlay()
+	switch {
+	case envSelected && !isExplicitEnvConfigKey(args.Key):
+		// Env-scoped reads return the effective active config: base values
+		// with the user-level overlay and the selected env applied, env
+		// tables hidden.
 		cfg, err := readWorkspaceConfig(ctx, parent)
 		if err != nil {
 			return "", err
 		}
 
-		effective, err := effectiveWorkspaceConfigBytes(cfg, envName)
+		effective, err := effectiveWorkspaceConfigBytes(parent, cfg, envName)
 		if err != nil {
 			return "", err
 		}
 
 		result, err := workspace.ReadConfigValue(effective, args.Key)
+		if err != nil {
+			return "", err
+		}
+		return dagql.String(result), nil
+
+	case overlay != nil:
+		// User-level overrides merge over the repo config for reads; env
+		// tables stay visible (including user-added envs) since no env is
+		// being applied here.
+		cfg, err := readWorkspaceConfig(ctx, parent)
+		if err != nil {
+			return "", err
+		}
+		merged, err := workspace.ApplyUserOverlay(cfg, overlay)
+		if err != nil {
+			return "", err
+		}
+
+		result, err := workspace.ReadConfigValue(workspace.SerializeConfig(merged), args.Key)
 		if err != nil {
 			return "", err
 		}
@@ -239,8 +264,16 @@ func isExplicitEnvConfigKey(key string) bool {
 	return key == "env" || strings.HasPrefix(key, "env.")
 }
 
-func effectiveWorkspaceConfigBytes(cfg *workspace.Config, envName string) ([]byte, error) {
-	applied, err := workspace.ApplyEnvOverlay(cfg, envName)
+// effectiveWorkspaceConfigBytes serializes cfg with the workspace's user-level
+// overlay and the selected env overlay (when envName is non-empty) applied.
+// The merge order matches module loading: base config, then user-level
+// overrides, then the selected environment.
+func effectiveWorkspaceConfigBytes(ws *core.Workspace, cfg *workspace.Config, envName string) ([]byte, error) {
+	applied, err := workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
+	if err != nil {
+		return nil, err
+	}
+	applied, err = workspace.ApplyEnvOverlay(applied, envName)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/workspace_env.go
+++ b/core/schema/workspace_env.go
@@ -22,6 +22,12 @@ func (s *workspaceSchema) envList(
 		return nil, err
 	}
 
+	// User-level overrides may add environments for this workspace.
+	cfg, err = workspace.ApplyUserOverlay(cfg, parent.UserConfigOverlay())
+	if err != nil {
+		return nil, err
+	}
+
 	names := workspace.EnvNames(cfg)
 	out := make(dagql.Array[dagql.String], len(names))
 	for i, name := range names {

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -179,10 +179,14 @@ func (s *workspaceSchema) moduleSettings(
 		return nil, err
 	}
 
-	// Source comes from base config; values come from the selected env overlay.
-	effectiveCfg := cfg
+	// Source comes from base config; values come from the user-level overlay
+	// and the selected env overlay, merged in the same order as module loading.
+	effectiveCfg, err := workspace.ApplyUserOverlay(cfg, ws.Self().UserConfigOverlay())
+	if err != nil {
+		return nil, err
+	}
 	if envName, ok := selectedWorkspaceEnv(ctx); ok {
-		effectiveCfg, err = workspace.ApplyEnvOverlay(cfg, envName)
+		effectiveCfg, err = workspace.ApplyEnvOverlay(effectiveCfg, envName)
 		if err != nil {
 			return nil, err
 		}

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -17,11 +17,74 @@ import (
 
 func TestWorkspacePrivateSourceFieldsAreNotGraphQLFields(t *testing.T) {
 	typ := reflect.TypeOf(core.Workspace{})
-	for _, name := range []string{"source", "rootfs", "hostPath", "ClientID"} {
+	for _, name := range []string{"source", "rootfs", "hostPath", "ClientID", "userConfigKey", "userConfigOverlay"} {
 		field, ok := typ.FieldByName(name)
 		require.True(t, ok, "missing Workspace field %s", name)
 		require.NotEqual(t, "true", field.Tag.Get("field"), "Workspace.%s must stay private", name)
 	}
+}
+
+// TestEffectiveWorkspaceConfigBytesAppliesUserOverlay verifies the schema-level
+// effective-config path merges in the same order as module loading: base
+// config, then the workspace's user-level overlay, then the selected env.
+func TestEffectiveWorkspaceConfigBytesAppliesUserOverlay(t *testing.T) {
+	t.Parallel()
+
+	baseCfg := func() *workspace.Config {
+		return &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"aws": {
+					Source:   "github.com/dagger/aws",
+					Settings: map[string]any{"profile": "shared", "region": "us-east-1"},
+				},
+			},
+		}
+	}
+	ws := &core.Workspace{}
+	ws.SetUserConfigOverlay(&workspace.UserWorkspaceOverlay{
+		Modules: map[string]workspace.EnvModuleOverlay{
+			"aws": {Settings: map[string]any{"profile": "alice-dev"}},
+		},
+		Env: map[string]workspace.EnvOverlay{
+			"dev": {Modules: map[string]workspace.EnvModuleOverlay{
+				"aws": {Settings: map[string]any{"region": "us-west-2"}},
+			}},
+		},
+	})
+
+	t.Run("without env", func(t *testing.T) {
+		t.Parallel()
+		data, err := effectiveWorkspaceConfigBytes(ws, baseCfg(), "")
+		require.NoError(t, err)
+
+		profile, err := workspace.ReadConfigValue(data, "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", profile)
+
+		region, err := workspace.ReadConfigValue(data, "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "us-east-1", region)
+	})
+
+	t.Run("with user-defined env", func(t *testing.T) {
+		t.Parallel()
+		data, err := effectiveWorkspaceConfigBytes(ws, baseCfg(), "dev")
+		require.NoError(t, err)
+
+		region, err := workspace.ReadConfigValue(data, "modules.aws.settings.region")
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", region)
+	})
+
+	t.Run("no overlay leaves config unchanged", func(t *testing.T) {
+		t.Parallel()
+		data, err := effectiveWorkspaceConfigBytes(&core.Workspace{}, baseCfg(), "")
+		require.NoError(t, err)
+
+		profile, err := workspace.ReadConfigValue(data, "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Equal(t, "shared", profile)
+	})
 }
 
 // TestInitialWorkspaceConfigOmitsCheckGenerated verifies the default dagger.toml

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -54,6 +54,16 @@ type Workspace struct {
 	// dagger.toml. Internal only.
 	compatWorkspace *workspacepkg.CompatWorkspace
 
+	// userConfigKey is the normalized Git remote key identifying this
+	// workspace in user-level config. Empty when the workspace has no usable
+	// remote. Internal only.
+	userConfigKey string
+
+	// userConfigOverlay is the user-level config overlay matched for this
+	// workspace by userConfigKey. Internal only — user config can carry
+	// personal values that must not surface through GraphQL or IDs.
+	userConfigOverlay *workspacepkg.UserWorkspaceOverlay
+
 	Address    string `field:"true" doc:"Canonical Dagger address of the workspace location, or an opaque identity for synthetic workspaces."`
 	Cwd        string
 	ConfigFile string
@@ -387,6 +397,28 @@ func (ws *Workspace) HostPath() string {
 // SetHostPath sets the internal host filesystem path.
 func (ws *Workspace) SetHostPath(p string) {
 	ws.hostPath = p
+}
+
+func (ws *Workspace) UserConfigKey() string {
+	if ws == nil {
+		return ""
+	}
+	return ws.userConfigKey
+}
+
+func (ws *Workspace) SetUserConfigKey(key string) {
+	ws.userConfigKey = key
+}
+
+func (ws *Workspace) UserConfigOverlay() *workspacepkg.UserWorkspaceOverlay {
+	if ws == nil {
+		return nil
+	}
+	return ws.userConfigOverlay
+}
+
+func (ws *Workspace) SetUserConfigOverlay(overlay *workspacepkg.UserWorkspaceOverlay) {
+	ws.userConfigOverlay = overlay
 }
 
 // CompatWorkspace returns the internal compat-workspace provenance for this

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -228,11 +228,21 @@ func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 		return nil, fmt.Errorf("workspace env %q is not defined", envName)
 	}
 
-	for moduleName, overlay := range env.Modules {
+	if err := applyModuleOverlays(applied, env.Modules, fmt.Sprintf("workspace env %q", envName)); err != nil {
+		return nil, err
+	}
+
+	return applied, nil
+}
+
+// applyModuleOverlays merges module overlays into applied in place. origin
+// names the overlay source ("workspace env %q", "user config") for errors.
+func applyModuleOverlays(applied *Config, overlays map[string]EnvModuleOverlay, origin string) error {
+	for moduleName, overlay := range overlays {
 		entry, ok := applied.Modules[moduleName]
 		if !ok {
 			if overlay.Source == "" {
-				return nil, fmt.Errorf("workspace env %q references unknown module %q", envName, moduleName)
+				return fmt.Errorf("%s references unknown module %q", origin, moduleName)
 			}
 			if applied.Modules == nil {
 				applied.Modules = map[string]ModuleEntry{}
@@ -255,8 +265,7 @@ func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 		}
 		applied.Modules[moduleName] = entry
 	}
-
-	return applied, nil
+	return nil
 }
 
 // EnvNames returns the configured environment names in deterministic order.

--- a/core/workspace/gitconfig.go
+++ b/core/workspace/gitconfig.go
@@ -1,0 +1,197 @@
+package workspace
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// maxGitConfigIncludeDepth mirrors git's own include recursion limit.
+const maxGitConfigIncludeDepth = 10
+
+// GitConfigState carries the repository state used to resolve git config
+// include directives and evaluate includeIf conditions.
+type GitConfigState struct {
+	// ConfigPath is the path of the config file being expanded; relative
+	// include paths resolve against its directory.
+	ConfigPath string
+	// GitDir is the repository's $GIT_DIR (the per-worktree gitdir for linked
+	// worktrees), matched by gitdir/gitdir:i conditions.
+	GitDir string
+	// Branch is the current short branch name, matched by onbranch
+	// conditions. Empty when detached or unknown.
+	Branch string
+}
+
+// ResolveGitConfigIncludes expands include and includeIf directives in git
+// config contents the way git does when reading configuration: each included
+// file is inlined at the location of its directive, recursively, up to git's
+// depth limit. Includes that cannot be read and includeIf sections whose
+// condition does not match are skipped. Conditions with home-relative (~)
+// patterns and hasconfig conditions are treated as non-matching, since the
+// caller's home directory and full config set are not available here.
+func ResolveGitConfigIncludes(
+	ctx context.Context,
+	readFile func(context.Context, string) ([]byte, error),
+	state GitConfigState,
+	data []byte,
+) []byte {
+	return resolveGitConfigIncludes(ctx, readFile, state, data, maxGitConfigIncludeDepth)
+}
+
+func resolveGitConfigIncludes(
+	ctx context.Context,
+	readFile func(context.Context, string) ([]byte, error),
+	state GitConfigState,
+	data []byte,
+	depth int,
+) []byte {
+	if depth <= 0 || readFile == nil {
+		return data
+	}
+
+	var b strings.Builder
+	includeActive := false
+	for line := range strings.Lines(string(data)) {
+		trimmed := strings.TrimSpace(strings.TrimSuffix(line, "\n"))
+
+		if strings.HasPrefix(trimmed, "[") {
+			includeActive = gitConfigIncludeSectionMatches(trimmed, state)
+			b.WriteString(line)
+			continue
+		}
+
+		if includeActive {
+			key, value, ok := strings.Cut(trimmed, "=")
+			if ok && strings.TrimSpace(key) == "path" {
+				includePath := strings.Trim(strings.TrimSpace(value), `"`)
+				if included, ok := readGitConfigInclude(ctx, readFile, state.ConfigPath, includePath); ok {
+					included = resolveGitConfigIncludes(ctx, readFile, GitConfigState{
+						ConfigPath: includePathResolved(state.ConfigPath, includePath),
+						GitDir:     state.GitDir,
+						Branch:     state.Branch,
+					}, included, depth-1)
+					b.Write(included)
+					if len(included) > 0 && included[len(included)-1] != '\n' {
+						b.WriteString("\n")
+					}
+				}
+				continue
+			}
+		}
+
+		b.WriteString(line)
+	}
+	return []byte(b.String())
+}
+
+func includePathResolved(configPath, includePath string) string {
+	if includePath == "" || strings.HasPrefix(includePath, "~") {
+		return includePath
+	}
+	if filepath.IsAbs(includePath) {
+		return filepath.Clean(includePath)
+	}
+	return filepath.Join(filepath.Dir(configPath), includePath)
+}
+
+func readGitConfigInclude(
+	ctx context.Context,
+	readFile func(context.Context, string) ([]byte, error),
+	configPath, includePath string,
+) ([]byte, bool) {
+	if includePath == "" || strings.HasPrefix(includePath, "~") {
+		// The caller's home directory cannot be resolved here.
+		return nil, false
+	}
+	data, err := readFile(ctx, includePathResolved(configPath, includePath))
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// gitConfigIncludeSectionMatches reports whether a section header line starts
+// an include section whose contents should be expanded: [include], or
+// [includeIf "cond"] with a matching condition.
+func gitConfigIncludeSectionMatches(header string, state GitConfigState) bool {
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(header, "["), "]"))
+	name, rest, _ := strings.Cut(inner, " ")
+	switch strings.ToLower(name) {
+	case "include":
+		return rest == ""
+	case "includeif":
+		cond := strings.Trim(strings.TrimSpace(rest), `"`)
+		return gitConfigIncludeCondMatches(cond, state)
+	}
+	return false
+}
+
+func gitConfigIncludeCondMatches(cond string, state GitConfigState) bool {
+	switch {
+	case strings.HasPrefix(cond, "gitdir:"):
+		return gitDirPatternMatches(strings.TrimPrefix(cond, "gitdir:"), state, false)
+	case strings.HasPrefix(cond, "gitdir/i:"):
+		return gitDirPatternMatches(strings.TrimPrefix(cond, "gitdir/i:"), state, true)
+	case strings.HasPrefix(cond, "onbranch:"):
+		return onBranchPatternMatches(strings.TrimPrefix(cond, "onbranch:"), state.Branch)
+	}
+	// hasconfig and unknown conditions are not evaluated here.
+	return false
+}
+
+// gitDirPatternMatches applies git's gitdir pattern transformations: a
+// leading ./ resolves against the config file's directory, patterns with no
+// absolute anchor get **/ prepended, and a trailing / matches everything
+// below. Home-relative (~) patterns are treated as non-matching.
+func gitDirPatternMatches(pattern string, state GitConfigState, insensitive bool) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" || state.GitDir == "" {
+		return false
+	}
+	if strings.HasPrefix(pattern, "~") {
+		return false
+	}
+	if strings.HasPrefix(pattern, "./") {
+		pattern = filepath.ToSlash(filepath.Dir(state.ConfigPath)) + pattern[1:]
+	}
+	if !strings.HasPrefix(pattern, "/") && !strings.HasPrefix(pattern, "**/") {
+		pattern = "**/" + pattern
+	}
+	if strings.HasSuffix(pattern, "/") {
+		pattern += "**"
+	}
+
+	gitDir := filepath.ToSlash(filepath.Clean(state.GitDir))
+	if insensitive {
+		pattern = strings.ToLower(pattern)
+		gitDir = strings.ToLower(gitDir)
+	}
+	ok, err := doublestar.Match(pattern, gitDir)
+	return err == nil && ok
+}
+
+func onBranchPatternMatches(pattern, branch string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" || branch == "" {
+		return false
+	}
+	if strings.HasSuffix(pattern, "/") {
+		pattern += "**"
+	}
+	ok, err := doublestar.Match(pattern, branch)
+	return err == nil && ok
+}
+
+// GitBranchFromHEAD parses .git/HEAD contents into the current short branch
+// name. A detached HEAD (or anything else) yields "".
+func GitBranchFromHEAD(data []byte) string {
+	ref := strings.TrimSpace(string(data))
+	branch, ok := strings.CutPrefix(ref, "ref: refs/heads/")
+	if !ok {
+		return ""
+	}
+	return branch
+}

--- a/core/workspace/gitconfig_test.go
+++ b/core/workspace/gitconfig_test.go
@@ -1,0 +1,194 @@
+package workspace
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func fakeGitConfigFS(files map[string]string) func(context.Context, string) ([]byte, error) {
+	return func(_ context.Context, path string) ([]byte, error) {
+		if data, ok := files[filepath.Clean(path)]; ok {
+			return []byte(data), nil
+		}
+		return nil, errNotExistForTest
+	}
+}
+
+type notExistError struct{}
+
+func (notExistError) Error() string { return "not found" }
+
+var errNotExistForTest = notExistError{}
+
+func resolveIncludesForTest(t *testing.T, files map[string]string, state GitConfigState) string {
+	t.Helper()
+	data := files[filepath.Clean(state.ConfigPath)]
+	return string(ResolveGitConfigIncludes(context.Background(), fakeGitConfigFS(files), state, []byte(data)))
+}
+
+func TestResolveGitConfigIncludes(t *testing.T) {
+	t.Parallel()
+
+	state := GitConfigState{
+		ConfigPath: "/repo/.git/config",
+		GitDir:     "/repo/.git",
+		Branch:     "main",
+	}
+
+	t.Run("unconditional include is inlined at its directive", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config": "[include]\n\tpath = origin.config\n",
+			"/repo/.git/origin.config": `[remote "origin"]
+	url = git@github.com:acme/api.git
+`,
+		}, state)
+
+		url, ok := GitRemoteURL([]byte(out), "origin")
+		require.True(t, ok)
+		require.Equal(t, "git@github.com:acme/api.git", url)
+	})
+
+	t.Run("relative include paths resolve against the including file", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config":           "[include]\n\tpath = ../shared/git.config\n",
+			"/repo/shared/git.config":     "[include]\n\tpath = nested.config\n",
+			"/repo/shared/nested.config":  `[remote "origin"]` + "\n\turl = https://github.com/acme/api\n",
+			"/elsewhere/unrelated.config": "",
+		}, state)
+
+		url, ok := GitRemoteURL([]byte(out), "origin")
+		require.True(t, ok)
+		require.Equal(t, "https://github.com/acme/api", url)
+	})
+
+	t.Run("quoted include paths", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config":        "[include]\n\tpath = \"origin.config\"\n",
+			"/repo/.git/origin.config": `[remote "origin"]` + "\n\turl = https://github.com/acme/api\n",
+		}, state)
+
+		_, ok := GitRemoteURL([]byte(out), "origin")
+		require.True(t, ok)
+	})
+
+	t.Run("unreadable includes are skipped", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config": "[include]\n\tpath = missing.config\n[user]\n\tname = alice\n",
+		}, state)
+		require.Contains(t, out, "name = alice")
+		_, ok := GitRemoteURL([]byte(out), "origin")
+		require.False(t, ok)
+	})
+
+	t.Run("home-relative includes are skipped", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config": "[include]\n\tpath = ~/git.config\n",
+		}, state)
+		_, ok := GitRemoteURL([]byte(out), "origin")
+		require.False(t, ok)
+	})
+
+	t.Run("include cycles stop at the depth limit", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config":      "[include]\n\tpath = loop.config\n",
+			"/repo/.git/loop.config": "[include]\n\tpath = loop.config\n",
+		}, state)
+		require.NotEmpty(t, out)
+	})
+
+	t.Run("includeIf gitdir", func(t *testing.T) {
+		t.Parallel()
+		files := func(cond string) map[string]string {
+			return map[string]string{
+				"/repo/.git/config":        "[includeIf \"" + cond + "\"]\n\tpath = origin.config\n",
+				"/repo/.git/origin.config": `[remote "origin"]` + "\n\turl = https://github.com/acme/api\n",
+			}
+		}
+
+		for cond, want := range map[string]bool{
+			"gitdir:/repo/":          true,  // trailing / matches everything below
+			"gitdir:/repo/.git":      true,  // exact
+			"gitdir:repo/.git":       true,  // relative patterns get **/ prepended
+			"gitdir:/other/":         false, // different repo
+			"gitdir:~/repos/":        false, // home-relative patterns cannot resolve
+			"gitdir/i:/REPO/":        true,  // case-insensitive variant
+			"gitdir:/REPO/":          false, // case-sensitive by default
+			"onbranch:main":          true,
+			"onbranch:release/":      false,
+			"onbranch:ma*":           true,
+			"hasconfig:remote.*.url": false, // not evaluated
+		} {
+			out := resolveIncludesForTest(t, files(cond), state)
+			_, ok := GitRemoteURL([]byte(out), "origin")
+			require.Equal(t, want, ok, "condition %q", cond)
+		}
+	})
+
+	t.Run("includeIf onbranch with slashes and detached HEAD", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]string{
+			"/repo/.git/config":        "[includeIf \"onbranch:release/\"]\n\tpath = origin.config\n",
+			"/repo/.git/origin.config": `[remote "origin"]` + "\n\turl = https://github.com/acme/api\n",
+		}
+
+		onRelease := state
+		onRelease.Branch = "release/v1"
+		_, ok := GitRemoteURL([]byte(resolveIncludesForTest(t, files, onRelease)), "origin")
+		require.True(t, ok)
+
+		detached := state
+		detached.Branch = ""
+		_, ok = GitRemoteURL([]byte(resolveIncludesForTest(t, files, detached)), "origin")
+		require.False(t, ok)
+	})
+
+	t.Run("gitdir pattern with leading dot-slash resolves against the config dir", func(t *testing.T) {
+		t.Parallel()
+		// From /main/.git/config, "./worktrees/" means /main/.git/worktrees/**.
+		out := resolveIncludesForTest(t, map[string]string{
+			"/main/.git/config":        "[includeIf \"gitdir:./worktrees/\"]\n\tpath = origin.config\n",
+			"/main/.git/origin.config": `[remote "origin"]` + "\n\turl = https://github.com/acme/api\n",
+		}, GitConfigState{
+			ConfigPath: "/main/.git/config",
+			GitDir:     "/main/.git/worktrees/feature",
+		})
+		_, ok := GitRemoteURL([]byte(out), "origin")
+		require.True(t, ok)
+	})
+
+	t.Run("later includes shadow earlier values like git config --get", func(t *testing.T) {
+		t.Parallel()
+		out := resolveIncludesForTest(t, map[string]string{
+			"/repo/.git/config": `[remote "origin"]
+	url = https://github.com/acme/old
+[include]
+	path = override.config
+`,
+			"/repo/.git/override.config": `[remote "origin"]
+	url = https://github.com/acme/new
+`,
+		}, state)
+
+		url, ok := GitRemoteURL([]byte(out), "origin")
+		require.True(t, ok)
+		require.Equal(t, "https://github.com/acme/new", url)
+	})
+}
+
+func TestGitBranchFromHEAD(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "main", GitBranchFromHEAD([]byte("ref: refs/heads/main\n")))
+	require.Equal(t, "release/v1", GitBranchFromHEAD([]byte("ref: refs/heads/release/v1")))
+	require.Empty(t, GitBranchFromHEAD([]byte("0123456789abcdef0123456789abcdef01234567\n")))
+	require.Empty(t, GitBranchFromHEAD(nil))
+}

--- a/core/workspace/userconfig.go
+++ b/core/workspace/userconfig.go
@@ -1,0 +1,328 @@
+package workspace
+
+import (
+	"fmt"
+	"strings"
+
+	toml "github.com/pelletier/go-toml"
+
+	"github.com/dagger/dagger/util/gitutil"
+)
+
+// UserConfig is the workspace-relevant portion of the user-level Dagger config
+// file (~/.config/dagger/config.toml, or $DAGGER_CONFIG). Only the
+// [workspaces.*] section is modeled here; other sections (e.g. [llm]) are
+// owned by other subsystems and ignored during parsing.
+type UserConfig struct {
+	Workspaces map[string]UserWorkspaceOverlay `toml:"workspaces"`
+}
+
+// UserWorkspaceOverlay is one workspace's user-level overlay, keyed in the
+// user config by the workspace's normalized Git remote (see
+// NormalizeGitRemote). It is a constrained subset of the workspace config:
+// always-applied module overlays plus personal environments. User-level
+// values take precedence over the repository's dagger.toml.
+type UserWorkspaceOverlay struct {
+	Modules map[string]EnvModuleOverlay `toml:"modules"`
+	Env     map[string]EnvOverlay       `toml:"env"`
+}
+
+// ParseUserConfig parses user-level Dagger config bytes. Unknown sections are
+// ignored so the file can be shared with other subsystems.
+func ParseUserConfig(data []byte) (*UserConfig, error) {
+	var cfg UserConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse user config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// MatchWorkspaceOverlay returns the overlay whose key identifies the same
+// remote as workspaceKey, or nil when none matches. Both sides are normalized
+// before comparison so equivalent remote URL forms (https, ssh, scp-style,
+// with or without .git) all match.
+func (c *UserConfig) MatchWorkspaceOverlay(workspaceKey string) *UserWorkspaceOverlay {
+	if c == nil || len(c.Workspaces) == 0 {
+		return nil
+	}
+	workspaceKey = NormalizeGitRemote(workspaceKey)
+	if workspaceKey == "" {
+		return nil
+	}
+	for key, overlay := range c.Workspaces {
+		if NormalizeGitRemote(key) == workspaceKey {
+			overlay := overlay
+			return &overlay
+		}
+	}
+	return nil
+}
+
+// ApplyUserOverlay returns a copy of cfg with the user-level workspace overlay
+// merged over it.
+//
+// Module overlays follow the same value semantics as environment overlays:
+// settings shadow the base values key by key, and a source (with its pin) adds
+// or replaces a module. Unlike environment overlays, an entry naming a module
+// that is neither installed nor given a source is skipped rather than an
+// error: the same workspace key spans every checkout and branch of a repo, so
+// an always-on user entry must not break checkouts where the module does not
+// exist. Environments are added to the config's env set; a user env that
+// shares a name with a repository env is merged over it with user values
+// winning.
+func ApplyUserOverlay(cfg *Config, overlay *UserWorkspaceOverlay) (*Config, error) {
+	if cfg == nil || overlay == nil {
+		return cfg, nil
+	}
+
+	applied := cloneConfig(cfg)
+	known := make(map[string]EnvModuleOverlay, len(overlay.Modules))
+	for name, moduleOverlay := range overlay.Modules {
+		if _, ok := applied.Modules[name]; !ok && moduleOverlay.Source == "" {
+			continue
+		}
+		known[name] = moduleOverlay
+	}
+	if err := applyModuleOverlays(applied, known, "user config"); err != nil {
+		return nil, err
+	}
+
+	if len(overlay.Env) > 0 {
+		if applied.Env == nil {
+			applied.Env = make(map[string]EnvOverlay, len(overlay.Env))
+		}
+		for name, userEnv := range overlay.Env {
+			applied.Env[name] = mergeEnvOverlay(applied.Env[name], userEnv)
+		}
+	}
+
+	return applied, nil
+}
+
+// mergeEnvOverlay merges over on top of base, with over's values winning at
+// the module-setting key level.
+func mergeEnvOverlay(base, over EnvOverlay) EnvOverlay {
+	merged := EnvOverlay{}
+	if len(base.Modules)+len(over.Modules) > 0 {
+		merged.Modules = make(map[string]EnvModuleOverlay, len(base.Modules)+len(over.Modules))
+	}
+	for name, overlay := range base.Modules {
+		merged.Modules[name] = EnvModuleOverlay{
+			Source:   overlay.Source,
+			Pin:      overlay.Pin,
+			Settings: cloneConfigMap(overlay.Settings),
+		}
+	}
+	for name, overlay := range over.Modules {
+		entry := merged.Modules[name]
+		if overlay.Source != "" {
+			entry.Source = overlay.Source
+			entry.Pin = overlay.Pin
+		} else if overlay.Pin != "" {
+			entry.Pin = overlay.Pin
+		}
+		if len(overlay.Settings) > 0 {
+			if entry.Settings == nil {
+				entry.Settings = make(map[string]any, len(overlay.Settings))
+			}
+			for key, value := range overlay.Settings {
+				entry.Settings[key] = value
+			}
+		}
+		merged.Modules[name] = entry
+	}
+	return merged
+}
+
+// NormalizeGitRemote converts a Git remote URL in any common form into the
+// canonical workspace key form used by user-level config: host/path with no
+// scheme, no user, no trailing .git, and a lowercased host. For example,
+// "git@github.com:acme/api.git", "https://github.com/acme/api", and
+// "ssh://git@github.com/acme/api" all normalize to "github.com/acme/api".
+//
+// Local filesystem remotes have no stable cross-machine identity and
+// normalize to "".
+func NormalizeGitRemote(remote string) string {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return ""
+	}
+	// Filesystem remotes (path or file:// forms) are not usable as keys.
+	if strings.HasPrefix(remote, "/") || strings.HasPrefix(remote, ".") ||
+		strings.HasPrefix(remote, "file://") || strings.HasPrefix(remote, "~") {
+		return ""
+	}
+
+	if u, err := gitutil.ParseURL(remote); err == nil {
+		host := strings.ToLower(u.Host)
+		path := strings.Trim(u.Path, "/")
+		path = strings.TrimSuffix(path, ".git")
+		if host == "" {
+			return ""
+		}
+		if path == "" {
+			return host
+		}
+		return host + "/" + path
+	}
+
+	// Already scheme-less ("github.com/acme/api"): apply the same trims so
+	// equivalent spellings still match.
+	remote = strings.Trim(remote, "/")
+	remote = strings.TrimSuffix(remote, ".git")
+	host, path, ok := strings.Cut(remote, "/")
+	if !ok {
+		return strings.ToLower(remote)
+	}
+	return strings.ToLower(host) + "/" + path
+}
+
+// GitRemoteURL extracts the URL of the named remote from raw git config file
+// contents (.git/config format).
+func GitRemoteURL(gitConfig []byte, remoteName string) (string, bool) {
+	section := fmt.Sprintf("[remote %q]", remoteName)
+	inRemote := false
+	for _, line := range strings.Split(string(gitConfig), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			inRemote = line == section
+			continue
+		}
+		if !inRemote {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if ok && strings.TrimSpace(key) == "url" {
+			url := strings.TrimSpace(value)
+			return url, url != ""
+		}
+	}
+	return "", false
+}
+
+// ParseGitDirFile parses a .git *file* (as written for worktrees and
+// submodules) and returns the gitdir path it points to.
+func ParseGitDirFile(data []byte) (string, bool) {
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+	if !ok {
+		return "", false
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	return gitDir, gitDir != ""
+}
+
+// userOverlayKeyParts validates that key addresses user-overridable config and
+// returns its parsed path segments. Only module settings may be stored in a
+// user-level overlay, always applied or scoped to an environment.
+func userOverlayKeyParts(key string) ([]string, error) {
+	parts, err := splitConfigPath(key)
+	if err != nil {
+		return nil, err
+	}
+	rest := parts
+	if len(rest) > 0 && rest[0] == "env" {
+		if len(rest) < 2 {
+			return nil, fmt.Errorf("key %q is missing an environment name", key)
+		}
+		rest = rest[2:]
+	}
+	if len(rest) < 4 || rest[0] != "modules" || rest[2] != "settings" {
+		return nil, fmt.Errorf("key %q cannot be stored in user-level config; only modules.<name>.settings.* and env.<name>.modules.<name>.settings.* are supported", key)
+	}
+	return parts, nil
+}
+
+// WriteUserConfigValue sets a config value under [workspaces.<workspaceKey>]
+// in user-level config bytes, preserving unrelated sections (e.g. [llm]) and
+// other workspace entries. The workspace key is canonicalized; when an entry
+// for an equivalent remote spelling already exists, it is updated in place
+// rather than duplicated. A non-nil values slice stores a string array
+// verbatim; otherwise rawValue is typed like repository config writes.
+func WriteUserConfigValue(existing []byte, workspaceKey, key, rawValue string, values []string) ([]byte, error) {
+	parts, err := userOverlayKeyParts(key)
+	if err != nil {
+		return nil, err
+	}
+	tree, entryKey, err := userConfigTreeAndEntryKey(existing, workspaceKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var value any
+	if values != nil {
+		value = values
+	} else {
+		value = parseValueString(parts, rawValue)
+	}
+	tree.SetPath(append([]string{"workspaces", entryKey}, parts...), value)
+
+	out, err := tree.ToTomlString()
+	if err != nil {
+		return nil, fmt.Errorf("serialize user config: %w", err)
+	}
+	return []byte(out), nil
+}
+
+// DeleteUserConfigValue removes a config value under
+// [workspaces.<workspaceKey>] in user-level config bytes, pruning any tables
+// the removal leaves empty. It errors when the key is not set for that
+// workspace.
+func DeleteUserConfigValue(existing []byte, workspaceKey, key string) ([]byte, error) {
+	parts, err := userOverlayKeyParts(key)
+	if err != nil {
+		return nil, err
+	}
+	tree, entryKey, err := userConfigTreeAndEntryKey(existing, workspaceKey)
+	if err != nil {
+		return nil, err
+	}
+
+	fullPath := append([]string{"workspaces", entryKey}, parts...)
+	if tree.GetPath(fullPath) == nil {
+		return nil, fmt.Errorf("key %q is not set in user-level config for workspace %q", key, entryKey)
+	}
+	if err := tree.DeletePath(fullPath); err != nil {
+		return nil, fmt.Errorf("unset %q: %w", key, err)
+	}
+	// Prune tables the removal left empty, innermost first.
+	for prefix := fullPath[:len(fullPath)-1]; len(prefix) > 0; prefix = prefix[:len(prefix)-1] {
+		parent, ok := tree.GetPath(prefix).(*toml.Tree)
+		if !ok || len(parent.Keys()) > 0 {
+			break
+		}
+		if err := tree.DeletePath(prefix); err != nil {
+			return nil, fmt.Errorf("prune empty table %q: %w", strings.Join(prefix, "."), err)
+		}
+	}
+
+	out, err := tree.ToTomlString()
+	if err != nil {
+		return nil, fmt.Errorf("serialize user config: %w", err)
+	}
+	return []byte(out), nil
+}
+
+// userConfigTreeAndEntryKey parses user config bytes and resolves the
+// [workspaces.*] entry key to operate on: an existing entry whose key
+// normalizes to the same remote, or the canonical key when none exists.
+func userConfigTreeAndEntryKey(existing []byte, workspaceKey string) (*toml.Tree, string, error) {
+	canonical := NormalizeGitRemote(workspaceKey)
+	if canonical == "" {
+		return nil, "", fmt.Errorf("workspace key %q is not a usable git remote", workspaceKey)
+	}
+	tree, err := toml.LoadBytes(existing)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse user config: %w", err)
+	}
+	if workspaces, ok := tree.Get("workspaces").(*toml.Tree); ok {
+		for _, existingKey := range workspaces.Keys() {
+			if NormalizeGitRemote(existingKey) == canonical {
+				return tree, existingKey, nil
+			}
+		}
+	}
+	return tree, canonical, nil
+}

--- a/core/workspace/userconfig.go
+++ b/core/workspace/userconfig.go
@@ -6,6 +6,7 @@ import (
 
 	toml "github.com/pelletier/go-toml"
 
+	"github.com/dagger/dagger/engine/client/pathutil"
 	"github.com/dagger/dagger/util/gitutil"
 )
 
@@ -147,9 +148,13 @@ func NormalizeGitRemote(remote string) string {
 	if remote == "" {
 		return ""
 	}
-	// Filesystem remotes (path or file:// forms) are not usable as keys.
-	if strings.HasPrefix(remote, "/") || strings.HasPrefix(remote, ".") ||
-		strings.HasPrefix(remote, "file://") || strings.HasPrefix(remote, "~") {
+	// Filesystem remotes are not usable as keys: POSIX paths, file:// URLs,
+	// and Windows drive-letter or UNC paths (checked with separators
+	// normalized, so C:\Users, C:/Users, and \\server\share are all caught).
+	slashed := strings.ReplaceAll(remote, "\\", "/")
+	if strings.HasPrefix(slashed, "/") || strings.HasPrefix(slashed, ".") ||
+		strings.HasPrefix(slashed, "file://") || strings.HasPrefix(slashed, "~") ||
+		pathutil.GetDrive(slashed) != "" {
 		return ""
 	}
 
@@ -177,11 +182,14 @@ func NormalizeGitRemote(remote string) string {
 	return strings.ToLower(host) + "/" + path
 }
 
-// GitRemoteURL extracts the URL of the named remote from raw git config file
-// contents (.git/config format).
+// GitRemoteURL extracts the URL of the named remote from git config file
+// contents (.git/config format, with any includes already expanded — see
+// ResolveGitConfigIncludes). Like `git config --get`, the last value wins
+// when the key appears more than once.
 func GitRemoteURL(gitConfig []byte, remoteName string) (string, bool) {
 	section := fmt.Sprintf("[remote %q]", remoteName)
 	inRemote := false
+	url := ""
 	for _, line := range strings.Split(string(gitConfig), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
@@ -196,11 +204,12 @@ func GitRemoteURL(gitConfig []byte, remoteName string) (string, bool) {
 		}
 		key, value, ok := strings.Cut(line, "=")
 		if ok && strings.TrimSpace(key) == "url" {
-			url := strings.TrimSpace(value)
-			return url, url != ""
+			if v := strings.TrimSpace(value); v != "" {
+				url = v
+			}
 		}
 	}
-	return "", false
+	return url, url != ""
 }
 
 // ParseGitDirFile parses a .git *file* (as written for worktrees and

--- a/core/workspace/userconfig_test.go
+++ b/core/workspace/userconfig_test.go
@@ -1,0 +1,569 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUserConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("workspace overlays with settings and envs", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := ParseUserConfig([]byte(`
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+
+[workspaces."github.com/acme/api".env.dev.modules.aws.settings]
+region = "us-west-2"
+
+[workspaces."github.com/acme/web".modules.vercel.settings]
+team = "acme-dev"
+`))
+		require.NoError(t, err)
+		require.Len(t, cfg.Workspaces, 2)
+
+		api := cfg.Workspaces["github.com/acme/api"]
+		require.Equal(t, "alice-dev", api.Modules["aws"].Settings["profile"])
+		require.Equal(t, "us-west-2", api.Env["dev"].Modules["aws"].Settings["region"])
+
+		web := cfg.Workspaces["github.com/acme/web"]
+		require.Equal(t, "acme-dev", web.Modules["vercel"].Settings["team"])
+	})
+
+	t.Run("unrelated sections are ignored", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := ParseUserConfig([]byte(`
+[llm]
+default_provider = "anthropic"
+
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`))
+		require.NoError(t, err)
+		require.Len(t, cfg.Workspaces, 1)
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := ParseUserConfig(nil)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Workspaces)
+	})
+
+	t.Run("malformed config errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseUserConfig([]byte(`[workspaces`))
+		require.Error(t, err)
+	})
+}
+
+func TestNormalizeGitRemote(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		remote string
+		want   string
+	}{
+		// Equivalent forms of the same remote all key identically.
+		{"https://github.com/acme/api", "github.com/acme/api"},
+		{"https://github.com/acme/api.git", "github.com/acme/api"},
+		{"http://github.com/acme/api.git", "github.com/acme/api"},
+		{"git@github.com:acme/api.git", "github.com/acme/api"},
+		{"git@github.com:acme/api", "github.com/acme/api"},
+		{"ssh://git@github.com/acme/api.git", "github.com/acme/api"},
+		{"git://github.com/acme/api.git", "github.com/acme/api"},
+		{"github.com/acme/api", "github.com/acme/api"},
+		{"github.com/acme/api.git", "github.com/acme/api"},
+		{"GitHub.com/acme/api", "github.com/acme/api"},
+		{"https://GitHub.com/acme/api", "github.com/acme/api"},
+
+		// Other hosts, nested paths, ports.
+		{"https://gitlab.example.com/team/sub/repo.git", "gitlab.example.com/team/sub/repo"},
+		{"ssh://git@gitlab.example.com:2222/team/repo.git", "gitlab.example.com:2222/team/repo"},
+
+		// Path case is preserved (only the host is case-insensitive).
+		{"https://github.com/Acme/API", "github.com/Acme/API"},
+
+		// Local filesystem remotes have no stable identity.
+		{"/home/alice/src/api", ""},
+		{"../api", ""},
+		{"./api", ""},
+		{"file:///home/alice/src/api", ""},
+		{"~/src/api", ""},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.remote, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, NormalizeGitRemote(tc.remote))
+		})
+	}
+}
+
+func TestMatchWorkspaceOverlay(t *testing.T) {
+	t.Parallel()
+
+	cfg := &UserConfig{
+		Workspaces: map[string]UserWorkspaceOverlay{
+			"github.com/acme/api": {
+				Modules: map[string]EnvModuleOverlay{
+					"aws": {Settings: map[string]any{"profile": "alice-dev"}},
+				},
+			},
+			// Users may key entries by any equivalent remote spelling.
+			"git@github.com:acme/web.git": {
+				Modules: map[string]EnvModuleOverlay{
+					"vercel": {Settings: map[string]any{"team": "acme-dev"}},
+				},
+			},
+		},
+	}
+
+	t.Run("exact key", func(t *testing.T) {
+		t.Parallel()
+		overlay := cfg.MatchWorkspaceOverlay("github.com/acme/api")
+		require.NotNil(t, overlay)
+		require.Equal(t, "alice-dev", overlay.Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("equivalent remote forms match", func(t *testing.T) {
+		t.Parallel()
+		for _, key := range []string{
+			"https://github.com/acme/api.git",
+			"git@github.com:acme/api.git",
+			"ssh://git@github.com/acme/api",
+		} {
+			overlay := cfg.MatchWorkspaceOverlay(key)
+			require.NotNil(t, overlay, "key %q should match", key)
+			require.Equal(t, "alice-dev", overlay.Modules["aws"].Settings["profile"])
+		}
+	})
+
+	t.Run("config key in non-canonical form matches", func(t *testing.T) {
+		t.Parallel()
+		overlay := cfg.MatchWorkspaceOverlay("https://github.com/acme/web")
+		require.NotNil(t, overlay)
+		require.Equal(t, "acme-dev", overlay.Modules["vercel"].Settings["team"])
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, cfg.MatchWorkspaceOverlay("github.com/other/repo"))
+	})
+
+	t.Run("empty key never matches", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, cfg.MatchWorkspaceOverlay(""))
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+		var nilCfg *UserConfig
+		require.Nil(t, nilCfg.MatchWorkspaceOverlay("github.com/acme/api"))
+	})
+}
+
+func TestApplyUserOverlay(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := func() *Config {
+		return &Config{
+			Modules: map[string]ModuleEntry{
+				"aws": {
+					Source:   "github.com/dagger/aws",
+					Settings: map[string]any{"profile": "shared", "region": "us-east-1"},
+				},
+			},
+			Env: map[string]EnvOverlay{
+				"staging": {
+					Modules: map[string]EnvModuleOverlay{
+						"aws": {Settings: map[string]any{"profile": "staging"}},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("user settings shadow repo settings", func(t *testing.T) {
+		t.Parallel()
+		applied, err := ApplyUserOverlay(baseConfig(), &UserWorkspaceOverlay{
+			Modules: map[string]EnvModuleOverlay{
+				"aws": {Settings: map[string]any{"profile": "alice-dev"}},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", applied.Modules["aws"].Settings["profile"])
+		// Untouched keys keep their repo values.
+		require.Equal(t, "us-east-1", applied.Modules["aws"].Settings["region"])
+	})
+
+	t.Run("base config is not mutated", func(t *testing.T) {
+		t.Parallel()
+		base := baseConfig()
+		_, err := ApplyUserOverlay(base, &UserWorkspaceOverlay{
+			Modules: map[string]EnvModuleOverlay{
+				"aws": {Settings: map[string]any{"profile": "alice-dev"}},
+			},
+			Env: map[string]EnvOverlay{
+				"staging": {Modules: map[string]EnvModuleOverlay{
+					"aws": {Settings: map[string]any{"profile": "mine"}},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "shared", base.Modules["aws"].Settings["profile"])
+		require.Equal(t, "staging", base.Env["staging"].Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("user overlay adds environments", func(t *testing.T) {
+		t.Parallel()
+		applied, err := ApplyUserOverlay(baseConfig(), &UserWorkspaceOverlay{
+			Env: map[string]EnvOverlay{
+				"dev": {Modules: map[string]EnvModuleOverlay{
+					"aws": {Settings: map[string]any{"profile": "alice-dev"}},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"dev", "staging"}, EnvNames(applied))
+
+		// The added env is selectable through the normal overlay path.
+		envApplied, err := ApplyEnvOverlay(applied, "dev")
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", envApplied.Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("user env merges over same-named repo env", func(t *testing.T) {
+		t.Parallel()
+		applied, err := ApplyUserOverlay(baseConfig(), &UserWorkspaceOverlay{
+			Env: map[string]EnvOverlay{
+				"staging": {Modules: map[string]EnvModuleOverlay{
+					"aws": {Settings: map[string]any{"region": "eu-west-1"}},
+				}},
+			},
+		})
+		require.NoError(t, err)
+
+		envApplied, err := ApplyEnvOverlay(applied, "staging")
+		require.NoError(t, err)
+		// Repo env value survives; user env value is layered on top.
+		require.Equal(t, "staging", envApplied.Modules["aws"].Settings["profile"])
+		require.Equal(t, "eu-west-1", envApplied.Modules["aws"].Settings["region"])
+	})
+
+	t.Run("user env values win over repo env values", func(t *testing.T) {
+		t.Parallel()
+		applied, err := ApplyUserOverlay(baseConfig(), &UserWorkspaceOverlay{
+			Env: map[string]EnvOverlay{
+				"staging": {Modules: map[string]EnvModuleOverlay{
+					"aws": {Settings: map[string]any{"profile": "alice-staging"}},
+				}},
+			},
+		})
+		require.NoError(t, err)
+
+		envApplied, err := ApplyEnvOverlay(applied, "staging")
+		require.NoError(t, err)
+		require.Equal(t, "alice-staging", envApplied.Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("user overlay may add a module with a source", func(t *testing.T) {
+		t.Parallel()
+		applied, err := ApplyUserOverlay(baseConfig(), &UserWorkspaceOverlay{
+			Modules: map[string]EnvModuleOverlay{
+				"tailscale": {
+					Source:   "github.com/acme/tailscale",
+					Settings: map[string]any{"hostname": "alice"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "github.com/acme/tailscale", applied.Modules["tailscale"].Source)
+		require.Equal(t, "alice", applied.Modules["tailscale"].Settings["hostname"])
+	})
+
+	t.Run("unknown module without source is skipped", func(t *testing.T) {
+		t.Parallel()
+		// The same workspace key spans every checkout and branch of a repo, so
+		// an entry for a module that does not exist here must not break the
+		// workspace — it just does nothing.
+		applied, err := ApplyUserOverlay(baseConfig(), &UserWorkspaceOverlay{
+			Modules: map[string]EnvModuleOverlay{
+				"missing": {Settings: map[string]any{"key": "value"}},
+				"aws":     {Settings: map[string]any{"profile": "alice-dev"}},
+			},
+		})
+		require.NoError(t, err)
+		require.NotContains(t, applied.Modules, "missing")
+		require.Equal(t, "alice-dev", applied.Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("nil config passes through", func(t *testing.T) {
+		t.Parallel()
+		applied, err := ApplyUserOverlay(nil, &UserWorkspaceOverlay{
+			Modules: map[string]EnvModuleOverlay{
+				"aws": {Settings: map[string]any{"profile": "alice"}},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, applied)
+	})
+
+	t.Run("nil overlay passes through", func(t *testing.T) {
+		t.Parallel()
+		base := baseConfig()
+		applied, err := ApplyUserOverlay(base, nil)
+		require.NoError(t, err)
+		require.Equal(t, base, applied)
+	})
+}
+
+func TestWriteUserConfigValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates the file structure from nothing", func(t *testing.T) {
+		t.Parallel()
+		out, err := WriteUserConfigValue(nil, "github.com/acme/api", "modules.aws.settings.profile", "alice-dev", nil)
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, "alice-dev", cfg.Workspaces["github.com/acme/api"].Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("preserves unrelated sections and workspaces", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte(`[llm]
+default_provider = "anthropic"
+
+[workspaces."github.com/acme/web".modules.vercel.settings]
+team = "acme-dev"
+`)
+		out, err := WriteUserConfigValue(existing, "github.com/acme/api", "modules.aws.settings.profile", "alice-dev", nil)
+		require.NoError(t, err)
+		require.Contains(t, string(out), `default_provider = "anthropic"`)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, "acme-dev", cfg.Workspaces["github.com/acme/web"].Modules["vercel"].Settings["team"])
+		require.Equal(t, "alice-dev", cfg.Workspaces["github.com/acme/api"].Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("workspace key is canonicalized", func(t *testing.T) {
+		t.Parallel()
+		out, err := WriteUserConfigValue(nil, "git@github.com:acme/api.git", "modules.aws.settings.profile", "alice-dev", nil)
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Contains(t, cfg.Workspaces, "github.com/acme/api")
+	})
+
+	t.Run("existing equivalent entry is updated in place", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte(`[workspaces."https://github.com/acme/api.git".modules.aws.settings]
+profile = "old"
+`)
+		out, err := WriteUserConfigValue(existing, "github.com/acme/api", "modules.aws.settings.profile", "alice-dev", nil)
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Len(t, cfg.Workspaces, 1)
+		require.Equal(t, "alice-dev", cfg.Workspaces["https://github.com/acme/api.git"].Modules["aws"].Settings["profile"])
+	})
+
+	t.Run("env-scoped keys", func(t *testing.T) {
+		t.Parallel()
+		out, err := WriteUserConfigValue(nil, "github.com/acme/api", "env.dev.modules.aws.settings.region", "us-west-2", nil)
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", cfg.Workspaces["github.com/acme/api"].Env["dev"].Modules["aws"].Settings["region"])
+	})
+
+	t.Run("values are typed like repository config writes", func(t *testing.T) {
+		t.Parallel()
+		out, err := WriteUserConfigValue(nil, "github.com/acme/api", "modules.aws.settings.retries", "3", nil)
+		require.NoError(t, err)
+		require.Contains(t, string(out), "retries = 3")
+
+		out, err = WriteUserConfigValue(nil, "github.com/acme/api", "modules.aws.settings.tags", "a, b", nil)
+		require.NoError(t, err)
+		require.Contains(t, string(out), `tags = ["a", "b"]`)
+	})
+
+	t.Run("explicit list values round-trip verbatim", func(t *testing.T) {
+		t.Parallel()
+		out, err := WriteUserConfigValue(nil, "github.com/acme/api", "modules.aws.settings.tags", "", []string{"a,b", "c"})
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, []any{"a,b", "c"}, cfg.Workspaces["github.com/acme/api"].Modules["aws"].Settings["tags"])
+	})
+
+	t.Run("only module settings keys are allowed", func(t *testing.T) {
+		t.Parallel()
+		for _, key := range []string{
+			"modules.aws.source",
+			"modules.aws.entrypoint",
+			"ignore",
+			"defaults_from_dotenv",
+			"env.dev.modules.aws.source",
+		} {
+			_, err := WriteUserConfigValue(nil, "github.com/acme/api", key, "x", nil)
+			require.Error(t, err, "key %q should be rejected", key)
+		}
+	})
+
+	t.Run("unusable workspace key errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := WriteUserConfigValue(nil, "/home/alice/src/api", "modules.aws.settings.profile", "x", nil)
+		require.ErrorContains(t, err, "not a usable git remote")
+	})
+}
+
+func TestDeleteUserConfigValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes the key and prunes empty tables", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte(`[llm]
+default_provider = "anthropic"
+
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`)
+		out, err := DeleteUserConfigValue(existing, "github.com/acme/api", "modules.aws.settings.profile")
+		require.NoError(t, err)
+		require.Contains(t, string(out), `default_provider = "anthropic"`)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Workspaces)
+	})
+
+	t.Run("keeps sibling values and workspaces", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte(`[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+region = "us-west-2"
+
+[workspaces."github.com/acme/web".modules.vercel.settings]
+team = "acme-dev"
+`)
+		out, err := DeleteUserConfigValue(existing, "github.com/acme/api", "modules.aws.settings.profile")
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, "us-west-2", cfg.Workspaces["github.com/acme/api"].Modules["aws"].Settings["region"])
+		require.Equal(t, "acme-dev", cfg.Workspaces["github.com/acme/web"].Modules["vercel"].Settings["team"])
+	})
+
+	t.Run("matches equivalent workspace key spellings", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte(`[workspaces."git@github.com:acme/api.git".modules.aws.settings]
+profile = "alice-dev"
+`)
+		out, err := DeleteUserConfigValue(existing, "github.com/acme/api", "modules.aws.settings.profile")
+		require.NoError(t, err)
+
+		cfg, err := ParseUserConfig(out)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Workspaces)
+	})
+
+	t.Run("missing key errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := DeleteUserConfigValue(nil, "github.com/acme/api", "modules.aws.settings.profile")
+		require.ErrorContains(t, err, "is not set in user-level config")
+	})
+}
+
+func TestGitRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("origin url", func(t *testing.T) {
+		t.Parallel()
+		url, ok := GitRemoteURL([]byte(`
+[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = git@github.com:acme/api.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`), "origin")
+		require.True(t, ok)
+		require.Equal(t, "git@github.com:acme/api.git", url)
+	})
+
+	t.Run("multiple remotes selects the named one", func(t *testing.T) {
+		t.Parallel()
+		config := []byte(`
+[remote "upstream"]
+	url = https://github.com/acme/api.git
+[remote "origin"]
+	url = git@github.com:alice/api.git
+`)
+		url, ok := GitRemoteURL(config, "origin")
+		require.True(t, ok)
+		require.Equal(t, "git@github.com:alice/api.git", url)
+
+		url, ok = GitRemoteURL(config, "upstream")
+		require.True(t, ok)
+		require.Equal(t, "https://github.com/acme/api.git", url)
+	})
+
+	t.Run("no remote", func(t *testing.T) {
+		t.Parallel()
+		_, ok := GitRemoteURL([]byte("[core]\n\tbare = false\n"), "origin")
+		require.False(t, ok)
+	})
+
+	t.Run("comments and blank lines are skipped", func(t *testing.T) {
+		t.Parallel()
+		url, ok := GitRemoteURL([]byte(`
+; comment
+[remote "origin"]
+	# comment
+	url = https://github.com/acme/api.git
+`), "origin")
+		require.True(t, ok)
+		require.Equal(t, "https://github.com/acme/api.git", url)
+	})
+}
+
+func TestParseGitDirFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("worktree gitdir", func(t *testing.T) {
+		t.Parallel()
+		dir, ok := ParseGitDirFile([]byte("gitdir: /home/alice/src/api/.git/worktrees/feature\n"))
+		require.True(t, ok)
+		require.Equal(t, "/home/alice/src/api/.git/worktrees/feature", dir)
+	})
+
+	t.Run("relative gitdir", func(t *testing.T) {
+		t.Parallel()
+		dir, ok := ParseGitDirFile([]byte("gitdir: ../.git/modules/sub"))
+		require.True(t, ok)
+		require.Equal(t, "../.git/modules/sub", dir)
+	})
+
+	t.Run("not a gitdir file", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ParseGitDirFile([]byte("ref: refs/heads/main"))
+		require.False(t, ok)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ParseGitDirFile(nil)
+		require.False(t, ok)
+	})
+}

--- a/core/workspace/userconfig_test.go
+++ b/core/workspace/userconfig_test.go
@@ -103,6 +103,21 @@ func TestNormalizeGitRemote(t *testing.T) {
 	}
 }
 
+func TestNormalizeGitRemoteRejectsWindowsFilesystemRemotes(t *testing.T) {
+	t.Parallel()
+
+	for _, remote := range []string{
+		`C:\Users\alice\api`,
+		`C:/Users/alice/api`,
+		`\\server\share\api`,
+	} {
+		t.Run(remote, func(t *testing.T) {
+			t.Parallel()
+			require.Empty(t, NormalizeGitRemote(remote))
+		})
+	}
+}
+
 func TestMatchWorkspaceOverlay(t *testing.T) {
 	t.Parallel()
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2541,8 +2541,9 @@ dagger settings [module] [key] [value...]
 ### Options
 
 ```
-      --here    Write workspace config at the selected workspace cwd
-  -u, --unset   Remove the setting from workspace config
+  -g, --global   Store the setting in user-level config instead of the repository, keyed by the workspace's git remote
+      --here     Write workspace config at the selected workspace cwd
+  -u, --unset    Remove the setting from workspace config
 ```
 
 ### Options inherited from parent commands
@@ -2873,8 +2874,9 @@ dagger workspace config [key] [value] [flags]
 ### Options
 
 ```
-      --here    Write workspace config at the selected workspace cwd
-  -u, --unset   Remove the value at the given key
+  -g, --global   Write to user-level config instead of the repository, keyed by the workspace's git remote
+      --here     Write workspace config at the selected workspace cwd
+  -u, --unset    Remove the value at the given key
 ```
 
 ### Options inherited from parent commands

--- a/docs/current_docs/reference/configuration/workspace.mdx
+++ b/docs/current_docs/reference/configuration/workspace.mdx
@@ -106,6 +106,37 @@ source = "modules/debugger"
 
 Write settings overlays with `dagger settings --env <name> <module> <key> <value>` (or `dagger workspace config --env <name> …` for raw access). Reads with `--env` show the effective view — the base configuration with the overlay applied — and the base is what every environment inherits.
 
+## User-level configuration
+
+Personal overrides that shouldn't be committed — private account profiles, local paths, personal environments — live in the user-level Dagger config file: `~/.config/dagger/config.toml`, or the file named by `$DAGGER_CONFIG`. The file is shared with other Dagger subsystems (such as `[llm]`); workspace overrides sit in a `[workspaces.*]` section keyed by the workspace's Git remote:
+
+```toml
+# Always applied when working in this workspace:
+[workspaces."github.com/acme/api".modules.eslint.settings]
+packageManager = "pnpm"
+
+# A personal environment, selected with `dagger --env dev ...`:
+[workspaces."github.com/acme/api".env.dev.modules.eslint.settings]
+baseImageAddress = "node:22-alpine"
+```
+
+The effective configuration is merged in a fixed order: base `dagger.toml`, then the matching user-level overrides, then the selected `--env` overlay. User-level values shadow repository values key by key, and user-level environments are added to (and merge over) the repository's, all without modifying `dagger.toml`.
+
+**Workspace key.** The key is the normalized `origin` remote: host and path, with no scheme, no user, and no `.git` suffix. Equivalent spellings all match — `git@github.com:acme/api.git`, `https://github.com/acme/api`, and `github.com/acme/api` identify the same workspace, both as the config key and in the repository's git config. A repository with multiple remotes is keyed by `origin` only; a repository with no remote (or a purely local one) matches no user-level overrides. Remote workspaces selected with `-W` are keyed by their clone address.
+
+**Writing.** Pass `-g/--global` to `dagger settings` or `dagger workspace config` to store a value user-level instead of in the repository:
+
+```shell
+dagger settings -g eslint packageManager pnpm
+dagger settings -g --env dev eslint baseImageAddress node:22-alpine
+dagger settings -g -u eslint packageManager        # remove the override
+dagger workspace config -g modules.eslint.settings.packageManager pnpm
+```
+
+`--global` selects where a write is stored; reads always show the effective merged view. Unsetting with `-g` removes only the user-level value — the repository value underneath is untouched.
+
+**Scope and safety.** Only module settings can be stored user-level: `modules.<name>.settings.*`, optionally under `env.<name>.*`. Because one key spans every branch and clone of a repository, an always-applied user entry for a module that doesn't exist in the current checkout is ignored there rather than being an error. User-level environments are validated normally when selected with `--env`.
+
 ## Other keys
 
 | Key | Description |

--- a/docs/current_docs/reference/configuration/workspace.mdx
+++ b/docs/current_docs/reference/configuration/workspace.mdx
@@ -135,6 +135,8 @@ dagger workspace config -g modules.eslint.settings.packageManager pnpm
 
 `--global` selects where a write is stored; reads always show the effective merged view. Unsetting with `-g` removes only the user-level value — the repository value underneath is untouched.
 
+`-g` also composes with `-W`: a remote workspace is a readable target whose repository config can't be written, but its user-level overrides live in your local config file, so `dagger -W https://github.com/acme/api settings -g aws profile alice-dev` works and keys the entry by the clone address.
+
 **Scope and safety.** Only module settings can be stored user-level: `modules.<name>.settings.*`, optionally under `env.<name>.*`. Because one key spans every branch and clone of a repository, an always-applied user entry for a module that doesn't exist in the current checkout is ignored there rather than being an error. User-level environments are validated normally when selected with `--env`.
 
 ## Other keys

--- a/docs/current_docs/using-dagger/environments.mdx
+++ b/docs/current_docs/using-dagger/environments.mdx
@@ -44,3 +44,34 @@ Without `--env`, you read and write the base configuration, which every environm
 ```shell
 dagger workspace config env.staging.modules.<module>.settings.<key> <value>
 ```
+
+## Personal overrides (user-level config)
+
+Some values should not be committed to the repository: private account profiles, local paths, personal development clusters. Keep those in your user-level Dagger config file — `~/.config/dagger/config.toml` (or the file named by `$DAGGER_CONFIG`) — under a `[workspaces.*]` section keyed by the workspace's Git remote:
+
+```toml
+# Always applied when working in the github.com/acme/api workspace:
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+
+# A personal environment, selected with `dagger --env dev ...`:
+[workspaces."github.com/acme/api".env.dev.modules.aws.settings]
+region = "us-west-2"
+```
+
+User-level values merge over the repository's `dagger.toml` without modifying it, and user-level environments are added to (and merge over) the repository's own. The merge order is: base config, then your user-level overrides, then the selected `--env` overlay.
+
+The workspace key is the normalized form of the repository's `origin` remote: host and path, with no scheme, no user, and no `.git` suffix. Equivalent remote URL spellings all match — `git@github.com:acme/api.git`, `https://github.com/acme/api`, and `github.com/acme/api` identify the same workspace, in the key and in your git config alike. A repository with multiple remotes is keyed by `origin` only, and a repository with no remote (or a purely local one) matches no user-level overrides.
+
+You don't have to edit the file by hand: pass `-g/--global` to `dagger settings` or `dagger workspace config` to target your user-level config instead of the repository's `dagger.toml`:
+
+```shell
+dagger settings -g aws profile alice-dev             # always applied here
+dagger settings -g --env dev aws region us-west-2    # personal env overlay
+dagger settings -g -u aws profile                    # remove the override
+dagger workspace config -g modules.aws.settings.profile alice-dev
+```
+
+`--global` chooses where a write is stored; reads always show the effective merged view. Only module settings can be stored user-level (`modules.<name>.settings.*`, optionally under `env.<name>.*`), and a user-level entry for a module that doesn't exist in some checkout is simply ignored there — the same key spans every branch and clone of the repository.
+
+See [Workspace configuration](../reference/configuration/workspace.mdx#user-level-configuration) for the full schema and key-normalization rules.

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -145,6 +145,10 @@ type Params struct {
 	// WorkspaceEnv explicitly selects the workspace environment overlay for this client.
 	WorkspaceEnv *string
 
+	// UserConfigPath is the caller-host path to the user-level Dagger config
+	// file, read by the engine for user-level workspace overrides.
+	UserConfigPath string
+
 	// WorkspaceModuleScope hints at the workspace module this client's first
 	// schema introspection targets (the leading CLI command token, unresolved).
 	WorkspaceModuleScope string
@@ -1476,6 +1480,9 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 	}
 	if c.WorkspaceEnv != nil {
 		md.WorkspaceEnv = c.WorkspaceEnv
+	}
+	if c.UserConfigPath != "" {
+		md.UserConfigPath = c.UserConfigPath
 	}
 
 	return md

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -147,6 +147,12 @@ type ClientMetadata struct {
 	// this client. When unset, no environment overlay is applied.
 	WorkspaceEnv *string `json:"workspace_env,omitempty"`
 
+	// UserConfigPath is the caller-host path to the user-level Dagger config
+	// file (~/.config/dagger/config.toml). The engine reads it through the
+	// caller host session to apply user-level workspace overrides. When unset,
+	// no user-level config is consulted.
+	UserConfigPath string `json:"user_config_path,omitempty"`
+
 	// WorkspaceModuleScope hints at the workspace module this client's first
 	// schema introspection targets: the leading CLI command token, unresolved
 	// (it may name a module, an entrypoint-proxied function, or a typo). The

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1323,6 +1323,9 @@ func (srv *Server) getOrInitClient(
 				client.clientMetadata.WorkspaceEnv = &env
 			}
 		}
+		if client.clientMetadata.UserConfigPath == "" && !client.workspaceLoaded {
+			client.clientMetadata.UserConfigPath = opts.ClientMetadata.UserConfigPath
+		}
 		// ExtraModules may arrive on a later request (e.g. /init) after the
 		// session attachable request already created the client without them.
 		if len(opts.ExtraModules) > 0 && len(client.pendingExtraModules) == 0 && !client.extraModulesLoaded {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1519,6 +1519,7 @@ func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.
 	var suppressCompatWorkspaceWarning bool
 	var workspaceRef *string
 	var workspaceEnv *string
+	var userConfigPath string
 	if md, _ := engine.ClientMetadataFromHTTPHeaders(h); md != nil {
 		clientMetadata.ClientVersion = md.ClientVersion
 		clientMetadata.AllowedLLMModules = slices.Clone(md.AllowedLLMModules)
@@ -1542,6 +1543,7 @@ func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.
 			env := declaredEnv
 			workspaceEnv = &env
 		}
+		userConfigPath = md.UserConfigPath
 	}
 
 	clientMetadata.ExtraModules = extraModules
@@ -1552,6 +1554,7 @@ func nestedClientMetadataForRequest(h http.Header, nestedClientMetadata *engine.
 	clientMetadata.SuppressCompatWorkspaceWarning = suppressCompatWorkspaceWarning
 	clientMetadata.Workspace = workspaceRef
 	clientMetadata.WorkspaceEnv = workspaceEnv
+	clientMetadata.UserConfigPath = userConfigPath
 	return &clientMetadata
 }
 

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1425,6 +1425,8 @@ func TestRemoteWorkspaceCwdUsesDetectionStart(t *testing.T) {
 		false,
 		dagql.ObjectResult[*core.Directory]{},
 		nil,
+		nil,
+		"",
 	)
 	require.NoError(t, err)
 	require.Equal(t, "subdir", client.workspace.Cwd)
@@ -1484,6 +1486,8 @@ func TestRemoteWorkspaceLoadsPlainModuleCompatFromCWD(t *testing.T) {
 		false,
 		dagql.ObjectResult[*core.Directory]{},
 		nil,
+		nil,
+		"",
 	)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join("subdir", "child"), client.workspace.Cwd)

--- a/engine/server/session_userconfig_test.go
+++ b/engine/server/session_userconfig_test.go
@@ -1,0 +1,356 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/engine"
+)
+
+const testUserConfigPath = "/home/alice/.config/dagger/config.toml"
+
+// userConfigTestHost fakes a local host filesystem: a git repo at /repo with a
+// dagger.toml, plus an optional user-level config file outside the repo.
+type userConfigTestHost struct {
+	files map[string]string
+	dirs  map[string]bool
+}
+
+func newUserConfigTestHost(gitConfig, daggerTOML, userConfig string) *userConfigTestHost {
+	h := &userConfigTestHost{
+		files: map[string]string{
+			"/repo/dagger.toml": daggerTOML,
+		},
+		dirs: map[string]bool{
+			"/repo/.git": true,
+		},
+	}
+	if gitConfig != "" {
+		h.files["/repo/.git/config"] = gitConfig
+	}
+	if userConfig != "" {
+		h.files[testUserConfigPath] = userConfig
+	}
+	return h
+}
+
+func (h *userConfigTestHost) statFS() core.StatFS {
+	return core.StatFSFunc(func(_ context.Context, path string) (string, *core.Stat, error) {
+		path = filepath.Clean(path)
+		if _, ok := h.files[path]; ok || h.dirs[path] {
+			return filepath.Dir(path), &core.Stat{Name: filepath.Base(path)}, nil
+		}
+		return "", nil, os.ErrNotExist
+	})
+}
+
+func (h *userConfigTestHost) readFile(_ context.Context, path string) ([]byte, error) {
+	if data, ok := h.files[filepath.Clean(path)]; ok {
+		return []byte(data), nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func loadUserConfigTestWorkspace(t *testing.T, h *userConfigTestHost, md *engine.ClientMetadata) (*daggerClient, error) {
+	t.Helper()
+
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID: "test-client",
+	})
+	client := &daggerClient{
+		pendingWorkspaceLoad: true,
+		clientMetadata:       md,
+	}
+	err := (&Server{}).detectAndLoadWorkspace(ctx, client,
+		h.statFS(),
+		h.readFile,
+		"/repo",
+		func(ws *workspace.Workspace, relPath string) string {
+			return filepath.Join(ws.Root, relPath)
+		},
+		nil,
+		true, // isLocal
+	)
+	return client, err
+}
+
+const userConfigTestDaggerTOML = `[modules.aws]
+source = "github.com/dagger/aws@main"
+
+[modules.aws.settings]
+profile = "shared"
+region = "us-east-1"
+
+[env.staging.modules.aws.settings]
+profile = "staging"
+`
+
+const userConfigTestGitConfig = `[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = git@github.com:acme/api.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`
+
+func pendingModuleByName(t *testing.T, client *daggerClient, name string) pendingModule {
+	t.Helper()
+	for _, mod := range client.pendingModules {
+		if mod.Name == name {
+			return mod
+		}
+	}
+	t.Fatalf("module %q not found in pending modules", name)
+	return pendingModule{}
+}
+
+func TestUserConfigOverridesWorkspaceSettings(t *testing.T) {
+	t.Parallel()
+
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`)
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "github.com/acme/api", client.workspace.UserConfigKey())
+	require.NotNil(t, client.workspace.UserConfigOverlay())
+
+	aws := pendingModuleByName(t, client, "aws")
+	// User-level value wins; untouched keys keep repo values.
+	require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
+	require.Equal(t, "us-east-1", aws.ConfigDefaults["region"])
+}
+
+func TestUserConfigAddsSelectableEnv(t *testing.T) {
+	t.Parallel()
+
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/api".env.dev.modules.aws.settings]
+profile = "alice-dev"
+region = "us-west-2"
+`)
+	env := "dev"
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+		WorkspaceEnv:         &env,
+	})
+	require.NoError(t, err)
+
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
+	require.Equal(t, "us-west-2", aws.ConfigDefaults["region"])
+}
+
+func TestUserConfigEnvMergesOverRepoEnv(t *testing.T) {
+	t.Parallel()
+
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/api".env.staging.modules.aws.settings]
+region = "eu-west-1"
+`)
+	env := "staging"
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+		WorkspaceEnv:         &env,
+	})
+	require.NoError(t, err)
+
+	aws := pendingModuleByName(t, client, "aws")
+	// Repo env value survives; user env value layers on top.
+	require.Equal(t, "staging", aws.ConfigDefaults["profile"])
+	require.Equal(t, "eu-west-1", aws.ConfigDefaults["region"])
+}
+
+func TestUserConfigMatchesEquivalentRemoteForms(t *testing.T) {
+	t.Parallel()
+
+	// Repo origin is scp-style ssh; the user config keys the same remote in
+	// https form with a .git suffix.
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, `
+[workspaces."https://github.com/acme/api.git".modules.aws.settings]
+profile = "alice-dev"
+`)
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
+}
+
+func TestUserConfigOtherWorkspaceDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/other".modules.aws.settings]
+profile = "alice-dev"
+`)
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+
+	require.Nil(t, client.workspace.UserConfigOverlay())
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "shared", aws.ConfigDefaults["profile"])
+}
+
+func TestUserConfigNoGitRemote(t *testing.T) {
+	t.Parallel()
+
+	// A git workspace with no origin remote has no user-config key, so
+	// user-level overrides never match it.
+	h := newUserConfigTestHost("[core]\n\tbare = false\n", userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`)
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, client.workspace.UserConfigKey())
+	require.Nil(t, client.workspace.UserConfigOverlay())
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "shared", aws.ConfigDefaults["profile"])
+}
+
+func TestUserConfigLocalPathRemote(t *testing.T) {
+	t.Parallel()
+
+	// Filesystem remotes have no stable cross-machine identity and produce no
+	// key.
+	h := newUserConfigTestHost(`[remote "origin"]
+	url = /home/alice/src/api
+`, userConfigTestDaggerTOML, "")
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+	require.Empty(t, client.workspace.UserConfigKey())
+}
+
+func TestUserConfigMissingFileIsFine(t *testing.T) {
+	t.Parallel()
+
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, "")
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+
+	// The key is still derived, but with no user config there is no overlay.
+	require.Equal(t, "github.com/acme/api", client.workspace.UserConfigKey())
+	require.Nil(t, client.workspace.UserConfigOverlay())
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "shared", aws.ConfigDefaults["profile"])
+}
+
+func TestUserConfigMalformedErrors(t *testing.T) {
+	t.Parallel()
+
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, "[workspaces")
+	_, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.ErrorContains(t, err, "parsing user config")
+}
+
+func TestUserConfigNoPathDeclared(t *testing.T) {
+	t.Parallel()
+
+	// Clients that do not declare a user config path (e.g. older CLIs) get no
+	// user-level behavior at all.
+	h := newUserConfigTestHost(userConfigTestGitConfig, userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`)
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, client.workspace.UserConfigKey())
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "shared", aws.ConfigDefaults["profile"])
+}
+
+func TestUserConfigWorktreeGitFile(t *testing.T) {
+	t.Parallel()
+
+	// A linked worktree stores a .git *file* pointing at the main repo's
+	// worktree gitdir; the shared config lives in the common git dir.
+	h := &userConfigTestHost{
+		files: map[string]string{
+			"/repo/dagger.toml":                      userConfigTestDaggerTOML,
+			"/repo/.git":                             "gitdir: /main/.git/worktrees/feature\n",
+			"/main/.git/worktrees/feature/commondir": "../..\n",
+			"/main/.git/config":                      userConfigTestGitConfig,
+			testUserConfigPath: `
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`,
+		},
+	}
+	client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+		LoadWorkspaceModules: true,
+		UserConfigPath:       testUserConfigPath,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "github.com/acme/api", client.workspace.UserConfigKey())
+	aws := pendingModuleByName(t, client, "aws")
+	require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
+}
+
+func TestUserConfigRemoteWorkspaceKey(t *testing.T) {
+	t.Parallel()
+
+	// attachUserWorkspaceOverlay with a pre-computed remote key: the tree is
+	// remote but the user config still comes from the caller's host.
+	ws := &workspace.Workspace{Root: ".", Cwd: ".", ConfigFile: workspace.ConfigFileName}
+	coreWS := &core.Workspace{}
+	hostReadFile := func(_ context.Context, path string) ([]byte, error) {
+		if filepath.Clean(path) == testUserConfigPath {
+			return []byte(`
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	err := attachUserWorkspaceOverlay(context.Background(),
+		&engine.ClientMetadata{UserConfigPath: testUserConfigPath},
+		nil,
+		hostReadFile,
+		ws,
+		coreWS,
+		workspace.NormalizeGitRemote("https://github.com/acme/api.git"),
+		false, // isLocal
+	)
+	require.NoError(t, err)
+	require.Equal(t, "github.com/acme/api", coreWS.UserConfigKey())
+	overlay := coreWS.UserConfigOverlay()
+	require.NotNil(t, overlay)
+	require.Equal(t, "alice-dev", overlay.Modules["aws"].Settings["profile"])
+}

--- a/engine/server/session_userconfig_test.go
+++ b/engine/server/session_userconfig_test.go
@@ -355,6 +355,64 @@ profile = "alice-dev"
 	}
 }
 
+func TestUserConfigIncludeIfConditionsFollowGitSemantics(t *testing.T) {
+	t.Parallel()
+
+	userConfig := `
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`
+
+	t.Run("non-matching gitdir condition is not followed", func(t *testing.T) {
+		t.Parallel()
+		h := newUserConfigTestHost(`[includeIf "gitdir:/elsewhere/"]
+	path = origin.config
+`, userConfigTestDaggerTOML, userConfig)
+		h.files["/repo/.git/origin.config"] = userConfigTestGitConfig
+
+		client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+			UserConfigPath:       testUserConfigPath,
+		})
+		require.NoError(t, err)
+		require.Empty(t, client.workspace.UserConfigKey())
+	})
+
+	t.Run("onbranch condition follows the checked-out branch", func(t *testing.T) {
+		t.Parallel()
+		h := newUserConfigTestHost(`[includeIf "onbranch:main"]
+	path = origin.config
+`, userConfigTestDaggerTOML, userConfig)
+		h.files["/repo/.git/origin.config"] = userConfigTestGitConfig
+		h.files["/repo/.git/HEAD"] = "ref: refs/heads/main\n"
+
+		client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+			UserConfigPath:       testUserConfigPath,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "github.com/acme/api", client.workspace.UserConfigKey())
+		aws := pendingModuleByName(t, client, "aws")
+		require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
+	})
+
+	t.Run("onbranch condition on another branch is not followed", func(t *testing.T) {
+		t.Parallel()
+		h := newUserConfigTestHost(`[includeIf "onbranch:main"]
+	path = origin.config
+`, userConfigTestDaggerTOML, userConfig)
+		h.files["/repo/.git/origin.config"] = userConfigTestGitConfig
+		h.files["/repo/.git/HEAD"] = "ref: refs/heads/other\n"
+
+		client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+			LoadWorkspaceModules: true,
+			UserConfigPath:       testUserConfigPath,
+		})
+		require.NoError(t, err)
+		require.Empty(t, client.workspace.UserConfigKey())
+	})
+}
+
 func TestUserConfigRemoteWorkspaceKey(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/session_userconfig_test.go
+++ b/engine/server/session_userconfig_test.go
@@ -322,6 +322,39 @@ profile = "alice-dev"
 	require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
 }
 
+func TestUserConfigOriginFromIncludedGitConfig(t *testing.T) {
+	t.Parallel()
+
+	for name, gitConfig := range map[string]string{
+		"include": `[include]
+	path = origin.config
+`,
+		"conditional include": `[includeIf "gitdir:/repo/"]
+	path = origin.config
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newUserConfigTestHost(gitConfig, userConfigTestDaggerTOML, `
+[workspaces."github.com/acme/api".modules.aws.settings]
+profile = "alice-dev"
+`)
+			h.files["/repo/.git/origin.config"] = userConfigTestGitConfig
+
+			client, err := loadUserConfigTestWorkspace(t, h, &engine.ClientMetadata{
+				LoadWorkspaceModules: true,
+				UserConfigPath:       testUserConfigPath,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, "github.com/acme/api", client.workspace.UserConfigKey())
+			aws := pendingModuleByName(t, client, "aws")
+			require.Equal(t, "alice-dev", aws.ConfigDefaults["profile"])
+		})
+	}
+}
+
 func TestUserConfigRemoteWorkspaceKey(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -943,17 +943,28 @@ func attachUserWorkspaceOverlay(
 }
 
 // localWorkspaceUserConfigKey derives the user-config key for a local
-// workspace from its git origin remote. Best-effort: a workspace without a
-// usable origin has no key and matches no user-level overrides.
+// workspace from its git origin remote, resolved the way `git config --get`
+// would see it (include/includeIf directives followed). Best-effort: a
+// workspace without a usable origin has no key and matches no user-level
+// overrides.
 func localWorkspaceUserConfigKey(
 	ctx context.Context,
 	readFile func(context.Context, string) ([]byte, error),
 	root string,
 ) string {
-	data, err := readLocalGitConfig(ctx, readFile, root)
+	data, configPath, gitDir, err := readLocalGitConfig(ctx, readFile, root)
 	if err != nil {
 		return ""
 	}
+	branch := ""
+	if headData, herr := readFile(ctx, filepath.Join(gitDir, "HEAD")); herr == nil {
+		branch = workspace.GitBranchFromHEAD(headData)
+	}
+	data = workspace.ResolveGitConfigIncludes(ctx, readFile, workspace.GitConfigState{
+		ConfigPath: configPath,
+		GitDir:     gitDir,
+		Branch:     branch,
+	}, data)
 	origin, ok := workspace.GitRemoteURL(data, "origin")
 	if !ok {
 		return ""
@@ -963,32 +974,37 @@ func localWorkspaceUserConfigKey(
 
 // readLocalGitConfig reads <root>/.git/config, following a .git worktree or
 // submodule file to its gitdir (and the gitdir's commondir) when .git is not a
-// directory.
+// directory. It returns the config contents together with the config file's
+// path and the repository's per-worktree gitdir, which include resolution and
+// includeIf conditions need.
 func readLocalGitConfig(
 	ctx context.Context,
 	readFile func(context.Context, string) ([]byte, error),
 	root string,
-) ([]byte, error) {
-	data, err := readFile(ctx, filepath.Join(root, ".git", "config"))
+) (data []byte, configPath, gitDir string, rerr error) {
+	gitDir = filepath.Join(root, ".git")
+	configPath = filepath.Join(gitDir, "config")
+	data, err := readFile(ctx, configPath)
 	if err == nil {
-		return data, nil
+		return data, configPath, gitDir, nil
 	}
 
 	gitFileData, ferr := readFile(ctx, filepath.Join(root, ".git"))
 	if ferr != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	gitDir, ok := workspace.ParseGitDirFile(gitFileData)
 	if !ok {
-		return nil, fmt.Errorf("invalid .git file in %s", root)
+		return nil, "", "", fmt.Errorf("invalid .git file in %s", root)
 	}
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(root, gitDir)
 	}
 	gitDir = filepath.Clean(gitDir)
 
-	if data, cerr := readFile(ctx, filepath.Join(gitDir, "config")); cerr == nil {
-		return data, nil
+	configPath = filepath.Join(gitDir, "config")
+	if data, cerr := readFile(ctx, configPath); cerr == nil {
+		return data, configPath, gitDir, nil
 	}
 	// Linked worktrees keep the shared config in the common git dir.
 	if commonData, cerr := readFile(ctx, filepath.Join(gitDir, "commondir")); cerr == nil {
@@ -997,10 +1013,13 @@ func readLocalGitConfig(
 			if !filepath.IsAbs(commonDir) {
 				commonDir = filepath.Join(gitDir, commonDir)
 			}
-			return readFile(ctx, filepath.Join(filepath.Clean(commonDir), "config"))
+			configPath = filepath.Join(filepath.Clean(commonDir), "config")
+			if data, cerr := readFile(ctx, configPath); cerr == nil {
+				return data, configPath, gitDir, nil
+			}
 		}
 	}
-	return nil, err
+	return nil, "", "", err
 }
 
 func localWorkspaceAddress(root, workspaceCwd string) string {

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -361,6 +361,10 @@ func (srv *Server) loadWorkspaceFromRemote(ctx context.Context, client *daggerCl
 		false, // isLocal
 		tree,  // pre-built rootfs for remote
 		core.NewWorkspaceSourceGitRef(gitRef.Result, gitutil.IsCommitSHA(parsedRef.version)),
+		// The workspace tree is remote, but user-level config still comes from
+		// the caller's host; the key is the declared remote itself.
+		client.engineUtilClient.ReadCallerHostFile,
+		workspace.NormalizeGitRemote(parsedRef.cloneRef),
 	)
 }
 
@@ -378,7 +382,9 @@ func (srv *Server) detectAndLoadWorkspace(
 	workspaceAddress func(ws *workspace.Workspace) string,
 	isLocal bool,
 ) error {
-	return srv.detectAndLoadWorkspaceWithRootfs(ctx, client, statFS, readFile, cwd, resolveLocalRef, workspaceAddress, isLocal, dagql.ObjectResult[*core.Directory]{}, nil)
+	// For local workspaces readFile already reads the caller's host, so it
+	// doubles as the user-level config reader.
+	return srv.detectAndLoadWorkspaceWithRootfs(ctx, client, statFS, readFile, cwd, resolveLocalRef, workspaceAddress, isLocal, dagql.ObjectResult[*core.Directory]{}, nil, readFile, "")
 }
 
 // pendingModule represents a module to be loaded from workspace discovery,
@@ -627,6 +633,12 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	isLocal bool,
 	prebuiltRootfs dagql.ObjectResult[*core.Directory],
 	prebuiltSource core.WorkspaceSource,
+	// hostReadFile reads files from the caller's host regardless of where the
+	// workspace tree lives; it serves the user-level config file.
+	hostReadFile func(context.Context, string) ([]byte, error),
+	// remoteKey is the pre-computed user-config key for remote workspaces.
+	// Empty for local workspaces, whose key derives from the git origin.
+	remoteKey string,
 ) error {
 	clientMD := client.clientMetadata
 	loadModules := client.pendingWorkspaceLoad &&
@@ -737,10 +749,22 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 		return fmt.Errorf("building workspace: %w", err)
 	}
 	coreWS.SetCompatWorkspace(compatWorkspace)
+	if err := attachUserWorkspaceOverlay(ctx, clientMD, readFile, hostReadFile, ws, coreWS, remoteKey, isLocal); err != nil {
+		return err
+	}
 	client.workspace = coreWS
 
 	if !loadModules {
 		return nil
+	}
+
+	// User-level overrides merge over the repository config before any env
+	// overlay so that user-defined environments are selectable.
+	if overlay := coreWS.UserConfigOverlay(); overlay != nil {
+		wsConfig, err = workspace.ApplyUserOverlay(wsConfig, overlay)
+		if err != nil {
+			return err
+		}
 	}
 
 	if hasWorkspaceEnv {
@@ -874,6 +898,109 @@ func (srv *Server) buildCoreWorkspace(
 	}
 
 	return coreWS, nil
+}
+
+// attachUserWorkspaceOverlay resolves the workspace's user-config key (its
+// normalized Git remote) and, when the caller's user-level config file has a
+// matching [workspaces.*] entry, attaches that overlay to coreWS. The overlay
+// is applied to the effective workspace config by module loading and by the
+// schema-level config read paths.
+func attachUserWorkspaceOverlay(
+	ctx context.Context,
+	clientMD *engine.ClientMetadata,
+	readFile func(context.Context, string) ([]byte, error),
+	hostReadFile func(context.Context, string) ([]byte, error),
+	ws *workspace.Workspace,
+	coreWS *core.Workspace,
+	remoteKey string,
+	isLocal bool,
+) error {
+	if clientMD == nil || clientMD.UserConfigPath == "" || hostReadFile == nil {
+		return nil
+	}
+	key := remoteKey
+	if key == "" && isLocal && ws.HasGitRoot {
+		key = localWorkspaceUserConfigKey(ctx, readFile, ws.Root)
+	}
+	if key == "" {
+		return nil
+	}
+	coreWS.SetUserConfigKey(key)
+
+	data, err := hostReadFile(ctx, clientMD.UserConfigPath)
+	if err != nil {
+		if isWorkspaceNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("reading user config %s: %w", clientMD.UserConfigPath, err)
+	}
+	userCfg, err := workspace.ParseUserConfig(data)
+	if err != nil {
+		return fmt.Errorf("parsing user config %s: %w", clientMD.UserConfigPath, err)
+	}
+	coreWS.SetUserConfigOverlay(userCfg.MatchWorkspaceOverlay(key))
+	return nil
+}
+
+// localWorkspaceUserConfigKey derives the user-config key for a local
+// workspace from its git origin remote. Best-effort: a workspace without a
+// usable origin has no key and matches no user-level overrides.
+func localWorkspaceUserConfigKey(
+	ctx context.Context,
+	readFile func(context.Context, string) ([]byte, error),
+	root string,
+) string {
+	data, err := readLocalGitConfig(ctx, readFile, root)
+	if err != nil {
+		return ""
+	}
+	origin, ok := workspace.GitRemoteURL(data, "origin")
+	if !ok {
+		return ""
+	}
+	return workspace.NormalizeGitRemote(origin)
+}
+
+// readLocalGitConfig reads <root>/.git/config, following a .git worktree or
+// submodule file to its gitdir (and the gitdir's commondir) when .git is not a
+// directory.
+func readLocalGitConfig(
+	ctx context.Context,
+	readFile func(context.Context, string) ([]byte, error),
+	root string,
+) ([]byte, error) {
+	data, err := readFile(ctx, filepath.Join(root, ".git", "config"))
+	if err == nil {
+		return data, nil
+	}
+
+	gitFileData, ferr := readFile(ctx, filepath.Join(root, ".git"))
+	if ferr != nil {
+		return nil, err
+	}
+	gitDir, ok := workspace.ParseGitDirFile(gitFileData)
+	if !ok {
+		return nil, fmt.Errorf("invalid .git file in %s", root)
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(root, gitDir)
+	}
+	gitDir = filepath.Clean(gitDir)
+
+	if data, cerr := readFile(ctx, filepath.Join(gitDir, "config")); cerr == nil {
+		return data, nil
+	}
+	// Linked worktrees keep the shared config in the common git dir.
+	if commonData, cerr := readFile(ctx, filepath.Join(gitDir, "commondir")); cerr == nil {
+		commonDir := strings.TrimSpace(string(commonData))
+		if commonDir != "" {
+			if !filepath.IsAbs(commonDir) {
+				commonDir = filepath.Join(gitDir, commonDir)
+			}
+			return readFile(ctx, filepath.Join(filepath.Clean(commonDir), "config"))
+		}
+	}
+	return nil, err
 }
 
 func localWorkspaceAddress(root, workspaceCwd string) string {

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 	"github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	"github.com/dagger/dagger/util/cleanups"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/muesli/termenv"
@@ -283,6 +284,12 @@ func applyWorkspaceClientParams(params *client.Params) error {
 	if params.WorkspaceEnv == nil && workspaceEnv != "" {
 		env := workspaceEnv
 		params.WorkspaceEnv = &env
+	}
+	if params.UserConfigPath == "" {
+		// The shared user-level config file (~/.config/dagger/config.toml, or
+		// $DAGGER_CONFIG). The engine reads its [workspaces.*] section for
+		// user-level workspace overrides.
+		params.UserConfigPath = llmconfig.ConfigFile
 	}
 	return nil
 }

--- a/internal/cmd/dagger/llmconfig/config.go
+++ b/internal/cmd/dagger/llmconfig/config.go
@@ -147,6 +147,37 @@ func (c *Config) Save() error {
 	return nil
 }
 
+// UpdateFile applies fn to the current config file contents under the
+// cross-process lock and writes the result back atomically with 0600
+// permissions. fn receives nil when the file does not exist yet. The file is
+// shared between subsystems ([llm], [workspaces], ...), so fn must preserve
+// sections it does not own.
+func UpdateFile(fn func(existing []byte) ([]byte, error)) error {
+	if err := os.MkdirAll(filepath.Dir(ConfigFile), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	lock := flock.New(ConfigFile + ".lock")
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	defer lock.Unlock()
+
+	data, err := os.ReadFile(ConfigFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read config file: %w", err)
+		}
+		data = nil
+	}
+
+	updated, err := fn(data)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(ConfigFile, updated, 0600)
+}
+
 // atomicWriteFile writes data to path atomically by writing to a temporary
 // file in the same directory and renaming it into place (rename is atomic on
 // POSIX). The temp file is removed if the write or rename fails.

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -666,10 +666,14 @@ func validateWorkspaceFlagPolicy(cmd *cobra.Command, args []string) error {
 }
 
 func workspaceFlagPolicy(cmd *cobra.Command, args []string) string {
-	if isWorkspaceConfigCommand(cmd) && len(args) == 2 {
+	// Writes to the repository's workspace config need a local workspace.
+	// --global writes target the user-level config file instead, which is
+	// always local to the caller, so a remote workspace stays selectable as
+	// the key/introspection target.
+	if isWorkspaceConfigCommand(cmd) && len(args) == 2 && !workspaceConfigGlobal {
 		return workspaceFlagPolicyLocalOnly
 	}
-	if isWorkspaceSettingsWriteCommand(cmd, args) {
+	if isWorkspaceSettingsWriteCommand(cmd, args) && !workspaceSettingsGlobal {
 		return workspaceFlagPolicyLocalOnly
 	}
 

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -75,7 +75,10 @@ func init() {
 	addWorkspaceHereFlag(settingsCmd)
 }
 
-var workspaceSettingsUnset bool
+var (
+	workspaceSettingsUnset  bool
+	workspaceSettingsGlobal bool
+)
 
 func newSettingsCmd(hidden bool) *cobra.Command {
 	cmd := &cobra.Command{
@@ -86,12 +89,16 @@ func newSettingsCmd(hidden bool) *cobra.Command {
 		RunE:   runWorkspaceSettings,
 	}
 	cmd.Flags().BoolVarP(&workspaceSettingsUnset, "unset", "u", false, "Remove the setting from workspace config")
+	cmd.Flags().BoolVarP(&workspaceSettingsGlobal, "global", "g", false, "Store the setting in user-level config instead of the repository, keyed by the workspace's git remote")
 	return cmd
 }
 
 func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 	if workspaceSettingsUnset && len(args) != 2 {
 		return fmt.Errorf("--unset requires MODULE and KEY arguments")
+	}
+	if workspaceSettingsGlobal && !workspaceSettingsUnset && len(args) < 3 {
+		return fmt.Errorf("--global stores a setting in user-level config; pass MODULE KEY VALUE to set or use --unset (reads always show the effective value)")
 	}
 	return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) error {
 		moduleName := ""
@@ -108,6 +115,9 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 			setting, err := state.lookupSetting(args[1])
 			if err != nil {
 				return err
+			}
+			if workspaceSettingsGlobal {
+				return unsetUserConfigValue(ctx, userScopedConfigKey(workspaceSettingConfigKey(setting.Module, setting.Key)))
 			}
 			return state.Workspace.
 				WithoutConfigValue(workspaceSettingConfigKey(setting.Module, setting.Key), dagger.WorkspaceWithoutConfigValueOpts{Here: workspaceHere}).
@@ -132,6 +142,9 @@ func runWorkspaceSettings(cmd *cobra.Command, args []string) error {
 			value, values, err := workspaceSettingWriteValue(setting, args[2:])
 			if err != nil {
 				return err
+			}
+			if workspaceSettingsGlobal {
+				return writeUserConfigValue(ctx, userScopedConfigKey(workspaceSettingConfigKey(setting.Module, setting.Key)), value, values)
 			}
 			return state.Workspace.
 				WithConfigValue(workspaceSettingConfigKey(setting.Module, setting.Key), value, dagger.WorkspaceWithConfigValueOpts{Values: values, Here: workspaceHere}).

--- a/internal/cmd/dagger/userconfig_key_test.go
+++ b/internal/cmd/dagger/userconfig_key_test.go
@@ -1,0 +1,71 @@
+package daggercmd
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserConfigWorkspaceKeyRemoteRefs pins the user-config key derived for
+// -W remote workspace refs: the normalized clone address, with any version
+// or subdir selection dropped so one key spans every ref of the repo.
+func TestUserConfigWorkspaceKeyRemoteRefs(t *testing.T) {
+	oldWorkspaceRef := workspaceRef
+	t.Cleanup(func() {
+		workspaceRef = oldWorkspaceRef
+	})
+
+	for ref, want := range map[string]string{
+		"https://github.com/dagger/dagger":            "github.com/dagger/dagger",
+		"https://github.com/dagger/dagger.git":        "github.com/dagger/dagger",
+		"github.com/dagger/dagger":                    "github.com/dagger/dagger",
+		"github.com/dagger/dagger@main":               "github.com/dagger/dagger",
+		"git@github.com:dagger/dagger.git":            "github.com/dagger/dagger",
+		"https://github.com/dagger/dagger.git#main":   "github.com/dagger/dagger",
+		"https://github.com/dagger/dagger#main:docs":  "github.com/dagger/dagger",
+		"github.com/dagger/dagger/modules/wolfi@main": "github.com/dagger/dagger",
+	} {
+		workspaceRef = ref
+		key, err := userConfigWorkspaceKey(context.Background())
+		require.NoError(t, err, "ref %q", ref)
+		require.Equal(t, want, key, "ref %q", ref)
+	}
+}
+
+// TestUserConfigWorkspaceKeyLocalCheckout covers the fallback for local
+// selections: the checkout's git origin.
+func TestUserConfigWorkspaceKeyLocalCheckout(t *testing.T) {
+	oldWorkspaceRef := workspaceRef
+	t.Cleanup(func() {
+		workspaceRef = oldWorkspaceRef
+	})
+
+	repoDir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"remote", "add", "origin", "git@github.com:acme/api.git"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	workspaceRef = repoDir
+	key, err := userConfigWorkspaceKey(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "github.com/acme/api", key)
+
+	// A local checkout without a usable remote has no key.
+	bare := t.TempDir()
+	cmd := exec.Command("git", "init", "-q", filepath.Base(bare))
+	cmd.Dir = filepath.Dir(bare)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	workspaceRef = bare
+	_, err = userConfigWorkspaceKey(context.Background())
+	require.Error(t, err)
+}

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
 	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	"github.com/dagger/dagger/util/gitutil"
 )
 
@@ -225,10 +226,14 @@ var activityCmd = &cobra.Command{
 
 var workspaceActivityAll bool
 
-var workspaceConfigUnset bool
+var (
+	workspaceConfigUnset  bool
+	workspaceConfigGlobal bool
+)
 
 func init() {
 	workspaceConfigCmd.Flags().BoolVarP(&workspaceConfigUnset, "unset", "u", false, "Remove the value at the given key")
+	workspaceConfigCmd.Flags().BoolVarP(&workspaceConfigGlobal, "global", "g", false, "Write to user-level config instead of the repository, keyed by the workspace's git remote")
 
 	workspaceCmd.AddCommand(workspaceConfigCmd)
 	workspaceCmd.AddCommand(workspaceConfigFileCmd)
@@ -248,6 +253,16 @@ func addWorkspaceHereFlag(cmd *cobra.Command) {
 func runWorkspaceConfig(cmd *cobra.Command, args []string) error {
 	if workspaceConfigUnset && len(args) != 1 {
 		return fmt.Errorf("--unset requires a KEY argument")
+	}
+	if workspaceConfigGlobal {
+		ctx := cmd.Context()
+		if workspaceConfigUnset {
+			return unsetUserConfigValue(ctx, userScopedConfigKey(args[0]))
+		}
+		if len(args) != 2 {
+			return fmt.Errorf("--global writes to user-level config; pass KEY VALUE to set or --unset KEY (reads always show the effective merged config)")
+		}
+		return writeUserConfigValue(ctx, userScopedConfigKey(args[0]), args[1], nil)
 	}
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
@@ -597,6 +612,69 @@ func WorkspaceActivity(cmd *cobra.Command, _ []string) error {
 	}
 	renderWorkspaceActivityRows(cmd, activityRows)
 	return nil
+}
+
+// userConfigWorkspaceKey resolves the selected workspace's user-level config
+// key: the normalized git remote of the -W target, or of the local checkout's
+// origin. Workspaces without a usable remote have no key and cannot store
+// user-level overrides.
+func userConfigWorkspaceKey(ctx context.Context) (string, error) {
+	address := strings.TrimSpace(workspaceRef)
+	if address != "" {
+		remote, ok, err := parseWorkspaceRemoteAddress(ctx, address)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			if key := workspacepkg.NormalizeGitRemote(remote.CloneRef); key != "" {
+				return key, nil
+			}
+			return "", fmt.Errorf("workspace remote %q has no stable identity for user-level config", remote.CloneRef)
+		}
+	}
+	info, err := localWorkspaceRemoteInfoForAddress(ctx, address)
+	if err != nil {
+		return "", fmt.Errorf("user-level config is keyed by the workspace's git remote: %w", err)
+	}
+	key := workspacepkg.NormalizeGitRemote(info.cloneRef)
+	if key == "" {
+		return "", fmt.Errorf("workspace git origin %q has no stable identity for user-level config", info.cloneRef)
+	}
+	return key, nil
+}
+
+// userScopedConfigKey mirrors the repository write path's env scoping for
+// user-level writes: with --env selected, non-explicit keys target that
+// environment's overlay.
+func userScopedConfigKey(key string) string {
+	if workspaceEnv == "" || key == "env" || strings.HasPrefix(key, "env.") {
+		return key
+	}
+	return workspacepkg.JoinConfigPath("env", workspaceEnv) + "." + key
+}
+
+// writeUserConfigValue stores a config value for the current workspace in the
+// user-level config file, under the cross-process lock.
+func writeUserConfigValue(ctx context.Context, key, value string, values []string) error {
+	workspaceKey, err := userConfigWorkspaceKey(ctx)
+	if err != nil {
+		return err
+	}
+	return llmconfig.UpdateFile(func(existing []byte) ([]byte, error) {
+		return workspacepkg.WriteUserConfigValue(existing, workspaceKey, key, value, values)
+	})
+}
+
+// unsetUserConfigValue removes a config value for the current workspace from
+// the user-level config file, under the cross-process lock.
+func unsetUserConfigValue(ctx context.Context, key string) error {
+	workspaceKey, err := userConfigWorkspaceKey(ctx)
+	if err != nil {
+		return err
+	}
+	return llmconfig.UpdateFile(func(existing []byte) ([]byte, error) {
+		return workspacepkg.DeleteUserConfigValue(existing, workspaceKey, key)
+	})
 }
 
 func currentWorkspaceRemoteAddress(ctx context.Context) (string, bool, error) {

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -423,6 +423,22 @@ func TestWorkspaceFlagPolicy(t *testing.T) {
 	require.ErrorContains(t, validateWorkspaceFlagPolicy(workspaceConfigCmd, []string{"modules.foo.source", "x"}), "must be a local path")
 	require.NoError(t, validateWorkspaceFlagPolicy(workspaceConfigCmd, []string{"modules.foo.source"}))
 
+	// --global writes go to the caller-local user config, so a remote
+	// workspace stays selectable as the key/introspection target.
+	oldSettingsGlobal := workspaceSettingsGlobal
+	oldConfigGlobal := workspaceConfigGlobal
+	t.Cleanup(func() {
+		workspaceSettingsGlobal = oldSettingsGlobal
+		workspaceConfigGlobal = oldConfigGlobal
+	})
+	workspaceSettingsGlobal = true
+	workspaceConfigGlobal = true
+	require.NoError(t, validateWorkspaceFlagPolicy(settingsCmd, []string{"foo", "bar", "baz"}))
+	require.NoError(t, validateWorkspaceFlagPolicy(workspaceSettingsCmd, []string{"foo", "bar", "baz"}))
+	require.NoError(t, validateWorkspaceFlagPolicy(workspaceConfigCmd, []string{"modules.foo.settings.x", "x"}))
+	workspaceSettingsGlobal = false
+	workspaceConfigGlobal = false
+
 	workspaceRef = "./local-workspace"
 	require.NoError(t, validateWorkspaceFlagPolicy(apiCallCmd.Command(), nil))
 	require.NoError(t, validateWorkspaceFlagPolicy(callModCmd.Command(), nil))


### PR DESCRIPTION
Closes #13815

## Summary

Adds user-level workspace configuration: personal overrides kept outside the repository in the user's Dagger config file (`~/.config/dagger/config.toml`, or `$DAGGER_CONFIG` — the same file that already holds `[llm]`), keyed by the workspace's normalized Git remote.

```toml
# Always applied when working in the github.com/acme/api workspace:
[workspaces."github.com/acme/api".modules.aws.settings]
profile = "alice-dev"

# A personal environment, selected with `dagger --env dev ...`:
[workspaces."github.com/acme/api".env.dev.modules.aws.settings]
region = "us-west-2"
```

- User-level values merge over the repository's `dagger.toml` without modifying it; user-level environments are added to (and merge over) the repository's own. Merge order is base → user overlay → selected `--env` overlay, applied consistently across module loading, `workspace config` reads, `envList`, and `dagger settings` display.
- The workspace key is the normalized `origin` remote for local checkouts (worktree/submodule `.git` files and `commondir` indirection included) and the clone address for `-W` remote workspaces. Equivalent remote spellings (`git@github.com:acme/api.git`, `https://github.com/acme/api`, `github.com/acme/api`) all match, on both sides of the comparison.
- `-g/--global` on `dagger settings` and `dagger workspace config` stores/unsets values user-level instead of in the repository, composing with `--env`. Writes happen client-side under the shared config file's lock, preserving unrelated sections. `-g` on a read errors: reads always show the effective merged view.

## Defined edge behavior (each pinned by a test)

- No remote, or a purely local/filesystem remote → no key, no overrides.
- Multiple remotes → keyed by `origin` only (fork checkouts key by the fork's URL).
- Missing user config file, or clients that don't declare a config path (older CLIs) → unchanged behavior; malformed user config errors loudly.
- An always-on user entry naming a module that doesn't exist in the current checkout is skipped, not an error — one key spans every branch and clone of a repo. User-level *environments* stay strictly validated when selected with `--env`.
- Only `modules.<name>.settings.*` (optionally under `env.<name>.*`) can be stored user-level.

## Implementation notes

- `core/workspace/userconfig.go`: parsing, `NormalizeGitRemote`, overlay matching, merge, and format-preserving write/delete helpers.
- New `ClientMetadata.UserConfigPath` carries the caller-host path (CLI fills it from the existing `llmconfig` path resolution); the engine reads the file through the caller host session during workspace load and stores the matched overlay in private (non-GraphQL) fields on `core.Workspace`.
- Docs: new "User-level configuration" section in the workspace configuration reference, a "Personal overrides" section in the environments guide, and a regenerated CLI reference.

Design follows the direction from the closed draft #13265 and its design doc, updated for the current CLI (no `dagger env` lifecycle commands; workspace-key-first schema so always-on overrides and personal envs both work).

## Validation

All test-driven, no host state involved (fake filesystems and `t.TempDir()` + `$DAGGER_CONFIG`):

- `core/workspace`: new unit tests for parsing, normalization, matching, merge, git-config parsing, and user-config write/delete.
- `engine/server`: 12 new session-level tests (fake host FS); full package passes (128).
- `core/schema`: effective-config and field-privacy tests; full package passes (158).
- `core/integration`: new `TestWorkspaceUserConfig` + `TestWorkspaceUserConfigWrites` (14 subtests, real CLI against dev engine); pre-existing settings/env/config suites pass as regression guard (79), plus the full CLI package tests (297).

🤖 Generated with [Claude Code](https://claude.com/claude-code)