### PR TITLE
fix(layercopy): preserve source visibility bounds

### DIFF
--- a/.changes/unreleased/Fixed-20260805-213119.yaml
+++ b/.changes/unreleased/Fixed-20260805-213119.yaml
@@ -6,4 +6,4 @@ body: |
 time: 2026-08-05T21:31:19Z
 custom:
   Author: sipsma
-  PR: ""
+  PR: 13848

--- a/.changes/unreleased/Fixed-20260805-213119.yaml
+++ b/.changes/unreleased/Fixed-20260805-213119.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  `Container.withDirectory` and `Directory.withDirectory` no longer restore
+  deleted nested files after execs remove and recreate an ancestor
+  directory.
+time: 2026-08-05T21:31:19Z
+custom:
+  Author: sipsma
+  PR: ""

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -362,6 +362,93 @@ func (DirectorySuite) TestWithDirectory(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (DirectorySuite) TestWithDirectoryOpaqueSourceAncestor(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	source := c.Container().
+		From(alpineImage).
+		WithDirectory("/data", c.Directory().
+			WithNewFile("a/x.txt", "old").
+			WithNewFile("a/b/y.txt", "old")).
+		WithExec([]string{"sh", "-c", "rm -rf /data/a && mkdir -p /data/a/b && echo new > /data/a/b/new.txt"}).
+		Directory("/data")
+
+	mountedFiles, err := c.Container().
+		From(alpineImage).
+		WithMountedDirectory("/view", source).
+		WithExec([]string{"sh", "-c", "find /view -type f | sed 's#^/view/##' | sort"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a/b/new.txt\n", mountedFiles)
+
+	exportPath := filepath.Join(t.TempDir(), "export")
+	_, err = source.Export(ctx, exportPath)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(exportPath, "a", "b", "new.txt"))
+	require.NoFileExists(t, filepath.Join(exportPath, "a", "x.txt"))
+	require.NoFileExists(t, filepath.Join(exportPath, "a", "b", "y.txt"))
+
+	copiedFiles, err := c.Container().
+		From(alpineImage).
+		WithDirectory("/view", source).
+		WithExec([]string{"sh", "-c", "find /view -type f | sed 's#^/view/##' | sort"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a/b/new.txt\n", copiedFiles)
+
+	copiedSubdirFiles, err := c.Container().
+		From(alpineImage).
+		WithDirectory("/view", source.Directory("a/b")).
+		WithExec([]string{"sh", "-c", "find /view -type f | sed 's#^/view/##' | sort"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new.txt\n", copiedSubdirFiles)
+}
+
+func (DirectorySuite) TestWithDirectoryWhiteoutSourceAncestor(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	source := c.Container().
+		From(alpineImage).
+		WithDirectory("/data", c.Directory().
+			WithNewFile("a/x.txt", "old").
+			WithNewFile("a/b/y.txt", "old").
+			WithNewFile("a/b/keep.txt", "old")).
+		WithExec([]string{"sh", "-c", "rm -rf /data/a/b"}).
+		WithExec([]string{"sh", "-c", "mkdir -p /data/a/b && echo new > /data/a/b/new.txt"}).
+		Directory("/data")
+
+	mountedFiles, err := c.Container().
+		From(alpineImage).
+		WithMountedDirectory("/view", source).
+		WithExec([]string{"sh", "-c", "find /view -type f | sed 's#^/view/##' | sort"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a/b/new.txt\na/x.txt\n", mountedFiles)
+
+	copied := c.Directory().WithDirectory("view", source)
+	copiedFiles, err := c.Container().
+		From(alpineImage).
+		WithMountedDirectory("/result", copied).
+		WithExec([]string{"sh", "-c", "find /result/view -type f | sed 's#^/result/view/##' | sort"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "a/b/new.txt\na/x.txt\n", copiedFiles)
+
+	contents, err := copied.File("view/a/b/new.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new\n", contents)
+
+	copiedSubdir := c.Directory().WithDirectory("view", source.Directory("a/b"))
+	copiedSubdirFiles, err := c.Container().
+		From(alpineImage).
+		WithMountedDirectory("/result", copiedSubdir).
+		WithExec([]string{"sh", "-c", "find /result/view -type f | sed 's#^/result/view/##' | sort"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "new.txt\n", copiedSubdirFiles)
+}
+
 func (DirectorySuite) TestWithDirectoryPermissionsOverride(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -86,6 +86,7 @@ func (c *Copier) copy(ctx context.Context, src *source, matcher *matcher, srcPat
 		ViewPath: src.baseView,
 		RealPath: src.baseReal,
 		Info:     src.baseInfo,
+		minLayer: src.baseMinLayer,
 	}
 
 	destPath = cleanContainerPath(destPath)
@@ -101,7 +102,7 @@ func (c *Copier) copy(ctx context.Context, src *source, matcher *matcher, srcPat
 		if err != nil {
 			return err
 		}
-		entries, err := src.readDir("")
+		entries, err := src.readDir("", root.minLayer)
 		if err != nil {
 			return err
 		}
@@ -159,6 +160,7 @@ func (c *Copier) copyFile(ctx context.Context, src *source, srcPath, destPath st
 		ViewPath: src.baseView,
 		RealPath: src.baseReal,
 		Info:     src.baseInfo,
+		minLayer: src.baseMinLayer,
 	}
 	return c.copyNode(ent, destPath, resolvedParent{}, opts)
 }
@@ -223,7 +225,7 @@ func (c *Copier) copyEntry(
 			return nil
 		}
 
-		children, err := src.readDir(ent.Rel)
+		children, err := src.readDir(ent.Rel, ent.minLayer)
 		if err != nil {
 			return err
 		}

--- a/util/layercopy/copy_linux.go
+++ b/util/layercopy/copy_linux.go
@@ -25,11 +25,14 @@ func NewCopier(dest Mount) (*Copier, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Copier{dest: d}, nil
+	return &Copier{
+		dest:         d,
+		sourceCaches: map[sourceCacheKey]*sourceCache{},
+	}, nil
 }
 
 func (c *Copier) Copy(ctx context.Context, src Mount, srcPath, destPath string, opts CopyOptions) error {
-	s, err := newSource(src)
+	s, err := c.sourceForCopy(src)
 	if err != nil {
 		return err
 	}
@@ -41,11 +44,30 @@ func (c *Copier) Copy(ctx context.Context, src Mount, srcPath, destPath string, 
 }
 
 func (c *Copier) CopyFile(ctx context.Context, src Mount, srcPath, destPath string, opts CopyOptions) error {
-	s, err := newSource(src)
+	s, err := c.sourceForCopy(src)
 	if err != nil {
 		return err
 	}
 	return c.copyFile(ctx, s, srcPath, destPath, opts)
+}
+
+func (c *Copier) sourceForCopy(m Mount) (*source, error) {
+	s, err := newSource(m)
+	if err != nil {
+		return nil, err
+	}
+	if !s.overlay {
+		return s, nil
+	}
+
+	key := sourceCacheKey{root: m.Root, mount: m.Mount}
+	cache := c.sourceCaches[key]
+	if cache == nil {
+		cache = &sourceCache{ancestorMinLayers: map[string]int{}}
+		c.sourceCaches[key] = cache
+	}
+	s.cache = cache
+	return s, nil
 }
 
 func (c *Copier) Mkdir(ctx context.Context, destPath string, opts CopyOptions) error {

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -220,6 +220,58 @@ func TestCopyOverlaySourceDoesNotFollowSymlinkLayer(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(dstRoot, "d", "hidden.txt"))
 }
 
+func TestCopierScopesOverlaySourceCacheByMount(t *testing.T) {
+	t.Parallel()
+
+	copier := &Copier{sourceCaches: map[sourceCacheKey]*sourceCache{}}
+	firstMount := &mount.Mount{Type: "overlay", Options: []string{"lowerdir=/first"}}
+	secondMount := &mount.Mount{Type: "overlay", Options: []string{"lowerdir=/first"}}
+
+	first, err := copier.sourceForCopy(Mount{Root: "/view", Mount: firstMount})
+	require.NoError(t, err)
+	repeated, err := copier.sourceForCopy(Mount{Root: "/view", Mount: firstMount})
+	require.NoError(t, err)
+	differentRoot, err := copier.sourceForCopy(Mount{Root: "/other", Mount: firstMount})
+	require.NoError(t, err)
+	differentMount, err := copier.sourceForCopy(Mount{Root: "/view", Mount: secondMount})
+	require.NoError(t, err)
+
+	require.Same(t, first.cache, repeated.cache)
+	require.NotSame(t, first.cache, differentRoot.cache)
+	require.NotSame(t, first.cache, differentMount.cache)
+	require.Len(t, copier.sourceCaches, 3)
+}
+
+func TestOverlayAncestorMinLayerCachesCumulativeBounds(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	layers := []string{
+		filepath.Join(root, "lower"),
+		filepath.Join(root, "middle"),
+		filepath.Join(root, "upper"),
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(layers[0], "a", "b"), 0o755))
+	require.NoError(t, os.MkdirAll(layers[1], 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(layers[1], "a"), []byte("cover"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(layers[2], "a", "b"), 0o755))
+
+	cache := &sourceCache{ancestorMinLayers: map[string]int{}}
+	src := &source{overlay: true, layers: layers, cache: cache}
+	minLayer, err := src.overlayAncestorMinLayer("a/b/file.txt")
+	require.NoError(t, err)
+	require.Equal(t, 1, minLayer)
+	require.Equal(t, map[string]int{
+		"":    0,
+		"a":   1,
+		"a/b": 1,
+	}, cache.ancestorMinLayers)
+
+	minLayer, err = src.overlayAncestorMinLayer("a/b/other.txt")
+	require.NoError(t, err)
+	require.Equal(t, 1, minLayer)
+}
+
 func TestCopyFileDestPathHintIsDir(t *testing.T) {
 	t.Parallel()
 

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -172,6 +172,54 @@ func TestCopyOverlaySourceStopsAtNonDirectoryLayer(t *testing.T) {
 	require.NoDirExists(t, filepath.Join(dstRoot, "d", "sub"))
 }
 
+func TestCopyOverlaySourceDoesNotFollowSymlinkLayer(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	lowerRoot := filepath.Join(root, "lower")
+	upperRoot := filepath.Join(root, "upper")
+	viewRoot := filepath.Join(root, "view")
+	dstRoot := filepath.Join(root, "dst")
+
+	for _, dir := range []string{
+		filepath.Join(lowerRoot, "target"),
+		filepath.Join(upperRoot, "d"),
+		filepath.Join(viewRoot, "d"),
+		dstRoot,
+	} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(lowerRoot, "target", "hidden.txt"), []byte("hidden"), 0o644))
+	require.NoError(t, os.Symlink("target", filepath.Join(lowerRoot, "d")))
+	require.NoError(t, os.WriteFile(filepath.Join(upperRoot, "d", "visible.txt"), []byte("visible"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(viewRoot, "d", "visible.txt"), []byte("visible"), 0o644))
+
+	copier, err := NewCopier(Mount{Root: dstRoot})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, copier.Close())
+	})
+
+	err = copier.Copy(context.Background(), Mount{
+		Root: viewRoot,
+		Mount: &mount.Mount{
+			Type: "overlay",
+			Options: []string{
+				"lowerdir=" + strings.Join([]string{upperRoot, lowerRoot}, ":"),
+			},
+		},
+	}, "/", "/", CopyOptions{
+		CopyDirContents: true,
+		ReplaceExisting: true,
+	})
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(filepath.Join(dstRoot, "d", "visible.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "visible", string(contents))
+	require.NoFileExists(t, filepath.Join(dstRoot, "d", "hidden.txt"))
+}
+
 func TestCopyFileDestPathHintIsDir(t *testing.T) {
 	t.Parallel()
 

--- a/util/layercopy/copy_linux_test.go
+++ b/util/layercopy/copy_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -117,6 +118,58 @@ func TestCopyDirectoryDisableSourceHardlinksPreservesInternalHardlinks(t *testin
 	got, err := os.ReadFile(filepath.Join(dstRoot, "file.txt"))
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(got))
+}
+
+func TestCopyOverlaySourceStopsAtNonDirectoryLayer(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	lowerRoot := filepath.Join(root, "lower")
+	middleRoot := filepath.Join(root, "middle")
+	upperRoot := filepath.Join(root, "upper")
+	viewRoot := filepath.Join(root, "view")
+	dstRoot := filepath.Join(root, "dst")
+
+	for _, dir := range []string{
+		filepath.Join(lowerRoot, "d", "sub"),
+		middleRoot,
+		filepath.Join(upperRoot, "d"),
+		filepath.Join(viewRoot, "d"),
+		dstRoot,
+	} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(lowerRoot, "d", "old.txt"), []byte("old"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(lowerRoot, "d", "sub", "deep.txt"), []byte("old"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(middleRoot, "d"), []byte("cover"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(upperRoot, "d", "new.txt"), []byte("new"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(viewRoot, "d", "new.txt"), []byte("new"), 0o644))
+
+	copier, err := NewCopier(Mount{Root: dstRoot})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, copier.Close())
+	})
+
+	err = copier.Copy(context.Background(), Mount{
+		Root: viewRoot,
+		Mount: &mount.Mount{
+			Type: "overlay",
+			Options: []string{
+				"lowerdir=" + strings.Join([]string{upperRoot, middleRoot, lowerRoot}, ":"),
+			},
+		},
+	}, "/", "/", CopyOptions{
+		CopyDirContents: true,
+		ReplaceExisting: true,
+	})
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(filepath.Join(dstRoot, "d", "new.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "new", string(contents))
+	require.NoFileExists(t, filepath.Join(dstRoot, "d", "old.txt"))
+	require.NoDirExists(t, filepath.Join(dstRoot, "d", "sub"))
 }
 
 func TestCopyFileDestPathHintIsDir(t *testing.T) {

--- a/util/layercopy/source_linux.go
+++ b/util/layercopy/source_linux.go
@@ -26,6 +26,7 @@ type source struct {
 	baseInfo     os.FileInfo
 	baseMinLayer int
 	baseCached   bool
+	cache        *sourceCache
 }
 
 type sourceEntry struct {
@@ -284,6 +285,15 @@ func (s *source) overlayAncestorMinLayer(rel string) (int, error) {
 
 	minLayer := 0
 	for _, ancestor := range ancestors {
+		if s.cache != nil {
+			if cached, ok := s.cache.ancestorMinLayers[ancestor]; ok {
+				if cached > minLayer {
+					minLayer = cached
+				}
+				continue
+			}
+		}
+
 		for i := len(s.layers) - 1; i >= minLayer; i-- {
 			_, hidesLower, err := overlayEntryState(filepath.Join(s.layers[i], ancestor))
 			if err != nil {
@@ -296,6 +306,9 @@ func (s *source) overlayAncestorMinLayer(rel string) (int, error) {
 				minLayer = i
 				break
 			}
+		}
+		if s.cache != nil {
+			s.cache.ancestorMinLayers[ancestor] = minLayer
 		}
 	}
 	return minLayer, nil

--- a/util/layercopy/source_linux.go
+++ b/util/layercopy/source_linux.go
@@ -16,15 +16,16 @@ import (
 )
 
 type source struct {
-	root       string
-	realRoot   string
-	layers     []string
-	overlay    bool
-	baseRel    string
-	baseView   string
-	baseReal   string
-	baseInfo   os.FileInfo
-	baseCached bool
+	root         string
+	realRoot     string
+	layers       []string
+	overlay      bool
+	baseRel      string
+	baseView     string
+	baseReal     string
+	baseInfo     os.FileInfo
+	baseMinLayer int
+	baseCached   bool
 }
 
 type sourceEntry struct {
@@ -33,6 +34,9 @@ type sourceEntry struct {
 	RealPath string
 	Info     os.FileInfo
 	StatErr  error
+	// minLayer is the lowest overlay layer visible below this entry. An opaque
+	// directory or whiteout in a higher layer hides lower-layer descendants.
+	minLayer int
 }
 
 func newSource(m Mount) (*source, error) {
@@ -86,11 +90,16 @@ func (s *source) selectBase(srcPath string, followFinalSymlink bool) error {
 	if err != nil {
 		return err
 	}
+	baseMinLayer, err := s.overlayAncestorMinLayer(baseRel)
+	if err != nil {
+		return err
+	}
 
 	s.baseView = baseView
 	s.baseRel = baseRel
 	s.baseInfo = info
-	realPath, realInfo, err := s.realPath("")
+	s.baseMinLayer = baseMinLayer
+	realPath, realInfo, err := s.realPath("", baseMinLayer)
 	if err != nil {
 		return err
 	}
@@ -100,7 +109,7 @@ func (s *source) selectBase(srcPath string, followFinalSymlink bool) error {
 	return nil
 }
 
-func (s *source) readDir(rel string) ([]sourceEntry, error) {
+func (s *source) readDir(rel string, minLayer int) ([]sourceEntry, error) {
 	if err := s.selectBase(".", false); err != nil {
 		return nil, err
 	}
@@ -108,7 +117,7 @@ func (s *source) readDir(rel string) ([]sourceEntry, error) {
 	if !s.overlay {
 		return s.readBindDir(rel)
 	}
-	return s.readOverlayDir(rel)
+	return s.readOverlayDir(rel, minLayer)
 }
 
 func (s *source) readBindDir(rel string) ([]sourceEntry, error) {
@@ -146,7 +155,7 @@ func (s *source) readBindDir(rel string) ([]sourceEntry, error) {
 	return entries, nil
 }
 
-func (s *source) readOverlayDir(rel string) ([]sourceEntry, error) {
+func (s *source) readOverlayDir(rel string, minLayer int) ([]sourceEntry, error) {
 	type visibleEntry struct {
 		realPath string
 		info     os.FileInfo
@@ -156,16 +165,18 @@ func (s *source) readOverlayDir(rel string) ([]sourceEntry, error) {
 	visible := map[string]visibleEntry{}
 	hidden := map[string]struct{}{}
 
-	for i := len(s.layers) - 1; i >= 0; i-- {
+	visibleMinLayer := minLayer
+	for i := len(s.layers) - 1; i >= minLayer; i-- {
 		layerDir := filepath.Join(s.layers[i], layerRel)
-		opaque, err := isOpaqueDir(layerDir)
+		hidesLower, err := hidesLowerLayers(layerDir)
 		if err != nil && !os.IsNotExist(err) && !isNotDir(err) {
 			return nil, err
 		}
 
 		dirents, err := os.ReadDir(layerDir)
 		if os.IsNotExist(err) || isNotDir(err) {
-			if opaque {
+			if hidesLower {
+				visibleMinLayer = i
 				break
 			}
 			continue
@@ -198,7 +209,8 @@ func (s *source) readOverlayDir(rel string) ([]sourceEntry, error) {
 				info:     info,
 			}
 		}
-		if opaque {
+		if hidesLower {
+			visibleMinLayer = i
 			break
 		}
 	}
@@ -218,12 +230,13 @@ func (s *source) readOverlayDir(rel string) ([]sourceEntry, error) {
 			ViewPath: filepath.Join(viewDir, name),
 			RealPath: ent.realPath,
 			Info:     ent.info,
+			minLayer: visibleMinLayer,
 		})
 	}
 	return entries, nil
 }
 
-func (s *source) realPath(rel string) (string, os.FileInfo, error) {
+func (s *source) realPath(rel string, minLayer int) (string, os.FileInfo, error) {
 	rel = cleanRel(filepath.Join(s.baseRel, rel))
 	if !s.overlay {
 		realPath := filepath.Join(s.realRoot, rel)
@@ -234,7 +247,7 @@ func (s *source) realPath(rel string) (string, os.FileInfo, error) {
 		return realPath, realInfo, nil
 	}
 
-	for i := len(s.layers) - 1; i >= 0; i-- {
+	for i := len(s.layers) - 1; i >= minLayer; i-- {
 		realPath := filepath.Join(s.layers[i], rel)
 		realInfo, err := os.Lstat(realPath)
 		if err == nil {
@@ -249,6 +262,40 @@ func (s *source) realPath(rel string) (string, os.FileInfo, error) {
 		return "", nil, err
 	}
 	return "", nil, fmt.Errorf("failed to resolve source path %q in overlay layers", rel)
+}
+
+func (s *source) overlayAncestorMinLayer(rel string) (int, error) {
+	if !s.overlay {
+		return 0, nil
+	}
+
+	ancestors := []string{""}
+	parent := cleanRel(filepath.Dir(rel))
+	if parent != "" {
+		var ancestor string
+		for _, part := range strings.Split(parent, string(filepath.Separator)) {
+			ancestor = filepath.Join(ancestor, part)
+			ancestors = append(ancestors, ancestor)
+		}
+	}
+
+	minLayer := 0
+	for _, ancestor := range ancestors {
+		for i := len(s.layers) - 1; i >= minLayer; i-- {
+			hidesLower, err := hidesLowerLayers(filepath.Join(s.layers[i], ancestor))
+			if err != nil {
+				if os.IsNotExist(err) || isNotDir(err) {
+					continue
+				}
+				return 0, err
+			}
+			if hidesLower {
+				minLayer = i
+				break
+			}
+		}
+	}
+	return minLayer, nil
 }
 
 func rootPath(root, p string, followFinalSymlink bool) (string, error) {
@@ -278,13 +325,16 @@ func isWhiteout(info os.FileInfo) bool {
 	return unix.Major(st.Rdev) == 0 && unix.Minor(st.Rdev) == 0
 }
 
-func isOpaqueDir(path string) (bool, error) {
+// hidesLowerLayers reports whether an overlay entry prevents lower layers from
+// contributing at and below this path. Non-directories cover everything lower
+// layers hold at the path, while opaque directories hide lower descendants.
+func hidesLowerLayers(path string) (bool, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return false, err
 	}
 	if !info.IsDir() {
-		return false, nil
+		return true, nil
 	}
 	for _, key := range []string{"trusted.overlay.opaque", "user.overlay.opaque"} {
 		val, err := sysx.LGetxattr(path, key)

--- a/util/layercopy/source_linux.go
+++ b/util/layercopy/source_linux.go
@@ -35,7 +35,7 @@ type sourceEntry struct {
 	Info     os.FileInfo
 	StatErr  error
 	// minLayer is the lowest overlay layer visible below this entry. An opaque
-	// directory or whiteout in a higher layer hides lower-layer descendants.
+	// directory or non-directory in a higher layer hides lower descendants.
 	minLayer int
 }
 
@@ -168,17 +168,20 @@ func (s *source) readOverlayDir(rel string, minLayer int) ([]sourceEntry, error)
 	visibleMinLayer := minLayer
 	for i := len(s.layers) - 1; i >= minLayer; i-- {
 		layerDir := filepath.Join(s.layers[i], layerRel)
-		hidesLower, err := hidesLowerLayers(layerDir)
-		if err != nil && !os.IsNotExist(err) && !isNotDir(err) {
+		isDir, hidesLower, err := overlayEntryState(layerDir)
+		if err != nil {
+			if os.IsNotExist(err) || isNotDir(err) {
+				continue
+			}
 			return nil, err
+		}
+		if !isDir {
+			visibleMinLayer = i
+			break
 		}
 
 		dirents, err := os.ReadDir(layerDir)
 		if os.IsNotExist(err) || isNotDir(err) {
-			if hidesLower {
-				visibleMinLayer = i
-				break
-			}
 			continue
 		}
 		if err != nil {
@@ -282,7 +285,7 @@ func (s *source) overlayAncestorMinLayer(rel string) (int, error) {
 	minLayer := 0
 	for _, ancestor := range ancestors {
 		for i := len(s.layers) - 1; i >= minLayer; i-- {
-			hidesLower, err := hidesLowerLayers(filepath.Join(s.layers[i], ancestor))
+			_, hidesLower, err := overlayEntryState(filepath.Join(s.layers[i], ancestor))
 			if err != nil {
 				if os.IsNotExist(err) || isNotDir(err) {
 					continue
@@ -325,16 +328,17 @@ func isWhiteout(info os.FileInfo) bool {
 	return unix.Major(st.Rdev) == 0 && unix.Minor(st.Rdev) == 0
 }
 
-// hidesLowerLayers reports whether an overlay entry prevents lower layers from
-// contributing at and below this path. Non-directories cover everything lower
-// layers hold at the path, while opaque directories hide lower descendants.
-func hidesLowerLayers(path string) (bool, error) {
+// overlayEntryState reports whether an overlay entry is a directory and
+// whether it prevents lower layers from contributing below its path.
+// Non-directories cover everything lower layers hold at the path, while opaque
+// directories hide lower descendants.
+func overlayEntryState(path string) (isDir, hidesLower bool, err error) {
 	info, err := os.Lstat(path)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if !info.IsDir() {
-		return true, nil
+		return false, true, nil
 	}
 	for _, key := range []string{"trusted.overlay.opaque", "user.overlay.opaque"} {
 		val, err := sysx.LGetxattr(path, key)
@@ -342,13 +346,13 @@ func hidesLowerLayers(path string) (bool, error) {
 			continue
 		}
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		if len(val) == 1 && val[0] == 'y' {
-			return true, nil
+			return true, true, nil
 		}
 	}
-	return false, nil
+	return true, false, nil
 }
 
 func isNotDir(err error) bool {

--- a/util/layercopy/types.go
+++ b/util/layercopy/types.go
@@ -24,6 +24,17 @@ type Mount struct {
 	Mount *mount.Mount
 }
 
+type sourceCacheKey struct {
+	root  string
+	mount *mount.Mount
+}
+
+type sourceCache struct {
+	// ancestorMinLayers maps an ancestor path to the lowest visible layer after
+	// applying every visibility bound from the source root through that path.
+	ancestorMinLayers map[string]int
+}
+
 type Ownership struct {
 	UID int
 	GID int
@@ -58,5 +69,6 @@ type CopyOptions struct {
 }
 
 type Copier struct {
-	dest *destination
+	dest         *destination
+	sourceCaches map[sourceCacheKey]*sourceCache
 }


### PR DESCRIPTION
## Summary

When an exec deletes and recreates a directory, copying that container `Directory` with `Container.withDirectory` or `Directory.withDirectory` can restore files that only exist below the deleted directory in older snapshot layers.

The mounted and exported views are correct because the kernel overlay mount already applies ancestor opacity and whiteouts. The bug is in layercopy's engine-side reconstruction: child directory walks could scan below the visibility bound established by an ancestor.

This change:

- carries the lowest visible overlay layer through recursive traversal and initializes it from ancestors of a selected copy root;
- treats opaque directories, whiteouts, and other non-directory entries as lower-layer visibility bounds, using `Lstat` so physical source-layer symlinks are not followed;
- caches cumulative ancestor bounds per `Copier` and mounted source, avoiding repeated layer scans for wildcard copy roots.

The cache does not change traversal results. In a local synthetic 500-match, 20-layer benchmark, it reduced repeated-copy time from roughly 0.5–0.6 seconds to 25–30 milliseconds, allocations from about 1.12 million to 132 thousand, and allocated bytes from about 99 MB to 7.7 MB per operation.

## Validation

- `go test -count=1 ./util/layercopy`
- focused non-directory, symlink, cache-scope, and cumulative-bound layercopy tests
- `go vet ./util/layercopy`
- Darwin and Windows layercopy cross-compilation
- `dagger api call engine-dev test --pkg ./core/integration --run='Test(Directory|Container)/TestWithDirectory(OpaqueSourceAncestor|WhiteoutSourceAncestor|Union)?$'` (14 passed using the source-built development engine)

The new integration regressions verify that mounted/exported views exclude deleted files and that engine-side copies now produce the same contents. Before the fix, those controls passed while the engine-side copy assertions failed for both opaque-directory and separate-layer whiteout cases.

Fixes #13844
