### PR TITLE
workspace: add native polyfill replacements

### DIFF
--- a/core/integration/contextual_workspace_test.go
+++ b/core/integration/contextual_workspace_test.go
@@ -299,3 +299,21 @@ func (ContextualWorkspaceSuite) TestContextualWorkspaceCLIExposure(ctx context.C
 		require.NotContains(t, help, "--source")
 	})
 }
+
+// TestContextualWorkspaceModuleSourceLocalDeps is the regression test for
+// https://github.com/dagger/dagger/issues/13139: loading a module that has a
+// local dependency from module code used to fail while resolving the
+// dependency — user-defaults loading ran the outer .env find-up against the
+// caller's host with the module's client metadata, which can only time out
+// ("failed to get requester session: context deadline exceeded"). The
+// outerEnvFile module-context guard fixed it; this pins the repro from the
+// issue: a module loading a sibling module that depends on "../dep".
+func (ContextualWorkspaceSuite) TestContextualWorkspaceModuleSourceLocalDeps(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	out, err := workspaceFixture(t, c, "module-source-local-deps").
+		With(daggerReportCall("direct")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "main", strings.TrimSpace(out))
+}

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -21,6 +21,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/testctx"
 )
 
@@ -163,6 +164,32 @@ func (ModuleConfigSuite) TestConfigs(ctx context.Context, t *testctx.T) {
 			})
 		})
 	})
+}
+
+// TestEngineVersionLatestPinsOnConfigWrite verifies that "latest" is accepted
+// as input but config writes resolve it to the current concrete version.
+func (ModuleConfigSuite) TestEngineVersionLatestPinsOnConfigWrite(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	moduleSource := func(engineVersion string) *dagger.ModuleSource {
+		return c.Directory().
+			WithNewFile("dagger.json", fmt.Sprintf(`{"name":"foo","engineVersion":%q,"sdk":{"source":"dang"}}`, engineVersion)).
+			WithNewFile("main.dang", "type Foo {\n  pub hello: String! {\n    \"hi\"\n  }\n}\n").
+			AsModuleSource()
+	}
+
+	writtenEngineVersion := func(ctx context.Context, t *testctx.T, src *dagger.ModuleSource) string {
+		t.Helper()
+		contents, err := src.GeneratedContextChangeset().Layer().File("dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		var modCfg modules.ModuleConfig
+		require.NoError(t, json.Unmarshal([]byte(contents), &modCfg))
+		return modCfg.EngineVersion
+	}
+
+	want := engine.NormalizeVersion(engine.Version)
+	require.Equal(t, want, writtenEngineVersion(ctx, t, moduleSource("latest").WithName("bar")))
+	require.Equal(t, want, writtenEngineVersion(ctx, t, moduleSource("v1.0.0").WithEngineVersion("latest")))
 }
 
 func (ModuleConfigSuite) TestCustomDepNames(ctx context.Context, t *testctx.T) {
@@ -949,47 +976,4 @@ func (ModuleConfigSuite) TestDepPins(ctx context.Context, t *testctx.T) {
 	out, err := ctr.With(daggerExec("call", "hello")).Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "VERSION 2")
-}
-
-// TestEngineVersionLatestStaysFloating covers the floating "latest"
-// engineVersion surviving config edits. A dagger.json can declare
-// "engineVersion": "latest" — module init writes exactly that — and the
-// engine resolves it to the newest version on every load. Config edits used
-// to serialize the resolved version back, silently pinning a config that
-// asked to float; now the declared form round-trips.
-func (ModuleConfigSuite) TestEngineVersionLatestStaysFloating(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
-
-	moduleSource := func(engineVersion string) *dagger.ModuleSource {
-		return c.Directory().
-			WithNewFile("dagger.json", fmt.Sprintf(`{"name":"foo","engineVersion":%q,"sdk":{"source":"dang"}}`, engineVersion)).
-			WithNewFile("main.dang", "type Foo {\n  pub hello: String! {\n    \"hi\"\n  }\n}\n").
-			AsModuleSource()
-	}
-
-	// generatedEngineVersion reads the engineVersion that a config edit
-	// writes back, from the dagger.json in the generated context.
-	generatedEngineVersion := func(ctx context.Context, t *testctx.T, src *dagger.ModuleSource) string {
-		t.Helper()
-		contents, err := src.GeneratedContextChangeset().Layer().File("dagger.json").Contents(ctx)
-		require.NoError(t, err)
-		var modCfg modules.ModuleConfig
-		require.NoError(t, json.Unmarshal([]byte(contents), &modCfg))
-		return modCfg.EngineVersion
-	}
-
-	t.Run("an unrelated edit does not pin a floating config", func(ctx context.Context, t *testctx.T) {
-		src := moduleSource("latest").WithName("bar")
-		require.Equal(t, "latest", generatedEngineVersion(ctx, t, src))
-	})
-
-	t.Run("withEngineVersion latest floats a pinned config", func(ctx context.Context, t *testctx.T) {
-		src := moduleSource("v1.0.0").WithEngineVersion("latest")
-		require.Equal(t, "latest", generatedEngineVersion(ctx, t, src))
-	})
-
-	t.Run("withEngineVersion pins a floating config", func(ctx context.Context, t *testctx.T) {
-		src := moduleSource("latest").WithEngineVersion("v1.0.0")
-		require.Equal(t, "v1.0.0", generatedEngineVersion(ctx, t, src))
-	})
 }

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -950,3 +950,46 @@ func (ModuleConfigSuite) TestDepPins(ctx context.Context, t *testctx.T) {
 	require.NoError(t, err)
 	require.Contains(t, out, "VERSION 2")
 }
+
+// TestEngineVersionLatestStaysFloating covers the floating "latest"
+// engineVersion surviving config edits. A dagger.json can declare
+// "engineVersion": "latest" — module init writes exactly that — and the
+// engine resolves it to the newest version on every load. Config edits used
+// to serialize the resolved version back, silently pinning a config that
+// asked to float; now the declared form round-trips.
+func (ModuleConfigSuite) TestEngineVersionLatestStaysFloating(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	moduleSource := func(engineVersion string) *dagger.ModuleSource {
+		return c.Directory().
+			WithNewFile("dagger.json", fmt.Sprintf(`{"name":"foo","engineVersion":%q,"sdk":{"source":"dang"}}`, engineVersion)).
+			WithNewFile("main.dang", "type Foo {\n  pub hello: String! {\n    \"hi\"\n  }\n}\n").
+			AsModuleSource()
+	}
+
+	// generatedEngineVersion reads the engineVersion that a config edit
+	// writes back, from the dagger.json in the generated context.
+	generatedEngineVersion := func(ctx context.Context, t *testctx.T, src *dagger.ModuleSource) string {
+		t.Helper()
+		contents, err := src.GeneratedContextChangeset().Layer().File("dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		var modCfg modules.ModuleConfig
+		require.NoError(t, json.Unmarshal([]byte(contents), &modCfg))
+		return modCfg.EngineVersion
+	}
+
+	t.Run("an unrelated edit does not pin a floating config", func(ctx context.Context, t *testctx.T) {
+		src := moduleSource("latest").WithName("bar")
+		require.Equal(t, "latest", generatedEngineVersion(ctx, t, src))
+	})
+
+	t.Run("withEngineVersion latest floats a pinned config", func(ctx context.Context, t *testctx.T) {
+		src := moduleSource("v1.0.0").WithEngineVersion("latest")
+		require.Equal(t, "latest", generatedEngineVersion(ctx, t, src))
+	})
+
+	t.Run("withEngineVersion pins a floating config", func(ctx context.Context, t *testctx.T) {
+		src := moduleSource("latest").WithEngineVersion("v1.0.0")
+		require.Equal(t, "v1.0.0", generatedEngineVersion(ctx, t, src))
+	})
+}

--- a/core/integration/testdata/workspaces/module-source-local-deps/.dagger/modules/repro/dagger.json
+++ b/core/integration/testdata/workspaces/module-source-local-deps/.dagger/modules/repro/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "repro",
+  "engineVersion": "v1.0.0",
+  "sdk": {
+    "source": "dang"
+  }
+}

--- a/core/integration/testdata/workspaces/module-source-local-deps/.dagger/modules/repro/main.dang
+++ b/core/integration/testdata/workspaces/module-source-local-deps/.dagger/modules/repro/main.dang
@@ -1,0 +1,12 @@
+type Repro {
+  """
+  Load the main module, which depends on ../dep, from module code.
+  """
+  pub direct(ws: Workspace!): String! {
+    ws
+      .directory("/", include: ["main/**", "dep/**"])
+      .asModuleSource(sourceRootPath: "main")
+      .sync
+      .sourceRootSubpath
+  }
+}

--- a/core/integration/testdata/workspaces/module-source-local-deps/dagger.toml
+++ b/core/integration/testdata/workspaces/module-source-local-deps/dagger.toml
@@ -1,0 +1,3 @@
+[modules.repro]
+source = ".dagger/modules/repro"
+entrypoint = true

--- a/core/integration/testdata/workspaces/module-source-local-deps/dep/dagger.json
+++ b/core/integration/testdata/workspaces/module-source-local-deps/dep/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "dep",
+  "engineVersion": "v1.0.0",
+  "sdk": {
+    "source": "dang"
+  }
+}

--- a/core/integration/testdata/workspaces/module-source-local-deps/dep/main.dang
+++ b/core/integration/testdata/workspaces/module-source-local-deps/dep/main.dang
@@ -1,0 +1,5 @@
+type Dep {
+  pub hello: String! {
+    "hello from dep"
+  }
+}

--- a/core/integration/testdata/workspaces/module-source-local-deps/main/dagger.json
+++ b/core/integration/testdata/workspaces/module-source-local-deps/main/dagger.json
@@ -1,0 +1,13 @@
+{
+  "name": "main",
+  "engineVersion": "v1.0.0",
+  "sdk": {
+    "source": "dang"
+  },
+  "dependencies": [
+    {
+      "name": "dep",
+      "source": "../dep"
+    }
+  ]
+}

--- a/core/integration/testdata/workspaces/module-source-local-deps/main/main.dang
+++ b/core/integration/testdata/workspaces/module-source-local-deps/main/main.dang
@@ -1,0 +1,5 @@
+type Main {
+  pub hello: String! {
+    "hello from main"
+  }
+}

--- a/core/integration/workspace_find_roots_test.go
+++ b/core/integration/workspace_find_roots_test.go
@@ -1,0 +1,168 @@
+package core
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests define the Workspace.findRoots contract: cwd-aware project-root
+// discovery from an explicit start path.
+//
+// Config files are named deno.json, not dagger.json, so the fixtures are not
+// mistaken for real modules.
+
+func findRootsSource(c *dagger.Client) *dagger.Directory {
+	return c.Directory().
+		WithNewFile("deno.json", "{}").
+		WithNewFile("dir/coucou.txt", "x").
+		WithNewFile("sub/deno.json", "{}").
+		WithNewFile("sub/dir/sub/deno.json", "{}").
+		WithNewFile("sub/toto/a.txt", "x")
+}
+
+// TestWorkspaceFindRootsWalkDown asserts that from the workspace root the
+// walk-down finds every directory holding a config file, and the find-up does
+// not duplicate the cwd.
+func (WorkspaceSuite) TestWorkspaceFindRootsWalkDown(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := findRootsSource(c).AsWorkspace()
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{".", "sub", "sub/dir/sub"}, dirs)
+}
+
+// TestWorkspaceFindRootsSubdir asserts that results are cwd-relative and
+// scoped: from a project subdirectory, the cwd's own project and the ones
+// beneath it are returned, and the workspace-root project is not.
+func (WorkspaceSuite) TestWorkspaceFindRootsSubdir(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := findRootsSource(c).AsWorkspace(dagger.DirectoryAsWorkspaceOpts{
+		Cwd: "/sub",
+	})
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{".", "dir/sub"}, dirs)
+}
+
+// TestWorkspaceFindRootsStart scopes discovery below an explicit path while
+// keeping results relative to the workspace cwd.
+func (WorkspaceSuite) TestWorkspaceFindRootsStart(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := findRootsSource(c).AsWorkspace()
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json"}, dagger.WorkspaceFindRootsOpts{
+		Start: "sub",
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"sub", "sub/dir/sub"}, dirs)
+}
+
+// TestWorkspaceFindRootsAncestor asserts that when the cwd holds no
+// config, the nearest enclosing project is returned as a ".."-prefixed path
+// that resolves through other workspace APIs unchanged.
+func (WorkspaceSuite) TestWorkspaceFindRootsAncestor(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := findRootsSource(c).AsWorkspace(dagger.DirectoryAsWorkspaceOpts{
+		Cwd: "/dir",
+	})
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json"})
+	require.NoError(t, err)
+	require.Equal(t, []string{".."}, dirs)
+
+	contents, err := ws.Directory("..").File("deno.json").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "{}", contents)
+}
+
+// TestWorkspaceFindRootsExclude asserts that exclude globs prune the
+// walk-down, and that without them vendored hits appear.
+func (WorkspaceSuite) TestWorkspaceFindRootsExclude(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := findRootsSource(c).
+		WithNewFile("sub/node_modules/pkg/deno.json", "{}").
+		AsWorkspace()
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json"})
+	require.NoError(t, err)
+	require.Contains(t, dirs, "sub/node_modules/pkg")
+
+	dirs, err = ws.FindRoots(ctx, []string{"deno.json"}, dagger.WorkspaceFindRootsOpts{
+		Exclude: []string{"**/node_modules/**"},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{".", "sub", "sub/dir/sub"}, dirs)
+}
+
+// TestWorkspaceFindRootsMultipleMarkers asserts that any of the given
+// filenames matches, and a directory holding several of them is returned once.
+func (WorkspaceSuite) TestWorkspaceFindRootsMultipleMarkers(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := c.Directory().
+		WithNewFile("deno.json", "{}").
+		WithNewFile("deno.jsonc", "{}").
+		WithNewFile("a/deno.jsonc", "{}").
+		AsWorkspace()
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json", "deno.jsonc"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{".", "a"}, dirs)
+}
+
+// TestWorkspaceFindRootsNearestMixedMarker asserts that the nearest
+// enclosing project wins across filenames: a farther-up project never shadows
+// a closer one written with a different filename.
+func (WorkspaceSuite) TestWorkspaceFindRootsNearestMixedMarker(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := c.Directory().
+		WithNewFile("deno.json", "{}").
+		WithNewFile("a/deno.jsonc", "{}").
+		WithNewFile("a/b/keep.txt", "x").
+		AsWorkspace(dagger.DirectoryAsWorkspaceOpts{
+			Cwd: "/a/b",
+		})
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json", "deno.jsonc"})
+	require.NoError(t, err)
+	require.Equal(t, []string{".."}, dirs)
+}
+
+// TestWorkspaceFindRootsCwdShadowsAncestor asserts that a marker in the
+// cwd itself suppresses the find-up entirely, even when the ancestor's config
+// uses a different filename: the walk-down already covers the cwd.
+func (WorkspaceSuite) TestWorkspaceFindRootsCwdShadowsAncestor(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := c.Directory().
+		WithNewFile("deno.json", "{}").
+		WithNewFile("sub/deno.jsonc", "{}").
+		AsWorkspace(dagger.DirectoryAsWorkspaceOpts{
+			Cwd: "/sub",
+		})
+
+	dirs, err := ws.FindRoots(ctx, []string{"deno.json", "deno.jsonc"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"."}, dirs)
+}
+
+// TestWorkspaceFindRootsValidatesMarkers asserts that markers are
+// required and must be basenames: a slash or parent segment would turn a name
+// match into path traversal.
+func (WorkspaceSuite) TestWorkspaceFindRootsValidatesMarkers(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	ws := findRootsSource(c).AsWorkspace()
+
+	_, err := ws.FindRoots(ctx, []string{})
+	require.ErrorContains(t, err, "at least one marker")
+
+	for _, name := range []string{"", ".", "..", "sub/deno.json", `sub\deno.json`} {
+		t.Run(name, func(ctx context.Context, t *testctx.T) {
+			_, err := ws.FindRoots(ctx, []string{name})
+			require.Error(t, err)
+		})
+	}
+}

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -18,6 +18,7 @@ import (
 
 	"dagger.io/dagger"
 	workspacecfg "github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -49,8 +50,9 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *
 		require.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
 			"module directory mode: got %#o, want %#o", info.Mode().Perm(), os.FileMode(0o755))
 
-		_, err = os.Stat(filepath.Join(workdir, "editor", workspacecfg.ModuleConfigFileName))
+		config, err := os.ReadFile(filepath.Join(workdir, "editor", workspacecfg.ModuleConfigFileName))
 		require.NoError(t, err, "engine-authored module config should be preserved")
+		require.Contains(t, string(config), fmt.Sprintf("engineVersion = %q", engine.Version))
 		_, err = os.Stat(filepath.Join(workdir, "editor", "main.dang"))
 		require.NoError(t, err, "SDK-authored starter source should be preserved")
 	})

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -176,17 +176,11 @@ func (src *ModuleSource) SelfCallsEnabled() bool {
 }
 
 type ModuleSource struct {
-	ConfigExists       bool `field:"true" name:"configExists" doc:"Whether an existing module config file was found."`
-	ConfigFilename     string
-	ModuleName         string `field:"true" name:"moduleName" doc:"The name of the module, including any setting via the withName API."`
-	ModuleOriginalName string `field:"true" name:"moduleOriginalName" doc:"The original name of the module as read from the module config file (or set for the first time with the withName API)."`
-	EngineVersion      string `field:"true" name:"engineVersion" doc:"The engine version of the module."`
-	// ConfigEngineVersion is the engine version as declared in the module
-	// config — possibly the floating "latest". EngineVersion always holds
-	// the resolved version that drives behavior; this one is what config
-	// edits write back, so a config that says "latest" stays floating
-	// instead of getting silently pinned on the next edit.
-	ConfigEngineVersion           string
+	ConfigExists                  bool `field:"true" name:"configExists" doc:"Whether an existing module config file was found."`
+	ConfigFilename                string
+	ModuleName                    string `field:"true" name:"moduleName" doc:"The name of the module, including any setting via the withName API."`
+	ModuleOriginalName            string `field:"true" name:"moduleOriginalName" doc:"The original name of the module as read from the module config file (or set for the first time with the withName API)."`
+	EngineVersion                 string `field:"true" name:"engineVersion" doc:"The engine version of the module."`
 	CodegenConfig                 *modules.ModuleCodegenConfig
 	ModuleConfigUserFields        modules.ModuleConfigUserFields
 	DisableDefaultFunctionCaching bool
@@ -455,7 +449,6 @@ type persistedModuleSourcePayload struct {
 	ModuleName                      string                                `json:"moduleName,omitempty"`
 	ModuleOriginalName              string                                `json:"moduleOriginalName,omitempty"`
 	EngineVersion                   string                                `json:"engineVersion,omitempty"`
-	ConfigEngineVersion             string                                `json:"configEngineVersion,omitempty"`
 	CodegenConfig                   *modules.ModuleCodegenConfig          `json:"codegenConfig,omitempty"`
 	ModuleConfigUserFields          modules.ModuleConfigUserFields        `json:"moduleConfigUserFields,omitempty"`
 	DisableDefaultFunctionCaching   bool                                  `json:"disableDefaultFunctionCaching,omitempty"`
@@ -778,7 +771,6 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		ModuleName:                    src.ModuleName,
 		ModuleOriginalName:            src.ModuleOriginalName,
 		EngineVersion:                 src.EngineVersion,
-		ConfigEngineVersion:           src.ConfigEngineVersion,
 		CodegenConfig:                 src.CodegenConfig,
 		ModuleConfigUserFields:        src.ModuleConfigUserFields,
 		DisableDefaultFunctionCaching: src.DisableDefaultFunctionCaching,
@@ -927,7 +919,6 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 		ModuleName:                    persisted.ModuleName,
 		ModuleOriginalName:            persisted.ModuleOriginalName,
 		EngineVersion:                 persisted.EngineVersion,
-		ConfigEngineVersion:           persisted.ConfigEngineVersion,
 		CodegenConfig:                 persisted.CodegenConfig,
 		ModuleConfigUserFields:        persisted.ModuleConfigUserFields,
 		DisableDefaultFunctionCaching: persisted.DisableDefaultFunctionCaching,

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -176,11 +176,11 @@ func (src *ModuleSource) SelfCallsEnabled() bool {
 }
 
 type ModuleSource struct {
-	ConfigExists                  bool `field:"true" name:"configExists" doc:"Whether an existing module config file was found."`
-	ConfigFilename                string
-	ModuleName                    string `field:"true" name:"moduleName" doc:"The name of the module, including any setting via the withName API."`
-	ModuleOriginalName            string `field:"true" name:"moduleOriginalName" doc:"The original name of the module as read from the module config file (or set for the first time with the withName API)."`
-	EngineVersion                 string `field:"true" name:"engineVersion" doc:"The engine version of the module."`
+	ConfigExists       bool `field:"true" name:"configExists" doc:"Whether an existing module config file was found."`
+	ConfigFilename     string
+	ModuleName         string `field:"true" name:"moduleName" doc:"The name of the module, including any setting via the withName API."`
+	ModuleOriginalName string `field:"true" name:"moduleOriginalName" doc:"The original name of the module as read from the module config file (or set for the first time with the withName API)."`
+	EngineVersion      string `field:"true" name:"engineVersion" doc:"The engine version of the module."`
 	// ConfigEngineVersion is the engine version as declared in the module
 	// config — possibly the floating "latest". EngineVersion always holds
 	// the resolved version that drives behavior; this one is what config

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -181,6 +181,12 @@ type ModuleSource struct {
 	ModuleName                    string `field:"true" name:"moduleName" doc:"The name of the module, including any setting via the withName API."`
 	ModuleOriginalName            string `field:"true" name:"moduleOriginalName" doc:"The original name of the module as read from the module config file (or set for the first time with the withName API)."`
 	EngineVersion                 string `field:"true" name:"engineVersion" doc:"The engine version of the module."`
+	// ConfigEngineVersion is the engine version as declared in the module
+	// config — possibly the floating "latest". EngineVersion always holds
+	// the resolved version that drives behavior; this one is what config
+	// edits write back, so a config that says "latest" stays floating
+	// instead of getting silently pinned on the next edit.
+	ConfigEngineVersion           string
 	CodegenConfig                 *modules.ModuleCodegenConfig
 	ModuleConfigUserFields        modules.ModuleConfigUserFields
 	DisableDefaultFunctionCaching bool
@@ -449,6 +455,7 @@ type persistedModuleSourcePayload struct {
 	ModuleName                      string                                `json:"moduleName,omitempty"`
 	ModuleOriginalName              string                                `json:"moduleOriginalName,omitempty"`
 	EngineVersion                   string                                `json:"engineVersion,omitempty"`
+	ConfigEngineVersion             string                                `json:"configEngineVersion,omitempty"`
 	CodegenConfig                   *modules.ModuleCodegenConfig          `json:"codegenConfig,omitempty"`
 	ModuleConfigUserFields          modules.ModuleConfigUserFields        `json:"moduleConfigUserFields,omitempty"`
 	DisableDefaultFunctionCaching   bool                                  `json:"disableDefaultFunctionCaching,omitempty"`
@@ -771,6 +778,7 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		ModuleName:                    src.ModuleName,
 		ModuleOriginalName:            src.ModuleOriginalName,
 		EngineVersion:                 src.EngineVersion,
+		ConfigEngineVersion:           src.ConfigEngineVersion,
 		CodegenConfig:                 src.CodegenConfig,
 		ModuleConfigUserFields:        src.ModuleConfigUserFields,
 		DisableDefaultFunctionCaching: src.DisableDefaultFunctionCaching,
@@ -919,6 +927,7 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 		ModuleName:                    persisted.ModuleName,
 		ModuleOriginalName:            persisted.ModuleOriginalName,
 		EngineVersion:                 persisted.EngineVersion,
+		ConfigEngineVersion:           persisted.ConfigEngineVersion,
 		CodegenConfig:                 persisted.CodegenConfig,
 		ModuleConfigUserFields:        persisted.ModuleConfigUserFields,
 		DisableDefaultFunctionCaching: persisted.DisableDefaultFunctionCaching,

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -456,7 +456,7 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 	dagql.Fields[*core.CurrentModuleAsSDK]{
 		dagql.Func("modules", s.currentModuleAsSDKModules).
 			View(AfterVersion("v1.0.0-0")).
-			Doc(`The workspace-local modules this SDK authors and manages.`),
+			Doc(`The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.`),
 		dagql.Func("clients", s.currentModuleAsSDKClients).
 			View(AfterVersion("v1.0.0-0")).
 			Doc(`The generated clients this SDK produces in the workspace.`),

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
@@ -63,6 +65,7 @@ func (s *moduleSchema) currentModuleAsSDK(
 	for _, mod := range entry.AsSDK.Modules {
 		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{Path: mod.Path})
 	}
+	result.Modules = currentModuleAsSDKModulesInScopeForCwd(result.Modules, ws.Cwd)
 	for _, client := range entry.AsSDK.Clients {
 		result.Clients = append(result.Clients, &core.CurrentModuleAsSDKClient{
 			Path:           client.Path,
@@ -95,6 +98,53 @@ func (s *moduleSchema) currentModuleAsSDKModules(
 	_ struct{},
 ) ([]*core.CurrentModuleAsSDKModule, error) {
 	return parent.Modules, nil
+}
+
+// currentModuleAsSDKModulesInScopeForCwd applies the same cwd selection policy
+// SDKs previously reconstructed with polyfill.findConfigDirs: all registered
+// modules at or below cwd, and, when cwd itself is not registered, the nearest
+// enclosing registered module. Results are the nearest ancestor first followed
+// by descendants in workspace-config order.
+func currentModuleAsSDKModulesInScopeForCwd(
+	modules []*core.CurrentModuleAsSDKModule,
+	cwd string,
+) []*core.CurrentModuleAsSDKModule {
+	cwd = cleanWorkspaceRelPath(cwd)
+
+	var descendants []*core.CurrentModuleAsSDKModule
+	var nearestAncestor *core.CurrentModuleAsSDKModule
+	hasExact := false
+	seen := map[string]bool{}
+
+	for _, mod := range modules {
+		if mod == nil {
+			continue
+		}
+		modPath := cleanWorkspaceRelPath(mod.Path)
+		if seen[modPath] {
+			continue
+		}
+		seen[modPath] = true
+
+		if cwd == "." || modPath == cwd || strings.HasPrefix(modPath, cwd+string(filepath.Separator)) {
+			descendants = append(descendants, mod)
+			if modPath == cwd {
+				hasExact = true
+			}
+			continue
+		}
+
+		if modPath == "." || strings.HasPrefix(cwd, modPath+string(filepath.Separator)) {
+			if nearestAncestor == nil || len(modPath) > len(cleanWorkspaceRelPath(nearestAncestor.Path)) {
+				nearestAncestor = mod
+			}
+		}
+	}
+
+	if hasExact || nearestAncestor == nil {
+		return descendants
+	}
+	return append([]*core.CurrentModuleAsSDKModule{nearestAncestor}, descendants...)
 }
 
 func (s *moduleSchema) currentModuleAsSDKClients(

--- a/core/schema/module_as_sdk_test.go
+++ b/core/schema/module_as_sdk_test.go
@@ -3,9 +3,59 @@ package schema
 import (
 	"testing"
 
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCurrentModuleAsSDKModulesInScopeForCwd(t *testing.T) {
+	modules := func(paths ...string) []*core.CurrentModuleAsSDKModule {
+		result := make([]*core.CurrentModuleAsSDKModule, 0, len(paths))
+		for _, path := range paths {
+			result = append(result, &core.CurrentModuleAsSDKModule{Path: path})
+		}
+		return result
+	}
+	paths := func(modules []*core.CurrentModuleAsSDKModule) []string {
+		result := make([]string, 0, len(modules))
+		for _, mod := range modules {
+			result = append(result, mod.Path)
+		}
+		return result
+	}
+
+	managed := modules(
+		".",
+		"services/api",
+		"services/api/src/tool",
+		"services/web",
+		"libraries/auth",
+	)
+	tests := []struct {
+		name string
+		cwd  string
+		want []string
+	}{
+		{name: "root sees all modules", cwd: ".", want: []string{".", "services/api", "services/api/src/tool", "services/web", "libraries/auth"}},
+		{name: "directory sees ancestor and descendants", cwd: "services", want: []string{".", "services/api", "services/api/src/tool", "services/web"}},
+		{name: "module cwd suppresses farther ancestor", cwd: "services/api", want: []string{"services/api", "services/api/src/tool"}},
+		{name: "inside module selects nearest ancestor", cwd: "services/api/src", want: []string{"services/api", "services/api/src/tool"}},
+		{name: "deep inside module selects nearest ancestor only", cwd: "services/api/internal", want: []string{"services/api"}},
+		{name: "unrelated directory selects root module", cwd: "other", want: []string{"."}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := currentModuleAsSDKModulesInScopeForCwd(managed, test.cwd)
+			require.Equal(t, test.want, paths(got))
+		})
+	}
+
+	t.Run("deduplicates normalized paths", func(t *testing.T) {
+		got := currentModuleAsSDKModulesInScopeForCwd(modules("services/api", "services/./api", "services/web"), "services")
+		require.Equal(t, []string{"services/api", "services/web"}, paths(got))
+	})
+}
 
 func TestResolveCurrentModuleSDKEntry(t *testing.T) {
 	goSDK := workspace.ModuleEntry{

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1100,6 +1100,9 @@ func (s *moduleSourceSchema) initFromModConfig(configBytes []byte, src *core.Mod
 	src.ConfigToolchains = modCfg.Toolchains
 	src.ConfigClients = modCfg.Clients
 
+	// Keep the version as declared before resolving it: config edits write
+	// the declared form back, so a config that says "latest" stays floating.
+	src.ConfigEngineVersion = modCfg.EngineVersion
 	engineVersion := modCfg.EngineVersion
 	switch engineVersion {
 	case "":
@@ -1585,11 +1588,19 @@ func (s *moduleSourceSchema) moduleSourceWithEngineVersion(
 	src = src.Clone()
 
 	engineVersion := args.Version
+	// Asking for "latest" keeps the config floating: the file says "latest"
+	// and resolves to the newest engine on every load. Asking for a concrete
+	// version pins the normalized form. Either way EngineVersion holds the
+	// resolved version, which is what drives behavior.
 	switch engineVersion {
 	case "":
 		engineVersion = engine.MinimumModuleVersion
+		src.ConfigEngineVersion = ""
 	case modules.EngineVersionLatest:
 		engineVersion = engine.Version
+		src.ConfigEngineVersion = modules.EngineVersionLatest
+	default:
+		src.ConfigEngineVersion = engine.NormalizeVersion(engineVersion)
 	}
 	engineVersion = engine.NormalizeVersion(engineVersion)
 	src.EngineVersion = engineVersion
@@ -2488,12 +2499,14 @@ func (s *moduleSourceSchema) loadModuleSourceConfig(
 		return nil, err
 	}
 
-	// Check version compatibility.
-	if !engine.CheckVersionCompatibility(modCfg.EngineVersion, engine.MinimumModuleVersion) {
-		return nil, fmt.Errorf("module requires dagger %s, but support for that version has been removed", modCfg.EngineVersion)
+	// Check version compatibility against the resolved version: the built
+	// config carries the version as declared — possibly the floating
+	// "latest" — while EngineVersion always holds what it resolved to.
+	if !engine.CheckVersionCompatibility(src.EngineVersion, engine.MinimumModuleVersion) {
+		return nil, fmt.Errorf("module requires dagger %s, but support for that version has been removed", src.EngineVersion)
 	}
-	if !engine.CheckMaxVersionCompatibility(modCfg.EngineVersion, engine.BaseVersion(engine.Version)) {
-		return nil, fmt.Errorf("module requires dagger %s, but you have %s", modCfg.EngineVersion, engine.Version)
+	if !engine.CheckMaxVersionCompatibility(src.EngineVersion, engine.BaseVersion(engine.Version)) {
+		return nil, fmt.Errorf("module requires dagger %s, but you have %s", src.EngineVersion, engine.Version)
 	}
 
 	return modCfg, nil
@@ -2509,11 +2522,15 @@ func (s *moduleSourceSchema) buildModuleConfig(
 	src *core.ModuleSource,
 ) (*modules.ModuleConfigWithUserFields, error) {
 	// construct the module config based on any config read during load and any settings changed via with* APIs
+	engineVersion := src.ConfigEngineVersion
+	if engineVersion == "" {
+		engineVersion = src.EngineVersion
+	}
 	modCfg := &modules.ModuleConfigWithUserFields{
 		ModuleConfigUserFields: src.ModuleConfigUserFields,
 		ModuleConfig: modules.ModuleConfig{
 			Name:          src.ModuleOriginalName,
-			EngineVersion: src.EngineVersion,
+			EngineVersion: engineVersion,
 			Include:       src.IncludePaths,
 			Codegen:       src.CodegenConfig,
 			Clients:       src.ConfigClients,

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1103,9 +1103,6 @@ func (s *moduleSourceSchema) initFromModConfig(configBytes []byte, src *core.Mod
 	src.ConfigToolchains = modCfg.Toolchains
 	src.ConfigClients = modCfg.Clients
 
-	// Keep the version as declared before resolving it: config edits write
-	// the declared form back, so a config that says "latest" stays floating.
-	src.ConfigEngineVersion = modCfg.EngineVersion
 	engineVersion := modCfg.EngineVersion
 	switch engineVersion {
 	case "":
@@ -1591,19 +1588,11 @@ func (s *moduleSourceSchema) moduleSourceWithEngineVersion(
 	src = src.Clone()
 
 	engineVersion := args.Version
-	// Asking for "latest" keeps the config floating: the file says "latest"
-	// and resolves to the newest engine on every load. Asking for a concrete
-	// version pins the normalized form. Either way EngineVersion holds the
-	// resolved version, which is what drives behavior.
 	switch engineVersion {
 	case "":
 		engineVersion = engine.MinimumModuleVersion
-		src.ConfigEngineVersion = ""
 	case modules.EngineVersionLatest:
 		engineVersion = engine.Version
-		src.ConfigEngineVersion = modules.EngineVersionLatest
-	default:
-		src.ConfigEngineVersion = engine.NormalizeVersion(engineVersion)
 	}
 	engineVersion = engine.NormalizeVersion(engineVersion)
 	src.EngineVersion = engineVersion
@@ -2502,14 +2491,12 @@ func (s *moduleSourceSchema) loadModuleSourceConfig(
 		return nil, err
 	}
 
-	// Check version compatibility against the resolved version: the built
-	// config carries the version as declared — possibly the floating
-	// "latest" — while EngineVersion always holds what it resolved to.
-	if !engine.CheckVersionCompatibility(src.EngineVersion, engine.MinimumModuleVersion) {
-		return nil, fmt.Errorf("module requires dagger %s, but support for that version has been removed", src.EngineVersion)
+	// Check version compatibility.
+	if !engine.CheckVersionCompatibility(modCfg.EngineVersion, engine.MinimumModuleVersion) {
+		return nil, fmt.Errorf("module requires dagger %s, but support for that version has been removed", modCfg.EngineVersion)
 	}
-	if !engine.CheckMaxVersionCompatibility(src.EngineVersion, engine.BaseVersion(engine.Version)) {
-		return nil, fmt.Errorf("module requires dagger %s, but you have %s", src.EngineVersion, engine.Version)
+	if !engine.CheckMaxVersionCompatibility(modCfg.EngineVersion, engine.BaseVersion(engine.Version)) {
+		return nil, fmt.Errorf("module requires dagger %s, but you have %s", modCfg.EngineVersion, engine.Version)
 	}
 
 	return modCfg, nil
@@ -2525,15 +2512,11 @@ func (s *moduleSourceSchema) buildModuleConfig(
 	src *core.ModuleSource,
 ) (*modules.ModuleConfigWithUserFields, error) {
 	// construct the module config based on any config read during load and any settings changed via with* APIs
-	engineVersion := src.ConfigEngineVersion
-	if engineVersion == "" {
-		engineVersion = src.EngineVersion
-	}
 	modCfg := &modules.ModuleConfigWithUserFields{
 		ModuleConfigUserFields: src.ModuleConfigUserFields,
 		ModuleConfig: modules.ModuleConfig{
 			Name:          src.ModuleOriginalName,
-			EngineVersion: engineVersion,
+			EngineVersion: src.EngineVersion,
 			Include:       src.IncludePaths,
 			Codegen:       src.CodegenConfig,
 			Clients:       src.ConfigClients,

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -221,6 +221,9 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 		dagql.NodeFunc("generatedContextChangeset", s.moduleSourceGeneratedContextChangeset).
 			Doc(`The generated files and directories made on top of the module source's context directory, returned as a Changeset.`),
 
+		// TODO: remove this field after the official SDK migrations have shipped.
+		// Older SDK releases still call it while loading, so hiding it would make
+		// those SDKs unusable with the engine before they can migrate.
 		dagql.NodeFunc("generateLocalDependencies", s.moduleSourceGenerateLocalDependencies).
 			View(AfterVersion("v1.0.0-0")).
 			Doc(`Generate this module's transitive local dependency closure and return the staged changes as a single changeset against the unstaged workspace root.`,

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -116,6 +116,17 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("name").Doc(`The name of the file or directory to search for.`),
 				dagql.Arg("from").Doc(`Path to start the search from. Relative paths resolve from the workspace cwd; absolute paths resolve from the workspace root.`),
 			),
+		dagql.NodeFunc("findRoots", s.findRoots).
+			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerClientInput).
+			Doc(`Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.`,
+				`Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.`,
+				`Each returned path is usable as-is with other workspace APIs, e.g. directory(path).`).
+			Args(
+				dagql.Arg("start").Doc(`Directory to start from. Relative paths resolve from the workspace cwd.`),
+				dagql.Arg("markers").Doc(`File basenames that mark a project root (e.g. ["go.mod"] or ["deno.json", "deno.jsonc"]).`),
+				dagql.Arg("exclude").Doc(`Glob patterns pruning the walk below start (e.g. ["**/node_modules/**"]).`),
+			),
 		dagql.NodeFunc("git", s.git).
 			View(AfterVersion("v1.0.0-0")).
 			WithInput(dagql.PerClientInput).
@@ -2548,6 +2559,159 @@ func (s *workspaceSchema) findUp(
 	}
 
 	return none, nil
+}
+
+type workspaceFindRootsArgs struct {
+	Start   string `default:"."`
+	Markers []string
+	Exclude []string `default:"[]"`
+}
+
+func (s *workspaceSchema) findRoots(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceFindRootsArgs,
+) (dagql.Array[dagql.String], error) {
+	if len(args.Markers) == 0 {
+		return nil, fmt.Errorf("workspace findRoots requires at least one marker")
+	}
+	for _, name := range args.Markers {
+		if !isWorkspaceBasename(name) {
+			return nil, fmt.Errorf("workspace findRoots marker must be a basename: %q", name)
+		}
+	}
+	start, err := resolveWorkspacePath(args.Start, parent.Self().Cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	var dirs []string
+	seen := map[string]bool{}
+	add := func(dir string) {
+		if !seen[dir] {
+			seen[dir] = true
+			dirs = append(dirs, dir)
+		}
+	}
+
+	ancestor, err := s.nearestAncestorRoot(ctx, parent, start, args.Markers)
+	if err != nil {
+		return nil, err
+	}
+	if ancestor != "" {
+		add(ancestor)
+	}
+
+	descendants, err := s.descendantRoots(ctx, parent, start, args.Markers, args.Exclude)
+	if err != nil {
+		return nil, err
+	}
+	for _, dir := range descendants {
+		add(dir)
+	}
+
+	return dagql.NewStringArray(dirs...), nil
+}
+
+// nearestAncestorRoot returns the closest strict ancestor of start holding a
+// marker, as a cwd-relative path, or "" when there is none.
+func (s *workspaceSchema) nearestAncestorRoot(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	start string,
+	markers []string,
+) (string, error) {
+	bestDir := ""
+	bestDepth := -1
+	for _, name := range markers {
+		hit, err := s.findUp(ctx, parent, workspaceFindUpArgs{Name: name, From: workspaceAPIPath(start)})
+		if err != nil {
+			return "", err
+		}
+		if !hit.Valid {
+			continue
+		}
+		// findUp returns a workspace-absolute path like "/sub/deno.json".
+		dir := strings.TrimPrefix(path.Dir(hit.Value.String()), "/")
+		if dir == "" {
+			dir = "."
+		}
+		if depth := workspaceDirDepth(dir); depth > bestDepth {
+			bestDepth = depth
+			bestDir = dir
+		}
+	}
+	if bestDepth < 0 {
+		return "", nil
+	}
+	if bestDir == cleanWorkspaceRelPath(start) {
+		return "", nil
+	}
+	return workspacePathRelativeToCwd(bestDir, parent.Self().Cwd)
+}
+
+// workspaceDirDepth returns the depth of a workspace-root-relative directory,
+// 0 at the root.
+func workspaceDirDepth(dir string) int {
+	if dir == "." {
+		return 0
+	}
+	return strings.Count(dir, "/") + 1
+}
+
+// descendantRoots returns every directory at or below start holding one of the
+// markers, as cwd-relative paths.
+func (s *workspaceSchema) descendantRoots(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	start string,
+	markers []string,
+	exclude []string,
+) ([]string, error) {
+	ws := parent.Self()
+	include := make([]string, len(markers))
+	for i, name := range markers {
+		include[i] = "**/" + name
+	}
+	dir, err := s.directoryAt(ctx, ws, start, workspaceDirectoryArgs{
+		Path: ".",
+		CopyFilter: core.CopyFilter{
+			Include: include,
+			Exclude: exclude,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, name := range markers {
+		var matches dagql.Array[dagql.String]
+		if err := srv.Select(ctx, dir, &matches, dagql.Selector{
+			Field: "glob",
+			Args: []dagql.NamedInput{
+				{Name: "pattern", Value: dagql.NewString("**/" + name)},
+			},
+		}); err != nil {
+			return nil, fmt.Errorf("glob %s: %w", name, err)
+		}
+		for _, match := range matches {
+			descendant := path.Dir(match.String())
+			if descendant == "/" || descendant == "" {
+				descendant = "."
+			}
+			root := cleanWorkspaceRelPath(filepath.Join(start, descendant))
+			rel, err := workspacePathRelativeToCwd(root, ws.Cwd)
+			if err != nil {
+				return nil, err
+			}
+			dirs = append(dirs, rel)
+		}
+	}
+	return dirs, nil
 }
 
 func isWorkspaceBasename(name string) bool {

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -12,6 +12,7 @@ import (
 	coresdk "github.com/dagger/dagger/core/sdk"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 )
 
 type workspaceInitModuleArgs struct {
@@ -346,7 +347,7 @@ func (s *workspaceSchema) workspaceModuleInitConfigDiff(
 	config, err := modules.MarshalModuleConfigForFilename(&modules.ModuleConfigWithUserFields{
 		ModuleConfig: modules.ModuleConfig{
 			Name:          args.Name,
-			EngineVersion: modules.EngineVersionLatest,
+			EngineVersion: engine.Version,
 			SDK:           &modules.SDK{Source: runtimeRef},
 			Source:        source,
 			Include:       append([]string(nil), args.Include...),

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6225,3 +6225,4 @@ type WorkspaceSDK implements Node {
   """The module reference this SDK was installed from."""
   ref: String!
 }
+

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1801,7 +1801,11 @@ type CurrentModuleAsSDK implements Node {
   """A unique identifier for this CurrentModuleAsSDK."""
   id: ID!
 
-  """The workspace-local modules this SDK authors and manages."""
+  """
+  The managed modules relevant to the bound workspace cwd: every module at or
+  below it, plus the nearest enclosing module when the cwd itself is not
+  managed.
+  """
   modules: [CurrentModuleAsSDKModule!]!
 
   """The user-facing name of this SDK in the workspace."""
@@ -5675,6 +5679,31 @@ type Workspace implements Node {
   ): File!
 
   """
+  Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+
+  Returns cwd-relative directory paths for every marked directory at or below
+  start, plus the nearest marked ancestor when start itself is not marked.
+
+  Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+  """
+  findRoots(
+    """
+    Directory to start from. Relative paths resolve from the workspace cwd.
+    """
+    start: String = "."
+
+    """
+    File basenames that mark a project root (e.g. ["go.mod"] or ["deno.json", "deno.jsonc"]).
+    """
+    markers: [String!]!
+
+    """
+    Glob patterns pruning the walk below start (e.g. ["**/node_modules/**"]).
+    """
+    exclude: [String!] = []
+  ): [String!]!
+
+  """
   Search for a file or directory by walking up from the start path within the workspace.
 
   Returns the absolute workspace path if found, or null if not found.
@@ -6196,4 +6225,3 @@ type WorkspaceSDK implements Node {
   """The module reference this SDK was installed from."""
   ref: String!
 }
-

--- a/docs/static/reference/php/Dagger/CurrentModuleAsSDK.html
+++ b/docs/static/reference/php/Dagger/CurrentModuleAsSDK.html
@@ -168,7 +168,7 @@
                 <div class="col-md-8">
                     <a href="#method_modules">modules</a>()
         
-                                            <p><p>The workspace-local modules this SDK authors and manages.</p></p>                </div>
+                                            <p><p>The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -352,7 +352,7 @@
             
 
         <div class="method-description">
-                            <p><p>The workspace-local modules this SDK authors and manages.</p></p>                        
+                            <p><p>The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -253,6 +253,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    array
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_findRoots">findRoots</a>(array $markers, string|null $start = &#039;.&#039;, array|null $exclude = [])
+        
+                                            <p><p>Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     string
                 </div>
                 <div class="col-md-8">
@@ -1112,8 +1122,61 @@
 
             </div>
                     <div class="method-item">
+                    <h3 id="method_findRoots">
+        <div class="location">at line 173</div>
+        <code>                    array
+    <strong>findRoots</strong>(array $markers, string|null $start = &#039;.&#039;, array|null $exclude = [])
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.</p></p>                <p><p>Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.</p>
+<p>Each returned path is usable as-is with other workspace APIs, e.g. directory(path).</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>array</td>
+                <td>$markers</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$start</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>array|null</td>
+                <td>$exclude</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>array</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
                     <h3 id="method_findUp">
-        <div class="location">at line 175</div>
+        <div class="location">at line 195</div>
         <code>                    string
     <strong>findUp</strong>(string $name, string|null $from = &#039;.&#039;)
         </code>
@@ -1162,7 +1225,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generators">
-        <div class="location">at line 188</div>
+        <div class="location">at line 208</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>generators</strong>(array|null $include = null)
         </code>
@@ -1204,7 +1267,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_git">
-        <div class="location">at line 200</div>
+        <div class="location">at line 220</div>
         <code>                    <a href="../Dagger/WorkspaceGit.html"><abbr title="Dagger\WorkspaceGit">WorkspaceGit</abbr></a>
     <strong>git</strong>()
         </code>
@@ -1236,7 +1299,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_glob">
-        <div class="location">at line 211</div>
+        <div class="location">at line 231</div>
         <code>                    array
     <strong>glob</strong>(string $pattern)
         </code>
@@ -1278,7 +1341,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 221</div>
+        <div class="location">at line 241</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1310,7 +1373,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_migrate">
-        <div class="location">at line 232</div>
+        <div class="location">at line 252</div>
         <code>                    <a href="../Dagger/WorkspaceMigration.html"><abbr title="Dagger\WorkspaceMigration">WorkspaceMigration</abbr></a>
     <strong>migrate</strong>()
         </code>
@@ -1342,7 +1405,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_module">
-        <div class="location">at line 243</div>
+        <div class="location">at line 263</div>
         <code>                    <a href="../Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a>
     <strong>module</strong>(string $name)
         </code>
@@ -1384,7 +1447,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleSource">
-        <div class="location">at line 257</div>
+        <div class="location">at line 277</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>moduleSource</strong>(string $path)
         </code>
@@ -1427,7 +1490,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_modules">
-        <div class="location">at line 269</div>
+        <div class="location">at line 289</div>
         <code>                    array
     <strong>modules</strong>()
         </code>
@@ -1459,7 +1522,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_reloaded">
-        <div class="location">at line 278</div>
+        <div class="location">at line 298</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>reloaded</strong>()
         </code>
@@ -1491,7 +1554,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 287</div>
+        <div class="location">at line 307</div>
         <code>                    <a href="../Dagger/WorkspaceSDK.html"><abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr></a>
     <strong>sdk</strong>(string $name)
         </code>
@@ -1533,7 +1596,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdks">
-        <div class="location">at line 297</div>
+        <div class="location">at line 317</div>
         <code>                    array
     <strong>sdks</strong>()
         </code>
@@ -1565,7 +1628,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_search">
-        <div class="location">at line 310</div>
+        <div class="location">at line 330</div>
         <code>                    array
     <strong>search</strong>(string $pattern, array|null $paths = [], array|null $globs = [], bool|null $literal = false, bool|null $multiline = false, bool|null $dotall = false, bool|null $insensitive = false, bool|null $skipIgnored = false, bool|null $skipHidden = false, bool|null $filesOnly = false, int|null $limit = null)
         </code>
@@ -1658,7 +1721,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 361</div>
+        <div class="location">at line 381</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1700,7 +1763,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 373</div>
+        <div class="location">at line 393</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withChanges</strong>(<a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a> $changes)
         </code>
@@ -1742,7 +1805,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConfigEnv">
-        <div class="location">at line 383</div>
+        <div class="location">at line 403</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -1789,7 +1852,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConfigValue">
-        <div class="location">at line 398</div>
+        <div class="location">at line 418</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withConfigValue</strong>(string $key, string $value, array|null $values = null, bool|null $here = false)
         </code>
@@ -1846,7 +1909,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 417</div>
+        <div class="location">at line 437</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -1913,7 +1976,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 446</div>
+        <div class="location">at line 466</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -1990,7 +2053,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 485</div>
+        <div class="location">at line 505</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -2042,7 +2105,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 503</div>
+        <div class="location">at line 523</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2089,7 +2152,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 516</div>
+        <div class="location">at line 536</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
         </code>
@@ -2136,7 +2199,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 527</div>
+        <div class="location">at line 547</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2183,7 +2246,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 538</div>
+        <div class="location">at line 558</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2235,7 +2298,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 552</div>
+        <div class="location">at line 572</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2292,7 +2355,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 571</div>
+        <div class="location">at line 591</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2324,7 +2387,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 580</div>
+        <div class="location">at line 600</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2366,7 +2429,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 590</div>
+        <div class="location">at line 610</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2413,7 +2476,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 607</div>
+        <div class="location">at line 627</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2461,7 +2524,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 620</div>
+        <div class="location">at line 640</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2503,7 +2566,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 630</div>
+        <div class="location">at line 650</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2545,7 +2608,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 642</div>
+        <div class="location">at line 662</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2592,7 +2655,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 655</div>
+        <div class="location">at line 675</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -736,7 +736,9 @@
 <abbr title="Dagger\Stat">Stat</abbr>::fileType</a>() &mdash; <em>Method in class <a href="Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a></em></dt>
                     <dd><p>file type</p></dd><dt><a href="Dagger/Workspace.html#method_file">
 <abbr title="Dagger\Workspace">Workspace</abbr>::file</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Returns a File from the workspace.</p></dd><dt><a href="Dagger/Workspace.html#method_findUp">
+                    <dd><p>Returns a File from the workspace.</p></dd><dt><a href="Dagger/Workspace.html#method_findRoots">
+<abbr title="Dagger\Workspace">Workspace</abbr>::findRoots</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.</p></dd><dt><a href="Dagger/Workspace.html#method_findUp">
 <abbr title="Dagger\Workspace">Workspace</abbr>::findUp</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Search for a file or directory by walking up from the start path within the workspace.</p></dd>        </dl><h2 id="letterG">G</h2>
         <dl id="indexG"><dt><a href="Dagger/Address.html#method_gitRef">
@@ -1129,7 +1131,7 @@
 <abbr title="Dagger\Container">Container</abbr>::mounts</a>() &mdash; <em>Method in class <a href="Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></em></dt>
                     <dd><p>Retrieves the list of paths where a directory is mounted.</p></dd><dt><a href="Dagger/CurrentModuleAsSDK.html#method_modules">
 <abbr title="Dagger\CurrentModuleAsSDK">CurrentModuleAsSDK</abbr>::modules</a>() &mdash; <em>Method in class <a href="Dagger/CurrentModuleAsSDK.html"><abbr title="Dagger\CurrentModuleAsSDK">CurrentModuleAsSDK</abbr></a></em></dt>
-                    <dd><p>The workspace-local modules this SDK authors and manages.</p></dd><dt><a href="Dagger/CurrentModuleAsSDKClient.html#method_module">
+                    <dd><p>The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.</p></dd><dt><a href="Dagger/CurrentModuleAsSDKClient.html#method_module">
 <abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr>::module</a>() &mdash; <em>Method in class <a href="Dagger/CurrentModuleAsSDKClient.html"><abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr></a></em></dt>
                     <dd><p>The module the client is bound to (workspace-relative path or canonical ref).</p></dd><dt><a href="Dagger/CurrentModuleAsSDKClient.html#method_moduleSource">
 <abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr>::moduleSource</a>() &mdash; <em>Method in class <a href="Dagger/CurrentModuleAsSDKClient.html"><abbr title="Dagger\CurrentModuleAsSDKClient">CurrentModuleAsSDKClient</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -3528,7 +3528,7 @@
 			"t": "M",
 			"n": "Dagger\\CurrentModuleAsSDK::modules",
 			"p": "Dagger/CurrentModuleAsSDK.html#method_modules",
-			"d": "<p>The workspace-local modules this SDK authors and manages.</p>"
+			"d": "<p>The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.</p>"
 		},
 		{
 			"t": "M",
@@ -7327,6 +7327,12 @@
 			"n": "Dagger\\Workspace::file",
 			"p": "Dagger/Workspace.html#method_file",
 			"d": "<p>Returns a File from the workspace.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\Workspace::findRoots",
+			"p": "Dagger/Workspace.html#method_findRoots",
+			"d": "<p>Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/elixir/lib/dagger/gen/current_module_as_sdk.ex
+++ b/sdk/elixir/lib/dagger/gen/current_module_as_sdk.ex
@@ -50,7 +50,7 @@ defmodule Dagger.CurrentModuleAsSDK do
   end
 
   @doc """
-  The workspace-local modules this SDK authors and manages.
+  The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.
   """
   @spec modules(t()) :: {:ok, [Dagger.CurrentModuleAsSDKModule.t()]} | {:error, term()}
   def modules(%__MODULE__{} = current_module_as_sdk) do

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -192,6 +192,26 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
+  Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+
+  Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.
+
+  Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+  """
+  @spec find_roots(t(), [String.t()], [{:start, String.t() | nil}, {:exclude, [String.t()]}]) ::
+          {:ok, [String.t()]} | {:error, term()}
+  def find_roots(%__MODULE__{} = workspace, markers, optional_args \\ []) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("findRoots")
+      |> QB.put_arg("markers", markers)
+      |> QB.maybe_put_arg("start", optional_args[:start])
+      |> QB.maybe_put_arg("exclude", optional_args[:exclude])
+
+    Client.execute(workspace.client, query_builder)
+  end
+
+  @doc """
   Search for a file or directory by walking up from the start path within the workspace.
 
   Returns the absolute workspace path if found, or null if not found.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3936,7 +3936,7 @@ func (r *CurrentModuleAsSDK) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// The workspace-local modules this SDK authors and manages.
+// The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.
 func (r *CurrentModuleAsSDK) Modules(ctx context.Context) ([]CurrentModuleAsSDKModule, error) {
 	q := r.query.Select("modules")
 
@@ -16045,6 +16045,41 @@ func (r *Workspace) File(path string) *File {
 	return &File{
 		query: q,
 	}
+}
+
+// WorkspaceFindRootsOpts contains options for Workspace.FindRoots
+type WorkspaceFindRootsOpts struct {
+	// Directory to start from. Relative paths resolve from the workspace cwd.
+	//
+	// Default: "."
+	Start string
+	// Glob patterns pruning the walk below start (e.g. ["**/node_modules/**"]).
+	Exclude []string
+}
+
+// Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+//
+// Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.
+//
+// Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+func (r *Workspace) FindRoots(ctx context.Context, markers []string, opts ...WorkspaceFindRootsOpts) ([]string, error) {
+	q := r.query.Select("findRoots")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `start` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Start) {
+			q = q.Arg("start", opts[i].Start)
+		}
+		// `exclude` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Exclude) {
+			q = q.Arg("exclude", opts[i].Exclude)
+		}
+	}
+	q = q.Arg("markers", markers)
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // WorkspaceFindUpOpts contains options for Workspace.FindUp

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Helpers.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Helpers.java
@@ -194,12 +194,17 @@ public class Helpers {
    *
    * <p>'$' is escaped for JavaPoet's format strings, while '&amp;', '&lt;' and '&gt;' are HTML
    * entities so that descriptions containing markup-like tokens (e.g. {@code <name>}) don't get
-   * parsed as HTML tags by the javadoc tool.
+   * parsed as HTML tags by the javadoc tool. The comment terminator is escaped so glob examples
+   * such as {@code **&#47;node_modules/**} cannot end the generated Javadoc early.
    */
   static String escapeJavadoc(String str) {
     if (str == null) {
       return "";
     }
-    return str.replace("$", "$$").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    return str.replace("$", "$$")
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("*/", "*&#47;");
   }
 }

--- a/sdk/php/generated/CurrentModuleAsSDK.php
+++ b/sdk/php/generated/CurrentModuleAsSDK.php
@@ -32,7 +32,7 @@ class CurrentModuleAsSDK extends Client\AbstractObject implements Client\IdAble,
     }
 
     /**
-     * The workspace-local modules this SDK authors and manages.
+     * The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.
      */
     public function modules(): array
     {

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -164,6 +164,26 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
+     * Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+     *
+     * Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.
+     *
+     * Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+     */
+    public function findRoots(array $markers, ?string $start = '.', ?array $exclude = []): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('findRoots');
+        $leafQueryBuilder->setArgument('markers', $markers);
+        if (null !== $start) {
+        $leafQueryBuilder->setArgument('start', $start);
+        }
+        if (null !== $exclude) {
+        $leafQueryBuilder->setArgument('exclude', $exclude);
+        }
+        return (array)$this->queryLeaf($leafQueryBuilder, 'findRoots');
+    }
+
+    /**
      * Search for a file or directory by walking up from the start path within the workspace.
      *
      * Returns the absolute workspace path if found, or null if not found.

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -4034,7 +4034,10 @@ class CurrentModuleAsSDK(Type):
         return await _ctx.execute(str)
 
     async def modules(self) -> list["CurrentModuleAsSDKModule"]:
-        """The workspace-local modules this SDK authors and manages."""
+        """The managed modules relevant to the bound workspace cwd: every module
+        at or below it, plus the nearest enclosing module when the cwd itself
+        is not managed.
+        """
         _args: list[Arg] = []
         _ctx = self._select("modules", _args)
         return await _ctx.execute_object_list(CurrentModuleAsSDKModule)
@@ -15211,6 +15214,57 @@ class Workspace(Type):
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
+
+    async def find_roots(
+        self,
+        markers: list[str],
+        *,
+        start: str | None = ".",
+        exclude: list[str] | None = None,
+    ) -> list[str]:
+        """Find project roots marked by any of the given filenames, starting from
+        a path relative to the workspace cwd.
+
+        Returns cwd-relative directory paths for every marked directory at or
+        below start, plus the nearest marked ancestor when start itself is not
+        marked.
+
+        Each returned path is usable as-is with other workspace APIs, e.g.
+        directory(path).
+
+        Parameters
+        ----------
+        markers:
+            File basenames that mark a project root (e.g. ["go.mod"] or
+            ["deno.json", "deno.jsonc"]).
+        start:
+            Directory to start from. Relative paths resolve from the workspace
+            cwd.
+        exclude:
+            Glob patterns pruning the walk below start (e.g.
+            ["**/node_modules/**"]).
+
+        Returns
+        -------
+        list[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("markers", markers),
+            Arg("start", start, "."),
+            Arg("exclude", [] if exclude is None else exclude, []),
+        ]
+        _ctx = self._select("findRoots", _args)
+        return await _ctx.execute(list[str])
 
     async def find_up(
         self,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4589,7 +4589,7 @@ impl CurrentModuleAsSdk {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// The workspace-local modules this SDK authors and manages.
+    /// The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.
     pub async fn modules(&self) -> Result<Vec<CurrentModuleAsSdkModule>, DaggerError> {
         let query = self.selection.select("modules");
         let query = query.select("id");
@@ -14892,6 +14892,15 @@ pub struct WorkspaceDirectoryOpts<'a> {
     pub include: Option<Vec<&'a str>>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct WorkspaceFindRootsOpts<'a> {
+    /// Glob patterns pruning the walk below start (e.g. ["**/node_modules/**"]).
+    #[builder(setter(into, strip_option), default)]
+    pub exclude: Option<Vec<&'a str>>,
+    /// Directory to start from. Relative paths resolve from the workspace cwd.
+    #[builder(setter(into, strip_option), default)]
+    pub start: Option<&'a str>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct WorkspaceFindUpOpts<'a> {
     /// Path to start the search from. Relative paths resolve from the workspace cwd; absolute paths resolve from the workspace root.
     #[builder(setter(into, strip_option), default)]
@@ -15257,6 +15266,57 @@ impl Workspace {
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
+    }
+    /// Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+    /// Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.
+    /// Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+    ///
+    /// # Arguments
+    ///
+    /// * `markers` - File basenames that mark a project root (e.g. ["go.mod"] or ["deno.json", "deno.jsonc"]).
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn find_roots(
+        &self,
+        markers: Vec<impl Into<String>>,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("findRoots");
+        query = query.arg(
+            "markers",
+            markers
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
+        query.execute(self.graphql_client.clone()).await
+    }
+    /// Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+    /// Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.
+    /// Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+    ///
+    /// # Arguments
+    ///
+    /// * `markers` - File basenames that mark a project root (e.g. ["go.mod"] or ["deno.json", "deno.jsonc"]).
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn find_roots_opts<'a>(
+        &self,
+        markers: Vec<impl Into<String>>,
+        opts: WorkspaceFindRootsOpts<'a>,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("findRoots");
+        query = query.arg(
+            "markers",
+            markers
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
+        if let Some(start) = opts.start {
+            query = query.arg("start", start);
+        }
+        if let Some(exclude) = opts.exclude {
+            query = query.arg("exclude", exclude);
+        }
+        query.execute(self.graphql_client.clone()).await
     }
     /// Search for a file or directory by walking up from the start path within the workspace.
     /// Returns the absolute workspace path if found, or null if not found.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3151,6 +3151,23 @@ export type WorkspaceDirectoryOpts = {
   gitignore?: boolean
 }
 
+export type WorkspaceFindRootsOpts = {
+  /**
+   * Directory to start from. Relative paths resolve from the workspace cwd.
+   */
+  start?: string
+
+  /**
+   * File basenames that mark a project root (e.g. ["go.mod"] or ["deno.json", "deno.jsonc"]).
+   */
+  markers: string[]
+
+  /**
+   * Glob patterns pruning the walk below start (e.g. ["**\/node_modules/**"]).
+   */
+  exclude?: string[]
+}
+
 export type WorkspaceFindUpOpts = {
   /**
    * Path to start the search from. Relative paths resolve from the workspace cwd; absolute paths resolve from the workspace root.
@@ -5849,7 +5866,7 @@ export class CurrentModuleAsSDK extends BaseClient {
   }
 
   /**
-   * The workspace-local modules this SDK authors and manages.
+   * The managed modules relevant to the bound workspace cwd: every module at or below it, plus the nearest enclosing module when the cwd itself is not managed.
    */
   modules = async (): Promise<CurrentModuleAsSDKModule[]> => {
     type modules = {
@@ -14998,6 +15015,24 @@ export class Workspace extends BaseClient {
   file = (path: string): File => {
     const ctx = this._ctx.select("file", { path })
     return new File(ctx)
+  }
+
+  /**
+   * Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.
+   *
+   * Returns cwd-relative directory paths for every marked directory at or below start, plus the nearest marked ancestor when start itself is not marked.
+   *
+   * Each returned path is usable as-is with other workspace APIs, e.g. directory(path).
+   * @param opts.start Directory to start from. Relative paths resolve from the workspace cwd.
+   * @param opts.markers File basenames that mark a project root (e.g. ["go.mod"] or ["deno.json", "deno.jsonc"]).
+   * @param opts.exclude Glob patterns pruning the walk below start (e.g. ["**\/node_modules/**"]).
+   */
+  findRoots = async (opts?: WorkspaceFindRootsOpts): Promise<string[]> => {
+    const ctx = this._ctx.select("findRoots", { ...opts })
+
+    const response: Awaited<string[]> = await ctx.execute()
+
+    return response
   }
 
   /**


### PR DESCRIPTION
`dagger/polyfill` currently provides two pieces of workspace logic that belong in the engine. This PR adds their native replacements without changing how changesets work.

`Workspace.findRoots` finds projects from marker files such as `go.mod` or `package.json`. It searches below the workspace cwd, includes the nearest enclosing project, and prunes excluded trees. `glob` remains the lower-level API for callers that only need path matching.

SDKs do not need to scan the filesystem for Dagger modules. Those modules are already registered in `dagger.toml`, so `currentModule.asSDK(workspace: ws).modules` returns the registered module objects relevant to the workspace cwd.

The PR also preserves a literal `engineVersion: "latest"` when editing module configuration and adds the missing regression test for loading local dependencies through `Workspace.moduleSource`.

#### Review

The main question is the API boundary: `findRoots` discovers ordinary projects from files, while `asSDK.modules` reads the Dagger modules already registered for that SDK.

#### Test

```console
go test ./core ./core/schema
dagger call engine-dev test --run 'TestWorkspaceFindRoots|TestEngineVersionLatestStaysFloating|TestContextualWorkspaceModuleSourceLocalDeps'
```

[#13855](https://github.com/dagger/dagger/pull/13855) builds on this with workspace generation and explicit changeset comparison.
