### PR TITLE
Workspace cache volume mounts (DRAFT, unfinished)

### DIFF
--- a/.changes/unreleased/Fixed-20260814-235900.yaml
+++ b/.changes/unreleased/Fixed-20260814-235900.yaml
@@ -1,0 +1,15 @@
+kind: Fixed
+body: |
+  Resetting invalid local cache state (e.g. after an unclean engine shutdown)
+  no longer blocks engine startup, and no longer saturates the disk while it
+  happens. The discarded worker state — often tens of GB across millions of
+  files — was previously deleted inline before the engine came up, pinning the
+  disk queue hard enough to make the whole machine stutter. It is now renamed
+  aside instantly and removed in the background at a bounded duty cycle,
+  switching to full speed only under disk pressure. Interrupted removals are
+  resumed on the next startup, and stale mounts left behind by the crashed
+  engine are detached instead of failing the reset.
+time: 2026-08-14T23:59:00Z
+custom:
+  Author: vito
+  PR: 0

--- a/core/directory.go
+++ b/core/directory.go
@@ -213,6 +213,7 @@ const (
 	persistedDirectoryLazyKindWithout                       = "directory.without"
 	persistedDirectoryLazyKindWithSymlink                   = "directory.withSymlink"
 	persistedDirectoryLazyKindChown                         = "directory.chown"
+	persistedDirectoryLazyKindCacheVolumeSnapshot           = "cacheVolume.__snapshotDirectory"
 )
 
 type persistedDirectoryPayload struct {
@@ -572,6 +573,10 @@ type persistedDirectoryChownLazy struct {
 	Owner          string `json:"owner"`
 }
 
+type persistedCacheVolumeSnapshotLazy struct {
+	VolumeResultID uint64 `json:"volumeResultID"`
+}
+
 func attachDirectoryResult(attach func(dagql.AnyResult) (dagql.AnyResult, error), res dagql.ObjectResult[*Directory], label string) (dagql.ObjectResult[*Directory], error) {
 	attached, err := attach(res)
 	if err != nil {
@@ -643,6 +648,9 @@ func encodePersistedDirectoryLazy(ctx context.Context, cache dagql.PersistedObje
 	case *DirectoryChownLazy:
 		payload, err := lazy.EncodePersisted(ctx, cache)
 		return persistedDirectoryLazyKindChown, payload, err
+	case *CacheVolumeSnapshotLazy:
+		payload, err := lazy.EncodePersisted(ctx, cache)
+		return persistedDirectoryLazyKindCacheVolumeSnapshot, payload, err
 	default:
 		return "", nil, fmt.Errorf("encode persisted directory lazy: unsupported lazy type %T", lazy)
 	}
@@ -865,6 +873,16 @@ func decodePersistedDirectoryLazy(ctx context.Context, dag *dagql.Server, lazyKi
 			return nil, err
 		}
 		return &DirectoryChownLazy{LazyState: NewLazyState(), Parent: parent, ChownPath: persisted.ChownPath, Owner: persisted.Owner}, nil
+	case persistedDirectoryLazyKindCacheVolumeSnapshot:
+		var persisted persistedCacheVolumeSnapshotLazy
+		if err := json.Unmarshal(payload, &persisted); err != nil {
+			return nil, fmt.Errorf("decode persisted cache volume snapshot lazy: %w", err)
+		}
+		volume, err := loadPersistedObjectResultByResultID[*CacheVolume](ctx, dag, persisted.VolumeResultID, "cache volume snapshot volume")
+		if err != nil {
+			return nil, err
+		}
+		return &CacheVolumeSnapshotLazy{LazyState: NewLazyState(), Volume: volume}, nil
 	default:
 		return nil, fmt.Errorf("decode persisted directory lazy payload: unsupported lazy kind %q", lazyKind)
 	}

--- a/core/integration/engine_persistence_test.go
+++ b/core/integration/engine_persistence_test.go
@@ -255,6 +255,24 @@ head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1 > /work/random.txt
 		randomB := runRandom(ctx, t, engineClientB)
 		require.NotEqual(t, randomA, randomB, "cache state from before the unclean shutdown should be discarded")
 
+		// The reset renames the invalid worker state aside to a sibling
+		// worker-trash-* directory and removes it in the background; poll the
+		// state volume until the trash is swept, so discarded state cannot
+		// leak across resets.
+		require.Eventually(t, func() bool {
+			out, err := c.
+				Container().
+				From(alpineImage).
+				WithMountedCache("/state", c.CacheVolume(stateKey)).
+				WithEnvVariable("CACHEBUSTER", identity.NewID()).
+				WithExec([]string{"sh", "-ec", "ls -d /state/worker-trash-* 2>/dev/null | wc -l"}).
+				Stdout(ctx)
+			if err != nil {
+				return false
+			}
+			return strings.TrimSpace(out) == "0"
+		}, 120*time.Second, 3*time.Second, "discarded worker state should be swept in the background")
+
 		stopEngine(ctx, t, upstreamSvcB, engineSvcB, engineClientB)
 		upstreamSvcB = nil
 		engineSvcB = nil

--- a/core/integration/testdata/services/container-provider/dagger.json
+++ b/core/integration/testdata/services/container-provider/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "container-provider",
-  "engineVersion": "v0.20.1",
+  "engineVersion": "v1.0.0",
   "sdk": {
     "source": "go"
   }

--- a/core/integration/testdata/services/container-provider/main.go
+++ b/core/integration/testdata/services/container-provider/main.go
@@ -23,3 +23,20 @@ func (m *ContainerProvider) Image() *dagger.Container {
 	}
 	return base.WithEnvVariable("PROVIDED_BY", "container-provider")
 }
+
+// Returns a directory for consumers.
+func (m *ContainerProvider) Directory() *dagger.Directory {
+	return dag.Directory().WithNewFile("provided-by", "container-provider")
+}
+
+// Returns a file for consumers.
+func (m *ContainerProvider) File() *dagger.File {
+	return m.Directory().File("provided-by")
+}
+
+// Returns a workspace for consumers.
+func (m *ContainerProvider) Workspace() *dagger.Workspace {
+	return dag.Directory().
+		WithNewFile("marker.txt", "container-provider").
+		AsWorkspace()
+}

--- a/core/integration/testdata/services/service-ref-consumer/main.go
+++ b/core/integration/testdata/services/service-ref-consumer/main.go
@@ -1,5 +1,5 @@
-// A module whose constructor accepts optional core-type args (Service,
-// Container), used to test wiring another module's function output in via
+// A module whose constructor accepts optional core-type args, used to test
+// wiring another module's function output in via
 // workspace settings.
 package main
 
@@ -11,8 +11,11 @@ import (
 )
 
 type ServiceRefConsumer struct {
-	App  *dagger.Service
-	Base *dagger.Container
+	App             *dagger.Service
+	Base            *dagger.Container
+	Directory       *dagger.Directory
+	File            *dagger.File
+	WorkspaceMarker *dagger.File
 }
 
 func New(
@@ -20,8 +23,21 @@ func New(
 	app *dagger.Service,
 	// +optional
 	base *dagger.Container,
+	// +optional
+	directory *dagger.Directory,
+	// +optional
+	file *dagger.File,
+	// +optional
+	sourceWorkspace *dagger.Workspace,
 ) *ServiceRefConsumer {
-	return &ServiceRefConsumer{App: app, Base: base}
+	var workspaceMarker *dagger.File
+	if sourceWorkspace != nil {
+		workspaceMarker = sourceWorkspace.File("marker.txt")
+	}
+	return &ServiceRefConsumer{
+		App: app, Base: base, Directory: directory, File: file,
+		WorkspaceMarker: workspaceMarker,
+	}
 }
 
 // Returns "true" if a Service was provided, "false" otherwise.
@@ -39,6 +55,33 @@ func (m *ServiceRefConsumer) ContainerProvidedBy(ctx context.Context) (string, e
 		return "none", nil
 	}
 	return m.Base.EnvVariable(ctx, "PROVIDED_BY")
+}
+
+// Returns the contents of the marker in the provided directory, or "none" if
+// no directory was provided.
+func (m *ServiceRefConsumer) DirectoryProvidedBy(ctx context.Context) (string, error) {
+	if m.Directory == nil {
+		return "none", nil
+	}
+	return m.Directory.File("provided-by").Contents(ctx)
+}
+
+// Returns the contents of the provided file, or "none" if no file was
+// provided.
+func (m *ServiceRefConsumer) FileProvidedBy(ctx context.Context) (string, error) {
+	if m.File == nil {
+		return "none", nil
+	}
+	return m.File.Contents(ctx)
+}
+
+// Returns the contents of the marker in the provided workspace, or "none" if
+// no workspace was provided.
+func (m *ServiceRefConsumer) WorkspaceProvidedBy(ctx context.Context) (string, error) {
+	if m.WorkspaceMarker == nil {
+		return "none", nil
+	}
+	return m.WorkspaceMarker.Contents(ctx)
 }
 
 // CheckService passes only when a Service was provided, used to test that

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -206,12 +207,18 @@ func (UpSuite) TestUpModuleWiring(ctx context.Context, t *testctx.T) {
 	// plain-string module reference in workspace settings:
 	// settings.<arg> = "<module>:<function>". These strings route through the
 	// Address decoders (see core/schema/address.go: resolveModuleRef, wired
-	// into .service() and .container()). Supported for Service (+up functions)
-	// and Container. The same decoders back CLI object flags, so a constructor
-	// arg like --app=<module>:<function> resolves identically.
+	// into the corresponding Address object decoders). Supported for Service
+	// (+up functions), Container, Directory, File, and Workspace. The same
+	// decoders back CLI object flags, so a constructor arg like
+	// --app=<module>:<function> resolves identically.
 	c := connect(ctx, t)
 	modGen, err := upTestEnv(t, c)
 	require.NoError(t, err)
+	// Optional Workspace args inherit the ambient workspace when no setting is
+	// configured. Keep its marker valid so the shared consumer fixture can
+	// derive a File in every subtest; the wiring case overrides this workspace
+	// with container-provider:workspace and observes a different marker.
+	modGen = modGen.WithNewFile("app/marker.txt", "ambient")
 
 	t.Run("without refs", func(ctx context.Context, t *testctx.T) {
 		ctr := modGen.
@@ -262,6 +269,38 @@ settings.base = "container-provider:image"
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-provider")
+	})
+
+	t.Run("artifact refs via settings", func(ctx context.Context, t *testctx.T) {
+		ctr := modGen.
+			WithWorkdir("app").
+			WithNewFile("dagger.toml", `[modules.container-provider]
+source = "../container-provider"
+
+[modules.service-ref-consumer]
+source = "../service-ref-consumer"
+settings.directory = "container-provider:directory"
+settings.file = "container-provider:file"
+settings.sourceWorkspace = "container-provider:workspace"
+`)
+
+		out, err := ctr.
+			With(daggerExec("call", "service-ref-consumer", "directory-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "container-provider", strings.TrimSpace(out))
+
+		out, err = ctr.
+			With(daggerExec("call", "service-ref-consumer", "file-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "container-provider", strings.TrimSpace(out))
+
+		out, err = ctr.
+			With(daggerExec("call", "service-ref-consumer", "workspace-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "container-provider", strings.TrimSpace(out))
 	})
 
 	t.Run("provider with required Workspace arg", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/buildkit/identity"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
@@ -885,6 +886,259 @@ func (WorkspaceAPISuite) TestWorkspaceMountsSearchGlobFindUp(ctx context.Context
 			got = mountedQuery(t, `findUp(name: "real.txt", from: "shadowed")`)
 			require.Nil(t, got["findUp"], "sources shadowed by a mount must not resurface")
 		})
+	})
+}
+
+// TestWorkspaceMountedCache covers Workspace.withMountedCache. A mounted cache
+// volume behaves like any other mount for reads — it shadows the source and
+// stays out of the pending changeset — but it is writable, and export commits
+// the edits made under it into the volume instead of into the workspace.
+func (WorkspaceAPISuite) TestWorkspaceMountedCache(ctx context.Context, t *testctx.T) {
+	// seededVolume returns a fresh cache volume with seed.txt already written by
+	// a container, so the workspace mount has pre-existing content to read.
+	seededVolume := func(ctx context.Context, t *testctx.T, c *dagger.Client) *dagger.CacheVolume {
+		t.Helper()
+		vol := c.CacheVolume("workspace-mounted-cache-" + identity.NewID())
+		_, err := c.Container().From(alpineImage).
+			WithMountedCache("/cache", vol).
+			WithExec([]string{"sh", "-c", "echo -n seeded > /cache/seed.txt"}).
+			Sync(ctx)
+		require.NoError(t, err)
+		return vol
+	}
+
+	// volumeFile reads a path from the volume through a container, which is the
+	// only view that proves write-through actually landed.
+	volumeFile := func(ctx context.Context, t *testctx.T, c *dagger.Client, vol *dagger.CacheVolume, path string) (string, error) {
+		t.Helper()
+		return c.Container().From(alpineImage).
+			WithMountedCache("/cache", vol).
+			WithExec([]string{"cat", "/cache/" + path}).
+			Stdout(ctx)
+	}
+
+	t.Run("reads the volume and shadows the source", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			WithNewFile("base.txt", "base").
+			WithNewFile("cache/real.txt", "real").
+			AsWorkspace().
+			WithMountedCache("cache", seededVolume(ctx, t, c))
+
+		contents, err := ws.File("cache/seed.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "seeded", contents)
+
+		entries, err := ws.Directory("cache").Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"seed.txt"}, entries, "the mount must shadow the source subtree")
+
+		// Mounted content shows up in listings above the mount point, and the
+		// source outside it is untouched.
+		entries, err = ws.Directory("/").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, entries, "base.txt")
+		require.Contains(t, entries, "cache/")
+
+		isEmpty, err := ws.Changes().IsEmpty(ctx)
+		require.NoError(t, err)
+		require.True(t, isEmpty, "a mounted cache is not a pending change")
+	})
+
+	t.Run("the volume is read at first use, not at mount time", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		vol := seededVolume(ctx, t, c)
+		ws := c.Directory().AsWorkspace().WithMountedCache("cache", vol)
+
+		// Run the mount server-side without touching the mount. Asking for the
+		// ID resolves withMountedCache and nothing under it.
+		_, err := ws.ID(ctx)
+		require.NoError(t, err)
+
+		_, err = c.Container().From(alpineImage).
+			WithMountedCache("/cache", vol).
+			WithExec([]string{"sh", "-c", "echo -n late > /cache/late.txt"}).
+			Sync(ctx)
+		require.NoError(t, err)
+
+		// Reading re-issues the same calls, which hit the session cache and hand
+		// back the still-unmaterialized mount — so this is the first thing that
+		// actually reads the volume, and it sees the write that landed after the
+		// mount. An eager mount would have copied the volume above and missed it.
+		entries, err := ws.Directory("cache").Entries(ctx)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"seed.txt", "late.txt"}, entries)
+	})
+
+	t.Run("edits under the mount are readable but not pending changes", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			AsWorkspace().
+			WithMountedCache("cache", seededVolume(ctx, t, c)).
+			WithNewFile("cache/written.txt", "written")
+
+		contents, err := ws.File("cache/written.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "written", contents)
+
+		// The seeded content is still there alongside the edit.
+		entries, err := ws.Directory("cache").Entries(ctx)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"seed.txt", "written.txt"}, entries)
+
+		isEmpty, err := ws.Changes().IsEmpty(ctx)
+		require.NoError(t, err)
+		require.True(t, isEmpty, "cache mount edits belong to the volume, not the workspace changeset")
+	})
+
+	t.Run("export commits edits into the volume", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		vol := seededVolume(ctx, t, c)
+
+		err := c.Directory().
+			AsWorkspace().
+			WithMountedCache("cache", vol).
+			WithNewFile("cache/written.txt", "written").
+			Export(ctx)
+		require.NoError(t, err)
+
+		contents, err := volumeFile(ctx, t, c, vol, "written.txt")
+		require.NoError(t, err)
+		require.Equal(t, "written", contents)
+
+		// Write-through is a delta: content the workspace never touched survives.
+		contents, err = volumeFile(ctx, t, c, vol, "seed.txt")
+		require.NoError(t, err)
+		require.Equal(t, "seeded", contents)
+	})
+
+	t.Run("export commits removals into the volume", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		vol := seededVolume(ctx, t, c)
+
+		err := c.Directory().
+			AsWorkspace().
+			WithMountedCache("cache", vol).
+			WithoutFile("cache/seed.txt").
+			Export(ctx)
+		require.NoError(t, err)
+
+		_, err = volumeFile(ctx, t, c, vol, "seed.txt")
+		require.Error(t, err, "the removal must have been committed into the volume")
+	})
+
+	t.Run("without export the volume is untouched", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		vol := seededVolume(ctx, t, c)
+
+		_, err := c.Directory().
+			AsWorkspace().
+			WithMountedCache("cache", vol).
+			WithNewFile("cache/written.txt", "written").
+			Changes().IsEmpty(ctx)
+		require.NoError(t, err)
+
+		_, err = volumeFile(ctx, t, c, vol, "written.txt")
+		require.Error(t, err, "edits reach the volume only through export")
+	})
+
+	t.Run("withoutMount restores the source", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			WithNewFile("cache/real.txt", "real").
+			AsWorkspace().
+			WithMountedCache("cache", seededVolume(ctx, t, c)).
+			WithoutMount("cache")
+
+		entries, err := ws.Directory("cache").Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"real.txt"}, entries)
+	})
+
+	t.Run("search and glob see the mounted cache", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ws := c.Directory().
+			WithNewFile("src/hay.txt", "needle in source\n").
+			AsWorkspace().
+			WithMountedCache("cache", seededVolume(ctx, t, c)).
+			WithNewFile("cache/written.txt", "needle written\n")
+
+		results, err := ws.Search(ctx, "needle", dagger.WorkspaceSearchOpts{Literal: true})
+		require.NoError(t, err)
+		paths := make([]string, 0, len(results))
+		for _, r := range results {
+			p, err := r.FilePath(ctx)
+			require.NoError(t, err)
+			paths = append(paths, p)
+		}
+		require.Contains(t, paths, "src/hay.txt")
+		require.Contains(t, paths, "cache/written.txt")
+
+		matches, err := ws.Glob(ctx, "**/*.txt")
+		require.NoError(t, err)
+		require.Contains(t, matches, "cache/seed.txt")
+		require.Contains(t, matches, "cache/written.txt")
+	})
+
+	t.Run("mounting over the workspace root is rejected", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		_, err := c.Directory().
+			AsWorkspace().
+			WithMountedCache(".", seededVolume(ctx, t, c)).
+			Changes().IsEmpty(ctx)
+		require.ErrorContains(t, err, "cannot mount over the workspace root")
+	})
+
+	t.Run("withChanges across a cache mount is rejected", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		changes := c.Directory().
+			WithNewFile("cache/patched.txt", "patched").
+			Changes(c.Directory())
+
+		_, err := c.Directory().
+			AsWorkspace().
+			WithMountedCache("cache", seededVolume(ctx, t, c)).
+			WithChanges(changes).
+			Changes().IsEmpty(ctx)
+		require.ErrorContains(t, err, "falls under cache mount")
+	})
+
+	t.Run("host workspace keeps cache edits out of its export", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		vol := seededVolume(ctx, t, c)
+		volID, err := vol.ID(ctx)
+		require.NoError(t, err)
+
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, "base.txt"), []byte("base"), 0o644))
+
+		queryPath := writeQueryDoc(t, workdir, "cache-mount-export.graphql", fmt.Sprintf(`{
+  currentWorkspace {
+    withMountedCache(path: "cache", cache: %q) {
+      withNewFile(path: "cache/written.txt", contents: "written") {
+        withNewFile(path: "staged.txt", contents: "staged") {
+          export
+        }
+      }
+    }
+  }
+}
+`, volID))
+		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+		require.NoError(t, err)
+
+		// The base edit landed on disk; the cache edit did not.
+		got, err := os.ReadFile(filepath.Join(workdir, "staged.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "staged", string(got))
+		_, err = os.Stat(filepath.Join(workdir, "cache"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+
+		// It went into the volume instead.
+		contents, err := volumeFile(ctx, t, c, vol, "written.txt")
+		require.NoError(t, err)
+		require.Equal(t, "written", contents)
 	})
 }
 

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -677,11 +677,6 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 			//  3) "workspace args" that are automatically injected
 			continue
 		}
-		// Check for Workspace arguments first - they're always injected
-		if argMetadata.IsWorkspace() {
-			workspaceArgs = append(workspaceArgs, argMetadata)
-			continue
-		}
 		userDefault, hasUserDefault, err := fn.UserDefault(ctx, argMetadata.Name)
 		if err != nil {
 			return fmt.Errorf("%s.%s(%s=): load user default: %w",
@@ -693,6 +688,12 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 		}
 		if hasUserDefault {
 			userDefaults = append(userDefaults, userDefault)
+		} else if argMetadata.IsWorkspace() {
+			// Workspace args inherit the workspace in scope only when the user
+			// did not configure one explicitly. A settings value may itself be
+			// a module reference, so it must go through the ordinary object
+			// default resolver above instead of being shadowed by injection.
+			workspaceArgs = append(workspaceArgs, argMetadata)
 		} else if argMetadata.isContextual() {
 			ctxArgs = append(ctxArgs, argMetadata)
 		}

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -299,6 +299,10 @@ func (s *addressSchema) Install(srv *dagql.Server) {
 			View(AfterVersion("v1.0.0-0")).
 			WithInput(dagql.PerCallInput).
 			Doc(`Load a volume from the address.`),
+		dagql.NodeFunc("workspace", s.workspace).
+			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerCallInput).
+			Doc(`Load a workspace from a module reference.`),
 	}.Install(srv)
 }
 
@@ -334,6 +338,9 @@ func (s *addressSchema) file(
 ) {
 	var q []dagql.Selector
 	addr := r.Self().Value
+	if matched, err := resolveModuleRef(ctx, addr, &inst); matched {
+		return inst, err
+	}
 	gitURL, err := gitutil.ParseURL(addr)
 	if err == nil {
 		// Remote file
@@ -423,6 +430,9 @@ func (s *addressSchema) directory(
 ) {
 	var q []dagql.Selector
 	addr := r.Self().Value
+	if matched, err := resolveModuleRef(ctx, addr, &inst); matched {
+		return inst, err
+	}
 	gitURL, err := gitutil.ParseURL(addr)
 	if err == nil {
 		// Remote directory (using git remote)
@@ -823,6 +833,21 @@ func (s *addressSchema) service(
 		return inst, err
 	}
 	return inst, nil
+}
+
+func (s *addressSchema) workspace(
+	ctx context.Context,
+	r dagql.ObjectResult[*core.Address],
+	args struct{},
+) (
+	inst dagql.ObjectResult[*core.Workspace],
+	err error,
+) {
+	addr := r.Self().Value
+	if matched, err := resolveModuleRef(ctx, addr, &inst); matched {
+		return inst, err
+	}
+	return inst, fmt.Errorf("workspace address %q must reference an installed module as <module>:<function>", addr)
 }
 
 func (s *addressSchema) volume(

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -34,7 +34,39 @@ func (s *cacheSchema) Install(srv *dagql.Server) {
 			),
 	}.Install(srv)
 
-	dagql.Fields[*core.CacheVolume]{}.Install(srv)
+	dagql.Fields[*core.CacheVolume]{
+		dagql.NodeFunc("__snapshotDirectory", s.snapshotDirectory).
+			WithInput(dagql.PerSessionInput).
+			NotReplayable("Reads the live cache volume; a recorded read is a snapshot, not a reproducible value.").
+			Doc("(Internal-only) A point-in-time Directory view of the cache volume's current content, materialized lazily."),
+	}.Install(srv)
+}
+
+// snapshotDirectory returns a point-in-time Directory view of the cache
+// volume's mutable content. The Directory is lazy: nothing reads the volume
+// until something evaluates it, so callers that only carry the view around —
+// like a workspace cache mount nobody has touched yet — never pay for the copy.
+//
+// It is scoped per session and not replayable, the same treatment
+// host.directory gets: within a session the view is stable, and a later session
+// re-reads the volume. (It cannot be DoNotCache — the Directory owns a snapshot
+// ref, and a do-not-cache result may neither be lazy nor implement OnReleaser.)
+// The resulting snapshot's digest is content-derived, so downstream reads of an
+// unchanged cache still dedup.
+func (s *cacheSchema) snapshotDirectory(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.CacheVolume],
+	_ struct{},
+) (dagql.ObjectResult[*core.Directory], error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Directory]{}, err
+	}
+	dir, err := parent.Self().SnapshotDirectory(ctx, parent)
+	if err != nil {
+		return dagql.ObjectResult[*core.Directory]{}, err
+	}
+	return dagql.NewObjectResultForCurrentCall(ctx, srv, dir)
 }
 
 type cacheArgs struct {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -209,6 +209,22 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("path").Doc("Location of the mounted file. Relative paths resolve from the workspace cwd."),
 				dagql.Arg("source").Doc("File to mount."),
 			),
+		dagql.NodeFunc("withMountedCache", s.withMountedCache).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Return this workspace with a cache volume mounted at the given path, without mutating the source.",
+				"Like a mounted directory, the cache shadows the source at the mount path and stays out of the pending changeset: it never appears in changes and is never exported to the workspace. Unlike a mounted directory it is writable, and export commits the edits made under it back into the cache volume.").
+			Args(
+				dagql.Arg("path").Doc("Location of the mounted cache. Relative paths resolve from the workspace cwd."),
+				dagql.Arg("cache").Doc("Cache volume to mount."),
+			),
+		dagql.NodeFunc("withoutMount", s.withoutMount).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Return this workspace with the content mounted at the given path unmounted.",
+				"Removes whatever is mounted there — a cache volume, directory or file — along with anything mounted inside it. Pending edits to a mounted cache volume are discarded rather than committed.").
+			Args(
+				dagql.Arg("path").Doc("Location of the mount to remove. Relative paths resolve from the workspace cwd."),
+			),
+
 		dagql.NodeFunc("withModule", s.withModule).
 			View(AfterVersion("v1.0.0-0")).
 			// Env-sensitive writes: what this records depends on the client's env
@@ -335,7 +351,8 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 		dagql.NodeFunc("export", s.export).
 			View(AfterVersion("v1.0.0-0")).
 			DoNotCache("Writes pending workspace changes to the local Git workspace").
-			Doc("Write this workspace's pending changes to its local Git workspace."),
+			Doc("Write this workspace's pending changes to its local Git workspace.",
+				"Edits made under a mounted cache volume are not pending changes; they are committed into that volume instead."),
 		dagql.NodeFunc("reloaded", s.reloaded).
 			View(AfterVersion("v1.0.0-0")).
 			WithInput(dagql.PerCallInput).
@@ -640,15 +657,16 @@ type workspaceDirectoryArgs struct {
 
 // resolveReadRootfs resolves a workspace read (Workspace.directory/file) with
 // mounted content visible:
-//   - Paths at or under a mount point resolve entirely against the read-only
-//     mounts tree — mounted content shadows the source.
+//   - Paths at or under a mount point resolve entirely against the mounts tree
+//     — mounted content shadows the source.
 //   - Paths with mount points beneath them get the mounted content overlaid on
 //     the source read, so listings include it. As with container mounts, the
 //     mount point's parents don't need to exist in the source.
 //
 // Everything that materializes the workspace *source* (module loading,
 // lockfiles, migration, git) resolves through resolveRootfs directly and never
-// sees mounts, mirroring how changes and export exclude them.
+// sees mounts, mirroring how changes excludes them and export writes them to
+// their own destination (a cache volume) rather than to the workspace.
 func (s *workspaceSchema) resolveReadRootfs(
 	ctx context.Context,
 	ws *core.Workspace,
@@ -1138,18 +1156,18 @@ func (s *workspaceSchema) withNewFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.workspaceEdit(ctx, parent, resolvedPath, nil, func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withNewFile",
 			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(resolvedPath)},
+				{Name: "path", Value: dagql.NewString(targetPath)},
 				{Name: "contents", Value: dagql.NewString(args.Contents)},
 				{Name: "permissions", Value: dagql.NewInt(args.Permissions)},
 			},
 		})
 		return updated, err
-	}, nil)
+	})
 }
 
 type workspaceSearchArgs struct {
@@ -1536,11 +1554,11 @@ func (s *workspaceSchema) withNewDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.workspaceEdit(ctx, parent, resolvedPath, nil, func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error) {
 		// Clearing first is what lets both overlay branches share this edit:
 		// an edit that ignores whatever the base holds at the path reads the
 		// same on a full read root as on a host overlay's delta root.
-		cleared, err := clearedForWrite(ctx, srv, base, resolvedPath)
+		cleared, err := clearedForWrite(ctx, srv, base, targetPath)
 		if err != nil {
 			return cleared, err
 		}
@@ -1548,12 +1566,12 @@ func (s *workspaceSchema) withNewDirectory(
 		err = srv.Select(ctx, cleared, &updated, dagql.Selector{
 			Field: "withDirectory",
 			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(resolvedPath)},
+				{Name: "path", Value: dagql.NewString(targetPath)},
 				{Name: "source", Value: dagql.NewID[*core.Directory](sourceID)},
 			},
 		})
 		return updated, err
-	}, nil)
+	})
 }
 
 func (s *workspaceSchema) withDirectory(
@@ -1578,17 +1596,17 @@ func (s *workspaceSchema) withDirectory(
 	}
 	// The edit layers onto what the path already holds, so the base has to
 	// carry it — see overlayEdit's readsExisting.
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.workspaceEdit(ctx, parent, resolvedPath, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withDirectory",
 			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(resolvedPath)},
+				{Name: "path", Value: dagql.NewString(targetPath)},
 				{Name: "source", Value: dagql.NewID[*core.Directory](sourceID)},
 			},
 		})
 		return updated, err
-	}, nil)
+	})
 }
 
 // clearedForWrite returns base holding nothing at path, ready for a write that
@@ -1634,16 +1652,16 @@ func (s *workspaceSchema) withoutFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.workspaceEdit(ctx, parent, resolvedPath, nil, func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withoutFile",
 			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(resolvedPath)},
+				{Name: "path", Value: dagql.NewString(targetPath)},
 			},
 		})
 		return updated, err
-	}, nil)
+	})
 }
 
 type workspaceWithoutDirectoryArgs struct {
@@ -1667,16 +1685,16 @@ func (s *workspaceSchema) withoutDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.workspaceEdit(ctx, parent, resolvedPath, nil, func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withoutDirectory",
 			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.NewString(resolvedPath)},
+				{Name: "path", Value: dagql.NewString(targetPath)},
 			},
 		})
 		return updated, err
-	}, nil)
+	})
 }
 
 func (s *workspaceSchema) withChanges(
@@ -1740,6 +1758,13 @@ func (s *workspaceSchema) applyChangeset(
 	for _, p := range touched {
 		if err := guardMountedPath(parent.Self(), p); err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+		// v1: a changeset that reaches into a cache mount is rejected. Its edits
+		// would have to be split by mount and routed into the mounts tree to
+		// reach the volume; applied to the overlay they would silently sit under
+		// the mount, invisible to reads and never committed (a follow-up).
+		if mount, ok := parent.Self().CacheMountForPath(p); ok {
+			return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("withChanges path %q falls under cache mount %q; applying a changeset across a cache mount boundary is not supported", p, mount.Target)
 		}
 	}
 	return s.overlayEdit(ctx, parent, touched, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
@@ -1815,12 +1840,9 @@ func withMountedSource[T dagql.Typed](
 	source dagql.ID[T],
 	field string,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	resolvedPath, err := resolveWorkspacePath(path, parent.Self().Cwd)
+	resolvedPath, err := resolveMountPath(path, parent.Self().Cwd)
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
-	}
-	if resolvedPath == "." {
-		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("cannot mount over the workspace root")
 	}
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
@@ -1830,11 +1852,9 @@ func withMountedSource[T dagql.Typed](
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	mounts, ok := parent.Self().MountsDir()
-	if !ok {
-		if err := srv.Select(ctx, srv.Root(), &mounts, dagql.Selector{Field: "directory"}); err != nil {
-			return dagql.ObjectResult[*core.Workspace]{}, err
-		}
+	mounts, err := workspaceMountsTree(ctx, srv, parent.Self())
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	var updated dagql.ObjectResult[*core.Directory]
 	if err := srv.Select(ctx, mounts, &updated, dagql.Selector{
@@ -1850,14 +1870,206 @@ func withMountedSource[T dagql.Typed](
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws)
 }
 
+// resolveMountPath resolves a mount path argument to a workspace-root-relative
+// path, rejecting the workspace root: mounting over it would shadow the whole
+// source, which no mount kind supports.
+func resolveMountPath(p, cwd string) (string, error) {
+	resolvedPath, err := resolveWorkspacePath(p, cwd)
+	if err != nil {
+		return "", err
+	}
+	if resolvedPath == "." || resolvedPath == "" {
+		return "", fmt.Errorf("cannot mount over the workspace root")
+	}
+	return resolvedPath, nil
+}
+
+// workspaceMountsTree returns the workspace's mounts tree, or a fresh empty
+// directory when nothing is mounted yet. Every mount kind shares this one tree,
+// keyed by workspace-root-relative path, so reads, search, glob and findUp pick
+// mounted content up without knowing what was mounted.
+func workspaceMountsTree(
+	ctx context.Context,
+	srv *dagql.Server,
+	ws *core.Workspace,
+) (dagql.ObjectResult[*core.Directory], error) {
+	if mounts, ok := ws.MountsDir(); ok {
+		return mounts, nil
+	}
+	var empty dagql.ObjectResult[*core.Directory]
+	err := srv.Select(ctx, srv.Root(), &empty, dagql.Selector{Field: "directory"})
+	return empty, err
+}
+
 // guardMountedPath rejects overlay edits that target a path at or under a
-// mount point, keeping mounted content read-only. It is a no-op when the
-// workspace has no mounts.
+// read-only mount point. Cache mounts are writable, so edits under them are
+// allowed and routed into the mounts tree instead (see workspaceEdit). It is a
+// no-op when the workspace has no mounts.
 func guardMountedPath(ws *core.Workspace, resolvedPath string) error {
+	if _, writable := ws.CacheMountForPath(resolvedPath); writable {
+		return nil
+	}
 	if ws.MountedPath(resolvedPath) {
 		return fmt.Errorf("workspace path %q is a read-only mount and cannot be modified", resolvedPath)
 	}
 	return nil
+}
+
+type workspaceWithMountedCacheArgs struct {
+	Path  string
+	Cache core.CacheVolumeID
+}
+
+// withMountedCache mounts a cache volume like withMountedDirectory mounts a
+// Directory: the volume's content goes into the mounts tree at the resolved
+// workspace path, so reads, search, glob and findUp see it shadowing the source
+// and it stays out of Workspace.changes. What differs is that the mount is
+// writable — edits under it update the mounts tree (see workspaceEdit) and
+// export commits them back into the volume, diffed against the baseline taken
+// here.
+//
+// Mounting itself copies nothing: the baseline Directory is lazy, so the volume
+// is read only once something actually reaches into the mount.
+func (s *workspaceSchema) withMountedCache(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceWithMountedCacheArgs,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	ws := parent.Self()
+	resolvedPath, err := resolveMountPath(args.Path, ws.Cwd)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	cache, err := args.Cache.Load(ctx, srv)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if cache.Self() == nil {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("cache volume is nil")
+	}
+
+	// A lazy immutable view of the volume's mutable content — no copy happens
+	// until it is evaluated. The read is session-scoped and not replayable, like
+	// host.directory; depending on it taints this call the same way, so the
+	// field itself needs no marker.
+	var baseline dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, cache, &baseline, dagql.Selector{
+		Field: "__snapshotDirectory",
+	}); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("snapshot cache volume: %w", err)
+	}
+	baselineID, err := baseline.ID()
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	mounts, err := workspaceMountsTree(ctx, srv, ws)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	var updated dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, mounts, &updated, dagql.Selector{
+		Field: "withDirectory",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.NewString(resolvedPath)},
+			{Name: "source", Value: dagql.NewID[*core.Directory](baselineID)},
+		},
+	}); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+
+	newWS := ws.WithCacheMounted(updated, core.WorkspaceCacheMount{
+		Target:   resolvedPath,
+		Volume:   cache,
+		Baseline: baseline,
+	})
+	return dagql.NewObjectResultForCurrentCall(ctx, srv, newWS)
+}
+
+type workspaceWithoutMountArgs struct {
+	Path string
+}
+
+// withoutMount drops whatever is mounted at the given path — a cache volume, a
+// directory or a file — along with anything mounted inside it, and removes its
+// content from the mounts tree so the workspace source shows through again.
+// Pending cache mount edits are discarded with the mount: only export commits
+// them.
+func (s *workspaceSchema) withoutMount(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceWithoutMountArgs,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	ws := parent.Self()
+	resolvedPath, err := resolveWorkspacePath(args.Path, ws.Cwd)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	mounts, ok := ws.MountsDir()
+	if !ok {
+		return dagql.NewObjectResultForCurrentCall(ctx, srv, ws.Clone())
+	}
+	// withoutDirectory removes the path whatever its type, so one call covers
+	// mounted files too.
+	var updated dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, mounts, &updated, dagql.Selector{
+		Field: "withoutDirectory",
+		Args:  []dagql.NamedInput{{Name: "path", Value: dagql.NewString(resolvedPath)}},
+	}); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	return dagql.NewObjectResultForCurrentCall(ctx, srv, ws.WithoutMountedAt(updated, resolvedPath))
+}
+
+// mountEdit applies an edit under a cache mount. Mounted content is keyed by
+// workspace-root-relative path, so the edit lands in the mounts tree at exactly
+// the path a base edit would have used — only the tree it writes to differs.
+// Nothing touches the overlay, so cache mount edits never show up in
+// Workspace.changes; export is what carries them into the volume.
+func (s *workspaceSchema) mountEdit(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	resolvedPath string,
+	edit func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error),
+) (dagql.ObjectResult[*core.Workspace], error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	mounts, ok := parent.Self().MountsDir()
+	if !ok {
+		// Unreachable: a path is only writable-mounted if something is mounted.
+		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("workspace path %q is under a cache mount but the workspace has no mounts", resolvedPath)
+	}
+	updated, err := edit(mounts, resolvedPath)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	return dagql.NewObjectResultForCurrentCall(ctx, srv, parent.Self().WithMountsDir(updated))
+}
+
+// workspaceEdit dispatches a single-path edit to either a cache mount (when the
+// path lands under one) or the base overlay.
+func (s *workspaceSchema) workspaceEdit(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	resolvedPath string,
+	readsExisting []string,
+	edit func(base dagql.ObjectResult[*core.Directory], targetPath string) (dagql.ObjectResult[*core.Directory], error),
+) (dagql.ObjectResult[*core.Workspace], error) {
+	if _, ok := parent.Self().CacheMountForPath(resolvedPath); ok {
+		return s.mountEdit(ctx, parent, resolvedPath, edit)
+	}
+	return s.overlayEdit(ctx, parent, []string{resolvedPath}, readsExisting, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+		return edit(base, resolvedPath)
+	}, nil)
 }
 
 func (s *workspaceSchema) changes(
@@ -2113,44 +2325,100 @@ func (s *workspaceSchema) export(
 	_ struct{},
 ) (core.Void, error) {
 	ws := parent.Self()
-	hostPath, err := ws.ExportHostPath()
-	if err != nil {
-		return core.Void{}, err
+
+	// Base export: write the primary overlay changeset to the local Git
+	// workspace. Only a non-empty base changeset requires a valid host path;
+	// cache mount write-through (below) runs regardless of the base source.
+	if changes, ok := ws.OverlayChanges(); ok && changes.Self() != nil {
+		isEmpty, err := changes.Self().IsEmpty(ctx)
+		if err != nil {
+			return core.Void{}, err
+		}
+		if !isEmpty {
+			hostPath, err := ws.ExportHostPath()
+			if err != nil {
+				return core.Void{}, err
+			}
+			exportCtx, err := s.withWorkspaceClientContext(ctx, ws)
+			if err != nil {
+				return core.Void{}, err
+			}
+			if err := changes.Self().Export(exportCtx, hostPath); err != nil {
+				return core.Void{}, err
+			}
+			if err := core.InvalidateCurrentWorkspace(exportCtx); err != nil {
+				slog.Warn("could not invalidate workspace after export", "error", err)
+			}
+			// The export just changed the workspace's on-disk content, so host
+			// reads (Workspace.file / .directory) cached earlier in this
+			// session are stale — they are cached per client for the client's
+			// whole lifetime (dagql.PerClientInput). Bump the client's read
+			// epoch so subsequent reads land in a fresh per-client cache
+			// namespace and re-read the live host. Best-effort, like the
+			// invalidation above: a bookkeeping failure must not fail an
+			// export that already succeeded.
+			if err := core.BumpWorkspaceReadEpoch(exportCtx); err != nil {
+				slog.Warn("could not bump workspace read epoch after export", "error", err)
+			}
+		}
 	}
 
-	changes, ok := ws.OverlayChanges()
-	if !ok || changes.Self() == nil {
-		return core.Void{}, nil
-	}
-	isEmpty, err := changes.Self().IsEmpty(ctx)
-	if err != nil {
-		return core.Void{}, err
-	}
-	if isEmpty {
-		return core.Void{}, nil
+	// Cache mount write-through: commit each mount's edits into its volume so
+	// containers and modules mounting the same volume observe them. Mounted
+	// content lives in the mounts tree, deliberately outside the overlay
+	// changeset, so this is the only path that persists it — and it runs
+	// regardless of the base source, since a value or remote workspace can still
+	// carry a writable cache mount.
+	if mounts, ok := ws.MountsDir(); ok {
+		for _, mount := range ws.CacheMounts() {
+			if mount.Volume.Self() == nil || mount.Baseline.Self() == nil {
+				continue
+			}
+			changes, err := s.cacheMountChanges(ctx, mounts, mount)
+			if err != nil {
+				return core.Void{}, fmt.Errorf("diff cache mount %q: %w", mount.Target, err)
+			}
+			if err := mount.Volume.Self().CommitChanges(ctx, changes.Self()); err != nil {
+				return core.Void{}, fmt.Errorf("commit cache mount %q: %w", mount.Target, err)
+			}
+		}
 	}
 
-	exportCtx, err := s.withWorkspaceClientContext(ctx, ws)
-	if err != nil {
-		return core.Void{}, err
-	}
-	if err := changes.Self().Export(exportCtx, hostPath); err != nil {
-		return core.Void{}, err
-	}
-	if err := core.InvalidateCurrentWorkspace(exportCtx); err != nil {
-		slog.Warn("could not invalidate workspace after export", "error", err)
-	}
-	// The export just changed the workspace's on-disk content, so host reads
-	// (Workspace.file / .directory) cached earlier in this session are stale —
-	// they are cached per client for the client's whole lifetime
-	// (dagql.PerClientInput). Bump the client's read epoch so subsequent reads
-	// land in a fresh per-client cache namespace and re-read the live host.
-	// Best-effort, like the invalidation above: a bookkeeping failure must not
-	// fail an export that already succeeded.
-	if err := core.BumpWorkspaceReadEpoch(exportCtx); err != nil {
-		slog.Warn("could not bump workspace read epoch after export", "error", err)
-	}
 	return core.Void{}, nil
+}
+
+// cacheMountChanges diffs a cache mount's current content in the mounts tree
+// against the baseline captured when it was mounted. Diffing against the
+// baseline rather than the volume's present content keeps write-through to the
+// edits made through this workspace, leaving anything another writer added to
+// the volume meanwhile in place.
+func (s *workspaceSchema) cacheMountChanges(
+	ctx context.Context,
+	mounts dagql.ObjectResult[*core.Directory],
+	mount core.WorkspaceCacheMount,
+) (inst dagql.ObjectResult[*core.Changeset], _ error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, err
+	}
+	var current dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, mounts, &current, dagql.Selector{
+		Field: "directory",
+		Args:  []dagql.NamedInput{{Name: "path", Value: dagql.NewString(mount.Target)}},
+	}); err != nil {
+		return inst, err
+	}
+	baselineID, err := mount.Baseline.ID()
+	if err != nil {
+		return inst, err
+	}
+	if err := srv.Select(ctx, current, &inst, dagql.Selector{
+		Field: "changes",
+		Args:  []dagql.NamedInput{{Name: "from", Value: dagql.NewID[*core.Directory](baselineID)}},
+	}); err != nil {
+		return inst, err
+	}
+	return inst, nil
 }
 
 // reloaded returns the workspace unchanged, having invalidated the workspace

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -102,20 +102,29 @@ type Workspace struct {
 	// directories lazily via per-call host.directory() instead.
 	rootfs dagql.ObjectResult[*Directory]
 
-	// mounts is an in-engine directory tree holding content attached read-only
-	// via Workspace.withMountedDirectory/withMountedFile, keyed by
+	// mounts is an in-engine directory tree holding content attached via
+	// Workspace.withMountedDirectory/withMountedFile/withMountedCache, keyed by
 	// workspace-root-relative mount path. Internal only — not a GraphQL field,
 	// but persisted and dependency-tracked like rootfs. Nil when the workspace
 	// has no mounts. It is intentionally kept separate from the overlay
 	// changeset so mounted content is readable through the normal workspace
-	// file tools but is never treated as a pending change or exported.
+	// file tools but is never treated as a pending change or exported to the
+	// workspace source.
 	mounts dagql.ObjectResult[*Directory]
 
 	// mountPoints lists the workspace-root-relative paths at which content is
 	// mounted, sorted and deduplicated. Reads at or under a mount point
-	// resolve from mounts (shadowing the source), and overlay edits there are
-	// rejected, keeping mounted content read-only.
+	// resolve from mounts (shadowing the source). Overlay edits there are
+	// rejected unless the mount is cache-backed (see cacheMounts), keeping
+	// mounted Directory/File content read-only.
 	mountPoints []string
+
+	// cacheMounts records which mount points are backed by a cache volume (see
+	// WorkspaceCacheMount). Cache mounts are the writable kind: edits under
+	// them land in mounts rather than the overlay changeset, so they never
+	// appear in Workspace.changes, and are committed into the volume on
+	// export. Internal only — persisted and dependency-tracked like mounts.
+	cacheMounts []WorkspaceCacheMount
 
 	// compatWorkspace stores the originating compat-workspace projection when
 	// this workspace was loaded from a legacy dagger.json instead of an explicit
@@ -160,6 +169,26 @@ type Workspace struct {
 	// generation fans out exponentially over the dependency DAG. Kept sorted
 	// and deduplicated; carried through Clone so derived workspaces keep it.
 	StagedGeneration []string
+}
+
+// WorkspaceCacheMount is a CacheVolume mounted into the workspace's mounts tree
+// at Target. It shadows base workspace content there and stays out of
+// Workspace.changes, like any other mount — but unlike a mounted Directory or
+// File it is writable: edits under Target update the mounts tree, and export
+// commits the resulting delta back into the volume.
+type WorkspaceCacheMount struct {
+	// Target is the workspace-root-relative mount path, cleaned, no leading
+	// slash (e.g. "foo", "build/cache"). It is also the key into the mounts
+	// tree, so the mount's current content is mounts.directory(Target).
+	Target string
+	// Volume is the cache volume backing this mount.
+	Volume dagql.ObjectResult[*CacheVolume]
+	// Baseline is the volume's content as of the mount — what the mounts tree
+	// held at Target before any edits. Export diffs the mount's current subtree
+	// against it, so only edits made through this workspace are written back and
+	// content another writer added to the volume meanwhile is left alone. It is
+	// a lazy Directory, so an untouched mount never materializes the volume.
+	Baseline dagql.ObjectResult[*Directory]
 }
 
 // WorkspaceSource is the private backing source for a Workspace.
@@ -510,9 +539,9 @@ func (ws *Workspace) SetUserConfigOverlay(overlay *workspacepkg.UserWorkspaceOve
 	ws.userConfigOverlay = overlay
 }
 
-// MountsDir returns the read-only directory tree holding mounted content,
-// keyed by workspace-root-relative mount path, or false when the workspace has
-// no mounts.
+// MountsDir returns the directory tree holding mounted content, keyed by
+// workspace-root-relative mount path, or false when the workspace has no
+// mounts.
 func (ws *Workspace) MountsDir() (dagql.ObjectResult[*Directory], bool) {
 	if ws == nil || ws.mounts.Self() == nil {
 		return dagql.ObjectResult[*Directory]{}, false
@@ -520,9 +549,9 @@ func (ws *Workspace) MountsDir() (dagql.ObjectResult[*Directory], bool) {
 	return ws.mounts, true
 }
 
-// WithMounted returns a copy of the workspace with the given read-only
-// mounted content tree and the workspace-root-relative path recorded as a
-// mount point, keeping the mount point list sorted and deduplicated.
+// WithMounted returns a copy of the workspace with the given mounted content
+// tree and the workspace-root-relative path recorded as a mount point, keeping
+// the mount point list sorted and deduplicated.
 func (ws *Workspace) WithMounted(newMounts dagql.ObjectResult[*Directory], path string) *Workspace {
 	cp := ws.Clone()
 	cp.mounts = newMounts
@@ -531,6 +560,100 @@ func (ws *Workspace) WithMounted(newMounts dagql.ObjectResult[*Directory], path 
 		cp.mountPoints = slices.Insert(cp.mountPoints, i, p)
 	}
 	return cp
+}
+
+// WithMountsDir returns a copy of the workspace with an updated mounts tree and
+// the mount points left as they are. Used to apply an edit under a cache mount,
+// which changes mounted content without mounting anything new.
+func (ws *Workspace) WithMountsDir(newMounts dagql.ObjectResult[*Directory]) *Workspace {
+	cp := ws.Clone()
+	cp.mounts = newMounts
+	return cp
+}
+
+// WithCacheMounted returns a copy of the workspace with the given mounted
+// content tree, the mount recorded as a cache-backed (writable) mount point,
+// and any mount previously covering the same target replaced.
+func (ws *Workspace) WithCacheMounted(newMounts dagql.ObjectResult[*Directory], mount WorkspaceCacheMount) *Workspace {
+	cp := ws.WithMounted(newMounts, mount.Target)
+	cacheMounts := make([]WorkspaceCacheMount, 0, len(cp.cacheMounts)+1)
+	for _, existing := range cp.cacheMounts {
+		if existing.Target != mount.Target {
+			cacheMounts = append(cacheMounts, existing)
+		}
+	}
+	cacheMounts = append(cacheMounts, mount)
+	slices.SortFunc(cacheMounts, func(a, b WorkspaceCacheMount) int {
+		return strings.Compare(a.Target, b.Target)
+	})
+	cp.cacheMounts = cacheMounts
+	return cp
+}
+
+// WithoutMountedAt returns a copy of the workspace with the given mounts tree
+// and every mount point at or under the workspace-root-relative path dropped —
+// unmounting a directory unmounts whatever was mounted inside it.
+func (ws *Workspace) WithoutMountedAt(newMounts dagql.ObjectResult[*Directory], path string) *Workspace {
+	cp := ws.Clone()
+	cp.mounts = newMounts
+	p := filepath.ToSlash(path)
+	covered := func(target string) bool {
+		return target == p || strings.HasPrefix(target, p+"/")
+	}
+	cp.mountPoints = slices.DeleteFunc(cp.mountPoints, covered)
+	cp.cacheMounts = slices.DeleteFunc(cp.cacheMounts, func(m WorkspaceCacheMount) bool {
+		return covered(m.Target)
+	})
+	return cp
+}
+
+// CacheMounts returns the workspace's cache-backed mounts (see
+// WorkspaceCacheMount).
+func (ws *Workspace) CacheMounts() []WorkspaceCacheMount {
+	if ws == nil {
+		return nil
+	}
+	return ws.cacheMounts
+}
+
+// CacheMountForPath returns the cache mount a workspace-root-relative path may
+// be edited through: the deepest mount point covering it, when that mount is
+// cache-backed. A Directory or File mount is read-only, and one nested under a
+// cache mount keeps its own subtree read-only.
+func (ws *Workspace) CacheMountForPath(resolvedPath string) (WorkspaceCacheMount, bool) {
+	mp, ok := ws.deepestMountPoint(resolvedPath)
+	if !ok {
+		return WorkspaceCacheMount{}, false
+	}
+	for _, m := range ws.cacheMounts {
+		if m.Target == mp {
+			return m, true
+		}
+	}
+	return WorkspaceCacheMount{}, false
+}
+
+// deepestMountPoint returns the longest mount point covering a
+// workspace-root-relative path, so a nested mount shadows the one it sits in.
+func (ws *Workspace) deepestMountPoint(resolvedPath string) (string, bool) {
+	if ws == nil {
+		return "", false
+	}
+	p := filepath.ToSlash(resolvedPath)
+	var (
+		best  string
+		found bool
+	)
+	for _, mp := range ws.mountPoints {
+		if p != mp && !strings.HasPrefix(p, mp+"/") {
+			continue
+		}
+		if !found || len(mp) > len(best) {
+			best = mp
+			found = true
+		}
+	}
+	return best, found
 }
 
 // MountedPath reports whether a workspace-root-relative path is at or under
@@ -593,23 +716,34 @@ var _ dagql.PersistedObjectDecoder = (*Workspace)(nil)
 var _ dagql.HasDependencyResults = (*Workspace)(nil)
 
 type persistedWorkspacePayload struct {
-	RootfsResultID  uint64                        `json:"rootfsResultID,omitempty"`
-	MountsResultID  uint64                        `json:"mountsResultID,omitempty"`
-	MountPoints     []string                      `json:"mountPoints,omitempty"`
-	Source          *persistedWorkspaceSource     `json:"source,omitempty"`
-	CompatWorkspace *workspacepkg.CompatWorkspace `json:"compatWorkspace,omitempty"`
-	Address         string                        `json:"address,omitempty"`
-	Cwd             string                        `json:"cwd,omitempty"`
-	ConfigFile      string                        `json:"configFile,omitempty"`
-	LockFile        string                        `json:"lockFile,omitempty"`
-	ClientID        string                        `json:"clientID,omitempty"`
-	HostPath        string                        `json:"hostPath,omitempty"`
+	RootfsResultID  uint64                         `json:"rootfsResultID,omitempty"`
+	MountsResultID  uint64                         `json:"mountsResultID,omitempty"`
+	MountPoints     []string                       `json:"mountPoints,omitempty"`
+	CacheMounts     []persistedWorkspaceCacheMount `json:"cacheMounts,omitempty"`
+	Source          *persistedWorkspaceSource      `json:"source,omitempty"`
+	CompatWorkspace *workspacepkg.CompatWorkspace  `json:"compatWorkspace,omitempty"`
+	Address         string                         `json:"address,omitempty"`
+	Cwd             string                         `json:"cwd,omitempty"`
+	ConfigFile      string                         `json:"configFile,omitempty"`
+	LockFile        string                         `json:"lockFile,omitempty"`
+	ClientID        string                         `json:"clientID,omitempty"`
+	HostPath        string                         `json:"hostPath,omitempty"`
 
 	StagedGeneration []string `json:"stagedGeneration,omitempty"`
 
 	// Decode-only names from main's pre-workspace-selection payload.
 	LegacyPath       string `json:"path,omitempty"`
 	LegacyConfigPath string `json:"configPath,omitempty"`
+}
+
+// persistedWorkspaceCacheMount is the on-disk encoding of a WorkspaceCacheMount:
+// its Target plus references to the backing volume and the baseline export
+// diffs against. The mounted content itself lives in the mounts tree, which is
+// persisted separately.
+type persistedWorkspaceCacheMount struct {
+	Target           string `json:"target,omitempty"`
+	VolumeResultID   uint64 `json:"volumeResultID,omitempty"`
+	BaselineResultID uint64 `json:"baselineResultID,omitempty"`
 }
 
 type persistedWorkspaceSource struct {
@@ -779,6 +913,24 @@ func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.Pers
 		}
 		payload.Source = source
 	}
+	for _, m := range ws.cacheMounts {
+		persistedMount := persistedWorkspaceCacheMount{Target: m.Target}
+		if m.Volume.Self() != nil {
+			volumeID, err := encodePersistedObjectRef(cache, m.Volume, "workspace cache mount volume")
+			if err != nil {
+				return dagql.PersistedObjectEncoding{}, err
+			}
+			persistedMount.VolumeResultID = volumeID
+		}
+		if m.Baseline.Self() != nil {
+			baselineID, err := encodePersistedObjectRef(cache, m.Baseline, "workspace cache mount baseline")
+			if err != nil {
+				return dagql.PersistedObjectEncoding{}, err
+			}
+			persistedMount.BaselineResultID = baselineID
+		}
+		payload.CacheMounts = append(payload.CacheMounts, persistedMount)
+	}
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -817,6 +969,26 @@ func (*Workspace) DecodePersistedObject(
 		}
 	}
 
+	var cacheMounts []WorkspaceCacheMount
+	for _, persistedMount := range persisted.CacheMounts {
+		mount := WorkspaceCacheMount{Target: persistedMount.Target}
+		if persistedMount.VolumeResultID != 0 {
+			volume, err := loadPersistedObjectResultByResultID[*CacheVolume](ctx, dag, persistedMount.VolumeResultID, "workspace cache mount volume")
+			if err != nil {
+				return nil, err
+			}
+			mount.Volume = volume
+		}
+		if persistedMount.BaselineResultID != 0 {
+			baseline, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persistedMount.BaselineResultID, "workspace cache mount baseline")
+			if err != nil {
+				return nil, err
+			}
+			mount.Baseline = baseline
+		}
+		cacheMounts = append(cacheMounts, mount)
+	}
+
 	cwd := persisted.Cwd
 	if cwd == "" {
 		cwd = persisted.LegacyPath
@@ -835,6 +1007,7 @@ func (*Workspace) DecodePersistedObject(
 		rootfs:           rootfs,
 		mounts:           mounts,
 		mountPoints:      persisted.MountPoints,
+		cacheMounts:      cacheMounts,
 		compatWorkspace:  persisted.CompatWorkspace,
 		Address:          persisted.Address,
 		Cwd:              cwd,
@@ -898,6 +1071,33 @@ func (ws *Workspace) AttachDependencyResults(
 		}
 		ws.mounts = typed
 		deps = append(deps, typed)
+	}
+
+	for i := range ws.cacheMounts {
+		if ws.cacheMounts[i].Volume.Self() != nil {
+			attached, err := attach(ws.cacheMounts[i].Volume)
+			if err != nil {
+				return nil, fmt.Errorf("attach workspace cache mount volume: %w", err)
+			}
+			typed, ok := attached.(dagql.ObjectResult[*CacheVolume])
+			if !ok {
+				return nil, fmt.Errorf("attach workspace cache mount volume: unexpected result %T", attached)
+			}
+			ws.cacheMounts[i].Volume = typed
+			deps = append(deps, typed)
+		}
+		if ws.cacheMounts[i].Baseline.Self() != nil {
+			attached, err := attach(ws.cacheMounts[i].Baseline)
+			if err != nil {
+				return nil, fmt.Errorf("attach workspace cache mount baseline: %w", err)
+			}
+			typed, ok := attached.(dagql.ObjectResult[*Directory])
+			if !ok {
+				return nil, fmt.Errorf("attach workspace cache mount baseline: unexpected result %T", attached)
+			}
+			ws.cacheMounts[i].Baseline = typed
+			deps = append(deps, typed)
+		}
 	}
 
 	return deps, nil
@@ -970,6 +1170,7 @@ func attachWorkspaceSource(
 func (ws *Workspace) Clone() *Workspace {
 	cp := *ws
 	cp.mountPoints = slices.Clone(ws.mountPoints)
+	cp.cacheMounts = slices.Clone(ws.cacheMounts)
 	return &cp
 }
 

--- a/core/workspace_volume.go
+++ b/core/workspace_volume.go
@@ -1,0 +1,259 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	bkcache "github.com/dagger/dagger/engine/snapshots"
+	bkclient "github.com/dagger/dagger/internal/buildkit/client"
+	"github.com/dagger/dagger/util/layercopy"
+
+	"github.com/dagger/dagger/dagql"
+)
+
+// CacheVolumeSnapshotLazy defers materializing a cache volume's mutable
+// content into an immutable Directory until something actually needs it.
+// Mounting a cache into a workspace is then free — the O(content) copy is paid
+// by the first read, search, glob or export that touches the mount, and only
+// once, since the evaluated snapshot is memoized on the Directory.
+type CacheVolumeSnapshotLazy struct {
+	LazyState
+	Volume dagql.ObjectResult[*CacheVolume]
+}
+
+func (lazy *CacheVolumeSnapshotLazy) Evaluate(ctx context.Context, dir *Directory) error {
+	return lazy.LazyState.Evaluate(ctx, "CacheVolume.__snapshotDirectory", func(ctx context.Context) error {
+		if lazy.Volume.Self() == nil {
+			return fmt.Errorf("cache volume snapshot: missing volume")
+		}
+		return lazy.Volume.Self().snapshotInto(ctx, dir)
+	})
+}
+
+func (lazy *CacheVolumeSnapshotLazy) AttachDependencies(
+	ctx context.Context,
+	attach func(dagql.AnyResult) (dagql.AnyResult, error),
+) ([]dagql.AnyResult, error) {
+	_ = ctx
+	if lazy.Volume.Self() == nil {
+		return nil, nil
+	}
+	attached, err := attach(lazy.Volume)
+	if err != nil {
+		return nil, fmt.Errorf("attach cache volume snapshot volume: %w", err)
+	}
+	typed, ok := attached.(dagql.ObjectResult[*CacheVolume])
+	if !ok {
+		return nil, fmt.Errorf("attach cache volume snapshot volume: unexpected result %T", attached)
+	}
+	lazy.Volume = typed
+	return []dagql.AnyResult{typed}, nil
+}
+
+func (lazy *CacheVolumeSnapshotLazy) EncodePersisted(
+	ctx context.Context,
+	cache dagql.PersistedObjectCache,
+) (json.RawMessage, error) {
+	_ = ctx
+	volumeID, err := encodePersistedObjectRef(cache, lazy.Volume, "cache volume snapshot volume")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(persistedCacheVolumeSnapshotLazy{VolumeResultID: volumeID})
+}
+
+// SnapshotDirectory returns a point-in-time, immutable Directory view of the
+// cache volume's current (mutable) content. The copy that produces it is
+// deferred (see CacheVolumeSnapshotLazy), so the volume is read when the
+// Directory is first evaluated rather than when this is called. The resulting
+// snapshot's digest is content-derived, so downstream reads of an unchanged
+// cache still dedup.
+func (cache *CacheVolume) SnapshotDirectory(
+	ctx context.Context,
+	self dagql.ObjectResult[*CacheVolume],
+) (*Directory, error) {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &Directory{
+		Platform: query.Platform(),
+		Lazy: &CacheVolumeSnapshotLazy{
+			LazyState: NewLazyState(),
+			Volume:    self,
+		},
+		Dir:      new(LazyAccessor[string, *Directory]),
+		Snapshot: new(LazyAccessor[bkcache.ImmutableRef, *Directory]),
+	}, nil
+}
+
+// snapshotInto copies the volume's live content into a fresh committed
+// snapshot and stores it on dir. It is the deferred half of SnapshotDirectory.
+func (cache *CacheVolume) snapshotInto(ctx context.Context, dir *Directory) (rerr error) {
+	if err := cache.InitializeSnapshot(ctx); err != nil {
+		return err
+	}
+	srcRef := cache.getSnapshot()
+	if srcRef == nil {
+		return fmt.Errorf("cache volume %q has no snapshot", cache.Key)
+	}
+	selector := cache.getSnapshotSelector()
+
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+
+	newRef, err := query.SnapshotManager().New(
+		ctx,
+		nil,
+		bkcache.WithRecordType(bkclient.UsageRecordTypeRegular),
+		bkcache.WithDescription(fmt.Sprintf("cache volume %q snapshot", cache.Key)),
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rerr != nil && newRef != nil {
+			newRef.Release(context.WithoutCancel(ctx))
+		}
+	}()
+
+	err = MountRef(ctx, newRef, func(destRoot string, destMnt *mount.Mount) error {
+		copier, err := layercopy.NewCopier(layercopy.Mount{Root: destRoot, Mount: destMnt})
+		if err != nil {
+			return err
+		}
+		defer copier.Close()
+		return MountRef(ctx, srcRef, func(srcRoot string, srcMnt *mount.Mount) error {
+			return copier.Copy(ctx,
+				layercopy.Mount{Root: srcRoot, Mount: srcMnt},
+				selector,
+				"/",
+				layercopy.CopyOptions{
+					CopyDirContents: true,
+					ReplaceExisting: true,
+				},
+			)
+		}, mountRefAsReadOnly)
+	})
+	if err != nil {
+		return fmt.Errorf("copy cache volume content: %w", err)
+	}
+
+	snap, err := newRef.Commit(ctx)
+	if err != nil {
+		return err
+	}
+	newRef = nil
+
+	dir.Dir.setValue("/")
+	dir.Snapshot.setValue(snap)
+	return nil
+}
+
+// CommitChanges applies a per-mount changeset delta into the cache volume's
+// live mutable snapshot (write-through): added/modified content is copied in,
+// removed paths are deleted. Callers hold the changeset from a mount edit;
+// committing it makes containers/modules that mount the same cache volume
+// observe the edits.
+func (cache *CacheVolume) CommitChanges(ctx context.Context, changes *Changeset) error {
+	if changes == nil {
+		return nil
+	}
+	empty, err := changes.IsEmpty(ctx)
+	if err != nil {
+		return err
+	}
+	if empty {
+		return nil
+	}
+	if err := cache.InitializeSnapshot(ctx); err != nil {
+		return err
+	}
+	ref := cache.getSnapshot()
+	if ref == nil {
+		return fmt.Errorf("cache volume %q has no snapshot", cache.Key)
+	}
+	return changes.CommitInto(ctx, ref, cache.getSnapshotSelector())
+}
+
+// CommitInto applies the changeset's delta into a mounted (mutable) ref at
+// targetDir: removed paths are deleted, then added/modified content is copied
+// in. It mirrors Directory.withChanges' snapshot application, but writes into
+// an existing mutable ref in place rather than a fresh snapshot.
+func (ch *Changeset) CommitInto(ctx context.Context, ref bkcache.MutableRef, targetDir string) (rerr error) {
+	if targetDir == "" {
+		targetDir = "/"
+	}
+	paths, err := ch.ComputePaths(ctx)
+	if err != nil {
+		return fmt.Errorf("compute paths: %w", err)
+	}
+
+	srv, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return err
+	}
+	afterID, err := ch.After.ID()
+	if err != nil {
+		return fmt.Errorf("after ID: %w", err)
+	}
+	var dir dagql.ObjectResult[*Directory]
+	if err := srv.Select(ctx, ch.Before, &dir, dagql.Selector{
+		Field: "diff",
+		Args: []dagql.NamedInput{
+			{Name: "other", Value: dagql.NewID[*Directory](afterID)},
+		},
+	}); err != nil {
+		return fmt.Errorf("get changeset diff directory: %w", err)
+	}
+	engineCache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return err
+	}
+	if err := engineCache.Evaluate(ctx, dir); err != nil {
+		return fmt.Errorf("evaluate changeset diff directory: %w", err)
+	}
+	diffSnapshot, err := dir.Self().Snapshot.GetOrEval(ctx, dir.Result)
+	if err != nil {
+		return fmt.Errorf("evaluate changeset diff snapshot: %w", err)
+	}
+	diffSelector, err := dir.Self().Dir.GetOrEval(ctx, dir.Result)
+	if err != nil {
+		return fmt.Errorf("evaluate changeset diff selector: %w", err)
+	}
+
+	return MountRef(ctx, ref, func(root string, destMnt *mount.Mount) error {
+		copier, err := layercopy.NewCopier(layercopy.Mount{Root: root, Mount: destMnt})
+		if err != nil {
+			return err
+		}
+		defer copier.Close()
+
+		if err := removeChangesetPaths(root, targetDir, paths.Removed); err != nil {
+			return err
+		}
+
+		if diffSnapshot != nil {
+			err = MountRef(ctx, diffSnapshot, func(srcRoot string, srcMnt *mount.Mount) error {
+				return copier.Copy(ctx,
+					layercopy.Mount{Root: srcRoot, Mount: srcMnt},
+					diffSelector,
+					targetDir,
+					layercopy.CopyOptions{
+						CopyDirContents: true,
+						ReplaceExisting: true,
+					},
+				)
+			}, mountRefAsReadOnly)
+			if err != nil {
+				return fmt.Errorf("copy changed paths into cache: %w", err)
+			}
+		}
+
+		return mkdirChangesetAddedDirs(ctx, copier, targetDir, paths)
+	})
+}

--- a/docs/current_docs/config/module-wiring.mdx
+++ b/docs/current_docs/config/module-wiring.mdx
@@ -47,6 +47,19 @@ way:
 baseCtr = "base-images:chromium"
 ```
 
+## Wire a file, directory, or workspace
+
+Build artifacts and workspaces can be passed between modules in the same way.
+A function returning a `File`, `Directory`, or `Workspace` can be referenced by
+a matching constructor argument:
+
+```toml
+[modules.packager.settings]
+binary = "builder:binary"
+assets = "frontend:assets"
+source = "source-prep:workspace"
+```
+
 ## Use a reference on the command line
 
 A module reference is an ordinary address string, so it also works as a CLI
@@ -75,8 +88,12 @@ dagger api call playwright --service=myapp:serve test
 If you author modules, wiring changes how you shape a constructor:
 
 - **Accept collaborators as optional constructor arguments.** An optional
-  `Service` or `Container` argument is a wiring point. Without one, users
-  need a glue module to connect yours to anything.
+  `Service`, `Container`, `File`, `Directory`, or `Workspace` argument is a
+  wiring point. Without one, users need a glue module to connect yours to
+  anything.
+- **Consume workspaces in the constructor.** A module object cannot retain a
+  `Workspace` as a field. Derive and store the `File`, `Directory`, or other
+  value your module needs from the wired workspace instead.
 - **Put workspace-level configuration on the constructor, not on function
   arguments.** Settings map to constructor arguments. A shard count, a
   service, or a base image belongs there if the workspace should configure it

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5710,7 +5710,11 @@ type Workspace implements Node {
   """List named environments defined in the workspace configuration."""
   envList: [String!]!
 
-  """Write this workspace's pending changes to its local Git workspace."""
+  """
+  Write this workspace's pending changes to its local Git workspace.
+
+  Edits made under a mounted cache volume are not pending changes; they are committed into that volume instead.
+  """
   export: Void!
 
   """
@@ -6037,6 +6041,24 @@ type Workspace implements Node {
   ): Workspace!
 
   """
+  Return this workspace with a cache volume mounted at the given path, without mutating the source.
+
+  Like a mounted directory, the cache shadows the source at the mount path and
+  stays out of the pending changeset: it never appears in changes and is never
+  exported to the workspace. Unlike a mounted directory it is writable, and
+  export commits the edits made under it back into the cache volume.
+  """
+  withMountedCache(
+    """
+    Location of the mounted cache. Relative paths resolve from the workspace cwd.
+    """
+    path: String!
+
+    """Cache volume to mount."""
+    cache: ID! @expectedType(name: "CacheVolume")
+  ): Workspace!
+
+  """
   Return this workspace with a directory mounted read-only at the given path, without mutating the source.
 
   Mounted content is readable through the normal workspace file tools but
@@ -6182,6 +6204,20 @@ type Workspace implements Node {
 
     """Write to the workspace config directory at the workspace cwd."""
     here: Boolean = false
+  ): Workspace!
+
+  """
+  Return this workspace with the content mounted at the given path unmounted.
+
+  Removes whatever is mounted there — a cache volume, directory or file —
+  along with anything mounted inside it. Pending edits to a mounted cache volume
+  are discarded rather than committed.
+  """
+  withoutMount(
+    """
+    Location of the mount to remove. Relative paths resolve from the workspace cwd.
+    """
+    path: String!
   ): Workspace!
 
   """Return this workspace with an SDK removed from its config."""

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -94,6 +94,9 @@ type Address implements Node {
 
   """Load a volume from the address."""
   volume: Volume!
+
+  """Load a workspace from a module reference."""
+  workspace: Workspace!
 }
 
 type Agent implements Node {

--- a/docs/static/reference/php/Dagger/Address.html
+++ b/docs/static/reference/php/Dagger/Address.html
@@ -251,6 +251,16 @@
                                             <p><p>Load a volume from the address.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_workspace">workspace</a>()
+        
+                                            <p><p>Load a workspace from a module reference.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
             </div>
 
 
@@ -737,6 +747,38 @@
                     <table class="table table-condensed">
         <tr>
             <td><a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_workspace">
+        <div class="location">at line 150</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>workspace</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Load a workspace from a module reference.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
             <td></td>
         </tr>
     </table>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1705,7 +1705,9 @@
                     <dd><p>A filesystem volume that can be mounted into containers.</p></dd><dt><a href="Dagger/WorkspaceModuleSetting.html#method_value">
 <abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::value</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
                     <dd><p>The configured value after applying the selected workspace environment, or empty when unset.</p></dd>        </dl><h2 id="letterW">W</h2>
-        <dl id="indexW"><dt><a href="Dagger/Changeset.html#method_withChangeset">
+        <dl id="indexW"><dt><a href="Dagger/Address.html#method_workspace">
+<abbr title="Dagger\Address">Address</abbr>::workspace</a>() &mdash; <em>Method in class <a href="Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a></em></dt>
+                    <dd><p>Load a workspace from a module reference.</p></dd><dt><a href="Dagger/Changeset.html#method_withChangeset">
 <abbr title="Dagger\Changeset">Changeset</abbr>::withChangeset</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
                     <dd><p>Add changes to an existing changeset</p></dd><dt><a href="Dagger/Changeset.html#method_withChangesets">
 <abbr title="Dagger\Changeset">Changeset</abbr>::withChangesets</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2000,6 +2000,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Address::workspace",
+			"p": "Dagger/Address.html#method_workspace",
+			"d": "<p>Load a workspace from a module reference.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Agent::description",
 			"p": "Dagger/Agent.html#method_description",
 			"d": "<p>The description of the agent</p>"

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -268,6 +268,10 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		return nil, err
 	}
 
+	// Sweep any worker state moved aside by a cache reset — this startup's or
+	// an interrupted sweep from a previous one — in the background.
+	srv.startLocalCacheTrashSweeper()
+
 	//
 	// clean up old hosts/resolv.conf file. ignore errors
 	//
@@ -664,8 +668,15 @@ func (srv *Server) closeLocalCacheStateForReset() error {
 }
 
 func (srv *Server) removeLocalCacheStateOnDisk() error {
-	if err := os.RemoveAll(srv.workerRootDir); err != nil {
-		return fmt.Errorf("remove worker state: %w", err)
+	trashDir, err := moveLocalCacheStateToTrash(srv.workerRootDir)
+	if err != nil {
+		return fmt.Errorf("move worker state to trash: %w", err)
+	}
+	if trashDir != "" {
+		// The rename is O(1), so startup proceeds immediately; the trash dir
+		// is removed in the background once startup settles (see
+		// startLocalCacheTrashSweeper).
+		slog.Info("moved invalid worker state aside for background removal", "dir", trashDir)
 	}
 	if err := dagql.RemoveCachePersistenceStore(filepath.Join(srv.rootDir, "dagql-cache.db")); err != nil {
 		return fmt.Errorf("remove dagql persistence state: %w", err)

--- a/engine/server/trash.go
+++ b/engine/server/trash.go
@@ -93,8 +93,9 @@ func findLocalCacheTrashDirs(rootDir string) ([]string, error) {
 }
 
 // startLocalCacheTrashSweeper scans for trash directories and, if any exist,
-// starts sweeping them in the background. Called once at startup, after the
-// local cache state (and any reset of it) is settled.
+// sweeps them. Under disk pressure it blocks startup so the engine has room to
+// operate; otherwise it sweeps in the background. Called once at startup,
+// after the local cache state (and any reset of it) is settled.
 func (srv *Server) startLocalCacheTrashSweeper() {
 	trashDirs, err := findLocalCacheTrashDirs(srv.rootDir)
 	if err != nil {
@@ -102,6 +103,11 @@ func (srv *Server) startLocalCacheTrashSweeper() {
 		return
 	}
 	if len(trashDirs) == 0 {
+		return
+	}
+	if srv.trashSweepFullSpeed() {
+		slog.Info("disk pressure detected; removing discarded local cache state before startup continues")
+		srv.sweepLocalCacheTrash(srv.shutdownCtx, trashDirs)
 		return
 	}
 	go srv.sweepLocalCacheTrash(srv.shutdownCtx, trashDirs)
@@ -115,7 +121,7 @@ func (srv *Server) sweepLocalCacheTrash(ctx context.Context, trashDirs []string)
 	}
 	for _, trashDir := range trashDirs {
 		start := time.Now()
-		slog.Info("removing discarded local cache state in background", "dir", trashDir)
+		slog.Info("removing discarded local cache state", "dir", trashDir)
 		// An uncleanly stopped engine can leave mounts behind (snapshotter
 		// overlays, cache mount binds) in the state it discarded; detach them
 		// first so the walk below removes the trash tree itself rather than

--- a/engine/server/trash.go
+++ b/engine/server/trash.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/internal/buildkit/util/disk"
+)
+
+// Discarded local cache state (the worker root dir: snapshots, content store,
+// cache mounts, ...) can be enormous — tens of GB across millions of inodes —
+// so deleting it inline at startup both blocks the engine from serving and
+// saturates the disk queue with unlink/journal traffic for as long as the
+// delete takes. Instead the invalid state is renamed aside to a sibling
+// "worker-trash-<unique>" directory (an O(1) rename; always the same
+// filesystem since the trash dir is a sibling), and a background sweeper
+// removes the tree with a bounded duty cycle so the filesystem journal can
+// drain between bursts. Leftover trash dirs from an interrupted sweep are
+// picked up on the next startup.
+const (
+	workerTrashPrefix = "worker-trash-"
+
+	// trashSweepWorkSlice/trashSweepRestSlice define the sweeper's duty
+	// cycle: unlink for up to workSlice, then idle for restSlice. The ~20%
+	// duty cycle trades a longer total sweep for leaving disk bandwidth to
+	// the rest of the system (a saturating delete storm is what makes
+	// desktop audio/video stutter during cache resets).
+	trashSweepWorkSlice = 50 * time.Millisecond
+	trashSweepRestSlice = 200 * time.Millisecond
+
+	// trashSweepBatch is how many directory entries are read per scan pass
+	// while walking a trash tree, bounding memory on huge directories.
+	trashSweepBatch = 256
+)
+
+// moveLocalCacheStateToTrash renames dir aside to a sibling trash directory
+// for background removal, returning the trash path. A missing dir is a no-op
+// returning "".
+func moveLocalCacheStateToTrash(dir string) (string, error) {
+	if _, err := os.Lstat(dir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	parent := filepath.Dir(dir)
+	for attempt := range 3 {
+		trashDir := filepath.Join(parent, workerTrashPrefix+strconv.FormatInt(time.Now().UnixNano(), 10))
+		err := os.Rename(dir, trashDir)
+		if err == nil {
+			return trashDir, nil
+		}
+		// A same-nanosecond collision with an existing trash dir is all but
+		// impossible, but cheap to retry under a fresh name.
+		collision := errors.Is(err, fs.ErrExist) || errors.Is(err, unix.ENOTEMPTY)
+		if attempt == 2 || !collision {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("move %s to trash: retries exhausted", dir)
+}
+
+// findLocalCacheTrashDirs lists the trash directories under rootDir: state
+// discarded by this startup plus any leftovers from a previous engine whose
+// sweep never finished.
+func findLocalCacheTrashDirs(rootDir string) ([]string, error) {
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var trashDirs []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), workerTrashPrefix) {
+			trashDirs = append(trashDirs, filepath.Join(rootDir, entry.Name()))
+		}
+	}
+	return trashDirs, nil
+}
+
+// startLocalCacheTrashSweeper scans for trash directories and, if any exist,
+// starts sweeping them in the background. Called once at startup, after the
+// local cache state (and any reset of it) is settled.
+func (srv *Server) startLocalCacheTrashSweeper() {
+	trashDirs, err := findLocalCacheTrashDirs(srv.rootDir)
+	if err != nil {
+		slog.Warn("failed to scan for discarded local cache state", "err", err)
+		return
+	}
+	if len(trashDirs) == 0 {
+		return
+	}
+	go srv.sweepLocalCacheTrash(srv.shutdownCtx, trashDirs)
+}
+
+func (srv *Server) sweepLocalCacheTrash(ctx context.Context, trashDirs []string) {
+	pacer := &trashPacer{
+		workSlice: trashSweepWorkSlice,
+		restSlice: trashSweepRestSlice,
+		fullSpeed: srv.trashSweepFullSpeed,
+	}
+	for _, trashDir := range trashDirs {
+		start := time.Now()
+		slog.Info("removing discarded local cache state in background", "dir", trashDir)
+		// An uncleanly stopped engine can leave mounts behind (snapshotter
+		// overlays, cache mount binds) in the state it discarded; detach them
+		// first so the walk below removes the trash tree itself rather than
+		// descending into mounted filesystems. Mount paths follow the rename,
+		// so they show up under the trash dir. Best-effort: anything missed
+		// is caught by the EBUSY fallback in removeOnePaced.
+		if err := mount.UnmountRecursive(trashDir, unix.MNT_DETACH); err != nil {
+			slog.Warn("failed to unmount leftover mounts under discarded local cache state", "dir", trashDir, "err", err)
+		}
+		err := removeAllPaced(ctx, trashDir, pacer)
+		switch {
+		case err == nil:
+			slog.Info("removed discarded local cache state", "dir", trashDir, "duration", time.Since(start).Round(time.Millisecond))
+		case errors.Is(err, context.Canceled):
+			slog.Info("interrupted removing discarded local cache state; resuming on next startup", "dir", trashDir)
+			return
+		default:
+			slog.Warn("failed to remove discarded local cache state; retrying on next startup", "dir", trashDir, "err", err)
+		}
+	}
+}
+
+// trashSweepFullSpeed reports whether the sweeper should skip its rest slices:
+// once the disk is under the same free-space pressure that triggers cache GC,
+// reclaiming the trashed bytes promptly matters more than smoothing I/O.
+func (srv *Server) trashSweepFullSpeed() bool {
+	if len(srv.workerGCPolicies) == 0 {
+		return false
+	}
+	dstat, err := disk.GetDiskStat(srv.rootDir)
+	if err != nil {
+		return false
+	}
+	return localCacheDiskPressureGCNeeded(srv.workerGCPolicies, dstat)
+}
+
+// trashPacer bounds the sweeper's duty cycle: removals proceed for up to
+// workSlice, then pause for restSlice, unless fullSpeed says the rest should
+// be skipped. A zero workSlice disables pacing entirely.
+type trashPacer struct {
+	workSlice time.Duration
+	restSlice time.Duration
+	fullSpeed func() bool
+
+	sliceEnd time.Time
+}
+
+// pace is called before each removal; it returns promptly while the current
+// work slice lasts and sleeps for restSlice once it is exhausted.
+func (p *trashPacer) pace(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p.workSlice <= 0 {
+		return nil
+	}
+	now := time.Now()
+	if p.sliceEnd.IsZero() {
+		p.sliceEnd = now.Add(p.workSlice)
+		return nil
+	}
+	if now.Before(p.sliceEnd) {
+		return nil
+	}
+	if p.fullSpeed != nil && p.fullSpeed() {
+		p.sliceEnd = now.Add(p.workSlice)
+		return nil
+	}
+	timer := time.NewTimer(p.restSlice)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+	}
+	p.sliceEnd = time.Now().Add(p.workSlice)
+	return nil
+}
+
+// removeAllPaced removes path and everything below it like os.RemoveAll, but
+// paced by pacer, and resilient to leftover mountpoints: an EBUSY removal
+// attempts a lazy unmount first, since an uncleanly stopped engine can leave
+// mounts behind in the state it discarded. It stops at the first hard error;
+// the sweep is retried on the next startup.
+func removeAllPaced(ctx context.Context, path string, pacer *trashPacer) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return removeOnePaced(ctx, path, pacer)
+	}
+	for {
+		names, err := readDirnamesBatch(path, trashSweepBatch)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if len(names) == 0 {
+			break
+		}
+		for _, name := range names {
+			if err := removeAllPaced(ctx, filepath.Join(path, name), pacer); err != nil {
+				return err
+			}
+		}
+		if len(names) < trashSweepBatch {
+			// The batch covered every remaining entry and all were removed,
+			// so the directory is empty now.
+			break
+		}
+	}
+	return removeOnePaced(ctx, path, pacer)
+}
+
+func removeOnePaced(ctx context.Context, path string, pacer *trashPacer) error {
+	if err := pacer.pace(ctx); err != nil {
+		return err
+	}
+	err := os.Remove(path)
+	if err == nil || errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if errors.Is(err, unix.EBUSY) {
+		// Likely a mountpoint left behind by an unclean shutdown; detach it
+		// and retry. MNT_DETACH succeeds even while the mount is in use.
+		if unmountErr := unix.Unmount(path, unix.MNT_DETACH); unmountErr == nil {
+			err = os.Remove(path)
+			if err == nil || errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+		}
+	}
+	return err
+}
+
+// readDirnamesBatch returns up to n names from dir. Reopening the directory
+// per batch resets the read position, which keeps the walk correct while
+// entries are being unlinked between batches.
+func readDirnamesBatch(dir string, n int) ([]string, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(n)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return names, nil
+}

--- a/engine/server/trash_test.go
+++ b/engine/server/trash_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagger/dagger/internal/buildkit/util/disk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,4 +129,27 @@ func TestSweepLocalCacheTrash(t *testing.T) {
 	require.NoDirExists(t, trashA)
 	require.NoDirExists(t, trashB)
 	require.DirExists(t, keep)
+}
+
+func TestStartLocalCacheTrashSweeperBlocksUnderDiskPressure(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	trashDir := filepath.Join(rootDir, workerTrashPrefix+"1")
+	writeTrashFixtureTree(t, trashDir)
+
+	dstat, err := disk.GetDiskStat(rootDir)
+	require.NoError(t, err)
+	srv := &Server{
+		rootDir:     rootDir,
+		shutdownCtx: context.Background(),
+		workerGCPolicies: []dagqlCachePrunePolicy{
+			{MinFreeSpace: dstat.Available + 1},
+		},
+	}
+
+	srv.startLocalCacheTrashSweeper()
+
+	// The call does not return until the trash is removed, ensuring startup
+	// has reclaimed space before the engine begins creating files again.
+	require.NoDirExists(t, trashDir)
 }

--- a/engine/server/trash_test.go
+++ b/engine/server/trash_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTrashFixtureTree(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "snapshots", "1", "fs"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "content", "blobs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "snapshots", "1", "fs", "data"), []byte("data"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "content", "blobs", "blob"), []byte("blob"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.db"), []byte("db"), 0o644))
+	require.NoError(t, os.Symlink("snapshots", filepath.Join(dir, "link")))
+}
+
+func TestMoveLocalCacheStateToTrash(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	workerDir := filepath.Join(rootDir, "worker")
+	writeTrashFixtureTree(t, workerDir)
+
+	trashDir, err := moveLocalCacheStateToTrash(workerDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, trashDir)
+	require.Equal(t, rootDir, filepath.Dir(trashDir))
+	require.True(t, len(filepath.Base(trashDir)) > len(workerTrashPrefix))
+	require.Contains(t, filepath.Base(trashDir), workerTrashPrefix)
+
+	// the worker dir is gone, its content moved under the trash dir
+	require.NoDirExists(t, workerDir)
+	require.FileExists(t, filepath.Join(trashDir, "snapshots", "1", "fs", "data"))
+	require.FileExists(t, filepath.Join(trashDir, "metadata.db"))
+
+	// a missing worker dir is a no-op
+	trashDir, err = moveLocalCacheStateToTrash(workerDir)
+	require.NoError(t, err)
+	require.Empty(t, trashDir)
+}
+
+func TestFindLocalCacheTrashDirs(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "worker"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, workerTrashPrefix+"1"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, workerTrashPrefix+"2"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "dagql-cache.db"), []byte("db"), 0o644))
+
+	trashDirs, err := findLocalCacheTrashDirs(rootDir)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(rootDir, workerTrashPrefix+"1"),
+		filepath.Join(rootDir, workerTrashPrefix+"2"),
+	}, trashDirs)
+
+	// a missing root dir is a no-op, not an error
+	trashDirs, err = findLocalCacheTrashDirs(filepath.Join(rootDir, "does-not-exist"))
+	require.NoError(t, err)
+	require.Empty(t, trashDirs)
+}
+
+func TestRemoveAllPaced(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	trashDir := filepath.Join(rootDir, workerTrashPrefix+"1")
+	writeTrashFixtureTree(t, trashDir)
+
+	// a tiny work slice forces the pacer through its rest path as well
+	pacer := &trashPacer{workSlice: time.Nanosecond, restSlice: time.Nanosecond}
+	require.NoError(t, removeAllPaced(context.Background(), trashDir, pacer))
+	require.NoDirExists(t, trashDir)
+
+	// removing an already-removed tree is a no-op
+	require.NoError(t, removeAllPaced(context.Background(), trashDir, pacer))
+}
+
+func TestRemoveAllPacedManyEntries(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	trashDir := filepath.Join(rootDir, workerTrashPrefix+"1")
+	// more entries than one readDirnamesBatch pass covers
+	require.NoError(t, os.MkdirAll(trashDir, 0o755))
+	for i := range trashSweepBatch + 100 {
+		require.NoError(t, os.WriteFile(filepath.Join(trashDir, "f"+strconv.Itoa(i)), nil, 0o644))
+	}
+
+	require.NoError(t, removeAllPaced(context.Background(), trashDir, &trashPacer{}))
+	require.NoDirExists(t, trashDir)
+}
+
+func TestRemoveAllPacedCanceled(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	trashDir := filepath.Join(rootDir, workerTrashPrefix+"1")
+	writeTrashFixtureTree(t, trashDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := removeAllPaced(ctx, trashDir, &trashPacer{})
+	require.ErrorIs(t, err, context.Canceled)
+	// the tree survives (partially or fully) for the next startup's sweep
+	require.DirExists(t, trashDir)
+}
+
+func TestSweepLocalCacheTrash(t *testing.T) {
+	t.Parallel()
+	rootDir := t.TempDir()
+	srv := &Server{rootDir: rootDir}
+
+	trashA := filepath.Join(rootDir, workerTrashPrefix+"a")
+	trashB := filepath.Join(rootDir, workerTrashPrefix+"b")
+	writeTrashFixtureTree(t, trashA)
+	writeTrashFixtureTree(t, trashB)
+	keep := filepath.Join(rootDir, "worker")
+	writeTrashFixtureTree(t, keep)
+
+	trashDirs, err := findLocalCacheTrashDirs(rootDir)
+	require.NoError(t, err)
+	srv.sweepLocalCacheTrash(context.Background(), trashDirs)
+
+	require.NoDirExists(t, trashA)
+	require.NoDirExists(t, trashB)
+	require.DirExists(t, keep)
+}

--- a/hack/designs/module-wiring.md
+++ b/hack/designs/module-wiring.md
@@ -20,14 +20,17 @@ together, defeating the purpose of reusable modules.
 
 Extend the address mechanism that already backs `settings.*` values and CLI flags to
 support **module wiring**: a value that resolves to the output of a function on
-another installed workspace module. Two types are supported today:
+another installed workspace module. Five types are supported today:
 
 - **`Service`** — conventionally referencing a `+up` function (the original
   motivation), though any `Service`-returning function resolves.
 - **`Container`** — referencing any function that returns a `Container`.
+- **`Directory`** — referencing any function that returns a `Directory`.
+- **`File`** — referencing any function that returns a `File`.
+- **`Workspace`** — referencing any function that returns a `Workspace`.
 
-Other core types (`Directory`, `File`, `Secret`) may follow; the resolution
-mechanism is type-agnostic.
+Other core types (`Secret`, for example) may follow; the resolution mechanism
+is type-agnostic.
 
 ### Config Syntax
 
@@ -105,11 +108,16 @@ service addresses are `tcp://`/`udp://` URLs, so the `://` alone disambiguates.
   module prefix followed by extra colons (e.g. `docusaurus:sites:serve`) is rejected
   with a clear error, not silently treated as an image ref. Deeper traversal is a
   forward-compatibility concern, addressed below.
-- Supported arg types are scoped to `Service` and `Container` by documentation and
-  test coverage, not by an engine-side type check. It is not (yet) a general-purpose
-  cross-module reference for arbitrary types.
-- The target constructor argument must accept `*dagger.Service` or `*dagger.Container`
-  (typically optional).
+- Supported arg types are scoped to `Service`, `Container`, `Directory`, `File`,
+  and `Workspace` by documentation and test coverage, not by an engine-side type
+  check. It is not (yet) a general-purpose cross-module reference for arbitrary
+  types.
+- The target constructor argument must accept `*dagger.Service`, `*dagger.Container`,
+  `*dagger.Directory`, `*dagger.File`, or `*dagger.Workspace` (typically optional).
+- A constructor must consume a wired `Workspace` rather than storing it directly on
+  the returned module object; module object fields cannot have the core `Workspace`
+  type. It can store values derived from that workspace, such as a `File` or
+  `Directory`.
 - Referenced functions take no arguments; a provider is parameterized via its own
   `settings.*` block, not at the reference site.
 - Invalid references (nonexistent function on a matched module, type mismatch, cycle)
@@ -198,16 +206,19 @@ The mechanics:
   carry the module entrypoints.)
 - **Typed Select for mismatch errors.** Once committed, resolution runs a two-step
   dagql `Select` from the `Query` root — module field, then function field — into the
-  **typed** destination (`*dagql.ObjectResult[*core.Service]` /
-  `[*core.Container]`). dagql's own typed Select produces the type-mismatch error when
-  the function's return type doesn't match, so the error message is dagql-native.
+  **typed** destination (for example, `*dagql.ObjectResult[*core.Service]` or
+  `*dagql.ObjectResult[*core.Directory]`). dagql's own typed Select produces the
+  type-mismatch error when the function's return type doesn't match, so the error
+  message is dagql-native.
 - **Context-chain cycle guard.** The chain of in-flight module-ref strings is
   carried on the `context.Context`. Context values propagate through dagql `Select`
   into nested module construction, so re-entry of an in-flight ref is detectable, and
   a cycle fails fast with a clean `a -> b -> a` error rather than hanging the engine
   with unbounded goroutine growth.
-Only `.container()` and `.service()` decode module refs today; the same hook can be
-added to `.directory()`, `.file()`, `.secret()` when those target types are in scope.
+
+The `.container()`, `.service()`, `.directory()`, `.file()`, and `.workspace()`
+decoders resolve module refs today; the same hook can be added to `.secret()` when
+that target type is in scope.
 
 ### Lint: shadowing warning
 
@@ -247,8 +258,9 @@ fully-qualified registry path is the documented remedy.
 - **Service groups / profiles**: Running a named subset of services via `dagger up` is
   out of scope for this design. Will be addressed separately.
 - **General-purpose cross-module wiring**: today's references are scoped to
-  `Service` (via `+up`) and `Container`. Wiring other types (Directory, File, Secret)
-  across modules is a natural follow-up but not in scope yet.
+  `Service` (via `+up`), `Container`, `Directory`, `File`, and `Workspace`. Wiring
+  other types (such as `Secret`) across modules is a natural follow-up but not in
+  scope yet.
 - **Config-time validation**: References are validated at runtime. Static config
   validation may be added later.
 - **Deep / collection traversal**: only two segments are accepted. Deeper paths and

--- a/sdk/elixir/lib/dagger/gen/address.ex
+++ b/sdk/elixir/lib/dagger/gen/address.ex
@@ -182,6 +182,20 @@ defmodule Dagger.Address do
       client: address.client
     }
   end
+
+  @doc """
+  Load a workspace from a module reference.
+  """
+  @spec workspace(t()) :: Dagger.Workspace.t()
+  def workspace(%__MODULE__{} = address) do
+    query_builder =
+      address.query_builder |> QB.select("workspace")
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: address.client
+    }
+  end
 end
 
 defimpl Jason.Encoder, for: Dagger.Address do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -410,6 +410,15 @@ func (r *Address) Volume() *Volume {
 	}
 }
 
+// Load a workspace from a module reference.
+func (r *Address) Workspace() *Workspace {
+	q := r.query.Select("workspace")
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // AsNode returns this Address as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Address) AsNode() Node {

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16301,6 +16301,8 @@ func (r *Workspace) EnvList(ctx context.Context) ([]string, error) {
 }
 
 // Write this workspace's pending changes to its local Git workspace.
+//
+// Edits made under a mounted cache volume are not pending changes; they are committed into that volume instead.
 func (r *Workspace) Export(ctx context.Context) error {
 	if r.export != nil {
 		return nil
@@ -16924,6 +16926,20 @@ func (r *Workspace) WithModule(ref string, opts ...WorkspaceWithModuleOpts) *Wor
 	}
 }
 
+// Return this workspace with a cache volume mounted at the given path, without mutating the source.
+//
+// Like a mounted directory, the cache shadows the source at the mount path and stays out of the pending changeset: it never appears in changes and is never exported to the workspace. Unlike a mounted directory it is writable, and export commits the edits made under it back into the cache volume.
+func (r *Workspace) WithMountedCache(path string, cache *CacheVolume) *Workspace {
+	assertNotNil("cache", cache)
+	q := r.query.Select("withMountedCache")
+	q = q.Arg("path", path)
+	q = q.Arg("cache", cache)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // Return this workspace with a directory mounted read-only at the given path, without mutating the source.
 //
 // Mounted content is readable through the normal workspace file tools but shadows the source at the mount path and stays out of the pending changeset: it never appears in changes, is never exported, and cannot be modified.
@@ -17130,6 +17146,18 @@ func (r *Workspace) WithoutModule(name string, opts ...WorkspaceWithoutModuleOpt
 		}
 	}
 	q = q.Arg("name", name)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
+// Return this workspace with the content mounted at the given path unmounted.
+//
+// Removes whatever is mounted there — a cache volume, directory or file — along with anything mounted inside it. Pending edits to a mounted cache volume are discarded rather than committed.
+func (r *Workspace) WithoutMount(path string) *Workspace {
+	q := r.query.Select("withoutMount")
+	q = q.Arg("path", path)
 
 	return &Workspace{
 		query: q,

--- a/sdk/php/generated/Address.php
+++ b/sdk/php/generated/Address.php
@@ -143,4 +143,13 @@ class Address extends Client\AbstractObject implements Client\IdAble, Node
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('volume');
         return new \Dagger\Volume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
+
+    /**
+     * Load a workspace from a module reference.
+     */
+    public function workspace(): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('workspace');
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -698,6 +698,12 @@ class Address(Type):
         _ctx = self._select("volume", _args)
         return Volume(_ctx)
 
+    def workspace(self) -> "Workspace":
+        """Load a workspace from a module reference."""
+        _args: list[Arg] = []
+        _ctx = self._select("workspace", _args)
+        return Workspace(_ctx)
+
 
 @typecheck
 class Agent(Type):

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -480,6 +480,15 @@ impl Address {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Load a workspace from a module reference.
+    pub fn workspace(&self) -> Workspace {
+        let query = self.selection.select("workspace");
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
 }
 impl Node for Address {
     fn id(&self) -> impl core::future::Future<Output = Result<Id, DaggerError>> + Send {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3523,6 +3523,14 @@ export class Address extends BaseClient {
     const ctx = this._ctx.select("volume")
     return new Volume(ctx)
   }
+
+  /**
+   * Load a workspace from a module reference.
+   */
+  workspace = (): Workspace => {
+    const ctx = this._ctx.select("workspace")
+    return new Workspace(ctx)
+  }
 }
 
 export class Agent extends BaseClient {


### PR DESCRIPTION
> [!WARNING]
> **Draft — not ready to merge.** This is unfinished work that the layers above it are built on, so it's here to be reviewable and to keep the stack honest, not to land as-is.

`Workspace.withMountedCache` mounts a cache volume at a path: it shadows base workspace content there, stays out of `Workspace.changes`, and commits into the volume on export. `withoutMount` removes it.

A mount carries its own pending changeset, so reads and writes under it route to the mount's effective tree rather than the base overlay. Reads resolve through a deepest-match lookup, which gives shadowing for free while references keep priority in their reserved prefix. `search`, `glob` and `findUp` union the base with each mount, shadowing the base subtree and prefixing results with the mount target. Writes go through a `workspaceEdit` dispatcher that replaces the old `overlayEdit`, and `withChanges` rejects a changeset straddling a mount boundary rather than splitting it. The baseline is materialized by an internal `DoNotCache` `CacheVolume` field, so reads reflect the volume at call time while the resulting `Directory`'s content-derived digest still dedups downstream.

**What's missing.** There are no tests across the four workspace types, so the write-through and persistence paths are unverified end to end. The baseline is copy-on-read rather than copy-on-write, export doesn't take a `LOCKED` share, and a whole-tree read doesn't shadow base content at a subtree mount.

It sits at this position in the stack because the `workspaceEdit` refactor is what every later workspace change is written against — reverting it produces ten conflict regions across ~450 lines, several of which interleave mount code with commit-staging code.
