### PR TITLE
fix(ci): use project `deploy tokens` for GitLab

### DIFF
--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -720,6 +720,7 @@ func (ModuleSuite) TestCrossSessionSecrets(ctx context.Context, t *testctx.T) {
 				With(daggerCall(
 					"fn",
 					"--cache-bust", cacheBust,
+					"--username", authTokenTestCase.httpAuthUsername,
 					"--token-plaintext", authTokenTestCase.token(),
 					"stdout",
 				)).
@@ -1222,7 +1223,7 @@ func (ModuleSuite) TestPrivateGitRepoArgCaching(ctx context.Context, t *testctx.
 	gitConfigFile1 := filepath.Join(gitConfigDir1, "config")
 	err := os.WriteFile(
 		gitConfigFile1,
-		[]byte(makeGitCredentials("https://"+tc.expectedHost, "git", decodedGitToken(tc.encodedToken))),
+		[]byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, decodedGitToken(tc.encodedToken))),
 		0644,
 	)
 	require.NoError(t, err)
@@ -1246,7 +1247,7 @@ func (ModuleSuite) TestPrivateGitRepoArgCaching(ctx context.Context, t *testctx.
 	gitConfigFile2 := filepath.Join(gitConfigDir2, "config")
 	err = os.WriteFile(
 		gitConfigFile2,
-		[]byte(makeGitCredentials("https://"+tc.expectedHost, "git", decodedGitToken(tc.encodedToken2))),
+		[]byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername2, decodedGitToken(tc.encodedToken2))),
 		0644,
 	)
 	require.NoError(t, err)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -786,13 +786,11 @@ func (GitSuite) TestAuthProviders(ctx context.Context, t *testctx.T) {
 	// })
 
 	t.Run("GitLab auth", func(ctx context.Context, t *testctx.T) {
-		// Base64-encoded read-only PAT for test repo
-		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := decodeAndTrimPAT(pat)
-		require.NoError(t, err)
+		tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
-		_, err = c.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git", dagger.GitOpts{
-			HTTPAuthToken: c.SetSecret("gitlab_pat", token),
+		_, err := c.Git(tc.gitTestRepoRef, dagger.GitOpts{
+			HTTPAuthUsername: tc.httpAuthUsername,
+			HTTPAuthToken:    c.SetSecret("gitlab_deploy_token", tc.token()),
 		}).
 			Branch("main").
 			Tree().

--- a/core/integration/gitcredential_test.go
+++ b/core/integration/gitcredential_test.go
@@ -27,7 +27,7 @@ func TestGitCredential(t *testing.T) {
 }
 
 // TestGitCredentialErrors verifies Git authentication for private modules across different providers
-// using host-specific PATs and isolated Git credentials per test.
+// using host-specific credentials and isolated Git configuration per test.
 func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testctx.T) {
 	// Decode base64-encoded PATs used in CI
 	decodeAndTrimPAT := func(encoded string) (string, error) {
@@ -39,9 +39,9 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 	}
 
 	// Creates isolated Git credentials per host to allow parallel test execution
-	setupGitCredentials := func(host, token, workDir string) []string {
+	setupGitCredentials := func(host, username, token, workDir string) []string {
 		gitConfigPath := filepath.Join(workDir, ".gitconfig")
-		err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials(host, "x-token-auth", token)), 0600)
+		err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials(host, username, token)), 0600)
 		require.NoError(t, err)
 		return []string{"GIT_CONFIG_GLOBAL=" + gitConfigPath}
 	}
@@ -88,7 +88,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 
-		env := setupGitCredentials("github.com", token, workDir)
+		env := setupGitCredentials("github.com", "x-token-auth", token, workDir)
 		modDir := filepath.Join(workDir, "module")
 		err = os.MkdirAll(modDir, 0755)
 		require.NoError(t, err)
@@ -117,17 +117,14 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 
 	t.Run("gitlab private module", func(ctx context.Context, t *testctx.T) {
 		workDir := t.TempDir()
+		tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
-		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := decodeAndTrimPAT(pat)
-		require.NoError(t, err)
-
-		env := setupGitCredentials("gitlab.com", token, workDir)
+		env := setupGitCredentials(tc.expectedHost, tc.httpAuthUsername, tc.token(), workDir)
 		modDir := filepath.Join(workDir, "module")
-		err = os.MkdirAll(modDir, 0755)
+		err := os.MkdirAll(modDir, 0755)
 		require.NoError(t, err)
 
-		out, err := execWithEnv(ctx, t, modDir, env, "-m", "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git", "api", "functions")
+		out, err := execWithEnv(ctx, t, modDir, env, "-m", tc.gitTestRepoRef, "api", "functions")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "Description")
 	})
@@ -140,7 +137,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 
-		env := setupGitCredentials("github.com", token, workDir)
+		env := setupGitCredentials("github.com", "x-token-auth", token, workDir)
 
 		rootDir := filepath.Join(workDir, "main")
 		copyTestdataFixture(ctx, t, rootDir, "modules", "go", "gitcredential-private-dir")

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -610,10 +610,13 @@ type vcsTestCase struct {
 	isPrivateRepo      bool
 	skipProxyTest      bool
 
-	// encodedToken is a based64 encoded read-only PAT
-	encodedToken string
+	// HTTP credentials for private repositories. Tokens are base64 encoded to
+	// avoid storing token-shaped strings directly in the source.
+	httpAuthUsername string
+	encodedToken     string
 	// encodedToken2 is an optional second token to test cases of using different tokens for the same repo
-	encodedToken2 string
+	httpAuthUsername2 string
+	encodedToken2     string
 	// sshKey determines whether to propagate the host's ssh-key
 	sshKey bool
 }
@@ -691,7 +694,7 @@ var vcsTestCases = []vcsTestCase{
 		skipProxyTest:            true,
 		sshKey:                   true,
 	},
-	// GitLab private repository using PAT
+	// GitLab private repository using project-scoped deploy tokens
 	{
 		name:                     "Private GitLab",
 		gitTestRepoRef:           "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git",
@@ -701,10 +704,11 @@ var vcsTestCases = []vcsTestCase{
 		expectedURLPathComponent: "tree",
 		expectedPathPrefix:       "",
 		isPrivateRepo:            true,
-		// NOTE: this is not a security vulnerability, these tokens are read-only and scoped to a test repository
-		// with no actual private code
-		encodedToken:  "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx",
-		encodedToken2: "Z2xwYXQtcFVIWDVmZmVCUmdjZ2FYTHdndjNPVzg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxa2oyMHJi",
+		// NOTE: these tokens are read-only and scoped to a test repository with no actual private code.
+		httpAuthUsername:  "dagger-read-only",
+		encodedToken:      "Z2xkdC1ucHU2TTFGRkF3WXFoUnFrcHhXdA==",
+		httpAuthUsername2: "dagger-read-only-2",
+		encodedToken2:     "Z2xkdC1LN3p3Q3I3RW1HclFocmJSZmcteg==",
 	},
 	// BitBucket private repository using SCP-like SSH reference format
 	{

--- a/core/integration/module_helpers_test.go
+++ b/core/integration/module_helpers_test.go
@@ -187,7 +187,7 @@ func privateRepoSetup(c *dagger.Client, t *testctx.T, tc vcsTestCase) (dagger.Wi
 		}
 		if token := tc.token(); token != "" {
 			ctr = ctr.
-				WithNewFile("/tmp/git-config", makeGitCredentials("https://"+tc.expectedHost, "git", token)).
+				WithNewFile("/tmp/git-config", makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, token)).
 				WithEnvVariable("GIT_CONFIG_GLOBAL", "/tmp/git-config")
 		}
 

--- a/core/integration/module_private_deps_test.go
+++ b/core/integration/module_private_deps_test.go
@@ -120,15 +120,15 @@ func (ModuleSuite) TestSSHAuthSockPathHandling(ctx context.Context, t *testctx.T
 // credential-resolving client has git and the configured credential helper,
 // matching how git credential forwarding is exercised in gitcredential_test.go.
 func (ModuleSuite) TestGeneratePrivateGitDependency(ctx context.Context, t *testctx.T) {
-	// HTTPS GitLab private repo authenticated with a read-only PAT, matching the
-	// originally reported scenario.
+	// Use a read-only deploy token for the same HTTPS credential-forwarding path
+	// as the originally reported PAT scenario.
 	tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
 	workDir := t.TempDir()
 
 	// Isolated git credential helper for the private repo's host.
 	gitConfigPath := filepath.Join(workDir, ".gitconfig")
-	err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials("https://"+tc.expectedHost, "x-token-auth", tc.token())), 0600)
+	err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, tc.token())), 0600)
 	require.NoError(t, err)
 
 	// run executes a dagger command on the host in workDir with a git

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -407,6 +407,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					run: func(t *testctx.T, c *dagger.Client, _ proxyTestFixtures) {
 						opts := dagger.GitOpts{}
 						if token := tc.token(); token != "" {
+							opts.HTTPAuthUsername = tc.httpAuthUsername
 							opts.HTTPAuthToken = c.SetSecret("TOKEN", token)
 						}
 						gitURL := "https://" + strings.TrimPrefix(tc.gitTestRepoRef, "https://")
@@ -448,6 +449,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					run: func(t *testctx.T, c *dagger.Client, _ proxyTestFixtures) {
 						opts := dagger.GitOpts{}
 						if token := tc.token(); token != "" {
+							opts.HTTPAuthUsername = tc.httpAuthUsername
 							opts.HTTPAuthToken = c.SetSecret("TOKEN", token)
 						}
 

--- a/core/integration/testdata/modules/go/cross-session-secret-contenthash/main.go
+++ b/core/integration/testdata/modules/go/cross-session-secret-contenthash/main.go
@@ -4,9 +4,12 @@ import "dagger/secreter/internal/dagger"
 
 type Secreter struct{}
 
-func (*Secreter) Fn(cacheBust string, tokenPlaintext string) *dagger.Container {
+func (*Secreter) Fn(cacheBust, username, tokenPlaintext string) *dagger.Container {
 	authSecret := dag.SetSecret("GIT_AUTH", tokenPlaintext)
-	gitRepo := dag.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private", dagger.GitOpts{HTTPAuthToken: authSecret}).
+	gitRepo := dag.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private", dagger.GitOpts{
+		HTTPAuthUsername: username,
+		HTTPAuthToken:    authSecret,
+	}).
 		Branch("main").
 		Tree()
 


### PR DESCRIPTION
GitLab automatically revokes user PATs when it detects that they were leaked. That is what these private repository tests used, and both tokens were revoked. GitLab does not document the same automatic response for project deploy tokens.

Replace the PATs with read-only deploy tokens scoped to the test project. Deploy tokens use a username and token pair, so pass the matching username through each Git authentication path.

These credentials are intentionally committed for end-to-end tests. They can only read one disposable test repository, which contains no private code or data, so exposing them does not grant access beyond the test fixture.

Keep both credentials in the shared VCS fixture so future rotations happen in one place. The second token is still needed to test two different credentials for the same repository.