### PR TITLE
LLM: @-referenced paths, configurable effort, `dang-dagger-modules` skill, ...

### DIFF
--- a/core/integration/llm_skills_test.go
+++ b/core/integration/llm_skills_test.go
@@ -36,6 +36,8 @@ func (LLMSuite) TestSkillsEngineEmbedded(ctx context.Context, t *testctx.T) {
 	skills := skillIndex(ctx, t, c.LLM())
 	require.Contains(t, skills, "dang-language")
 	require.NotEmpty(t, skills["dang-language"])
+	require.Contains(t, skills, "dang-dagger-modules")
+	require.NotEmpty(t, skills["dang-dagger-modules"])
 }
 
 func (LLMSuite) TestSkillsWorkspaceDiscovery(ctx context.Context, t *testctx.T) {

--- a/core/integration/llm_test.go
+++ b/core/integration/llm_test.go
@@ -949,3 +949,57 @@ func (LLMSuite) TestWorkspaceReloaded(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 	require.Equal(t, "NEW", after)
 }
+
+// TestNestedClientInheritsSessionConfig verifies that LLM configuration is
+// session-wide: a nested client (an experimentalPrivilegedNesting exec, e.g.
+// `dagger agent` running inside a container) with no LLM configuration of its
+// own inherits the session main client's config; its own config still wins
+// where set; and the underlying credentials never become readable from inside
+// the nested container — the env:// lookups resolve through the *main*
+// client's session, so nesting grants use of the LLM, not the keys.
+func (LLMSuite) TestNestedClientInheritsSessionConfig(ctx context.Context, t *testctx.T) {
+	// Config on the session's main client (this test process): the router
+	// resolves env:// through the client's session attachables at load time,
+	// so a plain os.Setenv is all it takes (same pattern as
+	// AddressSuite/TestSecret). The values are inert for other tests: replay
+	// models ignore credentials, and an anthropic model only routes when
+	// nothing higher-priority is configured.
+	sessionModel := "claude-session-wide-model"
+	apiKey := "secret" + identity.NewID()
+	os.Setenv("ANTHROPIC_MODEL", sessionModel)
+	os.Setenv("ANTHROPIC_API_KEY", apiKey)
+
+	// Each subtest connects on its own: LLM settings resolve once per session
+	// (see TestCrossSessionLLM), so a shared session would serve the first
+	// subtest's model to the others from the session cache.
+
+	t.Run("inherits main client config", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := goGitBase(t, c).
+			With(daggerExecRaw("core", "llm", "model")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, sessionModel, out)
+	})
+
+	t.Run("nested config wins where set", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := goGitBase(t, c).
+			WithEnvVariable("ANTHROPIC_MODEL", "claude-nested-override").
+			With(daggerExecRaw("core", "llm", "model")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "claude-nested-override", out)
+	})
+
+	t.Run("credentials stay with the main client", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// Inheritance must not hand out the keys: resolving the credential
+		// env var directly still happens inside the nested container, which
+		// doesn't have it.
+		_, err := goGitBase(t, c).
+			With(daggerExecRaw("core", "secret", "--uri", "env://ANTHROPIC_API_KEY", "plaintext")).
+			Sync(ctx)
+		requireErrOut(t, err, `secret env var not found: "ANT..."`)
+	})
+}

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -524,6 +524,131 @@ func (WorkspaceAPISuite) TestHostWorkspaceSparseOverlayDiff(ctx context.Context,
 	require.Equal(t, "one\nCHANGED\nthree\n", string(sparseGot))
 }
 
+// TestWorkspaceMounts covers Workspace.withMountedDirectory/withMountedFile:
+// mounted content is readable through the normal workspace file tools (shadowing
+// the source at the mount path, visible in listings above it), but stays out of
+// the pending changeset, is never exported, and cannot be modified.
+func (WorkspaceAPISuite) TestWorkspaceMounts(ctx context.Context, t *testctx.T) {
+	t.Run("mounted directory reads, listings and changes", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			WithNewFile("base.txt", "base").
+			AsWorkspace().
+			WithMountedDirectory(".refs/deps", c.Directory().WithNewFile("vendored.txt", "vendored"))
+
+		contents, err := ws.File(".refs/deps/vendored.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "vendored", contents)
+
+		entries, err := ws.Directory(".refs/deps").Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"vendored.txt"}, entries)
+
+		// The mount's parent doesn't exist in the source; the mounted content
+		// alone is served, like a container mount materializing its parents.
+		entries, err = ws.Directory(".refs").Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"deps/"}, entries)
+
+		// Mounted content shows up in listings above the mount point.
+		entries, err = ws.Directory("/").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, entries, "base.txt")
+		require.Contains(t, entries, ".refs/")
+
+		// But it never rides along with the pending changeset.
+		isEmpty, err := ws.Changes().IsEmpty(ctx)
+		require.NoError(t, err)
+		require.True(t, isEmpty)
+	})
+
+	t.Run("mounted file reads", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		note := c.Directory().WithNewFile("note.txt", "mounted note").File("note.txt")
+		ws := c.Directory().
+			WithNewFile("base.txt", "base").
+			AsWorkspace().
+			WithMountedFile(".refs/note.txt", note)
+
+		contents, err := ws.File(".refs/note.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "mounted note", contents)
+
+		entries, err := ws.Directory(".refs").Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"note.txt"}, entries)
+	})
+
+	t.Run("mounts shadow the source", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			WithNewFile("shadowed/real.txt", "real").
+			AsWorkspace().
+			WithMountedDirectory("shadowed", c.Directory().WithNewFile("vendored.txt", "vendored"))
+
+		entries, err := ws.Directory("shadowed").Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"vendored.txt"}, entries)
+	})
+
+	t.Run("mounted content is read-only", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			AsWorkspace().
+			WithMountedDirectory(".refs/deps", c.Directory().WithNewFile("vendored.txt", "vendored"))
+
+		_, err := ws.WithNewFile(".refs/deps/hack.txt", "nope").Changes().IsEmpty(ctx)
+		require.ErrorContains(t, err, "is a read-only mount and cannot be modified")
+
+		_, err = ws.WithoutDirectory(".refs/deps").Changes().IsEmpty(ctx)
+		require.ErrorContains(t, err, "is a read-only mount and cannot be modified")
+	})
+
+	t.Run("mounting over the workspace root is rejected", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		_, err := c.Directory().
+			AsWorkspace().
+			WithMountedDirectory(".", c.Directory().WithNewFile("vendored.txt", "vendored")).
+			Changes().IsEmpty(ctx)
+		require.ErrorContains(t, err, "cannot mount over the workspace root")
+	})
+
+	t.Run("host workspace reads mounted content", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, "base.txt"), []byte("base"), 0o644))
+
+		out, err := hostDaggerExec(ctx, t, workdir, "shell", "-c",
+			`current-workspace | with-mounted-directory .refs/deps $(directory | with-new-file vendored.txt "vendored") | file .refs/deps/vendored.txt | contents`)
+		require.NoError(t, err)
+		require.Contains(t, string(out), "vendored")
+
+		// The .refs parent exists only through the mount, never on the host.
+		out, err = hostDaggerExec(ctx, t, workdir, "shell", "-c",
+			`current-workspace | with-mounted-directory .refs/deps $(directory | with-new-file vendored.txt "vendored") | directory .refs | entries`)
+		require.NoError(t, err)
+		require.Contains(t, string(out), "deps")
+		_, err = os.Stat(filepath.Join(workdir, ".refs"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("export skips mounts", func(ctx context.Context, t *testctx.T) {
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, "base.txt"), []byte("base"), 0o644))
+
+		_, err := hostDaggerExec(ctx, t, workdir, "shell", "-c",
+			`current-workspace | with-mounted-directory .refs/deps $(directory | with-new-file vendored.txt "vendored") | with-new-file staged.txt "staged" | export`)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(workdir, "staged.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "staged", string(got))
+		_, err = os.Stat(filepath.Join(workdir, ".refs"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
 func (WorkspaceAPISuite) TestHostWorkspaceExportFromGitWorktree(ctx context.Context, t *testctx.T) {
 	tmp := t.TempDir()
 	repoDir := filepath.Join(tmp, "repo")

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -649,6 +649,162 @@ func (WorkspaceAPISuite) TestWorkspaceMounts(ctx context.Context, t *testctx.T) 
 	})
 }
 
+// TestWorkspaceMountsSearchGlobFindUp verifies that Workspace.search,
+// Workspace.glob, and Workspace.findUp observe mounted content the same way
+// Workspace.file and Workspace.directory do: mounted paths surface in results
+// (including mount points whose parents exist only through the mount) and
+// shadow the source at and under the mount point, on both value and
+// host-backed workspaces.
+func (WorkspaceAPISuite) TestWorkspaceMountsSearchGlobFindUp(ctx context.Context, t *testctx.T) {
+	// valueWorkspace mounts content at .refs/deps (whose parents exist only
+	// through the mount) and over the source directory shadowed/.
+	valueWorkspace := func(c *dagger.Client) *dagger.Workspace {
+		return c.Directory().
+			WithNewFile("src/hay.txt", "needle in source\n").
+			WithNewFile("shadowed/real.txt", "needle shadowed\n").
+			AsWorkspace().
+			WithMountedDirectory(".refs/deps", c.Directory().WithNewFile("vendored.txt", "needle vendored\n")).
+			WithMountedDirectory("shadowed", c.Directory().WithNewFile("mounted.txt", "needle mounted\n"))
+	}
+
+	searchFilePaths := func(ctx context.Context, t *testctx.T, results []dagger.SearchResult) []string {
+		t.Helper()
+		paths := make([]string, 0, len(results))
+		for _, r := range results {
+			p, err := r.FilePath(ctx)
+			require.NoError(t, err)
+			paths = append(paths, p)
+		}
+		return paths
+	}
+
+	t.Run("value workspace search", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		results, err := valueWorkspace(c).Search(ctx, "needle", dagger.WorkspaceSearchOpts{Literal: true})
+		require.NoError(t, err)
+		paths := searchFilePaths(ctx, t, results)
+		require.Contains(t, paths, "src/hay.txt")
+		require.Contains(t, paths, ".refs/deps/vendored.txt", "mounted content must be searchable")
+		require.Contains(t, paths, "shadowed/mounted.txt", "content mounted over a source directory must be searchable")
+		require.NotContains(t, paths, "shadowed/real.txt", "mounts must shadow the source in search results")
+	})
+
+	t.Run("value workspace search scoped to a mounted path", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		results, err := valueWorkspace(c).Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+			Literal: true,
+			Paths:   []string{"shadowed"},
+		})
+		require.NoError(t, err)
+		paths := searchFilePaths(ctx, t, results)
+		require.Equal(t, []string{"shadowed/mounted.txt"}, paths)
+	})
+
+	t.Run("value workspace glob", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		matches, err := valueWorkspace(c).Glob(ctx, "**/*.txt")
+		require.NoError(t, err)
+		require.Contains(t, matches, "src/hay.txt")
+		require.Contains(t, matches, ".refs/deps/vendored.txt", "mounted content must be globbable")
+		require.Contains(t, matches, "shadowed/mounted.txt")
+		require.NotContains(t, matches, "shadowed/real.txt", "mounts must shadow the source in glob results")
+	})
+
+	t.Run("value workspace findUp", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := valueWorkspace(c)
+
+		found, err := ws.FindUp(ctx, "vendored.txt", dagger.WorkspaceFindUpOpts{From: ".refs/deps"})
+		require.NoError(t, err)
+		require.Equal(t, "/.refs/deps/vendored.txt", found, "mounted content must be findable")
+
+		// A mount point is findable as a directory even though its parents
+		// exist only through the mount.
+		found, err = ws.FindUp(ctx, "deps", dagger.WorkspaceFindUpOpts{From: ".refs"})
+		require.NoError(t, err)
+		require.Equal(t, "/.refs/deps", found)
+
+		// The walk falls back to the source on its way up out of the mount.
+		found, err = ws.FindUp(ctx, "src", dagger.WorkspaceFindUpOpts{From: ".refs/deps"})
+		require.NoError(t, err)
+		require.Equal(t, "/src", found)
+
+		found, err = ws.FindUp(ctx, "mounted.txt", dagger.WorkspaceFindUpOpts{From: "shadowed"})
+		require.NoError(t, err)
+		require.Equal(t, "/shadowed/mounted.txt", found)
+
+		found, err = ws.FindUp(ctx, "real.txt", dagger.WorkspaceFindUpOpts{From: "shadowed"})
+		require.NoError(t, err)
+		require.Empty(t, found, "sources shadowed by a mount must not resurface")
+	})
+
+	t.Run("host workspace", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		// Mount sources are engine-side directories, so their IDs replay in
+		// the nested session.
+		depsID, err := c.Directory().WithNewFile("vendored.txt", "needle vendored\n").ID(ctx)
+		require.NoError(t, err)
+		shadowID, err := c.Directory().WithNewFile("mounted.txt", "needle mounted\n").ID(ctx)
+		require.NoError(t, err)
+
+		base := workspaceBase(t, c).
+			// The base image only has BusyBox grep; install ripgrep so the
+			// client-side search runs its primary code path.
+			WithExec([]string{"apk", "add", "ripgrep"}).
+			WithNewFile("hay.txt", "needle in host\n").
+			WithNewFile("shadowed/real.txt", "needle shadowed\n")
+
+		mountedQuery := func(t *testctx.T, body string) map[string]any {
+			t.Helper()
+			out, err := base.With(daggerQuery(fmt.Sprintf(`{
+				currentWorkspace {
+					withMountedDirectory(path: ".refs/deps", source: %q) {
+						withMountedDirectory(path: "shadowed", source: %q) {
+							%s
+						}
+					}
+				}
+			}`, depsID, shadowID, body))).Stdout(ctx)
+			require.NoError(t, err)
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal([]byte(out), &payload))
+			result := payload
+			for _, key := range []string{"currentWorkspace", "withMountedDirectory", "withMountedDirectory"} {
+				result = result[key].(map[string]any)
+			}
+			return result
+		}
+
+		t.Run("search sees mounts and shadows the host", func(ctx context.Context, t *testctx.T) {
+			got := mountedQuery(t, `search(pattern: "needle", literal: true) { filePath }`)
+			paths := []string{}
+			for _, raw := range got["search"].([]any) {
+				paths = append(paths, raw.(map[string]any)["filePath"].(string))
+			}
+			require.Contains(t, paths, "hay.txt")
+			require.Contains(t, paths, ".refs/deps/vendored.txt")
+			require.Contains(t, paths, "shadowed/mounted.txt")
+			require.NotContains(t, paths, "shadowed/real.txt")
+		})
+
+		t.Run("glob sees mounts and shadows the host", func(ctx context.Context, t *testctx.T) {
+			got := mountedQuery(t, `glob(pattern: "**/*.txt")`)
+			require.Contains(t, got["glob"], ".refs/deps/vendored.txt")
+			require.Contains(t, got["glob"], "shadowed/mounted.txt")
+			require.NotContains(t, got["glob"], "shadowed/real.txt")
+		})
+
+		t.Run("findUp sees mounts and shadows the host", func(ctx context.Context, t *testctx.T) {
+			got := mountedQuery(t, `findUp(name: "vendored.txt", from: ".refs/deps")`)
+			require.Equal(t, "/.refs/deps/vendored.txt", got["findUp"])
+
+			got = mountedQuery(t, `findUp(name: "real.txt", from: "shadowed")`)
+			require.Nil(t, got["findUp"], "sources shadowed by a mount must not resurface")
+		})
+	})
+}
+
 func (WorkspaceAPISuite) TestHostWorkspaceExportFromGitWorktree(ctx context.Context, t *testctx.T) {
 	tmp := t.TempDir()
 	repoDir := filepath.Join(tmp, "repo")

--- a/core/llm.go
+++ b/core/llm.go
@@ -99,6 +99,11 @@ type LLM struct {
 	model    string
 	provider string
 
+	// reasoningEffort, when set, overrides the provider-configured reasoning
+	// effort for this conversation (see LLMEndpoint.ReasoningEffort). "none"
+	// explicitly disables reasoning; empty defers to the provider config.
+	reasoningEffort string
+
 	endpoint    *LLMEndpoint
 	endpointMtx *sync.Mutex
 
@@ -1209,6 +1214,14 @@ func (llm *LLM) Endpoint(ctx context.Context) (*LLMEndpoint, error) {
 		}
 	}
 
+	// Apply the conversation-level reasoning effort override, if any. Route()
+	// builds a fresh endpoint per call, so mutating it here is safe. "none" is
+	// passed through: providers treat it the same as empty (reasoning off),
+	// but it must override a non-empty provider-configured effort.
+	if llm.reasoningEffort != "" {
+		endpoint.ReasoningEffort = llm.reasoningEffort
+	}
+
 	llm.endpoint = endpoint
 
 	return llm.endpoint, nil
@@ -1238,6 +1251,20 @@ func (llm *LLM) WithModel(model, provider string) *LLM {
 	llm = llm.Clone()
 	llm.model = model
 	llm.provider = provider
+
+	llm.endpointMtx.Lock()
+	defer llm.endpointMtx.Unlock()
+	llm.endpoint = nil
+
+	return llm
+}
+
+// WithReasoningEffort changes the reasoning effort for the rest of the
+// conversation, overriding any provider-configured default. "none" explicitly
+// disables reasoning.
+func (llm *LLM) WithReasoningEffort(effort string) *LLM {
+	llm = llm.Clone()
+	llm.reasoningEffort = effort
 
 	llm.endpointMtx.Lock()
 	defer llm.endpointMtx.Unlock()

--- a/core/llm.go
+++ b/core/llm.go
@@ -870,7 +870,7 @@ func (r *LLMRouter) Route(model, provider string) (*LLMEndpoint, error) {
 	return endpoint, nil
 }
 
-func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context, string) (string, error)) error {
+func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context, string) (string, error)) (suppliedLocal bool, _ error) {
 	if getenv == nil {
 		getenv = func(_ context.Context, key string) (string, error) { //nolint:unparam
 			return os.Getenv(key), nil
@@ -889,8 +889,17 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	}
 
 	var eg errgroup.Group
+	var anthropicKeySet, anthropicTokenSet bool
 	eg.Go(func() error {
-		return save("ANTHROPIC_API_KEY", &r.AnthropicAPIKey)
+		var v string
+		if err := save("ANTHROPIC_API_KEY", &v); err != nil {
+			return err
+		}
+		if v != "" {
+			r.AnthropicAPIKey = v
+			anthropicKeySet = true
+		}
+		return nil
 	})
 	eg.Go(func() error {
 		return save("ANTHROPIC_BASE_URL", &r.AnthropicBaseURL)
@@ -901,7 +910,15 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	eg.Go(func() error {
 		// OAuth (Claude Code subscription) bearer token, exported client-side
 		// from the persisted llmconfig by `dagger llm`.
-		return save("ANTHROPIC_AUTH_TOKEN", &r.AnthropicAuthToken)
+		var v string
+		if err := save("ANTHROPIC_AUTH_TOKEN", &v); err != nil {
+			return err
+		}
+		if v != "" {
+			r.AnthropicAuthToken = v
+			anthropicTokenSet = true
+		}
+		return nil
 	})
 	eg.Go(func() error {
 		return save("ANTHROPIC_REASONING_EFFORT", &r.AnthropicReasoningEffort)
@@ -946,7 +963,15 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	})
 
 	eg.Go(func() error {
-		return save("LOCAL_BASE_URL", &r.LocalBaseURL)
+		var v string
+		if err := save("LOCAL_BASE_URL", &v); err != nil {
+			return err
+		}
+		if v != "" {
+			r.LocalBaseURL = v
+			suppliedLocal = true
+		}
+		return nil
 	})
 	eg.Go(func() error {
 		return save("LOCAL_MODEL", &r.LocalModel)
@@ -966,21 +991,34 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	})
 
 	if err := eg.Wait(); err != nil {
-		return err
+		return false, err
 	}
 
 	if openAIDisableStreaming != "" {
 		v, err := strconv.ParseBool(openAIDisableStreaming)
 		if err != nil {
-			return err
+			return false, err
 		}
 		r.OpenAIDisableStreaming = v
+	}
+
+	// API key and subscription OAuth token are alternative credentials for
+	// the same provider. When this load supplies one but not the other, the
+	// supplied credential wins outright: clear the other so a value layered
+	// in by an earlier load (e.g. the host's OAuth login when a nested
+	// client sets an explicit API key) can't shadow it at request time —
+	// the Anthropic client prefers OAuth whenever a token is present.
+	if anthropicKeySet && !anthropicTokenSet {
+		r.AnthropicAuthToken = ""
+	}
+	if anthropicTokenSet && !anthropicKeySet {
+		r.AnthropicAPIKey = ""
 	}
 
 	// A bearer token implies OAuth (Claude Code) auth for Anthropic.
 	r.AnthropicIsOAuth = r.AnthropicAuthToken != ""
 
-	return nil
+	return suppliedLocal, nil
 }
 
 // LoadClientConfig loads LLM configuration from one client's environment into
@@ -988,7 +1026,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 // variables. Only values the client actually provides overwrite fields already
 // set on the router, so configuration can be layered — e.g. the session's main
 // client as the base with the calling client's own values on top.
-func (r *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) error {
+func (r *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) (suppliedLocal bool, _ error) {
 	// Get the secret plaintext, from either a URI (provider lookup) or a plaintext (no-op)
 	loadSecret := func(ctx context.Context, uriOrPlaintext string) (string, error) {
 		if _, _, err := secretprovider.ResolverForID(uriOrPlaintext); err == nil {
@@ -1035,7 +1073,7 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 	router := new(LLMRouter)
 	ctx, span := Tracer(ctx).Start(ctx, "load LLM router config", telemetry.Internal(), telemetry.Encapsulate())
 	defer telemetry.EndWithCause(span, &rerr)
-	err := router.LoadClientConfig(ctx, srv)
+	_, err := router.LoadClientConfig(ctx, srv)
 	return router, err
 }
 
@@ -1085,14 +1123,16 @@ func loadLLMRouter(ctx context.Context, query *Query) (_ *LLMRouter, rerr error)
 		if err != nil {
 			return err
 		}
-		localBefore := router.LocalBaseURL
-		if err := router.LoadClientConfig(clientCtx, srv); err != nil {
+		suppliedLocal, err := router.LoadClientConfig(clientCtx, srv)
+		if err != nil {
 			return err
 		}
 		// Remember which client supplied the local endpoint: a local base URL
 		// is reachable from that client's host, so the tunnel (see
-		// LLM.Endpoint) must run through that client's session.
-		if router.LocalBaseURL != localBefore {
+		// LLM.Endpoint) must run through that client's session. Later loads
+		// win regardless of whether the URL string differs — localhost names
+		// a different host per client.
+		if suppliedLocal {
 			router.localClient = client
 		}
 		return nil

--- a/core/llm.go
+++ b/core/llm.go
@@ -988,7 +988,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 // variables. Only values the client actually provides overwrite fields already
 // set on the router, so configuration can be layered — e.g. the session's main
 // client as the base with the calling client's own values on top.
-func (router *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) error {
+func (r *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) error {
 	// Get the secret plaintext, from either a URI (provider lookup) or a plaintext (no-op)
 	loadSecret := func(ctx context.Context, uriOrPlaintext string) (string, error) {
 		if _, _, err := secretprovider.ResolverForID(uriOrPlaintext); err == nil {
@@ -1017,7 +1017,7 @@ func (router *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server
 			env = e
 		}
 	}
-	return router.LoadConfig(ctx, func(ctx context.Context, k string) (string, error) {
+	return r.LoadConfig(ctx, func(ctx context.Context, k string) (string, error) {
 		// First lookup in the .env file
 		if v, ok := env[k]; ok {
 			return loadSecret(ctx, v)

--- a/core/llm.go
+++ b/core/llm.go
@@ -602,6 +602,12 @@ type LLMRouter struct {
 	LocalModel     string
 	LocalAPICompat string
 	LocalAPIKey    string
+
+	// localClient is the client whose configuration supplied LocalBaseURL.
+	// A local endpoint is reachable from that client's host, so the tunnel
+	// (see LLM.Endpoint) must run through that client's session. Set by
+	// loadLLMRouter; nil when the router was built for a single client.
+	localClient *engine.ClientMetadata
 }
 
 func (r *LLMRouter) isAnthropicModel(model string) bool {
@@ -977,8 +983,12 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	return nil
 }
 
-func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr error) {
-	router := new(LLMRouter)
+// LoadClientConfig loads LLM configuration from one client's environment into
+// the router: the client's ./.env file (if any) first, then its environment
+// variables. Only values the client actually provides overwrite fields already
+// set on the router, so configuration can be layered — e.g. the session's main
+// client as the base with the calling client's own values on top.
+func (router *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) error {
 	// Get the secret plaintext, from either a URI (provider lookup) or a plaintext (no-op)
 	loadSecret := func(ctx context.Context, uriOrPlaintext string) (string, error) {
 		if _, _, err := secretprovider.ResolverForID(uriOrPlaintext); err == nil {
@@ -1000,8 +1010,6 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 		// If it's a regular plaintext:
 		return uriOrPlaintext, nil
 	}
-	ctx, span := Tracer(ctx).Start(ctx, "load LLM router config", telemetry.Internal(), telemetry.Encapsulate())
-	defer telemetry.EndWithCause(span, &rerr)
 	env := make(map[string]string)
 	// Load .env from current directory, if it exists
 	if envFile, err := loadSecret(ctx, "file://.env"); err == nil {
@@ -1009,7 +1017,7 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 			env = e
 		}
 	}
-	err := router.LoadConfig(ctx, func(ctx context.Context, k string) (string, error) {
+	return router.LoadConfig(ctx, func(ctx context.Context, k string) (string, error) {
 		// First lookup in the .env file
 		if v, ok := env[k]; ok {
 			return loadSecret(ctx, v)
@@ -1021,6 +1029,13 @@ func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr er
 		}
 		return "", nil
 	})
+}
+
+func NewLLMRouter(ctx context.Context, srv *dagql.Server) (_ *LLMRouter, rerr error) {
+	router := new(LLMRouter)
+	ctx, span := Tracer(ctx).Start(ctx, "load LLM router config", telemetry.Internal(), telemetry.Encapsulate())
+	defer telemetry.EndWithCause(span, &rerr)
+	err := router.LoadClientConfig(ctx, srv)
 	return router, err
 }
 
@@ -1041,18 +1056,60 @@ func (q *Query) NewLLM(ctx context.Context, model, provider string) (*LLM, error
 	}, nil
 }
 
-// loadLLMRouter creates an LLM router that routes to the root client
-func loadLLMRouter(ctx context.Context, query *Query) (*LLMRouter, error) {
+// loadLLMRouter creates an LLM router for the calling client. LLM
+// configuration is a session-wide concern: the router is seeded from the
+// session's main client (the CLI on the host), then overlaid with the calling
+// (non-module) client's own configuration, which wins wherever it sets a
+// value.
+//
+// The seeding is what lets a nested client — e.g. an
+// experimentalPrivilegedNesting exec running `dagger agent` — inherit the
+// session's LLM auth without ever holding the credentials: the env:// and
+// file://.env lookups resolve through the *main* client's session, and only
+// the engine-side router sees the plaintext. Nothing is injected into the
+// nested container, so its processes cannot read the keys (its own env:// or
+// file:// secrets still resolve inside the container); they can only use the
+// LLM through the API.
+func loadLLMRouter(ctx context.Context, query *Query) (_ *LLMRouter, rerr error) {
+	ctx, span := Tracer(ctx).Start(ctx, "load LLM router config", telemetry.Internal(), telemetry.Encapsulate())
+	defer telemetry.EndWithCause(span, &rerr)
+
 	parentClient, err := query.NonModuleParentClientMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ctx = engine.ContextWithClientMetadata(ctx, parentClient)
-	mainSrv, err := query.Server.Server(ctx)
+	router := new(LLMRouter)
+	loadFrom := func(client *engine.ClientMetadata) error {
+		clientCtx := engine.ContextWithClientMetadata(ctx, client)
+		srv, err := query.Server.Server(clientCtx)
+		if err != nil {
+			return err
+		}
+		localBefore := router.LocalBaseURL
+		if err := router.LoadClientConfig(clientCtx, srv); err != nil {
+			return err
+		}
+		// Remember which client supplied the local endpoint: a local base URL
+		// is reachable from that client's host, so the tunnel (see
+		// LLM.Endpoint) must run through that client's session.
+		if router.LocalBaseURL != localBefore {
+			router.localClient = client
+		}
+		return nil
+	}
+	mainClient, err := query.MainClientCallerMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return NewLLMRouter(ctx, mainSrv)
+	if mainClient.ClientID != parentClient.ClientID {
+		if err := loadFrom(mainClient); err != nil {
+			return nil, err
+		}
+	}
+	if err := loadFrom(parentClient); err != nil {
+		return nil, err
+	}
+	return router, nil
 }
 
 // DefaultLLMRoute resolves the configured default model and the provider it
@@ -1192,9 +1249,16 @@ func (llm *LLM) Endpoint(ctx context.Context) (*LLMEndpoint, error) {
 	// traffic through the client's session, then rebuild the client so it
 	// dials through the tunnel.
 	if endpoint.Provider == Local {
-		parentClient, err := query.NonModuleParentClientMetadata(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("local LLM: parent client metadata: %w", err)
+		// Tunnel through the session of the client that configured the local
+		// endpoint (the base URL is reachable from *its* host) — the calling
+		// client by default, the session's main client when the config was
+		// inherited from it.
+		tunnelClient := router.localClient
+		if tunnelClient == nil {
+			tunnelClient, err = query.NonModuleParentClientMetadata(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("local LLM: parent client metadata: %w", err)
+			}
 		}
 		// The tunnel serves the endpoint beyond this call, so scope it to the
 		// client's session: it shuts down when the session closes.
@@ -1202,7 +1266,7 @@ func (llm *LLM) Endpoint(ctx context.Context) (*LLMEndpoint, error) {
 		if err != nil {
 			return nil, fmt.Errorf("local LLM: session context: %w", err)
 		}
-		tunnelCtx := engine.ContextWithClientMetadata(sessionCtx, parentClient)
+		tunnelCtx := engine.ContextWithClientMetadata(sessionCtx, tunnelClient)
 		if err := setupLocalTunnel(tunnelCtx, endpoint); err != nil {
 			return nil, fmt.Errorf("setup local LLM tunnel: %w", err)
 		}

--- a/core/llm_skills.go
+++ b/core/llm_skills.go
@@ -13,6 +13,7 @@ import (
 	dangskills "github.com/vito/dang/v2/.agents/skills"
 	"gopkg.in/yaml.v3"
 
+	daggerskills "github.com/dagger/dagger/core/skills"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/slog"
 )
@@ -27,9 +28,9 @@ import (
 // know how to write.
 //
 // Skills come from ordered sources behind a common skillSource interface:
-// engine-embedded skills (the dang-language skill shipped in the engine), skill
-// directories installed via LLM.withSkills, and SKILL.md files discovered in the
-// bound workspace.
+// engine-embedded skills (the dang-language skill vendored from the dang repo
+// and the Dagger-authored skills in core/skills), skill directories installed
+// via LLM.withSkills, and SKILL.md files discovered in the bound workspace.
 
 // errSkillNotFound signals that a source does not provide the requested skill, so
 // ReadSkill should consult the next source rather than fail.
@@ -65,12 +66,12 @@ type skillSource interface {
 }
 
 // skillSources returns the ordered skill origins consulted by ListSkills and
-// ReadSkill. Engine-embedded skills come first, so the dang-language skill
-// cannot be shadowed; directories installed explicitly via LLM.withSkills come
-// before skills discovered in the bound workspace, so an installed skill wins a
-// name collision with an ambient one.
+// ReadSkill. Engine-embedded skills come first, so the dang-language and
+// dang-dagger-modules skills cannot be shadowed; directories installed
+// explicitly via LLM.withSkills come before skills discovered in the bound
+// workspace, so an installed skill wins a name collision with an ambient one.
 func (m *MCP) skillSources() []skillSource {
-	sources := []skillSource{engineSkills}
+	sources := []skillSource{engineSkills, daggerSkills}
 	for _, dir := range m.skillDirs {
 		sources = append(sources, directorySkillSource{m: m, dir: dir})
 	}
@@ -84,6 +85,14 @@ func (m *MCP) skillSources() []skillSource {
 var engineSkills = embeddedSkillSource{
 	fsys:  dangskills.FS,
 	allow: []string{"dang-language"},
+}
+
+// daggerSkills exposes the Dagger-authored skills embedded in this repo
+// (core/skills) — guidance that belongs to Dagger rather than the Dang
+// language, like authoring Dagger modules in Dang.
+var daggerSkills = embeddedSkillSource{
+	fsys:  daggerskills.FS,
+	allow: []string{"dang-dagger-modules"},
 }
 
 // embeddedSkillSource serves an allowlisted subset of an embedded FS rooted at a

--- a/core/llm_skills_test.go
+++ b/core/llm_skills_test.go
@@ -218,11 +218,12 @@ func TestSkillSourcesOrder(t *testing.T) {
 		WithSkills(dagql.ObjectResult[*Directory]{}).
 		WithSkills(dagql.ObjectResult[*Directory]{})
 	sources := m.skillSources()
-	require.Len(t, sources, 4)
+	require.Len(t, sources, 5)
 	require.IsType(t, embeddedSkillSource{}, sources[0])
-	require.IsType(t, directorySkillSource{}, sources[1])
+	require.IsType(t, embeddedSkillSource{}, sources[1])
 	require.IsType(t, directorySkillSource{}, sources[2])
-	require.IsType(t, workspaceSkillSource{}, sources[3])
+	require.IsType(t, directorySkillSource{}, sources[3])
+	require.IsType(t, workspaceSkillSource{}, sources[4])
 }
 
 // TestEngineSkills checks the real embedded source: the dang-language skill is
@@ -251,5 +252,27 @@ func TestEngineSkills(t *testing.T) {
 	require.NotEmpty(t, ref)
 
 	_, err = engineSkills.read(ctx, "builtin-dsl", "")
+	require.ErrorIs(t, err, errSkillNotFound)
+}
+
+// TestDaggerSkills checks the Dagger-authored embedded source: the
+// dang-dagger-modules skill is exposed with a description and readable.
+func TestDaggerSkills(t *testing.T) {
+	ctx := context.Background()
+
+	metas, err := daggerSkills.list(ctx)
+	require.NoError(t, err)
+	names := make([]string, len(metas))
+	for i, m := range metas {
+		names[i] = m.Name
+		assert.NotEmpty(t, m.Description, "skill %q should have a description", m.Name)
+	}
+	require.Contains(t, names, "dang-dagger-modules")
+
+	skill, err := daggerSkills.read(ctx, "dang-dagger-modules", "")
+	require.NoError(t, err)
+	require.Contains(t, skill, "self-call")
+
+	_, err = daggerSkills.read(ctx, "dang-language", "")
 	require.ErrorIs(t, err, errSkillNotFound)
 }

--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -120,6 +120,110 @@ func TestLlmConfig(t *testing.T) {
 	assert.Equal(t, "local-api-key", r.LocalAPIKey)
 }
 
+// getenvFrom builds a LoadConfig getenv func serving values from a plain map,
+// so layering tests need no dagql plumbing.
+func getenvFrom(m map[string]string) func(context.Context, string) (string, error) {
+	return func(_ context.Context, k string) (string, error) {
+		return m[k], nil
+	}
+}
+
+// TestLlmConfigLayeredAnthropicAuth covers layered config loads (host client
+// first, then the calling/nested client): the Anthropic API key and the
+// subscription OAuth token are alternative credentials for the same slot, so
+// whichever one a later load supplies must win outright rather than being
+// shadowed by a credential accumulated from an earlier load.
+func TestLlmConfigLayeredAnthropicAuth(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("container API key overrides host OAuth login", func(t *testing.T) {
+		r := new(LLMRouter)
+		_, err := r.LoadConfig(ctx, getenvFrom(map[string]string{
+			"ANTHROPIC_AUTH_TOKEN": "host-oauth",
+		}))
+		require.NoError(t, err)
+		_, err = r.LoadConfig(ctx, getenvFrom(map[string]string{
+			"ANTHROPIC_API_KEY": "container-key",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "container-key", r.AnthropicAPIKey)
+		assert.Empty(t, r.AnthropicAuthToken)
+		assert.False(t, r.AnthropicIsOAuth)
+	})
+
+	t.Run("container OAuth overrides host API key", func(t *testing.T) {
+		r := new(LLMRouter)
+		_, err := r.LoadConfig(ctx, getenvFrom(map[string]string{
+			"ANTHROPIC_API_KEY": "host-key",
+		}))
+		require.NoError(t, err)
+		_, err = r.LoadConfig(ctx, getenvFrom(map[string]string{
+			"ANTHROPIC_AUTH_TOKEN": "container-oauth",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "container-oauth", r.AnthropicAuthToken)
+		assert.Empty(t, r.AnthropicAPIKey)
+		assert.True(t, r.AnthropicIsOAuth)
+	})
+
+	t.Run("container with no auth inherits host OAuth", func(t *testing.T) {
+		r := new(LLMRouter)
+		_, err := r.LoadConfig(ctx, getenvFrom(map[string]string{
+			"ANTHROPIC_AUTH_TOKEN": "host-oauth",
+		}))
+		require.NoError(t, err)
+		_, err = r.LoadConfig(ctx, getenvFrom(map[string]string{}))
+		require.NoError(t, err)
+		assert.Equal(t, "host-oauth", r.AnthropicAuthToken)
+		assert.True(t, r.AnthropicIsOAuth)
+	})
+
+	t.Run("single load with both prefers OAuth", func(t *testing.T) {
+		r := new(LLMRouter)
+		_, err := r.LoadConfig(ctx, getenvFrom(map[string]string{
+			"ANTHROPIC_API_KEY":    "key",
+			"ANTHROPIC_AUTH_TOKEN": "oauth",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "key", r.AnthropicAPIKey)
+		assert.Equal(t, "oauth", r.AnthropicAuthToken)
+		assert.True(t, r.AnthropicIsOAuth)
+	})
+}
+
+// TestLlmConfigLocalSupplied covers LoadConfig's report of whether THIS load
+// supplied a local base URL. The tunnel to a local model must run through the
+// session of the client that configured it, and localhost names a different
+// host per client — so the signal must fire even when the URL string is
+// unchanged from an earlier load.
+func TestLlmConfigLocalSupplied(t *testing.T) {
+	ctx := context.Background()
+
+	r := new(LLMRouter)
+	supplied, err := r.LoadConfig(ctx, getenvFrom(map[string]string{
+		"LOCAL_BASE_URL": "http://localhost:11434",
+	}))
+	require.NoError(t, err)
+	assert.True(t, supplied)
+	assert.Equal(t, "http://localhost:11434", r.LocalBaseURL)
+
+	// A load supplying nothing leaves the URL alone and reports false.
+	supplied, err = r.LoadConfig(ctx, getenvFrom(map[string]string{}))
+	require.NoError(t, err)
+	assert.False(t, supplied)
+	assert.Equal(t, "http://localhost:11434", r.LocalBaseURL)
+
+	// Supplying a value identical to the already-loaded one must still count:
+	// the same "http://localhost:11434" string reaches a different host from
+	// each client.
+	supplied, err = r.LoadConfig(ctx, getenvFrom(map[string]string{
+		"LOCAL_BASE_URL": "http://localhost:11434",
+	}))
+	require.NoError(t, err)
+	assert.True(t, supplied)
+	assert.Equal(t, "http://localhost:11434", r.LocalBaseURL)
+}
+
 func TestLocalModelRouting(t *testing.T) {
 	// A local endpoint is keyed by an exact model-name match (it has no naming
 	// convention to detect), and wins ahead of the prefix-based heuristics.

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -67,6 +67,16 @@ func (s llmSchema) Install(srv *dagql.Server) {
 					`The provider serving the model, e.g. "openai". Overrides the provider otherwise inferred from the model name — useful when the name matches no known pattern (e.g. a fine-tune), or matches the wrong one.`).
 					View(AfterVersion("v1.0.0-0")),
 			),
+		dagql.Func("reasoningEffort", s.reasoningEffort).
+			View(AfterVersion("v1.0.0-0")).
+			Doc(`The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.`),
+		dagql.Func("withReasoningEffort", s.withReasoningEffort).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.").
+			Args(
+				dagql.Arg("effort").Doc(
+					`The reasoning effort, e.g. "low", "medium", or "high"; "none" disables reasoning. Supported levels are model-specific — some models also accept e.g. "minimal", "xhigh", or "max".`),
+			),
 		dagql.Func("withPrompt", s.withPrompt).
 			Doc("Queue a user prompt, to be sent to the model on the next step or loop.").
 			Args(
@@ -291,6 +301,20 @@ func (s *llmSchema) withModel(ctx context.Context, llm *core.LLM, args struct {
 	Provider dagql.Optional[dagql.String]
 }) (*core.LLM, error) {
 	return llm.WithModel(args.Model, args.Provider.Value.String()), nil
+}
+
+func (s *llmSchema) reasoningEffort(ctx context.Context, llm *core.LLM, args struct{}) (string, error) {
+	ep, err := llm.Endpoint(ctx)
+	if err != nil {
+		return "", err
+	}
+	return ep.ReasoningEffort, nil
+}
+
+func (s *llmSchema) withReasoningEffort(ctx context.Context, llm *core.LLM, args struct {
+	Effort string
+}) (*core.LLM, error) {
+	return llm.WithReasoningEffort(args.Effort), nil
 }
 
 func (s *llmSchema) withPrompt(ctx context.Context, llm *core.LLM, args struct {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -172,6 +172,22 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("path").Doc("Workspace-relative path to use as the working directory."),
 			),
+		dagql.NodeFunc("withReferenceDirectory", s.withReferenceDirectory).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Return this workspace with a directory mounted read-only under the reserved references prefix.",
+				"Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.").
+			Args(
+				dagql.Arg("path").Doc("Reference-relative mount path under the reserved references prefix."),
+				dagql.Arg("source").Doc("Directory to mount read-only."),
+			),
+		dagql.NodeFunc("withReferenceFile", s.withReferenceFile).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Return this workspace with a file mounted read-only under the reserved references prefix.",
+				"Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.").
+			Args(
+				dagql.Arg("path").Doc("Reference-relative mount path under the reserved references prefix."),
+				dagql.Arg("source").Doc("File to mount read-only."),
+			),
 		dagql.NodeFunc("withModule", s.withModule).
 			View(AfterVersion("v1.0.0-0")).
 			Doc("Return this workspace with a module installed in its config.").
@@ -591,6 +607,14 @@ func (s *workspaceSchema) resolveRootfs(
 		return inst, err
 	}
 
+	// Reads under the reserved references prefix resolve against the read-only
+	// reference tree, never the host or the overlay changeset.
+	if refsDir, ok := ws.ReferencesDir(); ok {
+		if rel, isRef := referenceRelPath(resolvedPath); isRef {
+			return s.resolveRootfsFromDirectory(ctx, srv, ws, refsDir, rel, filter, gitignore)
+		}
+	}
+
 	if ws.HostPath() != "" && ws.ClientLocalBase() {
 		if changes, ok := ws.OverlayChanges(); ok {
 			return s.resolveHostOverlayRootfs(ctx, srv, ws, changes, resolvedPath, filter, gitignore)
@@ -953,6 +977,9 @@ func (s *workspaceSchema) withNewFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
+	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
@@ -1299,6 +1326,9 @@ func (s *workspaceSchema) withNewDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
+	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
@@ -1334,6 +1364,9 @@ func (s *workspaceSchema) withoutFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
+	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
@@ -1362,6 +1395,9 @@ func (s *workspaceSchema) withoutDirectory(
 ) (dagql.ObjectResult[*core.Workspace], error) {
 	resolvedPath, err := resolveWorkspacePath(args.Path, parent.Self().Cwd)
 	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
@@ -1438,6 +1474,11 @@ func (s *workspaceSchema) applyChangeset(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
+	for _, p := range touched {
+		if err := guardReferencePath(parent.Self(), p); err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+	}
 	return s.overlayEdit(ctx, parent, touched, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
@@ -1471,6 +1512,138 @@ func (s *workspaceSchema) withWorkdir(
 	ws := parent.Self().Clone()
 	ws.Cwd = cwd
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws)
+}
+
+type workspaceWithReferenceDirectoryArgs struct {
+	Path   string
+	Source core.DirectoryID
+}
+
+func (s *workspaceSchema) withReferenceDirectory(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceWithReferenceDirectoryArgs,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	relPath, err := referenceInternalPath(args.Path)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	sourceID, err := args.Source.ID()
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	return s.addReference(ctx, srv, parent, func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+		var updated dagql.ObjectResult[*core.Directory]
+		err := srv.Select(ctx, refs, &updated, dagql.Selector{
+			Field: "withDirectory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.NewString(relPath)},
+				{Name: "source", Value: dagql.NewID[*core.Directory](sourceID)},
+			},
+		})
+		return updated, err
+	})
+}
+
+type workspaceWithReferenceFileArgs struct {
+	Path   string
+	Source core.FileID
+}
+
+func (s *workspaceSchema) withReferenceFile(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceWithReferenceFileArgs,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	relPath, err := referenceInternalPath(args.Path)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	sourceID, err := args.Source.ID()
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	return s.addReference(ctx, srv, parent, func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+		var updated dagql.ObjectResult[*core.Directory]
+		err := srv.Select(ctx, refs, &updated, dagql.Selector{
+			Field: "withFile",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.NewString(relPath)},
+				{Name: "source", Value: dagql.NewID[*core.File](sourceID)},
+			},
+		})
+		return updated, err
+	})
+}
+
+// addReference applies an edit to the workspace's read-only reference directory
+// tree (creating it empty if absent) and returns a new workspace carrying the
+// updated tree. References live outside the overlay changeset, so this never
+// touches the source, the pending changes, or the export path.
+func (s *workspaceSchema) addReference(
+	ctx context.Context,
+	srv *dagql.Server,
+	parent dagql.ObjectResult[*core.Workspace],
+	edit func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error),
+) (dagql.ObjectResult[*core.Workspace], error) {
+	refs, ok := parent.Self().ReferencesDir()
+	if !ok {
+		if err := srv.Select(ctx, srv.Root(), &refs, dagql.Selector{Field: "directory"}); err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+	}
+	updated, err := edit(refs)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	ws := parent.Self().Clone()
+	ws.SetReferencesDir(updated)
+	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws)
+}
+
+// referenceInternalPath validates and normalizes a caller-supplied mount path
+// (relative to the references root), rejecting escapes and empty paths.
+func referenceInternalPath(p string) (string, error) {
+	clean := strings.TrimPrefix(path.Clean("/"+filepath.ToSlash(p)), "/")
+	if clean == "" || clean == "." {
+		return "", fmt.Errorf("reference path is required")
+	}
+	return clean, nil
+}
+
+// referenceRelPath reports whether a resolved workspace path lands under the
+// reserved references prefix and, if so, returns the path relative to the
+// references root ("." for the prefix itself).
+func referenceRelPath(resolvedPath string) (string, bool) {
+	p := filepath.ToSlash(resolvedPath)
+	if p == core.WorkspaceReferencePrefix {
+		return ".", true
+	}
+	if rel, ok := strings.CutPrefix(p, core.WorkspaceReferencePrefix+"/"); ok {
+		return rel, true
+	}
+	return "", false
+}
+
+// guardReferencePath rejects overlay edits that target the reserved references
+// prefix, keeping referenced content read-only. It is a no-op when the
+// workspace has no references.
+func guardReferencePath(ws *core.Workspace, resolvedPath string) error {
+	if _, ok := ws.ReferencesDir(); !ok {
+		return nil
+	}
+	if _, isRef := referenceRelPath(resolvedPath); isRef {
+		return fmt.Errorf("workspace path %q is a read-only reference and cannot be modified", resolvedPath)
+	}
+	return nil
 }
 
 func (s *workspaceSchema) changes(

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1118,6 +1118,7 @@ func (s *workspaceSchema) search(
 ) (dagql.Array[*core.SearchResult], error) {
 	ws := parent.Self()
 
+	var results []*core.SearchResult
 	if ws.HostPath() == "" {
 		// No host boundary: search the workspace's in-engine root filesystem.
 		// Overlay edits are already visible here: value/git overlays surface
@@ -1126,24 +1127,35 @@ func (s *workspaceSchema) search(
 		if err != nil {
 			return nil, err
 		}
-		results, err := rootfs.Self().Search(ctx, rootfs, args.SearchOpts, true, args.Paths, args.Globs)
+		results, err = rootfs.Self().Search(ctx, rootfs, args.SearchOpts, false, args.Paths, args.Globs)
 		if err != nil {
 			return nil, fmt.Errorf("search: %w", err)
 		}
-		return dagql.Array[*core.SearchResult](results), nil
-	}
-
-	results, err := s.searchHost(ctx, ws, args)
-	if err != nil {
-		return nil, fmt.Errorf("search: %w", err)
-	}
-
-	if _, ok := ws.OverlayChanges(); ok && ws.ClientLocalBase() {
-		overlayResults, err := s.overlaySearchResults(ctx, ws, args)
+	} else {
+		var err error
+		results, err = s.searchHost(ctx, ws, args)
 		if err != nil {
 			return nil, fmt.Errorf("search: %w", err)
 		}
-		results = mergeOverlaySearchResults(results, overlayResults, ws.OverlayPathTouched, args.Limit)
+
+		if _, ok := ws.OverlayChanges(); ok && ws.ClientLocalBase() {
+			overlayResults, err := s.overlaySearchResults(ctx, ws, args)
+			if err != nil {
+				return nil, fmt.Errorf("search: %w", err)
+			}
+			results = mergeSearchResults(results, overlayResults, ws.OverlayPathTouched, args.Limit)
+		}
+	}
+
+	// Mounted content is readable through the normal workspace file tools, so
+	// it is searchable too: the mounts tree's results win at and under mount
+	// points, mirroring resolveReadRootfs's shadowing.
+	if mounts, ok := ws.MountsDir(); ok {
+		mountResults, err := searchDirectoryTree(ctx, mounts, args)
+		if err != nil {
+			return nil, fmt.Errorf("search: mounts: %w", err)
+		}
+		results = mergeSearchResults(results, mountResults, ws.MountedPath, args.Limit)
 	}
 
 	emitSearchResults(ctx, results, args.FilesOnly)
@@ -1210,9 +1222,7 @@ func (s *workspaceSchema) searchHost(
 
 // overlaySearchResults searches the overlay's delta root — the accumulated
 // edits applied to an empty base, which holds the full after-state of every
-// touched path. The sparse delta lacks paths that only exist host-side, so
-// explicit search paths are applied as a post-filter instead of being passed
-// to ripgrep (which errors on missing path operands).
+// touched path.
 func (s *workspaceSchema) overlaySearchResults(
 	ctx context.Context,
 	ws *core.Workspace,
@@ -1222,11 +1232,28 @@ func (s *workspaceSchema) overlaySearchResults(
 	if !ok || delta.Self() == nil {
 		return nil, nil
 	}
-	opts := args.SearchOpts
-	opts.Limit = nil // the limit caps the merged results, not each side
-	results, err := delta.Self().Search(ctx, delta, opts, false, nil, args.Globs)
+	results, err := searchDirectoryTree(ctx, delta, args)
 	if err != nil {
 		return nil, fmt.Errorf("overlay: %w", err)
+	}
+	return results, nil
+}
+
+// searchDirectoryTree runs the search against a sparse in-engine tree (the
+// overlay's delta root or the mounts tree). The tree lacks paths that only
+// exist elsewhere in the workspace, so explicit search paths are applied as a
+// post-filter instead of being passed to ripgrep (which errors on missing
+// path operands).
+func searchDirectoryTree(
+	ctx context.Context,
+	tree dagql.ObjectResult[*core.Directory],
+	args workspaceSearchArgs,
+) ([]*core.SearchResult, error) {
+	opts := args.SearchOpts
+	opts.Limit = nil // the limit caps the merged results, not each side
+	results, err := tree.Self().Search(ctx, tree, opts, false, nil, args.Globs)
+	if err != nil {
+		return nil, err
 	}
 	if len(args.Paths) == 0 {
 		return results, nil
@@ -1240,23 +1267,23 @@ func (s *workspaceSchema) overlaySearchResults(
 	return scoped, nil
 }
 
-// mergeOverlaySearchResults combines host and overlay search results with
-// per-file replacement: the overlay's view wins for every path its edits
-// touch, so modified files don't surface stale host lines and removed files
-// drop out entirely. The merged set is sorted for determinism and capped at
-// limit when set.
-func mergeOverlaySearchResults(
-	host, overlay []*core.SearchResult,
-	touched func(string) bool,
+// mergeSearchResults combines two sides of a workspace search with per-file
+// replacement: the second side's view wins for every path the predicate
+// claims (an overlay's touched paths, a mount's shadowed paths), so replaced
+// files don't surface stale lines and removed files drop out entirely. The
+// merged set is sorted for determinism and capped at limit when set.
+func mergeSearchResults(
+	base, winning []*core.SearchResult,
+	claimed func(string) bool,
 	limit *int,
 ) []*core.SearchResult {
-	merged := make([]*core.SearchResult, 0, len(host)+len(overlay))
-	for _, r := range host {
-		if !touched(r.FilePath) {
+	merged := make([]*core.SearchResult, 0, len(base)+len(winning))
+	for _, r := range base {
+		if !claimed(r.FilePath) {
 			merged = append(merged, r)
 		}
 	}
-	merged = append(merged, overlay...)
+	merged = append(merged, winning...)
 	sort.SliceStable(merged, func(i, j int) bool {
 		if merged[i].FilePath != merged[j].FilePath {
 			return merged[i].FilePath < merged[j].FilePath
@@ -1312,6 +1339,7 @@ func (s *workspaceSchema) glob(
 ) (dagql.Array[dagql.String], error) {
 	ws := parent.Self()
 
+	var matches []string
 	if ws.HostPath() != "" {
 		hostCtx, err := s.withWorkspaceClientContext(ctx, ws)
 		if err != nil {
@@ -1325,7 +1353,7 @@ func (s *workspaceSchema) glob(
 		if err != nil {
 			return nil, fmt.Errorf("buildkit: %w", err)
 		}
-		matches, err := bk.GlobCallerHostPath(hostCtx, ws.HostPath(), args.Pattern)
+		matches, err = bk.GlobCallerHostPath(hostCtx, ws.HostPath(), args.Pattern)
 		if err != nil {
 			return nil, fmt.Errorf("glob: %w", err)
 		}
@@ -1334,29 +1362,31 @@ func (s *workspaceSchema) glob(
 			if err != nil {
 				return nil, fmt.Errorf("glob: %w", err)
 			}
-			matches = mergeOverlayGlobMatches(matches, overlayMatches, ws.OverlayPathTouched)
+			matches = mergeGlobMatches(matches, overlayMatches, ws.OverlayPathTouched)
 		}
-		return dagql.NewStringArray(matches...), nil
+	} else {
+		rootfs, err := workspaceRootfs(ws)
+		if err != nil {
+			return nil, err
+		}
+		matches, err = globDirectoryTree(ctx, rootfs, args.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("glob: %w", err)
+		}
 	}
 
-	rootfs, err := workspaceRootfs(ws)
-	if err != nil {
-		return nil, err
+	// Mounted content is readable through the normal workspace file tools, so
+	// it is globbable too: the mounts tree's matches win at and under mount
+	// points, mirroring resolveReadRootfs's shadowing.
+	if mounts, ok := ws.MountsDir(); ok {
+		mountMatches, err := globDirectoryTree(ctx, mounts, args.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("glob: mounts: %w", err)
+		}
+		matches = mergeGlobMatches(matches, mountMatches, ws.MountedPath)
 	}
-	srv, err := core.CurrentDagqlServer(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var matches dagql.Array[dagql.String]
-	if err := srv.Select(ctx, rootfs, &matches, dagql.Selector{
-		Field: "glob",
-		Args: []dagql.NamedInput{
-			{Name: "pattern", Value: dagql.NewString(args.Pattern)},
-		},
-	}); err != nil {
-		return nil, fmt.Errorf("glob: %w", err)
-	}
-	return matches, nil
+
+	return dagql.NewStringArray(matches...), nil
 }
 
 // overlayGlobMatches runs the glob against the overlay's delta root — the
@@ -1371,18 +1401,32 @@ func (s *workspaceSchema) overlayGlobMatches(
 	if !ok || delta.Self() == nil {
 		return nil, nil
 	}
+	matches, err := globDirectoryTree(ctx, delta, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("overlay: %w", err)
+	}
+	return matches, nil
+}
+
+// globDirectoryTree runs a glob against an in-engine directory tree (the
+// workspace rootfs, the overlay's delta root, or the mounts tree).
+func globDirectoryTree(
+	ctx context.Context,
+	tree dagql.ObjectResult[*core.Directory],
+	pattern string,
+) ([]string, error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var matches dagql.Array[dagql.String]
-	if err := srv.Select(ctx, delta, &matches, dagql.Selector{
+	if err := srv.Select(ctx, tree, &matches, dagql.Selector{
 		Field: "glob",
 		Args: []dagql.NamedInput{
 			{Name: "pattern", Value: dagql.NewString(pattern)},
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("overlay: %w", err)
+		return nil, err
 	}
 	out := make([]string, len(matches))
 	for i, m := range matches {
@@ -1391,14 +1435,15 @@ func (s *workspaceSchema) overlayGlobMatches(
 	return out, nil
 }
 
-// mergeOverlayGlobMatches combines host and overlay glob matches with
-// per-path replacement: the overlay's view wins for every path its edits
-// touch, so removed paths drop out and added ones come from the delta.
-// Parent directories of touched files exist in both trees and dedup to the
-// host's entry. The merged set is sorted for determinism.
-func mergeOverlayGlobMatches(host, overlay []string, touched func(string) bool) []string {
-	seen := make(map[string]bool, len(host)+len(overlay))
-	merged := make([]string, 0, len(host)+len(overlay))
+// mergeGlobMatches combines two sides of a workspace glob with per-path
+// replacement: the second side's view wins for every path the predicate
+// claims (an overlay's touched paths, a mount's shadowed paths), so removed
+// paths drop out and added ones come from the winning tree. Parent
+// directories that exist in both trees dedup to the base's entry. The merged
+// set is sorted for determinism.
+func mergeGlobMatches(base, winning []string, claimed func(string) bool) []string {
+	seen := make(map[string]bool, len(base)+len(winning))
+	merged := make([]string, 0, len(base)+len(winning))
 	add := func(m string) {
 		key := path.Clean(filepath.ToSlash(m))
 		if !seen[key] {
@@ -1406,13 +1451,13 @@ func mergeOverlayGlobMatches(host, overlay []string, touched func(string) bool) 
 			merged = append(merged, m)
 		}
 	}
-	for _, m := range host {
-		if touched(m) {
+	for _, m := range base {
+		if claimed(m) {
 			continue
 		}
 		add(m)
 	}
-	for _, m := range overlay {
+	for _, m := range winning {
 		add(m)
 	}
 	sort.Strings(merged)
@@ -2427,14 +2472,39 @@ func (s *workspaceSchema) findUp(
 		statFS = &core.DirectoryStatFS{Dir: rootfs}
 	}
 
+	// Mounted content is visible to findUp like any other workspace read: the
+	// mounts tree (which also materializes mount points' parents) is consulted
+	// first, and at or under a mount point it fully shadows the source.
+	var mountsFS core.StatFS
+	if mounts, ok := ws.MountsDir(); ok {
+		mountsFS = &core.DirectoryStatFS{Dir: mounts}
+	}
+	candidateExists := func(candidate string) (bool, error) {
+		if mountsFS != nil {
+			_, exists, err := core.StatFSExists(ctx, mountsFS, candidate)
+			if err != nil {
+				return false, err
+			}
+			if exists {
+				return true, nil
+			}
+			if ws.MountedPath(candidate) {
+				// The mount shadows whatever the source holds here.
+				return false, nil
+			}
+		}
+		statPath, err := pathForStat(candidate)
+		if err != nil {
+			return false, err
+		}
+		_, exists, err := core.StatFSExists(ctx, statFS, statPath)
+		return exists, err
+	}
+
 	// Walk up from the resolved start path, stopping at the workspace boundary.
 	for {
 		candidate := path.Join(curDir, args.Name)
-		statPath, err := pathForStat(candidate)
-		if err != nil {
-			return none, err
-		}
-		_, exists, err := core.StatFSExists(ctx, statFS, statPath)
+		exists, err := candidateExists(candidate)
 		if err != nil {
 			return none, fmt.Errorf("stat %s: %w", candidate, err)
 		}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1524,29 +1524,7 @@ func (s *workspaceSchema) withReferenceDirectory(
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceWithReferenceDirectoryArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	relPath, err := referenceInternalPath(args.Path)
-	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
-	}
-	srv, err := core.CurrentDagqlServer(ctx)
-	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
-	}
-	sourceID, err := args.Source.ID()
-	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
-	}
-	return s.addReference(ctx, srv, parent, func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
-		var updated dagql.ObjectResult[*core.Directory]
-		err := srv.Select(ctx, refs, &updated, dagql.Selector{
-			Field: "withDirectory",
-			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(relPath)},
-				{Name: "source", Value: dagql.NewID[*core.Directory](sourceID)},
-			},
-		})
-		return updated, err
-	})
+	return withReferenceSource(ctx, s, parent, args.Path, args.Source, "withDirectory")
 }
 
 type workspaceWithReferenceFileArgs struct {
@@ -1559,7 +1537,22 @@ func (s *workspaceSchema) withReferenceFile(
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceWithReferenceFileArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	relPath, err := referenceInternalPath(args.Path)
+	return withReferenceSource(ctx, s, parent, args.Path, args.Source, "withFile")
+}
+
+// withReferenceSource is the shared implementation of withReferenceDirectory
+// and withReferenceFile: it attaches the given source (a Directory or File) at
+// the reference-internal path via the named Directory field ("withDirectory"
+// or "withFile").
+func withReferenceSource[T dagql.Typed](
+	ctx context.Context,
+	s *workspaceSchema,
+	parent dagql.ObjectResult[*core.Workspace],
+	path string,
+	source dagql.ID[T],
+	field string,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	relPath, err := referenceInternalPath(path)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
@@ -1567,17 +1560,17 @@ func (s *workspaceSchema) withReferenceFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	sourceID, err := args.Source.ID()
+	sourceID, err := source.ID()
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	return s.addReference(ctx, srv, parent, func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, refs, &updated, dagql.Selector{
-			Field: "withFile",
+			Field: field,
 			Args: []dagql.NamedInput{
 				{Name: "path", Value: dagql.NewString(relPath)},
-				{Name: "source", Value: dagql.NewID[*core.File](sourceID)},
+				{Name: "source", Value: dagql.NewID[T](sourceID)},
 			},
 		})
 		return updated, err

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -172,21 +172,21 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("path").Doc("Workspace-relative path to use as the working directory."),
 			),
-		dagql.NodeFunc("withReferenceDirectory", s.withReferenceDirectory).
+		dagql.NodeFunc("withMountedDirectory", s.withMountedDirectory).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a directory mounted read-only under the reserved references prefix.",
-				"Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.").
+			Doc("Return this workspace with a directory mounted read-only at the given path, without mutating the source.",
+				"Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.").
 			Args(
-				dagql.Arg("path").Doc("Reference-relative mount path under the reserved references prefix."),
-				dagql.Arg("source").Doc("Directory to mount read-only."),
+				dagql.Arg("path").Doc("Location of the mounted directory. Relative paths resolve from the workspace cwd."),
+				dagql.Arg("source").Doc("Directory to mount."),
 			),
-		dagql.NodeFunc("withReferenceFile", s.withReferenceFile).
+		dagql.NodeFunc("withMountedFile", s.withMountedFile).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a file mounted read-only under the reserved references prefix.",
-				"Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.").
+			Doc("Return this workspace with a file mounted read-only at the given path, without mutating the source.",
+				"Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.").
 			Args(
-				dagql.Arg("path").Doc("Reference-relative mount path under the reserved references prefix."),
-				dagql.Arg("source").Doc("File to mount read-only."),
+				dagql.Arg("path").Doc("Location of the mounted file. Relative paths resolve from the workspace cwd."),
+				dagql.Arg("source").Doc("File to mount."),
 			),
 		dagql.NodeFunc("withModule", s.withModule).
 			View(AfterVersion("v1.0.0-0")).
@@ -591,6 +591,121 @@ type workspaceDirectoryArgs struct {
 	Gitignore bool `default:"false"`
 }
 
+// resolveReadRootfs resolves a workspace read (Workspace.directory/file) with
+// mounted content visible:
+//   - Paths at or under a mount point resolve entirely against the read-only
+//     mounts tree — mounted content shadows the source.
+//   - Paths with mount points beneath them get the mounted content overlaid on
+//     the source read, so listings include it. As with container mounts, the
+//     mount point's parents don't need to exist in the source.
+//
+// Everything that materializes the workspace *source* (module loading,
+// lockfiles, migration, git) resolves through resolveRootfs directly and never
+// sees mounts, mirroring how changes and export exclude them.
+func (s *workspaceSchema) resolveReadRootfs(
+	ctx context.Context,
+	ws *core.Workspace,
+	resolvedPath string,
+	filter core.CopyFilter,
+	gitignore bool,
+) (inst dagql.ObjectResult[*core.Directory], _ error) {
+	mounts, ok := ws.MountsDir()
+	if !ok {
+		return s.resolveRootfs(ctx, ws, resolvedPath, filter, gitignore)
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, err
+	}
+	if ws.MountedPath(resolvedPath) {
+		return s.resolveRootfsFromDirectory(ctx, srv, ws, mounts, resolvedPath, filter, gitignore)
+	}
+	if !ws.HasMountsUnder(resolvedPath) {
+		return s.resolveRootfs(ctx, ws, resolvedPath, filter, gitignore)
+	}
+	sub, err := s.resolveRootfsFromDirectory(ctx, srv, ws, mounts, resolvedPath, filter, gitignore)
+	if err != nil {
+		return inst, err
+	}
+	// The source path itself may not exist (mounts materialize their own
+	// parents); serve the mounted content alone rather than erroring on the
+	// source read.
+	exists, err := s.workspaceReadPathExists(ctx, ws, resolvedPath)
+	if err != nil {
+		return inst, err
+	}
+	if !exists {
+		return sub, nil
+	}
+	base, err := s.resolveRootfs(ctx, ws, resolvedPath, filter, gitignore)
+	if err != nil {
+		return inst, err
+	}
+	subID, err := sub.ID()
+	if err != nil {
+		return inst, err
+	}
+	var merged dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, base, &merged, dagql.Selector{
+		Field: "withDirectory",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.NewString("/")},
+			{Name: "source", Value: dagql.NewID[*core.Directory](subID)},
+		},
+	}); err != nil {
+		return inst, err
+	}
+	return merged, nil
+}
+
+// workspaceReadPathExists reports whether a resolved workspace path exists in
+// the workspace source (host, overlay edits, or in-engine tree), without
+// considering mounts.
+func (s *workspaceSchema) workspaceReadPathExists(
+	ctx context.Context,
+	ws *core.Workspace,
+	resolvedPath string,
+) (bool, error) {
+	rp := filepath.ToSlash(resolvedPath)
+	// Overlay edits can create paths that exist in no base source; host-backed
+	// overlays track them as touched paths (tree-backed overlays already fold
+	// edits into the source directory checked below).
+	if overlay, ok := ws.Source().(*core.WorkspaceSourceOverlay); ok {
+		for _, touched := range overlay.TouchedPaths {
+			tp := filepath.ToSlash(touched)
+			if tp == rp || strings.HasPrefix(tp, rp+"/") || rp == "." {
+				return true, nil
+			}
+		}
+	}
+	if ws.HostPath() != "" && ws.ClientLocalBase() {
+		ctx, err := s.withWorkspaceClientContext(ctx, ws)
+		if err != nil {
+			return false, err
+		}
+		query, err := core.CurrentQuery(ctx)
+		if err != nil {
+			return false, err
+		}
+		bk, err := query.Engine(ctx)
+		if err != nil {
+			return false, fmt.Errorf("buildkit: %w", err)
+		}
+		statPath, err := pathutil.SandboxedRelativePath(resolvedPath, ws.HostPath())
+		if err != nil {
+			return false, err
+		}
+		_, exists, err := core.StatFSExists(ctx, core.NewCallerStatFS(bk), statPath)
+		return exists, err
+	}
+	if root, ok := ws.SourceDirectory(); ok && root.Self() != nil {
+		_, exists, err := core.StatFSExists(ctx, &core.DirectoryStatFS{Dir: root}, rp)
+		return exists, err
+	}
+	// Rootless/synthetic workspaces have no base content.
+	return false, nil
+}
+
 // resolveRootfs returns a lazy directory reference for a resolved workspace path.
 // Local: per-call host.directory(absPath, include, exclude) via workspace client session.
 // Local with overlay edits: sparse host base + changeset applied on top.
@@ -605,14 +720,6 @@ func (s *workspaceSchema) resolveRootfs(
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
-	}
-
-	// Reads under the reserved references prefix resolve against the read-only
-	// reference tree, never the host or the overlay changeset.
-	if refsDir, ok := ws.ReferencesDir(); ok {
-		if rel, isRef := referenceRelPath(resolvedPath); isRef {
-			return s.resolveRootfsFromDirectory(ctx, srv, ws, refsDir, rel, filter, gitignore)
-		}
 	}
 
 	if ws.HostPath() != "" && ws.ClientLocalBase() {
@@ -916,7 +1023,7 @@ func (s *workspaceSchema) directoryAt(
 	if err != nil {
 		return inst, err
 	}
-	return s.resolveRootfs(ctx, ws, resolvedPath, args.CopyFilter, args.Gitignore)
+	return s.resolveReadRootfs(ctx, ws, resolvedPath, args.CopyFilter, args.Gitignore)
 }
 
 type workspaceFileArgs struct {
@@ -945,7 +1052,7 @@ func (s *workspaceSchema) fileAt(
 	parentDir := filepath.Dir(resolvedPath)
 	basename := filepath.Base(resolvedPath)
 
-	dir, err := s.resolveRootfs(ctx, ws, parentDir, core.CopyFilter{
+	dir, err := s.resolveReadRootfs(ctx, ws, parentDir, core.CopyFilter{
 		Include: []string{basename},
 	}, false)
 	if err != nil {
@@ -977,7 +1084,7 @@ func (s *workspaceSchema) withNewFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+	if err := guardMountedPath(parent.Self(), resolvedPath); err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
@@ -1326,7 +1433,7 @@ func (s *workspaceSchema) withNewDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+	if err := guardMountedPath(parent.Self(), resolvedPath); err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
@@ -1364,7 +1471,7 @@ func (s *workspaceSchema) withoutFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+	if err := guardMountedPath(parent.Self(), resolvedPath); err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
@@ -1397,7 +1504,7 @@ func (s *workspaceSchema) withoutDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	if err := guardReferencePath(parent.Self(), resolvedPath); err != nil {
+	if err := guardMountedPath(parent.Self(), resolvedPath); err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
@@ -1475,7 +1582,7 @@ func (s *workspaceSchema) applyChangeset(
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	for _, p := range touched {
-		if err := guardReferencePath(parent.Self(), p); err != nil {
+		if err := guardMountedPath(parent.Self(), p); err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
 		}
 	}
@@ -1514,47 +1621,50 @@ func (s *workspaceSchema) withWorkdir(
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws)
 }
 
-type workspaceWithReferenceDirectoryArgs struct {
+type workspaceWithMountedDirectoryArgs struct {
 	Path   string
 	Source core.DirectoryID
 }
 
-func (s *workspaceSchema) withReferenceDirectory(
+func (s *workspaceSchema) withMountedDirectory(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
-	args workspaceWithReferenceDirectoryArgs,
+	args workspaceWithMountedDirectoryArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	return withReferenceSource(ctx, s, parent, args.Path, args.Source, "withDirectory")
+	return withMountedSource(ctx, parent, args.Path, args.Source, "withDirectory")
 }
 
-type workspaceWithReferenceFileArgs struct {
+type workspaceWithMountedFileArgs struct {
 	Path   string
 	Source core.FileID
 }
 
-func (s *workspaceSchema) withReferenceFile(
+func (s *workspaceSchema) withMountedFile(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
-	args workspaceWithReferenceFileArgs,
+	args workspaceWithMountedFileArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	return withReferenceSource(ctx, s, parent, args.Path, args.Source, "withFile")
+	return withMountedSource(ctx, parent, args.Path, args.Source, "withFile")
 }
 
-// withReferenceSource is the shared implementation of withReferenceDirectory
-// and withReferenceFile: it attaches the given source (a Directory or File) at
-// the reference-internal path via the named Directory field ("withDirectory"
-// or "withFile").
-func withReferenceSource[T dagql.Typed](
+// withMountedSource is the shared implementation of withMountedDirectory and
+// withMountedFile: it attaches the given source (a Directory or File) into the
+// workspace's read-only mounts tree at the resolved workspace path via the
+// named Directory field ("withDirectory" or "withFile"), and records the mount
+// point.
+func withMountedSource[T dagql.Typed](
 	ctx context.Context,
-	s *workspaceSchema,
 	parent dagql.ObjectResult[*core.Workspace],
 	path string,
 	source dagql.ID[T],
 	field string,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	relPath, err := referenceInternalPath(path)
+	resolvedPath, err := resolveWorkspacePath(path, parent.Self().Cwd)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if resolvedPath == "." {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("cannot mount over the workspace root")
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
@@ -1564,77 +1674,32 @@ func withReferenceSource[T dagql.Typed](
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.addReference(ctx, srv, parent, func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
-		var updated dagql.ObjectResult[*core.Directory]
-		err := srv.Select(ctx, refs, &updated, dagql.Selector{
-			Field: field,
-			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(relPath)},
-				{Name: "source", Value: dagql.NewID[T](sourceID)},
-			},
-		})
-		return updated, err
-	})
-}
-
-// addReference applies an edit to the workspace's read-only reference directory
-// tree (creating it empty if absent) and returns a new workspace carrying the
-// updated tree. References live outside the overlay changeset, so this never
-// touches the source, the pending changes, or the export path.
-func (s *workspaceSchema) addReference(
-	ctx context.Context,
-	srv *dagql.Server,
-	parent dagql.ObjectResult[*core.Workspace],
-	edit func(refs dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error),
-) (dagql.ObjectResult[*core.Workspace], error) {
-	refs, ok := parent.Self().ReferencesDir()
+	mounts, ok := parent.Self().MountsDir()
 	if !ok {
-		if err := srv.Select(ctx, srv.Root(), &refs, dagql.Selector{Field: "directory"}); err != nil {
+		if err := srv.Select(ctx, srv.Root(), &mounts, dagql.Selector{Field: "directory"}); err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
 		}
 	}
-	updated, err := edit(refs)
-	if err != nil {
+	var updated dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, mounts, &updated, dagql.Selector{
+		Field: field,
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.NewString(resolvedPath)},
+			{Name: "source", Value: dagql.NewID[T](sourceID)},
+		},
+	}); err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	ws := parent.Self().Clone()
-	ws.SetReferencesDir(updated)
+	ws := parent.Self().WithMounted(updated, resolvedPath)
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws)
 }
 
-// referenceInternalPath validates and normalizes a caller-supplied mount path
-// (relative to the references root), rejecting escapes and empty paths.
-func referenceInternalPath(p string) (string, error) {
-	clean := strings.TrimPrefix(path.Clean("/"+filepath.ToSlash(p)), "/")
-	if clean == "" || clean == "." {
-		return "", fmt.Errorf("reference path is required")
-	}
-	return clean, nil
-}
-
-// referenceRelPath reports whether a resolved workspace path lands under the
-// reserved references prefix and, if so, returns the path relative to the
-// references root ("." for the prefix itself).
-func referenceRelPath(resolvedPath string) (string, bool) {
-	p := filepath.ToSlash(resolvedPath)
-	if p == core.WorkspaceReferencePrefix {
-		return ".", true
-	}
-	if rel, ok := strings.CutPrefix(p, core.WorkspaceReferencePrefix+"/"); ok {
-		return rel, true
-	}
-	return "", false
-}
-
-// guardReferencePath rejects overlay edits that target the reserved references
-// prefix, keeping referenced content read-only. It is a no-op when the
-// workspace has no references.
-func guardReferencePath(ws *core.Workspace, resolvedPath string) error {
-	if _, ok := ws.ReferencesDir(); !ok {
-		return nil
-	}
-	if _, isRef := referenceRelPath(resolvedPath); isRef {
-		return fmt.Errorf("workspace path %q is a read-only reference and cannot be modified", resolvedPath)
+// guardMountedPath rejects overlay edits that target a path at or under a
+// mount point, keeping mounted content read-only. It is a no-op when the
+// workspace has no mounts.
+func guardMountedPath(ws *core.Workspace, resolvedPath string) error {
+	if ws.MountedPath(resolvedPath) {
+		return fmt.Errorf("workspace path %q is a read-only mount and cannot be modified", resolvedPath)
 	}
 	return nil
 }

--- a/core/schema/workspace_overlay_search_test.go
+++ b/core/schema/workspace_overlay_search_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +16,7 @@ func touchedSet(paths ...string) func(string) bool {
 	return func(p string) bool { return set[p] }
 }
 
-func TestMergeOverlaySearchResults(t *testing.T) {
+func TestMergeSearchResults(t *testing.T) {
 	res := func(file string, line int) *core.SearchResult {
 		return &core.SearchResult{FilePath: file, LineNumber: line}
 	}
@@ -30,7 +31,7 @@ func TestMergeOverlaySearchResults(t *testing.T) {
 			res("edited.txt", 5),
 			res("created.txt", 1),
 		}
-		merged := mergeOverlaySearchResults(host, overlay,
+		merged := mergeSearchResults(host, overlay,
 			touchedSet("edited.txt", "doomed.txt", "created.txt"), nil)
 
 		require.Equal(t, []*core.SearchResult{
@@ -42,14 +43,14 @@ func TestMergeOverlaySearchResults(t *testing.T) {
 
 	t.Run("touched file with no overlay matches disappears", func(t *testing.T) {
 		host := []*core.SearchResult{res("edited.txt", 1)}
-		merged := mergeOverlaySearchResults(host, nil, touchedSet("edited.txt"), nil)
+		merged := mergeSearchResults(host, nil, touchedSet("edited.txt"), nil)
 		require.Empty(t, merged)
 	})
 
 	t.Run("sorted by file then line", func(t *testing.T) {
 		host := []*core.SearchResult{res("b.txt", 9), res("b.txt", 2)}
 		overlay := []*core.SearchResult{res("a.txt", 4)}
-		merged := mergeOverlaySearchResults(host, overlay, touchedSet("a.txt"), nil)
+		merged := mergeSearchResults(host, overlay, touchedSet("a.txt"), nil)
 		require.Equal(t, []*core.SearchResult{
 			res("a.txt", 4),
 			res("b.txt", 2),
@@ -61,8 +62,25 @@ func TestMergeOverlaySearchResults(t *testing.T) {
 		host := []*core.SearchResult{res("a.txt", 1), res("b.txt", 1)}
 		overlay := []*core.SearchResult{res("c.txt", 1)}
 		limit := 2
-		merged := mergeOverlaySearchResults(host, overlay, touchedSet("c.txt"), &limit)
+		merged := mergeSearchResults(host, overlay, touchedSet("c.txt"), &limit)
 		require.Equal(t, []*core.SearchResult{res("a.txt", 1), res("b.txt", 1)}, merged)
+	})
+
+	t.Run("mount points shadow source results beneath them", func(t *testing.T) {
+		// The mounts merge uses Workspace.MountedPath as its predicate: any
+		// source result at or under a mount point is replaced by the mounts
+		// tree's view.
+		ws := (&core.Workspace{}).WithMounted(dagql.ObjectResult[*core.Directory]{}, "deps/vendored")
+		host := []*core.SearchResult{
+			res("src/main.go", 1),
+			res("deps/vendored/stale.go", 3),
+		}
+		mounted := []*core.SearchResult{res("deps/vendored/pinned.go", 7)}
+		merged := mergeSearchResults(host, mounted, ws.MountedPath, nil)
+		require.Equal(t, []*core.SearchResult{
+			res("deps/vendored/pinned.go", 7),
+			res("src/main.go", 1),
+		}, merged)
 	})
 }
 
@@ -76,11 +94,11 @@ func TestSearchPathInScopes(t *testing.T) {
 	require.False(t, searchPathInScopes("docs-extra/new.md", []string{"docs"}))
 }
 
-func TestMergeOverlayGlobMatches(t *testing.T) {
+func TestMergeGlobMatches(t *testing.T) {
 	t.Run("overlay replaces host matches per path", func(t *testing.T) {
 		host := []string{"untouched.txt", "edited.txt", "doomed.txt"}
 		overlay := []string{"edited.txt", "created.txt"}
-		merged := mergeOverlayGlobMatches(host, overlay,
+		merged := mergeGlobMatches(host, overlay,
 			touchedSet("edited.txt", "doomed.txt", "created.txt"))
 		require.Equal(t, []string{"created.txt", "edited.txt", "untouched.txt"}, merged)
 	})
@@ -91,12 +109,20 @@ func TestMergeOverlayGlobMatches(t *testing.T) {
 		// the dedup.
 		host := []string{"sub/", "sub/inner.txt"}
 		overlay := []string{"sub/", "sub/new.txt"}
-		merged := mergeOverlayGlobMatches(host, overlay, touchedSet("sub/new.txt"))
+		merged := mergeGlobMatches(host, overlay, touchedSet("sub/new.txt"))
 		require.Equal(t, []string{"sub/", "sub/inner.txt", "sub/new.txt"}, merged)
 	})
 
 	t.Run("removed path with no overlay match disappears", func(t *testing.T) {
-		merged := mergeOverlayGlobMatches([]string{"doomed.txt"}, nil, touchedSet("doomed.txt"))
+		merged := mergeGlobMatches([]string{"doomed.txt"}, nil, touchedSet("doomed.txt"))
 		require.Empty(t, merged)
+	})
+
+	t.Run("mount points shadow source matches beneath them", func(t *testing.T) {
+		ws := (&core.Workspace{}).WithMounted(dagql.ObjectResult[*core.Directory]{}, "deps/vendored")
+		host := []string{"src/main.go", "deps/vendored/stale.go"}
+		mounted := []string{"deps/vendored/pinned.go"}
+		merged := mergeGlobMatches(host, mounted, ws.MountedPath)
+		require.Equal(t, []string{"deps/vendored/pinned.go", "src/main.go"}, merged)
 	})
 }

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWorkspacePrivateSourceFieldsAreNotGraphQLFields(t *testing.T) {
 	typ := reflect.TypeOf(core.Workspace{})
-	for _, name := range []string{"source", "rootfs", "references", "hostPath", "ClientID", "userConfigKey", "userConfigOverlay"} {
+	for _, name := range []string{"source", "rootfs", "mounts", "mountPoints", "hostPath", "ClientID", "userConfigKey", "userConfigOverlay"} {
 		field, ok := typ.FieldByName(name)
 		require.True(t, ok, "missing Workspace field %s", name)
 		require.NotEqual(t, "true", field.Tag.Get("field"), "Workspace.%s must stay private", name)
@@ -87,53 +88,60 @@ func TestEffectiveWorkspaceConfigBytesAppliesUserOverlay(t *testing.T) {
 	})
 }
 
-func TestReferenceInternalPath(t *testing.T) {
-	cases := []struct {
-		in      string
-		want    string
-		wantErr bool
-	}{
-		{"foo/bar.txt", "foo/bar.txt", false},
-		{"proj", "proj", false},
-		{"/leading/slash", "leading/slash", false},
-		// escapes are neutralized rather than allowed to climb out
-		{"../escape", "escape", false},
-		{"a/../../b", "b", false},
-		{"", "", true},
-		{".", "", true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			got, err := referenceInternalPath(tc.in)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tc.want, got)
-		})
-	}
-}
+func TestWorkspaceMountedPath(t *testing.T) {
+	ws := (&core.Workspace{}).
+		WithMounted(dagql.ObjectResult[*core.Directory]{}, ".refs/notes.txt").
+		WithMounted(dagql.ObjectResult[*core.Directory]{}, "deps/vendored")
 
-func TestReferenceRelPath(t *testing.T) {
-	cases := []struct {
-		in    string
-		want  string
-		isRef bool
-	}{
-		{core.WorkspaceReferencePrefix, ".", true},
-		{core.WorkspaceReferencePrefix + "/foo/bar.txt", "foo/bar.txt", true},
-		{"src/main.go", "", false},
-		{".refspoofing/x", "", false},
-		{".", "", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			got, isRef := referenceRelPath(tc.in)
-			require.Equal(t, tc.isRef, isRef)
-			require.Equal(t, tc.want, got)
-		})
-	}
+	t.Run("at or under a mount point", func(t *testing.T) {
+		cases := []struct {
+			in      string
+			mounted bool
+		}{
+			{".refs/notes.txt", true},
+			{"deps/vendored", true},
+			{"deps/vendored/lib/util.go", true},
+			// parents of mount points are not themselves mounted
+			{".refs", false},
+			{"deps", false},
+			{".", false},
+			// prefix spoofing does not match
+			{"deps/vendored-extra", false},
+			{".refs/notes.txt.bak", false},
+			{"src/main.go", false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.in, func(t *testing.T) {
+				require.Equal(t, tc.mounted, ws.MountedPath(tc.in))
+			})
+		}
+	})
+
+	t.Run("mounts under", func(t *testing.T) {
+		cases := []struct {
+			in    string
+			under bool
+		}{
+			{".", true},
+			{".refs", true},
+			{"deps", true},
+			// mount points themselves have no mounts strictly below
+			{"deps/vendored", false},
+			{"src", false},
+			{"deps/vendored-extra", false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.in, func(t *testing.T) {
+				require.Equal(t, tc.under, ws.HasMountsUnder(tc.in))
+			})
+		}
+	})
+
+	t.Run("no mounts", func(t *testing.T) {
+		empty := &core.Workspace{}
+		require.False(t, empty.MountedPath("anything"))
+		require.False(t, empty.HasMountsUnder("."))
+	})
 }
 
 // TestInitialWorkspaceConfigOmitsCheckGenerated verifies the default dagger.toml

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestWorkspacePrivateSourceFieldsAreNotGraphQLFields(t *testing.T) {
 	typ := reflect.TypeOf(core.Workspace{})
-	for _, name := range []string{"source", "rootfs", "hostPath", "ClientID", "userConfigKey", "userConfigOverlay"} {
+	for _, name := range []string{"source", "rootfs", "references", "hostPath", "ClientID", "userConfigKey", "userConfigOverlay"} {
 		field, ok := typ.FieldByName(name)
 		require.True(t, ok, "missing Workspace field %s", name)
 		require.NotEqual(t, "true", field.Tag.Get("field"), "Workspace.%s must stay private", name)
@@ -85,6 +85,55 @@ func TestEffectiveWorkspaceConfigBytesAppliesUserOverlay(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "shared", profile)
 	})
+}
+
+func TestReferenceInternalPath(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"foo/bar.txt", "foo/bar.txt", false},
+		{"proj", "proj", false},
+		{"/leading/slash", "leading/slash", false},
+		// escapes are neutralized rather than allowed to climb out
+		{"../escape", "escape", false},
+		{"a/../../b", "b", false},
+		{"", "", true},
+		{".", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := referenceInternalPath(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReferenceRelPath(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  string
+		isRef bool
+	}{
+		{core.WorkspaceReferencePrefix, ".", true},
+		{core.WorkspaceReferencePrefix + "/foo/bar.txt", "foo/bar.txt", true},
+		{"src/main.go", "", false},
+		{".refspoofing/x", "", false},
+		{".", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, isRef := referenceRelPath(tc.in)
+			require.Equal(t, tc.isRef, isRef)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestInitialWorkspaceConfigOmitsCheckGenerated verifies the default dagger.toml

--- a/core/search.go
+++ b/core/search.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -241,7 +242,7 @@ func (opts *SearchOpts) RunRipgrep(ctx context.Context, rg *exec.Cmd, verbose bo
 			return []*SearchResult{}, nil
 		}
 		if errBuf.Len() > 0 {
-			if strings.Contains(errBuf.String(), "No files were searched") {
+			if engine.RipgrepNoFilesSearched(errBuf.String()) {
 				if errs == nil {
 					return []*SearchResult{}, nil
 				}

--- a/core/skills/dang-dagger-modules/SKILL.md
+++ b/core/skills/dang-dagger-modules/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: dang-dagger-modules
+description: Authoring Dagger modules in Dang — dagger.json setup, the main type & constructor, what becomes module API, self-calls (supported; annotate returns as Dagger.<Type>!), dependencies, enums/interfaces/scalars, directives (@check, @cache, @defaultPath, @agent), Workspace args, and caching pitfalls. Use when writing or reviewing a Dagger module implemented in Dang.
+---
+
+# Dagger Modules in Dang
+
+**Audience: people writing Dagger modules in Dang.** For the language itself
+(syntax, nullability, copy-on-write mutation, control flow, GraphQL interop)
+see the `dang-language` skill; this skill covers only what is specific to Dang
+as a **Dagger module SDK**.
+
+## Mental model
+
+- A Dang module is a directory of `.dang` files plus a config naming `dang` as
+  the SDK. **All** top-level `.dang` files in the source directory form one
+  module (subdirectories and other files are ignored); declarations are
+  order-independent across files.
+- **No codegen, no container** — the engine interprets Dang natively. There is
+  no generated client: the Dagger API is auto-imported under the `Dagger`
+  namespace, and bare names work too (`container.from(...)` ≡
+  `Dagger.container.from(...)`).
+- Every **public top-level declaration** becomes module API: `type` → object
+  (plus constructor), `enum` → enum, `interface` → interface. `let` keeps a
+  binding private. Custom `scalar`s are exposed as strings.
+- The **main object** is the type whose name matches the module name.
+  Secondary types get module-prefixed schema names: `type Widget` in module
+  `test` lives in the schema as `TestWidget`.
+- **Self-calls are fully supported** (always enabled for the Dang SDK — no
+  experimental flag needed): a module can call its own functions through the
+  engine via its own root binding (`test.foo`, `tuiQa`). See the dedicated
+  section — the return-type annotation rule is the #1 gotcha.
+
+## Module setup
+
+```json
+{
+  "name": "counter",
+  "engineVersion": "v0.21.5",
+  "sdk": { "source": "dang" }
+}
+```
+
+- `"sdk": "dang"` (plain string) also works.
+- `engineVersion` selects the Dang major: `< v0.21.5` routes to frozen Dang v1
+  (where `.{ }` was GraphQL selection); `>= v0.21.5` is Dang v2 (`.{ }` is
+  dot-block application, `.{{ }}` is selection). Don't bump an old module's
+  `engineVersion` without checking its selection syntax.
+- Dependencies: `"dependencies": [{"name": "gochild", "source": "gochild"}]` —
+  deps may use any SDK (Go, Python, TypeScript, Dang) side by side.
+- `"disableDefaultFunctionCaching": true` turns off default function caching
+  module-wide (coarse alternative to per-function `@cache`).
+- Legacy `"sdk": {"experimental": {"SELF_CALLS": true}}` is obsolete: self-calls
+  graduated to a runtime-capability check and are always on for Dang.
+
+## Main type, constructor & API surface
+
+```dang
+type Greeter {
+  let secret: String! = "hidden"          # private state, never exposed
+  pub name: String!                        # data field (also a ctor param)
+
+  new(name: String! = "world") {           # explicit constructor
+    self.name = name.capitalize
+    self                                   # must end with self
+  }
+
+  pub greet: String! { "Hey, " + name }    # computed field / zero-arg function
+}
+```
+
+- Without `new`, the uninitialized public fields form an implicit constructor
+  in declaration order (positional construction works).
+- Constructor args become top-level flags: `dagger call --name alice greet`.
+  Arg names need not match field names; the body really executes.
+- `pub` and bare typed declarations are exposed; `let` is private — including
+  `let` *functions*, the idiom for internal helpers.
+- A field with a body is a function/computed field; a plain typed field is
+  data. Docstrings (`"""..."""` before a declaration or arg) become API
+  descriptions.
+- Private (`let`) fields persist across calls: they serialize into the
+  object's state and rehydrate on the next call. Chain state mutations
+  copy-on-write style: `with(x): Self! { self.x = x; self }`.
+- Non-null args (`T!`) are required; nullable args are optional — the idiom
+  for optional inputs is `arg: File = null`.
+- `Map[...]` **cannot** be exposed through the API; keep maps in `let` fields
+  (they serialize fine privately). Ad-hoc record types can't be exposed
+  either — declare a named `type`.
+- `Void` return marks an effect-only function; end the body with `null` (or a
+  `Void`-typed call), and use `.sync` to force container execution.
+
+## Self-calls
+
+A self-call invokes the module's **own** API through the engine, via the
+module's root binding (the module name in camelCase):
+
+```dang
+type Test {
+  pub containerEcho(msg: String!): Container! {
+    container.from("alpine").withExec(["echo", msg])
+  }
+
+  pub print(msg: String!): String! {
+    test.containerEcho(msg: msg).stdout    # self-call
+  }
+
+  pub fresh: Dagger.Test! { test }         # self-call the constructor
+}
+```
+
+- **Return-type annotation rule:** a function that *returns* a self-call
+  result must declare the return as `Dagger.<SchemaTypeName>!` — e.g.
+  `Dagger.Test!`, or `Dagger.TestWidget!` for a secondary `Widget` — not the
+  bare local type. A self-call yields the type *as installed in the runtime
+  schema* (namespaced, carrying a GraphQL id); the bare local type is a
+  different type. Annotating with the bare type makes the runtime receive a
+  raw ID string where an object is expected.
+- Constructing locally (`Widget(x)`) yields the bare local `Widget!`; only an
+  actual API call yields `Dagger.TestWidget!`.
+- Self-call results are real objects: fields read back fine
+  (`test.fresh.getMessage`), including on secondary types.
+- Self-calls also work when the module is used as a dependency, transitively.
+- Bare `test` (zero-arg constructor auto-call) is the way to reset to a fresh
+  instance from inside a method.
+
+## Dependencies
+
+- A dependency named `foo` is callable as the root binding `foo`:
+  `foo.curve(...)`, `dangchild.value`. Deps with constructor args are called
+  like functions: `engineDev(ws: source).test`.
+- A dependency's types appear module-namespaced: dep `foo`'s `enum EcCurve`
+  is `FooEcCurve`, dep `dep`'s `interface Greeter` is `DepGreeter`.
+
+## Enums, interfaces, scalars
+
+- `enum Status { PENDING RUNNING DONE }` — compare with `==`; CLI passes
+  members verbatim (`--status DONE`).
+- `interface Local { pub greet(name: String!): String! }` plus
+  `type Hey implements Local` — implementers must **not** declare the
+  synthesized `id: ID!` field Dagger adds to every interface.
+- Structural conformance crosses module boundaries: an object matching a dep
+  interface's shape passes as that interface without `implements`.
+- Interface methods touching core types annotate them qualified:
+  `apply(container: Dagger.Container!): Dagger.Container!`.
+- `scalar Timestamp` is exposed as a String at the boundary; values arrive as
+  strings.
+
+## Directives Dagger consumes
+
+- Function-level: `@check` (marks a check; typically on `Void` returns),
+  `@generate` (on Changeset-returning generators), `@up` (on `Service!`),
+  `@agent` (see below), `@cache`.
+- Arg-level: `@defaultPath(path: ...)` on `Directory!` args — relative paths
+  resolve against the module, `"/"` against the context root;
+  `@ignorePatterns(patterns: [...])` filters with gitignore-style patterns
+  (allowlisting via `"!keep"` works). Positional and named args both parse.
+- Placement: suffix (`screen: String! @cache(...)`) or prefix on the line
+  before the declaration.
+- Agent idiom:
+
+  ```dang
+  agent(base: LLM!): LLM! @agent {
+    base.withTools(currentNode).withSystemPrompt(systemPrompt)
+  }
+  ```
+
+## Workspace args
+
+- A `Workspace!`-typed arg (bare or `Dagger.Workspace!`) is auto-filled by the
+  caller's workspace — no flag needed on `dagger call`; for agents it's filled
+  from the bound workspace and hidden from the model.
+- `let ws: Workspace!` as an uninitialized field is the standard pattern for
+  holding it. Read with `ws.file(...)`, `ws.directory(path, exclude: [...])`.
+- The mounted workspace is a plain snapshot with **no `.git`** — `git diff`
+  won't work; use `Workspace.git.uncommitted` (a Changeset) with
+  `.diffStats` / `.asPatch`.
+
+## Caching pitfalls
+
+- The engine memoizes function results by (object id, field, args) within a
+  session. Side-effecting or live-reading functions **must** opt out:
+  `@cache(policy: FunctionCachePolicy.Never)` (mixes a per-call nonce into the
+  call id). `@cache(ttl: 300)` sets a time-to-live instead.
+- Even with `Never`, identical container execs still hit the exec cache — bust
+  with a nonce: `.withEnvVariable("NONCE", Random.string)`.
+
+## Shadowing core types
+
+- A module may declare types shadowing core names (`type Container`); the bare
+  name then means the local type, and `Dagger.Container!` / `Dagger.container`
+  disambiguates back to core.
+
+## Pitfalls checklist
+
+- Self-call return annotated with the bare local type instead of
+  `Dagger.<T>!` → runtime gets a raw ID string. (Self-calls DO work — don't
+  conclude otherwise from old comments.)
+- Missing `@cache(policy: FunctionCachePolicy.Never)` on a stateful/live tool
+  → the second call replays the first result.
+- `pub`-exposing a `Map[...]` or an ad-hoc record type → hard error.
+- Declaring `id` when implementing a dep interface → error; omit it.
+- Using v1 `.{ }` selection in a `>= v0.21.5` module — that's dot-block now;
+  select with `.{{ }}`.
+- Only *top-level* type declarations become module types; types defined inside
+  bodies aren't hoisted into the schema.

--- a/core/skills/dang-dagger-modules/SKILL.md
+++ b/core/skills/dang-dagger-modules/SKILL.md
@@ -58,14 +58,14 @@ as a **Dagger module SDK**.
 ```dang
 type Greeter {
   let secret: String! = "hidden"          # private state, never exposed
-  pub name: String!                        # data field (also a ctor param)
+  name: String!                            # public data field (also a ctor param)
 
   new(name: String! = "world") {           # explicit constructor
     self.name = name.capitalize
     self                                   # must end with self
   }
 
-  pub greet: String! { "Hey, " + name }    # computed field / zero-arg function
+  greet: String! { "Hey, " + name }        # computed field / zero-arg function
 }
 ```
 
@@ -73,8 +73,10 @@ type Greeter {
   in declaration order (positional construction works).
 - Constructor args become top-level flags: `dagger call --name alice greet`.
   Arg names need not match field names; the body really executes.
-- `pub` and bare typed declarations are exposed; `let` is private — including
-  `let` *functions*, the idiom for internal helpers.
+- Public is the default: bare typed declarations are exposed; `let` is
+  private — including `let` *functions*, the idiom for internal helpers. The
+  `pub` keyword is legacy: it still parses (as a no-op) and the formatter
+  strips it — don't write it in new code.
 - A field with a body is a function/computed field; a plain typed field is
   data. Docstrings (`"""..."""` before a declaration or arg) become API
   descriptions.
@@ -96,15 +98,15 @@ module's root binding (the module name in camelCase):
 
 ```dang
 type Test {
-  pub containerEcho(msg: String!): Container! {
+  containerEcho(msg: String!): Container! {
     container.from("alpine").withExec(["echo", msg])
   }
 
-  pub print(msg: String!): String! {
+  print(msg: String!): String! {
     test.containerEcho(msg: msg).stdout    # self-call
   }
 
-  pub fresh: Dagger.Test! { test }         # self-call the constructor
+  fresh: Dagger.Test! { test }             # self-call the constructor
 }
 ```
 
@@ -135,7 +137,7 @@ type Test {
 
 - `enum Status { PENDING RUNNING DONE }` — compare with `==`; CLI passes
   members verbatim (`--status DONE`).
-- `interface Local { pub greet(name: String!): String! }` plus
+- `interface Local { greet(name: String!): String! }` plus
   `type Hey implements Local` — implementers must **not** declare the
   synthesized `id: ID!` field Dagger adds to every interface.
 - Structural conformance crosses module boundaries: an object matching a dep
@@ -197,7 +199,7 @@ type Test {
   conclude otherwise from old comments.)
 - Missing `@cache(policy: FunctionCachePolicy.Never)` on a stateful/live tool
   → the second call replays the first result.
-- `pub`-exposing a `Map[...]` or an ad-hoc record type → hard error.
+- Exposing a `Map[...]` or an ad-hoc record type → hard error.
 - Declaring `id` when implementing a dep interface → error; omit it.
 - Using v1 `.{ }` selection in a `>= v0.21.5` module — that's dot-block now;
   select with `.{{ }}`.

--- a/core/skills/skills.go
+++ b/core/skills/skills.go
@@ -1,0 +1,10 @@
+// Package skills embeds the Dagger-authored skills the engine serves to models
+// via ListSkills/ReadSkill (see core/llm_skills.go). Each skill is a
+// subdirectory holding a SKILL.md plus optional reference files, mirroring the
+// layout of the dang-language skill embedded from the upstream dang repo.
+package skills
+
+import "embed"
+
+//go:embed all:dang-dagger-modules
+var FS embed.FS

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	workspacepkg "github.com/dagger/dagger/core/workspace"
@@ -90,14 +91,6 @@ func BumpWorkspaceReadEpoch(ctx context.Context) error {
 	return workspaceReadEpochBumper(ctx)
 }
 
-// WorkspaceReferencePrefix is the reserved workspace-relative directory under
-// which externally-referenced paths (e.g. those a user attaches with @ in the
-// agent prompt) are mounted read-only. Content under this prefix is readable
-// through the normal workspace file tools, but is deliberately excluded from
-// the overlay changeset: it never appears in Workspace.changes, is never
-// written to disk by export, and cannot be modified by the agent.
-const WorkspaceReferencePrefix = ".refs"
-
 // Workspace represents a detected workspace in the dagql schema.
 type Workspace struct {
 	// source is the private backing source for workspace filesystem and git
@@ -109,14 +102,20 @@ type Workspace struct {
 	// directories lazily via per-call host.directory() instead.
 	rootfs dagql.ObjectResult[*Directory]
 
-	// references is an in-engine directory tree mounted read-only under
-	// WorkspaceReferencePrefix, holding externally-referenced paths handed to
-	// the agent (see WorkspaceReferencePrefix). Internal only — not a GraphQL
-	// field, but persisted and dependency-tracked like rootfs. Nil when the
-	// workspace has no references. It is intentionally kept separate from the
-	// overlay changeset so referenced content is readable but is never treated
-	// as a pending change or exported.
-	references dagql.ObjectResult[*Directory]
+	// mounts is an in-engine directory tree holding content attached read-only
+	// via Workspace.withMountedDirectory/withMountedFile, keyed by
+	// workspace-root-relative mount path. Internal only — not a GraphQL field,
+	// but persisted and dependency-tracked like rootfs. Nil when the workspace
+	// has no mounts. It is intentionally kept separate from the overlay
+	// changeset so mounted content is readable through the normal workspace
+	// file tools but is never treated as a pending change or exported.
+	mounts dagql.ObjectResult[*Directory]
+
+	// mountPoints lists the workspace-root-relative paths at which content is
+	// mounted, sorted and deduplicated. Reads at or under a mount point
+	// resolve from mounts (shadowing the source), and overlay edits there are
+	// rejected, keeping mounted content read-only.
+	mountPoints []string
 
 	// compatWorkspace stores the originating compat-workspace projection when
 	// this workspace was loaded from a legacy dagger.json instead of an explicit
@@ -490,18 +489,60 @@ func (ws *Workspace) SetUserConfigOverlay(overlay *workspacepkg.UserWorkspaceOve
 	ws.userConfigOverlay = overlay
 }
 
-// ReferencesDir returns the read-only reference directory tree mounted under
-// WorkspaceReferencePrefix, or false when the workspace has no references.
-func (ws *Workspace) ReferencesDir() (dagql.ObjectResult[*Directory], bool) {
-	if ws == nil || ws.references.Self() == nil {
+// MountsDir returns the read-only directory tree holding mounted content,
+// keyed by workspace-root-relative mount path, or false when the workspace has
+// no mounts.
+func (ws *Workspace) MountsDir() (dagql.ObjectResult[*Directory], bool) {
+	if ws == nil || ws.mounts.Self() == nil {
 		return dagql.ObjectResult[*Directory]{}, false
 	}
-	return ws.references, true
+	return ws.mounts, true
 }
 
-// SetReferencesDir sets the read-only reference directory tree.
-func (ws *Workspace) SetReferencesDir(dir dagql.ObjectResult[*Directory]) {
-	ws.references = dir
+// WithMounted returns a copy of the workspace with the given read-only
+// mounted content tree and the workspace-root-relative path recorded as a
+// mount point, keeping the mount point list sorted and deduplicated.
+func (ws *Workspace) WithMounted(newMounts dagql.ObjectResult[*Directory], path string) *Workspace {
+	cp := ws.Clone()
+	cp.mounts = newMounts
+	p := filepath.ToSlash(path)
+	if i, found := slices.BinarySearch(cp.mountPoints, p); !found {
+		cp.mountPoints = slices.Insert(cp.mountPoints, i, p)
+	}
+	return cp
+}
+
+// MountedPath reports whether a workspace-root-relative path is at or under
+// one of the workspace's mount points.
+func (ws *Workspace) MountedPath(resolvedPath string) bool {
+	if ws == nil {
+		return false
+	}
+	p := filepath.ToSlash(resolvedPath)
+	for _, mp := range ws.mountPoints {
+		if p == mp || strings.HasPrefix(p, mp+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMountsUnder reports whether any mount point lies strictly below the given
+// workspace-root-relative path.
+func (ws *Workspace) HasMountsUnder(resolvedPath string) bool {
+	if ws == nil || len(ws.mountPoints) == 0 {
+		return false
+	}
+	p := filepath.ToSlash(resolvedPath)
+	if p == "." || p == "" {
+		return true
+	}
+	for _, mp := range ws.mountPoints {
+		if strings.HasPrefix(mp, p+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // CompatWorkspace returns the internal compat-workspace provenance for this
@@ -531,16 +572,17 @@ var _ dagql.PersistedObjectDecoder = (*Workspace)(nil)
 var _ dagql.HasDependencyResults = (*Workspace)(nil)
 
 type persistedWorkspacePayload struct {
-	RootfsResultID     uint64                        `json:"rootfsResultID,omitempty"`
-	ReferencesResultID uint64                        `json:"referencesResultID,omitempty"`
-	Source             *persistedWorkspaceSource     `json:"source,omitempty"`
-	CompatWorkspace    *workspacepkg.CompatWorkspace `json:"compatWorkspace,omitempty"`
-	Address            string                        `json:"address,omitempty"`
-	Cwd                string                        `json:"cwd,omitempty"`
-	ConfigFile         string                        `json:"configFile,omitempty"`
-	LockFile           string                        `json:"lockFile,omitempty"`
-	ClientID           string                        `json:"clientID,omitempty"`
-	HostPath           string                        `json:"hostPath,omitempty"`
+	RootfsResultID  uint64                        `json:"rootfsResultID,omitempty"`
+	MountsResultID  uint64                        `json:"mountsResultID,omitempty"`
+	MountPoints     []string                      `json:"mountPoints,omitempty"`
+	Source          *persistedWorkspaceSource     `json:"source,omitempty"`
+	CompatWorkspace *workspacepkg.CompatWorkspace `json:"compatWorkspace,omitempty"`
+	Address         string                        `json:"address,omitempty"`
+	Cwd             string                        `json:"cwd,omitempty"`
+	ConfigFile      string                        `json:"configFile,omitempty"`
+	LockFile        string                        `json:"lockFile,omitempty"`
+	ClientID        string                        `json:"clientID,omitempty"`
+	HostPath        string                        `json:"hostPath,omitempty"`
 
 	StagedGeneration []string `json:"stagedGeneration,omitempty"`
 
@@ -699,12 +741,13 @@ func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.Pers
 		}
 		payload.RootfsResultID = rootfsID
 	}
-	if ws.references.Self() != nil {
-		referencesID, err := encodePersistedObjectRef(cache, ws.references, "workspace references")
+	if ws.mounts.Self() != nil {
+		mountsID, err := encodePersistedObjectRef(cache, ws.mounts, "workspace mounts")
 		if err != nil {
 			return dagql.PersistedObjectEncoding{}, err
 		}
-		payload.ReferencesResultID = referencesID
+		payload.MountsResultID = mountsID
+		payload.MountPoints = ws.mountPoints
 	}
 	if ws.Source() != nil {
 		source, err := encodePersistedWorkspaceSource(cache, ws.Source())
@@ -742,10 +785,10 @@ func (*Workspace) DecodePersistedObject(
 		}
 	}
 
-	var references dagql.ObjectResult[*Directory]
-	if persisted.ReferencesResultID != 0 {
+	var mounts dagql.ObjectResult[*Directory]
+	if persisted.MountsResultID != 0 {
 		var err error
-		references, err = loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.ReferencesResultID, "workspace references")
+		mounts, err = loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.MountsResultID, "workspace mounts")
 		if err != nil {
 			return nil, err
 		}
@@ -767,7 +810,8 @@ func (*Workspace) DecodePersistedObject(
 
 	ws := &Workspace{
 		rootfs:           rootfs,
-		references:       references,
+		mounts:           mounts,
+		mountPoints:      persisted.MountPoints,
 		compatWorkspace:  persisted.CompatWorkspace,
 		Address:          persisted.Address,
 		Cwd:              cwd,
@@ -820,16 +864,16 @@ func (ws *Workspace) AttachDependencyResults(
 		deps = append(deps, sourceDeps...)
 	}
 
-	if ws.references.Self() != nil {
-		attached, err := attach(ws.references)
+	if ws.mounts.Self() != nil {
+		attached, err := attach(ws.mounts)
 		if err != nil {
-			return nil, fmt.Errorf("attach workspace references: %w", err)
+			return nil, fmt.Errorf("attach workspace mounts: %w", err)
 		}
 		typed, ok := attached.(dagql.ObjectResult[*Directory])
 		if !ok {
-			return nil, fmt.Errorf("attach workspace references: unexpected result %T", attached)
+			return nil, fmt.Errorf("attach workspace mounts: unexpected result %T", attached)
 		}
-		ws.references = typed
+		ws.mounts = typed
 		deps = append(deps, typed)
 	}
 
@@ -902,6 +946,7 @@ func attachWorkspaceSource(
 
 func (ws *Workspace) Clone() *Workspace {
 	cp := *ws
+	cp.mountPoints = slices.Clone(ws.mountPoints)
 	return &cp
 }
 

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -90,6 +90,14 @@ func BumpWorkspaceReadEpoch(ctx context.Context) error {
 	return workspaceReadEpochBumper(ctx)
 }
 
+// WorkspaceReferencePrefix is the reserved workspace-relative directory under
+// which externally-referenced paths (e.g. those a user attaches with @ in the
+// agent prompt) are mounted read-only. Content under this prefix is readable
+// through the normal workspace file tools, but is deliberately excluded from
+// the overlay changeset: it never appears in Workspace.changes, is never
+// written to disk by export, and cannot be modified by the agent.
+const WorkspaceReferencePrefix = ".refs"
+
 // Workspace represents a detected workspace in the dagql schema.
 type Workspace struct {
 	// source is the private backing source for workspace filesystem and git
@@ -100,6 +108,15 @@ type Workspace struct {
 	// Internal only — not exposed in GraphQL. Local workspaces resolve
 	// directories lazily via per-call host.directory() instead.
 	rootfs dagql.ObjectResult[*Directory]
+
+	// references is an in-engine directory tree mounted read-only under
+	// WorkspaceReferencePrefix, holding externally-referenced paths handed to
+	// the agent (see WorkspaceReferencePrefix). Internal only — not a GraphQL
+	// field, but persisted and dependency-tracked like rootfs. Nil when the
+	// workspace has no references. It is intentionally kept separate from the
+	// overlay changeset so referenced content is readable but is never treated
+	// as a pending change or exported.
+	references dagql.ObjectResult[*Directory]
 
 	// compatWorkspace stores the originating compat-workspace projection when
 	// this workspace was loaded from a legacy dagger.json instead of an explicit
@@ -473,6 +490,20 @@ func (ws *Workspace) SetUserConfigOverlay(overlay *workspacepkg.UserWorkspaceOve
 	ws.userConfigOverlay = overlay
 }
 
+// ReferencesDir returns the read-only reference directory tree mounted under
+// WorkspaceReferencePrefix, or false when the workspace has no references.
+func (ws *Workspace) ReferencesDir() (dagql.ObjectResult[*Directory], bool) {
+	if ws == nil || ws.references.Self() == nil {
+		return dagql.ObjectResult[*Directory]{}, false
+	}
+	return ws.references, true
+}
+
+// SetReferencesDir sets the read-only reference directory tree.
+func (ws *Workspace) SetReferencesDir(dir dagql.ObjectResult[*Directory]) {
+	ws.references = dir
+}
+
 // CompatWorkspace returns the internal compat-workspace provenance for this
 // workspace. Nil means this workspace was not loaded from legacy compat mode.
 func (ws *Workspace) CompatWorkspace() *workspacepkg.CompatWorkspace {
@@ -500,15 +531,16 @@ var _ dagql.PersistedObjectDecoder = (*Workspace)(nil)
 var _ dagql.HasDependencyResults = (*Workspace)(nil)
 
 type persistedWorkspacePayload struct {
-	RootfsResultID  uint64                        `json:"rootfsResultID,omitempty"`
-	Source          *persistedWorkspaceSource     `json:"source,omitempty"`
-	CompatWorkspace *workspacepkg.CompatWorkspace `json:"compatWorkspace,omitempty"`
-	Address         string                        `json:"address,omitempty"`
-	Cwd             string                        `json:"cwd,omitempty"`
-	ConfigFile      string                        `json:"configFile,omitempty"`
-	LockFile        string                        `json:"lockFile,omitempty"`
-	ClientID        string                        `json:"clientID,omitempty"`
-	HostPath        string                        `json:"hostPath,omitempty"`
+	RootfsResultID     uint64                        `json:"rootfsResultID,omitempty"`
+	ReferencesResultID uint64                        `json:"referencesResultID,omitempty"`
+	Source             *persistedWorkspaceSource     `json:"source,omitempty"`
+	CompatWorkspace    *workspacepkg.CompatWorkspace `json:"compatWorkspace,omitempty"`
+	Address            string                        `json:"address,omitempty"`
+	Cwd                string                        `json:"cwd,omitempty"`
+	ConfigFile         string                        `json:"configFile,omitempty"`
+	LockFile           string                        `json:"lockFile,omitempty"`
+	ClientID           string                        `json:"clientID,omitempty"`
+	HostPath           string                        `json:"hostPath,omitempty"`
 
 	StagedGeneration []string `json:"stagedGeneration,omitempty"`
 
@@ -667,6 +699,13 @@ func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.Pers
 		}
 		payload.RootfsResultID = rootfsID
 	}
+	if ws.references.Self() != nil {
+		referencesID, err := encodePersistedObjectRef(cache, ws.references, "workspace references")
+		if err != nil {
+			return dagql.PersistedObjectEncoding{}, err
+		}
+		payload.ReferencesResultID = referencesID
+	}
 	if ws.Source() != nil {
 		source, err := encodePersistedWorkspaceSource(cache, ws.Source())
 		if err != nil {
@@ -703,6 +742,15 @@ func (*Workspace) DecodePersistedObject(
 		}
 	}
 
+	var references dagql.ObjectResult[*Directory]
+	if persisted.ReferencesResultID != 0 {
+		var err error
+		references, err = loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.ReferencesResultID, "workspace references")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	cwd := persisted.Cwd
 	if cwd == "" {
 		cwd = persisted.LegacyPath
@@ -719,6 +767,7 @@ func (*Workspace) DecodePersistedObject(
 
 	ws := &Workspace{
 		rootfs:           rootfs,
+		references:       references,
 		compatWorkspace:  persisted.CompatWorkspace,
 		Address:          persisted.Address,
 		Cwd:              cwd,
@@ -744,23 +793,25 @@ func (ws *Workspace) AttachDependencyResults(
 	attach func(dagql.AnyResult) (dagql.AnyResult, error),
 ) ([]dagql.AnyResult, error) {
 	_ = ctx
-	if ws == nil || ws.rootfs.Self() == nil {
-		if ws != nil && ws.source != nil {
-			return attachWorkspaceSource(attach, ws.source)
-		}
+	if ws == nil {
 		return nil, nil
 	}
 
-	attached, err := attach(ws.rootfs)
-	if err != nil {
-		return nil, fmt.Errorf("attach workspace rootfs: %w", err)
+	var deps []dagql.AnyResult
+
+	if ws.rootfs.Self() != nil {
+		attached, err := attach(ws.rootfs)
+		if err != nil {
+			return nil, fmt.Errorf("attach workspace rootfs: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*Directory])
+		if !ok {
+			return nil, fmt.Errorf("attach workspace rootfs: unexpected result %T", attached)
+		}
+		ws.rootfs = typed
+		deps = append(deps, typed)
 	}
-	typed, ok := attached.(dagql.ObjectResult[*Directory])
-	if !ok {
-		return nil, fmt.Errorf("attach workspace rootfs: unexpected result %T", attached)
-	}
-	ws.rootfs = typed
-	deps := []dagql.AnyResult{typed}
+
 	if ws.source != nil {
 		sourceDeps, err := attachWorkspaceSource(attach, ws.source)
 		if err != nil {
@@ -768,6 +819,20 @@ func (ws *Workspace) AttachDependencyResults(
 		}
 		deps = append(deps, sourceDeps...)
 	}
+
+	if ws.references.Self() != nil {
+		attached, err := attach(ws.references)
+		if err != nil {
+			return nil, fmt.Errorf("attach workspace references: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*Directory])
+		if !ok {
+			return nil, fmt.Errorf("attach workspace references: unexpected result %T", attached)
+		}
+		ws.references = typed
+		deps = append(deps, typed)
+	}
+
 	return deps, nil
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -3694,6 +3694,11 @@ type LLM implements Node & Syncer {
   provider: String!
 
   """
+  The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.
+  """
+  reasoningEffort: String!
+
+  """
   Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.
   """
   replay: ID! @expectedType(name: "LLM")
@@ -3770,6 +3775,20 @@ type LLM implements Node & Syncer {
   withPromptFile(
     """The file to read the prompt from"""
     file: ID! @expectedType(name: "File")
+  ): LLM!
+
+  """
+  Change the reasoning effort for the rest of the conversation, overriding any
+  configured default. The message history is preserved; the new effort takes
+  effect on the next step.
+  """
+  withReasoningEffort(
+    """
+    The reasoning effort, e.g. "low", "medium", or "high"; "none" disables
+    reasoning. Supported levels are model-specific — some models also accept
+    e.g. "minimal", "xhigh", or "max".
+    """
+    effort: String!
   ): LLM!
 
   """

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5905,6 +5905,40 @@ type Workspace implements Node {
   ): Workspace!
 
   """
+  Return this workspace with a directory mounted read-only at the given path, without mutating the source.
+
+  Mounted content is readable through the normal workspace file tools but
+  shadows the source at the mount path and stays out of the pending changeset:
+  it never appears in changes, is never exported, and cannot be modified.
+  """
+  withMountedDirectory(
+    """
+    Location of the mounted directory. Relative paths resolve from the workspace cwd.
+    """
+    path: String!
+
+    """Directory to mount."""
+    source: ID! @expectedType(name: "Directory")
+  ): Workspace!
+
+  """
+  Return this workspace with a file mounted read-only at the given path, without mutating the source.
+
+  Mounted content is readable through the normal workspace file tools but
+  shadows the source at the mount path and stays out of the pending changeset:
+  it never appears in changes, is never exported, and cannot be modified.
+  """
+  withMountedFile(
+    """
+    Location of the mounted file. Relative paths resolve from the workspace cwd.
+    """
+    path: String!
+
+    """File to mount."""
+    source: ID! @expectedType(name: "File")
+  ): Workspace!
+
+  """
   Return this workspace with a directory added, without mutating the source.
   """
   withNewDirectory(

--- a/docs/static/reference/php/Dagger/LLM.html
+++ b/docs/static/reference/php/Dagger/LLM.html
@@ -253,6 +253,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    string
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_reasoningEffort">reasoningEffort</a>()
+        
+                                            <p><p>The reasoning effort in use, e.g. &quot;low&quot;, &quot;medium&quot;, or &quot;high&quot;. Empty or &quot;none&quot; when reasoning is disabled.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -359,6 +369,16 @@
                     <a href="#method_withPromptFile">withPromptFile</a>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $file)
         
                                             <p><p>Queue a file's contents as a user prompt, like withPrompt.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_withReasoningEffort">withReasoningEffort</a>(string $effort)
+        
+                                            <p><p>Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -934,8 +954,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_replay">
+                    <h3 id="method_reasoningEffort">
         <div class="location">at line 125</div>
+        <code>                    string
+    <strong>reasoningEffort</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>The reasoning effort in use, e.g. &quot;low&quot;, &quot;medium&quot;, or &quot;high&quot;. Empty or &quot;none&quot; when reasoning is disabled.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>string</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_replay">
+        <div class="location">at line 134</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>replay</strong>()
         </code>
@@ -967,7 +1019,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_skills">
-        <div class="location">at line 135</div>
+        <div class="location">at line 144</div>
         <code>                    array
     <strong>skills</strong>()
         </code>
@@ -999,7 +1051,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_step">
-        <div class="location">at line 144</div>
+        <div class="location">at line 153</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>step</strong>(int|null $maxTokens = null)
         </code>
@@ -1041,7 +1093,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 156</div>
+        <div class="location">at line 165</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1073,7 +1125,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tokenUsage">
-        <div class="location">at line 166</div>
+        <div class="location">at line 175</div>
         <code>                    <a href="../Dagger/LLMTokenUsage.html"><abbr title="Dagger\LLMTokenUsage">LLMTokenUsage</abbr></a>
     <strong>tokenUsage</strong>()
         </code>
@@ -1105,7 +1157,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tools">
-        <div class="location">at line 175</div>
+        <div class="location">at line 184</div>
         <code>                    string
     <strong>tools</strong>()
         </code>
@@ -1137,7 +1189,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_transcript">
-        <div class="location">at line 184</div>
+        <div class="location">at line 193</div>
         <code>                    string
     <strong>transcript</strong>()
         </code>
@@ -1169,7 +1221,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMCPServer">
-        <div class="location">at line 193</div>
+        <div class="location">at line 202</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withMCPServer</strong>(string $name, <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a> $service)
         </code>
@@ -1216,7 +1268,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModel">
-        <div class="location">at line 204</div>
+        <div class="location">at line 213</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withModel</strong>(string $model, string|null $provider = null)
         </code>
@@ -1263,7 +1315,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPrompt">
-        <div class="location">at line 217</div>
+        <div class="location">at line 226</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withPrompt</strong>(string $prompt)
         </code>
@@ -1305,7 +1357,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPromptFile">
-        <div class="location">at line 227</div>
+        <div class="location">at line 236</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withPromptFile</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $file)
         </code>
@@ -1346,8 +1398,50 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_withReasoningEffort">
+        <div class="location">at line 246</div>
+        <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
+    <strong>withReasoningEffort</strong>(string $effort)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.</p></p>                        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$effort</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_withResponse">
-        <div class="location">at line 237</div>
+        <div class="location">at line 256</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withResponse</strong>(array $content, int|null $inputTokens = 0, int|null $outputTokens = 0, int|null $cachedTokenReads = 0, int|null $cachedTokenWrites = 0, int|null $totalTokens = 0)
         </code>
@@ -1414,7 +1508,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSkills">
-        <div class="location">at line 268</div>
+        <div class="location">at line 287</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withSkills</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $directory)
         </code>
@@ -1456,7 +1550,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSystemPrompt">
-        <div class="location">at line 278</div>
+        <div class="location">at line 297</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withSystemPrompt</strong>(string $prompt)
         </code>
@@ -1498,7 +1592,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withToolResult">
-        <div class="location">at line 288</div>
+        <div class="location">at line 307</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withToolResult</strong>(string $callId, string $content, bool $errored)
         </code>
@@ -1550,7 +1644,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTools">
-        <div class="location">at line 300</div>
+        <div class="location">at line 319</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withTools</strong>(<a href="../Dagger/Node.html"><abbr title="Dagger\Node">Node</abbr></a> $object, array|null $except = [])
         </code>
@@ -1597,7 +1691,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkspace">
-        <div class="location">at line 313</div>
+        <div class="location">at line 332</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withWorkspace</strong>(<a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a> $workspace)
         </code>
@@ -1639,7 +1733,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultSystemPrompt">
-        <div class="location">at line 323</div>
+        <div class="location">at line 342</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withoutDefaultSystemPrompt</strong>()
         </code>
@@ -1671,7 +1765,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMessageHistory">
-        <div class="location">at line 332</div>
+        <div class="location">at line 351</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withoutMessageHistory</strong>()
         </code>
@@ -1703,7 +1797,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSystemPrompts">
-        <div class="location">at line 341</div>
+        <div class="location">at line 360</div>
         <code>                    <a href="../Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a>
     <strong>withoutSystemPrompts</strong>()
         </code>
@@ -1735,7 +1829,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workspace">
-        <div class="location">at line 350</div>
+        <div class="location">at line 369</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>workspace</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -426,7 +426,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
+                    <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
         
                                             <p><p>Return this workspace with a generated API client initialized.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -436,7 +436,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withInitModule">withInitModule</a>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
+                    <a href="#method_withInitModule">withInitModule</a>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
         
                                             <p><p>Return this workspace with a new module initialized.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -469,6 +469,26 @@
                     <a href="#method_withNewFile">withNewFile</a>(string $path, string $contents, int|null $permissions = 420)
         
                                             <p><p>Return this workspace with a new or replaced file, without mutating the source.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_withReferenceDirectory">withReferenceDirectory</a>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
+        
+                                            <p><p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_withReferenceFile">withReferenceFile</a>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
+        
+                                            <p><p>Return this workspace with a file mounted read-only under the reserved references prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -1826,9 +1846,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 411</div>
+        <div class="location">at line 409</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
+    <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
         </code>
     </h3>
     <div class="details">    
@@ -1836,7 +1856,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a generated API client initialized.</p></p>                <p><p>The SDK's generators run for the new client, so the returned workspace carries its generated bindings.</p></p>        
+                            <p><p>Return this workspace with a generated API client initialized.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1867,11 +1887,6 @@
                 <td>$here</td>
                 <td></td>
             </tr>
-                    <tr>
-                <td>bool|null</td>
-                <td>$noGenerate</td>
-                <td></td>
-            </tr>
             </table>
 
             
@@ -1893,9 +1908,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 440</div>
+        <div class="location">at line 432</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
+    <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
         </code>
     </h3>
     <div class="details">    
@@ -1903,7 +1918,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a new module initialized.</p></p>                <p><p>The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.</p></p>        
+                            <p><p>Return this workspace with a new module initialized.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1944,11 +1959,6 @@
                 <td>$here</td>
                 <td></td>
             </tr>
-                    <tr>
-                <td>bool|null</td>
-                <td>$noGenerate</td>
-                <td></td>
-            </tr>
             </table>
 
             
@@ -1970,7 +1980,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 477</div>
+        <div class="location">at line 465</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -2022,7 +2032,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 493</div>
+        <div class="location">at line 481</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2069,7 +2079,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 504</div>
+        <div class="location">at line 492</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2120,8 +2130,102 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_withReferenceDirectory">
+        <div class="location">at line 508</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>withReferenceDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p></p>                <p><p>Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$path</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></td>
+                <td>$source</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withReferenceFile">
+        <div class="location">at line 521</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>withReferenceFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Return this workspace with a file mounted read-only under the reserved references prefix.</p></p>                <p><p>Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$path</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a></td>
+                <td>$source</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 518</div>
+        <div class="location">at line 532</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2178,7 +2282,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 537</div>
+        <div class="location">at line 551</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2210,7 +2314,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 546</div>
+        <div class="location">at line 560</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2252,7 +2356,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 556</div>
+        <div class="location">at line 570</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2299,7 +2403,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 571</div>
+        <div class="location">at line 585</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2346,7 +2450,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 584</div>
+        <div class="location">at line 598</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2388,7 +2492,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 594</div>
+        <div class="location">at line 608</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2430,7 +2534,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 604</div>
+        <div class="location">at line 618</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2477,7 +2581,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 617</div>
+        <div class="location">at line 631</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -426,7 +426,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+                    <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         
                                             <p><p>Return this workspace with a generated API client initialized.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -436,7 +436,7 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withInitModule">withInitModule</a>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+                    <a href="#method_withInitModule">withInitModule</a>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         
                                             <p><p>Return this workspace with a new module initialized.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -449,6 +449,26 @@
                     <a href="#method_withModule">withModule</a>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         
                                             <p><p>Return this workspace with a module installed in its config.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_withMountedDirectory">withMountedDirectory</a>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
+        
+                                            <p><p>Return this workspace with a directory mounted read-only at the given path, without mutating the source.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_withMountedFile">withMountedFile</a>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
+        
+                                            <p><p>Return this workspace with a file mounted read-only at the given path, without mutating the source.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -469,26 +489,6 @@
                     <a href="#method_withNewFile">withNewFile</a>(string $path, string $contents, int|null $permissions = 420)
         
                                             <p><p>Return this workspace with a new or replaced file, without mutating the source.</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
-                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_withReferenceDirectory">withReferenceDirectory</a>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
-        
-                                            <p><p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p></p>                </div>
-                <div class="col-md-2"></div>
-            </div>
-                    <div class="row">
-                <div class="col-md-2 type">
-                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-                </div>
-                <div class="col-md-8">
-                    <a href="#method_withReferenceFile">withReferenceFile</a>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
-        
-                                            <p><p>Return this workspace with a file mounted read-only under the reserved references prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -1846,9 +1846,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 409</div>
+        <div class="location">at line 411</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+    <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
     </h3>
     <div class="details">    
@@ -1856,7 +1856,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a generated API client initialized.</p></p>                        
+                            <p><p>Return this workspace with a generated API client initialized.</p></p>                <p><p>The SDK's generators run for the new client, so the returned workspace carries its generated bindings.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1887,6 +1887,11 @@
                 <td>$here</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1908,9 +1913,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 432</div>
+        <div class="location">at line 440</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false)
+    <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
     </h3>
     <div class="details">    
@@ -1918,7 +1923,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a new module initialized.</p></p>                        
+                            <p><p>Return this workspace with a new module initialized.</p></p>                <p><p>The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -1959,6 +1964,11 @@
                 <td>$here</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>bool|null</td>
+                <td>$noGenerate</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -1980,7 +1990,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 465</div>
+        <div class="location">at line 477</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -2031,8 +2041,102 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_withMountedDirectory">
+        <div class="location">at line 495</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Return this workspace with a directory mounted read-only at the given path, without mutating the source.</p></p>                <p><p>Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$path</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></td>
+                <td>$source</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withMountedFile">
+        <div class="location">at line 508</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Return this workspace with a file mounted read-only at the given path, without mutating the source.</p></p>                <p><p>Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$path</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a></td>
+                <td>$source</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 481</div>
+        <div class="location">at line 519</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2079,7 +2183,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 492</div>
+        <div class="location">at line 530</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2130,102 +2234,8 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_withReferenceDirectory">
-        <div class="location">at line 508</div>
-        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withReferenceDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p></p>                <p><p>Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.</p></p>        
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td>string</td>
-                <td>$path</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td><a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></td>
-                <td>$source</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
-                    <h3 id="method_withReferenceFile">
-        <div class="location">at line 521</div>
-        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
-    <strong>withReferenceFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
-        </code>
-    </h3>
-    <div class="details">    
-    
-            
-
-        <div class="method-description">
-                            <p><p>Return this workspace with a file mounted read-only under the reserved references prefix.</p></p>                <p><p>Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.</p></p>        
-        </div>
-        <div class="tags">
-                            <h4>Parameters</h4>
-
-                    <table class="table table-condensed">
-                    <tr>
-                <td>string</td>
-                <td>$path</td>
-                <td></td>
-            </tr>
-                    <tr>
-                <td><a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a></td>
-                <td>$source</td>
-                <td></td>
-            </tr>
-            </table>
-
-            
-                            <h4>Return Value</h4>
-
-                    <table class="table table-condensed">
-        <tr>
-            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
-            <td></td>
-        </tr>
-    </table>
-
-            
-            
-            
-                    </div>
-    </div>
-
-            </div>
-                    <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 532</div>
+        <div class="location">at line 544</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2282,7 +2292,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 551</div>
+        <div class="location">at line 563</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2314,7 +2324,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 560</div>
+        <div class="location">at line 572</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2356,7 +2366,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 570</div>
+        <div class="location">at line 582</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2403,7 +2413,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 585</div>
+        <div class="location">at line 597</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2450,7 +2460,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 598</div>
+        <div class="location">at line 610</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2492,7 +2502,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 608</div>
+        <div class="location">at line 620</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2534,7 +2544,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 618</div>
+        <div class="location">at line 630</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2581,7 +2591,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 631</div>
+        <div class="location">at line 643</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -2179,15 +2179,15 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::withInitModule</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a new module initialized.</p></dd><dt><a href="Dagger/Workspace.html#method_withModule">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withModule</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a module installed in its config.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewDirectory">
+                    <dd><p>Return this workspace with a module installed in its config.</p></dd><dt><a href="Dagger/Workspace.html#method_withMountedDirectory">
+<abbr title="Dagger\Workspace">Workspace</abbr>::withMountedDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Return this workspace with a directory mounted read-only at the given path, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withMountedFile">
+<abbr title="Dagger\Workspace">Workspace</abbr>::withMountedFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Return this workspace with a file mounted read-only at the given path, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewDirectory">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withNewDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a directory added, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewFile">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withNewFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a new or replaced file, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withReferenceDirectory">
-<abbr title="Dagger\Workspace">Workspace</abbr>::withReferenceDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p></dd><dt><a href="Dagger/Workspace.html#method_withReferenceFile">
-<abbr title="Dagger\Workspace">Workspace</abbr>::withReferenceFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a file mounted read-only under the reserved references prefix.</p></dd><dt><a href="Dagger/Workspace.html#method_withSDK">
+                    <dd><p>Return this workspace with a new or replaced file, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withSDK">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withSDK</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with an SDK installed in its config.</p></dd><dt><a href="Dagger/Workspace.html#method_withUpdatedLock">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withUpdatedLock</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1394,7 +1394,9 @@
 <abbr title="Dagger\GitRepository">GitRepository</abbr>::ref</a>() &mdash; <em>Method in class <a href="Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a></em></dt>
                     <dd><p>Returns details of a ref.</p></dd><dt><a href="Dagger/HealthcheckConfig.html#method_retries">
 <abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr>::retries</a>() &mdash; <em>Method in class <a href="Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a></em></dt>
-                    <dd><p>The maximum number of consecutive failures before the container is marked as unhealthy. Example:3</p></dd><dt><a href="Dagger/LLM.html#method_replay">
+                    <dd><p>The maximum number of consecutive failures before the container is marked as unhealthy. Example:3</p></dd><dt><a href="Dagger/LLM.html#method_reasoningEffort">
+<abbr title="Dagger\LLM">LLM</abbr>::reasoningEffort</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
+                    <dd><p>The reasoning effort in use, e.g. &quot;low&quot;, &quot;medium&quot;, or &quot;high&quot;. Empty or &quot;none&quot; when reasoning is disabled.</p></dd><dt><a href="Dagger/LLM.html#method_replay">
 <abbr title="Dagger\LLM">LLM</abbr>::replay</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
                     <dd><p>Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.</p></dd><dt><a href="Dagger/LLMMessage.html#method_role">
 <abbr title="Dagger\LLMMessage">LLMMessage</abbr>::role</a>() &mdash; <em>Method in class <a href="Dagger/LLMMessage.html"><abbr title="Dagger\LLMMessage">LLMMessage</abbr></a></em></dt>
@@ -2070,7 +2072,9 @@
 <abbr title="Dagger\LLM">LLM</abbr>::withPrompt</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
                     <dd><p>Queue a user prompt, to be sent to the model on the next step or loop.</p></dd><dt><a href="Dagger/LLM.html#method_withPromptFile">
 <abbr title="Dagger\LLM">LLM</abbr>::withPromptFile</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
-                    <dd><p>Queue a file's contents as a user prompt, like withPrompt.</p></dd><dt><a href="Dagger/LLM.html#method_withResponse">
+                    <dd><p>Queue a file's contents as a user prompt, like withPrompt.</p></dd><dt><a href="Dagger/LLM.html#method_withReasoningEffort">
+<abbr title="Dagger\LLM">LLM</abbr>::withReasoningEffort</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
+                    <dd><p>Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.</p></dd><dt><a href="Dagger/LLM.html#method_withResponse">
 <abbr title="Dagger\LLM">LLM</abbr>::withResponse</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
                     <dd><p>Append an assistant response to the message history without calling the model, e.g. to reconstruct a conversation from another source.</p></dd><dt><a href="Dagger/LLM.html#method_withSkills">
 <abbr title="Dagger\LLM">LLM</abbr>::withSkills</a>() &mdash; <em>Method in class <a href="Dagger/LLM.html"><abbr title="Dagger\LLM">LLM</abbr></a></em></dt>
@@ -2179,7 +2183,11 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::withNewDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a directory added, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewFile">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withNewFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a new or replaced file, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withSDK">
+                    <dd><p>Return this workspace with a new or replaced file, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withReferenceDirectory">
+<abbr title="Dagger\Workspace">Workspace</abbr>::withReferenceDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p></dd><dt><a href="Dagger/Workspace.html#method_withReferenceFile">
+<abbr title="Dagger\Workspace">Workspace</abbr>::withReferenceFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Return this workspace with a file mounted read-only under the reserved references prefix.</p></dd><dt><a href="Dagger/Workspace.html#method_withSDK">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withSDK</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with an SDK installed in its config.</p></dd><dt><a href="Dagger/Workspace.html#method_withUpdatedLock">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withUpdatedLock</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -7450,6 +7450,18 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Workspace::withMountedDirectory",
+			"p": "Dagger/Workspace.html#method_withMountedDirectory",
+			"d": "<p>Return this workspace with a directory mounted read-only at the given path, without mutating the source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Workspace::withMountedFile",
+			"p": "Dagger/Workspace.html#method_withMountedFile",
+			"d": "<p>Return this workspace with a file mounted read-only at the given path, without mutating the source.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Workspace::withNewDirectory",
 			"p": "Dagger/Workspace.html#method_withNewDirectory",
 			"d": "<p>Return this workspace with a directory added, without mutating the source.</p>"
@@ -7459,18 +7471,6 @@
 			"n": "Dagger\\Workspace::withNewFile",
 			"p": "Dagger/Workspace.html#method_withNewFile",
 			"d": "<p>Return this workspace with a new or replaced file, without mutating the source.</p>"
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Workspace::withReferenceDirectory",
-			"p": "Dagger/Workspace.html#method_withReferenceDirectory",
-			"d": "<p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p>"
-		},
-		{
-			"t": "M",
-			"n": "Dagger\\Workspace::withReferenceFile",
-			"p": "Dagger/Workspace.html#method_withReferenceFile",
-			"d": "<p>Return this workspace with a file mounted read-only under the reserved references prefix.</p>"
 		},
 		{
 			"t": "M",

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -5830,6 +5830,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\LLM::reasoningEffort",
+			"p": "Dagger/LLM.html#method_reasoningEffort",
+			"d": "<p>The reasoning effort in use, e.g. &quot;low&quot;, &quot;medium&quot;, or &quot;high&quot;. Empty or &quot;none&quot; when reasoning is disabled.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\LLM::replay",
 			"p": "Dagger/LLM.html#method_replay",
 			"d": "<p>Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.</p>"
@@ -5893,6 +5899,12 @@
 			"n": "Dagger\\LLM::withPromptFile",
 			"p": "Dagger/LLM.html#method_withPromptFile",
 			"d": "<p>Queue a file's contents as a user prompt, like withPrompt.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\LLM::withReasoningEffort",
+			"p": "Dagger/LLM.html#method_withReasoningEffort",
+			"d": "<p>Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.</p>"
 		},
 		{
 			"t": "M",
@@ -7447,6 +7459,18 @@
 			"n": "Dagger\\Workspace::withNewFile",
 			"p": "Dagger/Workspace.html#method_withNewFile",
 			"d": "<p>Return this workspace with a new or replaced file, without mutating the source.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Workspace::withReferenceDirectory",
+			"p": "Dagger/Workspace.html#method_withReferenceDirectory",
+			"d": "<p>Return this workspace with a directory mounted read-only under the reserved references prefix.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Workspace::withReferenceFile",
+			"p": "Dagger/Workspace.html#method_withReferenceFile",
+			"d": "<p>Return this workspace with a file mounted read-only under the reserved references prefix.</p>"
 		},
 		{
 			"t": "M",

--- a/engine/client/filesync.go
+++ b/engine/client/filesync.go
@@ -632,6 +632,16 @@ func searchWithRipgrep(ctx context.Context, root string, rgPath string, opts *en
 			return nil, errors.Join(parseErr, waitErr)
 		}
 		if errBuf.Len() > 0 {
+			// "No files were searched" just means the filters (e.g. --glob)
+			// excluded everything in this tree. That's an empty result, not a
+			// failure: the caller merges these results with the workspace
+			// overlay's, which may well contain a file that only exists there
+			// (a pending edit that hasn't been written to the host yet).
+			// Failing here made such files invisible to search even though
+			// read/find served them fine.
+			if engine.RipgrepNoFilesSearched(errBuf.String()) {
+				return []engine.LocalSearchResult{}, nil
+			}
 			return nil, fmt.Errorf("ripgrep error: %s", errBuf.String())
 		}
 		return nil, waitErr

--- a/engine/client/filesync_test.go
+++ b/engine/client/filesync_test.go
@@ -152,4 +152,3 @@ exit 2
 		require.ErrorContains(t, err, "something actually went wrong")
 	})
 }
-

--- a/engine/client/filesync_test.go
+++ b/engine/client/filesync_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -40,3 +41,115 @@ func (*canceledDiffCopyStream) Recv() (*fstypes.Packet, error) { return nil, io.
 func (*canceledDiffCopyStream) SendMsg(any) error              { return nil }
 
 var _ filesync.FileSync_DiffCopyServer = (*canceledDiffCopyStream)(nil)
+
+// TestSearchHostPathNestedGitRepo covers the tree that host-side search walks:
+// a nested git repository (a subdirectory with its own .git) must not become a
+// hole in the search results, and a glob that happens to match nothing must
+// come back empty rather than blowing up the whole search.
+func TestSearchHostPathNestedGitRepo(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("ripgrep not installed; host search falls back to grep")
+	}
+
+	root := t.TempDir()
+
+	// outer repo
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored.txt\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "outer.txt"), []byte("needle\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored.txt"), []byte("needle\n"), 0o600))
+
+	// nested repo: a subdirectory that is itself a git repository
+	nested := filepath.Join(root, "nested")
+	require.NoError(t, os.MkdirAll(filepath.Join(nested, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "inner.txt"), []byte("needle\n"), 0o600))
+
+	paths := func(t *testing.T, results []engine.LocalSearchResult) []string {
+		t.Helper()
+		var out []string
+		for _, r := range results {
+			out = append(out, r.FilePath)
+		}
+		return out
+	}
+
+	t.Run("nested repo files are searched", func(t *testing.T) {
+		results, err := searchHostPath(context.Background(), root, &engine.LocalSearchOpts{
+			Pattern: "needle",
+		})
+		require.NoError(t, err)
+		require.Contains(t, paths(t, results), filepath.Join("nested", "inner.txt"))
+	})
+
+	t.Run("nested repo files are searched when honoring ignores", func(t *testing.T) {
+		results, err := searchHostPath(context.Background(), root, &engine.LocalSearchOpts{
+			Pattern:     "needle",
+			SkipIgnored: true,
+		})
+		require.NoError(t, err)
+		found := paths(t, results)
+		require.Contains(t, found, filepath.Join("nested", "inner.txt"))
+		require.Contains(t, found, "outer.txt")
+		// the outer repo's own .gitignore is still honored
+		require.NotContains(t, found, "ignored.txt")
+	})
+
+	t.Run("glob scoped to a nested repo file", func(t *testing.T) {
+		results, err := searchHostPath(context.Background(), root, &engine.LocalSearchOpts{
+			Pattern:     "needle",
+			SkipIgnored: true,
+			Globs:       []string{"nested/inner.txt"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{filepath.Join("nested", "inner.txt")}, paths(t, results))
+	})
+
+	t.Run("glob matching nothing is empty, not an error", func(t *testing.T) {
+		// ripgrep exits 2 with "No files were searched" here. That must not
+		// fail the search: results from other trees (workspace overlays) get
+		// merged with these, and may contain the file being looked for.
+		results, err := searchHostPath(context.Background(), root, &engine.LocalSearchOpts{
+			Pattern: "needle",
+			Globs:   []string{"nested/does-not-exist.txt"},
+		})
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
+}
+
+// TestSearchWithRipgrepNoFilesSearched pins the fix for the case above without
+// needing a real ripgrep: a stub that reproduces ripgrep's exit-2
+// "No files were searched" diagnostic must be reported as an empty result,
+// while any other stderr is still a real error.
+func TestSearchWithRipgrepNoFilesSearched(t *testing.T) {
+	stubRg := func(t *testing.T, script string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "rg")
+		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755))
+		return path
+	}
+
+	t.Run("no files searched is empty", func(t *testing.T) {
+		rg := stubRg(t, `echo "rg: No files were searched, which means ripgrep probably applied a filter you didn't expect." >&2
+exit 2
+`)
+		results, err := searchWithRipgrep(context.Background(), t.TempDir(), rg, &engine.LocalSearchOpts{
+			Pattern: "needle",
+			Globs:   []string{"nope"},
+		})
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
+
+	t.Run("other failures still error", func(t *testing.T) {
+		rg := stubRg(t, `echo "rg: something actually went wrong" >&2
+exit 2
+`)
+		_, err := searchWithRipgrep(context.Background(), t.TempDir(), rg, &engine.LocalSearchOpts{
+			Pattern: "needle",
+		})
+		require.ErrorContains(t, err, "something actually went wrong")
+	})
+}
+

--- a/engine/client/secretprovider/env.go
+++ b/engine/client/secretprovider/env.go
@@ -4,9 +4,48 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 )
 
-func envProvider(_ context.Context, name string) ([]byte, error) {
+// EnvRefresher is an optional hook, consulted by envProvider before it reads a
+// requested variable from the process environment. It lets a higher layer keep
+// a dynamically-managed env var (e.g. a short-lived OAuth bearer token) fresh:
+// the hook may refresh the credential and update os.Setenv for name before the
+// value is read. It is best-effort — errors and a nil hook are ignored, and
+// envProvider still reads whatever value is present afterwards.
+//
+// This indirection avoids a dependency from this low-level provider package on
+// the CLI's llmconfig package (which owns OAuth refresh); the CLI registers the
+// hook at startup via RegisterEnvRefresher.
+type EnvRefresher func(ctx context.Context, name string) error
+
+var (
+	envRefresherMu sync.RWMutex
+	envRefresher   EnvRefresher
+)
+
+// RegisterEnvRefresher installs the hook consulted by envProvider. Passing nil
+// clears it. It is safe to call concurrently.
+func RegisterEnvRefresher(r EnvRefresher) {
+	envRefresherMu.Lock()
+	defer envRefresherMu.Unlock()
+	envRefresher = r
+}
+
+func currentEnvRefresher() EnvRefresher {
+	envRefresherMu.RLock()
+	defer envRefresherMu.RUnlock()
+	return envRefresher
+}
+
+func envProvider(ctx context.Context, name string) ([]byte, error) {
+	// Give a registered refresher a chance to update this var before we read it
+	// (e.g. refreshing an expired OAuth token). Best-effort: on error we still
+	// read whatever is currently set, which yields the usual not-found or
+	// (possibly stale) value rather than masking the original request.
+	if r := currentEnvRefresher(); r != nil {
+		_ = r(ctx, name)
+	}
 	v, ok := os.LookupEnv(name)
 	if !ok {
 		// Don't show the entire env var name, in case the user accidentally passed the value instead...

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"unicode"
 
 	controlapi "github.com/dagger/dagger/internal/buildkit/api/services/control"
@@ -358,6 +359,20 @@ type LocalSearchOpts struct {
 	Limit       *int     `json:"limit,omitempty"`
 	Paths       []string `json:"paths,omitempty"`
 	Globs       []string `json:"globs,omitempty"`
+}
+
+// RipgrepNoFilesSearched reports whether ripgrep's stderr says it exited only
+// because every candidate file was excluded by a filter (globs, ignore rules,
+// hidden-file rules), rather than because something actually went wrong.
+//
+// ripgrep exits 2 with "No files were searched, which means ripgrep probably
+// applied a filter you didn't expect." even though "the filter matched nothing"
+// is a perfectly ordinary outcome of a search - e.g. a --glob naming a file
+// that doesn't exist in the tree being searched. Since search results from one
+// tree get merged with results from others (workspace overlays, cache mounts),
+// treating this as fatal loses matches that do exist in the other trees.
+func RipgrepNoFilesSearched(stderr string) bool {
+	return strings.Contains(stderr, "No files were searched")
 }
 
 type LocalExportOpts struct {

--- a/internal/cmd/dagger/llm.go
+++ b/internal/cmd/dagger/llm.go
@@ -93,6 +93,11 @@ type LLMSession struct {
 	// growth shown in --debug mode (see reportContextUsage).
 	prevContextTokens int
 	prevStepContext   int
+
+	// references tracks the host paths the user has attached with @ this
+	// session (see attachReferences). They are mounted read-only in the LLM's
+	// workspace, shown in the "References" sidebar, and dropped on .clear.
+	references []referenceInfo
 }
 
 func NewLLMSession(
@@ -192,6 +197,10 @@ func (s *LLMSession) Fork() *LLMSession {
 
 func (s *LLMSession) WithPrompt(ctx context.Context, input string) (*LLMSession, error) {
 	s = s.Fork()
+
+	// Resolve any @-path references in the prompt, mounting them read-only in
+	// the workspace and annotating the prompt with their workspace locations.
+	input = s.attachReferences(ctx, input)
 
 	resolvedModel, err := s.llm.Model(s.plumbingCtx)
 	if err != nil {
@@ -549,6 +558,8 @@ func (s *LLMSession) maybeAutoCompact(ctx context.Context) (_ *dagger.LLM, rerr 
 func (s *LLMSession) Clear() *LLMSession {
 	s = s.Fork()
 	s.reset()
+	s.references = nil
+	s.updateReferencesPreview()
 	return s
 }
 

--- a/internal/cmd/dagger/llm.go
+++ b/internal/cmd/dagger/llm.go
@@ -608,6 +608,19 @@ func (s *LLMSession) Model(model string) (*LLMSession, error) {
 	return s, nil
 }
 
+// Effort changes the reasoning effort for the rest of the conversation,
+// overriding any provider-configured default. "none" disables reasoning.
+func (s *LLMSession) Effort(effort string) (*LLMSession, error) {
+	s = s.Fork()
+	s.updateLLM(s.llm.WithReasoningEffort(effort))
+	// Resolve the endpoint eagerly so a configuration problem surfaces now
+	// rather than on the next prompt, mirroring Model above.
+	if _, err := s.llm.ReasoningEffort(s.plumbingCtx); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 //go:embed llm_branch_summary.md
 var branchSummaryPrompt string
 

--- a/internal/cmd/dagger/llm.go
+++ b/internal/cmd/dagger/llm.go
@@ -97,7 +97,18 @@ type LLMSession struct {
 	// references tracks the host paths the user has attached with @ this
 	// session (see attachReferences). They are mounted read-only in the LLM's
 	// workspace, shown in the "References" sidebar, and dropped on .clear.
+	// Paths already inside the workspace are not tracked here: they are
+	// rewritten to workspace-relative paths instead of being mounted.
 	references []referenceInfo
+
+	// workspaceHostRoot/workspaceHostCwd are the host filesystem paths of the
+	// workspace root and cwd, resolved lazily on the first @-path and cached
+	// for the session (workspaceHostResolved records that the lookup ran, since
+	// a non-local workspace legitimately resolves to empty). Used to detect
+	// @-paths that already live in the workspace.
+	workspaceHostResolved bool
+	workspaceHostRoot     string
+	workspaceHostCwd      string
 }
 
 func NewLLMSession(
@@ -198,9 +209,11 @@ func (s *LLMSession) Fork() *LLMSession {
 func (s *LLMSession) WithPrompt(ctx context.Context, input string) (*LLMSession, error) {
 	s = s.Fork()
 
-	// Resolve any @-path references in the prompt, mounting them read-only in
-	// the workspace and annotating the prompt with their workspace locations.
-	input = s.attachReferences(ctx, input)
+	// Resolve any @-path references in the prompt: paths already inside the
+	// workspace are rewritten to workspace-relative paths, and the rest are
+	// mounted read-only in the workspace with the prompt annotated with their
+	// workspace locations.
+	input = s.attachReferences(s.plumbingCtx, input)
 
 	resolvedModel, err := s.llm.Model(s.plumbingCtx)
 	if err != nil {

--- a/internal/cmd/dagger/llm_config.go
+++ b/internal/cmd/dagger/llm_config.go
@@ -12,9 +12,20 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/dagger/dagger/engine/client/secretprovider"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	"github.com/dagger/dagger/util/cleanups"
 )
+
+// oauthEnvProviders maps the auth-token environment variable the engine
+// resolves against the client to the llmconfig provider that owns it. Used to
+// refresh a subscription OAuth bearer token on demand (see the env refresher
+// registered below), so long-running sessions don't outlive the token.
+var oauthEnvProviders = map[string]string{
+	"ANTHROPIC_AUTH_TOKEN":    "anthropic",
+	"OPENAI_CODEX_AUTH_TOKEN": "openai-codex",
+}
 
 func init() {
 	rootCmd.AddCommand(llmParentCmd)
@@ -31,6 +42,29 @@ func init() {
 	// `dagger llm setup` takes effect for LLM usage (shell, call, etc.). The
 	// engine's LLM router resolves these via env:// against the client.
 	cobra.OnInitialize(applyLLMConfigEnv)
+
+	// Keep subscription OAuth bearer tokens fresh for the life of the session.
+	// applyLLMConfigEnv only refreshes and exports the token once, at startup;
+	// the access token typically expires within the hour, so a long-running
+	// session (dagger agent/shell, or a slow module) would keep sending an
+	// expired token and get 401s. The engine re-resolves the token via
+	// env://<KEY> against the client on each LLM router config load, so hook
+	// that resolution: when the engine asks for an OAuth auth-token var, refresh
+	// it if expired and update the process env before it's read.
+	secretprovider.RegisterEnvRefresher(func(_ context.Context, name string) error {
+		provider, ok := oauthEnvProviders[name]
+		if !ok {
+			return nil
+		}
+		token, err := llmconfig.RefreshOAuthProviderIfNeeded(provider)
+		if err != nil {
+			return err
+		}
+		if token != "" {
+			os.Setenv(name, token)
+		}
+		return nil
+	})
 }
 
 // applyLLMConfigEnv loads the persisted LLM config (written by `dagger llm
@@ -43,8 +77,12 @@ func init() {
 // expired). Anthropic (Claude Code) OAuth is wired end-to-end; Codex is not
 // yet, so its token is not exported.
 func applyLLMConfigEnv() {
-	// Refresh any expired OAuth tokens before exporting them.
-	_ = llmconfig.RefreshOAuthTokensIfNeeded()
+	// Refresh any expired OAuth tokens before exporting them. A failure here is
+	// non-fatal (we fall back to whatever token is persisted), but warn so an
+	// otherwise-silent 401 later on has a breadcrumb.
+	if err := llmconfig.RefreshOAuthTokensIfNeeded(); err != nil {
+		slog.Warn("failed to refresh LLM OAuth tokens", "error", err)
+	}
 	cfg, err := llmconfig.Load()
 	if err != nil || cfg == nil {
 		return

--- a/internal/cmd/dagger/llmconfig/config.go
+++ b/internal/cmd/dagger/llmconfig/config.go
@@ -309,7 +309,8 @@ func refreshProviderToken(name string, provider Provider) (Provider, bool, error
 func RefreshOAuthTokensIfNeeded() error {
 	cfg, err := Load()
 	if err != nil || cfg == nil {
-		return nil //nolint:nilerr // a missing or unreadable config is non-fatal here
+		// a missing or unreadable config is non-fatal here
+		return nil
 	}
 
 	var changed bool

--- a/internal/cmd/dagger/llmconfig/config.go
+++ b/internal/cmd/dagger/llmconfig/config.go
@@ -4,11 +4,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/adrg/xdg"
 	"github.com/gofrs/flock"
 	toml "github.com/pelletier/go-toml"
 )
+
+// oauthRefreshMu serializes OAuth load→refresh→persist sequences so
+// concurrent secret resolutions can't double-spend a one-time refresh
+// token (providers rotate them), or clobber another provider's freshly
+// rotated token via Save's whole-section rewrite.
+var oauthRefreshMu sync.Mutex
 
 const (
 	ConfigFileName = "config.toml"
@@ -307,6 +314,9 @@ func refreshProviderToken(name string, provider Provider) (Provider, bool, error
 // refreshes any expired tokens. This should be called client-side before
 // connecting to the engine.
 func RefreshOAuthTokensIfNeeded() error {
+	oauthRefreshMu.Lock()
+	defer oauthRefreshMu.Unlock()
+
 	cfg, err := Load()
 	if err != nil || cfg == nil {
 		// a missing or unreadable config is non-fatal here
@@ -340,6 +350,9 @@ func RefreshOAuthTokensIfNeeded() error {
 // an OAuth provider. Used to keep a long-running session's bearer token fresh:
 // the client re-resolves the token on demand rather than only at startup.
 func RefreshOAuthProviderIfNeeded(name string) (string, error) {
+	oauthRefreshMu.Lock()
+	defer oauthRefreshMu.Unlock()
+
 	cfg, err := Load()
 	if err != nil || cfg == nil {
 		return "", err

--- a/internal/cmd/dagger/llmconfig/config.go
+++ b/internal/cmd/dagger/llmconfig/config.go
@@ -281,6 +281,28 @@ func Remove() error {
 	return nil
 }
 
+// refreshProviderToken refreshes an expired OAuth provider in place, dispatching
+// to the provider-specific refresh flow. It returns the (possibly updated)
+// provider and whether it changed.
+func refreshProviderToken(name string, provider Provider) (Provider, bool, error) {
+	if !provider.IsOAuth() || !IsTokenExpired(&provider) {
+		return provider, false, nil
+	}
+	var refreshed *Provider
+	var err error
+	switch name {
+	case "openai-codex":
+		refreshed, err = RefreshOpenAIOAuthToken(&provider)
+	default:
+		// Anthropic and other providers use the standard refresh
+		refreshed, err = RefreshOAuthToken(&provider)
+	}
+	if err != nil {
+		return provider, false, fmt.Errorf("failed to refresh OAuth token for %s: %w", name, err)
+	}
+	return *refreshed, true, nil
+}
+
 // RefreshOAuthTokensIfNeeded checks all OAuth providers in the config and
 // refreshes any expired tokens. This should be called client-side before
 // connecting to the engine.
@@ -292,25 +314,14 @@ func RefreshOAuthTokensIfNeeded() error {
 
 	var changed bool
 	for name, provider := range cfg.LLM.Providers {
-		if !provider.IsOAuth() {
-			continue
-		}
-		if !IsTokenExpired(&provider) {
-			continue
-		}
-		var refreshed *Provider
-		switch name {
-		case "openai-codex":
-			refreshed, err = RefreshOpenAIOAuthToken(&provider)
-		default:
-			// Anthropic and other providers use the standard refresh
-			refreshed, err = RefreshOAuthToken(&provider)
-		}
+		refreshed, didChange, err := refreshProviderToken(name, provider)
 		if err != nil {
-			return fmt.Errorf("failed to refresh OAuth token for %s: %w", name, err)
+			return err
 		}
-		cfg.LLM.Providers[name] = *refreshed
-		changed = true
+		if didChange {
+			cfg.LLM.Providers[name] = refreshed
+			changed = true
+		}
 	}
 
 	if changed {
@@ -320,4 +331,31 @@ func RefreshOAuthTokensIfNeeded() error {
 	}
 
 	return nil
+}
+
+// RefreshOAuthProviderIfNeeded refreshes a single OAuth provider by name if its
+// token has expired, persisting the result. It returns the current access token
+// for the provider (refreshed or not), or "" if the provider is absent or not
+// an OAuth provider. Used to keep a long-running session's bearer token fresh:
+// the client re-resolves the token on demand rather than only at startup.
+func RefreshOAuthProviderIfNeeded(name string) (string, error) {
+	cfg, err := Load()
+	if err != nil || cfg == nil {
+		return "", err
+	}
+	provider, ok := cfg.LLM.Providers[name]
+	if !ok || !provider.IsOAuth() {
+		return "", nil
+	}
+	refreshed, changed, err := refreshProviderToken(name, provider)
+	if err != nil {
+		return "", err
+	}
+	if changed {
+		cfg.LLM.Providers[name] = refreshed
+		if err := cfg.Save(); err != nil {
+			return "", fmt.Errorf("failed to save refreshed tokens: %w", err)
+		}
+	}
+	return refreshed.AuthToken, nil
 }

--- a/internal/cmd/dagger/llmconfig/config_test.go
+++ b/internal/cmd/dagger/llmconfig/config_test.go
@@ -1,10 +1,16 @@
 package llmconfig
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	toml "github.com/pelletier/go-toml"
@@ -439,5 +445,149 @@ func TestConfigPreservesOtherSections(t *testing.T) {
 	}
 	if tree.Has("llm") {
 		t.Error("Remove() left the [llm] section behind")
+	}
+}
+
+// TestRefreshOAuthProviderConcurrent verifies that concurrent calls to
+// RefreshOAuthProviderIfNeeded for the same expired provider result in exactly
+// one refresh against the token endpoint. Refresh tokens are one-time-use
+// (providers rotate them), so without serialization a second interleaved call
+// would double-spend the refresh token and fail with invalid_grant.
+func TestRefreshOAuthProviderConcurrent(t *testing.T) {
+	tempDir := t.TempDir()
+
+	origConfigRoot := ConfigRoot
+	origConfigFile := ConfigFile
+	origTokenURL := oauthTokenURL
+	origProfileURL := oauthProfileURL
+	t.Cleanup(func() {
+		ConfigRoot = origConfigRoot
+		ConfigFile = origConfigFile
+		oauthTokenURL = origTokenURL
+		oauthProfileURL = origProfileURL
+	})
+
+	ConfigRoot = filepath.Join(tempDir, "dagger")
+	ConfigFile = filepath.Join(ConfigRoot, ConfigFileName)
+
+	// Fake OAuth server: the token endpoint rotates the refresh token on each
+	// successful grant, so a replayed (already-spent) refresh token gets
+	// invalid_grant — mirroring Anthropic's one-time refresh token behavior.
+	var (
+		mu                  sync.Mutex
+		currentRefreshToken = "rt-0"
+		refreshCalls        int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			var req struct {
+				GrantType    string `json:"grant_type"`
+				ClientID     string `json:"client_id"`
+				RefreshToken string `json:"refresh_token"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+				return
+			}
+			if req.GrantType != "refresh_token" || req.ClientID != oauthClientID {
+				http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if req.RefreshToken != currentRefreshToken {
+				http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+				return
+			}
+			refreshCalls++
+			currentRefreshToken = fmt.Sprintf("rt-%d", refreshCalls)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  fmt.Sprintf("access-%d", refreshCalls),
+				"refresh_token": currentRefreshToken,
+				"expires_in":    3600,
+			})
+		case "/profile":
+			// Best-effort subscription lookup; serve a minimal valid response
+			// so it doesn't hit the real network.
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"organization":{"organization_type":"claude_max"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	oauthTokenURL = srv.URL + "/token"
+	oauthProfileURL = srv.URL + "/profile"
+
+	// Seed an OAuth provider whose access token expired long ago.
+	cfg := &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": {
+					AuthType:     "oauth",
+					AuthToken:    "stale-access",
+					RefreshToken: "rt-0",
+					TokenExpiry:  1,
+					Enabled:      true,
+				},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	type result struct {
+		token string
+		err   error
+	}
+	const workers = 10
+	start := make(chan struct{})
+	results := make(chan result, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			<-start
+			token, err := RefreshOAuthProviderIfNeeded("anthropic")
+			results <- result{token, err}
+		}()
+	}
+	close(start)
+
+	for i := 0; i < workers; i++ {
+		res := <-results
+		if res.err != nil {
+			t.Errorf("RefreshOAuthProviderIfNeeded() call %d failed: %v", i, res.err)
+			continue
+		}
+		if res.token != "access-1" {
+			t.Errorf("RefreshOAuthProviderIfNeeded() call %d returned token %q, want %q", i, res.token, "access-1")
+		}
+	}
+
+	mu.Lock()
+	if refreshCalls != 1 {
+		t.Errorf("token endpoint hit %d times, want exactly 1", refreshCalls)
+	}
+	mu.Unlock()
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() after concurrent refresh failed: %v", err)
+	}
+	provider, ok := loaded.LLM.Providers["anthropic"]
+	if !ok {
+		t.Fatal("anthropic provider missing after refresh")
+	}
+	if provider.AuthToken != "access-1" {
+		t.Errorf("persisted AuthToken = %q, want %q", provider.AuthToken, "access-1")
+	}
+	if provider.RefreshToken != "rt-1" {
+		t.Errorf("persisted RefreshToken = %q, want %q", provider.RefreshToken, "rt-1")
+	}
+	if provider.TokenExpiry <= time.Now().UnixMilli() {
+		t.Errorf("persisted TokenExpiry %d not in the future", provider.TokenExpiry)
 	}
 }

--- a/internal/cmd/dagger/llmconfig/oauth.go
+++ b/internal/cmd/dagger/llmconfig/oauth.go
@@ -17,10 +17,15 @@ const (
 	// Claude Code OAuth configuration
 	oauthClientID    = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 	oauthAuthorize   = "https://claude.ai/oauth/authorize"
-	oauthTokenURL    = "https://console.anthropic.com/v1/oauth/token" //nolint:gosec // OAuth token endpoint URL, not a credential
 	oauthRedirectURI = "https://console.anthropic.com/oauth/code/callback"
 	oauthScopes      = "org:create_api_key user:profile user:inference"
-	oauthProfileURL  = "https://api.anthropic.com/api/oauth/profile"
+)
+
+// vars (not consts) so tests can point them at a local server, mirroring the
+// ConfigRoot/ConfigFile override pattern.
+var (
+	oauthTokenURL   = "https://console.anthropic.com/v1/oauth/token" //nolint:gosec // OAuth token endpoint URL, not a credential
+	oauthProfileURL = "https://api.anthropic.com/api/oauth/profile"
 )
 
 // OAuthTokenResponse represents the token endpoint response.

--- a/internal/cmd/dagger/references.go
+++ b/internal/cmd/dagger/references.go
@@ -1,0 +1,260 @@
+package daggercmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/muesli/termenv"
+	"github.com/vito/tuist"
+)
+
+// workspaceReferencePrefix mirrors core.WorkspaceReferencePrefix: the reserved
+// workspace-relative directory under which @-referenced host paths are mounted
+// read-only. Kept as a local constant so reference plumbing on the client side
+// doesn't need to import core; it is only used to render the workspace-relative
+// path back to the user and the model.
+const workspaceReferencePrefix = ".refs"
+
+// referenceInfo records a host path the user attached with @, along with the
+// read-only workspace path it was mounted at.
+type referenceInfo struct {
+	original string // path as typed after @, e.g. ~/foo/bar.txt
+	mount    string // workspace-relative mount path, e.g. .refs/foo/bar.txt
+	isDir    bool
+}
+
+// completeReferencePath completes an @-path against the host filesystem. frag
+// is the text typed after the leading "@". A leading "~" is expanded to the
+// home directory for listing, but the inserted text preserves the user's typed
+// prefix (e.g. "~/") so the token round-trips.
+func completeReferencePath(frag string) []tuist.Completion {
+	dirPart, base := frag, ""
+	if idx := strings.LastIndex(frag, "/"); idx >= 0 {
+		dirPart, base = frag[:idx+1], frag[idx+1:]
+	} else {
+		dirPart, base = "", frag
+	}
+
+	listDir := expandTilde(dirPart)
+	if listDir == "" {
+		listDir = "."
+	}
+	entries, err := os.ReadDir(listDir)
+	if err != nil {
+		return nil
+	}
+
+	var items []tuist.Completion
+	for _, entry := range entries {
+		name := entry.Name()
+		// Hide dotfiles unless the user has started typing one.
+		if !strings.HasPrefix(base, ".") && strings.HasPrefix(name, ".") {
+			continue
+		}
+		if !strings.HasPrefix(name, base) {
+			continue
+		}
+		isDir := entry.IsDir()
+		display := name
+		insert := "@" + dirPart + name
+		kind := "file"
+		if isDir {
+			display += "/"
+			insert += "/"
+			kind = "dir"
+		}
+		items = append(items, tuist.Completion{
+			Label:        insert,
+			DisplayLabel: display,
+			Detail:       kind,
+			Kind:         kind,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Label < items[j].Label
+	})
+	return items
+}
+
+// expandTilde expands a leading "~" or "~/" to the user's home directory. Other
+// paths (absolute or relative to the cwd) are returned unchanged.
+func expandTilde(p string) string {
+	if p == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return p
+	}
+	if rest, ok := strings.CutPrefix(p, "~/"); ok {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, rest)
+		}
+	}
+	return p
+}
+
+// expandReferencePath resolves an @-path (the text after "@") to an absolute
+// host path, expanding a leading "~" and resolving relative paths against the
+// current working directory.
+func expandReferencePath(p string) (string, error) {
+	if p == "~" {
+		return os.UserHomeDir()
+	}
+	if rest, ok := strings.CutPrefix(p, "~/"); ok {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, rest), nil
+	}
+	return filepath.Abs(p)
+}
+
+// referenceMountRel computes the reference-relative mount path for an absolute
+// host path: relative to the home directory when the path is under it,
+// otherwise just the basename.
+func referenceMountRel(abs string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if rel, err := filepath.Rel(home, abs); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return filepath.Base(abs)
+}
+
+// parseReferenceTokens extracts the @-path tokens from a prompt line. A token is
+// a whitespace-delimited word starting with "@"; surrounding quotes/backticks
+// and trailing sentence punctuation are stripped.
+func parseReferenceTokens(line string) []string {
+	var out []string
+	for _, field := range strings.Fields(line) {
+		rest, ok := strings.CutPrefix(field, "@")
+		if !ok || rest == "" {
+			continue
+		}
+		rest = strings.Trim(rest, "`'\"")
+		rest = strings.TrimRight(rest, ".,;:!?)")
+		if rest == "" {
+			continue
+		}
+		out = append(out, rest)
+	}
+	return out
+}
+
+func (s *LLMSession) hasReference(mount string) bool {
+	for _, r := range s.references {
+		if r.mount == mount {
+			return true
+		}
+	}
+	return false
+}
+
+// attachReferences resolves any @-path tokens in input, mounting each into the
+// LLM's workspace read-only under the references prefix (see
+// core.WorkspaceReferencePrefix). Newly-attached references are sticky for the
+// session and shown in the "References" sidebar. The returned string is the
+// prompt annotated with the referenced paths' workspace locations so the model
+// knows where to read them; nonexistent paths are skipped.
+func (s *LLMSession) attachReferences(ctx context.Context, input string) string {
+	_ = ctx
+	tokens := parseReferenceTokens(input)
+	if len(tokens) == 0 {
+		return input
+	}
+
+	llm := s.llm
+	changed := false
+	seen := map[string]bool{}
+	var mentioned []referenceInfo
+	for _, tok := range tokens {
+		abs, err := expandReferencePath(tok)
+		if err != nil {
+			continue
+		}
+		fi, err := os.Stat(abs)
+		if err != nil {
+			// Skip paths that don't resolve to a real host file/directory.
+			continue
+		}
+		rel := referenceMountRel(abs)
+		mount := workspaceReferencePrefix + "/" + rel
+		if seen[mount] {
+			continue
+		}
+		seen[mount] = true
+		info := referenceInfo{original: tok, mount: mount, isDir: fi.IsDir()}
+		mentioned = append(mentioned, info)
+
+		if s.hasReference(mount) {
+			// Already attached earlier this session; just re-mention it.
+			continue
+		}
+		ws := llm.Workspace()
+		if fi.IsDir() {
+			ws = ws.WithReferenceDirectory(rel, s.dag.Host().Directory(abs))
+		} else {
+			ws = ws.WithReferenceFile(rel, s.dag.Host().File(abs))
+		}
+		llm = llm.WithWorkspace(ws)
+		s.references = append(s.references, info)
+		changed = true
+	}
+
+	if changed {
+		s.llm = llm
+		s.updateReferencesPreview()
+	}
+	if len(mentioned) == 0 {
+		return input
+	}
+	return input + referenceAnnotation(mentioned)
+}
+
+// referenceAnnotation renders the trailing block appended to a prompt that maps
+// each referenced path to its read-only workspace location.
+func referenceAnnotation(refs []referenceInfo) string {
+	var b strings.Builder
+	b.WriteString("\n\n[Referenced paths (read-only, available in your workspace):")
+	for _, r := range refs {
+		kind := ""
+		if r.isDir {
+			kind = " (directory)"
+		}
+		fmt.Fprintf(&b, "\n- %s%s → %s", r.original, kind, r.mount)
+	}
+	b.WriteString("\nRead them with your normal file tools at the workspace paths shown.]")
+	return b.String()
+}
+
+// updateReferencesPreview refreshes the "References" sidebar section listing the
+// host paths attached this session. An empty list clears the section.
+func (s *LLMSession) updateReferencesPreview() {
+	if len(s.references) == 0 {
+		s.frontend.SetSidebarContent(idtui.SidebarSection{Title: "References"})
+		return
+	}
+	refs := make([]referenceInfo, len(s.references))
+	copy(refs, s.references)
+	s.frontend.SetSidebarContent(idtui.SidebarSection{
+		Title: "References",
+		ContentFunc: func(width int) string {
+			var buf strings.Builder
+			out := idtui.NewOutput(&buf)
+			for _, r := range refs {
+				name := r.original
+				if r.isDir && !strings.HasSuffix(name, "/") {
+					name += "/"
+				}
+				fmt.Fprintln(&buf, out.String(name).Foreground(termenv.ANSICyan).String())
+			}
+			return strings.TrimRight(buf.String(), "\n")
+		},
+	})
+}

--- a/internal/cmd/dagger/references.go
+++ b/internal/cmd/dagger/references.go
@@ -15,11 +15,11 @@ import (
 	"github.com/vito/tuist"
 )
 
-// workspaceReferencePrefix mirrors core.WorkspaceReferencePrefix: the reserved
-// workspace-relative directory under which @-referenced host paths are mounted
-// read-only. Kept as a local constant so reference plumbing on the client side
-// doesn't need to import core; it is only used to render the workspace-relative
-// path back to the user and the model.
+// workspaceReferencePrefix is the workspace directory under which @-referenced
+// host paths are mounted read-only (via Workspace.withMountedDirectory/
+// withMountedFile). Purely a CLI convention: the engine treats it like any
+// other mount path, so it only exists to give attached references a
+// predictable, out-of-the-way home in the workspace.
 const workspaceReferencePrefix = ".refs"
 
 // referenceInfo records a host path the user attached with @, along with the
@@ -226,7 +226,7 @@ func (s *LLMSession) hasReference(mount string) bool {
 // directly, so the token is simply rewritten in place to a path relative to the
 // workspace's cwd (e.g. "@/abs/path/to/foo.go" → "./foo.go"). Paths outside the
 // workspace are mounted into the LLM's workspace read-only under the references
-// prefix (see core.WorkspaceReferencePrefix); those are sticky for the session
+// prefix (see workspaceReferencePrefix); those are sticky for the session
 // and shown in the "References" sidebar, and the prompt is annotated with their
 // workspace locations so the model knows where to read them. Nonexistent paths
 // are left untouched.
@@ -274,9 +274,9 @@ func (s *LLMSession) attachReferences(ctx context.Context, input string) string 
 		}
 		ws := llm.Workspace()
 		if fi.IsDir() {
-			ws = ws.WithReferenceDirectory(rel, s.dag.Host().Directory(abs))
+			ws = ws.WithMountedDirectory(mount, s.dag.Host().Directory(abs))
 		} else {
-			ws = ws.WithReferenceFile(rel, s.dag.Host().File(abs))
+			ws = ws.WithMountedFile(mount, s.dag.Host().File(abs))
 		}
 		llm = llm.WithWorkspace(ws)
 		s.references = append(s.references, info)

--- a/internal/cmd/dagger/references.go
+++ b/internal/cmd/dagger/references.go
@@ -26,7 +26,7 @@ const workspaceReferencePrefix = ".refs"
 // read-only workspace path it was mounted at.
 type referenceInfo struct {
 	original string // path as typed after @, e.g. ~/foo/bar.txt
-	mount    string // workspace-relative mount path, e.g. .refs/foo/bar.txt
+	mount    string // workspace-relative mount path, e.g. .refs/~/foo/bar.txt
 	isDir    bool
 }
 
@@ -116,15 +116,22 @@ func expandReferencePath(p string) (string, error) {
 }
 
 // referenceMountRel computes the reference-relative mount path for an absolute
-// host path: relative to the home directory when the path is under it,
-// otherwise just the basename.
+// host path, preserving the full path shape so that distinct host paths never
+// collapse onto the same mount (e.g. /tmp/frontend/config.json vs
+// /tmp/backend/config.json). Paths under the home directory are shortened to a
+// "~/" prefix — mirroring how they're typed — and everything else keeps its
+// path from the root, minus the leading separator.
 func referenceMountRel(abs string) string {
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		if rel, err := filepath.Rel(home, abs); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-			return filepath.ToSlash(rel)
+		if rel, err := filepath.Rel(home, abs); err == nil && !strings.HasPrefix(rel, "..") {
+			if rel == "." {
+				return "~"
+			}
+			return "~/" + filepath.ToSlash(rel)
 		}
 	}
-	return filepath.Base(abs)
+	rel := strings.TrimPrefix(abs, filepath.VolumeName(abs))
+	return strings.TrimPrefix(filepath.ToSlash(rel), "/")
 }
 
 // parseReferenceTokens extracts the @-path tokens from a prompt line. A token is

--- a/internal/cmd/dagger/references.go
+++ b/internal/cmd/dagger/references.go
@@ -3,11 +3,13 @@ package daggercmd
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/muesli/termenv"
 	"github.com/vito/tuist"
@@ -133,18 +135,83 @@ func referenceMountRel(abs string) string {
 func parseReferenceTokens(line string) []string {
 	var out []string
 	for _, field := range strings.Fields(line) {
-		rest, ok := strings.CutPrefix(field, "@")
-		if !ok || rest == "" {
+		_, tok, _, ok := splitReferenceField(field)
+		if !ok {
 			continue
 		}
-		rest = strings.Trim(rest, "`'\"")
-		rest = strings.TrimRight(rest, ".,;:!?)")
-		if rest == "" {
-			continue
-		}
-		out = append(out, rest)
+		out = append(out, tok)
 	}
 	return out
+}
+
+// referenceQuoteChars are stripped from both ends of an @-token, and
+// referencePunctuation from its end, so a reference typed mid-sentence (e.g.
+// `@foo.go,`) still resolves.
+const (
+	referenceQuoteChars  = "`'\""
+	referencePunctuation = ".,;:!?)"
+)
+
+// splitReferenceField decomposes a whitespace-delimited word into the leading
+// "@" plus any opening quotes, the path token itself, and the trailing
+// quotes/punctuation. The three parts always concatenate back to field, so a
+// token can be rewritten in place. ok is false when the word is not an
+// @-reference.
+func splitReferenceField(field string) (prefix, tok, suffix string, ok bool) {
+	rest, ok := strings.CutPrefix(field, "@")
+	if !ok || rest == "" {
+		return "", "", "", false
+	}
+	lead := 0
+	for lead < len(rest) && strings.IndexByte(referenceQuoteChars, rest[lead]) >= 0 {
+		lead++
+	}
+	tail := len(rest)
+	for tail > lead && strings.IndexByte(referenceQuoteChars, rest[tail-1]) >= 0 {
+		tail--
+	}
+	body := rest[lead:tail]
+	tok = strings.TrimRight(body, referencePunctuation)
+	if tok == "" {
+		return "", "", "", false
+	}
+	return "@" + rest[:lead], tok, body[len(tok):] + rest[tail:], true
+}
+
+// rewriteReferenceTokens replaces @-tokens in line for which replace returns a
+// substitution, dropping the "@" sigil while preserving any quotes, trailing
+// punctuation and the line's original whitespace.
+func rewriteReferenceTokens(line string, replace func(tok string) (string, bool)) string {
+	var b strings.Builder
+	for i := 0; i < len(line); {
+		start := i
+		for i < len(line) && isReferenceSpace(line[i]) {
+			i++
+		}
+		b.WriteString(line[start:i])
+
+		start = i
+		for i < len(line) && !isReferenceSpace(line[i]) {
+			i++
+		}
+		field := line[start:i]
+		if prefix, tok, suffix, ok := splitReferenceField(field); ok {
+			if replacement, ok := replace(tok); ok {
+				b.WriteString(strings.TrimPrefix(prefix, "@") + replacement + suffix)
+				continue
+			}
+		}
+		b.WriteString(field)
+	}
+	return b.String()
+}
+
+func isReferenceSpace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	}
+	return false
 }
 
 func (s *LLMSession) hasReference(mount string) bool {
@@ -156,14 +223,16 @@ func (s *LLMSession) hasReference(mount string) bool {
 	return false
 }
 
-// attachReferences resolves any @-path tokens in input, mounting each into the
-// LLM's workspace read-only under the references prefix (see
-// core.WorkspaceReferencePrefix). Newly-attached references are sticky for the
-// session and shown in the "References" sidebar. The returned string is the
-// prompt annotated with the referenced paths' workspace locations so the model
-// knows where to read them; nonexistent paths are skipped.
+// attachReferences resolves any @-path tokens in input. Paths that already live
+// inside the current workspace need no mounting: the agent can read them
+// directly, so the token is simply rewritten in place to a path relative to the
+// workspace's cwd (e.g. "@/abs/path/to/foo.go" → "./foo.go"). Paths outside the
+// workspace are mounted into the LLM's workspace read-only under the references
+// prefix (see core.WorkspaceReferencePrefix); those are sticky for the session
+// and shown in the "References" sidebar, and the prompt is annotated with their
+// workspace locations so the model knows where to read them. Nonexistent paths
+// are left untouched.
 func (s *LLMSession) attachReferences(ctx context.Context, input string) string {
-	_ = ctx
 	tokens := parseReferenceTokens(input)
 	if len(tokens) == 0 {
 		return input
@@ -172,6 +241,7 @@ func (s *LLMSession) attachReferences(ctx context.Context, input string) string 
 	llm := s.llm
 	changed := false
 	seen := map[string]bool{}
+	local := map[string]string{}
 	var mentioned []referenceInfo
 	for _, tok := range tokens {
 		abs, err := expandReferencePath(tok)
@@ -183,6 +253,14 @@ func (s *LLMSession) attachReferences(ctx context.Context, input string) string 
 			// Skip paths that don't resolve to a real host file/directory.
 			continue
 		}
+
+		// Already in the workspace: no need to copy it into .refs, just point
+		// the model at it relative to the workspace cwd.
+		if rel, ok := s.workspaceRelativePath(ctx, abs); ok {
+			local[tok] = rel
+			continue
+		}
+
 		rel := referenceMountRel(abs)
 		mount := workspaceReferencePrefix + "/" + rel
 		if seen[mount] {
@@ -211,10 +289,97 @@ func (s *LLMSession) attachReferences(ctx context.Context, input string) string 
 		s.llm = llm
 		s.updateReferencesPreview()
 	}
+	if len(local) > 0 {
+		input = rewriteReferenceTokens(input, func(tok string) (string, bool) {
+			rel, ok := local[tok]
+			return rel, ok
+		})
+	}
 	if len(mentioned) == 0 {
 		return input
 	}
 	return input + referenceAnnotation(mentioned)
+}
+
+// workspaceRelativePath reports whether abs (an absolute host path) lies inside
+// the current workspace, and if so returns it as a path relative to the
+// workspace's cwd — the form the agent's own file tools take. Paths under the
+// cwd are prefixed with "./" so they read unambiguously as paths; paths
+// elsewhere in the workspace keep their "../" prefix.
+func (s *LLMSession) workspaceRelativePath(ctx context.Context, abs string) (string, bool) {
+	root, cwd, ok := s.workspaceHostPaths(ctx)
+	if !ok {
+		return "", false
+	}
+	abs = resolveSymlinks(abs)
+	if rel, err := filepath.Rel(root, abs); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// Outside the workspace boundary.
+		return "", false
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return rel, true
+	}
+	return "./" + rel, true
+}
+
+// workspaceHostPaths resolves the host filesystem paths of the workspace root
+// and its cwd, resolved once per session. Returns false for workspaces with no
+// host location (remote or synthetic ones), where @-paths always need mounting.
+func (s *LLMSession) workspaceHostPaths(ctx context.Context) (root, cwd string, ok bool) {
+	if !s.workspaceHostResolved {
+		s.workspaceHostResolved = true
+		s.workspaceHostRoot, s.workspaceHostCwd = resolveWorkspaceHostPaths(ctx, s.dag)
+	}
+	if s.workspaceHostRoot == "" {
+		return "", "", false
+	}
+	return s.workspaceHostRoot, s.workspaceHostCwd, true
+}
+
+// resolveWorkspaceHostPaths queries the current workspace for its address and
+// cwd and maps them back to host paths. Both are empty when the workspace isn't
+// local.
+func resolveWorkspaceHostPaths(ctx context.Context, dag *dagger.Client) (root, cwd string) {
+	ws := dag.CurrentWorkspace()
+	address, err := ws.Address(ctx)
+	if err != nil {
+		return "", ""
+	}
+	parsed, err := url.Parse(address)
+	if err != nil || parsed.Scheme != "file" {
+		// Remote or synthetic workspace: nothing on the host to compare to.
+		return "", ""
+	}
+	wsCwd, err := ws.Cwd(ctx)
+	if err != nil {
+		return "", ""
+	}
+	root, err = workspaceRootFromAddress(address, wsCwd)
+	if err != nil {
+		return "", ""
+	}
+	relCwd, err := workspaceRelativeCwd(wsCwd)
+	if err != nil {
+		return "", ""
+	}
+	root = resolveSymlinks(root)
+	return root, filepath.Join(root, relCwd)
+}
+
+// resolveSymlinks resolves symlinks in p, falling back to the cleaned input when
+// it can't (e.g. the path doesn't exist). Keeps host paths comparable when the
+// workspace root and an @-path reach the same place through different links,
+// such as macOS's /tmp → /private/tmp.
+func resolveSymlinks(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
 }
 
 // referenceAnnotation renders the trailing block appended to a prompt that maps

--- a/internal/cmd/dagger/references.go
+++ b/internal/cmd/dagger/references.go
@@ -35,11 +35,9 @@ type referenceInfo struct {
 // home directory for listing, but the inserted text preserves the user's typed
 // prefix (e.g. "~/") so the token round-trips.
 func completeReferencePath(frag string) []tuist.Completion {
-	dirPart, base := frag, ""
+	dirPart, base := "", frag
 	if idx := strings.LastIndex(frag, "/"); idx >= 0 {
 		dirPart, base = frag[:idx+1], frag[idx+1:]
-	} else {
-		dirPart, base = "", frag
 	}
 
 	listDir := expandTilde(dirPart)

--- a/internal/cmd/dagger/references_test.go
+++ b/internal/cmd/dagger/references_test.go
@@ -1,0 +1,128 @@
+package daggercmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReferenceTokens(t *testing.T) {
+	cases := []struct {
+		line string
+		want []string
+	}{
+		{"review @~/foo/bar.txt please", []string{"~/foo/bar.txt"}},
+		{"@/etc/hosts and @./rel.go", []string{"/etc/hosts", "./rel.go"}},
+		// trailing sentence punctuation is stripped
+		{"see @~/notes.", []string{"~/notes"}},
+		{"look at @~/a.txt, @~/b.txt;", []string{"~/a.txt", "~/b.txt"}},
+		// quoted tokens (quotes stripped; whitespace still delimits words)
+		{`open @"foo.txt"`, []string{`foo.txt`}},
+		// non-references are ignored
+		{"email me@example.com", nil},
+		{"a bare @ is ignored", nil},
+		{"no references here", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.line, func(t *testing.T) {
+			require.Equal(t, tc.want, parseReferenceTokens(tc.line))
+		})
+	}
+}
+
+func TestReferenceMountRel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Under home → relative to home.
+	require.Equal(t, "foo/bar.txt", referenceMountRel(filepath.Join(home, "foo", "bar.txt")))
+	require.Equal(t, "proj", referenceMountRel(filepath.Join(home, "proj")))
+
+	// Outside home → basename only.
+	require.Equal(t, "hosts", referenceMountRel("/etc/hosts"))
+}
+
+func TestExpandReferencePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := expandReferencePath("~/foo/bar.txt")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "foo", "bar.txt"), got)
+
+	got, err = expandReferencePath("~")
+	require.NoError(t, err)
+	require.Equal(t, home, got)
+
+	got, err = expandReferencePath("/etc/hosts")
+	require.NoError(t, err)
+	require.Equal(t, "/etc/hosts", got)
+}
+
+func TestCompleteReferencePath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "alpha.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "apex.go"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden"), []byte("x"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "beta"), 0o755))
+
+	toLabels := func(frag string) []string {
+		res := completeReferencePath(frag)
+		out := make([]string, 0, len(res))
+		for _, it := range res {
+			out = append(out, it.Label)
+		}
+		return out
+	}
+
+	// Listing the directory omits dotfiles and marks directories with a slash.
+	all := toLabels(dir + "/")
+	require.Contains(t, all, "@"+dir+"/alpha.txt")
+	require.Contains(t, all, "@"+dir+"/apex.go")
+	require.Contains(t, all, "@"+dir+"/beta/")
+	require.NotContains(t, all, "@"+dir+"/.hidden")
+	require.True(t, sortedStrings(all), "completions should be sorted: %v", all)
+
+	// A prefix narrows results.
+	ap := toLabels(dir + "/a")
+	require.ElementsMatch(t, []string{"@" + dir + "/alpha.txt", "@" + dir + "/apex.go"}, ap)
+
+	// An explicit dot shows dotfiles.
+	dot := toLabels(dir + "/.")
+	require.Contains(t, dot, "@"+dir+"/.hidden")
+
+	// A directory completion carries the display slash but the inserted label
+	// includes the full @-prefixed path.
+	res := completeReferencePath(dir + "/be")
+	require.Len(t, res, 1)
+	require.Equal(t, "@"+dir+"/beta/", res[0].Label)
+	require.Equal(t, "beta/", res[0].DisplayLabel)
+}
+
+func TestAutoCompleteReferencePath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.md"), []byte("x"), 0o644))
+
+	h := newShellCallHandler(nil, &idtui.FrontendMock{})
+	require.NoError(t, h.registerCommands())
+	h.mode = modePrompt
+
+	input := "please read @" + dir + "/r"
+	res := h.AutoComplete(input, len(input))
+	require.Equal(t, strings.Index(input, "@"), res.ReplaceFrom)
+	require.Len(t, res.Items, 1)
+	require.Equal(t, "@"+dir+"/readme.md", res.Items[0].Label)
+}
+
+func TestReferenceAnnotation(t *testing.T) {
+	out := referenceAnnotation([]referenceInfo{
+		{original: "~/foo/bar.txt", mount: ".refs/foo/bar.txt", isDir: false},
+		{original: "~/proj", mount: ".refs/proj", isDir: true},
+	})
+	require.Contains(t, out, "~/foo/bar.txt → .refs/foo/bar.txt")
+	require.Contains(t, out, "~/proj (directory) → .refs/proj")
+}

--- a/internal/cmd/dagger/references_test.go
+++ b/internal/cmd/dagger/references_test.go
@@ -126,3 +126,78 @@ func TestReferenceAnnotation(t *testing.T) {
 	require.Contains(t, out, "~/foo/bar.txt → .refs/foo/bar.txt")
 	require.Contains(t, out, "~/proj (directory) → .refs/proj")
 }
+
+func TestRewriteReferenceTokens(t *testing.T) {
+	// The "@" sigil is dropped and quotes/punctuation/whitespace preserved.
+	rewrite := func(line string) string {
+		return rewriteReferenceTokens(line, func(tok string) (string, bool) {
+			if tok == "/ws/foo.go" {
+				return "./foo.go", true
+			}
+			return "", false
+		})
+	}
+
+	require.Equal(t, "review ./foo.go please", rewrite("review @/ws/foo.go please"))
+	require.Equal(t, "see ./foo.go.", rewrite("see @/ws/foo.go."))
+	require.Equal(t, `open "./foo.go"`, rewrite(`open @"/ws/foo.go"`))
+
+	// Unmatched tokens (and non-references) are left exactly as typed.
+	require.Equal(t, "read @/elsewhere/x.go", rewrite("read @/elsewhere/x.go"))
+	require.Equal(t, "mail me@example.com", rewrite("mail me@example.com"))
+
+	// Original whitespace, including newlines, is preserved verbatim.
+	require.Equal(t, "  a\n\t./foo.go  b\n", rewrite("  a\n\t@/ws/foo.go  b\n"))
+}
+
+func TestWorkspaceRelativePath(t *testing.T) {
+	root := t.TempDir()
+	// t.TempDir may hand back a symlinked path (e.g. macOS /tmp); compare
+	// against the resolved form, which is what the session caches.
+	root = resolveSymlinks(root)
+	sub := filepath.Join(root, "services", "api")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	// Session pinned to a workspace rooted at root, with cwd services/api.
+	s := &LLMSession{
+		workspaceHostResolved: true,
+		workspaceHostRoot:     root,
+		workspaceHostCwd:      sub,
+	}
+	ctx := t.Context()
+
+	// Under the cwd → "./"-prefixed.
+	rel, ok := s.workspaceRelativePath(ctx, filepath.Join(sub, "main.go"))
+	require.True(t, ok)
+	require.Equal(t, "./main.go", rel)
+
+	rel, ok = s.workspaceRelativePath(ctx, filepath.Join(sub, "pkg", "x.go"))
+	require.True(t, ok)
+	require.Equal(t, "./pkg/x.go", rel)
+
+	// The cwd itself.
+	rel, ok = s.workspaceRelativePath(ctx, sub)
+	require.True(t, ok)
+	require.Equal(t, ".", rel)
+
+	// Elsewhere in the workspace → keeps its "../" prefix.
+	rel, ok = s.workspaceRelativePath(ctx, filepath.Join(root, "README.md"))
+	require.True(t, ok)
+	require.Equal(t, "../../README.md", rel)
+
+	// Outside the workspace → not workspace-relative, so it gets mounted.
+	_, ok = s.workspaceRelativePath(ctx, "/etc/hosts")
+	require.False(t, ok)
+
+	// A sibling of the root whose name merely shares its prefix is outside.
+	_, ok = s.workspaceRelativePath(ctx, root+"-other/x.go")
+	require.False(t, ok)
+}
+
+func TestWorkspaceRelativePathNonLocalWorkspace(t *testing.T) {
+	// A remote/synthetic workspace has no host root, so every @-path falls
+	// through to the mounting path.
+	s := &LLMSession{workspaceHostResolved: true}
+	_, ok := s.workspaceRelativePath(t.Context(), "/etc/hosts")
+	require.False(t, ok)
+}

--- a/internal/cmd/dagger/references_test.go
+++ b/internal/cmd/dagger/references_test.go
@@ -38,12 +38,16 @@ func TestReferenceMountRel(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Under home → relative to home.
-	require.Equal(t, "foo/bar.txt", referenceMountRel(filepath.Join(home, "foo", "bar.txt")))
-	require.Equal(t, "proj", referenceMountRel(filepath.Join(home, "proj")))
+	// Under home → "~/"-prefixed, relative to home.
+	require.Equal(t, "~/foo/bar.txt", referenceMountRel(filepath.Join(home, "foo", "bar.txt")))
+	require.Equal(t, "~/proj", referenceMountRel(filepath.Join(home, "proj")))
+	require.Equal(t, "~", referenceMountRel(home))
 
-	// Outside home → basename only.
-	require.Equal(t, "hosts", referenceMountRel("/etc/hosts"))
+	// Outside home → the full path minus the leading separator, so paths
+	// sharing a basename keep distinct mounts.
+	require.Equal(t, "etc/hosts", referenceMountRel("/etc/hosts"))
+	require.Equal(t, "tmp/frontend/config.json", referenceMountRel("/tmp/frontend/config.json"))
+	require.Equal(t, "tmp/backend/config.json", referenceMountRel("/tmp/backend/config.json"))
 }
 
 func TestExpandReferencePath(t *testing.T) {
@@ -120,11 +124,11 @@ func TestAutoCompleteReferencePath(t *testing.T) {
 
 func TestReferenceAnnotation(t *testing.T) {
 	out := referenceAnnotation([]referenceInfo{
-		{original: "~/foo/bar.txt", mount: ".refs/foo/bar.txt", isDir: false},
-		{original: "~/proj", mount: ".refs/proj", isDir: true},
+		{original: "~/foo/bar.txt", mount: ".refs/~/foo/bar.txt", isDir: false},
+		{original: "~/proj", mount: ".refs/~/proj", isDir: true},
 	})
-	require.Contains(t, out, "~/foo/bar.txt → .refs/foo/bar.txt")
-	require.Contains(t, out, "~/proj (directory) → .refs/proj")
+	require.Contains(t, out, "~/foo/bar.txt → .refs/~/foo/bar.txt")
+	require.Contains(t, out, "~/proj (directory) → .refs/~/proj")
 }
 
 func TestRewriteReferenceTokens(t *testing.T) {

--- a/internal/cmd/dagger/shell.go
+++ b/internal/cmd/dagger/shell.go
@@ -665,6 +665,15 @@ func (h *shellCallHandler) AutoComplete(input string, cursorPos int) tuist.Compl
 				ReplaceFrom: wordStart,
 			}
 		}
+		// Path completion: a word starting with "@" references a host path to
+		// hand to the agent (see attachReferences). Complete it against the host
+		// filesystem, expanding a leading "~".
+		if strings.HasPrefix(word, "@") {
+			return tuist.CompletionResult{
+				Items:       completeReferencePath(word[1:]),
+				ReplaceFrom: wordStart,
+			}
+		}
 		return tuist.CompletionResult{}
 	}
 

--- a/internal/cmd/dagger/shell_commands.go
+++ b/internal/cmd/dagger/shell_commands.go
@@ -287,6 +287,28 @@ func (h *shellCallHandler) llmBuiltins() []*ShellCommand {
 			},
 		},
 		{
+			Use:         ".effort [level]",
+			Description: "Set the LLM reasoning effort (interactive picker if no level given)",
+			GroupID:     "llm",
+			Args:        MaximumArgs(1),
+			State:       NoState,
+			Run: func(ctx context.Context, _ *ShellCommand, args []string, _ *ShellState) error {
+				if len(args) == 0 {
+					return h.selectEffortInteractive(ctx)
+				}
+				llm, err := h.llm(ctx)
+				if err != nil {
+					return err
+				}
+				newLLM, err := llm.Effort(args[0])
+				if err != nil {
+					return err
+				}
+				h.llmSession = newLLM
+				return nil
+			},
+		},
+		{
 			Use:         ".resume [session]",
 			Description: "Resume a saved session (interactive picker if no id given)",
 			GroupID:     "llm",
@@ -427,6 +449,78 @@ func (h *shellCallHandler) selectModelInteractive(ctx context.Context) error {
 	h.llmSession = newLLM
 	h.llmModel = newLLM.model
 	return nil
+}
+
+// selectEffortInteractive presents a picker of the reasoning effort levels the
+// current model supports and applies the chosen one. It mirrors the
+// ".effort <level>" path once a level is selected, and no-ops if the user
+// aborts the form.
+func (h *shellCallHandler) selectEffortInteractive(ctx context.Context) error {
+	llm, err := h.llm(ctx)
+	if err != nil {
+		return err
+	}
+
+	options := reasoningEffortOptions(h.llmModel)
+
+	var selected string
+	form := idtui.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Reasoning effort").
+				Height(min(len(options)+2, 12)).
+				Options(options...).
+				Value(&selected),
+		),
+	)
+
+	if err := Frontend.HandleForm(ctx, form); err != nil {
+		return err
+	}
+
+	if selected == "" {
+		return nil // user aborted
+	}
+
+	newLLM, err := llm.Effort(selected)
+	if err != nil {
+		return err
+	}
+	h.llmSession = newLLM
+	return nil
+}
+
+// reasoningEffortOptions builds the option list for the interactive ".effort"
+// picker from the current model's catwalk metadata: the levels the model
+// actually supports, plus "none" to disable reasoning. When the model isn't in
+// the catalog (e.g. a local or custom endpoint), it falls back to the
+// conventional low/medium/high levels.
+func reasoningEffortOptions(model string) []huh.Option[string] {
+	var levels []string
+	var defaultLevel string
+	for _, e := range llmconfig.ProviderEntries() {
+		if m, ok := llmconfig.ModelByID(e.ConfigKey, model); ok && m.CanReason {
+			levels = m.ReasoningLevels
+			defaultLevel = m.DefaultReasoningEffort
+			break
+		}
+	}
+	if len(levels) == 0 {
+		levels = []string{"low", "medium", "high"}
+	}
+	if !slices.Contains(levels, "none") {
+		levels = append([]string{"none"}, levels...)
+	}
+
+	var options []huh.Option[string]
+	for _, level := range levels {
+		label := level
+		if level == defaultLevel {
+			label += " (default)"
+		}
+		options = append(options, huh.NewOption(label, level))
+	}
+	return options
 }
 
 // availableModelOptions builds the option list for the interactive ".model"

--- a/internal/cmd/dagger/shell_commands.go
+++ b/internal/cmd/dagger/shell_commands.go
@@ -493,19 +493,27 @@ func (h *shellCallHandler) selectEffortInteractive(ctx context.Context) error {
 // reasoningEffortOptions builds the option list for the interactive ".effort"
 // picker from the current model's catwalk metadata: the levels the model
 // actually supports, plus "none" to disable reasoning. When the model isn't in
-// the catalog (e.g. a local or custom endpoint), it falls back to the
-// conventional low/medium/high levels.
+// the catalog (e.g. a local or custom endpoint), or is a reasoning-capable
+// model without explicit levels, it falls back to the conventional
+// low/medium/high levels. Known models that can't reason at all get only
+// "none".
 func reasoningEffortOptions(model string) []huh.Option[string] {
 	var levels []string
 	var defaultLevel string
+	canReason := true // unknown models get the conventional fallback below
 	for _, e := range llmconfig.ProviderEntries() {
-		if m, ok := llmconfig.ModelByID(e.ConfigKey, model); ok && m.CanReason {
+		m, ok := llmconfig.ModelByID(e.ConfigKey, model)
+		if !ok {
+			continue
+		}
+		canReason = m.CanReason
+		if m.CanReason {
 			levels = m.ReasoningLevels
 			defaultLevel = m.DefaultReasoningEffort
 			break
 		}
 	}
-	if len(levels) == 0 {
+	if canReason && len(levels) == 0 {
 		levels = []string{"low", "medium", "high"}
 	}
 	if !slices.Contains(levels, "none") {

--- a/internal/cmd/dagger/shell_commands_test.go
+++ b/internal/cmd/dagger/shell_commands_test.go
@@ -1,0 +1,30 @@
+package daggercmd
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/huh"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReasoningEffortOptions(t *testing.T) {
+	values := func(opts []huh.Option[string]) []string {
+		var vs []string
+		for _, o := range opts {
+			vs = append(vs, o.Value)
+		}
+		return vs
+	}
+
+	// Catalog model marked non-reasoning: only "none", no invented levels.
+	require.Equal(t, []string{"none"}, values(reasoningEffortOptions("ai21/jamba-large-1.7")))
+
+	// Unknown model: conventional fallback.
+	require.Equal(t, []string{"none", "low", "medium", "high"},
+		values(reasoningEffortOptions("my-local-model")))
+
+	// Catalog model that can reason but declares no explicit levels
+	// (e.g. Anthropic): conventional fallback.
+	require.Equal(t, []string{"none", "low", "medium", "high"},
+		values(reasoningEffortOptions("claude-sonnet-4-5-20250929")))
+}

--- a/internal/cmd/dagger/shell_slash_test.go
+++ b/internal/cmd/dagger/shell_slash_test.go
@@ -33,6 +33,7 @@ func TestPromptSlashCommandMapping(t *testing.T) {
 		// arguments are carried through verbatim
 		{"/resume abc123", ".resume abc123", true},
 		{"/model claude-sonnet-4-5", ".model claude-sonnet-4-5", true},
+		{"/effort high", ".effort high", true},
 		{"/help\tcreate", ".help\tcreate", true},
 		// hidden builtins are still runnable as slash commands
 		{"/cd ./sub", ".cd ./sub", true},

--- a/sdk/elixir/lib/dagger/gen/llm.ex
+++ b/sdk/elixir/lib/dagger/gen/llm.ex
@@ -159,6 +159,17 @@ defmodule Dagger.LLM do
   end
 
   @doc """
+  The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.
+  """
+  @spec reasoning_effort(t()) :: {:ok, String.t()} | {:error, term()}
+  def reasoning_effort(%__MODULE__{} = llm) do
+    query_builder =
+      llm.query_builder |> QB.select("reasoningEffort")
+
+    Client.execute(llm.client, query_builder)
+  end
+
+  @doc """
   Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.
   """
   @spec replay(t()) :: {:ok, Dagger.LLM.t()} | {:error, term()}
@@ -330,6 +341,20 @@ defmodule Dagger.LLM do
   def with_prompt_file(%__MODULE__{} = llm, file) do
     query_builder =
       llm.query_builder |> QB.select("withPromptFile") |> QB.put_arg("file", Dagger.ID.id!(file))
+
+    %Dagger.LLM{
+      query_builder: query_builder,
+      client: llm.client
+    }
+  end
+
+  @doc """
+  Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.
+  """
+  @spec with_reasoning_effort(t(), String.t()) :: Dagger.LLM.t()
+  def with_reasoning_effort(%__MODULE__{} = llm, effort) do
+    query_builder =
+      llm.query_builder |> QB.select("withReasoningEffort") |> QB.put_arg("effort", effort)
 
     %Dagger.LLM{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -625,6 +625,44 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
+  Return this workspace with a directory mounted read-only under the reserved references prefix.
+
+  Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+  """
+  @spec with_reference_directory(t(), String.t(), Dagger.Directory.t()) :: Dagger.Workspace.t()
+  def with_reference_directory(%__MODULE__{} = workspace, path, source) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("withReferenceDirectory")
+      |> QB.put_arg("path", path)
+      |> QB.put_arg("source", Dagger.ID.id!(source))
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
+
+  @doc """
+  Return this workspace with a file mounted read-only under the reserved references prefix.
+
+  Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+  """
+  @spec with_reference_file(t(), String.t(), Dagger.File.t()) :: Dagger.Workspace.t()
+  def with_reference_file(%__MODULE__{} = workspace, path, source) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("withReferenceFile")
+      |> QB.put_arg("path", path)
+      |> QB.put_arg("source", Dagger.ID.id!(source))
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
+
+  @doc """
   Return this workspace with an SDK installed in its config.
   """
   @spec with_sdk(t(), String.t(), [

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -589,6 +589,44 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
+  Return this workspace with a directory mounted read-only at the given path, without mutating the source.
+
+  Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+  """
+  @spec with_mounted_directory(t(), String.t(), Dagger.Directory.t()) :: Dagger.Workspace.t()
+  def with_mounted_directory(%__MODULE__{} = workspace, path, source) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("withMountedDirectory")
+      |> QB.put_arg("path", path)
+      |> QB.put_arg("source", Dagger.ID.id!(source))
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
+
+  @doc """
+  Return this workspace with a file mounted read-only at the given path, without mutating the source.
+
+  Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+  """
+  @spec with_mounted_file(t(), String.t(), Dagger.File.t()) :: Dagger.Workspace.t()
+  def with_mounted_file(%__MODULE__{} = workspace, path, source) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("withMountedFile")
+      |> QB.put_arg("path", path)
+      |> QB.put_arg("source", Dagger.ID.id!(source))
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
+
+  @doc """
   Return this workspace with a directory added, without mutating the source.
   """
   @spec with_new_directory(t(), String.t(), Dagger.Directory.t()) :: Dagger.Workspace.t()
@@ -617,44 +655,6 @@ defmodule Dagger.Workspace do
       |> QB.put_arg("path", path)
       |> QB.put_arg("contents", contents)
       |> QB.maybe_put_arg("permissions", optional_args[:permissions])
-
-    %Dagger.Workspace{
-      query_builder: query_builder,
-      client: workspace.client
-    }
-  end
-
-  @doc """
-  Return this workspace with a directory mounted read-only under the reserved references prefix.
-
-  Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-  """
-  @spec with_reference_directory(t(), String.t(), Dagger.Directory.t()) :: Dagger.Workspace.t()
-  def with_reference_directory(%__MODULE__{} = workspace, path, source) do
-    query_builder =
-      workspace.query_builder
-      |> QB.select("withReferenceDirectory")
-      |> QB.put_arg("path", path)
-      |> QB.put_arg("source", Dagger.ID.id!(source))
-
-    %Dagger.Workspace{
-      query_builder: query_builder,
-      client: workspace.client
-    }
-  end
-
-  @doc """
-  Return this workspace with a file mounted read-only under the reserved references prefix.
-
-  Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-  """
-  @spec with_reference_file(t(), String.t(), Dagger.File.t()) :: Dagger.Workspace.t()
-  def with_reference_file(%__MODULE__{} = workspace, path, source) do
-    query_builder =
-      workspace.query_builder
-      |> QB.select("withReferenceFile")
-      |> QB.put_arg("path", path)
-      |> QB.put_arg("source", Dagger.ID.id!(source))
 
     %Dagger.Workspace{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16593,6 +16593,34 @@ func (r *Workspace) WithNewFile(path string, contents string, opts ...WorkspaceW
 	}
 }
 
+// Return this workspace with a directory mounted read-only under the reserved references prefix.
+//
+// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+func (r *Workspace) WithReferenceDirectory(path string, source *Directory) *Workspace {
+	assertNotNil("source", source)
+	q := r.query.Select("withReferenceDirectory")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
+// Return this workspace with a file mounted read-only under the reserved references prefix.
+//
+// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+func (r *Workspace) WithReferenceFile(path string, source *File) *Workspace {
+	assertNotNil("source", source)
+	q := r.query.Select("withReferenceFile")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // WorkspaceWithSDKOpts contains options for Workspace.WithSDK
 type WorkspaceWithSDKOpts struct {
 	// Override name for the installed SDK entry.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16580,6 +16580,34 @@ func (r *Workspace) WithModule(ref string, opts ...WorkspaceWithModuleOpts) *Wor
 	}
 }
 
+// Return this workspace with a directory mounted read-only at the given path, without mutating the source.
+//
+// Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+func (r *Workspace) WithMountedDirectory(path string, source *Directory) *Workspace {
+	assertNotNil("source", source)
+	q := r.query.Select("withMountedDirectory")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
+// Return this workspace with a file mounted read-only at the given path, without mutating the source.
+//
+// Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+func (r *Workspace) WithMountedFile(path string, source *File) *Workspace {
+	assertNotNil("source", source)
+	q := r.query.Select("withMountedFile")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // Return this workspace with a directory added, without mutating the source.
 func (r *Workspace) WithNewDirectory(path string, source *Directory) *Workspace {
 	assertNotNil("source", source)
@@ -16611,34 +16639,6 @@ func (r *Workspace) WithNewFile(path string, contents string, opts ...WorkspaceW
 	}
 	q = q.Arg("path", path)
 	q = q.Arg("contents", contents)
-
-	return &Workspace{
-		query: q,
-	}
-}
-
-// Return this workspace with a directory mounted read-only under the reserved references prefix.
-//
-// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-func (r *Workspace) WithReferenceDirectory(path string, source *Directory) *Workspace {
-	assertNotNil("source", source)
-	q := r.query.Select("withReferenceDirectory")
-	q = q.Arg("path", path)
-	q = q.Arg("source", source)
-
-	return &Workspace{
-		query: q,
-	}
-}
-
-// Return this workspace with a file mounted read-only under the reserved references prefix.
-//
-// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-func (r *Workspace) WithReferenceFile(path string, source *File) *Workspace {
-	assertNotNil("source", source)
-	q := r.query.Select("withReferenceFile")
-	q = q.Arg("path", path)
-	q = q.Arg("source", source)
 
 	return &Workspace{
 		query: q,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -10081,18 +10081,19 @@ func (r *JSONValue) AsNode() Node {
 type LLM struct {
 	query *querybuilder.Selection
 
-	contextTokens *int
-	contextWindow *int
-	hasPending    *bool
-	id            *ID
-	lastReply     *string
-	model         *string
-	portableID    *ID
-	provider      *string
-	replay        *ID
-	sync          *ID
-	tools         *string
-	transcript    *string
+	contextTokens   *int
+	contextWindow   *int
+	hasPending      *bool
+	id              *ID
+	lastReply       *string
+	model           *string
+	portableID      *ID
+	provider        *string
+	reasoningEffort *string
+	replay          *ID
+	sync            *ID
+	tools           *string
+	transcript      *string
 }
 type WithLLMFunc func(r *LLM) *LLM
 
@@ -10310,6 +10311,19 @@ func (r *LLM) Provider(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
+// The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.
+func (r *LLM) ReasoningEffort(ctx context.Context) (string, error) {
+	if r.reasoningEffort != nil {
+		return *r.reasoningEffort, nil
+	}
+	q := r.query.Select("reasoningEffort")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.
 func (r *LLM) Replay(ctx context.Context) (*LLM, error) {
 	q := r.query.Select("replay")
@@ -10474,6 +10488,16 @@ func (r *LLM) WithPromptFile(file *File) *LLM {
 	assertNotNil("file", file)
 	q := r.query.Select("withPromptFile")
 	q = q.Arg("file", file)
+
+	return &LLM{
+		query: q,
+	}
+}
+
+// Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.
+func (r *LLM) WithReasoningEffort(effort string) *LLM {
+	q := r.query.Select("withReasoningEffort")
+	q = q.Arg("effort", effort)
 
 	return &LLM{
 		query: q,

--- a/sdk/php/generated/LLM.php
+++ b/sdk/php/generated/LLM.php
@@ -120,6 +120,15 @@ class LLM extends Client\AbstractObject implements Client\IdAble, Node, Syncer
     }
 
     /**
+     * The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.
+     */
+    public function reasoningEffort(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('reasoningEffort');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'reasoningEffort');
+    }
+
+    /**
      * Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.
      */
     public function replay(): LLM
@@ -228,6 +237,16 @@ class LLM extends Client\AbstractObject implements Client\IdAble, Node, Syncer
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withPromptFile');
         $innerQueryBuilder->setArgument('file', $file);
+        return new \Dagger\LLM($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.
+     */
+    public function withReasoningEffort(string $effort): LLM
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withReasoningEffort');
+        $innerQueryBuilder->setArgument('effort', $effort);
         return new \Dagger\LLM($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -513,6 +513,32 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
+     * Return this workspace with a directory mounted read-only under the reserved references prefix.
+     *
+     * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+     */
+    public function withReferenceDirectory(string $path, Directory $source): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withReferenceDirectory');
+        $innerQueryBuilder->setArgument('path', $path);
+        $innerQueryBuilder->setArgument('source', $source);
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Return this workspace with a file mounted read-only under the reserved references prefix.
+     *
+     * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+     */
+    public function withReferenceFile(string $path, File $source): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withReferenceFile');
+        $innerQueryBuilder->setArgument('path', $path);
+        $innerQueryBuilder->setArgument('source', $source);
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Return this workspace with an SDK installed in its config.
      */
     public function withSDK(string $ref, ?string $name = '', ?bool $here = false, ?string $asSdkName = ''): Workspace

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -488,6 +488,32 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
+     * Return this workspace with a directory mounted read-only at the given path, without mutating the source.
+     *
+     * Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+     */
+    public function withMountedDirectory(string $path, Directory $source): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedDirectory');
+        $innerQueryBuilder->setArgument('path', $path);
+        $innerQueryBuilder->setArgument('source', $source);
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Return this workspace with a file mounted read-only at the given path, without mutating the source.
+     *
+     * Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+     */
+    public function withMountedFile(string $path, File $source): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedFile');
+        $innerQueryBuilder->setArgument('path', $path);
+        $innerQueryBuilder->setArgument('source', $source);
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Return this workspace with a directory added, without mutating the source.
      */
     public function withNewDirectory(string $path, Directory $source): Workspace
@@ -509,32 +535,6 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
         if (null !== $permissions) {
         $innerQueryBuilder->setArgument('permissions', $permissions);
         }
-        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
-     * Return this workspace with a directory mounted read-only under the reserved references prefix.
-     *
-     * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-     */
-    public function withReferenceDirectory(string $path, Directory $source): Workspace
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withReferenceDirectory');
-        $innerQueryBuilder->setArgument('path', $path);
-        $innerQueryBuilder->setArgument('source', $source);
-        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
-     * Return this workspace with a file mounted read-only under the reserved references prefix.
-     *
-     * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-     */
-    public function withReferenceFile(string $path, File $source): Workspace
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withReferenceFile');
-        $innerQueryBuilder->setArgument('path', $path);
-        $innerQueryBuilder->setArgument('source', $source);
         return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15563,8 +15563,12 @@ class Workspace(Type):
         *,
         args: JSON | None = None,
         here: bool | None = False,
+        no_generate: bool | None = False,
     ) -> Self:
         """Return this workspace with a generated API client initialized.
+
+        The SDK's generators run for the new client, so the returned workspace
+        carries its generated bindings.
 
         Parameters
         ----------
@@ -15579,6 +15583,8 @@ class Workspace(Type):
             SDK-specific init arguments.
         here:
             Write to the workspace config directory at the workspace cwd.
+        no_generate:
+            Skip running the SDK's generators for the new client.
         """
         _args = [
             Arg("path", path),
@@ -15586,6 +15592,7 @@ class Workspace(Type):
             Arg("module", module),
             Arg("args", args, None),
             Arg("here", here, False),
+            Arg("noGenerate", no_generate, False),
         ]
         _ctx = self._select("withInitClient", _args)
         return Workspace(_ctx)
@@ -15600,8 +15607,12 @@ class Workspace(Type):
         include: list[str] | None = None,
         args: JSON | None = None,
         here: bool | None = False,
+        no_generate: bool | None = False,
     ) -> Self:
         """Return this workspace with a new module initialized.
+
+        The SDK's generators run for the new module, so the returned workspace
+        carries the generated code it needs to be loadable.
 
         Parameters
         ----------
@@ -15619,6 +15630,8 @@ class Workspace(Type):
             SDK-specific init arguments.
         here:
             Write to the workspace config directory at the workspace cwd.
+        no_generate:
+            Skip running the SDK's generators for the new module.
         """
         _args = [
             Arg("name", name),
@@ -15628,6 +15641,7 @@ class Workspace(Type):
             Arg("include", [] if include is None else include, []),
             Arg("args", args, None),
             Arg("here", here, False),
+            Arg("noGenerate", no_generate, False),
         ]
         _ctx = self._select("withInitModule", _args)
         return Workspace(_ctx)
@@ -15656,6 +15670,54 @@ class Workspace(Type):
             Arg("here", here, False),
         ]
         _ctx = self._select("withModule", _args)
+        return Workspace(_ctx)
+
+    def with_mounted_directory(self, path: str, source: Directory) -> Self:
+        """Return this workspace with a directory mounted read-only at the given
+        path, without mutating the source.
+
+        Mounted content is readable through the normal workspace file tools
+        but shadows the source at the mount path and stays out of the pending
+        changeset: it never appears in changes, is never exported, and cannot
+        be modified.
+
+        Parameters
+        ----------
+        path:
+            Location of the mounted directory. Relative paths resolve from the
+            workspace cwd.
+        source:
+            Directory to mount.
+        """
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withMountedDirectory", _args)
+        return Workspace(_ctx)
+
+    def with_mounted_file(self, path: str, source: File) -> Self:
+        """Return this workspace with a file mounted read-only at the given path,
+        without mutating the source.
+
+        Mounted content is readable through the normal workspace file tools
+        but shadows the source at the mount path and stays out of the pending
+        changeset: it never appears in changes, is never exported, and cannot
+        be modified.
+
+        Parameters
+        ----------
+        path:
+            Location of the mounted file. Relative paths resolve from the
+            workspace cwd.
+        source:
+            File to mount.
+        """
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withMountedFile", _args)
         return Workspace(_ctx)
 
     def with_new_directory(self, path: str, source: Directory) -> Self:
@@ -15703,52 +15765,6 @@ class Workspace(Type):
             Arg("permissions", permissions, 420),
         ]
         _ctx = self._select("withNewFile", _args)
-        return Workspace(_ctx)
-
-    def with_reference_directory(self, path: str, source: Directory) -> Self:
-        """Return this workspace with a directory mounted read-only under the
-        reserved references prefix.
-
-        Referenced content is readable through the normal workspace file tools
-        but is excluded from the pending changeset: it never appears in
-        changes and is never exported.
-
-        Parameters
-        ----------
-        path:
-            Reference-relative mount path under the reserved references
-            prefix.
-        source:
-            Directory to mount read-only.
-        """
-        _args = [
-            Arg("path", path),
-            Arg("source", source),
-        ]
-        _ctx = self._select("withReferenceDirectory", _args)
-        return Workspace(_ctx)
-
-    def with_reference_file(self, path: str, source: File) -> Self:
-        """Return this workspace with a file mounted read-only under the reserved
-        references prefix.
-
-        Referenced content is readable through the normal workspace file tools
-        but is excluded from the pending changeset: it never appears in
-        changes and is never exported.
-
-        Parameters
-        ----------
-        path:
-            Reference-relative mount path under the reserved references
-            prefix.
-        source:
-            File to mount read-only.
-        """
-        _args = [
-            Arg("path", path),
-            Arg("source", source),
-        ]
-        _ctx = self._select("withReferenceFile", _args)
         return Workspace(_ctx)
 
     def with_sdk(

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -9955,6 +9955,28 @@ class LLM(Type):
         _ctx = self._select("provider", _args)
         return await _ctx.execute(str)
 
+    async def reasoning_effort(self) -> str:
+        """The reasoning effort in use, e.g. "low", "medium", or "high". Empty or
+        "none" when reasoning is disabled.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("reasoningEffort", _args)
+        return await _ctx.execute(str)
+
     async def replay(self) -> Self:
         """Re-emit telemetry spans for the full message history, so a loaded
         conversation displays in the TUI.
@@ -10132,6 +10154,24 @@ class LLM(Type):
             Arg("file", file),
         ]
         _ctx = self._select("withPromptFile", _args)
+        return LLM(_ctx)
+
+    def with_reasoning_effort(self, effort: str) -> Self:
+        """Change the reasoning effort for the rest of the conversation,
+        overriding any configured default. The message history is preserved;
+        the new effort takes effect on the next step.
+
+        Parameters
+        ----------
+        effort:
+            The reasoning effort, e.g. "low", "medium", or "high"; "none"
+            disables reasoning. Supported levels are model-specific — some
+            models also accept e.g. "minimal", "xhigh", or "max".
+        """
+        _args = [
+            Arg("effort", effort),
+        ]
+        _ctx = self._select("withReasoningEffort", _args)
         return LLM(_ctx)
 
     def with_response(
@@ -15523,12 +15563,8 @@ class Workspace(Type):
         *,
         args: JSON | None = None,
         here: bool | None = False,
-        no_generate: bool | None = False,
     ) -> Self:
         """Return this workspace with a generated API client initialized.
-
-        The SDK's generators run for the new client, so the returned workspace
-        carries its generated bindings.
 
         Parameters
         ----------
@@ -15543,8 +15579,6 @@ class Workspace(Type):
             SDK-specific init arguments.
         here:
             Write to the workspace config directory at the workspace cwd.
-        no_generate:
-            Skip running the SDK's generators for the new client.
         """
         _args = [
             Arg("path", path),
@@ -15552,7 +15586,6 @@ class Workspace(Type):
             Arg("module", module),
             Arg("args", args, None),
             Arg("here", here, False),
-            Arg("noGenerate", no_generate, False),
         ]
         _ctx = self._select("withInitClient", _args)
         return Workspace(_ctx)
@@ -15567,12 +15600,8 @@ class Workspace(Type):
         include: list[str] | None = None,
         args: JSON | None = None,
         here: bool | None = False,
-        no_generate: bool | None = False,
     ) -> Self:
         """Return this workspace with a new module initialized.
-
-        The SDK's generators run for the new module, so the returned workspace
-        carries the generated code it needs to be loadable.
 
         Parameters
         ----------
@@ -15590,8 +15619,6 @@ class Workspace(Type):
             SDK-specific init arguments.
         here:
             Write to the workspace config directory at the workspace cwd.
-        no_generate:
-            Skip running the SDK's generators for the new module.
         """
         _args = [
             Arg("name", name),
@@ -15601,7 +15628,6 @@ class Workspace(Type):
             Arg("include", [] if include is None else include, []),
             Arg("args", args, None),
             Arg("here", here, False),
-            Arg("noGenerate", no_generate, False),
         ]
         _ctx = self._select("withInitModule", _args)
         return Workspace(_ctx)
@@ -15677,6 +15703,52 @@ class Workspace(Type):
             Arg("permissions", permissions, 420),
         ]
         _ctx = self._select("withNewFile", _args)
+        return Workspace(_ctx)
+
+    def with_reference_directory(self, path: str, source: Directory) -> Self:
+        """Return this workspace with a directory mounted read-only under the
+        reserved references prefix.
+
+        Referenced content is readable through the normal workspace file tools
+        but is excluded from the pending changeset: it never appears in
+        changes and is never exported.
+
+        Parameters
+        ----------
+        path:
+            Reference-relative mount path under the reserved references
+            prefix.
+        source:
+            Directory to mount read-only.
+        """
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withReferenceDirectory", _args)
+        return Workspace(_ctx)
+
+    def with_reference_file(self, path: str, source: File) -> Self:
+        """Return this workspace with a file mounted read-only under the reserved
+        references prefix.
+
+        Referenced content is readable through the normal workspace file tools
+        but is excluded from the pending changeset: it never appears in
+        changes and is never exported.
+
+        Parameters
+        ----------
+        path:
+            Reference-relative mount path under the reserved references
+            prefix.
+        source:
+            File to mount read-only.
+        """
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withReferenceFile", _args)
         return Workspace(_ctx)
 
     def with_sdk(

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -14953,6 +14953,9 @@ pub struct WorkspaceWithInitClientOpts {
     /// Write to the workspace config directory at the workspace cwd.
     #[builder(setter(into, strip_option), default)]
     pub here: Option<bool>,
+    /// Skip running the SDK's generators for the new client.
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceWithInitModuleOpts<'a> {
@@ -14965,6 +14968,9 @@ pub struct WorkspaceWithInitModuleOpts<'a> {
     /// Additional include patterns for the module.
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
+    /// Skip running the SDK's generators for the new module.
+    #[builder(setter(into, strip_option), default)]
+    pub no_generate: Option<bool>,
     /// Workspace-relative path for the new module.
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
@@ -15645,6 +15651,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a generated API client initialized.
+    /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
     /// # Arguments
     ///
@@ -15669,6 +15676,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a generated API client initialized.
+    /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
     /// # Arguments
     ///
@@ -15693,6 +15701,9 @@ impl Workspace {
         if let Some(here) = opts.here {
             query = query.arg("here", here);
         }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
+        }
         Workspace {
             proc: self.proc.clone(),
             selection: query,
@@ -15700,6 +15711,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a new module initialized.
+    /// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
     ///
     /// # Arguments
     ///
@@ -15717,6 +15729,7 @@ impl Workspace {
         }
     }
     /// Return this workspace with a new module initialized.
+    /// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
     ///
     /// # Arguments
     ///
@@ -15746,6 +15759,9 @@ impl Workspace {
         }
         if let Some(here) = opts.here {
             query = query.arg("here", here);
+        }
+        if let Some(no_generate) = opts.no_generate {
+            query = query.arg("noGenerate", no_generate);
         }
         Workspace {
             proc: self.proc.clone(),
@@ -15787,6 +15803,56 @@ impl Workspace {
         if let Some(here) = opts.here {
             query = query.arg("here", here);
         }
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return this workspace with a directory mounted read-only at the given path, without mutating the source.
+    /// Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the mounted directory. Relative paths resolve from the workspace cwd.
+    /// * `source` - Directory to mount.
+    pub fn with_mounted_directory(
+        &self,
+        path: impl Into<String>,
+        source: impl IntoID<Id>,
+    ) -> Workspace {
+        let mut query = self.selection.select("withMountedDirectory");
+        query = query.arg("path", path.into());
+        query = query.arg_lazy(
+            "source",
+            Box::new(move || {
+                let source = source.clone();
+                Box::pin(async move { source.into_id().await.unwrap().quote() })
+            }),
+        );
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return this workspace with a file mounted read-only at the given path, without mutating the source.
+    /// Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the mounted file. Relative paths resolve from the workspace cwd.
+    /// * `source` - File to mount.
+    pub fn with_mounted_file(&self, path: impl Into<String>, source: impl IntoID<Id>) -> Workspace {
+        let mut query = self.selection.select("withMountedFile");
+        query = query.arg("path", path.into());
+        query = query.arg_lazy(
+            "source",
+            Box::new(move || {
+                let source = source.clone();
+                Box::pin(async move { source.into_id().await.unwrap().quote() })
+            }),
+        );
         Workspace {
             proc: self.proc.clone(),
             selection: query,
@@ -15855,60 +15921,6 @@ impl Workspace {
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-        Workspace {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
-    /// Return this workspace with a directory mounted read-only under the reserved references prefix.
-    /// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Reference-relative mount path under the reserved references prefix.
-    /// * `source` - Directory to mount read-only.
-    pub fn with_reference_directory(
-        &self,
-        path: impl Into<String>,
-        source: impl IntoID<Id>,
-    ) -> Workspace {
-        let mut query = self.selection.select("withReferenceDirectory");
-        query = query.arg("path", path.into());
-        query = query.arg_lazy(
-            "source",
-            Box::new(move || {
-                let source = source.clone();
-                Box::pin(async move { source.into_id().await.unwrap().quote() })
-            }),
-        );
-        Workspace {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
-    /// Return this workspace with a file mounted read-only under the reserved references prefix.
-    /// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Reference-relative mount path under the reserved references prefix.
-    /// * `source` - File to mount read-only.
-    pub fn with_reference_file(
-        &self,
-        path: impl Into<String>,
-        source: impl IntoID<Id>,
-    ) -> Workspace {
-        let mut query = self.selection.select("withReferenceFile");
-        query = query.arg("path", path.into());
-        query = query.arg_lazy(
-            "source",
-            Box::new(move || {
-                let source = source.clone();
-                Box::pin(async move { source.into_id().await.unwrap().quote() })
-            }),
-        );
         Workspace {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -10095,6 +10095,11 @@ impl Llm {
         let query = self.selection.select("provider");
         query.execute(self.graphql_client.clone()).await
     }
+    /// The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.
+    pub async fn reasoning_effort(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("reasoningEffort");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.
     pub async fn replay(&self) -> Result<Llm, DaggerError> {
         let query = self.selection.select("replay");
@@ -10271,6 +10276,20 @@ impl Llm {
                 Box::pin(async move { file.into_id().await.unwrap().quote() })
             }),
         );
+        Llm {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.
+    ///
+    /// # Arguments
+    ///
+    /// * `effort` - The reasoning effort, e.g. "low", "medium", or "high"; "none" disables reasoning. Supported levels are model-specific — some models also accept e.g. "minimal", "xhigh", or "max".
+    pub fn with_reasoning_effort(&self, effort: impl Into<String>) -> Llm {
+        let mut query = self.selection.select("withReasoningEffort");
+        query = query.arg("effort", effort.into());
         Llm {
             proc: self.proc.clone(),
             selection: query,
@@ -14934,9 +14953,6 @@ pub struct WorkspaceWithInitClientOpts {
     /// Write to the workspace config directory at the workspace cwd.
     #[builder(setter(into, strip_option), default)]
     pub here: Option<bool>,
-    /// Skip running the SDK's generators for the new client.
-    #[builder(setter(into, strip_option), default)]
-    pub no_generate: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceWithInitModuleOpts<'a> {
@@ -14949,9 +14965,6 @@ pub struct WorkspaceWithInitModuleOpts<'a> {
     /// Additional include patterns for the module.
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
-    /// Skip running the SDK's generators for the new module.
-    #[builder(setter(into, strip_option), default)]
-    pub no_generate: Option<bool>,
     /// Workspace-relative path for the new module.
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
@@ -15632,7 +15645,6 @@ impl Workspace {
         }
     }
     /// Return this workspace with a generated API client initialized.
-    /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
     /// # Arguments
     ///
@@ -15657,7 +15669,6 @@ impl Workspace {
         }
     }
     /// Return this workspace with a generated API client initialized.
-    /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
     /// # Arguments
     ///
@@ -15682,9 +15693,6 @@ impl Workspace {
         if let Some(here) = opts.here {
             query = query.arg("here", here);
         }
-        if let Some(no_generate) = opts.no_generate {
-            query = query.arg("noGenerate", no_generate);
-        }
         Workspace {
             proc: self.proc.clone(),
             selection: query,
@@ -15692,7 +15700,6 @@ impl Workspace {
         }
     }
     /// Return this workspace with a new module initialized.
-    /// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
     ///
     /// # Arguments
     ///
@@ -15710,7 +15717,6 @@ impl Workspace {
         }
     }
     /// Return this workspace with a new module initialized.
-    /// The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
     ///
     /// # Arguments
     ///
@@ -15740,9 +15746,6 @@ impl Workspace {
         }
         if let Some(here) = opts.here {
             query = query.arg("here", here);
-        }
-        if let Some(no_generate) = opts.no_generate {
-            query = query.arg("noGenerate", no_generate);
         }
         Workspace {
             proc: self.proc.clone(),
@@ -15852,6 +15855,60 @@ impl Workspace {
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return this workspace with a directory mounted read-only under the reserved references prefix.
+    /// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Reference-relative mount path under the reserved references prefix.
+    /// * `source` - Directory to mount read-only.
+    pub fn with_reference_directory(
+        &self,
+        path: impl Into<String>,
+        source: impl IntoID<Id>,
+    ) -> Workspace {
+        let mut query = self.selection.select("withReferenceDirectory");
+        query = query.arg("path", path.into());
+        query = query.arg_lazy(
+            "source",
+            Box::new(move || {
+                let source = source.clone();
+                Box::pin(async move { source.into_id().await.unwrap().quote() })
+            }),
+        );
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return this workspace with a file mounted read-only under the reserved references prefix.
+    /// Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Reference-relative mount path under the reserved references prefix.
+    /// * `source` - File to mount read-only.
+    pub fn with_reference_file(
+        &self,
+        path: impl Into<String>,
+        source: impl IntoID<Id>,
+    ) -> Workspace {
+        let mut query = self.selection.select("withReferenceFile");
+        query = query.arg("path", path.into());
+        query = query.arg_lazy(
+            "source",
+            Box::new(move || {
+                let source = source.clone();
+                Box::pin(async move { source.into_id().await.unwrap().quote() })
+            }),
+        );
         Workspace {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3248,6 +3248,11 @@ export type WorkspaceWithInitClientOpts = {
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
+
+  /**
+   * Skip running the SDK's generators for the new client.
+   */
+  noGenerate?: boolean
 }
 
 export type WorkspaceWithInitModuleOpts = {
@@ -3275,6 +3280,11 @@ export type WorkspaceWithInitModuleOpts = {
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
+
+  /**
+   * Skip running the SDK's generators for the new module.
+   */
+  noGenerate?: boolean
 }
 
 export type WorkspaceWithModuleOpts = {
@@ -15200,11 +15210,14 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a generated API client initialized.
+   *
+   * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
    * @param path Workspace-relative output directory for the generated client.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param module Workspace-relative path or canonical ref for the module the client binds to.
    * @param opts.args SDK-specific init arguments.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
+   * @param opts.noGenerate Skip running the SDK's generators for the new client.
    */
   withInitClient = (
     path: string,
@@ -15223,6 +15236,8 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a new module initialized.
+   *
+   * The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
    * @param name Name of the new module.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param opts.path Workspace-relative path for the new module.
@@ -15230,6 +15245,7 @@ export class Workspace extends BaseClient {
    * @param opts.include Additional include patterns for the module.
    * @param opts.args SDK-specific init arguments.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
+   * @param opts.noGenerate Skip running the SDK's generators for the new module.
    */
   withInitModule = (
     name: string,
@@ -15248,6 +15264,30 @@ export class Workspace extends BaseClient {
    */
   withModule = (ref: string, opts?: WorkspaceWithModuleOpts): Workspace => {
     const ctx = this._ctx.select("withModule", { ref, ...opts })
+    return new Workspace(ctx)
+  }
+
+  /**
+   * Return this workspace with a directory mounted read-only at the given path, without mutating the source.
+   *
+   * Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+   * @param path Location of the mounted directory. Relative paths resolve from the workspace cwd.
+   * @param source Directory to mount.
+   */
+  withMountedDirectory = (path: string, source: Directory): Workspace => {
+    const ctx = this._ctx.select("withMountedDirectory", { path, source })
+    return new Workspace(ctx)
+  }
+
+  /**
+   * Return this workspace with a file mounted read-only at the given path, without mutating the source.
+   *
+   * Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
+   * @param path Location of the mounted file. Relative paths resolve from the workspace cwd.
+   * @param source File to mount.
+   */
+  withMountedFile = (path: string, source: File): Workspace => {
+    const ctx = this._ctx.select("withMountedFile", { path, source })
     return new Workspace(ctx)
   }
 
@@ -15273,30 +15313,6 @@ export class Workspace extends BaseClient {
     opts?: WorkspaceWithNewFileOpts,
   ): Workspace => {
     const ctx = this._ctx.select("withNewFile", { path, contents, ...opts })
-    return new Workspace(ctx)
-  }
-
-  /**
-   * Return this workspace with a directory mounted read-only under the reserved references prefix.
-   *
-   * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-   * @param path Reference-relative mount path under the reserved references prefix.
-   * @param source Directory to mount read-only.
-   */
-  withReferenceDirectory = (path: string, source: Directory): Workspace => {
-    const ctx = this._ctx.select("withReferenceDirectory", { path, source })
-    return new Workspace(ctx)
-  }
-
-  /**
-   * Return this workspace with a file mounted read-only under the reserved references prefix.
-   *
-   * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
-   * @param path Reference-relative mount path under the reserved references prefix.
-   * @param source File to mount read-only.
-   */
-  withReferenceFile = (path: string, source: File): Workspace => {
-    const ctx = this._ctx.select("withReferenceFile", { path, source })
     return new Workspace(ctx)
   }
 

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3248,11 +3248,6 @@ export type WorkspaceWithInitClientOpts = {
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
-
-  /**
-   * Skip running the SDK's generators for the new client.
-   */
-  noGenerate?: boolean
 }
 
 export type WorkspaceWithInitModuleOpts = {
@@ -3280,11 +3275,6 @@ export type WorkspaceWithInitModuleOpts = {
    * Write to the workspace config directory at the workspace cwd.
    */
   here?: boolean
-
-  /**
-   * Skip running the SDK's generators for the new module.
-   */
-  noGenerate?: boolean
 }
 
 export type WorkspaceWithModuleOpts = {
@@ -10427,6 +10417,7 @@ export class LLM extends BaseClient {
   private readonly _model?: string = undefined
   private readonly _portableID?: ID = undefined
   private readonly _provider?: string = undefined
+  private readonly _reasoningEffort?: string = undefined
   private readonly _replay?: ID = undefined
   private readonly _sync?: ID = undefined
   private readonly _tools?: string = undefined
@@ -10445,6 +10436,7 @@ export class LLM extends BaseClient {
     _model?: string,
     _portableID?: ID,
     _provider?: string,
+    _reasoningEffort?: string,
     _replay?: ID,
     _sync?: ID,
     _tools?: string,
@@ -10460,6 +10452,7 @@ export class LLM extends BaseClient {
     this._model = _model
     this._portableID = _portableID
     this._provider = _provider
+    this._reasoningEffort = _reasoningEffort
     this._replay = _replay
     this._sync = _sync
     this._tools = _tools
@@ -10623,6 +10616,21 @@ export class LLM extends BaseClient {
   }
 
   /**
+   * The reasoning effort in use, e.g. "low", "medium", or "high". Empty or "none" when reasoning is disabled.
+   */
+  reasoningEffort = async (): Promise<string> => {
+    if (this._reasoningEffort) {
+      return this._reasoningEffort
+    }
+
+    const ctx = this._ctx.select("reasoningEffort")
+
+    const response: Awaited<string> = await ctx.execute()
+
+    return response
+  }
+
+  /**
    * Re-emit telemetry spans for the full message history, so a loaded conversation displays in the TUI.
    */
   replay = async (): Promise<LLM> => {
@@ -10743,6 +10751,15 @@ export class LLM extends BaseClient {
    */
   withPromptFile = (file: File): LLM => {
     const ctx = this._ctx.select("withPromptFile", { file })
+    return new LLM(ctx)
+  }
+
+  /**
+   * Change the reasoning effort for the rest of the conversation, overriding any configured default. The message history is preserved; the new effort takes effect on the next step.
+   * @param effort The reasoning effort, e.g. "low", "medium", or "high"; "none" disables reasoning. Supported levels are model-specific — some models also accept e.g. "minimal", "xhigh", or "max".
+   */
+  withReasoningEffort = (effort: string): LLM => {
+    const ctx = this._ctx.select("withReasoningEffort", { effort })
     return new LLM(ctx)
   }
 
@@ -15183,14 +15200,11 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a generated API client initialized.
-   *
-   * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
    * @param path Workspace-relative output directory for the generated client.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param module Workspace-relative path or canonical ref for the module the client binds to.
    * @param opts.args SDK-specific init arguments.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
-   * @param opts.noGenerate Skip running the SDK's generators for the new client.
    */
   withInitClient = (
     path: string,
@@ -15209,8 +15223,6 @@ export class Workspace extends BaseClient {
 
   /**
    * Return this workspace with a new module initialized.
-   *
-   * The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
    * @param name Name of the new module.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param opts.path Workspace-relative path for the new module.
@@ -15218,7 +15230,6 @@ export class Workspace extends BaseClient {
    * @param opts.include Additional include patterns for the module.
    * @param opts.args SDK-specific init arguments.
    * @param opts.here Write to the workspace config directory at the workspace cwd.
-   * @param opts.noGenerate Skip running the SDK's generators for the new module.
    */
   withInitModule = (
     name: string,
@@ -15262,6 +15273,30 @@ export class Workspace extends BaseClient {
     opts?: WorkspaceWithNewFileOpts,
   ): Workspace => {
     const ctx = this._ctx.select("withNewFile", { path, contents, ...opts })
+    return new Workspace(ctx)
+  }
+
+  /**
+   * Return this workspace with a directory mounted read-only under the reserved references prefix.
+   *
+   * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+   * @param path Reference-relative mount path under the reserved references prefix.
+   * @param source Directory to mount read-only.
+   */
+  withReferenceDirectory = (path: string, source: Directory): Workspace => {
+    const ctx = this._ctx.select("withReferenceDirectory", { path, source })
+    return new Workspace(ctx)
+  }
+
+  /**
+   * Return this workspace with a file mounted read-only under the reserved references prefix.
+   *
+   * Referenced content is readable through the normal workspace file tools but is excluded from the pending changeset: it never appears in changes and is never exported.
+   * @param path Reference-relative mount path under the reserved references prefix.
+   * @param source File to mount read-only.
+   */
+  withReferenceFile = (path: string, source: File): Workspace => {
+    const ctx = this._ctx.select("withReferenceFile", { path, source })
     return new Workspace(ctx)
   }
 


### PR DESCRIPTION
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/bcc4aa5f-50dc-44d1-b5ec-d5e78d34f6ed" />

Assorted knobs and fixes the agent work needed, none of which deserve a PR of their own.

**Workspace mounts.** New `Workspace.withMountedFile` / `withMountedDirectory` APIs attach a `File` or `Directory` at an arbitrary workspace path. The "mounted" framing is borrowed from `Container` and carries the same semantics: the content is readable in place, but it doesn't ride along with changesets or exporting. Reads at or under a mount point resolve entirely from the read-only mounts tree and shadow the source; listings above a mount point include the mounted content, and mount parents materialize even when absent from the source. Overlay edits at or under a mount point are rejected, source materializations (module loading, lockfiles, migration, git) never see mounts, and mounting over the workspace root is rejected. `search`, `glob` and `findUp` read through mounts with the same shadowing as `file` and `directory`.

**`dagger agent` path references**: `@path` in a prompt mounts a host path read-only under the workspace's `.refs` prefix and rewrites the prompt to point at the mounted location, so the model reads it through the ordinary file tools — with host-filesystem completion, a References sidebar, and a reset on `.clear`. Paths already inside the workspace are annotated in place rather than mounted. `.refs` is purely a CLI convention now — the engine no longer reserves the prefix, and the mount is made relative to the workspace cwd so the path the model sees always matches what its file tools resolve. Subscription OAuth tokens are now refreshed on demand rather than once at startup, so a long session stops collecting 401s an hour in.

**LLM knobs.** `LLM.withReasoningEffort` overrides the provider-configured effort mid-conversation and survives a later `withModel`, reachable as `.effort` / `/effort` with a picker built from the current model's catwalk levels. LLM configuration becomes session-wide: a nested client running `dagger agent` inherits the session's auth without ever holding the credentials, since only the engine-side router sees the plaintext. And the engine ships a `dang-dagger-modules` skill, which the `dang-language` skill's routing table pointed at but which existed nowhere an agent could read.

Plus one engine fix: grepping for a file that exists only as a pending overlay edit no longer fails outright, since a `--glob` naming a brand-new file excludes every host-side candidate and rg's exit 2 was being turned into a hard error before the overlay results were merged.
