### PR TITLE
Revert "engine/server: scope Dang telemetry flush to the call"

### DIFF
--- a/core/query.go
+++ b/core/query.go
@@ -172,8 +172,8 @@ type Server interface {
 	// resolve operator-managed volumes at exec time.
 	EngineVolumeState() EngineVolumeState
 
-	// Flush telemetry for the calling client and any clients nested beneath it.
-	FlushCallTelemetry(ctx context.Context) error
+	// Flush telemetry for all clients in the current session.
+	FlushSessionTelemetry(ctx context.Context) error
 
 	// SessionScopedContext returns a context that lives for the remainder of
 	// the current client's session: it is detached from the given context's

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -142,7 +142,7 @@ func (s *currentTypeDefsTestServer) EngineVolumeState() core.EngineVolumeState {
 	return core.EngineVolumeState{}
 }
 
-func (s *currentTypeDefsTestServer) FlushCallTelemetry(context.Context) error {
+func (s *currentTypeDefsTestServer) FlushSessionTelemetry(context.Context) error {
 	return nil
 }
 

--- a/core/sdk/dang/v1/helpers.go
+++ b/core/sdk/dang/v1/helpers.go
@@ -53,7 +53,7 @@ func (r *runtime) eval(
 			return nil, err
 		}
 
-		if flushErr := query.Server.FlushCallTelemetry(ctx); flushErr != nil {
+		if flushErr := query.Server.FlushSessionTelemetry(ctx); flushErr != nil {
 			slog.Debug("failed to flush telemetry after Dang eval", "error", flushErr)
 		}
 

--- a/core/sdk/dang/v2/helpers.go
+++ b/core/sdk/dang/v2/helpers.go
@@ -70,7 +70,7 @@ func (r *runtime) eval(
 			return nil, err
 		}
 
-		if flushErr := query.Server.FlushCallTelemetry(ctx); flushErr != nil {
+		if flushErr := query.Server.FlushSessionTelemetry(ctx); flushErr != nil {
 			slog.Debug("failed to flush telemetry after Dang eval", "error", flushErr)
 		}
 

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -178,7 +178,7 @@ func (ms *mockServer) SnapshotManager() bkcache.SnapshotManager        { return 
 func (ms *mockServer) Locker() *locker.Locker                          { return nil }
 func (ms *mockServer) SecretSalt() []byte                              { return nil }
 func (ms *mockServer) EngineVolumeState() EngineVolumeState            { return EngineVolumeState{} }
-func (ms *mockServer) FlushCallTelemetry(context.Context) error        { return nil }
+func (ms *mockServer) FlushSessionTelemetry(context.Context) error     { return nil }
 func (ms *mockServer) SessionScopedContext(ctx context.Context) (context.Context, error) {
 	return context.WithoutCancel(ctx), nil
 }

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -433,6 +433,9 @@ func (sess *daggerSession) StoreTelemetrySeenKey(key string) {
 var inflightSessionTelemetryFlushes atomic.Int64
 
 func (sess *daggerSession) FlushTelemetry(ctx context.Context, reason string) error {
+	inflight := inflightSessionTelemetryFlushes.Add(1)
+	defer inflightSessionTelemetryFlushes.Add(-1)
+
 	sess.clientMu.Lock()
 	clients := make([]*daggerClient, 0, len(sess.clients))
 	for _, client := range sess.clients {
@@ -440,53 +443,8 @@ func (sess *daggerSession) FlushTelemetry(ctx context.Context, reason string) er
 	}
 	sess.clientMu.Unlock()
 
-	return sess.flushClientsTelemetry(ctx, clients, "session", reason)
-}
-
-// FlushSubtreeTelemetry flushes root and every client nested beneath it,
-// leaving the rest of the session alone.
-//
-// Exports already fan out to the emitting client and all of its ancestors (see
-// exportSpans and friends), so anything a descendant still has buffered lands
-// in root's providers once that descendant flushes. Clients elsewhere in the
-// session cannot hold telemetry produced beneath root, so flushing them is
-// pure overhead: each provider flush allocates a full-capacity record buffer
-// regardless of how much is queued.
-func (sess *daggerSession) FlushSubtreeTelemetry(ctx context.Context, root *daggerClient, reason string) error {
-	return sess.flushClientsTelemetry(ctx, sess.subtreeClients(root), "subtree", reason)
-}
-
-// subtreeClients returns root along with every client in the session nested
-// beneath it, at any depth. A client's parents hold its full ancestry, so
-// membership is a single containment check.
-func (sess *daggerSession) subtreeClients(root *daggerClient) []*daggerClient {
-	sess.clientMu.RLock()
-	defer sess.clientMu.RUnlock()
-
-	clients := []*daggerClient{root}
-	for _, client := range sess.clients {
-		if client != root && slices.Contains(client.parents, root) {
-			clients = append(clients, client)
-		}
-	}
-	return clients
-}
-
-// flushClientsTelemetry force flushes the given clients' telemetry providers
-// concurrently. scope describes how the client set was chosen, so a wide
-// session-wide flush can be told apart from a narrow subtree flush in logs.
-func (sess *daggerSession) flushClientsTelemetry(
-	ctx context.Context,
-	clients []*daggerClient,
-	scope string,
-	reason string,
-) error {
-	inflight := inflightSessionTelemetryFlushes.Add(1)
-	defer inflightSessionTelemetryFlushes.Add(-1)
-
 	lg := slog.With(
 		"sessionID", sess.sessionID,
-		"scope", scope,
 		"reason", reason,
 		"clients", len(clients),
 		"inflightSessionFlushes", inflight)
@@ -2856,15 +2814,13 @@ func (srv *Server) SecretSalt() []byte {
 	return srv.secretSalt
 }
 
-// FlushCallTelemetry flushes telemetry for the calling client and any clients
-// nested beneath it, so telemetry emitted while serving the current call is
-// durable before that call returns.
-func (srv *Server) FlushCallTelemetry(ctx context.Context) error {
+// Provides access to the client's telemetry database.
+func (srv *Server) FlushSessionTelemetry(ctx context.Context) error {
 	client, err := srv.clientFromContext(ctx)
 	if err != nil {
 		return err
 	}
-	return client.daggerSession.FlushSubtreeTelemetry(ctx, client, "FlushCallTelemetry API")
+	return client.daggerSession.FlushTelemetry(ctx, "FlushSessionTelemetry API")
 }
 
 func (srv *Server) ClientTelemetry(ctx context.Context, sessID, clientID string) (*clientdb.DB, error) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -2230,70 +2229,4 @@ func sessionTestModuleResult(t *testing.T, name string) dagql.ObjectResult[*core
 	)
 	require.NoError(t, err)
 	return res
-}
-
-// TestSubtreeClientsSelectsOnlyNestedClients pins the scoping of a call-level
-// telemetry flush: a Dang eval flushes what it produced, not the whole session.
-// Sibling clients accumulate for the lifetime of a session, so including them
-// makes each flush cost grow with session age.
-func TestSubtreeClientsSelectsOnlyNestedClients(t *testing.T) {
-	t.Parallel()
-
-	root := &daggerClient{clientID: "root"}
-	caller := &daggerClient{clientID: "caller", parents: []*daggerClient{root}}
-	child := &daggerClient{clientID: "child", parents: []*daggerClient{root, caller}}
-	grandchild := &daggerClient{
-		clientID: "grandchild",
-		parents:  []*daggerClient{root, caller, child},
-	}
-	sibling := &daggerClient{clientID: "sibling", parents: []*daggerClient{root}}
-
-	sess := &daggerSession{clients: map[string]*daggerClient{}}
-	for _, client := range []*daggerClient{root, caller, child, grandchild, sibling} {
-		sess.clients[client.clientID] = client
-	}
-
-	ids := func(clients []*daggerClient) []string {
-		out := make([]string, 0, len(clients))
-		for _, client := range clients {
-			out = append(out, client.clientID)
-		}
-		sort.Strings(out)
-		return out
-	}
-
-	// The caller flushes itself and everything nested beneath it, at any depth.
-	require.Equal(t,
-		[]string{"caller", "child", "grandchild"},
-		ids(sess.subtreeClients(caller)))
-
-	// A leaf flushes only itself, even with siblings present.
-	require.Equal(t, []string{"grandchild"}, ids(sess.subtreeClients(grandchild)))
-
-	// The root still covers the whole session when it is the one calling.
-	require.Equal(t,
-		[]string{"caller", "child", "grandchild", "root", "sibling"},
-		ids(sess.subtreeClients(root)))
-}
-
-// TestSubtreeClientsIgnoresUnrelatedSiblings is the regression this scoping
-// exists for: a session that has accumulated many sibling clients must not turn
-// a single call's flush into a session-wide fan-out.
-func TestSubtreeClientsIgnoresUnrelatedSiblings(t *testing.T) {
-	t.Parallel()
-
-	root := &daggerClient{clientID: "root"}
-	sess := &daggerSession{clients: map[string]*daggerClient{"root": root}}
-
-	caller := &daggerClient{clientID: "caller", parents: []*daggerClient{root}}
-	sess.clients[caller.clientID] = caller
-	for i := range 500 {
-		sibling := &daggerClient{
-			clientID: fmt.Sprintf("sibling-%d", i),
-			parents:  []*daggerClient{root},
-		}
-		sess.clients[sibling.clientID] = sibling
-	}
-
-	require.Len(t, sess.subtreeClients(caller), 1)
 }


### PR DESCRIPTION
Reverts dagger/dagger#13841

Guessing this is the cause for this type of flake:

https://dagger.cloud/dagger/checks/github.com/dagger/dagger@29da3f3ddb3ed88f793803de7a6524670c293c10?check=test-split:test-workspaces&listen=119801227345c049&run=fb66f5dd-37e4-4ba2-b230-68eaf2f9d810&test=TestWorkspaceAPI/TestWorkspacePathSafety/parent-directory_traversal_is_rejected/directory_traversal&viewMode=tests