### PR TITLE
fix: inherit workspace locks in module runtimes

### DIFF
--- a/.changes/unreleased/Fixed-20260805-041700.yaml
+++ b/.changes/unreleased/Fixed-20260805-041700.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Nested module runtimes now use the invoking workspace lock for their lookups,
+  so dependency generators record live pins and frozen generation can consume
+  them without inheriting the caller's `currentWorkspace`.
+time: 2026-08-05T04:17:00Z
+custom:
+  Author: sipsma
+  PR: 13843

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -12,10 +12,13 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -1137,5 +1140,102 @@ func (GeneratorsSuite) TestWorkspaceGeneratorsSeeOverlayEdits(ctx context.Contex
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "generated from: B-OVERLAY")
+	})
+}
+
+// TestWorkspaceGeneratorUsesWorkspaceLock covers a workspace generator
+// implemented by a remote SDK module. The generator's nested Dagger client must
+// read and write the invoking workspace's lock without inheriting that workspace
+// as its currentWorkspace.
+func (GeneratorsSuite) TestWorkspaceGeneratorUsesWorkspaceLock(ctx context.Context, t *testctx.T) {
+	const goSDKRef = "github.com/dagger/go-sdk@407c08e2b527fdc3e95ceb69345fec440cc03197"
+	const goImage = "golang:1.26-alpine"
+
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	require.NoError(t, os.MkdirAll(filepath.Join(workdir, ".dagger", "modules", "app"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "dagger.toml"), []byte(`[modules.app]
+source = ".dagger/modules/app"
+
+[modules.dagger-go-sdk]
+source = "`+goSDKRef+`"
+
+[modules.dagger-go-sdk.as-sdk]
+name = "go"
+
+[[modules.dagger-go-sdk.as-sdk.modules]]
+path = ".dagger/modules/app"
+`), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workdir, ".dagger", "modules", "app", "dagger-module.toml"),
+		[]byte(`name = "app"
+engineVersion = "v1.0.0-beta.9"
+
+[runtime]
+  source = "go"
+`),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workdir, ".dagger", "modules", "app", "go.mod"),
+		[]byte("module dagger/app\n\ngo 1.26\n"),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workdir, ".dagger", "modules", "app", "main.go"),
+		[]byte(`package main
+
+type App struct{}
+
+func (m *App) Hello() string {
+	return "hello"
+}
+`),
+		0o600,
+	))
+
+	// First produce the committed generated state without consulting a lock.
+	// This keeps the regression focused on frozen generator execution, not
+	// initial module migration or missing generated files. A separate host CLI
+	// session prevents the frozen runs from reusing the generator function call.
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=disabled", "generate", "-y")
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(workdir, ".dagger", "modules", "app", "dagger.gen.go"))
+	require.NoError(t, err)
+
+	// The same inherited binding must support writes. Without it, live mode
+	// silently falls back to disabled mode inside the nested SDK runtime and
+	// leaves the subsequent frozen runs without a usable lock.
+	_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--lock=live", "generate", "-y")
+	require.NoError(t, err)
+	lockBytes, err := os.ReadFile(filepath.Join(workdir, workspace.LockFileName))
+	require.NoError(t, err, "live mode did not create the workspace lock")
+	lock, err := workspace.ParseLock(lockBytes)
+	require.NoError(t, err)
+	lockedImage, found, err := lock.GetLookup("", "container.from", []any{
+		"docker.io/library/" + goImage,
+		lockTestPlatform(ctx, t),
+	})
+	require.NoError(t, err)
+	require.True(t, found, "live mode did not record the nested SDK runtime lookup")
+	require.Equal(t, workspace.PolicyPin, lockedImage.Policy)
+	require.True(t, strings.HasPrefix(lockedImage.Value, "sha256:"))
+
+	t.Run("generate no-apply", func(ctx context.Context, t *testctx.T) {
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "generate", "--no-apply")
+		require.NoError(t, err)
+
+		lockAfter, err := os.ReadFile(filepath.Join(workdir, "dagger.lock"))
+		require.NoError(t, err)
+		require.Equal(t, lockBytes, lockAfter)
+	})
+
+	t.Run("check generate", func(ctx context.Context, t *testctx.T) {
+		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--lock=frozen", "check", "--generate")
+		require.NoError(t, err)
+
+		lockAfter, err := os.ReadFile(filepath.Join(workdir, "dagger.lock"))
+		require.NoError(t, err)
+		require.Equal(t, lockBytes, lockAfter)
 	})
 }

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2185,7 +2185,7 @@ func (srv *Server) CurrentWorkspaceLock(ctx context.Context, requireWritable boo
 		return nil, false, err
 	}
 	if !requireWritable {
-		lock, ok, err := readImmutableRemoteWorkspaceLock(ctx, client.workspace)
+		lock, ok, err := readImmutableRemoteWorkspaceLock(ctx, workspaceForLock(client))
 		if err != nil || ok {
 			return lock, ok, err
 		}
@@ -2258,8 +2258,34 @@ func (srv *Server) SetCurrentWorkspaceLookup(
 	return nil
 }
 
+// workspaceForLock returns the nearest workspace that owns lock state for the
+// current call. Lock context follows nested clients across module-runtime
+// boundaries even though workspace context deliberately does not: dependency
+// modules need the invoking workspace's pins without gaining access to its
+// files or module configuration.
+func workspaceForLock(client *daggerClient) *core.Workspace {
+	if client == nil {
+		return nil
+	}
+	// Do not lock the current client here. Loading a declared remote workspace
+	// can re-enter lock lookup while already holding this mutex.
+	if client.workspace != nil {
+		return client.workspace
+	}
+	for i := len(client.parents) - 1; i >= 0; i-- {
+		parent := client.parents[i]
+		parent.workspaceMu.Lock()
+		ws := parent.workspace
+		parent.workspaceMu.Unlock()
+		if ws != nil {
+			return ws
+		}
+	}
+	return nil
+}
+
 func (srv *Server) currentWorkspaceLockBinding(client *daggerClient) (*core.Workspace, workspaceLockKey, string, bool, error) {
-	ws := client.workspace
+	ws := workspaceForLock(client)
 	if ws == nil || ws.HostPath() == "" || ws.LockFile == "" {
 		return nil, workspaceLockKey{}, "", false, nil
 	}

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1628,6 +1628,29 @@ func TestEnsureWorkspaceLoadedDoesNotInheritBetweenFunctionCallRuntimes(t *testi
 	require.Nil(t, child.workspace)
 }
 
+func TestWorkspaceForLockInheritsAcrossFunctionCallRuntimes(t *testing.T) {
+	t.Parallel()
+
+	rootWorkspace := &core.Workspace{ClientID: "root-client"}
+	parentWorkspace := &core.Workspace{ClientID: "parent-client"}
+	root := &daggerClient{workspace: rootWorkspace}
+	moduleParent := &daggerClient{
+		workspace: parentWorkspace,
+		parents:   []*daggerClient{root},
+		fnCall:    &core.FunctionCall{Name: "parent"},
+	}
+	child := &daggerClient{
+		parents: []*daggerClient{root, moduleParent},
+		fnCall:  &core.FunctionCall{Name: "child"},
+	}
+
+	require.Same(t, parentWorkspace, workspaceForLock(child))
+
+	childWorkspace := &core.Workspace{ClientID: "child-client"}
+	child.workspace = childWorkspace
+	require.Same(t, childWorkspace, workspaceForLock(child))
+}
+
 // TestEnsureWorkspaceLoadedNonModuleClientInheritsThroughModuleParent keeps the
 // new boundary narrow: regular nested clients still inherit a parent workspace.
 func TestEnsureWorkspaceLoadedNonModuleClientInheritsThroughModuleParent(t *testing.T) {

--- a/future/done/2026-05-27-workspace-disable-inheritance.md
+++ b/future/done/2026-05-27-workspace-disable-inheritance.md
@@ -20,6 +20,25 @@ Final rule: gate on the **active function call only** (`CurrentFunctionCall` /
 which is the real A -> B boundary. The `CurrentModule` / `client.mod` checks are
 dropped. The required semantics below are unchanged; only the predicate narrows.
 
+## Amendment (2026-08-05): Workspace Locks Remain Invocation-Scoped
+
+Nested client metadata deliberately inherits the caller's `LockMode` while
+resetting `Workspace`, `WorkspaceEnv`, and `WorkspaceModuleScope`. A dependency
+module therefore must use the invoking workspace's lock state for its own
+engine-mediated lookups even though it must not receive that workspace as its
+`currentWorkspace`.
+
+Session lock lookup may select the nearest ancestor workspace when the current
+module runtime has no workspace binding. This is a lock-only exception: it does
+not assign `client.workspace`, inject a `Workspace` argument, or expose workspace
+files and module configuration. Local live and pinned invocations can record
+truthful lookup results through the workspace owner; immutable remote workspaces
+remain read-only and available only to frozen mode.
+
+Dropping `LockMode` at the module-runtime boundary is not an alternative. It
+would make frozen invocations silently resolve dependency lookups without pins,
+defeating the invocation-wide reproducibility policy.
+
 ## Purpose
 
 Workspace context must not leak from a user invocation into modules that are


### PR DESCRIPTION
## Summary

- preserve workspace lock policy across nested module-runtime calls without inheriting the caller's `currentWorkspace`
- let nested dependency lookups record live/pinned entries and consume frozen entries from the invoking workspace lock
- cover the remote Go SDK generator path that exposed the regression and document the lock-only workspace-isolation exception

## Problem

Nested client metadata inherits `LockMode`, but deliberately resets workspace metadata at module-runtime boundaries. Lock lookup still depended only on the current client's workspace binding.

When a workspace generator's SDK called a dependency module, that dependency runtime therefore entered frozen mode with no lock binding. Its first lookup failed before reading the existing pin:

```text
container.from lockfile: no writable workspace lockfile is available
```

In live mode, the same missing binding silently downgraded the nested lookup to disabled mode, so its pin was not recorded.

## Fix

Lock lookup now uses the current client's workspace when present, otherwise the nearest ancestor workspace in the same session. This changes only lock authority: it does not assign `client.workspace`, inject a `Workspace` argument, or expose caller files and module configuration to dependency modules.

The workspace owner still performs local lockfile I/O, immutable remote workspaces remain read-only, and an explicitly bound child workspace takes precedence once loaded.

## Testing

```console
dagger api call engine-dev test --pkg ./core/integration --run='^TestGenerators/TestWorkspaceGeneratorUsesWorkspaceLock$' # 4 passed
dagger api call engine-dev test --pkg ./core/integration --run='^TestGenerators$' # 109 passed
dagger api call engine-dev test --pkg ./core/integration --run='^TestLockfile$' # 24 passed
dagger api call engine-dev test --pkg ./core/integration --run='^TestModule/TestRuntimeDependencyDoesNotInheritWorkspace$' # 6 passed
go test ./engine/server -run 'TestWorkspaceForLock|TestEnsureWorkspaceLoaded' -count=1 -race
dagger api call golang lint-all
dagger api call markdown-lint lint
dagger api call docs check
```
