### PR TITLE
LLM continuations: tools that return a conversation

### DIFF
--- a/core/integration/agents_test.go
+++ b/core/integration/agents_test.go
@@ -13,7 +13,9 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"dagger.io/dagger"
@@ -219,6 +221,163 @@ func (AgentsSuite) TestAgentReadsSeedWorkspace(ctx context.Context, t *testctx.T
 		With(daggerQuery(`{workspace: currentWorkspace{agents{compose{tools}}}}`)).
 		Stdout(ctx)
 	require.NoError(t, err)
+}
+
+// editorSourceWithDoc is the editor fixture's source with readFile's doc string
+// swapped for the given marker, used to prove overlay-staged module edits are
+// visible to agent composition.
+func editorSourceWithDoc(doc string) string {
+	return fmt.Sprintf(`"""A basic coding agent, for @agent integration tests."""
+type Editor {
+  """Compose the editor's tools onto a base LLM. Base named `+"`base`"+`."""
+  agent(base: LLM!): LLM! @agent {
+    base
+      .withTools(currentNode)
+      .withSystemPrompt("editor agent system prompt")
+  }
+
+  """%s"""
+  readFile(path: String!): String! {
+    `+"`read ${path}`"+`
+  }
+
+  """shared tool from editor"""
+  shared(x: String!): String! {
+    `+"`editor shared ${x}`"+`
+  }
+}
+`, doc)
+}
+
+// TestOverlayModuleSourceIsResolvedThroughOverlay pins the half of the overlay
+// module machinery that works today: Workspace.moduleSource, resolved off a
+// workspace carrying a staged (unexported) edit, loads the module from the
+// overlay rather than from disk. workspaceOverlayModules (core/schema/
+// workspace_overlay_modules.go) resolves its modules exactly this way.
+func (AgentsSuite) TestOverlayModuleSourceIsResolvedThroughOverlay(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := installAgents(t, c, "editor")
+	require.NoError(t, err)
+
+	const marker = "OVERLAY EDITED DOC MARKER"
+	out, err := modGen.
+		With(daggerQuery(
+			`{workspace: currentWorkspace{withNewFile(path:"/modules/editor/main.dang", contents:%s){moduleSource(path:"/modules/editor"){asModule{name objects{asObject{name functions{name description}}}}}}}}`,
+			strconv.Quote(editorSourceWithDoc(marker)),
+		)).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, marker)
+	require.NotContains(t, out, "Read a file (stub).")
+}
+
+// TestOverlayModuleSourceEdit locks in the self-repair loop: an agent that
+// edits a module's source and recomposes itself must see its own STAGED edit,
+// with nothing exported to disk. The edit is staged and the toolset selected in
+// a single query, off the Workspace returned by withNewFile. Two layers
+// cooperate: workspaceOverlayModules re-resolves the module through the overlay
+// for composition (Workspace.agents), and WorkspaceServedSchema layers the same
+// overlay modules onto the served schema LLM.tools renders from.
+func (AgentsSuite) TestOverlayModuleSourceEdit(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := installAgents(t, c, "editor")
+	require.NoError(t, err)
+
+	const marker = "OVERLAY EDITED DOC MARKER"
+
+	out, err := modGen.
+		With(daggerQuery(
+			`{workspace: currentWorkspace{withNewFile(path:"/modules/editor/main.dang", contents:%s){agents{compose{tools}}}}}`,
+			strconv.Quote(editorSourceWithDoc(marker)),
+		)).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "## readFile")
+	require.Contains(t, out, marker)
+	require.NotContains(t, out, "Read a file (stub).")
+
+	// Control: the un-staged workspace still composes the on-disk source.
+	out, err = modGen.
+		With(daggerQuery(`{workspace: currentWorkspace{agents{compose{tools}}}}`)).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "Read a file (stub).")
+	require.NotContains(t, out, marker)
+}
+
+// TestOverlayWithModule covers the other half: a module installed into the
+// workspace config through the overlay (Workspace.withModule, i.e. the agent's
+// `install` tool) contributes its agent's tools without any export to disk —
+// including its type existing in the LLM's bound schema, which the served
+// (on-disk) module set alone cannot provide.
+func (AgentsSuite) TestOverlayWithModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	// Only editor is installed on disk; godoc arrives via the overlay.
+	modGen, err := installAgents(t, c, "editor")
+	require.NoError(t, err)
+
+	out, err := modGen.
+		With(daggerQuery(`{workspace: currentWorkspace{withModule(ref:"../godoc"){agents{compose{tools}}}}}`)).
+		Stdout(ctx)
+	require.NoError(t, err)
+	// Both fixtures define `shared`, so the collision namespaces both toolsets
+	// — the same shape TestComposeToolset asserts for the on-disk install.
+	require.Contains(t, out, "## godoc_goDoc")
+	require.Contains(t, out, "## godoc_shared")
+	require.Contains(t, out, "shared tool from godoc")
+	require.Contains(t, out, "## editor_readFile")
+	require.Contains(t, out, "## editor_shared")
+}
+
+// TestOverlayUnrelatedEditKeepsToolset is the regression guard: an overlay that
+// touches nothing module-related must compose exactly the served toolset, i.e.
+// the overlay re-resolution must not kick in (or duplicate anything) for
+// unrelated edits.
+func (AgentsSuite) TestOverlayUnrelatedEditKeepsToolset(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := installAgents(t, c, "editor", "godoc")
+	require.NoError(t, err)
+
+	baseline, err := modGen.
+		With(daggerQuery(`{workspace: currentWorkspace{agents{compose{tools}}}}`)).
+		Stdout(ctx)
+	require.NoError(t, err)
+
+	out, err := modGen.
+		With(daggerQuery(
+			`{workspace: currentWorkspace{withNewFile(path:"/README.md", contents:%s){agents{compose{tools}}}}}`,
+			strconv.Quote("unrelated overlay edit\n"),
+		)).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, agentToolsFromQuery(t, baseline), agentToolsFromQuery(t, out))
+}
+
+// agentToolsFromQuery digs the composed `tools` string out of a
+// `dagger query` response, whatever wrapper fields the query nested it under.
+func agentToolsFromQuery(t *testctx.T, out string) string {
+	t.Helper()
+	var res any
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	var find func(any) (string, bool)
+	find = func(v any) (string, bool) {
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		if tools, ok := obj["tools"].(string); ok {
+			return tools, true
+		}
+		for _, child := range obj {
+			if tools, ok := find(child); ok {
+				return tools, true
+			}
+		}
+		return "", false
+	}
+	tools, ok := find(res)
+	require.True(t, ok, "no tools field in %s", out)
+	return tools
 }
 
 func (AgentsSuite) TestEmptySelectionComposesBareLLM(ctx context.Context, t *testctx.T) {

--- a/core/integration/llm_object_tools_test.go
+++ b/core/integration/llm_object_tools_test.go
@@ -70,6 +70,51 @@ func (LLMSuite) TestObjectToolset(ctx context.Context, t *testctx.T) {
 	})
 }
 
+// TestDirectoryWorkspaceHandleBoundTool keeps module tools callable when
+// withTools receives a runtime handle, as currentNode and same-type tool returns
+// do. A value-backed workspace deliberately has only the core served schema, so
+// the handle must be loaded and traced back to its recipe's module schema rather
+// than pinning the core schema as the tool's definition.
+func (LLMSuite) TestDirectoryWorkspaceHandleBoundTool(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	source := c.Directory().
+		WithNewFile("dagger.toml", "[modules.editor]\nsource = \"modules/editor\"\n").
+		WithNewFile("modules/editor/dagger.json", `{"name":"editor","engineVersion":"v1.0.0-0","sdk":"dang"}`).
+		WithNewFile("modules/editor/main.dang", `
+type Editor {
+  agent(base: LLM!): LLM! @agent {
+    base.withTools(currentNode)
+  }
+
+  todoWrite(item: String!): Editor! {
+    print(item)
+    self
+  }
+}
+`)
+	ws := source.AsWorkspace()
+	model := cannedReplayModel(ctx, t, c, c.LLM().
+		WithPrompt("track it").
+		WithResponse([]dagger.LLMContentBlockInput{{
+			Kind:      dagger.LLMContentBlockKindToolCall,
+			CallID:    "call_1",
+			ToolName:  "todoWrite",
+			Arguments: dagger.JSON(`{"item":"tracked"}`),
+		}}).
+		WithToolResult("call_1", "", false).
+		WithResponse([]dagger.LLMContentBlockInput{{
+			Kind: dagger.LLMContentBlockKindText,
+			Text: "done",
+		}}))
+	base := c.LLM(dagger.LLMOpts{Model: model}).WithWorkspace(ws)
+	transcript, err := ws.Agents().Compose(dagger.AgentMiddlewareGroupComposeOpts{Base: base}).
+		WithPrompt("track it").
+		Loop().
+		Transcript(ctx)
+	require.NoError(t, err)
+	require.Contains(t, transcript, "done")
+}
+
 // TestParallelChangesetToolsMergeResults locks in that Changeset-returning tools
 // from one model response run as a batch and all of their changes are retained.
 func (LLMSuite) TestParallelChangesetToolsMergeResults(ctx context.Context, t *testctx.T) {

--- a/core/integration/llm_object_tools_test.go
+++ b/core/integration/llm_object_tools_test.go
@@ -300,3 +300,142 @@ func (LLMSuite) TestWorkspaceToolMountsSummarizeCompactly(ctx context.Context, t
 	require.NotContains(t, out, "vendored-three.txt")
 	require.Contains(t, out, "NOTE.txt")
 }
+
+// TestToolReturningLLMContinues locks in the continuation ring of the state-return
+// convention: a tool that returns an LLM replaces the conversation, and the loop
+// resumes from the returned one (routeObjectMethodResult -> applyStateReturn ->
+// adoptLLM). The tool's LLM! argument is auto-injected with the conversation up
+// to and including its own call, so `install`/`reload`-style self-extension is a
+// plain transform.
+func (LLMSuite) TestToolReturningLLMContinues(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := workspaceFixture(t, c, "workspace-tool-return")
+
+	t.Run("the loop resumes from the returned conversation", func(ctx context.Context, t *testctx.T) {
+		model := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt("continue").
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_1", ToolName: "continueWithMarker"},
+			}).
+			WithToolResult("call_1", "", false).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		// continueWithMarker returns llm.withWorkspace(<workspace + marker>). The
+		// marker is only reachable if the loop adopted the RETURNED LLM: without
+		// the continuation arm the returned LLM would merely be synced and
+		// described, leaving the original workspace bound, and this would error.
+		out, err := base.With(daggerShell(fmt.Sprintf(
+			`llm --model="%s" | with-workspace --workspace $(current-workspace) | with-tools $(swapper) | with-prompt "continue" | loop | workspace | file CONTINUED.txt | contents`,
+			model,
+		))).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "swapped by continuation", strings.TrimSpace(out))
+	})
+
+	t.Run("the conversation survives the swap", func(ctx context.Context, t *testctx.T) {
+		model := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt("continue").
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_1", ToolName: "continueWithMarker"},
+			}).
+			WithToolResult("call_1", "", false).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		// The turn's tool result is appended to the returned LLM, and the loop
+		// carries on from there — the prompt, the tool call and the final reply
+		// are all in one transcript.
+		out, err := base.With(daggerShell(fmt.Sprintf(
+			`llm --model="%s" | with-workspace --workspace $(current-workspace) | with-tools $(swapper) | with-prompt "continue" | loop | transcript`,
+			model,
+		))).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "continue")
+		require.Contains(t, out, "Continuing from the returned conversation.")
+		require.Contains(t, out, "done")
+	})
+
+	t.Run("a conversation that replaces the current one is adopted", func(ctx context.Context, t *testctx.T) {
+		model := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt("start fresh").
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_1", ToolName: "startFresh"},
+			}).
+			WithToolResult("call_1", "", false).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		// The adopted conversation replays a *second* script: after adoption its
+		// history is not the one the outer script recorded, but the engine's
+		// degraded continuation notice (toolResultSelectors' plain-message arm,
+		// carrying summarizeContinuation's summary as the tool result). The
+		// fixture's startFresh points the fresh conversation at this model, read
+		// from the workspace file written below. If summarizeContinuation's
+		// wording — or the swapper's tool count — changes, this string has to
+		// change with it; the replay provider compares message text exactly.
+		continued := strings.Join([]string{
+			"[continued via tool startFresh]",
+			"Continuing from the returned conversation.",
+			"Toolset unchanged (12 tools).",
+			"Conversation history replaced: 2 messages -> 0 messages.",
+		}, "\n")
+		continuationModel := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt(continued).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		// startFresh wipes the history it was handed. There is no lineage gate, so
+		// it is adopted like any other continuation (self-compaction and
+		// summarize-and-restart have exactly this shape) — and the model is TOLD,
+		// which is what makes the swap safe. The turn's tool result has no matching
+		// tool call in the adopted history, so it is carried as a plain message
+		// rather than a protocol-invalid tool result.
+		out, err := base.
+			WithNewFile("continuation-model.txt", continuationModel).
+			With(daggerShell(fmt.Sprintf(
+				`llm --model="%s" | with-workspace --workspace $(current-workspace) | with-tools $(swapper) | with-prompt "start fresh" | loop | transcript`,
+				model,
+			))).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "Continuing from the returned conversation.")
+		require.Contains(t, out, "Conversation history replaced:")
+		require.Contains(t, out, "[continued via tool startFresh]")
+		require.Contains(t, out, "done")
+	})
+
+	t.Run("at most one continuation per turn", func(ctx context.Context, t *testctx.T) {
+		model := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt("continue twice").
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_1", ToolName: "continueWithMarker"},
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_2", ToolName: "continueWithMarker"},
+			}).
+			WithToolResult("call_1", "", false).
+			WithToolResult("call_2", "", true).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		// LLMs do not merge the way Changesets do, so the second swap in a batch is
+		// refused rather than silently discarding the first.
+		out, err := base.With(daggerShell(fmt.Sprintf(
+			`llm --model="%s" | with-workspace --workspace $(current-workspace) | with-tools $(swapper) | with-prompt "continue twice" | loop | transcript`,
+			model,
+		))).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "only one is allowed")
+		require.Contains(t, out, "done")
+	})
+
+	t.Run("the base workspace does not already contain the marker", func(ctx context.Context, t *testctx.T) {
+		_, err := base.With(daggerShell(
+			`current-workspace | file CONTINUED.txt | contents`,
+		)).Stdout(ctx)
+		require.Error(t, err)
+	})
+}

--- a/core/integration/llm_object_tools_test.go
+++ b/core/integration/llm_object_tools_test.go
@@ -10,6 +10,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -437,5 +438,95 @@ func (LLMSuite) TestToolReturningLLMContinues(ctx context.Context, t *testctx.T)
 			`current-workspace | file CONTINUED.txt | contents`,
 		)).Stdout(ctx)
 		require.Error(t, err)
+	})
+}
+
+// TestAddressableToolArgs covers address lifting of object-typed tool args end
+// to end (hack/designs/sandboxes.md §4): a module function with a required
+// Container! arg still becomes a tool — the arg renders as an address string,
+// and a model-supplied image ref is lifted into a real container via
+// Query.address at dispatch — while a required arg of any other object type
+// (here Directory!) still disqualifies its function, since Container is the
+// only type to have passed the capability review for model-typed address
+// strings (liftableTypes in core/llm_object_tools.go).
+func (LLMSuite) TestAddressableToolArgs(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := workspaceFixture(t, c, "workspace-addressable-args")
+
+	t.Run("a required Container arg renders as an address", func(ctx context.Context, t *testctx.T) {
+		tools, err := base.With(daggerShell("llm | with-tools $(runner) | tools")).Stdout(ctx)
+		require.NoError(t, err)
+
+		// exec IS a tool despite its required Container! arg...
+		require.Contains(t, tools, "## exec\n")
+		// ...and its sandbox parameter is described as an address — with the
+		// type's syntax hint from liftableTypes — not as a bare ID.
+		require.Contains(t, tools, "(Container address:")
+		require.Contains(t, tools, "or a Container ID from a prior tool result")
+
+		// lsDir's required Directory! arg is not liftable (host-path
+		// fallback), so lsDir is not exposed as a tool.
+		require.NotContains(t, tools, "## lsDir\n")
+	})
+
+	t.Run("an image ref lifts into a real container", func(ctx context.Context, t *testctx.T) {
+		model := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt("what OS is the sandbox running?").
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_1", ToolName: "exec",
+					Arguments: dagger.JSON(fmt.Sprintf(`{"cmd":["cat","/etc/os-release"],"sandbox":%q}`, alpineImage))},
+			}).
+			// Placeholder result: the real tool runs during replay (tool
+			// results are excluded from the replayer's history matching), so
+			// the live stdout flows through.
+			WithToolResult("call_1", "", false).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		out, err := base.With(daggerShell(fmt.Sprintf(
+			`llm --model="%s" | with-tools $(runner) | with-prompt "what OS is the sandbox running?" | loop | transcript`,
+			model,
+		))).Stdout(ctx)
+		require.NoError(t, err)
+		// The tool result is the stdout of the command run inside the lifted
+		// container — proof the address resolved to the real image. "Alpine
+		// Linux" appears only in /etc/os-release; the tool call's argument
+		// says "alpine:<version>", so a failed lift can't false-positive.
+		require.Contains(t, out, "Alpine Linux")
+	})
+
+	t.Run("an encoded Container ID round-trips", func(ctx context.Context, t *testctx.T) {
+		const marker = "address-lift round-trip"
+		ctrID, err := c.Container().From(alpineImage).
+			WithNewFile("/marker.txt", marker).ID(ctx)
+		require.NoError(t, err)
+		args, err := json.Marshal(map[string]any{
+			"cmd":     []string{"cat", "/marker.txt"},
+			"sandbox": string(ctrID),
+		})
+		require.NoError(t, err)
+
+		model := cannedReplayModel(ctx, t, c, c.LLM().
+			WithPrompt("read the marker").
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindToolCall, CallID: "call_1", ToolName: "exec",
+					Arguments: dagger.JSON(args)},
+			}).
+			WithToolResult("call_1", "", false).
+			WithResponse([]dagger.LLMContentBlockInput{
+				{Kind: dagger.LLMContentBlockKindText, Text: "done"},
+			}))
+
+		out, err := base.With(daggerShell(fmt.Sprintf(
+			`llm --model="%s" | with-tools $(runner) | with-prompt "read the marker" | loop | transcript`,
+			model,
+		))).Stdout(ctx)
+		require.NoError(t, err)
+		// The marker is plaintext only inside the container's filesystem —
+		// in the tool call's arguments it is buried in the encoded
+		// (protobuf+base64) ID — so seeing it in the transcript proves the
+		// ID decoded directly into the same container, no address lookup.
+		require.Contains(t, out, marker)
 	})
 }

--- a/core/integration/testdata/workspaces/workspace-addressable-args/.dagger/modules/runner/dagger.json
+++ b/core/integration/testdata/workspaces/workspace-addressable-args/.dagger/modules/runner/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "runner",
+  "engineVersion": "v1.0.0-0",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/workspaces/workspace-addressable-args/.dagger/modules/runner/main.dang
+++ b/core/integration/testdata/workspaces/workspace-addressable-args/.dagger/modules/runner/main.dang
@@ -1,0 +1,28 @@
+"""
+Tools with required object-typed args, for the address-lifting integration
+tests (hack/designs/sandboxes.md §4).
+"""
+type Runner {
+  """
+  Run a command in a sandbox container and return its stdout.
+
+  The required Container! arg is address-liftable, so this function must
+  still be exposed as a tool, with sandbox rendered as an address string:
+  the model can pass an image ref (or a Container ID from a prior tool
+  result) and the engine lifts it via Query.address at dispatch.
+  """
+  exec(cmd: [String!]!, sandbox: Container!): String! {
+    sandbox.withExec(cmd).stdout
+  }
+
+  """
+  List a directory's entries.
+
+  The required Directory! arg is NOT address-liftable (Directory addresses
+  fall back to host paths — a capability the model must not gain), so this
+  function must NOT be exposed as a tool.
+  """
+  lsDir(dir: Directory!): [String!]! {
+    dir.entries
+  }
+}

--- a/core/integration/testdata/workspaces/workspace-addressable-args/dagger.toml
+++ b/core/integration/testdata/workspaces/workspace-addressable-args/dagger.toml
@@ -1,0 +1,2 @@
+[modules.runner]
+source = ".dagger/modules/runner"

--- a/core/integration/testdata/workspaces/workspace-tool-return/.dagger/modules/swapper/main.dang
+++ b/core/integration/testdata/workspaces/workspace-tool-return/.dagger/modules/swapper/main.dang
@@ -27,6 +27,36 @@ type Swapper {
     ws.withoutMount("mnt/vendored")
   }
 
+  """
+  Continue the conversation with a workspace that has a marker file.
+
+  The auto-injected LLM! is the conversation up to and including this tool
+  call; returning a derived LLM makes the tool a continuation — the agent loop
+  resumes from the returned conversation instead of the one that called it.
+  """
+  continueWithMarker(llm: LLM!): LLM! {
+    llm.withWorkspace(llm.workspace.withNewFile("CONTINUED.txt", "swapped by continuation"))
+  }
+
+  """
+  Hand back a conversation whose history has been wiped.
+
+  There is no lineage gate: any LLM may be adopted, so this IS adopted — the
+  shape of a self-compaction or summarize-and-restart continuation. The turn's
+  tool result has no matching tool call in the returned history, so it is
+  appended as a plain message instead of a (protocol-invalid) tool result.
+
+  The returned conversation is re-pointed at the model recorded in
+  continuation-model.txt: the post-adoption history no longer matches the
+  script the calling conversation was replaying (its first message is the
+  engine's "[continued via tool ...]" notice), so a replay-driven test has to
+  hand the fresh conversation the script that DOES match. The test writes that
+  file into the workspace.
+  """
+  startFresh(llm: LLM!): LLM! {
+    llm.withoutMessageHistory.withModel(llm.workspace.file("continuation-model.txt").contents)
+  }
+
   addFirst(ws: Workspace!): Changeset! {
     let root = ws.directory("/")
     root.withNewFile("FIRST.txt", "first parallel change").changes(root)

--- a/core/integration/workspace_addresses_test.go
+++ b/core/integration/workspace_addresses_test.go
@@ -1,0 +1,134 @@
+package core
+
+// These tests cover Workspace.addresses: discovery of module functions loadable
+// as bare "module:function" address references (hack/designs/sandboxes.md §5).
+// They verify return-type filtering, the required-arg rule (auto-injected
+// Workspace args are exempt), entrypoint-module exclusion, kebab-case value
+// rendering, and that a rendered value round-trips through Query.address.
+//
+// See also:
+// - workspace_modules_test.go: installing and listing workspace modules.
+// - agents_test.go: sibling rollup APIs over the same module set.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// WorkspaceAddressesSuite owns address discovery over workspace-installed
+// modules: which functions are listed, how values render, and that listed
+// values resolve.
+type WorkspaceAddressesSuite struct{}
+
+func TestWorkspaceAddresses(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(WorkspaceAddressesSuite{})
+}
+
+const workspaceAddressesSandboxesSource = `
+type Sandboxes {
+  """Go development sandbox."""
+  go: Container! {
+    container.from("` + alpineImage + `")
+  }
+
+  """Workspace-aware sandbox; the Workspace arg is auto-injected."""
+  wsAware(ws: Workspace!): Container! {
+    container.from("` + alpineImage + `")
+  }
+
+  plain: Container! {
+    container.from("` + alpineImage + `")
+  }
+
+  """Requires an image argument; not addressable."""
+  custom(image: String!): Container! {
+    container.from(image)
+  }
+
+  """A Directory, not a Container."""
+  data: Directory! {
+    directory.withNewFile("hello.txt", "hi")
+  }
+
+  """Not an object at all."""
+  greet: String! {
+    "hello"
+  }
+}
+`
+
+const workspaceAddressesEntrySource = `
+type Entry {
+  """Hoisted onto the root; not addressable as entry:entry-ctr."""
+  entryCtr: Container! {
+    container.from("` + alpineImage + `")
+  }
+}
+`
+
+func (WorkspaceAddressesSuite) TestWorkspaceAddresses(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceBase(t, c).
+		WithNewFile("dagger.toml", `[modules.sandboxes]
+source = ".dagger/modules/sandboxes"
+
+[modules.entry]
+source = ".dagger/modules/entry"
+entrypoint = true
+`).
+		WithNewFile(".dagger/modules/sandboxes/dagger.json", `{"name":"sandboxes","sdk":{"source":"dang"}}`).
+		WithNewFile(".dagger/modules/sandboxes/main.dang", workspaceAddressesSandboxesSource).
+		WithNewFile(".dagger/modules/entry/dagger.json", `{"name":"entry","sdk":{"source":"dang"}}`).
+		WithNewFile(".dagger/modules/entry/main.dang", workspaceAddressesEntrySource)
+
+	t.Run("container addresses", func(ctx context.Context, t *testctx.T) {
+		// go and plain appear (zero args); wsAware appears (its only required
+		// arg is an auto-injected Workspace); custom is dropped (required
+		// String arg); data and greet are dropped (wrong return type); entry's
+		// entryCtr is dropped (entrypoint modules are hoisted, not
+		// addressable). Values are kebab-case and sorted; plain has no
+		// docstring, so its description is empty.
+		out, err := base.
+			With(daggerQuery(`{currentWorkspace{addresses(type:"Container"){value description}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"addresses":[
+			{"value":"sandboxes:go","description":"Go development sandbox."},
+			{"value":"sandboxes:plain","description":""},
+			{"value":"sandboxes:ws-aware","description":"Workspace-aware sandbox; the Workspace arg is auto-injected."}
+		]}}`, out)
+	})
+
+	t.Run("directory addresses", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerQuery(`{currentWorkspace{addresses(type:"Directory"){value description}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"addresses":[
+			{"value":"sandboxes:data","description":"A Directory, not a Container."}
+		]}}`, out)
+	})
+
+	t.Run("no matches", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerQuery(`{currentWorkspace{addresses(type:"Service"){value}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"currentWorkspace":{"addresses":[]}}`, out)
+	})
+
+	t.Run("listed value resolves through Query.address", func(ctx context.Context, t *testctx.T) {
+		// The rendered kebab-case value must be loadable by the address
+		// machinery the discovery exists for (resolveModuleRef normalizes
+		// both segments, so ws-aware resolves to wsAware).
+		out, err := base.
+			With(daggerQuery(`{address(value:"sandboxes:ws-aware"){container{platform}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "platform")
+	})
+}

--- a/core/llm.go
+++ b/core/llm.go
@@ -1469,13 +1469,13 @@ func (llm *LLM) WithToolResult(callID, content string, errored bool) *LLM {
 	return llm
 }
 
-// WithTools binds an object so every eligible method becomes a tool
-// (hack/designs/workspace-agents.md). A tool that returns the bound object's own type rebinds
-// it as the new agent state; except lists method names to exclude (e.g. the
-// module's own entrypoint).
-func (llm *LLM) WithTools(obj dagql.AnyObjectResult, except []string) *LLM {
+// WithTools binds an object so every eligible method from definingSchema becomes
+// a tool (hack/designs/workspace-agents.md). A tool that returns the bound object's
+// own type rebinds it as the new agent state; except lists method names to exclude
+// (e.g. the module's own entrypoint).
+func (llm *LLM) WithTools(obj dagql.AnyObjectResult, definingSchema *ast.Schema, except []string) *LLM {
 	llm = llm.Clone()
-	llm.mcp = llm.mcp.WithTools(obj, except)
+	llm.mcp = llm.mcp.WithTools(obj, definingSchema, except)
 	return llm
 }
 

--- a/core/llm.go
+++ b/core/llm.go
@@ -1636,7 +1636,6 @@ func (llm *LLM) step(ctx context.Context, inst dagql.ObjectResult[*LLM], maxToke
 	if err != nil {
 		return inst, err
 	}
-	sels := []dagql.Selector{responseSel}
 	// Extract tool calls from response content blocks for the MCP layer.
 	var toolCalls []*LLMToolCall
 	for _, block := range res.Content {
@@ -1648,73 +1647,10 @@ func (llm *LLM) step(ctx context.Context, inst dagql.ObjectResult[*LLM], maxToke
 			})
 		}
 	}
-	for _, msg := range llm.mcp.CallBatch(ctx, tools, toolCalls, res.ToolCallDisplays) {
-		sels = append(sels, dagql.Selector{
-			Field: "withToolResult",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "callId",
-					Value: dagql.NewString(msg.ToolResultCallID()),
-				},
-				{
-					Name:  "content",
-					Value: dagql.NewString(msg.ToolResultContent()),
-				},
-				{
-					Name:  "errored",
-					Value: dagql.NewBoolean(msg.ToolResultErrored()),
-				},
-			},
-		})
-	}
 
-	// Persist an in-step workspace change (e.g. a tool returned a Changeset that
-	// was overlaid onto the bound workspace) so the edit survives the LLM history
-	// rebuild — a rebuild otherwise re-binds the original workspace (via NewLLM or
-	// the last recorded withWorkspace) and loses the overlay. Handle-safe compare
-	// (post-eval IDs are handle-form).
-	if wsAfter, err := llm.mcp.WorkspaceID(); err == nil && wsAfter != nil &&
-		stableIDDigest(wsAfter) != stableIDDigest(wsBefore) {
-		sels = append(sels, dagql.Selector{
-			Field: "withWorkspace",
-			Args: []dagql.NamedInput{
-				{
-					Name:  "workspace",
-					Value: dagql.NewID[*Workspace](wsAfter),
-				},
-			},
-		})
-	}
-
-	// Persist an in-step state transition: a tool that returned its bound object's
-	// own type rebinds it (hack/designs/workspace-agents.md). Re-emit a withTools selector for
-	// each binding whose object changed, so the new state survives the history
-	// rebuild — the same shape as the withWorkspace persist above.
-	if toolsAfter, err := llm.mcp.BoundToolBindings(); err == nil {
-		for i, after := range toolsAfter {
-			if i < len(toolsBefore) &&
-				stableIDDigest(after.ID) == stableIDDigest(toolsBefore[i].ID) {
-				continue
-			}
-			sels = append(sels, dagql.Selector{
-				Field: "withTools",
-				Args: []dagql.NamedInput{
-					{
-						Name:  "object",
-						Value: dagql.NewAnyID(after.ID),
-					},
-					{
-						Name:  "except",
-						Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(after.Except...)),
-					},
-				},
-			})
-		}
-	}
-
-	// Tool-call display spans were already ended by CallBatch as each tool
-	// returned. End the remaining (text/thinking) spans now that the turn's
-	// results have been applied, so they close in the order they streamed.
+	// Tool-call display spans are ended by CallBatch as each tool returns. End
+	// the remaining (text/thinking) spans once the turn's results have been
+	// applied, so they close in the order they streamed.
 	endedByCallBatch := make(map[trace.Span]bool, len(res.ToolCallDisplays))
 	for _, tc := range res.ToolCallDisplays {
 		endedByCallBatch[tc.Span] = true
@@ -1727,14 +1663,172 @@ func (llm *LLM) step(ctx context.Context, inst dagql.ObjectResult[*LLM], maxToke
 		}
 	}
 
+	// Materialize the assistant response BEFORE dispatching the tool calls, so
+	// a continuation tool can be handed the conversation up to and including
+	// its own call (MCP.SetSelfLLM -> LLMToContext -> loadLLMArg). This is the
+	// same chain a single multi-selector Select would build; only the timing
+	// differs.
+	var responded dagql.ObjectResult[*LLM]
+	if err := srv.Select(ctx, inst, &responded, responseSel); err != nil {
+		for _, s := range res.DisplaySpans {
+			s.End()
+		}
+		return inst, err
+	}
+	llm.mcp.SetSelfLLM(responded)
+
+	resultMsgs := llm.mcp.CallBatch(ctx, tools, toolCalls, res.ToolCallDisplays)
+
+	// A tool may have returned an LLM: it acted as a continuation, and the turn
+	// resumes from THAT conversation — its env, tools, system prompts and
+	// history — instead of the one that made the call (see MCP.adoptLLM). Its ID
+	// records the transform, so replay lands on it.
+	//
+	// The swap subsumes the workspace/bound-tool persistence below: whatever the
+	// continuation binds is already part of its own ID. Persisting the calling
+	// LLM's mutated bindings on top would override the continuation's.
+	base := responded
+	cont := llm.mcp.Continuation()
+	if cont.Self() != nil {
+		base = cont
+	}
+
+	toolNames := make(map[string]string, len(toolCalls))
+	for _, tc := range toolCalls {
+		toolNames[tc.CallID] = tc.Name
+	}
+	sels := toolResultSelectors(base.Self(), resultMsgs, toolNames)
+
+	if cont.Self() == nil {
+		// Persist an in-step workspace change (e.g. a tool returned a Changeset that
+		// was overlaid onto the bound workspace) so the edit survives the LLM history
+		// rebuild — a rebuild otherwise re-binds the original workspace (via NewLLM or
+		// the last recorded withWorkspace) and loses the overlay. Handle-safe compare
+		// (post-eval IDs are handle-form).
+		if wsAfter, err := llm.mcp.WorkspaceID(); err == nil && wsAfter != nil &&
+			stableIDDigest(wsAfter) != stableIDDigest(wsBefore) {
+			sels = append(sels, dagql.Selector{
+				Field: "withWorkspace",
+				Args: []dagql.NamedInput{
+					{
+						Name:  "workspace",
+						Value: dagql.NewID[*Workspace](wsAfter),
+					},
+				},
+			})
+		}
+
+		// Persist an in-step state transition: a tool that returned its bound object's
+		// own type rebinds it (hack/designs/workspace-agents.md). Re-emit a withTools selector for
+		// each binding whose object changed, so the new state survives the history
+		// rebuild — the same shape as the withWorkspace persist above.
+		if toolsAfter, err := llm.mcp.BoundToolBindings(); err == nil {
+			for i, after := range toolsAfter {
+				if i < len(toolsBefore) &&
+					stableIDDigest(after.ID) == stableIDDigest(toolsBefore[i].ID) {
+					continue
+				}
+				sels = append(sels, dagql.Selector{
+					Field: "withTools",
+					Args: []dagql.NamedInput{
+						{
+							Name:  "object",
+							Value: dagql.NewAnyID(after.ID),
+						},
+						{
+							Name:  "except",
+							Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(after.Except...)),
+						},
+					},
+				})
+			}
+		}
+	}
+
 	var stepped dagql.ObjectResult[*LLM]
-	if err := srv.Select(ctx, inst, &stepped, sels...); err != nil {
+	if len(sels) == 0 {
+		// No tool calls this turn: the response is already materialized.
+		endRemainingDisplaySpans()
+		return base, nil
+	}
+	if err := srv.Select(ctx, base, &stepped, sels...); err != nil {
 		endRemainingDisplaySpans()
 		return inst, err
 	}
 	endRemainingDisplaySpans()
 
 	return stepped, nil
+}
+
+// toolResultSelectors builds the selectors that append this turn's tool results
+// to `target` — normally the LLM that made the calls, but after a continuation
+// (MCP.adoptLLM) an arbitrary conversation the tool handed back.
+//
+// Providers require every tool_result to follow the matching tool_use, keyed by
+// call ID. An adopted conversation need not contain this turn's tool call at
+// all — a self-compaction or summarize-and-restart continuation legitimately
+// drops it — so appending the result as a tool-result block there would produce
+// a protocol-invalid history. Such an orphaned result is instead appended as a
+// plain user message carrying the same information, so nothing is lost and the
+// history stays valid. Where the call IS present (the install/reload case,
+// which preserves history) results append normally.
+func toolResultSelectors(target *LLM, msgs []*LLMMessage, toolNames map[string]string) []dagql.Selector {
+	var sels []dagql.Selector
+	for _, msg := range msgs {
+		callID := msg.ToolResultCallID()
+		if target != nil && !hasToolCall(target.Messages, callID) {
+			name := toolNames[callID]
+			if name == "" {
+				name = callID
+			}
+			sels = append(sels, dagql.Selector{
+				Field: "withPrompt",
+				Args: []dagql.NamedInput{
+					{
+						Name: "prompt",
+						Value: dagql.NewString(fmt.Sprintf("[continued via tool %s]\n%s",
+							name, msg.ToolResultContent())),
+					},
+				},
+			})
+			continue
+		}
+		sels = append(sels, dagql.Selector{
+			Field: "withToolResult",
+			Args: []dagql.NamedInput{
+				{
+					Name:  "callId",
+					Value: dagql.NewString(callID),
+				},
+				{
+					Name:  "content",
+					Value: dagql.NewString(msg.ToolResultContent()),
+				},
+				{
+					Name:  "errored",
+					Value: dagql.NewBoolean(msg.ToolResultErrored()),
+				},
+			},
+		})
+	}
+	return sels
+}
+
+// hasToolCall reports whether any message in the history contains a tool-call
+// block with the given call ID — i.e. whether a tool result for it would have
+// something to attach to.
+func hasToolCall(msgs []*LLMMessage, callID string) bool {
+	if callID == "" {
+		return false
+	}
+	for _, msg := range msgs {
+		for _, block := range msg.Content {
+			if block != nil && block.Kind == LLMContentToolCall && block.CallID == callID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // emitNewMessageSpans emits display spans for the messages appended since the

--- a/core/llm.go
+++ b/core/llm.go
@@ -1480,11 +1480,11 @@ func (llm *LLM) WithTools(obj dagql.AnyObjectResult, except []string) *LLM {
 }
 
 // WithLazyTools binds an object's methods as tools from its unevaluated ID,
-// without loading it — the object is loaded only when a tool is invoked on it.
+// preserving the schema that defined its type without loading the object.
 // See MCP.WithLazyTools.
-func (llm *LLM) WithLazyTools(id *call.ID, objType dagql.ObjectType, except []string) *LLM {
+func (llm *LLM) WithLazyTools(id *call.ID, objType dagql.ObjectType, definingSchema *ast.Schema, except []string) *LLM {
 	llm = llm.Clone()
-	llm.mcp = llm.mcp.WithLazyTools(id, objType, except)
+	llm.mcp = llm.mcp.WithLazyTools(id, objType, definingSchema, except)
 	return llm
 }
 

--- a/core/llm_context.go
+++ b/core/llm_context.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"context"
+
+	"github.com/dagger/dagger/dagql"
+)
+
+type llmContextKey struct{}
+
+// LLMToContext binds the in-flight conversation into the context so that a tool
+// invoked by that conversation can receive it: a module function declaring an
+// `LLM!` argument has it auto-filled from here, exactly as a `Workspace!`
+// argument is auto-filled from [WorkspaceToContext].
+//
+// The bound value is the conversation UP TO AND INCLUDING the tool call being
+// dispatched (inst + withResponse), so a tool that transforms it and returns
+// the result acts as a continuation: the loop resumes from the returned LLM
+// instead of the one that made the call. See MCP.adoptLLM.
+//
+// It is only ever set at LLM tool dispatch (MCP.Call), so an ordinary call
+// never inherits a conversation.
+func LLMToContext(ctx context.Context, llm dagql.ObjectResult[*LLM]) context.Context {
+	return context.WithValue(ctx, llmContextKey{}, llm)
+}
+
+// LLMFromContext returns the conversation bound into the context by
+// [LLMToContext], if any.
+func LLMFromContext(ctx context.Context) (dagql.ObjectResult[*LLM], bool) {
+	if llm, ok := ctx.Value(llmContextKey{}).(dagql.ObjectResult[*LLM]); ok && llm.Self() != nil {
+		return llm, true
+	}
+	return dagql.ObjectResult[*LLM]{}, false
+}

--- a/core/llm_continuation_test.go
+++ b/core/llm_continuation_test.go
@@ -1,0 +1,219 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/dagql"
+)
+
+func textMsg(role LLMMessageRole, text string) *LLMMessage {
+	return &LLMMessage{
+		Role:    role,
+		Content: []*LLMContentBlock{{Kind: LLMContentText, Text: text}},
+	}
+}
+
+func TestHistoryPreserved(t *testing.T) {
+	base := []*LLMMessage{
+		textMsg(LLMMessageRoleUser, "hello"),
+		textMsg(LLMMessageRoleAssistant, "hi"),
+	}
+
+	// historyPreserved is not a gate — nothing is rejected for failing it. It
+	// only decides whether the adoption summary tells the model its history
+	// changed shape.
+	t.Run("identical history is preserved", func(t *testing.T) {
+		require.True(t, historyPreserved(&LLM{Messages: base}, &LLM{Messages: base}))
+	})
+
+	t.Run("appended history is preserved", func(t *testing.T) {
+		next := append(append([]*LLMMessage{}, base...), textMsg(LLMMessageRoleUser, "more"))
+		require.True(t, historyPreserved(&LLM{Messages: base}, &LLM{Messages: next}))
+	})
+
+	t.Run("equal-by-value (not pointer) history is preserved", func(t *testing.T) {
+		// A history that round-tripped through the API is rebuilt from fresh
+		// structs, so the comparison must be on content, not identity.
+		rebuilt := []*LLMMessage{
+			textMsg(LLMMessageRoleUser, "hello"),
+			textMsg(LLMMessageRoleAssistant, "hi"),
+		}
+		require.True(t, historyPreserved(&LLM{Messages: base}, &LLM{Messages: rebuilt}))
+	})
+
+	t.Run("fresh conversation is not preserved", func(t *testing.T) {
+		require.False(t, historyPreserved(&LLM{Messages: base}, &LLM{}))
+	})
+
+	t.Run("truncated history is not preserved", func(t *testing.T) {
+		require.False(t, historyPreserved(&LLM{Messages: base}, &LLM{Messages: base[:1]}))
+	})
+
+	t.Run("rewritten history is not preserved", func(t *testing.T) {
+		rewritten := []*LLMMessage{
+			textMsg(LLMMessageRoleUser, "hello"),
+			textMsg(LLMMessageRoleAssistant, "something else entirely"),
+		}
+		require.False(t, historyPreserved(&LLM{Messages: base}, &LLM{Messages: rewritten}))
+	})
+
+	t.Run("empty current is preserved by anything", func(t *testing.T) {
+		require.True(t, historyPreserved(&LLM{}, &LLM{Messages: base}))
+	})
+
+	t.Run("nil is never preserved", func(t *testing.T) {
+		require.False(t, historyPreserved(nil, &LLM{Messages: base}))
+		require.False(t, historyPreserved(&LLM{Messages: base}, nil))
+	})
+}
+
+func TestMessagesEqual(t *testing.T) {
+	toolCall := func(args string) *LLMMessage {
+		return &LLMMessage{
+			Role: LLMMessageRoleAssistant,
+			Content: []*LLMContentBlock{{
+				Kind:      LLMContentToolCall,
+				CallID:    "call-1",
+				ToolName:  "install",
+				Arguments: JSON(args),
+			}},
+		}
+	}
+	require.True(t, messagesEqual(toolCall(`{"ref":"./m"}`), toolCall(`{"ref":"./m"}`)))
+	require.False(t, messagesEqual(toolCall(`{"ref":"./m"}`), toolCall(`{"ref":"./n"}`)))
+
+	// Role, block count, and every block field participate.
+	require.False(t, messagesEqual(
+		textMsg(LLMMessageRoleUser, "x"),
+		textMsg(LLMMessageRoleAssistant, "x"),
+	))
+	require.False(t, messagesEqual(
+		&LLMMessage{Role: LLMMessageRoleUser},
+		textMsg(LLMMessageRoleUser, "x"),
+	))
+	require.False(t, messagesEqual(
+		&LLMMessage{Role: LLMMessageRoleAssistant, Content: []*LLMContentBlock{{
+			Kind: LLMContentThinking, Text: "t", Signature: "sig-a",
+		}}},
+		&LLMMessage{Role: LLMMessageRoleAssistant, Content: []*LLMContentBlock{{
+			Kind: LLMContentThinking, Text: "t", Signature: "sig-b",
+		}}},
+	))
+}
+
+func TestSummarizeToolsetChange(t *testing.T) {
+	tools := func(names ...string) []LLMTool {
+		out := make([]LLMTool, len(names))
+		for i, n := range names {
+			out[i] = LLMTool{Name: n}
+		}
+		return out
+	}
+
+	t.Run("added tools are listed", func(t *testing.T) {
+		out := summarizeToolsetChange(tools("read", "write"), tools("read", "write", "zoom", "screen"))
+		require.Contains(t, out, "Continuing from the returned conversation.")
+		require.Contains(t, out, "Tools added: screen, zoom")
+		require.NotContains(t, out, "Tools removed")
+	})
+
+	t.Run("removed tools are listed", func(t *testing.T) {
+		out := summarizeToolsetChange(tools("read", "write"), tools("read"))
+		require.Contains(t, out, "Tools removed: write")
+	})
+
+	t.Run("unchanged toolset reports its size", func(t *testing.T) {
+		out := summarizeToolsetChange(tools("read", "write"), tools("write", "read"))
+		require.Contains(t, out, "Toolset unchanged (2 tools).")
+	})
+
+	t.Run("unknown previous toolset reports everything as added", func(t *testing.T) {
+		out := summarizeToolsetChange(nil, tools("read"))
+		require.Contains(t, out, "Tools added: read")
+	})
+}
+
+func TestSummarizeContinuation(t *testing.T) {
+	tools := []LLMTool{{Name: "read"}}
+	base := []*LLMMessage{
+		textMsg(LLMMessageRoleUser, "hello"),
+		textMsg(LLMMessageRoleAssistant, "hi"),
+	}
+
+	t.Run("preserved history says nothing extra", func(t *testing.T) {
+		next := append(append([]*LLMMessage{}, base...), textMsg(LLMMessageRoleUser, "more"))
+		out := summarizeContinuation(&LLM{Messages: base}, &LLM{Messages: next}, tools, tools)
+		require.NotContains(t, out, "Conversation history replaced")
+	})
+
+	t.Run("replaced history is reported", func(t *testing.T) {
+		out := summarizeContinuation(
+			&LLM{Messages: base},
+			&LLM{Messages: []*LLMMessage{textMsg(LLMMessageRoleUser, "summary so far")}},
+			tools, tools,
+		)
+		require.Contains(t, out, "Conversation history replaced: 2 messages -> 1 messages.")
+		// The toolset diff is still there: the two notices compose.
+		require.Contains(t, out, "Toolset unchanged (1 tools).")
+	})
+}
+
+func TestToolResultSelectors(t *testing.T) {
+	toolCallMsg := func(callID, name string) *LLMMessage {
+		return &LLMMessage{
+			Role: LLMMessageRoleAssistant,
+			Content: []*LLMContentBlock{{
+				Kind:     LLMContentToolCall,
+				CallID:   callID,
+				ToolName: name,
+			}},
+		}
+	}
+	resultMsg := func(callID, text string) *LLMMessage {
+		return &LLMMessage{
+			Role: LLMMessageRoleUser,
+			Content: []*LLMContentBlock{{
+				Kind:   LLMContentToolResult,
+				CallID: callID,
+				Text:   text,
+			}},
+		}
+	}
+	names := map[string]string{"call-1": "reload"}
+
+	t.Run("result whose call is in the adopted history appends normally", func(t *testing.T) {
+		target := &LLM{Messages: []*LLMMessage{toolCallMsg("call-1", "reload")}}
+		sels := toolResultSelectors(target, []*LLMMessage{resultMsg("call-1", "ok")}, names)
+		require.Len(t, sels, 1)
+		require.Equal(t, "withToolResult", sels[0].Field)
+		require.Equal(t, dagql.NewString("call-1"), sels[0].Args[0].Value)
+	})
+
+	t.Run("orphaned result degrades to a user message", func(t *testing.T) {
+		// The adopted conversation dropped the call (self-compaction,
+		// summarize-and-restart): a tool_result block with no matching tool_use
+		// would be protocol-invalid, so the information is carried as prose.
+		target := &LLM{Messages: []*LLMMessage{textMsg(LLMMessageRoleUser, "summary so far")}}
+		sels := toolResultSelectors(target, []*LLMMessage{resultMsg("call-1", "ok")}, names)
+		require.Len(t, sels, 1)
+		require.Equal(t, "withPrompt", sels[0].Field)
+		require.Equal(t, "prompt", sels[0].Args[0].Name)
+		require.Equal(t, dagql.NewString("[continued via tool reload]\nok"), sels[0].Args[0].Value)
+	})
+
+	t.Run("unknown tool name falls back to the call ID", func(t *testing.T) {
+		target := &LLM{}
+		sels := toolResultSelectors(target, []*LLMMessage{resultMsg("call-9", "ok")}, names)
+		require.Len(t, sels, 1)
+		require.Equal(t, "withPrompt", sels[0].Field)
+		require.Equal(t, dagql.NewString("[continued via tool call-9]\nok"), sels[0].Args[0].Value)
+	})
+
+	t.Run("a nil target keeps tool results as tool results", func(t *testing.T) {
+		sels := toolResultSelectors(nil, []*LLMMessage{resultMsg("call-1", "ok")}, names)
+		require.Len(t, sels, 1)
+		require.Equal(t, "withToolResult", sels[0].Field)
+	})
+}

--- a/core/llm_google.go
+++ b/core/llm_google.go
@@ -543,6 +543,18 @@ func bbiSchemaToGenaiSchema(bbi map[string]any) (*genai.Schema, error) {
 	schema := &genai.Schema{}
 	for key, param := range bbi {
 		switch key {
+		case "anyOf":
+			variants, err := toSchemaMaps(param)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert anyOf field: %w", err)
+			}
+			for i, variant := range variants {
+				variantSchema, err := bbiSchemaToGenaiSchema(variant)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert anyOf variant %d: %w", i, err)
+				}
+				schema.AnyOf = append(schema.AnyOf, variantSchema)
+			}
 		case "description":
 			if schema.Description != "" {
 				schema.Description += " "
@@ -630,6 +642,25 @@ func bbiSchemaToGenaiSchema(bbi map[string]any) (*genai.Schema, error) {
 	return schema, nil
 }
 
+func toSchemaMaps(val any) ([]map[string]any, error) {
+	switch x := val.(type) {
+	case []any:
+		res := make([]map[string]any, len(x))
+		for i, v := range x {
+			var ok bool
+			res[i], ok = v.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("array element must be an object, got %T", v)
+			}
+		}
+		return res, nil
+	case []map[string]any:
+		return x, nil
+	default:
+		return nil, fmt.Errorf("value must be []map[string]any or []any, got %T", x)
+	}
+}
+
 func toStringSlice(val any) ([]string, error) {
 	var res []string
 	switch x := val.(type) {
@@ -664,6 +695,8 @@ func bbiTypeToGenaiType(bbi string) genai.Type {
 		return genai.TypeArray
 	case "object":
 		return genai.TypeObject
+	case "null":
+		return genai.TypeNULL
 	default: // should not happen
 		return genai.TypeUnspecified
 	}

--- a/core/llm_google_test.go
+++ b/core/llm_google_test.go
@@ -10,6 +10,25 @@ import (
 	"google.golang.org/genai"
 )
 
+func TestGenaiNullableSchema(t *testing.T) {
+	schema, err := bbiSchemaToGenaiSchema(map[string]any{
+		"anyOf": []any{
+			map[string]any{"type": "string", "enum": []string{"FAST", "SLOW"}},
+			map[string]any{"type": "null"},
+		},
+		"description": "An optional mode.",
+		"default":     nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, schema.AnyOf, 2)
+	assert.Equal(t, genai.TypeString, schema.AnyOf[0].Type)
+	assert.Equal(t, []string{"FAST", "SLOW"}, schema.AnyOf[0].Enum)
+	assert.Equal(t, genai.TypeNULL, schema.AnyOf[1].Type)
+	require.NotNil(t, schema.Nullable)
+	assert.True(t, *schema.Nullable)
+	assert.Equal(t, "An optional mode.", schema.Description)
+}
+
 func TestDecodeThoughtSignature(t *testing.T) {
 	raw := []byte("some-opaque-signature")
 	encoded := base64.StdEncoding.EncodeToString(raw)

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -652,46 +652,57 @@ func argTypeToJSONSchema(schema *ast.Schema, t *ast.Type) (map[string]any, error
 			return nil, fmt.Errorf("elem type: %w", err)
 		}
 		jsonSchema["items"] = items
-		return jsonSchema, nil
-	}
-	switch t.NamedType {
-	case "Int":
-		jsonSchema["type"] = "integer"
-	case "Float":
-		jsonSchema["type"] = "number"
-	case "String", "ID":
-		jsonSchema["type"] = "string"
-	case "Boolean":
-		jsonSchema["type"] = "boolean"
-	default:
-		typeDef, found := schema.Types[t.NamedType]
-		if !found {
-			return nil, fmt.Errorf("unknown type: %q", t.NamedType)
-		}
-		switch typeDef.Kind {
-		case ast.InputObject:
-			jsonSchema["type"] = "object"
-			properties := map[string]any{}
-			for _, f := range typeDef.Fields {
-				fieldSpec, err := argTypeToJSONSchema(schema, f.Type)
-				if err != nil {
-					return nil, fmt.Errorf("field %q type: %w", f.Name, err)
-				}
-				properties[f.Name] = fieldSpec
-			}
-			jsonSchema["properties"] = properties
-		case ast.Enum:
+	} else {
+		switch t.NamedType {
+		case "Int":
+			jsonSchema["type"] = "integer"
+		case "Float":
+			jsonSchema["type"] = "number"
+		case "String", "ID":
 			jsonSchema["type"] = "string"
-			var enum []string
-			for _, val := range typeDef.EnumValues {
-				enum = append(enum, val.Name)
-			}
-			jsonSchema["enum"] = enum
-		case ast.Scalar:
-			jsonSchema["type"] = "string"
+		case "Boolean":
+			jsonSchema["type"] = "boolean"
 		default:
-			return nil, fmt.Errorf("unhandled type: %s (%s)", t, typeDef.Kind)
+			typeDef, found := schema.Types[t.NamedType]
+			if !found {
+				return nil, fmt.Errorf("unknown type: %q", t.NamedType)
+			}
+			switch typeDef.Kind {
+			case ast.InputObject:
+				jsonSchema["type"] = "object"
+				properties := map[string]any{}
+				for _, f := range typeDef.Fields {
+					fieldSpec, err := argTypeToJSONSchema(schema, f.Type)
+					if err != nil {
+						return nil, fmt.Errorf("field %q type: %w", f.Name, err)
+					}
+					properties[f.Name] = fieldSpec
+				}
+				jsonSchema["properties"] = properties
+			case ast.Enum:
+				jsonSchema["type"] = "string"
+				var enum []string
+				for _, val := range typeDef.EnumValues {
+					enum = append(enum, val.Name)
+				}
+				jsonSchema["enum"] = enum
+			case ast.Scalar:
+				jsonSchema["type"] = "string"
+			default:
+				return nil, fmt.Errorf("unhandled type: %s (%s)", t, typeDef.Kind)
+			}
 		}
+	}
+	// GraphQL nullability applies at every type boundary, including list
+	// elements. Keep the concrete schema intact so enums and nested objects still
+	// constrain non-null values, and add null as a separate valid alternative.
+	if !t.NonNull {
+		return map[string]any{
+			"anyOf": []any{
+				jsonSchema,
+				map[string]any{"type": "null"},
+			},
+		}, nil
 	}
 	return jsonSchema, nil
 }

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -447,7 +447,9 @@ func (m *MCP) toolsForBoundObject(srv *dagql.Server, schema *ast.Schema, b bound
 // except, must not be an internal/reserved field, and every REQUIRED argument
 // must be expressible without an object handle — a required object-typed arg
 // (other than the auto-injected Workspace) disqualifies it, since the model has
-// no handle to pass.
+// no handle to pass. Exception: a required arg of a LIFTABLE type (see
+// liftableTypes) does not disqualify — the model can supply an address string,
+// lifted into the object at dispatch time via the core Address API.
 func objectToolEligible(field *ast.FieldDefinition, except []string) bool {
 	if slices.Contains(except, field.Name) {
 		return false
@@ -475,7 +477,9 @@ func objectToolEligible(field *ast.FieldDefinition, except []string) bool {
 		}
 		required := arg.Type.NonNull && arg.DefaultValue == nil
 		if required && isObjectArg(arg) {
-			return false
+			if _, ok := liftableObjectArg(arg); !ok {
+				return false
+			}
 		}
 	}
 	return true
@@ -485,6 +489,64 @@ func objectToolEligible(field *ast.FieldDefinition, except []string) bool {
 // wire as an `ID` scalar carrying an @expectedType directive.
 func isObjectArg(arg *ast.ArgumentDefinition) bool {
 	return arg.Directives.ForName("expectedType") != nil
+}
+
+// liftableType describes an object type admitted to address lifting: how a
+// plain address string supplied for an arg of the type resolves into the
+// object, and how to document the accepted syntaxes to the model.
+type liftableType struct {
+	// addressField is the Address field that loads the type:
+	// Query.address(value: <addr>).<addressField> — the same lifting the CLI
+	// performs for object-typed flags (internal/cmd/dagger/flags.go), see
+	// core/schema/address.go.
+	addressField string
+	// hint documents the accepted address syntaxes; the tool schema renders
+	// it as "(<Type> address: <hint>)" prefixed to the arg's own docstring,
+	// so each type carries its own syntax examples.
+	hint string
+}
+
+// liftableTypes is the allowlist of object types whose tool args accept a
+// plain address string. Admission is a CAPABILITY decision, not a convenience
+// one: a CLI flag is human-typed, but a tool arg is MODEL-typed, and several
+// Address decoders resolve strings into capabilities the model doesn't
+// otherwise hold — Address.secret mints secrets from env:// / file:// /
+// op:// URIs, Address.directory/.file/.socket fall back to HOST paths, and
+// the service/git decoders reach the host's network and local repos.
+// Container has no host fallback (image refs pull from registries, bare refs
+// resolve installed modules), so it is the only entry today. Admitting
+// another of the CLI's nine addressable types is a one-line change here plus
+// that type's own capability review — see hack/designs/sandboxes.md §4, "The
+// liftable set is a capability decision".
+var liftableTypes = map[string]liftableType{
+	"Container": {
+		addressField: "container",
+		hint:         `an image ref like "golang:1.26", an installed module function like "mymod:dev", or a Container ID from a prior tool result`,
+	},
+}
+
+// liftableObjectArg returns the @expectedType name of an object-typed
+// argument when that type is liftable — resolvable from an address string via
+// the core Address API AND admitted by the liftableTypes capability
+// allowlist. Only single-object args qualify: a list of IDs ([ID!]! with
+// @expectedType) is not lifted.
+func liftableObjectArg(arg *ast.ArgumentDefinition) (string, bool) {
+	if arg.Type == nil || arg.Type.NamedType != "ID" {
+		// Lists of object IDs (arg.Type.Elem != nil) are not liftable.
+		return "", false
+	}
+	d := arg.Directives.ForName("expectedType")
+	if d == nil {
+		return "", false
+	}
+	name := d.Arguments.ForName("name")
+	if name == nil || name.Value == nil {
+		return "", false
+	}
+	if _, ok := liftableTypes[name.Value.Raw]; !ok {
+		return "", false
+	}
+	return name.Value.Raw, true
 }
 
 // isAutoInjectedArg reports whether an argument is filled in by the engine
@@ -507,8 +569,9 @@ func isExpectedTypeArg(arg *ast.ArgumentDefinition, typeName string) bool {
 
 // objectMethodSchema builds a tool's JSON-schema parameters from a field's
 // visible arguments — its scalars, enums, lists, and input objects — omitting the
-// auto-injected Workspace and LLM arguments. Object args (when optional) render
-// as ID strings, annotated with their expected type.
+// auto-injected Workspace and LLM arguments. Object args render as ID strings
+// annotated with their expected type; liftable object args (required or
+// optional) render as address strings instead, with the type's syntax hint.
 func objectMethodSchema(schema *ast.Schema, field *ast.FieldDefinition) (map[string]any, error) {
 	properties := map[string]any{}
 	var required []string
@@ -523,10 +586,17 @@ func objectMethodSchema(schema *ast.Schema, field *ast.FieldDefinition) (map[str
 		desc := arg.Description
 		if d := arg.Directives.ForName("expectedType"); d != nil {
 			if name := d.Arguments.ForName("name"); name != nil && name.Value != nil {
+				// A liftable arg accepts an address string (per the type's
+				// hint — see liftableTypes) as well as an ID from a previous
+				// tool result; anything else only accepts an ID.
+				prefix := fmt.Sprintf("(%s ID)", name.Value.Raw)
+				if typeName, ok := liftableObjectArg(arg); ok {
+					prefix = fmt.Sprintf("(%s address: %s)", typeName, liftableTypes[typeName].hint)
+				}
 				if desc == "" {
-					desc = fmt.Sprintf("(%s ID)", name.Value.Raw)
+					desc = prefix
 				} else {
-					desc = fmt.Sprintf("(%s ID) %s", name.Value.Raw, desc)
+					desc = prefix + " " + desc
 				}
 			}
 		}
@@ -617,7 +687,6 @@ func argTypeToJSONSchema(schema *ast.Schema, t *ast.Type) (map[string]any, error
 // threaded into ctx by MCP.Call so Workspace-typed args auto-inject, then routes
 // the result by type.
 func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.FieldDefinition) LLMToolFunc {
-	fieldName := field.Name
 	return func(ctx context.Context, rawArgs any) (any, error) {
 		args, ok := rawArgs.(map[string]any)
 		if !ok {
@@ -630,7 +699,7 @@ func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.Fi
 		if !ok {
 			return nil, fmt.Errorf("no object of type %q is bound", typeName)
 		}
-		sel, err := buildObjectMethodSelector(ctx, srv, recv.ObjectType(), fieldName, args)
+		sel, err := buildObjectMethodSelector(ctx, srv, recv.ObjectType(), field, args)
 		if err != nil {
 			return nil, err
 		}
@@ -647,10 +716,17 @@ func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.Fi
 
 // buildObjectMethodSelector converts the model's tool arguments into a selector
 // for the method. It decodes each provided argument through the field's input
-// spec. A declared-optional Workspace argument is omitted and auto-injected
-// downstream; a required one is filled from the LLM's bound workspace, since
-// dagql rejects a missing non-null argument before that injection runs.
-func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType dagql.ObjectType, fieldName string, args map[string]any) (dagql.Selector, error) {
+// spec; the Workspace argument is omitted here and auto-injected downstream.
+// An object-typed argument of a liftable type (see liftableTypes) additionally
+// accepts an address string: when the value fails to decode as an ID, it is
+// lifted into the object via the core Address API
+// (Query.address(value: <addr>).<field>) and the resulting object's ID is used
+// instead — the same lifting the CLI performs for object flags
+// (internal/cmd/dagger/flags.go). ctx and srv are the session's, so addresses
+// resolve against the workspace client schema with all installed modules
+// visible.
+func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType dagql.ObjectType, astField *ast.FieldDefinition, args map[string]any) (dagql.Selector, error) {
+	fieldName := astField.Name
 	sel := dagql.Selector{View: srv.View, Field: fieldName}
 	field, ok := recvType.FieldSpec(fieldName, srv.View)
 	if !ok {
@@ -671,7 +747,16 @@ func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType 
 		delete(provided, arg.Name)
 		input, err := arg.Type.Decoder().DecodeInput(val)
 		if err != nil {
-			return sel, fmt.Errorf("arg %q: decode %T: %w", arg.Name, val, err)
+			// Not a valid ID: for a liftable object arg, fall back to
+			// interpreting the string as an address.
+			lifted, ok, liftErr := liftObjectArg(ctx, srv, astField, arg, val, err)
+			if liftErr != nil {
+				return sel, fmt.Errorf("arg %q: %w", arg.Name, liftErr)
+			}
+			if !ok {
+				return sel, fmt.Errorf("arg %q: decode %T: %w", arg.Name, val, err)
+			}
+			input = lifted
 		}
 		sel.Args = append(sel.Args, dagql.NamedInput{Name: arg.Name, Value: input})
 	}
@@ -684,6 +769,62 @@ func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType 
 		return sel, fmt.Errorf("unknown arguments: %s", strings.Join(unknown, ", "))
 	}
 	return sel, nil
+}
+
+// liftObjectArg resolves an address string supplied for a liftable
+// object-typed argument into that object's ID. It selects
+// Query.address(value: <addr>).<addressField> on the session server, then
+// re-encodes the resulting object's ID through the argument's own decoder so
+// the input matches whatever ID type the field expects (including
+// optional-wrapped IDs). Returns ok=false — without an error — when the
+// argument is not a liftable object arg or the value is not a string, so
+// the caller surfaces the original ID decode error instead. idErr is that
+// original error, folded into the message when address resolution also fails.
+func liftObjectArg(ctx context.Context, srv *dagql.Server, astField *ast.FieldDefinition, spec dagql.InputSpec, val any, idErr error) (dagql.Input, bool, error) {
+	astArg := astField.Arguments.ForName(spec.Name)
+	if astArg == nil {
+		return nil, false, nil
+	}
+	typeName, ok := liftableObjectArg(astArg)
+	if !ok {
+		return nil, false, nil
+	}
+	addr, ok := val.(string)
+	if !ok {
+		return nil, false, nil
+	}
+	var obj dagql.AnyObjectResult
+	// Address resolution is user-facing work of the tool call — possibly an
+	// image pull — not engine bookkeeping: run it non-internal (matching the
+	// method call's Select in callObjectMethod) so it renders in the trace as
+	// part of the tool call instead of hiding as internal spans.
+	if err := srv.Select(dagql.WithNonInternalTelemetry(ctx), srv.Root(), &obj,
+		dagql.Selector{
+			View:  srv.View,
+			Field: "address",
+			Args:  []dagql.NamedInput{{Name: "value", Value: dagql.String(addr)}},
+		},
+		dagql.Selector{
+			View:  srv.View,
+			Field: liftableTypes[typeName].addressField,
+		},
+	); err != nil {
+		return nil, false, fmt.Errorf("%q is neither a %s ID (%s) nor a resolvable %s address: %w",
+			addr, typeName, idErr, typeName, err)
+	}
+	objID, err := obj.ID()
+	if err != nil {
+		return nil, false, fmt.Errorf("get %s ID for address %q: %w", typeName, addr, err)
+	}
+	encoded, err := objID.Encode()
+	if err != nil {
+		return nil, false, fmt.Errorf("encode %s ID for address %q: %w", typeName, addr, err)
+	}
+	input, err := spec.Type.Decoder().DecodeInput(encoded)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode lifted %s ID for address %q: %w", typeName, addr, err)
+	}
+	return input, true, nil
 }
 
 // routeObjectMethodResult renders a method's result for the model, per the

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -55,7 +55,12 @@ type boundTool struct {
 	// objType is the bound object's GraphQL type, known without loading, so the
 	// toolset can be built from a lazy binding.
 	objType dagql.ObjectType
-	Except  []string
+	// definingSchema is the schema that originally defined objType. The bound
+	// Workspace normally supplies the tool schema, so overlay edits can replace
+	// it; this is only the fallback when that schema does not contain the bound
+	// type (for example while recovering from a broken overlay module).
+	definingSchema *ast.Schema
+	Except         []string
 }
 
 // typeName returns the bound object's type name without forcing a load.
@@ -93,12 +98,13 @@ func (m *MCP) WithTools(obj dagql.AnyObjectResult, except []string) *MCP {
 // without loading it. Used when restoring a persisted session: the referenced
 // object is only loaded if and when a tool is actually invoked on it (see
 // MCP.boundToolObject), so restoring the conversation never re-runs the call
-// that produced the object. objType is the object's GraphQL type, resolved from
-// the ID's return type, so the toolset can still be built.
-func (m *MCP) WithLazyTools(id *call.ID, objType dagql.ObjectType, except []string) *MCP {
+// that produced the object. objType and definingSchema describe the object's
+// GraphQL type without loading it, so the toolset can still be built even if a
+// later Workspace schema does not contain that type.
+func (m *MCP) WithLazyTools(id *call.ID, objType dagql.ObjectType, definingSchema *ast.Schema, except []string) *MCP {
 	m = m.Clone()
 	typeName := objType.TypeName()
-	binding := boundTool{id: id, objType: objType, Except: except}
+	binding := boundTool{id: id, objType: objType, definingSchema: definingSchema, Except: except}
 	for i, b := range m.boundTools {
 		if b.typeName() == typeName {
 			m.boundTools[i] = binding
@@ -407,6 +413,17 @@ func (m *MCP) ToolNameCollisions(ctx context.Context) (map[string][]string, erro
 func (m *MCP) toolsForBoundObject(srv *dagql.Server, schema *ast.Schema, b boundTool) ([]LLMTool, error) {
 	typeName := b.typeName()
 	def := schema.Types[typeName]
+	toolSchema := schema
+	if (def == nil || (def.Kind != ast.Object && def.Kind != ast.Interface)) && b.definingSchema != nil {
+		// A broken Workspace overlay falls back to the served schema so existing
+		// repair tools remain callable. That schema may legitimately omit a bound
+		// object from another module (nested agents are a common source). Use the
+		// schema captured when withTools resolved the object's module provenance,
+		// but only when the Workspace schema has no usable definition: valid
+		// overlays must continue to replace tool signatures and documentation.
+		def = b.definingSchema.Types[typeName]
+		toolSchema = b.definingSchema
+	}
 	if def == nil || (def.Kind != ast.Object && def.Kind != ast.Interface) {
 		return nil, fmt.Errorf("bound object type %q is not an object in the workspace schema", typeName)
 	}
@@ -415,7 +432,7 @@ func (m *MCP) toolsForBoundObject(srv *dagql.Server, schema *ast.Schema, b bound
 		if !objectToolEligible(field, b.Except) {
 			continue
 		}
-		toolSchema, err := objectMethodSchema(schema, field)
+		methodSchema, err := objectMethodSchema(toolSchema, field)
 		if err != nil {
 			return nil, fmt.Errorf("build schema for %s.%s: %w", typeName, field.Name, err)
 		}
@@ -424,7 +441,7 @@ func (m *MCP) toolsForBoundObject(srv *dagql.Server, schema *ast.Schema, b bound
 			Name:        field.Name,
 			Field:       field,
 			Description: strings.TrimSpace(field.Description),
-			Schema:      toolSchema,
+			Schema:      methodSchema,
 			// A method that returns the bound object's own type, a Workspace, or
 			// an LLM mutates shared state and must run sequentially — an LLM
 			// return replaces the whole conversation, and at most one may be

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -55,10 +55,9 @@ type boundTool struct {
 	// objType is the bound object's GraphQL type, known without loading, so the
 	// toolset can be built from a lazy binding.
 	objType dagql.ObjectType
-	// definingSchema is the schema that originally defined objType. The bound
-	// Workspace normally supplies the tool schema, so overlay edits can replace
-	// it; this is only the fallback when that schema does not contain the bound
-	// type (for example while recovering from a broken overlay module).
+	// definingSchema is the schema that defined objType when this binding was
+	// composed. It is authoritative for the lifetime of the binding: workspace
+	// edits only affect tools after explicit recomposition creates a new LLM.
 	definingSchema *ast.Schema
 	Except         []string
 }
@@ -74,16 +73,23 @@ func (b boundTool) typeName() string {
 	return ""
 }
 
-// WithTools binds obj's methods as tools, carrying except. At most one binding
-// per object type is kept: binding an object whose type is already bound replaces
-// it in place. That is the state-update shape — a method returning the bound type
-// rebinds through here — so the binding list stays bounded and a recorded
-// withTools selector replays to the same state deterministically.
-func (m *MCP) WithTools(obj dagql.AnyObjectResult, except []string) *MCP {
+// WithTools binds obj's methods as tools, carrying the schema that defined the
+// receiver at composition time and except. At most one binding per object type
+// is kept: binding an object whose type is already bound replaces it in place.
+// That is the state-update shape — a method returning the bound type rebinds
+// through here — so the binding list stays bounded and a recorded withTools
+// selector replays to the same state deterministically.
+func (m *MCP) WithTools(obj dagql.AnyObjectResult, definingSchema *ast.Schema, except []string) *MCP {
 	m = m.Clone()
 	typeName := obj.Type().Name()
 	id, _ := obj.ID()
-	binding := boundTool{object: obj, id: id, objType: obj.ObjectType(), Except: except}
+	binding := boundTool{
+		object:         obj,
+		id:             id,
+		objType:        obj.ObjectType(),
+		definingSchema: definingSchema,
+		Except:         except,
+	}
 	for i, b := range m.boundTools {
 		if b.typeName() == typeName {
 			m.boundTools[i] = binding
@@ -99,8 +105,8 @@ func (m *MCP) WithTools(obj dagql.AnyObjectResult, except []string) *MCP {
 // object is only loaded if and when a tool is actually invoked on it (see
 // MCP.boundToolObject), so restoring the conversation never re-runs the call
 // that produced the object. objType and definingSchema describe the object's
-// GraphQL type without loading it, so the toolset can still be built even if a
-// later Workspace schema does not contain that type.
+// GraphQL type without loading it. The defining schema stays authoritative even
+// if the bound Workspace later contains another definition of the same type.
 func (m *MCP) WithLazyTools(id *call.ID, objType dagql.ObjectType, definingSchema *ast.Schema, except []string) *MCP {
 	m = m.Clone()
 	typeName := objType.TypeName()
@@ -272,7 +278,7 @@ func (m *MCP) bindWorkspaceModuleTools(ctx context.Context) (*MCP, error) {
 		}); err != nil {
 			return nil, fmt.Errorf("construct workspace module %q: %w", mod.Name(), err)
 		}
-		m = m.WithTools(obj, nil)
+		m = m.WithTools(obj, canonical.Schema(), nil)
 	}
 	return m, nil
 }
@@ -314,10 +320,9 @@ func (m *MCP) boundToolsets(srv *dagql.Server) ([]bindingToolset, error) {
 	if len(bindings) == 0 {
 		return nil, nil
 	}
-	schema := srv.Schema()
 	toolsets := make([]bindingToolset, 0, len(bindings))
 	for _, b := range bindings {
-		tools, err := m.toolsForBoundObject(srv, schema, b)
+		tools, err := m.toolsForBoundObject(srv, b)
 		if err != nil {
 			return nil, err
 		}
@@ -410,22 +415,15 @@ func (m *MCP) ToolNameCollisions(ctx context.Context) (map[string][]string, erro
 
 // toolsForBoundObject generates the tools for a single bound object: one per
 // eligible field of its schema type.
-func (m *MCP) toolsForBoundObject(srv *dagql.Server, schema *ast.Schema, b boundTool) ([]LLMTool, error) {
+func (m *MCP) toolsForBoundObject(srv *dagql.Server, b boundTool) ([]LLMTool, error) {
 	typeName := b.typeName()
-	def := schema.Types[typeName]
-	toolSchema := schema
-	if (def == nil || (def.Kind != ast.Object && def.Kind != ast.Interface)) && b.definingSchema != nil {
-		// A broken Workspace overlay falls back to the served schema so existing
-		// repair tools remain callable. That schema may legitimately omit a bound
-		// object from another module (nested agents are a common source). Use the
-		// schema captured when withTools resolved the object's module provenance,
-		// but only when the Workspace schema has no usable definition: valid
-		// overlays must continue to replace tool signatures and documentation.
-		def = b.definingSchema.Types[typeName]
-		toolSchema = b.definingSchema
+	toolSchema := b.definingSchema
+	if toolSchema == nil {
+		return nil, fmt.Errorf("bound object type %q has no defining schema", typeName)
 	}
+	def := toolSchema.Types[typeName]
 	if def == nil || (def.Kind != ast.Object && def.Kind != ast.Interface) {
-		return nil, fmt.Errorf("bound object type %q is not an object in the workspace schema", typeName)
+		return nil, fmt.Errorf("bound object type %q is not an object in its defining schema", typeName)
 	}
 	var tools []LLMTool
 	for _, field := range def.Fields {

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -31,6 +31,13 @@ const llmToolLogsMaxLines = 8
 // from the generated tool schema.
 const workspaceTypeName = "Workspace"
 
+// llmTypeName is the object type the engine auto-injects into a module
+// function's arguments from the conversation making the call (see
+// core/llm_context.go). Like Workspace, such arguments are hidden from the
+// generated tool schema. A method returning it is a continuation: the loop
+// resumes from the returned conversation (MCP.adoptLLM).
+const llmTypeName = "LLM"
+
 // boundTool is one object bound into the LLM's toolset via withTools. It carries
 // enough to build the toolset (the object's type, via objType) and to dispatch a
 // tool call (the object itself, as the receiver). The object may be held lazily
@@ -418,11 +425,16 @@ func (m *MCP) toolsForBoundObject(srv *dagql.Server, schema *ast.Schema, b bound
 			Field:       field,
 			Description: strings.TrimSpace(field.Description),
 			Schema:      toolSchema,
-			// A method that returns the bound object's own type or a Workspace
-			// mutates shared state and must run sequentially. Changeset-returning
-			// methods run in parallel; CallBatch merges their results before applying
-			// them to the workspace.
-			ReadOnly:         retType != typeName && retType != "Changeset" && retType != "Workspace",
+			// A method that returns the bound object's own type, a Workspace, or
+			// an LLM mutates shared state and must run sequentially — an LLM
+			// return replaces the whole conversation, and at most one may be
+			// adopted per turn. Changeset-returning methods run in parallel;
+			// CallBatch merges their results before applying them to the
+			// workspace.
+			ReadOnly: retType != typeName &&
+				retType != "Changeset" &&
+				retType != workspaceTypeName &&
+				retType != llmTypeName,
 			ReturnsChangeset: retType == "Changeset",
 			Call:             m.callObjectMethod(srv, typeName, field),
 			Server:           typeName,
@@ -456,8 +468,9 @@ func objectToolEligible(field *ast.FieldDefinition, except []string) bool {
 		return false
 	}
 	for _, arg := range field.Arguments {
-		if isWorkspaceArg(arg) {
-			// Auto-injected from the bound Workspace; treated as optional.
+		if isAutoInjectedArg(arg) {
+			// Auto-injected from the bound Workspace / current conversation;
+			// treated as optional.
 			continue
 		}
 		required := arg.Type.NonNull && arg.DefaultValue == nil
@@ -474,27 +487,33 @@ func isObjectArg(arg *ast.ArgumentDefinition) bool {
 	return arg.Directives.ForName("expectedType") != nil
 }
 
-// isWorkspaceArg reports whether an argument is the auto-injected Workspace,
-// identified by @expectedType(name: "Workspace"). Such args are filled from the
-// bound Workspace and never shown to the model.
-func isWorkspaceArg(arg *ast.ArgumentDefinition) bool {
+// isAutoInjectedArg reports whether an argument is filled in by the engine
+// rather than by the model: the bound Workspace (@expectedType(name:
+// "Workspace")), or the conversation making the call (an `LLM!` arg — see
+// core/llm_context.go). Both are hidden from the generated tool schema and
+// never disqualify a method from being a tool.
+func isAutoInjectedArg(arg *ast.ArgumentDefinition) bool {
+	return isExpectedTypeArg(arg, workspaceTypeName) || isExpectedTypeArg(arg, llmTypeName)
+}
+
+func isExpectedTypeArg(arg *ast.ArgumentDefinition, typeName string) bool {
 	d := arg.Directives.ForName("expectedType")
 	if d == nil {
 		return false
 	}
 	name := d.Arguments.ForName("name")
-	return name != nil && name.Value != nil && name.Value.Raw == workspaceTypeName
+	return name != nil && name.Value != nil && name.Value.Raw == typeName
 }
 
 // objectMethodSchema builds a tool's JSON-schema parameters from a field's
 // visible arguments — its scalars, enums, lists, and input objects — omitting the
-// auto-injected Workspace argument. Object args (when optional) render as ID
-// strings, annotated with their expected type.
+// auto-injected Workspace and LLM arguments. Object args (when optional) render
+// as ID strings, annotated with their expected type.
 func objectMethodSchema(schema *ast.Schema, field *ast.FieldDefinition) (map[string]any, error) {
 	properties := map[string]any{}
 	var required []string
 	for _, arg := range field.Arguments {
-		if isWorkspaceArg(arg) {
+		if isAutoInjectedArg(arg) {
 			continue
 		}
 		argSchema, err := argTypeToJSONSchema(schema, arg.Type)
@@ -671,14 +690,16 @@ func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType 
 // return-type table in hack/designs/workspace-agents.md:
 //   - Changeset: overlay onto the workspace, return the patch summary.
 //   - Workspace: replace the current workspace, return the diff summary.
+//   - LLM: replace the conversation — the loop resumes from it (a continuation).
 //   - the bound object's own type: rebind it as the new state, return its print.
 //   - any other object: sync it, return its print (else a type description).
 //   - Void/null: return its print, else "(done)".
 //   - scalar/list/record: return the value.
 func (m *MCP) routeObjectMethodResult(ctx context.Context, srv *dagql.Server, typeName string, val dagql.AnyResult) (any, error) {
-	// A Changeset overlays onto the workspace (and a Workspace replaces it),
-	// returning a patch summary. step() persists the resulting workspace via a
-	// withWorkspace selector.
+	// A Changeset overlays onto the workspace (a Workspace replaces it, an LLM
+	// replaces the whole conversation), returning a summary. step() persists the
+	// resulting workspace via a withWorkspace selector, or resumes from the
+	// returned conversation.
 	if handled, out, err := m.applyStateReturn(ctx, srv, val); handled {
 		if logs := m.toolLogs(ctx); logs != "" {
 			if out == "" {

--- a/core/llm_object_tools_test.go
+++ b/core/llm_object_tools_test.go
@@ -47,8 +47,11 @@ type Doug {
   "Update the TODO list."
   todoWrite(pending: [String!]! = []): Doug!
 
-  "Build an agent — requires an object arg, so ineligible."
+  "Build an agent — its LLM! arg is auto-injected, so it IS eligible."
   agent(base: ID! @expectedType(name: "LLM")): LLM!
+
+  "Apply a changeset — requires a non-injected object arg, so ineligible."
+  apply(changes: ID! @expectedType(name: "Changeset")): Doug!
 
   old: String! @deprecated(reason: "gone")
 }
@@ -77,9 +80,13 @@ func TestObjectToolEligible(t *testing.T) {
 	require.True(t, objectToolEligible(fieldByName(doug, "write"), nil))
 	require.True(t, objectToolEligible(fieldByName(doug, "todoWrite"), nil))
 
-	// A required object-typed argument (LLM, not the auto-injected Workspace)
-	// disqualifies the method — the model has no handle to pass.
-	require.False(t, objectToolEligible(fieldByName(doug, "agent"), nil))
+	// A required object-typed argument disqualifies the method — the model has no
+	// handle to pass.
+	require.False(t, objectToolEligible(fieldByName(doug, "apply"), nil))
+
+	// ...except when the engine fills it in: an `LLM!` arg is auto-injected with
+	// the conversation making the call, so it does not disqualify.
+	require.True(t, objectToolEligible(fieldByName(doug, "agent"), nil))
 
 	// except drops a method by name.
 	require.False(t, objectToolEligible(fieldByName(doug, "read"), []string{"read"}))

--- a/core/llm_object_tools_test.go
+++ b/core/llm_object_tools_test.go
@@ -394,6 +394,25 @@ func newAddressLiftTestServer(t *testing.T) *dagql.Server {
 	return srv
 }
 
+func TestBoundToolsUseTheirDefiningSchemaAsFallback(t *testing.T) {
+	defining := newAddressLiftTestServer(t)
+	objType, ok := defining.ObjectType("LiftTestRunner")
+	require.True(t, ok)
+
+	current := newCoreDagqlServerForTest(t, &Query{})
+	mcp := newMCP().WithLazyTools(nil, objType, defining.Schema(), nil)
+	toolsets, err := mcp.boundToolsets(current)
+	require.NoError(t, err)
+	require.Len(t, toolsets, 1)
+	require.Equal(t, "LiftTestRunner", toolsets[0].typeName)
+
+	names := make([]string, 0, len(toolsets[0].tools))
+	for _, tool := range toolsets[0].tools {
+		names = append(names, tool.Name)
+	}
+	require.ElementsMatch(t, []string{"exec", "nullable", "withDir"}, names)
+}
+
 // TestBuildObjectMethodSelectorAddressLift covers dispatch: a model-supplied
 // string for a liftable object arg first tries the ID decode (IDs from
 // previous tool results keep working), then falls back to lifting the string

--- a/core/llm_object_tools_test.go
+++ b/core/llm_object_tools_test.go
@@ -32,6 +32,13 @@ type Container { id: ID! }
 type Directory { id: ID! }
 type Secret { id: ID! }
 
+enum Mode { FAST SLOW }
+input Options {
+  label: String
+  mode: Mode
+  values: [String]
+}
+
 "A coding agent."
 type Doug {
   id: ID!
@@ -100,6 +107,19 @@ func fieldByName(def *ast.Definition, name string) *ast.FieldDefinition {
 		}
 	}
 	return nil
+}
+
+func requireNullableJSONSchema(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	variants, ok := schema["anyOf"].([]any)
+	require.True(t, ok, "nullable schema must use anyOf: %#v", schema)
+	require.Len(t, variants, 2)
+	nonNull, ok := variants[0].(map[string]any)
+	require.True(t, ok)
+	nullSchema, ok := variants[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "null", nullSchema["type"])
+	return nonNull
 }
 
 func TestObjectToolEligible(t *testing.T) {
@@ -172,9 +192,10 @@ func TestObjectMethodSchema(t *testing.T) {
 	require.Equal(t, "string", props["filePath"].(map[string]any)["type"])
 	require.Equal(t, "integer", props["offset"].(map[string]any)["type"])
 	require.EqualValues(t, 0, props["offset"].(map[string]any)["default"])
-	require.Equal(t, "string", props["date"].(map[string]any)["type"])
-	require.Contains(t, props["date"].(map[string]any), "default")
-	require.Nil(t, props["date"].(map[string]any)["default"])
+	date := props["date"].(map[string]any)
+	require.Equal(t, "string", requireNullableJSONSchema(t, date)["type"])
+	require.Contains(t, date, "default")
+	require.Nil(t, date["default"])
 	require.Equal(t, []string{"filePath"}, readSchema["required"])
 	require.Equal(t, false, readSchema["additionalProperties"])
 
@@ -203,18 +224,20 @@ func TestObjectMethodSchema(t *testing.T) {
 	// both.
 	debugSchema, err := objectMethodSchema(schema, fieldByName(doug, "debug"))
 	require.NoError(t, err)
-	debug := debugSchema["properties"].(map[string]any)["sandbox"].(map[string]any)
+	debugProperty := debugSchema["properties"].(map[string]any)["sandbox"].(map[string]any)
+	debug := requireNullableJSONSchema(t, debugProperty)
 	require.Equal(t, "string", debug["type"])
-	require.Equal(t, containerHint, debug["description"])
+	require.Equal(t, containerHint, debugProperty["description"])
 
 	// An optional arg of an addressable-but-not-liftable type keeps the ID
 	// convention: the model may hand back an ID from a prior tool result, but
 	// is not invited to write an address (dispatch would refuse it anyway).
 	dirSchema, err := objectMethodSchema(schema, fieldByName(doug, "withDir"))
 	require.NoError(t, err)
-	dir := dirSchema["properties"].(map[string]any)["dir"].(map[string]any)
+	dirProperty := dirSchema["properties"].(map[string]any)["dir"].(map[string]any)
+	dir := requireNullableJSONSchema(t, dirProperty)
 	require.Equal(t, "string", dir["type"])
-	require.Equal(t, "(Directory ID)", dir["description"])
+	require.Equal(t, "(Directory ID)", dirProperty["description"])
 
 	// A non-addressable object arg keeps the ID convention.
 	applySchema, err := objectMethodSchema(schema, fieldByName(doug, "apply"))
@@ -285,6 +308,35 @@ func TestArgTypeToJSONSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "array", got["type"])
 	require.Equal(t, "string", got["items"].(map[string]any)["type"])
+
+	// Nullable wrappers apply at every GraphQL type boundary, including list
+	// elements, enums, and fields nested in input objects.
+	nullableList := &ast.Type{Elem: &ast.Type{NamedType: "String"}}
+	got, err = argTypeToJSONSchema(schema, nullableList)
+	require.NoError(t, err)
+	listSchema := requireNullableJSONSchema(t, got)
+	require.Equal(t, "array", listSchema["type"])
+	require.Equal(t, "string", requireNullableJSONSchema(t,
+		listSchema["items"].(map[string]any))["type"])
+
+	got, err = argTypeToJSONSchema(schema, &ast.Type{NamedType: "Mode"})
+	require.NoError(t, err)
+	enumSchema := requireNullableJSONSchema(t, got)
+	require.Equal(t, "string", enumSchema["type"])
+	require.Equal(t, []string{"FAST", "SLOW"}, enumSchema["enum"])
+
+	got, err = argTypeToJSONSchema(schema, &ast.Type{NamedType: "Options"})
+	require.NoError(t, err)
+	inputSchema := requireNullableJSONSchema(t, got)
+	require.Equal(t, "object", inputSchema["type"])
+	inputProps := inputSchema["properties"].(map[string]any)
+	require.Equal(t, "string", requireNullableJSONSchema(t,
+		inputProps["label"].(map[string]any))["type"])
+	require.Equal(t, "string", requireNullableJSONSchema(t,
+		inputProps["mode"].(map[string]any))["type"])
+	nestedList := requireNullableJSONSchema(t, inputProps["values"].(map[string]any))
+	require.Equal(t, "string", requireNullableJSONSchema(t,
+		nestedList["items"].(map[string]any))["type"])
 }
 
 // TestCombineSpanResult covers the combined result's contract: the target's
@@ -394,6 +446,14 @@ func newAddressLiftTestServer(t *testing.T) *dagql.Server {
 		}) (*liftTestRunner, error) {
 			return r, nil
 		}),
+		dagql.Func("nullable", func(_ context.Context, _ *liftTestRunner, args struct {
+			Date dagql.Optional[dagql.String]
+		}) (dagql.String, error) {
+			if !args.Date.Valid {
+				return "null", nil
+			}
+			return args.Date.Value, nil
+		}),
 	}.Install(srv)
 	return srv
 }
@@ -476,6 +536,18 @@ func TestBuildObjectMethodSelectorAddressLift(t *testing.T) {
 	typeName, ok := liftableObjectArg(execField.Arguments.ForName("sandbox"))
 	require.True(t, ok)
 	require.Equal(t, "Container", typeName)
+
+	t.Run("explicit null decodes for a nullable argument", func(t *testing.T) {
+		nullableField := fieldByName(srv.Schema().Types["LiftTestRunner"], "nullable")
+		require.NotNil(t, nullableField)
+		sel, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), nullableField, map[string]any{
+			"date": nil,
+		})
+		require.NoError(t, err)
+		var out dagql.String
+		require.NoError(t, srv.Select(ctx, runner, &out, sel))
+		require.Equal(t, "null", out.String())
+	})
 
 	t.Run("address string lifts into the object", func(t *testing.T) {
 		sel, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), execField, map[string]any{

--- a/core/llm_object_tools_test.go
+++ b/core/llm_object_tools_test.go
@@ -42,6 +42,7 @@ type Doug {
     source: ID! @expectedType(name: "Workspace"),
     filePath: String!,
     offset: Int! = 0,
+    date: String = null,
   ): String!
 
   "Write a file."
@@ -171,6 +172,9 @@ func TestObjectMethodSchema(t *testing.T) {
 	require.Equal(t, "string", props["filePath"].(map[string]any)["type"])
 	require.Equal(t, "integer", props["offset"].(map[string]any)["type"])
 	require.EqualValues(t, 0, props["offset"].(map[string]any)["default"])
+	require.Equal(t, "string", props["date"].(map[string]any)["type"])
+	require.Contains(t, props["date"].(map[string]any), "default")
+	require.Nil(t, props["date"].(map[string]any)["default"])
 	require.Equal(t, []string{"filePath"}, readSchema["required"])
 	require.Equal(t, false, readSchema["additionalProperties"])
 

--- a/core/llm_object_tools_test.go
+++ b/core/llm_object_tools_test.go
@@ -394,23 +394,55 @@ func newAddressLiftTestServer(t *testing.T) *dagql.Server {
 	return srv
 }
 
-func TestBoundToolsUseTheirDefiningSchemaAsFallback(t *testing.T) {
+func TestBoundToolsUseTheirDefiningSchemaAuthoritatively(t *testing.T) {
 	defining := newAddressLiftTestServer(t)
 	objType, ok := defining.ObjectType("LiftTestRunner")
 	require.True(t, ok)
 
 	current := newCoreDagqlServerForTest(t, &Query{})
-	mcp := newMCP().WithLazyTools(nil, objType, defining.Schema(), nil)
-	toolsets, err := mcp.boundToolsets(current)
-	require.NoError(t, err)
-	require.Len(t, toolsets, 1)
-	require.Equal(t, "LiftTestRunner", toolsets[0].typeName)
+	current.InstallObject(dagql.NewClass(current, dagql.ClassOpts[*liftTestRunner]{Typed: &liftTestRunner{}}))
+	dagql.Fields[*liftTestRunner]{
+		dagql.Func("replacement", func(_ context.Context, _ *liftTestRunner, _ struct{}) (dagql.String, error) {
+			return "replacement", nil
+		}),
+	}.Install(current)
 
-	names := make([]string, 0, len(toolsets[0].tools))
-	for _, tool := range toolsets[0].tools {
-		names = append(names, tool.Name)
+	assertDefiningTools := func(t *testing.T, mcp *MCP) []LLMTool {
+		t.Helper()
+		toolsets, err := mcp.boundToolsets(current)
+		require.NoError(t, err)
+		require.Len(t, toolsets, 1)
+		require.Equal(t, "LiftTestRunner", toolsets[0].typeName)
+		names := make([]string, 0, len(toolsets[0].tools))
+		for _, tool := range toolsets[0].tools {
+			names = append(names, tool.Name)
+		}
+		require.ElementsMatch(t, []string{"exec", "nullable", "withDir"}, names)
+		require.NotContains(t, names, "replacement")
+		return toolsets[0].tools
 	}
-	require.ElementsMatch(t, []string{"exec", "nullable", "withDir"}, names)
+
+	t.Run("lazy", func(t *testing.T) {
+		assertDefiningTools(t, newMCP().WithLazyTools(nil, objType, defining.Schema(), nil))
+	})
+	t.Run("eager", func(t *testing.T) {
+		ctx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{ClientID: "defining-schema-test", SessionID: "defining-schema-test"})
+		cache, err := dagql.NewCache(ctx, "", nil, nil)
+		require.NoError(t, err)
+		ctx = dagql.ContextWithCache(ctx, cache)
+		var runner dagql.AnyObjectResult
+		require.NoError(t, defining.Select(ctx, defining.Root(), &runner, dagql.Selector{Field: "runner"}))
+		tools := assertDefiningTools(t, newMCP().WithTools(runner, defining.Schema(), nil))
+		for _, tool := range tools {
+			if tool.Name == "nullable" {
+				out, err := tool.Call(ctx, map[string]any{"date": "still active"})
+				require.NoError(t, err)
+				require.Equal(t, "still active", out)
+				return
+			}
+		}
+		t.Fatal("nullable tool not found")
+	})
 }
 
 // TestBuildObjectMethodSelectorAddressLift covers dispatch: a model-supplied

--- a/core/llm_object_tools_test.go
+++ b/core/llm_object_tools_test.go
@@ -1,9 +1,13 @@
 package core
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -24,6 +28,9 @@ type Query { doug: Doug! }
 type Workspace { id: ID! }
 type Changeset { id: ID! }
 type LLM { id: ID! }
+type Container { id: ID! }
+type Directory { id: ID! }
+type Secret { id: ID! }
 
 "A coding agent."
 type Doug {
@@ -50,8 +57,32 @@ type Doug {
   "Build an agent — its LLM! arg is auto-injected, so it IS eligible."
   agent(base: ID! @expectedType(name: "LLM")): LLM!
 
-  "Apply a changeset — requires a non-injected object arg, so ineligible."
+  "Apply a changeset — requires a non-liftable object arg, so ineligible."
   apply(changes: ID! @expectedType(name: "Changeset")): Doug!
+
+  "Run a command — its required Container arg is LIFTABLE, so eligible."
+  exec(
+    cmd: String!,
+    sandbox: ID! @expectedType(name: "Container"),
+  ): String!
+
+  "Run everywhere — a required LIST of object args is not liftable."
+  execAll(
+    cmd: String!,
+    sandboxes: [ID!]! @expectedType(name: "Container"),
+  ): String!
+
+  "Debug in a sandbox — an optional liftable arg."
+  debug(sandbox: ID @expectedType(name: "Container")): Doug!
+
+  "Mount a directory — Directory is addressable but NOT liftable."
+  withDir(dir: ID @expectedType(name: "Directory")): Doug!
+
+  "Import a directory — a required non-liftable arg, so ineligible."
+  importDir(dir: ID! @expectedType(name: "Directory")): Doug!
+
+  "Authenticate — a required Secret arg, deliberately not liftable."
+  withToken(token: ID! @expectedType(name: "Secret")): Doug!
 
   old: String! @deprecated(reason: "gone")
 }
@@ -87,6 +118,33 @@ func TestObjectToolEligible(t *testing.T) {
 	// ...except when the engine fills it in: an `LLM!` arg is auto-injected with
 	// the conversation making the call, so it does not disqualify.
 	require.True(t, objectToolEligible(fieldByName(doug, "agent"), nil))
+
+	// ...or when the type is LIFTABLE: a required Container arg renders as an
+	// address string and is lifted via the core Address API at dispatch time.
+	require.True(t, objectToolEligible(fieldByName(doug, "exec"), nil))
+
+	// A required LIST of liftable objects is not lifted, so it still
+	// disqualifies.
+	require.False(t, objectToolEligible(fieldByName(doug, "execAll"), nil))
+
+	// An optional object arg never disqualified; still doesn't — liftable or
+	// not.
+	require.True(t, objectToolEligible(fieldByName(doug, "debug"), nil))
+	require.True(t, objectToolEligible(fieldByName(doug, "withDir"), nil))
+
+	// Directory IS address-resolvable (the CLI lifts it for flags), but it is
+	// NOT in the liftableTypes allowlist — its Address decoder falls back to
+	// HOST paths, a capability the model must not gain from a string — so a
+	// required Directory arg disqualifies.
+	require.False(t, objectToolEligible(fieldByName(doug, "importDir"), nil))
+
+	// Secret is deliberately not liftable: Address.secret resolves env:// /
+	// file:// / op:// URIs, so lifting would let the model MINT secrets by
+	// guessing URIs instead of only receiving handles it was given. Each type
+	// joins the allowlist only after its own capability review — see
+	// hack/designs/sandboxes.md §4, "The liftable set is a capability
+	// decision".
+	require.False(t, objectToolEligible(fieldByName(doug, "withToken"), nil))
 
 	// except drops a method by name.
 	require.False(t, objectToolEligible(fieldByName(doug, "read"), []string{"read"}))
@@ -124,6 +182,88 @@ func TestObjectMethodSchema(t *testing.T) {
 	require.Equal(t, "array", pending["type"])
 	require.Equal(t, "string", pending["items"].(map[string]any)["type"])
 	require.NotContains(t, todoSchema, "required") // pending has a default
+
+	// A required liftable object arg renders as a string, described as an
+	// address — with the type's own syntax hint from liftableTypes — and is
+	// required.
+	const containerHint = `(Container address: an image ref like "golang:1.26", an installed module function like "mymod:dev", or a Container ID from a prior tool result)`
+	execSchema, err := objectMethodSchema(schema, fieldByName(doug, "exec"))
+	require.NoError(t, err)
+	execProps := execSchema["properties"].(map[string]any)
+	sandbox := execProps["sandbox"].(map[string]any)
+	require.Equal(t, "string", sandbox["type"])
+	require.Equal(t, containerHint, sandbox["description"])
+	require.ElementsMatch(t, []string{"cmd", "sandbox"}, execSchema["required"])
+
+	// An optional liftable object arg says "address" too — dispatch lifts
+	// both.
+	debugSchema, err := objectMethodSchema(schema, fieldByName(doug, "debug"))
+	require.NoError(t, err)
+	debug := debugSchema["properties"].(map[string]any)["sandbox"].(map[string]any)
+	require.Equal(t, "string", debug["type"])
+	require.Equal(t, containerHint, debug["description"])
+
+	// An optional arg of an addressable-but-not-liftable type keeps the ID
+	// convention: the model may hand back an ID from a prior tool result, but
+	// is not invited to write an address (dispatch would refuse it anyway).
+	dirSchema, err := objectMethodSchema(schema, fieldByName(doug, "withDir"))
+	require.NoError(t, err)
+	dir := dirSchema["properties"].(map[string]any)["dir"].(map[string]any)
+	require.Equal(t, "string", dir["type"])
+	require.Equal(t, "(Directory ID)", dir["description"])
+
+	// A non-addressable object arg keeps the ID convention.
+	applySchema, err := objectMethodSchema(schema, fieldByName(doug, "apply"))
+	require.NoError(t, err)
+	changes := applySchema["properties"].(map[string]any)["changes"].(map[string]any)
+	require.Equal(t, "(Changeset ID)", changes["description"])
+
+	// A LIST of liftable objects is not lifted, so it keeps the ID
+	// convention as well.
+	execAllSchema, err := objectMethodSchema(schema, fieldByName(doug, "execAll"))
+	require.NoError(t, err)
+	sandboxes := execAllSchema["properties"].(map[string]any)["sandboxes"].(map[string]any)
+	require.Equal(t, "array", sandboxes["type"])
+	require.Equal(t, "(Container ID)", sandboxes["description"])
+}
+
+func TestLiftableObjectArg(t *testing.T) {
+	schema := objectToolsTestSchema(t)
+	doug := schema.Types["Doug"]
+
+	arg := func(field, name string) *ast.ArgumentDefinition {
+		f := fieldByName(doug, field)
+		require.NotNil(t, f)
+		return f.Arguments.ForName(name)
+	}
+
+	// Liftable types qualify, required or optional.
+	typeName, ok := liftableObjectArg(arg("exec", "sandbox"))
+	require.True(t, ok)
+	require.Equal(t, "Container", typeName)
+	typeName, ok = liftableObjectArg(arg("debug", "sandbox"))
+	require.True(t, ok)
+	require.Equal(t, "Container", typeName)
+
+	// Addressable types OUTSIDE the capability allowlist do not — Directory
+	// falls back to host paths, Secret mints from env://-style URIs (see
+	// liftableTypes; each admission needs its own capability review).
+	_, ok = liftableObjectArg(arg("withDir", "dir"))
+	require.False(t, ok)
+	_, ok = liftableObjectArg(arg("importDir", "dir"))
+	require.False(t, ok)
+	_, ok = liftableObjectArg(arg("withToken", "token"))
+	require.False(t, ok)
+
+	// Non-addressable object types do not.
+	_, ok = liftableObjectArg(arg("apply", "changes"))
+	require.False(t, ok)
+
+	// Nor do plain scalars, or LISTS of liftable objects.
+	_, ok = liftableObjectArg(arg("exec", "cmd"))
+	require.False(t, ok)
+	_, ok = liftableObjectArg(arg("execAll", "sandboxes"))
+	require.False(t, ok)
 }
 
 func TestArgTypeToJSONSchema(t *testing.T) {
@@ -190,4 +330,194 @@ func TestDirectLogs(t *testing.T) {
 		{text: "nested", direct: false},
 		{text: "b", direct: true},
 	}))
+}
+
+// liftTestRunner is a minimal receiver type for exercising
+// buildObjectMethodSelector's address lifting against a real dagql server.
+type liftTestRunner struct{}
+
+func (*liftTestRunner) Type() *ast.Type {
+	return &ast.Type{NamedType: "LiftTestRunner", NonNull: true}
+}
+
+// newAddressLiftTestServer builds a dagql server with a miniature Address API
+// — Query.address(value).container — mirroring core/schema/address.go, plus a
+// LiftTestRunner receiver whose exec method takes a required Container arg
+// and whose withDir method takes an optional Directory arg (addressable in
+// the CLI, but outside the liftableTypes allowlist). The fake .container
+// resolver records the address in the container's ImageRef, so tests can
+// observe which address resolved, and fails for "bogus:ref" to exercise the
+// both-attempts-failed error. No .directory field exists, so an (incorrect)
+// lift attempt for a Directory arg would fail loudly rather than silently.
+func newAddressLiftTestServer(t *testing.T) *dagql.Server {
+	t.Helper()
+	srv := newCoreDagqlServerForTest(t, &Query{})
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*Container]{Typed: &Container{}}))
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*Directory]{Typed: &Directory{}}))
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*Address]{Typed: &Address{}}))
+	srv.InstallObject(dagql.NewClass(srv, dagql.ClassOpts[*liftTestRunner]{Typed: &liftTestRunner{}}))
+	dagql.Fields[*Query]{
+		dagql.Func("address", func(_ context.Context, _ *Query, args struct {
+			Value dagql.String
+		}) (*Address, error) {
+			return &Address{Value: args.Value.String()}, nil
+		}),
+		dagql.Func("runner", func(_ context.Context, _ *Query, _ struct{}) (*liftTestRunner, error) {
+			return &liftTestRunner{}, nil
+		}),
+	}.Install(srv)
+	dagql.Fields[*Address]{
+		dagql.Func("container", func(_ context.Context, addr *Address, _ struct{}) (*Container, error) {
+			if addr.Value == "bogus:ref" {
+				return nil, fmt.Errorf("no such image %q", addr.Value)
+			}
+			return &Container{ImageRef: addr.Value}, nil
+		}),
+	}.Install(srv)
+	dagql.Fields[*liftTestRunner]{
+		dagql.Func("exec", func(ctx context.Context, _ *liftTestRunner, args struct {
+			Cmd     dagql.String
+			Sandbox dagql.ID[*Container]
+		}) (dagql.String, error) {
+			ctr, err := args.Sandbox.Load(ctx, srv)
+			if err != nil {
+				return "", err
+			}
+			return dagql.String(args.Cmd.String() + " in " + ctr.Self().ImageRef), nil
+		}),
+		dagql.Func("withDir", func(_ context.Context, r *liftTestRunner, _ struct {
+			Dir dagql.Optional[dagql.ID[*Directory]]
+		}) (*liftTestRunner, error) {
+			return r, nil
+		}),
+	}.Install(srv)
+	return srv
+}
+
+// TestBuildObjectMethodSelectorAddressLift covers dispatch: a model-supplied
+// string for a liftable object arg first tries the ID decode (IDs from
+// previous tool results keep working), then falls back to lifting the string
+// through Query.address(value).<addressField>. Args of addressable types
+// outside the liftableTypes allowlist only ever take the ID path.
+func TestBuildObjectMethodSelectorAddressLift(t *testing.T) {
+	// Select requires client metadata and a dagql cache in ctx (cache sessions
+	// are per-client).
+	ctx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+		ClientID:  "lift-test",
+		SessionID: "lift-test",
+	})
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	ctx = dagql.ContextWithCache(ctx, cache)
+	srv := newAddressLiftTestServer(t)
+
+	var runner dagql.AnyObjectResult
+	require.NoError(t, srv.Select(ctx, srv.Root(), &runner, dagql.Selector{Field: "runner"}))
+
+	execField := fieldByName(srv.Schema().Types["LiftTestRunner"], "exec")
+	require.NotNil(t, execField)
+	// The generated schema carries @expectedType for the ID-typed arg — this is
+	// what liftableObjectArg keys off at dispatch time.
+	typeName, ok := liftableObjectArg(execField.Arguments.ForName("sandbox"))
+	require.True(t, ok)
+	require.Equal(t, "Container", typeName)
+
+	t.Run("address string lifts into the object", func(t *testing.T) {
+		sel, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), execField, map[string]any{
+			"cmd":     "make",
+			"sandbox": "alpine:latest",
+		})
+		require.NoError(t, err)
+		var out dagql.String
+		require.NoError(t, srv.Select(ctx, runner, &out, sel))
+		require.Equal(t, "make in alpine:latest", out.String())
+	})
+
+	t.Run("a real ID still decodes directly", func(t *testing.T) {
+		var ctr dagql.AnyObjectResult
+		require.NoError(t, srv.Select(ctx, srv.Root(), &ctr,
+			dagql.Selector{
+				Field: "address",
+				Args:  []dagql.NamedInput{{Name: "value", Value: dagql.String("premade")}},
+			},
+			dagql.Selector{Field: "container"},
+		))
+		ctrID, err := ctr.ID()
+		require.NoError(t, err)
+		encoded, err := ctrID.Encode()
+		require.NoError(t, err)
+
+		sel, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), execField, map[string]any{
+			"cmd":     "make",
+			"sandbox": encoded,
+		})
+		require.NoError(t, err)
+		// The ID passed through unchanged — no address() wrapping.
+		var found bool
+		for _, arg := range sel.Args {
+			if arg.Name != "sandbox" {
+				continue
+			}
+			found = true
+			argID, err := arg.Value.(dagql.IDable).ID()
+			require.NoError(t, err)
+			reEncoded, err := argID.Encode()
+			require.NoError(t, err)
+			require.Equal(t, encoded, reEncoded)
+		}
+		require.True(t, found)
+		var out dagql.String
+		require.NoError(t, srv.Select(ctx, runner, &out, sel))
+		require.Equal(t, "make in premade", out.String())
+	})
+
+	t.Run("unresolvable address reports both attempts", func(t *testing.T) {
+		_, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), execField, map[string]any{
+			"cmd":     "make",
+			"sandbox": "bogus:ref",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `"bogus:ref" is neither a Container ID`)
+		require.Contains(t, err.Error(), "nor a resolvable Container address")
+		require.Contains(t, err.Error(), "no such image")
+	})
+
+	t.Run("non-string values surface the plain decode error", func(t *testing.T) {
+		_, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), execField, map[string]any{
+			"cmd":     "make",
+			"sandbox": 42,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `arg "sandbox": decode int`)
+	})
+
+	t.Run("non-addressable args do not lift", func(t *testing.T) {
+		// cmd is a plain String: a bad value errors without any address lookup.
+		_, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), execField, map[string]any{
+			"cmd":     42,
+			"sandbox": "alpine:latest",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `arg "cmd"`)
+	})
+
+	t.Run("addressable-but-not-liftable args do not lift", func(t *testing.T) {
+		// Directory is addressable in the CLI, but outside the liftableTypes
+		// capability allowlist (its Address decoder falls back to HOST paths).
+		// A plain string for a Directory arg therefore surfaces the ID decode
+		// error with NO address lookup attempted — the test server's Address
+		// has no .directory field, so an attempted lift would produce a
+		// "neither ... nor a resolvable ... address" error instead.
+		withDirField := fieldByName(srv.Schema().Types["LiftTestRunner"], "withDir")
+		require.NotNil(t, withDirField)
+		_, ok := liftableObjectArg(withDirField.Arguments.ForName("dir"))
+		require.False(t, ok)
+
+		_, err := buildObjectMethodSelector(ctx, srv, runner.ObjectType(), withDirField, map[string]any{
+			"dir": "some/host/path",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `arg "dir": decode string`)
+		require.NotContains(t, err.Error(), "address")
+	})
 }

--- a/core/llm_openai.go
+++ b/core/llm_openai.go
@@ -171,7 +171,6 @@ func (c *OpenAIClient) SendQuery(ctx context.Context, history []*LLMMessage, too
 					Name:        tool.Name,
 					Description: openai.Opt(tool.Description),
 					Parameters:  openai.FunctionParameters(tool.Schema),
-					Strict:      openai.Opt(tool.Strict),
 				},
 			})
 		}

--- a/core/llm_skills.go
+++ b/core/llm_skills.go
@@ -474,7 +474,6 @@ func (m *MCP) loadSkillTools(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{},
 			"additionalProperties": false,
 		},
-		Strict: true,
 		Call: ToolFunc(srv, func(ctx context.Context, _ struct{}) (any, error) {
 			return listSkills(ctx, sources)
 		}),

--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -330,10 +330,10 @@ func TestExplicitProviderRouting(t *testing.T) {
 	assert.ErrorContains(t, err, `unknown LLM provider "bogus"`)
 }
 
-// TestOpenAIRequestOmitsToolStrict locks the provider boundary to the
-// non-strict JSON schema our GraphQL-derived tools use. Optional/defaulted
-// arguments remain properties but are intentionally absent from required.
-func TestOpenAIRequestOmitsToolStrict(t *testing.T) {
+// TestOpenAIRequestUsesNonStrictNullableToolSchema locks the provider boundary:
+// strict mode stays off, while nullable GraphQL arguments remain properties
+// that explicitly accept null without becoming required.
+func TestOpenAIRequestUsesNonStrictNullableToolSchema(t *testing.T) {
 	requestBody := make(chan []byte, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -383,7 +383,10 @@ func TestOpenAIRequestOmitsToolStrict(t *testing.T) {
 	parameters := function["parameters"].(map[string]any)
 	properties := parameters["properties"].(map[string]any)
 	require.Contains(t, properties, "offset")
-	require.Contains(t, properties, "date")
+	date := properties["date"].(map[string]any)
+	require.Equal(t, "string", requireNullableJSONSchema(t, date)["type"])
+	require.Contains(t, date, "default")
+	require.Nil(t, date["default"])
 	require.Equal(t, []any{"filePath"}, parameters["required"])
 }
 

--- a/core/llm_test.go
+++ b/core/llm_test.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -326,6 +328,63 @@ func TestExplicitProviderRouting(t *testing.T) {
 	// An unknown provider is an error, not a silent fallback.
 	_, err = r.Route("some-model", "bogus")
 	assert.ErrorContains(t, err, `unknown LLM provider "bogus"`)
+}
+
+// TestOpenAIRequestOmitsToolStrict locks the provider boundary to the
+// non-strict JSON schema our GraphQL-derived tools use. Optional/defaulted
+// arguments remain properties but are intentionally absent from required.
+func TestOpenAIRequestOmitsToolStrict(t *testing.T) {
+	requestBody := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requestBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":0,
+			"model":"test-model",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	t.Cleanup(server.Close)
+
+	schema := objectToolsTestSchema(t)
+	toolSchema, err := objectMethodSchema(schema, fieldByName(schema.Types["Doug"], "read"))
+	require.NoError(t, err)
+
+	endpoint := &LLMEndpoint{
+		Model:    "test-model",
+		Provider: OpenAI,
+		BaseURL:  server.URL,
+	}
+	client := newOpenAIClient(endpoint, "", true)
+	_, err = client.SendQuery(t.Context(), []*LLMMessage{{
+		Role:    LLMMessageRoleUser,
+		Content: []*LLMContentBlock{{Kind: LLMContentText, Text: "hi"}},
+	}}, []LLMTool{{
+		Name:   "read",
+		Schema: toolSchema,
+	}}, &LLMCallOpts{})
+	require.NoError(t, err)
+
+	var request map[string]any
+	require.NoError(t, json.Unmarshal(<-requestBody, &request))
+	tools := request["tools"].([]any)
+	require.Len(t, tools, 1)
+	function := tools[0].(map[string]any)["function"].(map[string]any)
+	require.NotContains(t, function, "strict")
+
+	parameters := function["parameters"].(map[string]any)
+	properties := parameters["properties"].(map[string]any)
+	require.Contains(t, properties, "offset")
+	require.Contains(t, properties, "date")
+	require.Equal(t, []any{"filePath"}, parameters["required"])
 }
 
 func TestContentBlockInputRoundTrip(t *testing.T) {

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -49,9 +49,6 @@ type LLMTool struct {
 	Description string `json:"description"`
 	// Tool argument schema. Key is argument name. Value is unmarshalled json-schema for the argument.
 	Schema map[string]any `json:"schema"`
-	// Whether the tool schema is strict.
-	// https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat
-	Strict bool `json:"-"`
 	// Whether we should hide the LLM tool call span in favor of just showing its
 	// child spans.
 	HideSelf bool `json:"-"`
@@ -2155,7 +2152,6 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{"span"},
 			"additionalProperties": false,
 		},
-		Strict: false,
 		Call:   m.readLogsTool(srv),
 	})
 	allTools.Add(LLMTool{
@@ -2184,7 +2180,6 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{},
 			"additionalProperties": false,
 		},
-		Strict: false,
 		Call:   m.readTraceTool(srv),
 	})
 	allTools.Add(LLMTool{
@@ -2200,7 +2195,6 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{},
 			"additionalProperties": false,
 		},
-		Strict: false,
 		Call:   m.listServicesTool(srv),
 	})
 }

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -2152,7 +2152,7 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{"span"},
 			"additionalProperties": false,
 		},
-		Call:   m.readLogsTool(srv),
+		Call: m.readLogsTool(srv),
 	})
 	allTools.Add(LLMTool{
 		Name: "ReadTrace",
@@ -2180,7 +2180,7 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{},
 			"additionalProperties": false,
 		},
-		Call:   m.readTraceTool(srv),
+		Call: m.readTraceTool(srv),
 	})
 	allTools.Add(LLMTool{
 		Name: "ListServices",
@@ -2195,7 +2195,7 @@ func (m *MCP) loadBuiltins(srv *dagql.Server, allTools *LLMToolSet) {
 			"required":             []string{},
 			"additionalProperties": false,
 		},
-		Call:   m.listServicesTool(srv),
+		Call: m.listServicesTool(srv),
 	})
 }
 

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -202,12 +202,12 @@ func (m *MCP) LastResult() dagql.Typed {
 	return m.lastResult
 }
 
-// Server returns the GraphQL schema the LLM sees — the schema its Dang scripts
-// evaluate against and the schema tools introspect. When the LLM is bound to a
-// Workspace (via LLM.withWorkspace), the schema derives from THAT workspace's
-// served modules, so the model sees exactly what the Dagger CLI would serve for
-// its own workspace, not the outer client's. Absent a binding it falls back to
-// the env's served deps.
+// Server returns the stable GraphQL schema used for core builtins and tool
+// dispatch. When the LLM is bound to a Workspace (via LLM.withWorkspace), it
+// uses that workspace's served snapshot but deliberately does not compile
+// pending overlay module edits. Bound object tools use the defining schemas
+// captured at composition; explicit recomposition is what adopts an overlay.
+// Without a workspace binding it falls back to the current client's served deps.
 func (m *MCP) Server(ctx context.Context) (*dagql.Server, error) {
 	if m.workspace.Self() != nil {
 		return WorkspaceServedSchema(ctx, m.workspace)

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -99,6 +99,18 @@ type MCP struct {
 	// the model through ListSkills/ReadSkill alongside the engine-embedded and
 	// workspace-discovered skills.
 	skillDirs []dagql.ObjectResult[*Directory]
+	// selfLLM is the conversation dispatching the current step's tool calls —
+	// inst + withResponse, i.e. up to and including the in-flight tool call.
+	// step() sets it before CallBatch; MCP.Call threads it into tool dispatch
+	// (LLMToContext) so a tool's `LLM!` argument auto-fills with it. Transient:
+	// cleared by Clone, never persisted.
+	selfLLM dagql.ObjectResult[*LLM]
+	// continuation is an LLM returned by a tool during this step (see
+	// applyStateReturn / adoptLLM). When set, step() appends the turn's tool
+	// results to IT rather than to the LLM that made the call, so the loop
+	// resumes from the returned conversation — env, tools, prompts and all.
+	// Transient: cleared by Clone.
+	continuation dagql.ObjectResult[*LLM]
 	// Configured MCP servers.
 	mcpServers map[string]*MCPServerConfig
 	// Persistent MCP sessions.
@@ -150,8 +162,36 @@ func (m *MCP) Clone() *MCP {
 	cp.mcpServers = maps.Clone(cp.mcpServers)
 	cp.mcpSessions = maps.Clone(cp.mcpSessions)
 	cp.returned = false
+	// Per-step scratch state: the dispatching conversation and any continuation
+	// a tool returned belong to the step that set them, not to the clone.
+	cp.selfLLM = dagql.ObjectResult[*LLM]{}
+	cp.continuation = dagql.ObjectResult[*LLM]{}
 	cp.mu = &sync.Mutex{}
 	return &cp
+}
+
+// SetSelfLLM records the conversation dispatching this step's tool calls, so
+// MCP.Call can hand it to a tool that declares an `LLM!` argument. Called by
+// step() on its transient MCP clone, immediately before CallBatch.
+func (m *MCP) SetSelfLLM(llm dagql.ObjectResult[*LLM]) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.selfLLM = llm
+}
+
+// Continuation returns the LLM a tool returned during this step, if any. step()
+// resumes from it instead of the LLM that made the call.
+func (m *MCP) Continuation() dagql.ObjectResult[*LLM] {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.continuation
+}
+
+// currentLLM returns the conversation dispatching this step's tool calls.
+func (m *MCP) currentLLM() dagql.ObjectResult[*LLM] {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.selfLLM
 }
 
 func (m *MCP) Returned() bool {
@@ -393,7 +433,7 @@ type changesetCapture struct {
 }
 
 // applyStateReturn implements the state-mutation convention shared by tool calls
-// and Dang eval results. Two kinds of value advance the agent's workspace:
+// and Dang eval results. Three kinds of value advance the agent's state:
 //
 //   - a Changeset overlays onto the bound workspace (via Workspace.withChanges,
 //     yielding a new immutable overlay Workspace) so the agent's edits accumulate
@@ -401,12 +441,20 @@ type changesetCapture struct {
 //   - a Workspace *replaces* the bound one — a tool that produces a whole new
 //     workspace (e.g. a checkout or install) makes it the agent's current
 //     workspace, mirroring the Changeset convention.
+//   - an LLM *replaces the conversation*: the tool acts as a continuation and
+//     the loop resumes from the returned LLM — its env, tools, system prompts
+//     and history — instead of the one that made the call. Since an LLM binds a
+//     workspace, this subsumes the Workspace case. See adoptLLM.
 //
-// Either way it summarizes the resulting patch. step() persists the new workspace
-// via a withWorkspace selector so the change survives history rebuilds. It reports
-// handled=false for any other value so the caller can fall through to normal
-// object/scalar output.
+// Either way it summarizes what changed. step() persists a new workspace via a
+// withWorkspace selector, or resumes from the continuation, so the change
+// survives history rebuilds. It reports handled=false for any other value so the
+// caller can fall through to normal object/scalar output.
 func (m *MCP) applyStateReturn(ctx context.Context, srv *dagql.Server, val dagql.Typed) (handled bool, out string, err error) {
+	if next, ok := dagql.UnwrapAs[dagql.ObjectResult[*LLM]](val); ok {
+		out, err := m.adoptLLM(ctx, next)
+		return true, out, err
+	}
 	if changes, ok := dagql.UnwrapAs[dagql.ObjectResult[*Changeset]](val); ok {
 		if capture, ok := ctx.Value(changesetCaptureKey{}).(*changesetCapture); ok {
 			capture.changes = changes
@@ -534,6 +582,178 @@ func summarizeMountChanges(prev, next *Workspace) string {
 		if !slices.Contains(next.MountPoints(), mp) {
 			lines = append(lines, fmt.Sprintf("Unmounted: %s", mp))
 		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// adoptLLM makes a tool-returned LLM the conversation the agent loop resumes
+// from — the continuation ring of the state-return convention. The tool is
+// handed the current conversation through an auto-injected `LLM!` argument
+// (see loadLLMArg), transforms it, and returns the result; step() then appends
+// this turn's tool results to the RETURNED LLM instead of the one that made the
+// call, so the swap takes effect mid-turn without restarting the session.
+//
+// ANY LLM may be adopted — there is no lineage gate. This mirrors
+// rebindWorkspace, the sibling ring of the same convention: a tool may return
+// any workspace at all, and what makes that safe is not prevention but
+// VISIBILITY (a patch summary the model reads). Continuations are written by
+// the env's author, so refusing a "suspicious" history protects nobody, while
+// a lineage rule would block the uses this exists for: self-compaction,
+// summarize-and-restart, handing a sub-agent's conversation back.
+//
+// What remains:
+//
+//   - eager validation: the returned LLM's env/tools are loaded HERE rather
+//     than lazily on the next turn, so e.g. installing a module that fails to
+//     load fails the tool call instead of bricking the loop. A failure here is
+//     an ordinary failed tool call: the agent survives, the old conversation
+//     stands.
+//   - one per turn: LLMs do not merge the way Changesets do, so at most one
+//     continuation may be adopted per batch of tool calls.
+//   - visibility: the string returned here is the model's notice of what
+//     changed — which tools came and went, and whether the conversation
+//     history itself was replaced. A swap is never silent.
+//
+// One mechanical detail the caller handles rather than this function: step()
+// appends the turn's tool results to the adopted LLM, and a tool-result block
+// is only valid where the matching tool call exists in the history. See
+// toolResultSelectors in llm.go, which degrades an orphaned result to a plain
+// user message.
+func (m *MCP) adoptLLM(ctx context.Context, next dagql.ObjectResult[*LLM]) (string, error) {
+	if next.Self() == nil {
+		return "", fmt.Errorf("cannot continue from a null LLM")
+	}
+	current, ok := LLMFromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("cannot continue: no conversation is bound to this tool call")
+	}
+
+	// Load the new toolset now, so a broken env fails the tool call rather than
+	// the next turn. Doubles as the material for the summary below.
+	after, err := next.Self().mcp.Tools(ctx)
+	if err != nil {
+		return "", fmt.Errorf("returned LLM's tools failed to load: %w", err)
+	}
+	before, err := current.Self().mcp.Tools(ctx)
+	if err != nil {
+		// Non-fatal: without the old toolset we just can't diff it.
+		slog.Warn("failed to load current LLM tools for continuation summary", "error", err)
+		before = nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.continuation.Self() != nil {
+		return "", fmt.Errorf("a conversation-replacing tool call already ran this turn; only one is allowed")
+	}
+	m.continuation = next
+	return summarizeContinuation(current.Self(), next.Self(), before, after), nil
+}
+
+// historyPreserved reports whether next's message history still contains
+// current's, unchanged, as a prefix — i.e. the conversation was transformed
+// (install/reload) rather than replaced.
+//
+// This is NOT a gate: it is an input to the adoption summary, so the model is
+// told when its history changed shape. Comparing histories by VALUE rather
+// than chasing the dagql ID chain is deliberate: a Result's ID is an opaque
+// runtime handle, and an LLM is usually transformed by being PASSED to
+// something (`agents.compose(base: llm)`) rather than received by it, so ID
+// ancestry is both awkward to compute and easy to get wrong.
+func historyPreserved(current, next *LLM) bool {
+	if current == nil || next == nil {
+		return false
+	}
+	if len(next.Messages) < len(current.Messages) {
+		return false
+	}
+	for i, msg := range current.Messages {
+		if !messagesEqual(msg, next.Messages[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func messagesEqual(a, b *LLMMessage) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Role != b.Role || len(a.Content) != len(b.Content) {
+		return false
+	}
+	for i, blockA := range a.Content {
+		blockB := b.Content[i]
+		if blockA == blockB {
+			continue
+		}
+		if blockA == nil || blockB == nil {
+			return false
+		}
+		if blockA.Kind != blockB.Kind ||
+			blockA.Text != blockB.Text ||
+			blockA.CallID != blockB.CallID ||
+			blockA.ToolName != blockB.ToolName ||
+			string(blockA.Arguments) != string(blockB.Arguments) ||
+			blockA.Errored != blockB.Errored ||
+			blockA.Signature != blockB.Signature {
+			return false
+		}
+	}
+	return true
+}
+
+// summarizeContinuation is the model's notice of what a continuation changed:
+// the toolset diff, plus a line about the conversation history when it was
+// replaced rather than extended. When the history is preserved — the common
+// install/reload case — it says nothing extra.
+func summarizeContinuation(current, next *LLM, before, after []LLMTool) string {
+	summary := summarizeToolsetChange(before, after)
+	if current == nil || next == nil || historyPreserved(current, next) {
+		return summary
+	}
+	return summary + "\n" + fmt.Sprintf(
+		"Conversation history replaced: %d messages -> %d messages.",
+		len(current.Messages), len(next.Messages))
+}
+
+// summarizeToolsetChange reports how a continuation changed the agent's
+// toolset — the thing the model most needs to know after an install/reload.
+func summarizeToolsetChange(before, after []LLMTool) string {
+	beforeNames := make(map[string]bool, len(before))
+	for _, t := range before {
+		beforeNames[t.Name] = true
+	}
+	afterNames := make(map[string]bool, len(after))
+	for _, t := range after {
+		afterNames[t.Name] = true
+	}
+	var added, removed []string
+	for _, t := range after {
+		if !beforeNames[t.Name] {
+			added = append(added, t.Name)
+		}
+	}
+	for _, t := range before {
+		if !afterNames[t.Name] {
+			removed = append(removed, t.Name)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+
+	lines := []string{"Continuing from the returned conversation."}
+	if len(added) > 0 {
+		lines = append(lines, "Tools added: "+strings.Join(added, ", "))
+	}
+	if len(removed) > 0 {
+		lines = append(lines, "Tools removed: "+strings.Join(removed, ", "))
+	}
+	if len(added) == 0 && len(removed) == 0 {
+		lines = append(lines, fmt.Sprintf("Toolset unchanged (%d tools).", len(after)))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -919,6 +1139,13 @@ func (m *MCP) Call(ctx context.Context, tools []LLMTool, toolCall *LLMToolCall) 
 		// Bind the LLM's Workspace so the tool's contextual (+defaultPath) and
 		// Workspace-typed args resolve against it, not the ambient workspace.
 		toolCtx = WorkspaceToContext(toolCtx, m.workspace)
+	}
+	if self := m.currentLLM(); self.Self() != nil {
+		// Bind the conversation making this call so the tool's LLM-typed args
+		// auto-fill with it — the continuation hook (see adoptLLM). Note this
+		// must happen here rather than on the loop's ctx: a tool call runs under
+		// its display span's context, captured while the response streamed.
+		toolCtx = LLMToContext(toolCtx, self)
 	}
 	result, err := tool.Call(toolCtx, args)
 	if err != nil {

--- a/core/mcp_test.go
+++ b/core/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	telemetry "github.com/dagger/otel-go"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -16,12 +17,43 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine/clientdb"
 	"github.com/dagger/dagger/engine/telemetryattrs"
 )
+
+func TestGenMCPToolPreservesSchema(t *testing.T) {
+	tool, err := genMcpTool(LLMTool{
+		Name:        "commit",
+		Description: "Commit changes.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"date": map[string]any{
+					"anyOf": []any{
+						map[string]any{"type": "string"},
+						map[string]any{"type": "null"},
+					},
+					"default": nil,
+				},
+			},
+			"additionalProperties": false,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "commit", tool.Name)
+	require.Equal(t, "Commit changes.", tool.Description)
+	require.JSONEq(t, `{
+		"type":"object",
+		"properties":{
+			"date":{
+				"anyOf":[{"type":"string"},{"type":"null"}],
+				"default":null
+			}
+		},
+		"additionalProperties":false
+	}`, string(tool.RawInputSchema))
+}
 
 // TestAssembleLines covers log-line assembly from raw stdio segments: log
 // records aren't guaranteed to be line-aligned, so a line that straddles two

--- a/core/mcpserver.go
+++ b/core/mcpserver.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
-	"slices"
 	"strings"
 
 	"github.com/dagger/dagger/dagql"
@@ -16,95 +15,12 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-// mcpDefaultAny lets us skip the typed defaults
-func mcpDefaultAny(v any) mcp.PropertyOption {
-	return func(schema map[string]any) {
-		schema["default"] = v
+func genMcpTool(tool LLMTool) (mcp.Tool, error) {
+	schema, err := json.Marshal(tool.Schema)
+	if err != nil {
+		return mcp.Tool{}, fmt.Errorf("marshal schema for tool %q: %w", tool.Name, err)
 	}
-}
-
-func genMcpToolOpts(tool LLMTool) ([]mcp.ToolOption, error) {
-	toolOpts := []mcp.ToolOption{
-		mcp.WithDescription(tool.Description),
-	}
-	var required []string
-	if v, ok := tool.Schema["required"]; ok {
-		required, ok = v.([]string)
-		if !ok {
-			return nil, fmt.Errorf("expecting type []string for \"required\" for tool %q", tool.Name)
-		}
-	}
-	props, ok := tool.Schema["properties"]
-	if !ok {
-		return nil, fmt.Errorf("schema of tool %q is missing \"properties\": %+v", tool.Name, tool.Schema)
-	}
-	for argName, v := range props.(map[string]any) {
-		var propOpts []mcp.PropertyOption
-		argSchema := v.(map[string]any)
-		if desc, ok := argSchema["description"]; ok {
-			s, ok := desc.(string)
-			if !ok {
-				return nil, fmt.Errorf("description of arg %q of tool %q is expected to be of type string, but is %T", argName, tool.Name, desc)
-			}
-			propOpts = append(propOpts, mcp.Description(s))
-		}
-		var typ string
-		var strictNullable bool
-		if v, ok := argSchema["type"]; !ok {
-			return nil, fmt.Errorf("schema of arg %q of tool %q is missing \"type\": %+v", argName, tool.Name, argSchema)
-		} else {
-			switch x := v.(type) {
-			case string:
-				typ = x
-			case []string:
-				typ = x[0]
-				if len(x) < 2 {
-					return nil, fmt.Errorf("schema of arg %q of tool %q should have a \"type\" entry of type string or []string with at least two elements, got %T", argName, tool.Name, v)
-				}
-				if x[1] == "null" {
-					strictNullable = true
-				} else {
-					return nil, fmt.Errorf("schema of arg %q of tool %q should have a \"type\" entry of type string or []string with \"null\" as the second element, got %T", argName, tool.Name, v)
-				}
-			default:
-				return nil, fmt.Errorf("schema of arg %q of tool %q should have a \"type\" entry of type string or []string, got %T", argName, tool.Name, v)
-			}
-		}
-
-		if v, ok := argSchema["default"]; ok {
-			propOpts = append(propOpts, mcpDefaultAny(v))
-		}
-		if slices.Contains(required, argName) && !strictNullable {
-			propOpts = append(propOpts, mcp.Required())
-		}
-
-		var mcpArg func(string, ...mcp.PropertyOption) mcp.ToolOption
-		switch typ {
-		case "array":
-			items, ok := argSchema["items"]
-			if !ok {
-				return nil, fmt.Errorf("schema of array arg %q of tool %q should have an \"items\" entry", argName, tool.Name)
-			}
-			// TODO: verify items has a valid schema: {"type": string} ? At least OpenAI requires it.
-			mcpArg = mcp.WithArray
-			propOpts = append(propOpts, mcp.Items(items))
-		case "boolean":
-			mcpArg = mcp.WithBoolean
-		case "integer":
-			mcpArg = mcp.WithNumber
-		case "number":
-			mcpArg = mcp.WithNumber
-		case "object":
-			mcpArg = mcp.WithObject
-		case "string":
-			// TODO: should we do anything fancy if argSchema["format"] is present (e.g., ID or CustomType)?
-			mcpArg = mcp.WithString
-		default:
-			return nil, fmt.Errorf("arg %q of tool %q is of unsupported type %q", argName, tool.Name, typ)
-		}
-		toolOpts = append(toolOpts, mcpArg(argName, propOpts...))
-	}
-	return toolOpts, nil
+	return mcp.NewToolWithRawSchema(tool.Name, tool.Description, schema), nil
 }
 
 type mcpServer struct {
@@ -153,11 +69,11 @@ func (s mcpServer) convertToMcpTools(llmTools []LLMTool) ([]mcpserver.ServerTool
 			continue
 		}
 
-		toolOpts, err := genMcpToolOpts(tool)
+		mcpTool, err := genMcpTool(tool)
 		if err != nil {
 			return nil, err
 		}
-		mcpTools = append(mcpTools, mcpserver.ServerTool{Tool: mcp.NewTool(tool.Name, toolOpts...), Handler: s.genMcpToolHandler(tool)})
+		mcpTools = append(mcpTools, mcpserver.ServerTool{Tool: mcpTool, Handler: s.genMcpToolHandler(tool)})
 	}
 	return mcpTools, nil
 }

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -112,30 +112,6 @@ func (b *SchemaBuilder) With(mod Mod, opts InstallOpts) *SchemaBuilder {
 	return cp
 }
 
-// Replacing returns a builder in which each given mod REPLACES the same-named
-// entry — keeping that entry's install opts and position — or is appended when
-// no entry matches. Unlike With, which keeps the existing mod on a name match
-// (its callers only promote install opts), Replacing swaps the module itself:
-// it exists for serving a fresher build of an already-served module, e.g. one
-// re-resolved through a workspace overlay.
-func (b *SchemaBuilder) Replacing(mods ...Mod) *SchemaBuilder {
-	cp := b.Clone()
-	for _, mod := range mods {
-		replaced := false
-		for i, e := range cp.entries {
-			if e.mod.Name() == mod.Name() {
-				cp.entries[i].mod = mod
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			cp.entries = append(cp.entries, modDepEntry{mod: mod})
-		}
-	}
-	return cp
-}
-
 func (b *SchemaBuilder) Lookup(name string) (Mod, bool) {
 	if b == nil {
 		return nil, false

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -112,6 +112,30 @@ func (b *SchemaBuilder) With(mod Mod, opts InstallOpts) *SchemaBuilder {
 	return cp
 }
 
+// Replacing returns a builder in which each given mod REPLACES the same-named
+// entry — keeping that entry's install opts and position — or is appended when
+// no entry matches. Unlike With, which keeps the existing mod on a name match
+// (its callers only promote install opts), Replacing swaps the module itself:
+// it exists for serving a fresher build of an already-served module, e.g. one
+// re-resolved through a workspace overlay.
+func (b *SchemaBuilder) Replacing(mods ...Mod) *SchemaBuilder {
+	cp := b.Clone()
+	for _, mod := range mods {
+		replaced := false
+		for i, e := range cp.entries {
+			if e.mod.Name() == mod.Name() {
+				cp.entries[i].mod = mod
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			cp.entries = append(cp.entries, modDepEntry{mod: mod})
+		}
+	}
+	return cp
+}
+
 func (b *SchemaBuilder) Lookup(name string) (Mod, bool) {
 	if b == nil {
 		return nil, false

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -646,6 +646,7 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 ) error {
 	var ctxArgs []*FunctionArg
 	var workspaceArgs []*FunctionArg
+	var llmArgs []*FunctionArg
 	var userDefaults []*UserDefault
 
 	// The decoded args map includes schema defaults, but the call ID only
@@ -677,6 +678,14 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 			//  3) "workspace args" that are automatically injected
 			continue
 		}
+		// An LLM argument on a non-@agent function is auto-injected with the
+		// conversation that dispatched the tool call, making the function a
+		// continuation (see loadLLMArg). An @agent's `base: LLM!` is the
+		// composition entrypoint and is always passed explicitly.
+		if !fn.metadata.IsAgent && argMetadata.IsLLM() {
+			llmArgs = append(llmArgs, argMetadata)
+			continue
+		}
 		userDefault, hasUserDefault, err := fn.UserDefault(ctx, argMetadata.Name)
 		if err != nil {
 			return fmt.Errorf("%s.%s(%s=): load user default: %w",
@@ -699,7 +708,7 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 		}
 	}
 
-	if len(ctxArgs) > 0 || len(userDefaults) > 0 || len(workspaceArgs) > 0 {
+	if len(ctxArgs) > 0 || len(userDefaults) > 0 || len(workspaceArgs) > 0 || len(llmArgs) > 0 {
 		type argInput struct {
 			argName string
 			val     dagql.IDType
@@ -749,6 +758,25 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 			})
 		}
 
+		// Process LLM arguments - automatically injected with the conversation
+		// that dispatched this call, when there is one.
+		llmArgVals := make([]*argInput, len(llmArgs))
+		for i, arg := range llmArgs {
+			eg.Go(func() error {
+				llmVal, err := fn.loadLLMArg(ctx)
+				if err != nil {
+					return fmt.Errorf("load llm arg %q: %w", arg.Name, err)
+				}
+
+				llmArgVals[i] = &argInput{
+					argName: arg.Name,
+					val:     llmVal,
+				}
+
+				return nil
+			})
+		}
+
 		// Process user-defined user defaults for objects (and lists of objects)
 		type userDefaultArgInput struct {
 			argName string
@@ -784,6 +812,15 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 			}
 		}
 		for _, arg := range workspaceArgVals {
+			if arg == nil {
+				continue
+			}
+			args[arg.argName] = dagql.Opt(arg.val)
+			if err := req.SetArgInput(ctx, arg.argName, dagql.Opt(arg.val), false); err != nil {
+				return err
+			}
+		}
+		for _, arg := range llmArgVals {
 			if arg == nil {
 				continue
 			}
@@ -1292,6 +1329,27 @@ func (fn *ModuleFunction) loadWorkspaceArg(
 		return nil, fmt.Errorf("get workspace ID: %w", err)
 	}
 	return dagql.NewID[*Workspace](wsID), nil
+}
+
+// loadLLMArg fills an auto-injected LLM argument with the conversation that
+// dispatched this call, bound into the context at LLM tool dispatch (MCP.Call
+// -> [LLMToContext]). The value is the conversation up to and including the
+// in-flight tool call, so a function that transforms it and returns an LLM acts
+// as a continuation: the agent loop resumes from the returned conversation.
+//
+// Unlike a Workspace argument there is no ambient fallback — a conversation
+// only exists at tool dispatch — so calling such a function any other way is an
+// error rather than a silent inheritance.
+func (fn *ModuleFunction) loadLLMArg(ctx context.Context) (dagql.IDType, error) {
+	boundLLM, ok := LLMFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no conversation in context: an LLM argument is only auto-injected when the function is invoked as an agent tool")
+	}
+	llmID, err := boundLLM.ID()
+	if err != nil {
+		return nil, fmt.Errorf("get bound LLM ID: %w", err)
+	}
+	return dagql.NewID[*LLM](llmID), nil
 }
 
 func (fn *ModuleFunction) applyIgnoreOnDir(ctx context.Context, dag *dagql.Server, arg *FunctionArg, value any) (any, error) {

--- a/core/module.go
+++ b/core/module.go
@@ -288,6 +288,28 @@ func functionRequiresCallerArgs(fn *Function) bool {
 	return false
 }
 
+// FunctionRequiresArgsExceptWorkspace reports whether a function has required
+// arguments beyond Workspace-typed ones. A required Workspace! argument is
+// auto-injected at call time (see FunctionArg.IsWorkspace), so it does not stop
+// the function from being called with no caller-supplied arguments — the
+// contract a bare "module:function" address reference relies on
+// (Workspace.addresses, hack/designs/sandboxes.md §5). Any other required
+// argument disqualifies, including a non-agent LLM arg: only Workspace is
+// exempted here.
+func FunctionRequiresArgsExceptWorkspace(fn *Function) bool {
+	for _, argRes := range fn.Args {
+		arg := argRes.Self()
+		if !argRequired(arg) {
+			continue
+		}
+		if arg.IsWorkspace() {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func sameAttachedResult(a, b dagql.IDable) bool {
 	if a == nil || b == nil {
 		return false

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -392,7 +392,7 @@ func (s *llmSchema) withTools(ctx context.Context, llm *core.LLM, args struct {
 	if err != nil {
 		return nil, err
 	}
-	return llm.WithTools(obj, args.Except), nil
+	return llm.WithTools(obj, srv.Schema(), args.Except), nil
 }
 
 func (s *llmSchema) withoutDefaultSystemPrompt(ctx context.Context, llm *core.LLM, args struct{}) (*core.LLM, error) {

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -379,12 +379,12 @@ func (s *llmSchema) withTools(ctx context.Context, llm *core.LLM, args struct {
 	// persisted session restore a binding whose object has side effects or is no
 	// longer reproducible without re-running its construction.
 	if id.Type() != nil {
-		objType, ok, err := srv.ObjectTypeForID(ctx, id)
+		objType, definingServer, ok, err := srv.ObjectTypeAndServerForID(ctx, id)
 		if err != nil {
 			return nil, err
 		}
 		if ok {
-			return llm.WithLazyTools(id, objType, args.Except), nil
+			return llm.WithLazyTools(id, objType, definingServer.Schema(), args.Except), nil
 		}
 	}
 	// Fall back to eager loading if the type isn't resolvable structurally.

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -387,12 +387,27 @@ func (s *llmSchema) withTools(ctx context.Context, llm *core.LLM, args struct {
 			return llm.WithLazyTools(id, objType, definingServer.Schema(), args.Except), nil
 		}
 	}
-	// Fall back to eager loading if the type isn't resolvable structurally.
+	// Fall back to eager loading if the type isn't resolvable structurally. This
+	// includes handle-form IDs such as currentNode: handles deliberately carry no
+	// module provenance. Once loaded, recover the semantic recipe ID and resolve
+	// its defining server so the binding still captures the module schema rather
+	// than the current bootstrap schema.
 	obj, err := srv.Load(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return llm.WithTools(obj, srv.Schema(), args.Except), nil
+	recipeID, err := obj.RecipeID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve bound object recipe: %w", err)
+	}
+	_, definingServer, ok, err := srv.ObjectTypeAndServerForID(ctx, recipeID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("resolve defining schema for bound object type %q", obj.Type().Name())
+	}
+	return llm.WithTools(obj, definingServer.Schema(), args.Except), nil
 }
 
 func (s *llmSchema) withoutDefaultSystemPrompt(ctx context.Context, llm *core.LLM, args struct{}) (*core.LLM, error) {

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -372,12 +372,18 @@ func (s *llmSchema) withTools(ctx context.Context, llm *core.LLM, args struct {
 		return nil, err
 	}
 	// Resolve the bound object's type from its ID without evaluating it, so the
-	// toolset can be built lazily. The object itself is loaded only when a tool
-	// is actually invoked on it (see MCP.boundToolObject). This is what lets a
+	// toolset can be built lazily. For a user-module type absent from the current
+	// bootstrap schema, ObjectTypeForID rebuilds its defining schema from the
+	// call's module provenance. The object itself is loaded only when a tool is
+	// actually invoked on it (see MCP.boundToolObject). This is what lets a
 	// persisted session restore a binding whose object has side effects or is no
 	// longer reproducible without re-running its construction.
 	if id.Type() != nil {
-		if objType, ok := srv.ObjectType(id.Type().NamedType()); ok {
+		objType, ok, err := srv.ObjectTypeForID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return llm.WithLazyTools(id, objType, args.Except), nil
 		}
 	}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -28,6 +28,11 @@ type workspaceSchema struct{}
 var _ SchemaResolvers = &workspaceSchema{}
 
 func (s *workspaceSchema) Install(srv *dagql.Server) {
+	// Let core derive workspace-served schemas (WorkspaceServedSchema) through
+	// the overlay: re-resolving overlay-affected modules needs the overlay
+	// rootfs machinery that lives in this package.
+	core.SetWorkspaceOverlayModuleLoader(s.overlayModuleLoader)
+
 	currentWorkspaceField := dagql.NodeFunc("currentWorkspace", s.currentWorkspace).
 		WithInput(dagql.PerCallInput, dagql.PerSessionInput).
 		NotReplayable("Resolves the calling client's workspace; the result carries that client's ID, which only resolves inside its own session.").
@@ -4597,6 +4602,16 @@ func (s *workspaceSchema) agents(
 	if err != nil {
 		return nil, err
 	}
+
+	// The served modules above are the workspace as it was on disk when the
+	// session started. Re-resolve whatever the workspace's pending overlay
+	// touches, so an agent recomposing itself (install/reload) sees its own
+	// staged edits to module source and to dagger.toml.
+	overlayMods, err := s.workspaceOverlayModules(ctx, parentResult, include)
+	if err != nil {
+		return nil, err
+	}
+	mods = mergeOverlayModules(mods, overlayMods)
 
 	var allAgents []*core.Agent
 	for _, mod := range mods {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dagger/dagger/engine/client/pathutil"
 	"github.com/dagger/dagger/engine/slog"
 	telemetry "github.com/dagger/otel-go"
+	"github.com/iancoleman/strcase"
 	"golang.org/x/mod/semver"
 )
 
@@ -484,6 +485,12 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("include").Doc("Only include agents matching the specified patterns"),
 			),
+		dagql.Func("addresses", s.addresses).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Addresses loadable from the workspace's installed modules: functions whose return type matches `type` and whose required args (beyond an auto-injected Workspace) are none, rendered as bare \"module:function\" references.").
+			Args(
+				dagql.Arg("type").Doc(`Name of the type the function must return to be listed, e.g. "Container".`),
+			),
 		migrateField,
 	}.Install(srv)
 
@@ -495,6 +502,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 	srv.InstallObject(dagql.NewClass[*core.WorkspaceSDK](srv).View(AfterVersion("v1.0.0-0")))
 	srv.InstallObject(dagql.NewClass[*core.WorkspaceMigration](srv).View(AfterVersion("v1.0.0-0")))
 	srv.InstallObject(dagql.NewClass[*core.WorkspaceMigrationStep](srv).View(AfterVersion("v1.0.0-0")))
+	srv.InstallObject(dagql.NewClass[*core.WorkspaceAddress](srv).View(AfterVersion("v1.0.0-0")))
 
 	dagql.Fields[*core.WorkspaceGit]{
 		dagql.NodeFunc("__repository", s.workspaceGitRepository).
@@ -532,6 +540,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 	dagql.Fields[*core.WorkspaceSDK]{}.Install(srv)
 	dagql.Fields[*core.WorkspaceMigration]{}.Install(srv)
 	dagql.Fields[*core.WorkspaceMigrationStep]{}.Install(srv)
+	dagql.Fields[*core.WorkspaceAddress]{}.Install(srv)
 }
 
 type workspaceArgs struct {
@@ -4635,6 +4644,90 @@ func (s *workspaceSchema) agents(
 	}
 
 	return &core.AgentGroup{Agents: allAgents, BoundWorkspace: parentResult}, nil
+}
+
+// addresses lists module functions loadable as bare "module:function" address
+// references (hack/designs/sandboxes.md §5): top-level functions on each
+// installed module's main object — the only shape resolveModuleRef can load —
+// whose return type name matches the requested type and whose required args
+// (beyond an auto-injected Workspace) are none.
+func (s *workspaceSchema) addresses(
+	ctx context.Context,
+	parent *core.Workspace,
+	args struct {
+		Type string
+	},
+) ([]*core.WorkspaceAddress, error) {
+	if isSyntheticWorkspace(parent) {
+		return []*core.WorkspaceAddress{}, nil
+	}
+
+	ctx, err := s.withWorkspaceClientContext(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Best-effort, like generators: discovery lists what is loadable, and a
+	// module that fails to load contributes no loadable addresses anyway
+	// (resolveModuleRef hard-errors on it). A broken module must not hide the
+	// rest of the workspace's addresses; its load failure surfaces as a
+	// warning from EnsureWorkspaceModules.
+	if _, err := ensureWorkspaceModulesLoaded(ctx, nil, true); err != nil {
+		return nil, err
+	}
+	mods, err := currentWorkspacePrimaryModules(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// An entrypoint module's functions are hoisted onto the Query root and no
+	// module field is served for it, so a "module:function" reference can never
+	// resolve (see demandLoadInstalledModule); exclude those modules here.
+	cfg, err := workspaceConfigWithCompatFallback(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	entrypoints := make(map[string]bool, len(cfg.Modules))
+	for name, entry := range cfg.Modules {
+		if entry.Entrypoint {
+			entrypoints[strcase.ToKebab(name)] = true
+		}
+	}
+
+	var addresses core.WorkspaceAddresses
+	for _, mod := range mods {
+		modName := mod.Self().Name()
+		if entrypoints[strcase.ToKebab(modName)] {
+			continue
+		}
+		mainObj, ok := mod.Self().MainObject()
+		if !ok {
+			continue
+		}
+		for _, fnRes := range mainObj.Functions {
+			fn := fnRes.Self()
+			retType := fn.ReturnType.Self()
+			// A list return can't be lifted into a single object; ast.Type.Name
+			// would still report the element type's name, so rule lists out first.
+			if retType.Kind == core.TypeDefKindList {
+				continue
+			}
+			if retType.ToType().Name() != args.Type {
+				continue
+			}
+			if core.FunctionRequiresArgsExceptWorkspace(fn) {
+				continue
+			}
+			// Kebab-case both segments for consistency with CLI-facing names;
+			// resolveModuleRef normalizes with ToLowerCamel, so this round-trips.
+			addresses = append(addresses, &core.WorkspaceAddress{
+				Value:       strcase.ToKebab(modName) + ":" + strcase.ToKebab(fn.Name),
+				Description: fn.Description,
+			})
+		}
+	}
+	addresses.Sort()
+	return addresses, nil
 }
 
 func workspaceIncludePatterns(includeArg dagql.Optional[dagql.ArrayInput[dagql.String]]) []string {

--- a/core/schema/workspace_overlay_modules.go
+++ b/core/schema/workspace_overlay_modules.go
@@ -1,0 +1,315 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/dagger/dagger/core"
+	coresdk "github.com/dagger/dagger/core/sdk"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
+	"github.com/iancoleman/strcase"
+)
+
+// overlayModule is a workspace-config module loaded through the workspace's
+// pending overlay rather than the session's served (on-disk) module set.
+type overlayModule struct {
+	name string
+	mod  dagql.ObjectResult[*core.Module]
+}
+
+// overlayModuleLoader adapts workspaceOverlayModules to the hook core's
+// WorkspaceServedSchema consumes (core.SetWorkspaceOverlayModuleLoader), so the
+// schema an overlay-carrying workspace serves — the one the LLM's tools render
+// from and dispatch against — reflects the same overlay-resolved modules that
+// Workspace.agents composes.
+func (s *workspaceSchema) overlayModuleLoader(
+	ctx context.Context,
+	ws dagql.ObjectResult[*core.Workspace],
+) ([]dagql.ObjectResult[*core.Module], error) {
+	overlay, err := s.workspaceOverlayModules(ctx, ws, nil)
+	if err != nil {
+		return nil, err
+	}
+	mods := make([]dagql.ObjectResult[*core.Module], 0, len(overlay))
+	for _, om := range overlay {
+		mods = append(mods, om.mod)
+	}
+	return mods, nil
+}
+
+// workspaceOverlayModules loads the workspace modules that the workspace's
+// pending overlay affects, resolving their source through the overlay instead
+// of the host checkout.
+//
+// The session's served modules (client.pendingModules, gathered once at
+// workspace detection) are a snapshot of the on-disk workspace: an agent that
+// edits a module's source, or installs a module by staging a dagger.toml edit,
+// cannot see its own work when the conversation is recomposed
+// (Workspace.agents). This resolves the affected entries from
+// workspaceOverlayRootfs, which is host + the overlay's changeset, so the
+// self-repair loop (edit module -> reload -> new behavior) closes fully
+// in-session. The resulting module identity is keyed on the overlay directory's
+// ID, so a further edit yields a further reload and an unchanged overlay is a
+// cache hit.
+//
+// Only entries the overlay actually touches are re-resolved; everything else
+// keeps using the served module, so a clean workspace (or one whose edits are
+// unrelated to any module) behaves exactly as before.
+//
+// Known limitations, deliberate for now:
+//   - an entry REMOVED from dagger.toml in the overlay still resolves through
+//     the served module: this only ever adds or replaces.
+//   - legacy +defaultPath entries (entry.LegacyDefaultPath) are left to the
+//     served path, whose host-ref based context resolution has no overlay
+//     equivalent.
+func (s *workspaceSchema) workspaceOverlayModules(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	include []string,
+) ([]overlayModule, error) {
+	ws := parent.Self()
+	if ws == nil || ws.ConfigFile == "" {
+		return nil, nil
+	}
+	if _, ok := ws.OverlayChanges(); !ok {
+		return nil, nil
+	}
+
+	configFile, err := workspaceConfigFile(ws)
+	if err != nil {
+		return nil, err
+	}
+	configDir, err := workspaceConfigDirectory(ws)
+	if err != nil {
+		return nil, err
+	}
+	// A config edit can add, remove or repoint any entry, so every entry is
+	// suspect; otherwise only the entries whose source tree was edited are.
+	configTouched := ws.OverlayPathTouched(configFile)
+
+	cfg, err := readWorkspaceConfig(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(cfg.Modules) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(cfg.Modules))
+	for name := range cfg.Modules {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	wanted := overlayIncludedModuleNames(names, include)
+
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var loaded []overlayModule
+	for _, name := range names {
+		if wanted != nil {
+			if _, ok := wanted[canonicalOverlayModuleName(name)]; !ok {
+				continue
+			}
+		}
+		entry := cfg.Modules[name]
+		// A built-in SDK install entry carries [as-sdk] authoring metadata, not
+		// a loadable module ref (see workspaceConfigPendingModules).
+		if entry.AsSDK != nil && coresdk.IsBuiltinSDKName(entry.Source) {
+			continue
+		}
+		if entry.LegacyDefaultPath {
+			continue
+		}
+
+		src, relevant, err := s.workspaceOverlayModuleSource(ctx, srv, parent, entry, configDir, configTouched)
+		if err != nil {
+			return nil, fmt.Errorf("module %q: %w", name, err)
+		}
+		if !relevant {
+			continue
+		}
+
+		asModuleArgs, err := BuildLegacyAsModuleArgs(
+			name,
+			false, // legacy +defaultPath entries are skipped above
+			"", "",
+			entry.Settings,
+			cfg.DefaultsFromDotEnv,
+			nil,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("module %q: %w", name, err)
+		}
+
+		var mod dagql.ObjectResult[*core.Module]
+		if err := srv.Select(ctx, src, &mod,
+			dagql.Selector{Field: "asModule", Args: asModuleArgs},
+		); err != nil {
+			return nil, fmt.Errorf("module %q: load from workspace overlay: %w", name, err)
+		}
+		loaded = append(loaded, overlayModule{name: name, mod: mod})
+	}
+	return loaded, nil
+}
+
+// workspaceOverlayModuleSource resolves one config entry's module source, and
+// reports whether the overlay affects it at all. Local entries inside the
+// workspace resolve through the overlay rootfs (host + pending edits); entries
+// outside it — absolute paths and remote refs — have no overlay representation,
+// so they are only re-resolved when the config itself was edited (a freshly
+// installed dependency), through the same root moduleSource field the session
+// loader uses.
+func (s *workspaceSchema) workspaceOverlayModuleSource(
+	ctx context.Context,
+	srv *dagql.Server,
+	parent dagql.ObjectResult[*core.Workspace],
+	entry workspace.ModuleEntry,
+	configDir string,
+	configTouched bool,
+) (src dagql.ObjectResult[*core.ModuleSource], relevant bool, _ error) {
+	ws := parent.Self()
+
+	if core.FastModuleSourceKindCheck(entry.Source, "") == core.ModuleSourceKindLocal {
+		resolved := workspace.ResolveModuleEntrySource(configDir, entry.Source)
+		if !filepath.IsAbs(resolved) {
+			if !configTouched && !overlayTouchesTree(ws, resolved) {
+				return src, false, nil
+			}
+			if err := srv.Select(ctx, parent, &src, dagql.Selector{
+				Field: "moduleSource",
+				Args: []dagql.NamedInput{
+					{Name: "path", Value: dagql.String(workspaceAPIPath(resolved))},
+				},
+			}); err != nil {
+				return src, false, err
+			}
+			return src, true, nil
+		}
+		if !configTouched {
+			return src, false, nil
+		}
+		return s.rootModuleSource(ctx, srv, resolved)
+	}
+
+	if !configTouched {
+		return src, false, nil
+	}
+	return s.rootModuleSource(ctx, srv, entry.Source)
+}
+
+func (s *workspaceSchema) rootModuleSource(
+	ctx context.Context,
+	srv *dagql.Server,
+	ref string,
+) (src dagql.ObjectResult[*core.ModuleSource], relevant bool, _ error) {
+	if err := srv.Select(ctx, srv.Root(), &src, dagql.Selector{
+		Field: "moduleSource",
+		Args: []dagql.NamedInput{
+			{Name: "refString", Value: dagql.String(ref)},
+			{Name: "disableFindUp", Value: dagql.Boolean(true)},
+		},
+	}); err != nil {
+		return src, false, err
+	}
+	return src, true, nil
+}
+
+// overlayIncludedModuleNames maps include patterns ("module" or "module:item")
+// onto config module names, mirroring the session loader's narrowing
+// (filterPendingWorkspaceModulesBySelectorInclude). A nil result means "don't
+// narrow": either no patterns, or a pattern naming nothing known, in which case
+// the loader can't tell which module it refers to.
+func overlayIncludedModuleNames(names, include []string) map[string]struct{} {
+	if len(include) == 0 {
+		return nil
+	}
+	known := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		known[canonicalOverlayModuleName(name)] = struct{}{}
+	}
+	wanted := make(map[string]struct{}, len(include))
+	for _, pattern := range include {
+		modName, _, _ := strings.Cut(pattern, ":")
+		modName = canonicalOverlayModuleName(modName)
+		if _, ok := known[modName]; !ok {
+			return nil
+		}
+		wanted[modName] = struct{}{}
+	}
+	return wanted
+}
+
+func canonicalOverlayModuleName(name string) string {
+	return strcase.ToKebab(name)
+}
+
+// overlayTouchesTree reports whether any of the overlay's edits fall inside the
+// given workspace-relative directory. Workspace.OverlayPathTouched answers the
+// other direction — whether a single file is covered by a touched path — which
+// alone would miss the common case here: a module source ROOT whose edited file
+// (modules/foo/main.dang) is the touched path.
+func overlayTouchesTree(ws *core.Workspace, dir string) bool {
+	if ws.OverlayPathTouched(dir) {
+		return true
+	}
+	dir = path.Clean(filepath.ToSlash(dir))
+	if dir == "." {
+		return len(ws.OverlayTouchedPaths()) > 0
+	}
+	for _, touched := range ws.OverlayTouchedPaths() {
+		touched = path.Clean(filepath.ToSlash(touched))
+		if touched == dir || strings.HasPrefix(touched, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeOverlayModules layers the overlay-resolved modules onto the session's
+// served modules: an entry present in both is replaced in place (keeping the
+// served order), and entries the session never loaded — a module installed
+// mid-conversation — are appended in config order.
+func mergeOverlayModules(
+	served []dagql.ObjectResult[*core.Module],
+	overlay []overlayModule,
+) []dagql.ObjectResult[*core.Module] {
+	if len(overlay) == 0 {
+		return served
+	}
+	merged := slices.Clone(served)
+	for _, om := range overlay {
+		if om.mod.Self() == nil {
+			continue
+		}
+		replaced := false
+		for i, mod := range merged {
+			if mod.Self() == nil {
+				continue
+			}
+			if canonicalOverlayModuleName(mod.Self().Name()) != canonicalOverlayModuleName(om.name) {
+				continue
+			}
+			merged[i] = om.mod
+			replaced = true
+			break
+		}
+		if !replaced {
+			merged = append(merged, om.mod)
+		}
+	}
+	return merged
+}

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -687,12 +687,31 @@ func (arg *FunctionArg) isContextual() bool {
 // the call, since preselect rejects a missing non-null argument before that
 // hook runs.
 func (arg *FunctionArg) IsWorkspace() bool {
+	return arg.isCoreObjectType("Workspace")
+}
+
+// IsLLM returns true if the argument is of type LLM. On a non-@agent function,
+// such an argument is optional and auto-injected with the conversation that
+// dispatched the call (see [LLMToContext]), making the function a continuation:
+// it can transform the conversation it was handed and return the result.
+//
+// @agent middlewares are excluded by their callers (see Function.FieldSpec and
+// ModuleFunction.setCallInputs): their `base: LLM!` is the composition
+// entrypoint, always passed explicitly, and must stay required.
+func (arg *FunctionArg) IsLLM() bool {
+	return arg.isCoreObjectType("LLM")
+}
+
+func (arg *FunctionArg) isCoreObjectType(name string) bool {
 	typeDef := arg.TypeDef.Self()
-	return typeDef.Kind == TypeDefKindObject &&
-		typeDef.AsObject.Value.Self().Name == "Workspace" &&
+	if typeDef == nil || typeDef.Kind != TypeDefKindObject || !typeDef.AsObject.Valid {
+		return false
+	}
+	obj := typeDef.AsObject.Value.Self()
+	return obj != nil && obj.Name == name &&
 		// Functions can't currently accept types from other modules, but be
 		// explicit anyway.
-		typeDef.AsObject.Value.Self().SourceModuleName == ""
+		obj.SourceModuleName == ""
 }
 
 func (arg FunctionArg) Directives() []*ast.Directive {

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -26,6 +26,29 @@ func SetWorkspaceInvalidator(fn func(context.Context) error) {
 	workspaceInvalidator = fn
 }
 
+// workspaceOverlayModuleLoader resolves the workspace-config modules a
+// workspace's pending overlay affects, loading their source through the overlay
+// instead of the session's served (on-disk) snapshot. Set by core/schema (which
+// owns overlay rootfs resolution); nil in contexts without the workspace
+// schema, where overlay module resolution degrades to the served set.
+var workspaceOverlayModuleLoader func(context.Context, dagql.ObjectResult[*Workspace]) ([]dagql.ObjectResult[*Module], error)
+
+// SetWorkspaceOverlayModuleLoader registers the hook used to re-resolve
+// overlay-affected workspace modules. Mirrors SetWorkspaceInvalidator.
+func SetWorkspaceOverlayModuleLoader(fn func(context.Context, dagql.ObjectResult[*Workspace]) ([]dagql.ObjectResult[*Module], error)) {
+	workspaceOverlayModuleLoader = fn
+}
+
+// WorkspaceOverlayModules re-resolves the workspace-config modules the given
+// workspace's pending overlay affects, or nil when there is no overlay (or no
+// registered loader). See core/schema's workspaceOverlayModules for semantics.
+func WorkspaceOverlayModules(ctx context.Context, ws dagql.ObjectResult[*Workspace]) ([]dagql.ObjectResult[*Module], error) {
+	if workspaceOverlayModuleLoader == nil {
+		return nil, nil
+	}
+	return workspaceOverlayModuleLoader(ctx, ws)
+}
+
 // InvalidateCurrentWorkspace drops the calling client's cached workspace
 // detection so the next access re-detects it from the host. Used after writing
 // workspace config files to the host (e.g. applying a migration changeset),

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
@@ -175,6 +176,17 @@ func workspaceClientContext(ctx context.Context, ws *Workspace) (context.Context
 // workspace, the owning client is the current client, so this resolves to the
 // same schema the CLI serves. For a value/synthetic Workspace (no owning client
 // or config) it degrades gracefully to the current client's schema.
+//
+// When the workspace carries a pending overlay that affects module loading —
+// staged edits to a module's source, or to dagger.toml itself — the affected
+// modules are re-resolved through the overlay and REPLACE their served
+// counterparts in the derived schema (newly-configured ones are appended). The
+// served set is a snapshot of the on-disk workspace taken at session start;
+// without this, an agent that edits its own modules and recomposes
+// (Workspace.agents) would compose the fresh module but serve tools from the
+// stale schema. Callers that resolve client-scoped root fields directly under
+// [WorkspaceServedContext] (e.g. currentTypeDefs introspection) still see the
+// served snapshot; the overlay layering applies to the derived schema only.
 func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace]) (*dagql.Server, error) {
 	wsCtx, err := WorkspaceServedContext(ctx, ws)
 	if err != nil {
@@ -188,7 +200,80 @@ func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace
 	if err != nil {
 		return nil, fmt.Errorf("workspace served deps: %w", err)
 	}
+	deps, err = workspaceOverlayServedDeps(wsCtx, ws, deps)
+	if err != nil {
+		return nil, fmt.Errorf("workspace overlay modules: %w", err)
+	}
 	return deps.Schema(wsCtx)
+}
+
+// overlayDepsCache memoizes the overlay-layered SchemaBuilder per (served deps
+// instance, workspace value). The layered builder must be a stable instance so
+// its own lazily-built schema server is reused across LLM steps: MCP.Server
+// derives the schema on every tool listing and dispatch, and rebuilding it each
+// time would re-install every module's typedefs per call. Keying on the served
+// builder's pointer identity makes a change to the client's served set (which
+// produces a new builder) miss naturally; keying on the workspace ID digest
+// makes any further overlay edit miss naturally. Bounded: reaching the cap
+// (many distinct overlay states composed in one engine's lifetime) clears the
+// map, which only costs a rebuild on next use.
+var overlayDepsCache = struct {
+	sync.Mutex
+	m map[string]*SchemaBuilder
+}{m: map[string]*SchemaBuilder{}}
+
+const overlayDepsCacheLimit = 64
+
+// workspaceOverlayServedDeps layers the workspace overlay's re-resolved modules
+// onto the served deps, replacing same-named entries. No overlay influence
+// returns deps unchanged.
+func workspaceOverlayServedDeps(ctx context.Context, ws dagql.ObjectResult[*Workspace], deps *SchemaBuilder) (*SchemaBuilder, error) {
+	if _, ok := ws.Self().OverlayChanges(); !ok {
+		return deps, nil
+	}
+
+	wsID, err := ws.ID()
+	if err != nil {
+		return nil, err
+	}
+	// A workspace loaded in this session may carry a handle-form ID (an engine
+	// result handle) instead of a recipe; handles have no digest but their
+	// result ID is just as unique to the value.
+	var wsKey string
+	if wsID.IsHandle() {
+		wsKey = fmt.Sprintf("handle:%d", wsID.EngineResultID())
+	} else {
+		wsKey = wsID.Digest().String()
+	}
+	key := fmt.Sprintf("%p|%s", deps, wsKey)
+
+	overlayDepsCache.Lock()
+	cached, ok := overlayDepsCache.m[key]
+	overlayDepsCache.Unlock()
+	if ok {
+		return cached, nil
+	}
+
+	overlayMods, err := WorkspaceOverlayModules(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	layered := deps
+	if len(overlayMods) > 0 {
+		mods := make([]Mod, len(overlayMods))
+		for i, mod := range overlayMods {
+			mods[i] = NewUserMod(mod)
+		}
+		layered = deps.Replacing(mods...)
+	}
+
+	overlayDepsCache.Lock()
+	if len(overlayDepsCache.m) >= overlayDepsCacheLimit {
+		overlayDepsCache.m = map[string]*SchemaBuilder{}
+	}
+	overlayDepsCache.m[key] = layered
+	overlayDepsCache.Unlock()
+	return layered, nil
 }
 
 // WorkspaceServedContext switches ctx to the Workspace's owning client and

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sync"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
@@ -163,30 +162,9 @@ func workspaceClientContext(ctx context.Context, ws *Workspace) (context.Context
 	return engine.ContextWithClientMetadata(ctx, clientMetadata), nil
 }
 
-// WorkspaceServedSchema derives the served GraphQL schema for a specific
-// Workspace, independent of which client is currently executing. It switches to
-// the workspace's owning client (so the served-module set reflects that
-// workspace's dagger.toml / installed modules), forces the full module set to
-// load — the LLM needs the whole schema, not whatever a prior request
-// demand-loaded — and returns the built schema server.
-//
-// This is what makes the LLM's schema derive from its OWN Workspace (the one it
-// was bound to via LLM.withWorkspace) rather than from the outer client's env.
-// For the common case where the bound Workspace is the current client's
-// workspace, the owning client is the current client, so this resolves to the
-// same schema the CLI serves. For a value/synthetic Workspace (no owning client
-// or config) it degrades gracefully to the current client's schema.
-//
-// When the workspace carries a pending overlay that affects module loading —
-// staged edits to a module's source, or to dagger.toml itself — the affected
-// modules are re-resolved through the overlay and REPLACE their served
-// counterparts in the derived schema (newly-configured ones are appended). The
-// served set is a snapshot of the on-disk workspace taken at session start;
-// without this, an agent that edits its own modules and recomposes
-// (Workspace.agents) would compose the fresh module but serve tools from the
-// stale schema. Callers that resolve client-scoped root fields directly under
-// [WorkspaceServedContext] (e.g. currentTypeDefs introspection) still see the
-// served snapshot; the overlay layering applies to the derived schema only.
+// WorkspaceServedSchema returns the stable served GraphQL schema for a
+// Workspace. Pending overlays are resolved only by explicit agent
+// recomposition; bound object tools retain the schema that defined them.
 func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace]) (*dagql.Server, error) {
 	wsCtx, err := WorkspaceServedContext(ctx, ws)
 	if err != nil {
@@ -200,80 +178,7 @@ func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace
 	if err != nil {
 		return nil, fmt.Errorf("workspace served deps: %w", err)
 	}
-	deps, err = workspaceOverlayServedDeps(wsCtx, ws, deps)
-	if err != nil {
-		return nil, fmt.Errorf("workspace overlay modules: %w", err)
-	}
 	return deps.Schema(wsCtx)
-}
-
-// overlayDepsCache memoizes the overlay-layered SchemaBuilder per (served deps
-// instance, workspace value). The layered builder must be a stable instance so
-// its own lazily-built schema server is reused across LLM steps: MCP.Server
-// derives the schema on every tool listing and dispatch, and rebuilding it each
-// time would re-install every module's typedefs per call. Keying on the served
-// builder's pointer identity makes a change to the client's served set (which
-// produces a new builder) miss naturally; keying on the workspace ID digest
-// makes any further overlay edit miss naturally. Bounded: reaching the cap
-// (many distinct overlay states composed in one engine's lifetime) clears the
-// map, which only costs a rebuild on next use.
-var overlayDepsCache = struct {
-	sync.Mutex
-	m map[string]*SchemaBuilder
-}{m: map[string]*SchemaBuilder{}}
-
-const overlayDepsCacheLimit = 64
-
-// workspaceOverlayServedDeps layers the workspace overlay's re-resolved modules
-// onto the served deps, replacing same-named entries. No overlay influence
-// returns deps unchanged.
-func workspaceOverlayServedDeps(ctx context.Context, ws dagql.ObjectResult[*Workspace], deps *SchemaBuilder) (*SchemaBuilder, error) {
-	if _, ok := ws.Self().OverlayChanges(); !ok {
-		return deps, nil
-	}
-
-	wsID, err := ws.ID()
-	if err != nil {
-		return nil, err
-	}
-	// A workspace loaded in this session may carry a handle-form ID (an engine
-	// result handle) instead of a recipe; handles have no digest but their
-	// result ID is just as unique to the value.
-	var wsKey string
-	if wsID.IsHandle() {
-		wsKey = fmt.Sprintf("handle:%d", wsID.EngineResultID())
-	} else {
-		wsKey = wsID.Digest().String()
-	}
-	key := fmt.Sprintf("%p|%s", deps, wsKey)
-
-	overlayDepsCache.Lock()
-	cached, ok := overlayDepsCache.m[key]
-	overlayDepsCache.Unlock()
-	if ok {
-		return cached, nil
-	}
-
-	overlayMods, err := WorkspaceOverlayModules(ctx, ws)
-	if err != nil {
-		return nil, err
-	}
-	layered := deps
-	if len(overlayMods) > 0 {
-		mods := make([]Mod, len(overlayMods))
-		for i, mod := range overlayMods {
-			mods[i] = NewUserMod(mod)
-		}
-		layered = deps.Replacing(mods...)
-	}
-
-	overlayDepsCache.Lock()
-	if len(overlayDepsCache.m) >= overlayDepsCacheLimit {
-		overlayDepsCache.m = map[string]*SchemaBuilder{}
-	}
-	overlayDepsCache.m[key] = layered
-	overlayDepsCache.Unlock()
-	return layered, nil
 }
 
 // WorkspaceServedContext switches ctx to the Workspace's owning client and

--- a/core/workspace_module.go
+++ b/core/workspace_module.go
@@ -99,6 +99,55 @@ func (m WorkspaceModules) Sort() {
 	})
 }
 
+// WorkspaceAddress describes a module function loadable as an address: a bare
+// "module:function" reference that Query.address resolves (see
+// hack/designs/sandboxes.md §5).
+type WorkspaceAddress struct {
+	Value       string `field:"true" doc:"The address value, e.g. \"sandboxes:go\"."`
+	Description string `field:"true" doc:"The function's doc string."`
+}
+
+var _ dagql.PersistedObject = (*WorkspaceAddress)(nil)
+var _ dagql.PersistedObjectDecoder = (*WorkspaceAddress)(nil)
+
+func (*WorkspaceAddress) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "WorkspaceAddress",
+		NonNull:   true,
+	}
+}
+
+func (*WorkspaceAddress) TypeDescription() string {
+	return "A module function loadable as an address."
+}
+
+func (a *WorkspaceAddress) EncodePersistedObject(ctx context.Context, cache dagql.PersistedObjectCache) (dagql.PersistedObjectEncoding, error) {
+	_ = ctx
+	_ = cache
+	if a == nil {
+		return dagql.PersistedObjectEncoding{}, fmt.Errorf("encode persisted workspace address: nil workspace address")
+	}
+	return encodePersistedObjectPayload(a)
+}
+
+func (*WorkspaceAddress) DecodePersistedObject(ctx context.Context, dag *dagql.Server, _ uint64, _ *dagql.ResultCall, payload json.RawMessage) (dagql.Typed, error) {
+	_ = ctx
+	_ = dag
+	var a WorkspaceAddress
+	if err := json.Unmarshal(payload, &a); err != nil {
+		return nil, fmt.Errorf("decode persisted workspace address payload: %w", err)
+	}
+	return &a, nil
+}
+
+type WorkspaceAddresses []*WorkspaceAddress
+
+func (a WorkspaceAddresses) Sort() {
+	sort.Slice(a, func(i, j int) bool {
+		return a[i].Value < a[j].Value
+	})
+}
+
 // WorkspaceSDK describes a module entry installed as an SDK in the workspace
 // config.
 type WorkspaceSDK struct {

--- a/dagql/call/id_test.go
+++ b/dagql/call/id_test.go
@@ -363,6 +363,7 @@ func TestBytesRoundTripUsesRawBytesForIdentity(t *testing.T) {
 }
 
 func TestDigestedStringRoundTrip(t *testing.T) {
+	const canary = "CHECKPOINT-CANARY-raw-recipe-only"
 	typ := &ast.Type{
 		NamedType: "String",
 		NonNull:   true,
@@ -371,8 +372,23 @@ func TestDigestedStringRoundTrip(t *testing.T) {
 	orig := New().Append(
 		typ,
 		"withExec",
-		WithArgs(NewArgument("execMD", NewLiteralDigestedString(`{"nested":true}`, execMDDigest), false)),
+		WithArgs(NewArgument("execMD", NewLiteralDigestedString(canary, execMDDigest), false)),
 	)
+
+	for name, display := range map[string]string{
+		"ID display":      orig.Display(),
+		"literal display": orig.Arg("execMD").Value().Display(),
+		"literal AST":     orig.Arg("execMD").Value().ToAST().String(),
+	} {
+		if strings.Contains(display, canary) {
+			t.Fatalf("%s exposed digested-string value: %q", name, display)
+		}
+		for _, want := range []string{"digested-string", execMDDigest.String(), "size=33B"} {
+			if !strings.Contains(display, want) {
+				t.Errorf("%s = %q, missing %q", name, display, want)
+			}
+		}
+	}
 
 	enc, err := orig.Encode()
 	if err != nil {
@@ -396,7 +412,10 @@ func TestDigestedStringRoundTrip(t *testing.T) {
 	if lit.Digest() != execMDDigest {
 		t.Fatalf("digested-string digest mismatch after round-trip: got %s, want %s", lit.Digest(), execMDDigest)
 	}
-	if lit.Value() != `{"nested":true}` {
+	if lit.Value() != canary {
 		t.Fatalf("digested-string value mismatch after round-trip: got %q", lit.Value())
+	}
+	if got := decoded.Call().GetArgs()[0].GetValue().GetDigestedString().GetValue(); got != canary {
+		t.Fatalf("raw recipe lost digested-string value: got %q", got)
 	}
 }

--- a/dagql/call/literal.go
+++ b/dagql/call/literal.go
@@ -155,11 +155,18 @@ func (lit *LiteralDigestedString) Modules() []*Module {
 	return nil
 }
 
-func (lit *LiteralDigestedString) Display() string {
-	if lit.digest == "" {
-		return "<digested-string>"
+// DisplayDigestedString renders a value's identity and byte size without
+// exposing its serialized contents.
+func DisplayDigestedString(value string, dgst digest.Digest) string {
+	digestLabel := dgst.String()
+	if digestLabel == "" {
+		digestLabel = "none"
 	}
-	return fmt.Sprintf("<digested-string:%s>", lit.digest)
+	return fmt.Sprintf("<digested-string digest=%s size=%dB>", digestLabel, len(value))
+}
+
+func (lit *LiteralDigestedString) Display() string {
+	return DisplayDigestedString(lit.value, lit.digest)
 }
 
 func (lit *LiteralDigestedString) ToInput() any {
@@ -167,12 +174,8 @@ func (lit *LiteralDigestedString) ToInput() any {
 }
 
 func (lit *LiteralDigestedString) ToAST() *ast.Value {
-	raw := "<digested-string>"
-	if lit.digest != "" {
-		raw = fmt.Sprintf("<digested-string:%s>", lit.digest)
-	}
 	return &ast.Value{
-		Raw:  strconv.Quote(raw),
+		Raw:  strconv.Quote(lit.Display()),
 		Kind: ast.StringValue,
 	}
 }

--- a/dagql/call_request_input.go
+++ b/dagql/call_request_input.go
@@ -2,6 +2,7 @@ package dagql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -435,7 +436,19 @@ func handleIDFromResultCallRef(ctx context.Context, ref *ResultCallRef) (*call.I
 	if ref.Call != nil {
 		resultID, err := cache.resultIDForCall(ref.Call)
 		if err != nil {
-			return nil, err
+			// The inline recipe has no attached result in the e-graph — e.g.
+			// a client-supplied recipe-form handle (rebuilt from telemetry)
+			// whose producing call's results were released. Hand back the
+			// recipe form itself: the consumer then evaluates it on use,
+			// exactly as node(id:) on the same handle would, instead of
+			// refusing an argument that is perfectly addressable. The
+			// pre-resolved ResultID is only a shortcut; the recipe is the
+			// truth.
+			recipeID, recipeErr := ref.Call.RecipeID(ctx)
+			if recipeErr != nil {
+				return nil, errors.Join(err, fmt.Errorf("rebuild recipe ID: %w", recipeErr))
+			}
+			return recipeID, nil
 		}
 		ref = &ResultCallRef{ResultID: uint64(resultID)}
 	}

--- a/dagql/dagui/dot.go
+++ b/dagql/dagui/dot.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 )
@@ -299,6 +301,11 @@ func displayLit(lit *callpbv1.Literal) string {
 		return fmt.Sprintf("%q", val.String_)
 	case *callpbv1.Literal_Bytes:
 		return call.DisplayBytes(val.Bytes)
+	case *callpbv1.Literal_DigestedString:
+		return call.DisplayDigestedString(
+			val.DigestedString.GetValue(),
+			digest.Digest(val.DigestedString.GetDigest()),
+		)
 	case *callpbv1.Literal_CallDigest:
 		return "<input>"
 	case *callpbv1.Literal_Enum:

--- a/dagql/dagui/extract.go
+++ b/dagql/dagui/extract.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 )
@@ -222,7 +224,10 @@ func literalLabel(lit *callpbv1.Literal) string {
 	case *callpbv1.Literal_String_:
 		return strconv.Quote(truncateLiteral(v.String_))
 	case *callpbv1.Literal_DigestedString:
-		return strconv.Quote(truncateLiteral(v.DigestedString.GetValue()))
+		return call.DisplayDigestedString(
+			v.DigestedString.GetValue(),
+			digest.Digest(v.DigestedString.GetDigest()),
+		)
 	case *callpbv1.Literal_Bytes:
 		return call.DisplayBytes(v.Bytes)
 	case *callpbv1.Literal_List:

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/iancoleman/strcase"
 	"github.com/muesli/termenv"
+	"github.com/opencontainers/go-digest"
 	"github.com/vito/tuist"
 	"go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -721,6 +722,11 @@ func (r *renderer) renderLiteral(out TermOutput, lit *callpbv1.Literal) {
 		fmt.Fprint(out, out.String(fmt.Sprintf("%q", val.String_)).Foreground(termenv.ANSIYellow))
 	case *callpbv1.Literal_Bytes:
 		fmt.Fprint(out, out.String(call.DisplayBytes(val.Bytes)).Foreground(termenv.ANSIYellow))
+	case *callpbv1.Literal_DigestedString:
+		fmt.Fprint(out, out.String(call.DisplayDigestedString(
+			val.DigestedString.GetValue(),
+			digest.Digest(val.DigestedString.GetDigest()),
+		)).Foreground(termenv.ANSIYellow))
 	case *callpbv1.Literal_CallDigest:
 		fmt.Fprint(out, out.String(val.CallDigest).Foreground(termenv.ANSIMagenta))
 	case *callpbv1.Literal_Enum:

--- a/dagql/idtui/frontend_pretty_test.go
+++ b/dagql/idtui/frontend_pretty_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dagger/dagger/engine/telemetryattrs"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/muesli/termenv"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/require"
 	"github.com/vito/tuist"
 	"go.opentelemetry.io/otel/codes"
@@ -133,6 +134,30 @@ func TestCallPayloadRecordsExcludedFromFrontendLogs(t *testing.T) {
 		require.NotNil(t, spanLogs)
 		require.Equal(t, "before\nafter\n", spanLogs.rawBuf.String())
 	})
+}
+
+func TestRenderDigestedLiteralIsOpaque(t *testing.T) {
+	const canary = "CHECKPOINT-CANARY-tui-raw-only"
+	payloadDigest := digest.FromString("checkpoint-chunk")
+	lit := &callpbv1.Literal{Value: &callpbv1.Literal_DigestedString{
+		DigestedString: &callpbv1.DigestedString{
+			Value:  canary,
+			Digest: payloadDigest.String(),
+		},
+	}}
+
+	var buf strings.Builder
+	out := termenv.NewOutput(&buf, termenv.WithProfile(termenv.Ascii))
+	newRenderer(dagui.NewDB(), 0, dagui.FrontendOpts{}, true).renderLiteral(out, lit)
+	rendered := buf.String()
+	if strings.Contains(rendered, canary) {
+		t.Fatalf("TUI exposed digested value: %q", rendered)
+	}
+	for _, want := range []string{"digested-string", payloadDigest.String(), fmt.Sprintf("size=%dB", len(canary))} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("TUI rendering %q missing %q", rendered, want)
+		}
+	}
 }
 
 func TestSortErrorOriginsUsesCurrentSpanData(t *testing.T) {

--- a/dagql/lazy_ref_arg_test.go
+++ b/dagql/lazy_ref_arg_test.go
@@ -53,9 +53,10 @@ func TestObjectTypeForIDUsesModuleProvenance(t *testing.T) {
 	objectID := call.New().Append((&moduleToolSet{}).Type(), "missingConstructor",
 		call.WithModule(call.NewModule(moduleRefID, "tools", "", "")),
 	)
-	objType, ok, err := bootstrap.ObjectTypeForID(ctx, objectID)
+	objType, definingServer, ok, err := bootstrap.ObjectTypeAndServerForID(ctx, objectID)
 	assert.NilError(t, err)
 	assert.Assert(t, ok)
+	assert.Equal(t, moduleSchema, definingServer)
 	assert.Equal(t, "ModuleToolSet", objType.TypeName())
 	_, ok = objType.FieldSpec("check", "")
 	assert.Assert(t, ok)

--- a/dagql/lazy_ref_arg_test.go
+++ b/dagql/lazy_ref_arg_test.go
@@ -4,12 +4,62 @@ import (
 	"context"
 	"testing"
 
+	"github.com/vektah/gqlparser/v2/ast"
 	"gotest.tools/v3/assert"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/internal/points"
 )
+
+type moduleToolSet struct{}
+
+func (*moduleToolSet) Type() *ast.Type {
+	return &ast.Type{NamedType: "ModuleToolSet", NonNull: true}
+}
+
+// TestObjectTypeForIDUsesModuleProvenance covers lazy references to user-module
+// objects when the loading server only has the bootstrap schema. The object's
+// recipe deliberately names no real field: resolving its type can only succeed
+// by loading its module provenance and must never evaluate the object recipe.
+func TestObjectTypeForIDUsesModuleProvenance(t *testing.T) {
+	cache := newCache(t)
+	ctx := dagql.ContextWithCache(testContext(), cache)
+
+	bootstrap := newExternalDagqlServerForTest(t, Query{})
+	points.Install[Query](bootstrap)
+	var moduleRef dagql.ObjectResult[*points.Point]
+	assert.NilError(t, bootstrap.Select(ctx, bootstrap.Root(), &moduleRef,
+		dagql.Selector{Field: "point"},
+	))
+	moduleRefID, err := moduleRef.RecipeID(ctx)
+	assert.NilError(t, err)
+
+	moduleSchema := newExternalDagqlServerForTest(t, Query{})
+	moduleSchema.InstallObject(dagql.NewClass[*moduleToolSet](moduleSchema))
+	dagql.Fields[*moduleToolSet]{
+		dagql.Func("check", func(context.Context, *moduleToolSet, struct{}) (string, error) {
+			return "ok", nil
+		}),
+	}.Install(moduleSchema)
+
+	bootstrap.SetResultServerForCall(func(_ context.Context, frame *dagql.ResultCall) (*dagql.Server, error) {
+		assert.Assert(t, frame.Module != nil)
+		assert.Assert(t, frame.Module.ResultRef != nil)
+		assert.Assert(t, frame.Module.ResultRef.ResultID != 0)
+		return moduleSchema, nil
+	})
+
+	objectID := call.New().Append((&moduleToolSet{}).Type(), "missingConstructor",
+		call.WithModule(call.NewModule(moduleRefID, "tools", "", "")),
+	)
+	objType, ok, err := bootstrap.ObjectTypeForID(ctx, objectID)
+	assert.NilError(t, err)
+	assert.Assert(t, ok)
+	assert.Equal(t, "ModuleToolSet", objType.TypeName())
+	_, ok = objType.FieldSpec("check", "")
+	assert.Assert(t, ok)
+}
 
 // TestLazyRefArgNotEvaluatedOnLoad reproduces the failure mode where
 // restoring a persisted session re-evaluated a side-effecting tool call that had

--- a/dagql/recipe_replay_test.go
+++ b/dagql/recipe_replay_test.go
@@ -1,0 +1,431 @@
+package dagql_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/dagql/internal/points"
+	"github.com/dagger/dagger/engine"
+)
+
+// This file measures what the recipe loader actually does when it is forced to
+// re-execute a recorded call, rather than what it is documented to do.
+//
+// Background (internal-docs/recipe_replay.md): a field marked
+// [dagql.Field.NotReplayable] taints itself and every recorded call above it
+// when the recipe is loaded by a session other than the one that recorded it.
+// A tainted vertex skips BOTH of loadRecipeVertex's cache lookups
+// (dagql/server.go ~1530-1610) and falls through to baseObj.Select — the
+// ordinary call path.
+//
+// The part that is not documented, and is the subject of these tests: that
+// fall-through re-resolves the field's implicit inputs from scratch
+// (dagql/objects.go:566, FieldSpec.resolveImplicitInputCallArgs). The recorded
+// implicit inputs are copied verbatim only into the *frame* used for the
+// lookups that taint just skipped; they never reach the executed call. So a
+// field carrying dagql.PerCallInput mints a brand new nonce on every load
+// (dagql/cache_inputs.go:70-77), which means:
+//
+//   - the value the load returns has an identity nobody recorded, and
+//   - the entry it caches is keyed under that fresh identity, so the NEXT load
+//     cannot find it and executes again, forever.
+//
+// That is the shape of the reported bug: a module function declared
+// @cache(policy: Never) — which is exactly dagql.PerCallInput and nothing else
+// (core/modfunc.go:124-139) — spawned a live agent every time a saved session
+// recipe was resumed, instead of once.
+//
+// The fixture below models the three field shapes that matter:
+//
+//	liveBase  NotReplayable + PerSessionInput   (host.directory / currentWorkspace)
+//	pure      plain cacheable                   (withEnvVariable, withPrompt, ...)
+//	nonced    PerCallInput                      (@cache(policy: Never) module function)
+//	spawned   PerCallInput + DoNotCache         (core LLM.spawn)
+
+type replayFixture struct {
+	t     *testing.T
+	srv   *dagql.Server
+	cache *dagql.Cache
+
+	// Every counter is bumped by its field's resolver, so it counts real
+	// executions rather than cache hits.
+	liveReads   atomic.Int64
+	pureCalls   atomic.Int64
+	noncedCalls atomic.Int64
+	spawnCalls  atomic.Int64
+}
+
+func newReplayFixture(t *testing.T) *replayFixture {
+	f := &replayFixture{
+		t:     t,
+		srv:   newExternalDagqlServerForTest(t, Query{}),
+		cache: newCache(t),
+	}
+	points.Install[Query](f.srv)
+
+	dagql.Fields[Query]{
+		// liveBase stands in for Host.directory / Query.currentWorkspace: a
+		// value that is only meaningful to the session that read it, so a
+		// recorded call to it must be re-executed by any other session.
+		dagql.Func("liveBase", func(ctx context.Context, _ Query, _ struct{}) (*points.Point, error) {
+			return &points.Point{X: int(f.liveReads.Add(1))}, nil
+		}).
+			WithInput(dagql.PerSessionInput).
+			NotReplayable("test: the recorded digest is a stable key for an unstable value"),
+	}.Install(f.srv)
+
+	dagql.Fields[*points.Point]{
+		// pure stands in for the ordinary reproducible calls a recipe is
+		// mostly made of. Replaying these from cache is correct.
+		dagql.Func("pure", func(ctx context.Context, self *points.Point, _ struct{}) (*points.Point, error) {
+			f.pureCalls.Add(1)
+			return &points.Point{X: self.X, Y: self.Y + 1}, nil
+		}),
+		// nonced is precisely a module function declared @cache(policy:
+		// Never): dagql.PerCallInput as its only implicit input, and no
+		// DoNotCache (core/modfunc.go:132-133). Its result IS cached — under a
+		// key containing the nonce minted for that one invocation.
+		dagql.Func("nonced", func(ctx context.Context, self *points.Point, _ struct{}) (*points.Point, error) {
+			return &points.Point{X: self.X, Y: int(f.noncedCalls.Add(1))}, nil
+		}).
+			WithInput(dagql.PerCallInput),
+		// spawned is the core LLM.spawn shape: a per-call nonce AND
+		// DoNotCache, so nothing is ever stored under the recorded digest.
+		dagql.Func("spawned", func(ctx context.Context, self *points.Point, _ struct{}) (*points.Point, error) {
+			return &points.Point{X: self.X, Y: int(f.spawnCalls.Add(1))}, nil
+		}).
+			WithInput(dagql.PerCallInput).
+			DoNotCache("test: every spawn mints a distinct instance"),
+	}.Install(f.srv)
+
+	return f
+}
+
+func (f *replayFixture) ctxFor(sessionID string) context.Context {
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID:  "same-client",
+		SessionID: sessionID,
+	})
+	return dagql.ContextWithCache(ctx, f.cache)
+}
+
+// record builds a chain in the given session and returns its recipe-form ID,
+// the way LLM.portableID hands one to a session save file.
+func (f *replayFixture) record(ctx context.Context, sels ...dagql.Selector) *call.ID {
+	f.t.Helper()
+	var base dagql.ObjectResult[*points.Point]
+	require.NoError(f.t, f.srv.Select(ctx, f.srv.Root(), &base, dagql.Selector{Field: "liveBase"}))
+	var chain dagql.ObjectResult[*points.Point]
+	require.NoError(f.t, f.srv.Select(ctx, base, &chain, sels...))
+	id, err := chain.RecipeID(ctx)
+	require.NoError(f.t, err)
+	require.False(f.t, id.IsHandle(), "the saved ID must be recipe-form")
+	return id
+}
+
+// loadObj replays a recorded ID the way Server.LoadType does for a saved
+// session file.
+func (f *replayFixture) loadObj(ctx context.Context, id *call.ID) dagql.AnyObjectResult {
+	f.t.Helper()
+	res, err := f.srv.LoadType(ctx, id)
+	require.NoError(f.t, err)
+	obj, ok := res.(dagql.AnyObjectResult)
+	require.True(f.t, ok)
+	return obj
+}
+
+// load replays a recorded ID and returns the recipe ID of what came back, so a
+// caller can compare the loaded call's identity against the recorded one.
+func (f *replayFixture) load(ctx context.Context, id *call.ID) *call.ID {
+	f.t.Helper()
+	got, err := f.loadObj(ctx, id).RecipeID(ctx)
+	require.NoError(f.t, err)
+	return got
+}
+
+// implicitInputValue reads a recorded implicit input off a call, the same way
+// recipeLoadState.recordedSessionStamp does (dagql/server.go:1516).
+func implicitInputValue(t *testing.T, id *call.ID, name string) string {
+	t.Helper()
+	for _, in := range id.ImplicitInputs() {
+		if in == nil || in.Name() != name {
+			continue
+		}
+		lit, ok := in.Value().(*call.LiteralString)
+		require.True(t, ok, "implicit input %q is not a string literal", name)
+		return lit.Value()
+	}
+	t.Fatalf("no implicit input %q on %s", name, id.Field())
+	return ""
+}
+
+// TestRecipeLoadSameSessionServesTheRecordedCall pins claim 4: inside the
+// session that recorded it, a recipe carrying a per-call nonce loads straight
+// off the cache. Nothing re-executes and the loaded value's identity is bit
+// for bit the recorded one — the recorded nonce is still a live cache key
+// here, so neither lookup in loadRecipeVertex is skipped.
+//
+// This is correct behaviour, and it is the control for the cross-session
+// measurements below: the difference they show is caused by the session
+// boundary, not by the nonce alone.
+func TestRecipeLoadSameSessionServesTheRecordedCall(t *testing.T) {
+	f := newReplayFixture(t)
+	ctxA := f.ctxFor("session-a")
+
+	// liveBase -> nonced -> pure: a per-call-nonce call sitting above a
+	// NotReplayable read, with an ordinary recorded call above it.
+	recorded := f.record(ctxA,
+		dagql.Selector{Field: "nonced"},
+		dagql.Selector{Field: "pure"},
+	)
+	recordedNonce := implicitInputValue(t, recorded.Receiver(), dagql.PerCallInput.Name)
+
+	const loads = 5
+	for range loads {
+		got := f.load(ctxA, recorded)
+		assert.Check(t, cmp.Equal(got.Digest(), recorded.Digest()),
+			"a same-session load must return the recorded call, not a new one")
+		assert.Check(t, cmp.Equal(
+			implicitInputValue(t, got.Receiver(), dagql.PerCallInput.Name), recordedNonce),
+			"a same-session load must not re-mint the recorded nonce")
+	}
+
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(1)), "liveBase executions")
+	assert.Check(t, cmp.Equal(f.noncedCalls.Load(), int64(1)), "nonced executions")
+	assert.Check(t, cmp.Equal(f.pureCalls.Load(), int64(1)), "pure executions")
+}
+
+// TestRecipeLoadCrossSessionCachesTheTaintForcedExecution pins claim 1 for
+// ordinary, reproducible calls: the taint costs exactly one re-execution per
+// loading session, not one per load.
+//
+// The first load in a new session re-executes liveBase (its recorded
+// cachePerSession stamp names another session) and re-executes the pure call
+// above it, because that call's receiver is now a different value. Both
+// results are then cached under the new session's digests, and the four
+// remaining loads are served from them even though the vertices are still
+// tainted — taint only skips the *recipe loader's* lookups; the re-issued call
+// still consults the ordinary cache, and for a field with no per-call input it
+// hits.
+//
+// This is correct behaviour, and it is what makes the failure in
+// TestRecipeLoadTaintedNonceReExecutesOnEveryLoad specific to the nonce rather
+// than inherent to the taint path.
+func TestRecipeLoadCrossSessionCachesTheTaintForcedExecution(t *testing.T) {
+	f := newReplayFixture(t)
+
+	recorded := f.record(f.ctxFor("session-a"), dagql.Selector{Field: "pure"})
+
+	ctxB := f.ctxFor("session-b")
+	var first *call.ID
+	const loads = 5
+	for i := range loads {
+		got := f.load(ctxB, recorded)
+		if i == 0 {
+			first = got
+			assert.Check(t, got.Digest() != recorded.Digest(),
+				"the re-executed chain is re-recorded under the loading session")
+			continue
+		}
+		assert.Check(t, cmp.Equal(got.Digest(), first.Digest()),
+			"repeated loads in one session must converge on a single identity")
+	}
+
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)),
+		"liveBase: once when recorded, once when the new session first loads it")
+	assert.Check(t, cmp.Equal(f.pureCalls.Load(), int64(2)),
+		"pure: once when recorded, once on top of the re-read base")
+}
+
+// TestRecipeLoadTaintedNonceReExecutesOnEveryLoad pins the hazard that makes
+// "an effectful call must never enter a persisted recipe" a RULE rather than a
+// preference. It characterizes the loader as it stands; it is not a wish.
+//
+// Setup mirrors the reported failure: a saved recipe whose chain contains a
+// module function declared @cache(policy: Never) (here `nonced`, carrying only
+// dagql.PerCallInput) that transitively depends on a NotReplayable read, then
+// resumed in a different session. Loading it five times in one new session:
+//
+//	liveBase executions   2  (1 recorded + 1 forced)
+//	nonced   executions   6  (1 recorded + 5 forced)
+//	pure     executions   6  (1 recorded + 5 forced)
+//	distinct loaded IDs   5
+//
+// Every load re-enters loadRecipeVertex with the taint set, skips both
+// lookups, and re-issues the call — at which point
+// FieldSpec.resolveImplicitInputCallArgs mints a fresh cachePerCall nonce
+// (dagql/cache_inputs.go:72-77). The executed call therefore has an identity
+// no load can predict, so the result it caches is unreachable to the next
+// load, which executes again. Three recorded spawns replayed across eleven
+// loads is thirty-three live agents.
+//
+// Note the cascade: `pure` sits ABOVE `nonced` and is an ordinary cacheable
+// field, yet it also re-executes on every load, because its receiver is a
+// different value each time. A single per-call nonce buried in a recipe
+// invalidates every recorded call above it, on every load.
+//
+// THE FIX IS NOT HERE, deliberately. Making the loader identity-stable (replay
+// the recorded cachePerCall inputs, or memoize the forced execution per
+// loading session) would turn 33 agents into 3 — quieter, not smaller in kind,
+// and three agents wearing the user's workers' names with none of their
+// history is the failure this defect was already misdiagnosed as once. The fix
+// is at the API layer: keep effectful calls out of persisted recipes, so a
+// resumed chain re-executes nothing worth re-executing. This test exists so
+// that the cost of breaking that rule stays measured and visible, and it
+// should be UPDATED, not deleted, if the loader ever does change.
+func TestRecipeLoadTaintedNonceReExecutesOnEveryLoad(t *testing.T) {
+	f := newReplayFixture(t)
+
+	recorded := f.record(f.ctxFor("session-a"),
+		dagql.Selector{Field: "nonced"},
+		dagql.Selector{Field: "pure"},
+	)
+	recordedNonce := implicitInputValue(t, recorded.Receiver(), dagql.PerCallInput.Name)
+
+	ctxB := f.ctxFor("session-b")
+	const loads = 5
+	seen := map[string]int{}
+	for range loads {
+		got := f.load(ctxB, recorded)
+		seen[got.Digest().String()]++
+
+		// Measurement, not a wish: the re-executed call is minted with a new
+		// nonce rather than the recorded one. A fix may legitimately either
+		// replay the recorded nonce or mint one nonce per loading session —
+		// what it must not do is mint a new one per load, which is what the
+		// identity-stability assertion below pins.
+		assert.Check(t,
+			implicitInputValue(t, got.Receiver(), dagql.PerCallInput.Name) != recordedNonce,
+			"the taint path re-resolves implicit inputs instead of replaying them")
+	}
+
+	// The cost of one nonce in a recipe: the effectful call runs once per
+	// LOAD, not once per loading session. This is the number that turned 3
+	// recorded spawns into 33 live agents.
+	assert.Check(t, cmp.Equal(f.noncedCalls.Load(), int64(1+loads)),
+		"a nonce-bearing call under a taint re-executes on every load")
+
+	// The same cause, one level up: every recorded call above the nonce
+	// loses its cache too, because its receiver has a fresh identity on
+	// each load. The blast radius of one effectful call is the whole chain
+	// recorded above it.
+	assert.Check(t, cmp.Equal(f.pureCalls.Load(), int64(1+loads)),
+		"an ordinary cacheable call above the nonce is dragged into "+
+			"re-executing on every load")
+
+	// Identity never converges: each load produces a distinct ID, so a
+	// caller that saves the loaded ID saves a value nothing else can
+	// address — which is also why the next load cannot reuse the last
+	// load's cached result.
+	assert.Check(t, cmp.Equal(len(seen), loads),
+		"repeated loads of one recorded ID produce one identity each")
+
+	// The contrast that localizes the cause to the nonce and not the taint:
+	// the NotReplayable read is re-executed once for the new session and
+	// then served from cache, exactly as
+	// TestRecipeLoadCrossSessionCachesTheTaintForcedExecution shows for a
+	// nonce-free chain.
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)),
+		"liveBase: once when recorded, once when the new session first loads it")
+}
+
+// TestRecipeLoadTaintIsScopedNotPermanent pins claim 2: the taint is recomputed
+// per load against the loading session, so it does not accumulate.
+//
+// A chain re-recorded by the new session carries that session's cachePerSession
+// stamp, and fieldNotReplayable compares the recorded stamp to the loading
+// session (dagql/server.go:1506-1511). Loading it — or a longer chain built on
+// top of it — inside that same session is therefore clean: nothing re-executes,
+// including the per-call-nonce call underneath, whose recorded nonce is a live
+// cache key again. A previous session's input does not confer permanent taint.
+//
+// Crossing another boundary re-taints, exactly once for the NotReplayable read.
+func TestRecipeLoadTaintIsScopedNotPermanent(t *testing.T) {
+	f := newReplayFixture(t)
+
+	recorded := f.record(f.ctxFor("session-a"), dagql.Selector{Field: "nonced"})
+
+	// One tainted load. Everything below is measured against the chain this
+	// produces, which session B recorded itself.
+	ctxB := f.ctxFor("session-b")
+	loadedInB := f.load(ctxB, recorded)
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)))
+	assert.Check(t, cmp.Equal(f.noncedCalls.Load(), int64(2)))
+
+	// Extend it, the way a resumed conversation keeps making calls.
+	obj := f.loadObj(ctxB, loadedInB)
+	var extended dagql.ObjectResult[*points.Point]
+	require.NoError(t, f.srv.Select(ctxB, obj, &extended, dagql.Selector{Field: "pure"}))
+	extendedID, err := extended.RecipeID(ctxB)
+	require.NoError(t, err)
+
+	before := [3]int64{f.liveReads.Load(), f.pureCalls.Load(), f.noncedCalls.Load()}
+	for range 3 {
+		got := f.load(ctxB, extendedID)
+		assert.Check(t, cmp.Equal(got.Digest(), extendedID.Digest()),
+			"a chain recorded by this session loads as itself")
+	}
+	after := [3]int64{f.liveReads.Load(), f.pureCalls.Load(), f.noncedCalls.Load()}
+	assert.Check(t, cmp.Equal(after, before),
+		"a chain recorded in the loading session must not inherit taint from "+
+			"the previous-session input it was derived from")
+
+	// A third session re-taints the same chain — once for the NotReplayable
+	// read, which is the scoping working as intended. (The calls above it do
+	// re-execute per load, for the reason
+	// TestRecipeLoadTaintedNonceReExecutesOnEveryLoad pins.)
+	ctxC := f.ctxFor("session-c")
+	for range 3 {
+		f.load(ctxC, extendedID)
+	}
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(3)),
+		"the taint is evaluated against the loading session, not remembered")
+}
+
+// TestRecipeLoadDoNotCacheReExecutesOnEveryLoad records the neighbouring
+// behaviour of the core LLM.spawn shape — dagql.PerCallInput plus DoNotCache —
+// which needs no taint at all to re-execute.
+//
+// Because nothing is stored under the recorded digest, both of
+// loadRecipeVertex's lookups miss even inside the recording session, and the
+// call is re-issued with a fresh nonce. So a recipe whose top call is
+// DoNotCache re-executes on EVERY load, in EVERY session, forever.
+//
+// Asserted as current behaviour rather than as a defect: DoNotCache does say
+// "never serve this from cache". core/schema/llm.go avoids the consequence by
+// pinning spawn's result identity through the cached `agent(id:)` lookup, so a
+// saved conversation's recipe never contains a bare spawn. A module function
+// has no such mitigation, which is why the defect above bites at
+// @cache(policy: Never).
+func TestRecipeLoadDoNotCacheReExecutesOnEveryLoad(t *testing.T) {
+	f := newReplayFixture(t)
+	ctxA := f.ctxFor("session-a")
+
+	recorded := f.record(ctxA, dagql.Selector{Field: "spawned"})
+	assert.Check(t, cmp.Equal(f.spawnCalls.Load(), int64(1)))
+
+	const loads = 5
+	for range loads {
+		f.load(ctxA, recorded)
+	}
+	assert.Check(t, cmp.Equal(f.spawnCalls.Load(), int64(1+loads)),
+		"a DoNotCache call is re-executed by every load, even in its own session")
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(1)),
+		"the untainted NotReplayable read below it stays on the cache path")
+
+	ctxB := f.ctxFor("session-b")
+	for range loads {
+		f.load(ctxB, recorded)
+	}
+	assert.Check(t, cmp.Equal(f.spawnCalls.Load(), int64(1+2*loads)),
+		"crossing the session boundary adds taint but changes nothing here")
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)),
+		"the NotReplayable read is still re-executed exactly once per session")
+}

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1249,6 +1249,56 @@ func interfaceFieldsPresent(iface *Interface, objectType ObjectType, view call.V
 	return true
 }
 
+// ObjectTypeForID resolves the object type named by id without evaluating the
+// object itself. When the current schema does not carry the type, a recipe's
+// module provenance is loaded and used to rebuild the dependency-aware schema
+// that defined it.
+func (s *Server) ObjectTypeForID(ctx context.Context, id *call.ID) (ObjectType, bool, error) {
+	if id == nil || id.Type() == nil {
+		return nil, false, nil
+	}
+	typeName := id.Type().NamedType()
+	if objType, ok := s.ObjectType(typeName); ok {
+		return objType, true, nil
+	}
+	if id.IsHandle() || id.Module() == nil || id.Module().ID() == nil || s.resultServerForCall == nil {
+		return nil, false, nil
+	}
+
+	moduleResult, err := s.LoadType(ctx, id.Module().ID())
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve object type %q module: %w", typeName, err)
+	}
+	if moduleResult == nil {
+		return nil, false, fmt.Errorf("resolve object type %q module: result is null", typeName)
+	}
+	shared := moduleResult.cacheSharedResult()
+	if shared == nil || shared.id == 0 {
+		return nil, false, fmt.Errorf("resolve object type %q module: result is not attached", typeName)
+	}
+	resultCall := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(id.Type().ToAST()),
+		Field: id.Field(),
+		View:  id.View(),
+		Module: &ResultCallModule{
+			ResultRef: &ResultCallRef{ResultID: uint64(shared.id), shared: shared},
+			Name:      id.Module().Name(),
+			Ref:       id.Module().Ref(),
+			Pin:       id.Module().Pin(),
+		},
+	}
+	resolved, err := s.resultServerForCall(ctx, resultCall)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve object type %q schema: %w", typeName, err)
+	}
+	if resolved == nil {
+		return nil, false, nil
+	}
+	objType, ok := resolved.ObjectType(typeName)
+	return objType, ok, nil
+}
+
 // Load loads the object with the given ID.
 func (s *Server) Load(ctx context.Context, id *call.ID) (AnyObjectResult, error) {
 	ctx = srvToContext(ctx, s)

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1254,27 +1254,36 @@ func interfaceFieldsPresent(iface *Interface, objectType ObjectType, view call.V
 // module provenance is loaded and used to rebuild the dependency-aware schema
 // that defined it.
 func (s *Server) ObjectTypeForID(ctx context.Context, id *call.ID) (ObjectType, bool, error) {
+	objType, _, ok, err := s.ObjectTypeAndServerForID(ctx, id)
+	return objType, ok, err
+}
+
+// ObjectTypeAndServerForID resolves the object type named by id and the server
+// whose schema defines it, without evaluating the object itself. The defining
+// server matters to callers that must retain the type's schema after switching
+// to another schema which may not contain the type.
+func (s *Server) ObjectTypeAndServerForID(ctx context.Context, id *call.ID) (ObjectType, *Server, bool, error) {
 	if id == nil || id.Type() == nil {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 	typeName := id.Type().NamedType()
 	if objType, ok := s.ObjectType(typeName); ok {
-		return objType, true, nil
+		return objType, s, true, nil
 	}
 	if id.IsHandle() || id.Module() == nil || id.Module().ID() == nil || s.resultServerForCall == nil {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	moduleResult, err := s.LoadType(ctx, id.Module().ID())
 	if err != nil {
-		return nil, false, fmt.Errorf("resolve object type %q module: %w", typeName, err)
+		return nil, nil, false, fmt.Errorf("resolve object type %q module: %w", typeName, err)
 	}
 	if moduleResult == nil {
-		return nil, false, fmt.Errorf("resolve object type %q module: result is null", typeName)
+		return nil, nil, false, fmt.Errorf("resolve object type %q module: result is null", typeName)
 	}
 	shared := moduleResult.cacheSharedResult()
 	if shared == nil || shared.id == 0 {
-		return nil, false, fmt.Errorf("resolve object type %q module: result is not attached", typeName)
+		return nil, nil, false, fmt.Errorf("resolve object type %q module: result is not attached", typeName)
 	}
 	resultCall := &ResultCall{
 		Kind:  ResultCallKindField,
@@ -1290,13 +1299,13 @@ func (s *Server) ObjectTypeForID(ctx context.Context, id *call.ID) (ObjectType, 
 	}
 	resolved, err := s.resultServerForCall(ctx, resultCall)
 	if err != nil {
-		return nil, false, fmt.Errorf("resolve object type %q schema: %w", typeName, err)
+		return nil, nil, false, fmt.Errorf("resolve object type %q schema: %w", typeName, err)
 	}
 	if resolved == nil {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 	objType, ok := resolved.ObjectType(typeName)
-	return objType, ok, nil
+	return objType, resolved, ok, nil
 }
 
 // Load loads the object with the given ID.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5619,6 +5619,18 @@ type Workspace implements Node {
   """
   address: String!
 
+  """
+  Addresses loadable from the workspace's installed modules: functions whose
+  return type matches `type` and whose required args (beyond an auto-injected
+  Workspace) are none, rendered as bare "module:function" references.
+  """
+  addresses(
+    """
+    Name of the type the function must return to be listed, e.g. "Container".
+    """
+    type: String!
+  ): [WorkspaceAddress!]!
+
   """Return all agent middlewares from modules loaded in the workspace."""
   agents(
     """Only include agents matching the specified patterns"""
@@ -6317,6 +6329,18 @@ type Workspace implements Node {
     """Write to the workspace config directory at the workspace cwd."""
     here: Boolean = false
   ): Workspace!
+}
+
+"""A module function loadable as an address."""
+type WorkspaceAddress implements Node {
+  """The function's doc string."""
+  description: String!
+
+  """A unique identifier for this WorkspaceAddress."""
+  id: ID!
+
+  """The address value, e.g. "sandboxes:go"."""
+  value: String!
 }
 
 """

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16121,6 +16121,40 @@ func (r *Workspace) Address(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx)
 }
 
+// Addresses loadable from the workspace's installed modules: functions whose return type matches `type` and whose required args (beyond an auto-injected Workspace) are none, rendered as bare "module:function" references.
+func (r *Workspace) Addresses(ctx context.Context, type_ string) ([]WorkspaceAddress, error) {
+	q := r.query.Select("addresses")
+	q = q.Arg("type", type_)
+
+	q = q.Select("id")
+
+	type addresses struct {
+		Id ID
+	}
+
+	convert := func(fields []addresses) []WorkspaceAddress {
+		out := []WorkspaceAddress{}
+
+		for i := range fields {
+			val := WorkspaceAddress{id: &fields[i].Id}
+			val.query = selectNode(q.Root(), fields[i].Id, "WorkspaceAddress")
+			out = append(out, val)
+		}
+
+		return out
+	}
+	var response []addresses
+
+	q = q.Bind(&response)
+
+	err := q.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
+}
+
 // WorkspaceAgentsOpts contains options for Workspace.Agents
 type WorkspaceAgentsOpts struct {
 	// Only include agents matching the specified patterns
@@ -17317,6 +17351,95 @@ func (r *Workspace) WithoutSDK(name string, opts ...WorkspaceWithoutSDKOpts) *Wo
 // AsNode returns this Workspace as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Workspace) AsNode() Node {
+	return &NodeClient{
+		query: r.query,
+	}
+}
+
+// A module function loadable as an address.
+type WorkspaceAddress struct {
+	query *querybuilder.Selection
+
+	description *string
+	id          *ID
+	value       *string
+}
+
+func (r *WorkspaceAddress) WithGraphQLQuery(q *querybuilder.Selection) *WorkspaceAddress {
+	return &WorkspaceAddress{
+		query: q,
+	}
+}
+
+// The function's doc string.
+func (r *WorkspaceAddress) Description(ctx context.Context) (string, error) {
+	if r.description != nil {
+		return *r.description, nil
+	}
+	q := r.query.Select("description")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// A unique identifier for this WorkspaceAddress.
+func (r *WorkspaceAddress) ID(ctx context.Context) (ID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
+	q := r.query.Select("id")
+
+	var response ID
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *WorkspaceAddress) XXX_GraphQLType() string {
+	return "WorkspaceAddress"
+}
+
+// XXX_GraphQLIDType is an internal function. It returns the native GraphQL type name for the ID of this object
+func (r *WorkspaceAddress) XXX_GraphQLIDType() string {
+	return "ID"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *WorkspaceAddress) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
+}
+
+func (r *WorkspaceAddress) MarshalJSON() ([]byte, error) {
+	id, err := r.ID(marshalCtx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(id)
+}
+
+// The address value, e.g. "sandboxes:go".
+func (r *WorkspaceAddress) Value(ctx context.Context) (string, error) {
+	if r.value != nil {
+		return *r.value, nil
+	}
+	q := r.query.Select("value")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// AsNode returns this WorkspaceAddress as a Node.
+// This is a local type conversion — no GraphQL call.
+func (r *WorkspaceAddress) AsNode() Node {
 	return &NodeClient{
 		query: r.query,
 	}


### PR DESCRIPTION
Extends the tool-result state convention with one more ring: a tool that returns an LLM acts as a continuation. The agent loop resumes from the returned conversation — its env, tools, system prompts and history — instead of the one that made the call, so an agent can install a module or reload its own edited modules mid-conversation without restarting and losing context.

A module function's `LLM!` argument is auto-filled with the conversation dispatching the tool call, exactly as a `Workspace!` argument is filled from the bound workspace, and hidden from the generated tool schema so the model never sees it. An `@agent`'s `base` stays required, since it's the composition entrypoint.

Adoption mirrors the workspace convention rather than gating on lineage: the returned LLM's env and tools load eagerly so a broken module fails the tool call instead of bricking the next turn, at most one continuation is adopted per turn since LLMs don't merge the way Changesets do, and the swap is reported. A lineage check was tried and removed — it was inconsistent with `rebindWorkspace` accepting any workspace, it protected an env author from their own tools, and its first real use (editor's `reload`, which strips and re-adds system prompts) tripped it as a false positive.

Protocol coherence replaces the gate's one real service. `step()` materializes the assistant response before dispatching tool calls, so the continuation is handed the conversation up to and including its own call, then appends the turn's tool results to the adopted LLM — degrading to a plain user message when the matching call ID isn't in the adopted history, since providers reject a `tool_result` with no matching `tool_use`.

**The other half is making self-extension actually work.** An agent that edits its own modules and then recomposes itself couldn't see its own staged work, because module source and config were re-read from the on-disk checkout the session loaded at startup. Composition now re-resolves, through the overlay rootfs, every config entry the overlay affects. That alone wasn't enough: `LLM.tools` renders and dispatches against the served snapshot, so a replaced module showed stale docs and an overlay-installed one failed as "not an object in the workspace schema" — the served schema now layers the same overlay modules on, memoized so per-step derivation stays cheap.
