### PR TITLE
feat(schema): require workspace arg on asSDK

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -359,7 +359,7 @@ type ClientGeneratorFixture struct{}
 
 // +generate
 func (m *ClientGeneratorFixture) GenerateClients(ctx context.Context, ws *dagger.Workspace) (*dagger.Changeset, error) {
-	clients, err := dag.CurrentModule().AsSDK(dagger.CurrentModuleAsSDKOpts{Workspace: ws}).Clients(ctx)
+	clients, err := dag.CurrentModule().AsSDK(ws).Clients(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +488,7 @@ func (m *InitFixture) GenerateModules(ctx context.Context, ws *dagger.Workspace)
 	if err != nil {
 		return nil, err
 	}
-	modules, err := dag.CurrentModule().AsSDK(dagger.CurrentModuleAsSDKOpts{Workspace: ws}).Modules(ctx)
+	modules, err := dag.CurrentModule().AsSDK(ws).Modules(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (m *InitFixture) GenerateClients(ctx context.Context, ws *dagger.Workspace)
 	if err != nil {
 		return nil, err
 	}
-	clients, err := dag.CurrentModule().AsSDK(dagger.CurrentModuleAsSDKOpts{Workspace: ws}).Clients(ctx)
+	clients, err := dag.CurrentModule().AsSDK(ws).Clients(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -432,7 +432,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 				`Errors if the current module is not installed as an SDK in this workspace.`).
 			Args(
 				dagql.Arg("workspace").Doc(
-					`The workspace to resolve SDK-role data against. Defaults to the current workspace.`),
+					`The workspace to resolve SDK-role data against.`),
 			),
 	}.Install(dag)
 

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -18,35 +18,22 @@ func (s *moduleSchema) currentModuleAsSDK(
 	ctx context.Context,
 	curMod *core.CurrentModule,
 	args struct {
-		// FIXME: optional for now to ease the rollout; make it required. See the
-		// fallback below.
-		Workspace dagql.Optional[dagql.ID[*core.Workspace]]
+		Workspace dagql.ID[*core.Workspace]
 	},
 ) (*core.CurrentModuleAsSDK, error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// The workspace is meant to be passed explicitly: a module resolving its SDK
-	// role — as a dependency driven by another module, or as a generator run by
-	// the framework — hands in the workspace it was given rather than inheriting
-	// the caller's ambient one. Config reads route through that workspace's own
-	// rootfs/owner client, so there is no sandbox concern, and a synthetic (value)
-	// workspace that carries config is honored just like a detected one.
-	//
-	// FIXME: the workspace should be required. For now it's optional and, when
-	// omitted, falls back to the ambient current workspace, as asSDK did before
-	// the argument existed. Drop this fallback once the argument is required.
-	var wsResult dagql.ObjectResult[*core.Workspace]
-	if args.Workspace.Valid {
-		wsResult, err = args.Workspace.Value.Load(ctx, srv)
-		if err != nil {
-			return nil, fmt.Errorf("load workspace argument: %w", err)
-		}
-	} else if err := srv.Select(ctx, srv.Root(), &wsResult,
-		dagql.Selector{Field: "currentWorkspace"},
-	); err != nil {
-		return nil, fmt.Errorf("get current workspace: %w", err)
+	// The workspace is passed explicitly: a module resolving its SDK role — as a
+	// dependency driven by another module, or as a generator run by the framework
+	// — hands in the workspace it was given rather than inheriting the caller's
+	// ambient one. Config reads route through that workspace's own rootfs/owner
+	// client, so there is no sandbox concern, and a synthetic (value) workspace
+	// that carries config is honored just like a detected one.
+	wsResult, err := args.Workspace.Load(ctx, srv)
+	if err != nil {
+		return nil, fmt.Errorf("load workspace argument: %w", err)
 	}
 	ws := wsResult.Self()
 	if ws.ConfigFile == "" {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1689,10 +1689,8 @@ type CurrentModule implements Node {
   Errors if the current module is not installed as an SDK in this workspace.
   """
   asSDK(
-    """
-    The workspace to resolve SDK-role data against. Defaults to the current workspace.
-    """
-    workspace: ID @expectedType(name: "Workspace")
+    """The workspace to resolve SDK-role data against."""
+    workspace: ID! @expectedType(name: "Workspace")
   ): CurrentModuleAsSDK!
 
   """The dependencies of the module."""

--- a/docs/static/reference/php/Dagger/CurrentModule.html
+++ b/docs/static/reference/php/Dagger/CurrentModule.html
@@ -146,7 +146,7 @@
                     <a href="../Dagger/CurrentModuleAsSDK.html"><abbr title="Dagger\CurrentModuleAsSDK">CurrentModuleAsSDK</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_asSDK">asSDK</a>(<abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $workspace = null)
+                    <a href="#method_asSDK">asSDK</a>(<a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a> $workspace)
         
                                             <p><p>Treat the currently executing module as an SDK installed in the given workspace, exposing the modules and clients it manages.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -330,7 +330,7 @@
                     <h3 id="method_asSDK">
         <div class="location">at line 21</div>
         <code>                    <a href="../Dagger/CurrentModuleAsSDK.html"><abbr title="Dagger\CurrentModuleAsSDK">CurrentModuleAsSDK</abbr></a>
-    <strong>asSDK</strong>(<abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null $workspace = null)
+    <strong>asSDK</strong>(<a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a> $workspace)
         </code>
     </h3>
     <div class="details">    
@@ -345,7 +345,7 @@
 
                     <table class="table table-condensed">
                     <tr>
-                <td><abbr title="Dagger\Dagger\Workspace">Workspace</abbr>|null</td>
+                <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
                 <td>$workspace</td>
                 <td></td>
             </tr>
@@ -370,7 +370,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_dependencies">
-        <div class="location">at line 33</div>
+        <div class="location">at line 31</div>
         <code>                    array
     <strong>dependencies</strong>()
         </code>
@@ -402,7 +402,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generatedContextDirectory">
-        <div class="location">at line 42</div>
+        <div class="location">at line 40</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>generatedContextDirectory</strong>()
         </code>
@@ -434,7 +434,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generators">
-        <div class="location">at line 51</div>
+        <div class="location">at line 49</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>generators</strong>(array|null $include = null)
         </code>
@@ -476,7 +476,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 63</div>
+        <div class="location">at line 61</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -508,7 +508,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 72</div>
+        <div class="location">at line 70</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -540,7 +540,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_source">
-        <div class="location">at line 81</div>
+        <div class="location">at line 79</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>source</strong>()
         </code>
@@ -572,7 +572,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 90</div>
+        <div class="location">at line 88</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>workdir</strong>(string $path, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false)
         </code>
@@ -629,7 +629,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdirFile">
-        <div class="location">at line 113</div>
+        <div class="location">at line 111</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>workdirFile</strong>(string $path)
         </code>

--- a/sdk/elixir/lib/dagger/gen/current_module.ex
+++ b/sdk/elixir/lib/dagger/gen/current_module.ex
@@ -20,15 +20,12 @@ defmodule Dagger.CurrentModule do
 
   Errors if the current module is not installed as an SDK in this workspace.
   """
-  @spec as_sdk(t(), [{:workspace, Dagger.Workspace.t() | nil}]) :: Dagger.CurrentModuleAsSDK.t()
-  def as_sdk(%__MODULE__{} = current_module, optional_args \\ []) do
+  @spec as_sdk(t(), Dagger.Workspace.t()) :: Dagger.CurrentModuleAsSDK.t()
+  def as_sdk(%__MODULE__{} = current_module, workspace) do
     query_builder =
       current_module.query_builder
       |> QB.select("asSDK")
-      |> QB.maybe_put_arg(
-        "workspace",
-        if(optional_args[:workspace], do: Dagger.ID.id!(optional_args[:workspace]), else: nil)
-      )
+      |> QB.put_arg("workspace", Dagger.ID.id!(workspace))
 
     %Dagger.CurrentModuleAsSDK{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3436,23 +3436,13 @@ func (r *CurrentModule) WithGraphQLQuery(q *querybuilder.Selection) *CurrentModu
 	}
 }
 
-// CurrentModuleAsSDKOpts contains options for CurrentModule.AsSDK
-type CurrentModuleAsSDKOpts struct {
-	// The workspace to resolve SDK-role data against. Defaults to the current workspace.
-	Workspace *Workspace
-}
-
 // Treat the currently executing module as an SDK installed in the given workspace, exposing the modules and clients it manages.
 //
 // Errors if the current module is not installed as an SDK in this workspace.
-func (r *CurrentModule) AsSDK(opts ...CurrentModuleAsSDKOpts) *CurrentModuleAsSDK {
+func (r *CurrentModule) AsSDK(workspace *Workspace) *CurrentModuleAsSDK {
+	assertNotNil("workspace", workspace)
 	q := r.query.Select("asSDK")
-	for i := len(opts) - 1; i >= 0; i-- {
-		// `workspace` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Workspace) {
-			q = q.Arg("workspace", opts[i].Workspace)
-		}
-	}
+	q = q.Arg("workspace", workspace)
 
 	return &CurrentModuleAsSDK{
 		query: q,

--- a/sdk/php/generated/CurrentModule.php
+++ b/sdk/php/generated/CurrentModule.php
@@ -18,12 +18,10 @@ class CurrentModule extends Client\AbstractObject implements Client\IdAble, Node
      *
      * Errors if the current module is not installed as an SDK in this workspace.
      */
-    public function asSDK(?Workspace $workspace = null): CurrentModuleAsSDK
+    public function asSDK(Workspace $workspace): CurrentModuleAsSDK
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asSDK');
-        if (null !== $workspace) {
         $innerQueryBuilder->setArgument('workspace', $workspace);
-        }
         return new \Dagger\CurrentModuleAsSDK($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3677,11 +3677,7 @@ class Container(Type):
 class CurrentModule(Type):
     """Reflective module API provided to functions at runtime."""
 
-    def as_sdk(
-        self,
-        *,
-        workspace: "Workspace | None" = None,
-    ) -> "CurrentModuleAsSDK":
+    def as_sdk(self, workspace: "Workspace") -> "CurrentModuleAsSDK":
         """Treat the currently executing module as an SDK installed in the given
         workspace, exposing the modules and clients it manages.
 
@@ -3691,11 +3687,10 @@ class CurrentModule(Type):
         Parameters
         ----------
         workspace:
-            The workspace to resolve SDK-role data against. Defaults to the
-            current workspace.
+            The workspace to resolve SDK-role data against.
         """
         _args = [
-            Arg("workspace", workspace, None),
+            Arg("workspace", workspace),
         ]
         _ctx = self._select("asSDK", _args)
         return CurrentModuleAsSDK(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4174,12 +4174,6 @@ pub struct CurrentModule {
     pub graphql_client: DynGraphQLClient,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct CurrentModuleAsSdkOpts {
-    /// The workspace to resolve SDK-role data against. Defaults to the current workspace.
-    #[builder(setter(into, strip_option), default)]
-    pub workspace: Option<Id>,
-}
-#[derive(Builder, Debug, PartialEq)]
 pub struct CurrentModuleGeneratorsOpts<'a> {
     /// Only include generators matching the specified patterns
     #[builder(setter(into, strip_option), default)]
@@ -4226,26 +4220,16 @@ impl CurrentModule {
     ///
     /// # Arguments
     ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_sdk(&self) -> CurrentModuleAsSdk {
-        let query = self.selection.select("asSDK");
-        CurrentModuleAsSdk {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
-    /// Treat the currently executing module as an SDK installed in the given workspace, exposing the modules and clients it manages.
-    /// Errors if the current module is not installed as an SDK in this workspace.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_sdk_opts(&self, opts: CurrentModuleAsSdkOpts) -> CurrentModuleAsSdk {
+    /// * `workspace` - The workspace to resolve SDK-role data against.
+    pub fn as_sdk(&self, workspace: impl IntoID<Id>) -> CurrentModuleAsSdk {
         let mut query = self.selection.select("asSDK");
-        if let Some(workspace) = opts.workspace {
-            query = query.arg("workspace", workspace);
-        }
+        query = query.arg_lazy(
+            "workspace",
+            Box::new(move || {
+                let workspace = workspace.clone();
+                Box::pin(async move { workspace.into_id().await.unwrap().quote() })
+            }),
+        );
         CurrentModuleAsSdk {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1012,13 +1012,6 @@ export type ContainerWithoutUnixSocketOpts = {
   expand?: boolean
 }
 
-export type CurrentModuleAsSdkOpts = {
-  /**
-   * The workspace to resolve SDK-role data against. Defaults to the current workspace.
-   */
-  workspace?: Workspace
-}
-
 export type CurrentModuleGeneratorsOpts = {
   /**
    * Only include generators matching the specified patterns
@@ -5511,10 +5504,10 @@ export class CurrentModule extends BaseClient {
    * Treat the currently executing module as an SDK installed in the given workspace, exposing the modules and clients it manages.
    *
    * Errors if the current module is not installed as an SDK in this workspace.
-   * @param opts.workspace The workspace to resolve SDK-role data against. Defaults to the current workspace.
+   * @param workspace The workspace to resolve SDK-role data against.
    */
-  asSDK = (opts?: CurrentModuleAsSdkOpts): CurrentModuleAsSDK => {
-    const ctx = this._ctx.select("asSDK", { ...opts })
+  asSDK = (workspace: Workspace): CurrentModuleAsSDK => {
+    const ctx = this._ctx.select("asSDK", { workspace })
     return new CurrentModuleAsSDK(ctx)
   }
 


### PR DESCRIPTION
## What

`currentModule.asSDK(workspace:)` is now required. The fallback to the ambient current workspace is gone.

Part of #13790 — the `asSDK` half only. The other half, module functions that declare `ws: Workspace!` but are still published as nullable (`core/typedef.go:252-256`, which is what produces `dagger.FooOpts{Ws: ws}` when calling another module), is not addressed here.

## Why

#13727 landed the argument as optional to avoid updating every SDK in lockstep, leaving two `FIXME`s naming the required argument as the end state. That rollout is finished — every official SDK module passes a workspace explicitly, as of 2026-07-27:

| Repo | Call site |
|---|---|
| `dagger/go-sdk` | `go-sdk.dang:32,116` |
| `dagger/typescript-sdk` | `typescript-sdk.dang:59,641` |
| `dagger/python-sdk` | `python-sdk.dang:26` |
| `dagger/php-sdk` | `php-sdk.dang:32` |

Optional was also a lie in practice. Since #13229 a module driven as a dependency does not inherit its caller's workspace, so the fallback either failed with `no current workspace: workspace not loaded` (the failure #13727 was filed for) or, when the caller held a synthetic `asWorkspace` value or a staged overlay reached outside a generator group, silently read the wrong config. And because the argument was nullable, Go codegen rendered it as opts, so the only correct call was `dag.CurrentModule().AsSDK(dagger.CurrentModuleAsSDKOpts{Workspace: ws})` — same shape in TypeScript, Python and Rust.

## How

- `currentModuleAsSDK` takes `dagql.ID[*core.Workspace]` and loads it directly; the `currentWorkspace` fallback and both `FIXME`s are gone.
- The three in-repo fixtures in `core/integration/generators_test.go` drop the opts wrapper (they already passed the workspace).
- Regenerated: schema, all six SDK clients, PHP reference docs. `CurrentModuleAsSDKOpts` / `CurrentModuleAsSdkOpts` disappear from Go, TypeScript and Rust; Go is now `AsSDK(workspace *Workspace)`.

## Compatibility

The field is gated to `AfterVersion("v1.0.0-0")`, so this only touches pre-GA v1 surface. Breakage is limited to a workspace pinning an SDK module older than 2026-07-27 and running a newer engine; the error names the argument (`missing required argument: "workspace"`) and `dagger lock update` moves the pin forward. No coordinated SDK release needed.

## Not included

`toolchains/{engine-dev,cli-dev,go}/internal/dagger/dagger.gen.go` still carry the old optional signature — they only regenerate against a dev engine, and nothing in those toolchains calls `AsSDK`. `toolchains/go` is a separate matter: it pins `engineVersion = "v0.21.7"` yet its client already carries v1-only surface (`Workspace.Cwd`), which predates this change.