### PR TITLE
Add DAGGER_GO_SDK_OFFLINE support

### DIFF
--- a/cmd/codegen/generator/go/generate_module.go
+++ b/cmd/codegen/generator/go/generate_module.go
@@ -318,14 +318,21 @@ func (g *GoGenerator) syncModReplaceAndTidy(mod *modfile.File, genSt *generator.
 		}
 	}
 
-	// Check if the module go.mod replaces the dagger.io/dagger library with a custom path.
-	// If so, we keep it as is.
-	// Otherwise, we install the given dagger.io/dagger package version.
+	// Check if the module go.mod replaces the dagger.io/dagger
+	// library with a custom path.  If so, we keep it as
+	// is. Otherwise, we install the dagger.io/dagger package
+	// version, or skip if LibVersion is empty (when
+	// DAGGER_GO_SDK_OFFLINE) so `go mod tidy` doesn't try to
+	// resolve dagger.io/dagger
 	if !isDaggerPkgCustomReplaced(mod.Replace) {
-		genSt.PostCommands = append(genSt.PostCommands,
-			// Do not pass -u here: LibVersion pins dagger.io/dagger, while -u also
-			// asks Go to upgrade transitive dependencies during generation.
-			exec.Command("go", "get", daggerImportPath+"@"+g.Config.ModuleConfig.LibVersion))
+		if g.Config.ModuleConfig.LibVersion != "" {
+			genSt.PostCommands = append(genSt.PostCommands,
+				// Do not pass -u here: LibVersion pins dagger.io/dagger, while -u also
+				// asks Go to upgrade transitive dependencies during generation.
+				exec.Command("go", "get", daggerImportPath+"@"+g.Config.ModuleConfig.LibVersion))
+		} else {
+			_ = mod.DropRequire(daggerImportPath)
+		}
 	}
 
 	genSt.PostCommands = append(genSt.PostCommands,

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -25,7 +25,25 @@ const (
 	// change is needed in the generated library.
 	// Otherwise, update it to the latest known commit during release.
 	goSDKLibVersion = "1309520660f6a5b35ef97b4fbe151e32a06a8dc5" // v0.21.7
+
+	// goSDKOfflineEnv, when set to any non-empty value on the
+	// engine container, omits --lib-version from codegen
+	// calls. That makes the Go codegen skip the `go get
+	// dagger.io/dagger@<commit>` step and drops the require from
+	// the generated go.mod, so module init/develop works without
+	// network access to dagger.io.
+	goSDKOfflineEnv = "DAGGER_GO_SDK_OFFLINE"
 )
+
+// goSDKLibVersionArgs returns the --lib-version arg pair for codegen, unless
+// the offline env var is set, in which case it returns nil so codegen treats
+// LibVersion as empty.
+func goSDKLibVersionArgs() dagql.ArrayInput[dagql.String] {
+	if os.Getenv(goSDKOfflineEnv) != "" {
+		return nil
+	}
+	return dagql.ArrayInput[dagql.String]{"--lib-version", dagql.String(goSDKLibVersion)}
+}
 
 /*
 goSDK is the one special sdk not implemented as module, instead the
@@ -559,8 +577,8 @@ func (sdk *goSDK) baseWithCodegen(
 		"--module-source-path", dagql.String(filepath.Join(goSDKUserModContextDirPath, srcSubpath)),
 		"--module-name", dagql.String(modName),
 		"--introspection-json-path", goSDKIntrospectionJSONPath,
-		"--lib-version", dagql.String(goSDKLibVersion),
 	}
+	codegenArgs = append(codegenArgs, goSDKLibVersionArgs()...)
 	if !src.Self().ConfigExists {
 		codegenArgs = append(codegenArgs, "--is-init")
 	}

--- a/core/sdk/loader_test.go
+++ b/core/sdk/loader_test.go
@@ -180,3 +180,29 @@ func TestWorkspaceModuleForRuntime(t *testing.T) {
 		})
 	}
 }
+
+// TestWorkspaceModuleForRuntimeGoSDKOffline verifies that DAGGER_GO_SDK_OFFLINE
+// stops the Go SDK from being mapped to its github.com/dagger/go-sdk git
+// workspace module (so the engine-embedded builtin Go SDK is used instead),
+// while leaving the other builtin SDKs untouched (they have no embedded copy).
+func TestWorkspaceModuleForRuntimeGoSDKOffline(t *testing.T) {
+	originalTag := engine.Tag
+	defer func() { engine.Tag = originalTag }()
+	engine.Tag = "v0.12.6"
+
+	t.Setenv(goSDKOfflineEnv, "1")
+
+	// go: gated -> no workspace module, falls back to the embedded builtin SDK.
+	got, ok, err := WorkspaceModuleForRuntime("go")
+	require.NoError(t, err)
+	require.False(t, ok, "go SDK must not resolve to a git workspace module when offline")
+	require.Empty(t, got)
+
+	// other builtin SDKs are unaffected (still resolve to their git modules).
+	for _, runtime := range []string{"typescript", "python"} {
+		got, ok, err := WorkspaceModuleForRuntime(runtime)
+		require.NoError(t, err)
+		require.True(t, ok, "%s SDK should be unaffected by DAGGER_GO_SDK_OFFLINE", runtime)
+		require.NotEmpty(t, got.Source)
+	}
+}

--- a/core/sdk/workspace_module.go
+++ b/core/sdk/workspace_module.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"errors"
+	"os"
 
 	"github.com/dagger/dagger/core/sdk/sdkmeta"
 )
@@ -38,6 +39,11 @@ func WorkspaceModuleForRuntime(runtime string) (WorkspaceModule, bool, error) {
 func workspaceModuleForBuiltinSDK(sdkName sdk, suffix string) (WorkspaceModule, bool) {
 	switch sdkName {
 	case sdkGo:
+		// When DAGGER_GO_SDK_OFFLINE is set (see goSDKOfflineEnv in go_sdk.go),
+		// do NOT install the Go SDK as a git workspace module, instead use the builtin.
+		if os.Getenv(goSDKOfflineEnv) != "" {
+			return WorkspaceModule{}, false
+		}
 		return WorkspaceModule{Name: "go-sdk", Source: "github.com/dagger/go-sdk"}, true
 	case sdkDang:
 		return WorkspaceModule{Name: "dang-sdk", Source: "github.com/dagger/dang-sdk"}, true


### PR DESCRIPTION
This is needed for modules in airgapped environments, so that `go build` does not try to reach `dagger.io` for modules.