### PR TITLE
feat(schema): require declared Workspace! args on module functions

### DIFF
--- a/core/integration/contextual_workspace_test.go
+++ b/core/integration/contextual_workspace_test.go
@@ -279,8 +279,9 @@ func (ContextualWorkspaceSuite) TestContextualWorkspaceCaching(ctx context.Conte
 }
 
 // TestContextualWorkspaceCLIExposure covers user-visible behavior that is
-// specific to Workspace being injected from context rather than passed
-// explicitly.
+// specific to Workspace being defaulted from context rather than passed
+// explicitly. The greeter fixture's constructor declares `source: Workspace!`,
+// so it also pins that a required Workspace stays callable without a flag.
 func (ContextualWorkspaceSuite) TestContextualWorkspaceCLIExposure(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
@@ -293,9 +294,13 @@ func (ContextualWorkspaceSuite) TestContextualWorkspaceCLIExposure(ctx context.C
 		require.Equal(t, "hello from workspace", strings.TrimSpace(out))
 	})
 
-	t.Run("workspace arg is not exposed as a CLI flag", func(ctx context.Context, t *testctx.T) {
+	t.Run("workspace arg is an optional CLI flag", func(ctx context.Context, t *testctx.T) {
 		help, err := ctr.With(daggerReportCall("greeter", "--help")).Stdout(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, help, "--source")
+		// Offered, so a caller can aim the function at another workspace.
+		require.Contains(t, help, "--source")
+		// Never required, even though it's declared Workspace!: the CLI defaults
+		// it to the current workspace, which the subtest above exercises.
+		require.NotRegexp(t, `--source[^\n]*\[required\]`, help)
 	})
 }

--- a/core/integration/module_dependency_runtime_test.go
+++ b/core/integration/module_dependency_runtime_test.go
@@ -10,6 +10,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"dagger.io/dagger"
@@ -113,10 +114,15 @@ func (ModuleSuite) TestRuntimeDependencyDoesNotInheritWorkspace(ctx context.Cont
 		WithNewFile("marker.txt", "workspace marker")
 
 	// A can still share its workspace with B when it passes the value explicitly.
+	//
+	// Driven through `dagger call` rather than a raw query: A's own Workspace!
+	// is required, and the CLI defaults it to the current workspace. A raw
+	// GraphQL document gets no such help — it fails validation before reaching
+	// the engine — so passing one there means naming the ID by hand.
 	t.Run("explicit workspace pass succeeds", func(ctx context.Context, t *testctx.T) {
-		out, err := modGen.With(daggerQueryAt(".", `{explicitWorkspaceArg}`)).Stdout(ctx)
+		out, err := modGen.With(daggerCallAt(".", "explicit-workspace-arg")).Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"explicitWorkspaceArg":"workspace marker"}`, out)
+		require.Equal(t, "workspace marker", strings.TrimSpace(out))
 	})
 
 	// B must not receive A's contextual workspace through an omitted argument.

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -550,7 +550,7 @@ func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.Fi
 		if !ok {
 			return nil, fmt.Errorf("no object of type %q is bound", typeName)
 		}
-		sel, err := buildObjectMethodSelector(srv, recv.ObjectType(), fieldName, args)
+		sel, err := buildObjectMethodSelector(ctx, srv, recv.ObjectType(), fieldName, args)
 		if err != nil {
 			return nil, err
 		}
@@ -564,8 +564,10 @@ func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.Fi
 
 // buildObjectMethodSelector converts the model's tool arguments into a selector
 // for the method. It decodes each provided argument through the field's input
-// spec; the Workspace argument is omitted here and auto-injected downstream.
-func buildObjectMethodSelector(srv *dagql.Server, recvType dagql.ObjectType, fieldName string, args map[string]any) (dagql.Selector, error) {
+// spec. A declared-optional Workspace argument is omitted and auto-injected
+// downstream; a required one is filled from the LLM's bound workspace, since
+// dagql rejects a missing non-null argument before that injection runs.
+func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType dagql.ObjectType, fieldName string, args map[string]any) (dagql.Selector, error) {
 	sel := dagql.Selector{View: srv.View, Field: fieldName}
 	field, ok := recvType.FieldSpec(fieldName, srv.View)
 	if !ok {
@@ -578,6 +580,9 @@ func buildObjectMethodSelector(srv *dagql.Server, recvType dagql.ObjectType, fie
 		}
 		val, ok := args[arg.Name]
 		if !ok {
+			if wsInput, ok := boundWorkspaceInput(ctx, srv, arg); ok {
+				sel.Args = append(sel.Args, dagql.NamedInput{Name: arg.Name, Value: wsInput})
+			}
 			continue
 		}
 		delete(provided, arg.Name)

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -610,7 +610,7 @@ func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.Fi
 		if !ok {
 			return nil, fmt.Errorf("no object of type %q is bound", typeName)
 		}
-		sel, err := buildObjectMethodSelector(srv, recv.ObjectType(), fieldName, args)
+		sel, err := buildObjectMethodSelector(ctx, srv, recv.ObjectType(), fieldName, args)
 		if err != nil {
 			return nil, err
 		}
@@ -624,8 +624,10 @@ func (m *MCP) callObjectMethod(srv *dagql.Server, typeName string, field *ast.Fi
 
 // buildObjectMethodSelector converts the model's tool arguments into a selector
 // for the method. It decodes each provided argument through the field's input
-// spec; the Workspace argument is omitted here and auto-injected downstream.
-func buildObjectMethodSelector(srv *dagql.Server, recvType dagql.ObjectType, fieldName string, args map[string]any) (dagql.Selector, error) {
+// spec. A declared-optional Workspace argument is omitted and auto-injected
+// downstream; a required one is filled from the LLM's bound workspace, since
+// dagql rejects a missing non-null argument before that injection runs.
+func buildObjectMethodSelector(ctx context.Context, srv *dagql.Server, recvType dagql.ObjectType, fieldName string, args map[string]any) (dagql.Selector, error) {
 	sel := dagql.Selector{View: srv.View, Field: fieldName}
 	field, ok := recvType.FieldSpec(fieldName, srv.View)
 	if !ok {
@@ -638,6 +640,9 @@ func buildObjectMethodSelector(srv *dagql.Server, recvType dagql.ObjectType, fie
 		}
 		val, ok := args[arg.Name]
 		if !ok {
+			if wsInput, ok := boundWorkspaceInput(ctx, srv, arg); ok {
+				sel.Args = append(sel.Args, dagql.NamedInput{Name: arg.Name, Value: wsInput})
+			}
 			continue
 		}
 		delete(provided, arg.Name)

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -241,8 +241,8 @@ func (m *MCP) bindWorkspaceModuleTools(ctx context.Context) (*MCP, error) {
 			if !arg.Type.Type().NonNull {
 				continue
 			}
-			if arg.Type.Type().Name() == workspaceTypeName {
-				// Auto-injected from the current workspace.
+			if inputSpecIsWorkspace(arg) {
+				// Supplied from the workspace in scope, not by the caller.
 				continue
 			}
 			constructible = false

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -651,7 +651,18 @@ func (node *ModTreeNode) dagqlValue(ctx context.Context, dest any, leafArgs []da
 		if mod == nil {
 			return fmt.Errorf("%q: get value: missing module", node.PathString())
 		}
-		return srv.Select(ctx, srv.Root(), dest, dagql.Selector{Field: gqlFieldName(mod.Name()), Args: leafArgs})
+		var ctor *Function
+		if objType := node.ObjectType(); objType != nil && objType.Constructor.Valid {
+			ctor = objType.Constructor.Value.Self()
+		}
+		args, err := boundWorkspaceArgs(ctx, srv, ctor)
+		if err != nil {
+			return fmt.Errorf("%q: get value: %w", node.PathString(), err)
+		}
+		return srv.Select(ctx, srv.Root(), dest, dagql.Selector{
+			Field: gqlFieldName(mod.Name()),
+			Args:  append(args, leafArgs...),
+		})
 	}
 	// 2. Is parent an object?
 	if parentObjType := node.Parent.ObjectType(); parentObjType != nil {
@@ -659,7 +670,15 @@ func (node *ModTreeNode) dagqlValue(ctx context.Context, dest any, leafArgs []da
 		if err := node.Parent.DagqlValue(ctx, &parentObjValue); err != nil {
 			return err
 		}
-		return srv.Select(dagql.WithNonInternalTelemetry(ctx), parentObjValue, dest, dagql.Selector{Field: node.Name, Args: leafArgs})
+		fn, _ := parentObjType.FunctionByName(node.Name)
+		args, err := boundWorkspaceArgs(ctx, srv, fn)
+		if err != nil {
+			return fmt.Errorf("%q: get value: %w", node.PathString(), err)
+		}
+		return srv.Select(dagql.WithNonInternalTelemetry(ctx), parentObjValue, dest, dagql.Selector{
+			Field: node.Name,
+			Args:  append(args, leafArgs...),
+		})
 	}
 	return fmt.Errorf("%q: get value: parent is not an object", node.PathString())
 }
@@ -702,6 +721,47 @@ func (node *ModTreeNode) agentBaseArg() string {
 		}
 	}
 	return agentBaseArgName
+}
+
+// boundWorkspaceArgs supplies fn's required Workspace argument. A
+// declared-optional Workspace arg is skipped: dagql's injection hook
+// (GetDynamicInput) still fills those in, but it runs after the non-null check
+// in preselect, so a required one has to be on the selector before the call is
+// made.
+//
+// The value resolves the same way loadWorkspaceArg's does: the workspace the
+// enclosing group threaded into the context, else the session's ambient one.
+// The fallback is what keeps a generator reached outside a group working —
+// Module.generator(name:) sets no BoundWorkspace, which is the shape the
+// scale-out check query builds.
+func boundWorkspaceArgs(ctx context.Context, srv *dagql.Server, fn *Function) ([]dagql.NamedInput, error) {
+	if fn == nil {
+		return nil, nil
+	}
+	var argName string
+	for _, argRes := range fn.Args {
+		arg := argRes.Self()
+		if arg.IsWorkspace() && !arg.TypeDef.Self().Optional {
+			argName = arg.Name
+			break
+		}
+	}
+	if argName == "" {
+		return nil, nil
+	}
+	wsID, err := workspaceArgValue(ctx, srv)
+	if err != nil {
+		return nil, err
+	}
+	if wsID == nil {
+		// Nothing to inherit: leave the arg off and let dagql report it as
+		// missing, which names both the argument and the field.
+		return nil, nil
+	}
+	return []dagql.NamedInput{{
+		Name:  argName,
+		Value: wsID,
+	}}, nil
 }
 
 func debugTrace(ctx context.Context, msg string, args ...any) {

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -651,7 +651,18 @@ func (node *ModTreeNode) dagqlValue(ctx context.Context, dest any, leafArgs []da
 		if mod == nil {
 			return fmt.Errorf("%q: get value: missing module", node.PathString())
 		}
-		return srv.Select(ctx, srv.Root(), dest, dagql.Selector{Field: gqlFieldName(mod.Name()), Args: leafArgs})
+		var ctor *Function
+		if objType := node.ObjectType(); objType != nil && objType.Constructor.Valid {
+			ctor = objType.Constructor.Value.Self()
+		}
+		args, err := boundWorkspaceArgs(ctx, srv, ctor)
+		if err != nil {
+			return fmt.Errorf("%q: get value: %w", node.PathString(), err)
+		}
+		return srv.Select(ctx, srv.Root(), dest, dagql.Selector{
+			Field: gqlFieldName(mod.Name()),
+			Args:  append(args, leafArgs...),
+		})
 	}
 	// 2. Is parent an object?
 	if parentObjType := node.Parent.ObjectType(); parentObjType != nil {
@@ -659,7 +670,15 @@ func (node *ModTreeNode) dagqlValue(ctx context.Context, dest any, leafArgs []da
 		if err := node.Parent.DagqlValue(ctx, &parentObjValue); err != nil {
 			return err
 		}
-		return srv.Select(dagql.WithNonInternalTelemetry(ctx), parentObjValue, dest, dagql.Selector{Field: node.Name, Args: leafArgs})
+		fn, _ := parentObjType.FunctionByName(node.Name)
+		args, err := boundWorkspaceArgs(ctx, srv, fn)
+		if err != nil {
+			return fmt.Errorf("%q: get value: %w", node.PathString(), err)
+		}
+		return srv.Select(dagql.WithNonInternalTelemetry(ctx), parentObjValue, dest, dagql.Selector{
+			Field: node.Name,
+			Args:  append(args, leafArgs...),
+		})
 	}
 	return fmt.Errorf("%q: get value: parent is not an object", node.PathString())
 }
@@ -702,6 +721,47 @@ func (node *ModTreeNode) agentBaseArg() string {
 		}
 	}
 	return agentBaseArgName
+}
+
+// boundWorkspaceArgs supplies fn's required Workspace argument. A
+// declared-optional Workspace arg is skipped: dagql's injection hook
+// (GetDynamicInput) still fills those in, but it runs after the non-null check
+// in preselect, so a required one has to be on the selector before the call is
+// made.
+//
+// The value resolves the same way loadWorkspaceArg's does: the workspace the
+// enclosing group threaded into the context, else the session's ambient one.
+// The fallback is what keeps a generator reached outside a group working —
+// Module.generator(name:) sets no BoundWorkspace, which is the shape the
+// scale-out check query builds.
+func boundWorkspaceArgs(ctx context.Context, srv *dagql.Server, fn *Function) ([]dagql.NamedInput, error) {
+	if fn == nil {
+		return nil, nil
+	}
+	var argName string
+	for _, argRes := range fn.Args {
+		arg := argRes.Self()
+		if arg.IsWorkspace() && !arg.TypeDef.Self().Optional {
+			argName = arg.Name
+			break
+		}
+	}
+	if argName == "" {
+		return nil, nil
+	}
+	wsID, err := workspaceArgValue(ctx, srv)
+	if err != nil {
+		return nil, err
+	}
+	if wsID == nil {
+		// Nothing to inherit: leave the arg off and let dagql report it as
+		// missing, which names both the argument and the field.
+		return nil, nil
+	}
+	return []dagql.NamedInput{{
+		Name:  argName,
+		Value: wsID,
+	}}, nil
 }
 
 func debugTrace(ctx context.Context, msg string, args ...any) {
@@ -945,10 +1005,11 @@ func (node *ModTreeNode) Children(ctx context.Context) ([]*ModTreeNode, error) {
 		nodeType := objType.Name
 		for _, fnRes := range objType.Functions {
 			fn := fnRes.Self()
-			// @agent functions declare a required `base: LLM!` that the compose
-			// fold supplies explicitly; exempt that one arg so agent leaves are
-			// not dropped. Any *other* required arg still disqualifies.
-			if functionRequiresArgsExceptAgentBase(fn) {
+			// Only args the caller must supply disqualify a function here.
+			// Engine-supplied ones (an @agent's `base: LLM!`, a `Workspace!`)
+			// are filled in at selection time, so a leaf declaring one must
+			// still be discovered — see boundWorkspaceArgs.
+			if functionRequiresCallerArgs(fn) {
 				continue
 			}
 			returnType := fn.ReturnType.Self().ToType().Name()

--- a/core/module.go
+++ b/core/module.go
@@ -159,6 +159,12 @@ func argRequired(arg *FunctionArg) bool {
 	if arg.DefaultValue != nil {
 		return false
 	}
+	// engine-supplied -> not required. A Workspace is declared required so the
+	// signature says so, but it resolves from the workspace in scope rather than
+	// from the caller — the same reason a contextual arg is exempt above.
+	if arg.IsWorkspace() {
+		return false
+	}
 	return true
 }
 
@@ -257,12 +263,16 @@ func validateAgentFunction(obj *ObjectTypeDef, fn *Function) error {
 	return nil
 }
 
-// functionRequiresArgsExceptAgentBase reports whether a function has required
-// arguments, except that for an @agent function it exempts a single required
-// LLM! argument — the base the compose fold supplies explicitly
-// (hack/designs/workspace-agents.md §3). Any *other* required argument still
-// disqualifies the function from no-arg enumeration.
-func functionRequiresArgsExceptAgentBase(fn *Function) bool {
+// functionRequiresCallerArgs reports whether a function has required arguments
+// the caller has to supply, which disqualifies it from no-arg enumeration.
+//
+// Engine-supplied arguments don't count, because nothing is asked of the
+// caller: an @agent function's single required LLM! is the base the compose
+// fold supplies explicitly (hack/designs/workspace-agents.md §3), and a
+// Workspace! — exempted in argRequired, alongside contextual args — resolves
+// from the workspace in scope. Both are declared required so the signature says
+// so, and both are filled in before the call.
+func functionRequiresCallerArgs(fn *Function) bool {
 	baseExempted := false
 	for _, argRes := range fn.Args {
 		arg := argRes.Self()

--- a/core/object.go
+++ b/core/object.go
@@ -1313,6 +1313,7 @@ func (obj *ModuleObject) installEntrypointMethods(ctx context.Context, dag *dagq
 				if query != nil && query.ConstructorArgs != nil {
 					ctorNamedArgs = orderedNamedInputs(constructorArgs, query.ConstructorArgs)
 				}
+				ctorNamedArgs = withBoundWorkspaceArgs(ctx, canonical, constructorArgs, ctorNamedArgs)
 				var result dagql.AnyResult
 				if err := canonical.Select(ctx, canonical.Root(), &result,
 					dagql.Selector{
@@ -1357,6 +1358,7 @@ func (obj *ModuleObject) installEntrypointMethods(ctx context.Context, dag *dagq
 				if query != nil && query.ConstructorArgs != nil {
 					ctorNamedArgs = orderedNamedInputs(constructorArgs, query.ConstructorArgs)
 				}
+				ctorNamedArgs = withBoundWorkspaceArgs(ctx, canonical, constructorArgs, ctorNamedArgs)
 				var result dagql.AnyResult
 				if err := canonical.Select(ctx, canonical.Root(), &result,
 					dagql.Selector{

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -763,13 +763,6 @@ func (s *moduleSchema) functionArg(ctx context.Context, _ *core.Query, args stru
 		}
 	}
 	arg := core.NewFunctionArg(args.Name, typeDef, args.Description, args.DefaultValue, args.DefaultPath, args.DefaultAddress, args.Ignore, args.Deprecated)
-	if arg.IsWorkspace() {
-		typeDef, err = s.withOptional(ctx, dag, arg.TypeDef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to optionalize workspace arg type: %w", err)
-		}
-		arg.TypeDef = typeDef
-	}
 	sourceMap, err := s.loadSourceMapResult(ctx, args.SourceMap)
 	if err != nil {
 		return nil, err
@@ -815,13 +808,6 @@ func (s *moduleSchema) internalFunctionArg(ctx context.Context, _ *core.Query, a
 		Ignore:         args.Ignore,
 		Deprecated:     args.Deprecated,
 		OriginalName:   args.Name,
-	}
-	if arg.IsWorkspace() {
-		typeDef, err = s.withOptional(ctx, dag, arg.TypeDef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to optionalize workspace arg type: %w", err)
-		}
-		arg.TypeDef = typeDef
 	}
 	sourceMap, err := s.loadSourceMapResult(ctx, args.SourceMap)
 	if err != nil {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -680,9 +680,12 @@ func (arg *FunctionArg) isContextual() bool {
 }
 
 // IsWorkspace returns true if the argument is of type Workspace.
-// A Workspace argument declared optional is still auto-injected when unset; one
-// declared required must be passed by the caller, since dagql rejects a missing
-// non-null argument before the injection hook runs.
+//
+// Either way it is supplied by the engine rather than the caller (see
+// argRequired); the declaration only decides how. An optional one is filled by
+// dagql's injection hook, while a required one has to be on the selector before
+// the call, since preselect rejects a missing non-null argument before that
+// hook runs.
 func (arg *FunctionArg) IsWorkspace() bool {
 	typeDef := arg.TypeDef.Self()
 	return typeDef.Kind == TypeDefKindObject &&

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -257,12 +257,6 @@ func (fn *Function) FieldSpec(ctx context.Context, mod Mod) (dagql.FieldSpec, er
 			return spec, fmt.Errorf("failed to resolve canonical typedef for arg %q: %w", argSelf.Name, err)
 		}
 
-		// Workspace arguments are always optional, regardless of how they're declared in code.
-		// They are automatically injected when not explicitly set.
-		if argSelf.IsWorkspace() {
-			argTypeDef.Self().Optional = true
-		}
-
 		input := argTypeDef.Self().ToInput()
 		var defaultVal dagql.Input
 		if argSelf.DefaultValue != nil {
@@ -686,7 +680,9 @@ func (arg *FunctionArg) isContextual() bool {
 }
 
 // IsWorkspace returns true if the argument is of type Workspace.
-// Workspace arguments are always optional and automatically injected when not set.
+// A Workspace argument declared optional is still auto-injected when unset; one
+// declared required must be passed by the caller, since dagql rejects a missing
+// non-null argument before the injection hook runs.
 func (arg *FunctionArg) IsWorkspace() bool {
 	typeDef := arg.TypeDef.Self()
 	return typeDef.Kind == TypeDefKindObject &&

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 type workspaceContextKey struct{}
@@ -40,6 +41,75 @@ func WorkspaceFromContext(ctx context.Context) (dagql.ObjectResult[*Workspace], 
 		return ws, true
 	}
 	return dagql.ObjectResult[*Workspace]{}, false
+}
+
+// workspaceArgValue resolves the Workspace that a framework-built call should
+// pass for a required Workspace argument: the one an enclosing group bound into
+// the context, else the session's ambient current workspace. Returns a nil
+// input when neither applies, leaving the argument off so dagql reports it as
+// missing by name.
+//
+// This mirrors [ModuleFunction.loadWorkspaceArg], which fills the same argument
+// for calls that can rely on dagql's injection hook. A required argument can't:
+// preselect rejects a missing non-null argument before the hook runs, so the
+// value has to be on the selector instead.
+func workspaceArgValue(ctx context.Context, srv *dagql.Server) (dagql.Input, error) {
+	if ws, ok := WorkspaceFromContext(ctx); ok {
+		wsID, err := ws.ID()
+		if err != nil {
+			return nil, fmt.Errorf("get bound workspace ID: %w", err)
+		}
+		return dagql.NewID[*Workspace](wsID), nil
+	}
+	if srv == nil {
+		return nil, nil
+	}
+	// A running module function must pass a Workspace to its dependencies
+	// explicitly, so it doesn't silently inherit its caller's.
+	if inModuleFunction, err := callerInModuleFunction(ctx); err != nil {
+		return nil, err
+	} else if inModuleFunction {
+		return nil, nil
+	}
+	var ws dagql.ObjectResult[*Workspace]
+	if err := srv.Select(ctx, srv.Root(), &ws, dagql.Selector{
+		Field: "currentWorkspace",
+		Args: []dagql.NamedInput{
+			{Name: "skipMigrationCheck", Value: dagql.Boolean(true)},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("load current workspace: %w", err)
+	}
+	wsID, err := ws.ID()
+	if err != nil {
+		return nil, fmt.Errorf("get current workspace ID: %w", err)
+	}
+	return dagql.NewID[*Workspace](wsID), nil
+}
+
+// boundWorkspaceInput returns the Workspace to pass for arg, if arg is a
+// required Workspace-typed argument the caller left unset. Optional ones are
+// left to dagql's injection hook.
+//
+// A module function's object args are published as plain ID scalars, so the
+// @expectedType directive is where the object type survives on the input spec —
+// the same identification [isWorkspaceArg] makes against the AST.
+func boundWorkspaceInput(ctx context.Context, srv *dagql.Server, arg dagql.InputSpec) (dagql.Input, bool) {
+	if !arg.Type.Type().NonNull {
+		return nil, false
+	}
+	d := ast.DirectiveList(arg.Directives).ForName("expectedType")
+	if d == nil {
+		return nil, false
+	}
+	if name := d.Arguments.ForName("name"); name == nil || name.Value == nil || name.Value.Raw != workspaceTypeName {
+		return nil, false
+	}
+	val, err := workspaceArgValue(ctx, srv)
+	if err != nil || val == nil {
+		return nil, false
+	}
+	return val, true
 }
 
 // workspaceClientContext switches ctx to the Workspace's owning client so that

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -3,9 +3,11 @@ package core
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 type workspaceContextKey struct{}
@@ -40,6 +42,99 @@ func WorkspaceFromContext(ctx context.Context) (dagql.ObjectResult[*Workspace], 
 		return ws, true
 	}
 	return dagql.ObjectResult[*Workspace]{}, false
+}
+
+// workspaceArgValue resolves the Workspace that a framework-built call should
+// pass for a required Workspace argument: the one an enclosing group bound into
+// the context, else the session's ambient current workspace. Returns a nil
+// input when neither applies, leaving the argument off so dagql reports it as
+// missing by name.
+//
+// This mirrors [ModuleFunction.loadWorkspaceArg], which fills the same argument
+// for calls that can rely on dagql's injection hook. A required argument can't:
+// preselect rejects a missing non-null argument before the hook runs, so the
+// value has to be on the selector instead.
+func workspaceArgValue(ctx context.Context, srv *dagql.Server) (dagql.Input, error) {
+	if ws, ok := WorkspaceFromContext(ctx); ok {
+		wsID, err := ws.ID()
+		if err != nil {
+			return nil, fmt.Errorf("get bound workspace ID: %w", err)
+		}
+		return dagql.NewID[*Workspace](wsID), nil
+	}
+	if srv == nil {
+		return nil, nil
+	}
+	// A running module function must pass a Workspace to its dependencies
+	// explicitly, so it doesn't silently inherit its caller's.
+	if inModuleFunction, err := callerInModuleFunction(ctx); err != nil {
+		return nil, err
+	} else if inModuleFunction {
+		return nil, nil
+	}
+	var ws dagql.ObjectResult[*Workspace]
+	if err := srv.Select(ctx, srv.Root(), &ws, dagql.Selector{
+		Field: "currentWorkspace",
+		Args: []dagql.NamedInput{
+			{Name: "skipMigrationCheck", Value: dagql.Boolean(true)},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("load current workspace: %w", err)
+	}
+	wsID, err := ws.ID()
+	if err != nil {
+		return nil, fmt.Errorf("get current workspace ID: %w", err)
+	}
+	return dagql.NewID[*Workspace](wsID), nil
+}
+
+// withBoundWorkspaceArgs supplies the workspace for any required Workspace
+// argument in specs that named doesn't already carry.
+//
+// Callers that assemble a selector themselves — the entrypoint proxies building
+// their inner constructor call, like ModTreeNode.DagqlValue — have to fill a
+// required Workspace before selecting, since dagql's injection hook runs after
+// the non-null check.
+func withBoundWorkspaceArgs(
+	ctx context.Context,
+	srv *dagql.Server,
+	specs []dagql.InputSpec,
+	named []dagql.NamedInput,
+) []dagql.NamedInput {
+	for _, spec := range specs {
+		if slices.ContainsFunc(named, func(n dagql.NamedInput) bool { return n.Name == spec.Name }) {
+			continue
+		}
+		if val, ok := boundWorkspaceInput(ctx, srv, spec); ok {
+			named = append(named, dagql.NamedInput{Name: spec.Name, Value: val})
+		}
+	}
+	return named
+}
+
+// boundWorkspaceInput returns the Workspace to pass for arg, if arg is a
+// required Workspace-typed argument the caller left unset. Optional ones are
+// left to dagql's injection hook.
+//
+// A module function's object args are published as plain ID scalars, so the
+// @expectedType directive is where the object type survives on the input spec —
+// the same identification [isWorkspaceArg] makes against the AST.
+func boundWorkspaceInput(ctx context.Context, srv *dagql.Server, arg dagql.InputSpec) (dagql.Input, bool) {
+	if !arg.Type.Type().NonNull {
+		return nil, false
+	}
+	d := ast.DirectiveList(arg.Directives).ForName("expectedType")
+	if d == nil {
+		return nil, false
+	}
+	if name := d.Arguments.ForName("name"); name == nil || name.Value == nil || name.Value.Raw != workspaceTypeName {
+		return nil, false
+	}
+	val, err := workspaceArgValue(ctx, srv)
+	if err != nil || val == nil {
+		return nil, false
+	}
+	return val, true
 }
 
 // workspaceClientContext switches ctx to the Workspace's owning client so that

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -75,9 +75,6 @@ func workspaceArgValue(ctx context.Context, srv *dagql.Server) (dagql.Input, err
 	var ws dagql.ObjectResult[*Workspace]
 	if err := srv.Select(ctx, srv.Root(), &ws, dagql.Selector{
 		Field: "currentWorkspace",
-		Args: []dagql.NamedInput{
-			{Name: "skipMigrationCheck", Value: dagql.Boolean(true)},
-		},
 	}); err != nil {
 		return nil, fmt.Errorf("load current workspace: %w", err)
 	}
@@ -112,22 +109,26 @@ func withBoundWorkspaceArgs(
 	return named
 }
 
+// inputSpecIsWorkspace reports whether spec is a Workspace-typed argument.
+//
+// A module function's object args are published as plain ID scalars — checking
+// spec.Type.Type().Name() would compare against "ID" and never match — so the
+// @expectedType directive is where the object type survives on the input spec.
+// This is the same identification [isWorkspaceArg] makes against the AST.
+func inputSpecIsWorkspace(spec dagql.InputSpec) bool {
+	d := ast.DirectiveList(spec.Directives).ForName("expectedType")
+	if d == nil {
+		return false
+	}
+	name := d.Arguments.ForName("name")
+	return name != nil && name.Value != nil && name.Value.Raw == workspaceTypeName
+}
+
 // boundWorkspaceInput returns the Workspace to pass for arg, if arg is a
 // required Workspace-typed argument the caller left unset. Optional ones are
 // left to dagql's injection hook.
-//
-// A module function's object args are published as plain ID scalars, so the
-// @expectedType directive is where the object type survives on the input spec —
-// the same identification [isWorkspaceArg] makes against the AST.
 func boundWorkspaceInput(ctx context.Context, srv *dagql.Server, arg dagql.InputSpec) (dagql.Input, bool) {
-	if !arg.Type.Type().NonNull {
-		return nil, false
-	}
-	d := ast.DirectiveList(arg.Directives).ForName("expectedType")
-	if d == nil {
-		return nil, false
-	}
-	if name := d.Arguments.ForName("name"); name == nil || name.Value == nil || name.Value.Raw != workspaceTypeName {
+	if !arg.Type.Type().NonNull || !inputSpecIsWorkspace(arg) {
 		return nil, false
 	}
 	val, err := workspaceArgValue(ctx, srv)

--- a/internal/cmd/dagger/flags.go
+++ b/internal/cmd/dagger/flags.go
@@ -63,6 +63,8 @@ func GetCustomFlagValue(name string) DaggerValue {
 		return &gitRepositoryValue{}
 	case GitRef:
 		return &gitRefValue{}
+	case Workspace:
+		return &workspaceValue{}
 	}
 	return nil
 }
@@ -308,6 +310,31 @@ func (v *directoryValue) Get(ctx context.Context, dag *dagger.Client, modSrc *da
 				Exclude: modArg.Ignore,
 			},
 		).Sync(ctx)
+}
+
+// workspaceValue is a pflag.Value that builds a dagger.Workspace from an
+// address. Left unset, the CLI fills the argument with the session's current
+// workspace instead (see selectFunc), so the flag only has to cover the case
+// where the caller wants a different one.
+type workspaceValue struct {
+	address string
+}
+
+func (v *workspaceValue) Type() string {
+	return Workspace
+}
+
+func (v *workspaceValue) Set(s string) error {
+	v.address = s
+	return nil
+}
+
+func (v *workspaceValue) String() string {
+	return v.address
+}
+
+func (v *workspaceValue) Get(_ context.Context, dag *dagger.Client, _ *dagger.ModuleSource, _ *modFunctionArg) (any, error) {
+	return dag.Address(v.address).Directory().AsWorkspace(), nil
 }
 
 // fileValue is a pflag.Value that builds a dagger.File from a host path.

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -56,6 +56,7 @@ const (
 	Socket        string = "Socket"
 	GitRepository string = "GitRepository"
 	GitRef        string = "GitRef"
+	Workspace     string = "Workspace"
 )
 
 var (
@@ -596,7 +597,10 @@ func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) 
 			}
 			return err
 		}
-		if arg.IsRequired() {
+		// A required Workspace stays optional at the CLI: selectFunc defaults it
+		// to the session's current workspace, so marking it required would reject
+		// the call before it could be filled in.
+		if arg.IsRequired() && !arg.IsWorkspace() {
 			cmd.MarkFlagRequired(arg.FlagName())
 		}
 		cmd.Flags().SetAnnotation(
@@ -683,6 +687,7 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 	fc.q = fc.q.Select(fn.Name)
 
 	missingFlags := []string{}
+	workspaceArgs := []string{}
 
 	type flagResult struct {
 		idx   int
@@ -695,14 +700,14 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 	flags := cmd.LocalNonPersistentFlags()
 	for i, a := range fn.SupportedArgs() {
 		flag := flags.Lookup(a.FlagName())
-		if flag == nil {
-			if a.IsRequired() {
-				missingFlags = append(missingFlags, a.FlagName())
+		if flag == nil || !flag.Changed {
+			// A required Workspace comes from the session, not the user: fill it
+			// from currentWorkspace so the call doesn't demand a flag for the
+			// thing the CLI already knows.
+			if a.IsWorkspace() && a.IsRequired() {
+				workspaceArgs = append(workspaceArgs, a.Name)
+				continue
 			}
-			continue
-		}
-
-		if !flag.Changed {
 			if a.IsRequired() {
 				missingFlags = append(missingFlags, a.FlagName())
 			}
@@ -734,6 +739,16 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 
 	if len(missingFlags) > 0 {
 		return fmt.Errorf(`required flag(s) "%s" not set`, strings.Join(missingFlags, `", "`))
+	}
+
+	if len(workspaceArgs) > 0 {
+		wsID, err := fc.c.Dagger().CurrentWorkspace().ID(fc.ctx)
+		if err != nil {
+			return fmt.Errorf("resolve current workspace for %q: %w", fn.Name, err)
+		}
+		for _, name := range workspaceArgs {
+			fc.q = fc.q.Arg(name, wsID)
+		}
 	}
 
 	return nil

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -56,6 +56,7 @@ const (
 	Socket        string = "Socket"
 	GitRepository string = "GitRepository"
 	GitRef        string = "GitRef"
+	Workspace     string = "Workspace"
 )
 
 var (
@@ -599,7 +600,7 @@ func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) 
 			}
 			return err
 		}
-		if arg.IsRequired() {
+		if arg.IsCallerRequired() {
 			cmd.MarkFlagRequired(arg.FlagName())
 		}
 		cmd.Flags().SetAnnotation(
@@ -686,6 +687,7 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 	fc.q = fc.q.Select(fn.Name)
 
 	missingFlags := []string{}
+	workspaceArgs := []string{}
 
 	type flagResult struct {
 		idx   int
@@ -698,14 +700,14 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 	flags := cmd.LocalNonPersistentFlags()
 	for i, a := range fn.SupportedArgs() {
 		flag := flags.Lookup(a.FlagName())
-		if flag == nil {
-			if a.IsRequired() {
-				missingFlags = append(missingFlags, a.FlagName())
+		if flag == nil || !flag.Changed {
+			// A required Workspace comes from the session, not the user: fill it
+			// from currentWorkspace so the call doesn't demand a flag for the
+			// thing the CLI already knows.
+			if a.IsWorkspace() && a.IsRequired() {
+				workspaceArgs = append(workspaceArgs, a.Name)
+				continue
 			}
-			continue
-		}
-
-		if !flag.Changed {
 			if a.IsRequired() {
 				missingFlags = append(missingFlags, a.FlagName())
 			}
@@ -737,6 +739,16 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 
 	if len(missingFlags) > 0 {
 		return fmt.Errorf(`required flag(s) "%s" not set`, strings.Join(missingFlags, `", "`))
+	}
+
+	if len(workspaceArgs) > 0 {
+		wsID, err := fc.c.Dagger().CurrentWorkspace().ID(fc.ctx)
+		if err != nil {
+			return fmt.Errorf("resolve current workspace for %q: %w", fn.Name, err)
+		}
+		for _, name := range workspaceArgs {
+			fc.q = fc.q.Arg(name, wsID)
+		}
 	}
 
 	return nil

--- a/internal/cmd/dagger/module_inspect.go
+++ b/internal/cmd/dagger/module_inspect.go
@@ -1075,7 +1075,7 @@ func (f *modFunction) HasRequiredArgs() bool {
 func (f *modFunction) RequiredArgs() []*modFunctionArg {
 	args := make([]*modFunctionArg, 0, len(f.Args))
 	for _, arg := range f.Args {
-		if arg.IsRequired() {
+		if arg.IsCallerRequired() {
 			args = append(args, arg)
 		}
 	}
@@ -1085,7 +1085,7 @@ func (f *modFunction) RequiredArgs() []*modFunctionArg {
 func (f *modFunction) OptionalArgs() []*modFunctionArg {
 	args := make([]*modFunctionArg, 0, len(f.Args))
 	for _, arg := range f.Args {
-		if !arg.IsRequired() {
+		if !arg.IsCallerRequired() {
 			args = append(args, arg)
 		}
 	}
@@ -1128,6 +1128,17 @@ type modFunctionArg struct {
 	Ignore       []string
 	flagName     string
 	once         sync.Once
+}
+
+// IsWorkspace reports whether the argument is a core Workspace. The CLI fills
+// these from the session's current workspace rather than exposing a flag, so
+// `dagger call` on a function that declares one stays a plain call.
+func (r *modFunctionArg) IsWorkspace() bool {
+	typeDef := r.TypeDef
+	if typeDef == nil || typeDef.Kind != dagger.TypeDefKindObjectKind || typeDef.AsObject == nil {
+		return false
+	}
+	return typeDef.AsObject.Name == "Workspace" && typeDef.AsObject.SourceModuleName == ""
 }
 
 // FlagName returns the name of the argument using CLI naming conventions.
@@ -1178,6 +1189,16 @@ func (r *modFunctionArg) Long() string {
 
 func (r *modFunctionArg) IsRequired() bool {
 	return !r.TypeDef.Optional && r.DefaultValue == ""
+}
+
+// IsCallerRequired reports whether the caller has to supply the argument.
+//
+// A Workspace is required of the *function* — the signature says so — but not
+// of the caller: the CLI defaults it to the session's current workspace. So it
+// is never a mandatory shell positional and never gets MarkFlagRequired, while
+// staying overridable by passing it explicitly.
+func (r *modFunctionArg) IsCallerRequired() bool {
+	return r.IsRequired() && !r.IsWorkspace()
 }
 
 func (r *modFunctionArg) IsUnsupportedFlag() bool {

--- a/internal/cmd/dagger/module_inspect.go
+++ b/internal/cmd/dagger/module_inspect.go
@@ -1130,6 +1130,17 @@ type modFunctionArg struct {
 	once         sync.Once
 }
 
+// IsWorkspace reports whether the argument is a core Workspace. The CLI fills
+// these from the session's current workspace rather than exposing a flag, so
+// `dagger call` on a function that declares one stays a plain call.
+func (r *modFunctionArg) IsWorkspace() bool {
+	typeDef := r.TypeDef
+	if typeDef == nil || typeDef.Kind != dagger.TypeDefKindObjectKind || typeDef.AsObject == nil {
+		return false
+	}
+	return typeDef.AsObject.Name == "Workspace" && typeDef.AsObject.SourceModuleName == ""
+}
+
 // FlagName returns the name of the argument using CLI naming conventions.
 func (r *modFunctionArg) FlagName() string {
 	r.once.Do(func() {

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -543,20 +543,12 @@ func sdkInitFunctionExtraArgs(fn *modFunction, kind sdkInitKind) []*modFunctionA
 
 	extra := make([]*modFunctionArg, 0, len(fn.Args))
 	for _, arg := range fn.Args {
-		if standard[arg.Name] || sdkInitArgIsWorkspace(arg) {
+		if standard[arg.Name] || arg.IsWorkspace() {
 			continue
 		}
 		extra = append(extra, arg)
 	}
 	return extra
-}
-
-func sdkInitArgIsWorkspace(arg *modFunctionArg) bool {
-	typeDef := arg.TypeDef
-	if typeDef == nil || typeDef.Kind != dagger.TypeDefKindObjectKind || typeDef.AsObject == nil {
-		return false
-	}
-	return typeDef.AsObject.Name == "Workspace" && typeDef.AsObject.SourceModuleName == ""
 }
 
 func sdkInitArgsJSON(cmd *cobra.Command) (string, error) {

--- a/internal/cmd/dagger/shell_exec.go
+++ b/internal/cmd/dagger/shell_exec.go
@@ -693,7 +693,7 @@ func (h *shellCallHandler) parseArgumentValues(
 
 	// no further processing needed
 	if len(newArgs) == 0 {
-		return values, nil
+		return h.defaultWorkspaceArgs(ctx, fn, values)
 	}
 
 	flags := pflag.NewFlagSet(fn.CmdName(), pflag.ContinueOnError)
@@ -810,6 +810,32 @@ func (h *shellCallHandler) parseArgumentValues(
 		values[val.flag] = val.value
 	}
 
+	return h.defaultWorkspaceArgs(ctx, fn, values)
+}
+
+// defaultWorkspaceArgs fills any Workspace argument the caller left unset with
+// the session's current workspace, matching what selectFunc does for
+// `dagger call`. Without it a required Workspace would be a mandatory
+// positional here (see IsCallerRequired) and the two would disagree about
+// whether a workspace is something you have to supply.
+func (h *shellCallHandler) defaultWorkspaceArgs(
+	ctx context.Context,
+	fn *modFunction,
+	values map[string]any,
+) (map[string]any, error) {
+	for _, arg := range fn.Args {
+		if !arg.IsWorkspace() || !arg.IsRequired() {
+			continue
+		}
+		if _, ok := values[arg.Name]; ok {
+			continue
+		}
+		wsID, err := h.dag.CurrentWorkspace().ID(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolve current workspace for %q: %w", fn.CmdName(), err)
+		}
+		values[arg.Name] = wsID
+	}
 	return values, nil
 }
 


### PR DESCRIPTION
Follows #13845, which made `currentModule.asSDK`'s workspace argument required. This does the same for module functions.

## Problem

Workspace arguments on module functions were published as nullable no matter how they were declared, because the engine injects one when the caller leaves it unset (`core/typedef.go`, plus two spots in `core/schema/module.go`). So a function declaring `ws: Workspace!` advertised an optional argument — the same lie `asSDK` told before #13845.

The modules already declare the truth. The Go SDK registers a plain `ws *dagger.Workspace` with no `.WithOptional(true)`, unlike a `// +optional` arg next to it:

```go
// .dagger/modules/engine-dev/dagger.gen.go
WithArg("ws", dag.TypeDef().WithObject("Workspace"), ...).
WithArg("clientDockerConfig", dag.TypeDef().WithObject("Secret").WithOptional(true), ...).
```

The engine was overriding that. This stops the override.

## Why the callers had to change

The injection can't rescue a required argument. dagql rejects a missing non-null argument in `preselect` (`dagql/objects.go`) *before* it runs the `GetDynamicInput` hook that fills workspace args in. So everything that relied on injection for a required arg now puts it on the selector, resolving it the way `loadWorkspaceArg` does — the workspace an enclosing group bound into the context, else the session's ambient one, and never inherited across a module function boundary.

- **generators, checks, up** — all funnel through `ModTreeNode.DagqlValue`, so they're covered in one place, for the root constructor as well as the leaf function.
- **scale-out** — needs no query change. It selects `Module.generator(name:)`, which binds no workspace, so it lands on the ambient fallback, which is what it relied on before.
- **LLM tools** — `buildObjectMethodSelector` fills a required Workspace from the LLM's bound workspace.
- **`dagger call`** — defaults it to `currentWorkspace`. `--ws` is still registered, via a new `workspaceValue` that resolves an address the way `--dir` does, so a caller can aim a function at a different workspace. It just never gets `MarkFlagRequired`, which would otherwise reject the call before the default could be filled in.

An argument declared *optional* is unaffected: it stays nullable and keeps its injection. That's why `TestRuntimeDependencyDoesNotInheritWorkspace` is untouched — its fixture declares `// +optional`, so the #13229 isolation behavior and error message are unchanged.

## No codegen

Deliberately none. Both edited files are on the module-runtime path, not the core schema: `FunctionSpec` builds the dagql `FieldSpec` for a module's functions at load time, and the `core/schema/module.go` blocks were inside the `functionArg`/`internalFunctionArg` resolvers, mutating the value they return rather than the schema shape. `schema.graphqls`, the SDK clients, the reference docs and the vendored toolchain clients are all unchanged, and module `dagger.gen.go` files would regenerate byte-identical.

## Draft: not yet run

Compiles and vets clean for linux, and the integration test typechecks — but nothing here has executed. `core` and `core/integration` can't build natively on darwin (`engine/engineutil` uses linux-only syscalls), so this needs a dev engine run before it's reviewable. The generators/checks/up threading and the `dagger call` default-fill are the paths to exercise first.

Changie entry still to add.