### PR TITLE
Add support for toolchain customizations with glob patterns

### DIFF
--- a/.changes/unreleased/Added-20260807-150609.yaml
+++ b/.changes/unreleased/Added-20260807-150609.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Legacy toolchain customizations now support glob patterns in the `function` and `argument` fields, so one customization can target many functions. The last matching customization wins, letting a specific function name override an earlier wildcard. Function and argument names also match regardless of case, hyphens, and underscores, so `kebab-argument` matches `kebabArgument`.
+time: 2026-08-07T15:06:09.18738442-04:00
+custom:
+    Author: '@suprjinx'
+    PR: "11906"

--- a/core/integration/testdata/test-blueprint/hello/main.go
+++ b/core/integration/testdata/test-blueprint/hello/main.go
@@ -19,6 +19,13 @@ func (m *Hello) ConfigurableMessage(
 	return fmt.Sprintf("%s from blueprint", message)
 }
 
+func (m *Hello) ShoutMessage(
+	// +default="hello"
+	message string,
+) string {
+	return fmt.Sprintf("%s FROM BLUEPRINT!!!", message)
+}
+
 // This should read Hello's own config file
 func (m *Hello) BlueprintConfig(ctx context.Context) (string, error) {
 	return dag.CurrentModule().Source().File("blueprint-config.txt").Contents(ctx)

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -289,6 +289,135 @@ func (WorkspaceCompatSuite) TestLegacyToolchainCompat(ctx context.Context, t *te
 	})
 }
 
+// TestLegacyToolchainGlobCustomizations covers glob patterns in the `function`
+// and `argument` fields of legacy toolchain customizations, plus name matching
+// that ignores case, hyphens, and underscores. Last matching customization
+// wins, so a specific function name overrides an earlier wildcard.
+func (WorkspaceCompatSuite) TestLegacyToolchainGlobCustomizations(ctx context.Context, t *testctx.T) {
+	legacyToolchainConfig := func(customizations string) string {
+		return fmt.Sprintf(`{
+  "name": "app",
+  "engineVersion": "v0.20.6",
+  "toolchains": [
+    {
+      "name": "hello",
+      "source": "../hello",
+      "customizations": [%s]
+    }
+  ]
+}`, customizations)
+	}
+
+	t.Run("wildcard function pattern applies to all matching functions", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := legacyBlueprintTestEnv(t, c).
+			WithWorkdir("app").
+			WithNewFile("dagger.json", legacyToolchainConfig(`
+      {
+        "function": ["*"],
+        "argument": "message",
+        "default": "hola"
+      }
+`))
+
+		out, err := modGen.
+			With(daggerExec("call", "hello", "configurable-message")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hola from blueprint")
+
+		out, err = modGen.
+			With(daggerExec("call", "hello", "shout-message")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hola FROM BLUEPRINT!!!")
+	})
+
+	t.Run("specific function pattern takes precedence over wildcard", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := legacyBlueprintTestEnv(t, c).
+			WithWorkdir("app").
+			WithNewFile("dagger.json", legacyToolchainConfig(`
+      {
+        "function": ["*"],
+        "argument": "message",
+        "default": "hola"
+      },
+      {
+        "function": ["configurableMessage"],
+        "argument": "message",
+        "default": "bonjour"
+      }
+`))
+
+		out, err := modGen.
+			With(daggerExec("call", "hello", "configurable-message")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "bonjour from blueprint")
+
+		out, err = modGen.
+			With(daggerExec("call", "hello", "shout-message")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hola FROM BLUEPRINT!!!")
+	})
+
+	t.Run("function and argument names match across casing styles", func(ctx context.Context, t *testctx.T) {
+		for _, tc := range []struct {
+			name     string
+			function string
+			argument string
+		}{
+			{"camelCase", "configurableMessage", "message"},
+			{"kebab-case", "configurable-message", "message"},
+			{"snake_case", "configurable_message", "message"},
+		} {
+			t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+				c := connect(ctx, t)
+
+				modGen := legacyBlueprintTestEnv(t, c).
+					WithWorkdir("app").
+					WithNewFile("dagger.json", legacyToolchainConfig(fmt.Sprintf(`
+      {
+        "function": [%q],
+        "argument": %q,
+        "default": "hey"
+      }
+`, tc.function, tc.argument)))
+
+				out, err := modGen.
+					With(daggerExec("call", "hello", "configurable-message")).
+					Stdout(ctx)
+				require.NoError(t, err)
+				require.Contains(t, out, "hey from blueprint")
+			})
+		}
+	})
+
+	t.Run("override function default argument in chained function with glob patterns", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := legacyBlueprintTestEnv(t, c).
+			WithWorkdir("app").
+			WithNewFile("dagger.json", legacyToolchainConfig(`
+      {
+        "function": ["gre*", "pla*"],
+        "argument": "planet",
+        "default": "Mars"
+      }
+`))
+
+		out, err := modGen.
+			With(daggerExec("call", "hello", "greet", "planet")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "Greetings from Mars!")
+	})
+}
+
 // TestCompatEntrypointWithLocalDepsGenerate is a regression test for
 // https://github.com/dagger/dagger/issues/13742: `dagger generate` in a legacy
 // dagger.json project whose root module is the workspace entrypoint and has

--- a/core/module.go
+++ b/core/module.go
@@ -669,7 +669,6 @@ func (mod *Module) patchFunctionArg(
 	return updatedFn, !sameAttachedResult(updatedFn, fn), nil
 }
 
-//nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
 func (mod *Module) ApplyLegacyCustomizationsToTypeDefs(ctx context.Context, dag *dagql.Server, customizations []*modules.ModuleConfigArgument) error {
 	if len(customizations) == 0 {
 		return nil
@@ -690,129 +689,137 @@ func (mod *Module) ApplyLegacyCustomizationsToTypeDefs(ctx context.Context, dag 
 				snapshots = append(snapshots, cust.Function)
 			}
 		}
-		for _, snapshot := range snapshots {
-			fresh := mod.customizationTargets(snapshot)
-			if len(fresh) == 0 {
-				continue
-			}
-			target := fresh[0]
-			objDef := target.objDef
-			fn := target.fn
-			constructor := target.constructor
-			if !objDef.Self().AsObject.Valid {
-				continue
-			}
-			updatedFn, changed, err := mod.patchFunctionArg(ctx, dag, fn, cust.Argument, func(arg dagql.ObjectResult[*FunctionArg]) (dagql.ObjectResult[*FunctionArg], error) {
-				updatedArg := arg
-				argSelf := arg.Self()
-				setOptional := cust.DefaultPath != "" || cust.DefaultAddress != ""
-				if setOptional && !argSelf.TypeDef.Self().Optional {
-					var updatedTypeDef dagql.ObjectResult[*TypeDef]
-					if err := dag.Select(ctx, argSelf.TypeDef, &updatedTypeDef, dagql.Selector{
-						Field: "withOptional",
-						Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(true)}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q optional type: %w", argSelf.Name, err)
-					}
-					if !sameAttachedResult(updatedTypeDef, argSelf.TypeDef) {
-						typeDefID, err := ResultIDInput(updatedTypeDef)
-						if err != nil {
-							return updatedArg, fmt.Errorf("legacy customization arg %q optional type id: %w", argSelf.Name, err)
-						}
-						if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-							Field: "__withTypeDef",
-							Args:  []dagql.NamedInput{{Name: "typeDef", Value: typeDefID}},
-						}); err != nil {
-							return updatedArg, fmt.Errorf("legacy customization arg %q optional type apply: %w", argSelf.Name, err)
-						}
-					}
-				}
-				if jsonValue, ok := legacyArgDefaultValue(argSelf.TypeDef.Self(), cust.Default); ok {
-					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withDefaultValue",
-						Args:  []dagql.NamedInput{{Name: "defaultValue", Value: jsonValue}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q default value: %w", argSelf.Name, err)
-					}
-				}
-				if cust.DefaultPath != "" {
-					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withDefaultPath",
-						Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String(cust.DefaultPath)}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q default path: %w", argSelf.Name, err)
-					}
-					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withDefaultAddress",
-						Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String("")}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q clear default address: %w", argSelf.Name, err)
-					}
-				}
-				if cust.DefaultAddress != "" {
-					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withDefaultAddress",
-						Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String(cust.DefaultAddress)}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q default address: %w", argSelf.Name, err)
-					}
-					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withDefaultPath",
-						Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String("")}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q clear default path: %w", argSelf.Name, err)
-					}
-				}
-				if len(cust.Ignore) > 0 {
-					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withIgnore",
-						Args:  []dagql.NamedInput{{Name: "ignore", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(cust.Ignore...))}},
-					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q ignore: %w", argSelf.Name, err)
-					}
-				}
-				return updatedArg, nil
-			})
-			if err != nil {
-				return err
-			}
-			if !changed {
-				continue
-			}
-			updatedObjectTypeDef := objDef.Self().AsObject.Value
-			fnID, err := ResultIDInput(updatedFn)
-			if err != nil {
-				return fmt.Errorf("legacy customization function id: %w", err)
-			}
-			if constructor {
-				if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
-					Field: "__withConstructor",
-					Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
+		if err := mod.applyLegacyCustomizationToTargets(ctx, dag, cust, snapshots); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
+func (mod *Module) applyLegacyCustomizationToTargets(ctx context.Context, dag *dagql.Server, cust *modules.ModuleConfigArgument, snapshots [][]string) error {
+	for _, snapshot := range snapshots {
+		fresh := mod.customizationTargets(snapshot)
+		if len(fresh) == 0 {
+			continue
+		}
+		target := fresh[0]
+		objDef := target.objDef
+		fn := target.fn
+		constructor := target.constructor
+		if !objDef.Self().AsObject.Valid {
+			continue
+		}
+		updatedFn, changed, err := mod.patchFunctionArg(ctx, dag, fn, cust.Argument, func(arg dagql.ObjectResult[*FunctionArg]) (dagql.ObjectResult[*FunctionArg], error) {
+			updatedArg := arg
+			argSelf := arg.Self()
+			setOptional := cust.DefaultPath != "" || cust.DefaultAddress != ""
+			if setOptional && !argSelf.TypeDef.Self().Optional {
+				var updatedTypeDef dagql.ObjectResult[*TypeDef]
+				if err := dag.Select(ctx, argSelf.TypeDef, &updatedTypeDef, dagql.Selector{
+					Field: "withOptional",
+					Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(true)}},
 				}); err != nil {
-					return fmt.Errorf("legacy customization constructor %v: %w", cust.Function, err)
+					return updatedArg, fmt.Errorf("legacy customization arg %q optional type: %w", argSelf.Name, err)
 				}
-			} else {
-				if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
-					Field: "__withFunction",
-					Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
-				}); err != nil {
-					return fmt.Errorf("legacy customization function %v: %w", cust.Function, err)
-				}
-			}
-			objectTypeDefID, err := ResultIDInput(updatedObjectTypeDef)
-			if err != nil {
-				return fmt.Errorf("legacy customization object typedef id: %w", err)
-			}
-			for i, existing := range mod.ObjectDefs {
-				if sameAttachedResult(existing, objDef) {
-					if err := dag.Select(ctx, existing, &mod.ObjectDefs[i], dagql.Selector{
-						Field: "__withObjectTypeDef",
-						Args:  []dagql.NamedInput{{Name: "objectTypeDef", Value: objectTypeDefID}},
-					}); err != nil {
-						return fmt.Errorf("legacy customization object typedef: %w", err)
+				if !sameAttachedResult(updatedTypeDef, argSelf.TypeDef) {
+					typeDefID, err := ResultIDInput(updatedTypeDef)
+					if err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q optional type id: %w", argSelf.Name, err)
 					}
-					break
+					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+						Field: "__withTypeDef",
+						Args:  []dagql.NamedInput{{Name: "typeDef", Value: typeDefID}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q optional type apply: %w", argSelf.Name, err)
+					}
 				}
+			}
+			if jsonValue, ok := legacyArgDefaultValue(argSelf.TypeDef.Self(), cust.Default); ok {
+				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+					Field: "__withDefaultValue",
+					Args:  []dagql.NamedInput{{Name: "defaultValue", Value: jsonValue}},
+				}); err != nil {
+					return updatedArg, fmt.Errorf("legacy customization arg %q default value: %w", argSelf.Name, err)
+				}
+			}
+			if cust.DefaultPath != "" {
+				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+					Field: "__withDefaultPath",
+					Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String(cust.DefaultPath)}},
+				}); err != nil {
+					return updatedArg, fmt.Errorf("legacy customization arg %q default path: %w", argSelf.Name, err)
+				}
+				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+					Field: "__withDefaultAddress",
+					Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String("")}},
+				}); err != nil {
+					return updatedArg, fmt.Errorf("legacy customization arg %q clear default address: %w", argSelf.Name, err)
+				}
+			}
+			if cust.DefaultAddress != "" {
+				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+					Field: "__withDefaultAddress",
+					Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String(cust.DefaultAddress)}},
+				}); err != nil {
+					return updatedArg, fmt.Errorf("legacy customization arg %q default address: %w", argSelf.Name, err)
+				}
+				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+					Field: "__withDefaultPath",
+					Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String("")}},
+				}); err != nil {
+					return updatedArg, fmt.Errorf("legacy customization arg %q clear default path: %w", argSelf.Name, err)
+				}
+			}
+			if len(cust.Ignore) > 0 {
+				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+					Field: "__withIgnore",
+					Args:  []dagql.NamedInput{{Name: "ignore", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(cust.Ignore...))}},
+				}); err != nil {
+					return updatedArg, fmt.Errorf("legacy customization arg %q ignore: %w", argSelf.Name, err)
+				}
+			}
+			return updatedArg, nil
+		})
+		if err != nil {
+			return err
+		}
+		if !changed {
+			continue
+		}
+		updatedObjectTypeDef := objDef.Self().AsObject.Value
+		fnID, err := ResultIDInput(updatedFn)
+		if err != nil {
+			return fmt.Errorf("legacy customization function id: %w", err)
+		}
+		if constructor {
+			if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
+				Field: "__withConstructor",
+				Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
+			}); err != nil {
+				return fmt.Errorf("legacy customization constructor %v: %w", cust.Function, err)
+			}
+		} else {
+			if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
+				Field: "__withFunction",
+				Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
+			}); err != nil {
+				return fmt.Errorf("legacy customization function %v: %w", cust.Function, err)
+			}
+		}
+		objectTypeDefID, err := ResultIDInput(updatedObjectTypeDef)
+		if err != nil {
+			return fmt.Errorf("legacy customization object typedef id: %w", err)
+		}
+		for i, existing := range mod.ObjectDefs {
+			if sameAttachedResult(existing, objDef) {
+				if err := dag.Select(ctx, existing, &mod.ObjectDefs[i], dagql.Selector{
+					Field: "__withObjectTypeDef",
+					Args:  []dagql.NamedInput{{Name: "objectTypeDef", Value: objectTypeDefID}},
+				}); err != nil {
+					return fmt.Errorf("legacy customization object typedef: %w", err)
+				}
+				break
 			}
 		}
 	}

--- a/core/module.go
+++ b/core/module.go
@@ -514,10 +514,26 @@ func (mod *Module) ApplyWorkspaceDefaultsToTypeDefs(ctx context.Context, dag *da
 	return nil
 }
 
+func nameMatches(pattern string, names ...string) bool {
+	norm := func(s string) string {
+		s = strings.ToLower(s)
+		s = strings.ReplaceAll(s, "-", "")
+		s = strings.ReplaceAll(s, "_", "")
+		return s
+	}
+	p := norm(pattern)
+	for _, name := range names {
+		if matched, err := filepath.Match(p, norm(name)); err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
 func functionResultByOriginalName(obj *ObjectTypeDef, name string) (dagql.ObjectResult[*Function], bool) {
 	for _, fn := range obj.Functions {
 		fnSelf := fn.Self()
-		if strings.EqualFold(fnSelf.OriginalName, name) || strings.EqualFold(fnSelf.Name, gqlFieldName(name)) {
+		if nameMatches(name, fnSelf.OriginalName, fnSelf.Name) {
 			return fn, true
 		}
 	}
@@ -527,7 +543,7 @@ func functionResultByOriginalName(obj *ObjectTypeDef, name string) (dagql.Object
 func functionArgResultByName(fn *Function, name string) (dagql.ObjectResult[*FunctionArg], bool) {
 	for _, arg := range fn.Args {
 		argSelf := arg.Self()
-		if strings.EqualFold(argSelf.OriginalName, name) || strings.EqualFold(argSelf.Name, gqlFieldName(name)) {
+		if nameMatches(name, argSelf.OriginalName, argSelf.Name) {
 			return arg, true
 		}
 	}
@@ -568,41 +584,57 @@ func (mod *Module) mainObjectTypeDefResult() (dagql.ObjectResult[*TypeDef], bool
 	return mod.objectTypeDefResultByOriginalName(name)
 }
 
-func (mod *Module) customizationTarget(path []string) (dagql.ObjectResult[*TypeDef], dagql.ObjectResult[*Function], bool) {
+type customizationTargetMatch struct {
+	objDef      dagql.ObjectResult[*TypeDef]
+	fn          dagql.ObjectResult[*Function]
+	constructor bool
+}
+
+func (mod *Module) customizationTargets(path []string) []customizationTargetMatch {
 	objDef, ok := mod.mainObjectTypeDefResult()
 	if !ok {
-		return dagql.ObjectResult[*TypeDef]{}, dagql.ObjectResult[*Function]{}, false
+		return nil
 	}
 	obj := objDef.Self().AsObject.Value.Self()
 	if len(path) == 0 {
 		if !obj.Constructor.Valid {
-			return dagql.ObjectResult[*TypeDef]{}, dagql.ObjectResult[*Function]{}, false
+			return nil
 		}
-		return objDef, obj.Constructor.Value, true
+		return []customizationTargetMatch{{objDef: objDef, fn: obj.Constructor.Value, constructor: true}}
+	}
+	if len(path) == 1 {
+		var matches []customizationTargetMatch
+		for _, fn := range obj.Functions {
+			fnSelf := fn.Self()
+			if nameMatches(path[0], fnSelf.OriginalName, fnSelf.Name) {
+				matches = append(matches, customizationTargetMatch{objDef: objDef, fn: fn})
+			}
+		}
+		return matches
 	}
 	for i, segment := range path {
 		fn, ok := functionResultByOriginalName(obj, segment)
 		if !ok {
-			return dagql.ObjectResult[*TypeDef]{}, dagql.ObjectResult[*Function]{}, false
+			return nil
 		}
 		if i == len(path)-1 {
-			return objDef, fn, false
+			return []customizationTargetMatch{{objDef: objDef, fn: fn}}
 		}
 		returnType := fn.Self().ReturnType.Self()
 		if returnType == nil || !returnType.AsObject.Valid {
-			return dagql.ObjectResult[*TypeDef]{}, dagql.ObjectResult[*Function]{}, false
+			return nil
 		}
 		nextObjDef, ok := mod.objectTypeDefResultByOriginalName(returnType.AsObject.Value.Self().OriginalName)
 		if !ok {
 			nextObjDef, ok = mod.objectTypeDefResultByName(returnType.AsObject.Value.Self().Name)
 			if !ok {
-				return dagql.ObjectResult[*TypeDef]{}, dagql.ObjectResult[*Function]{}, false
+				return nil
 			}
 		}
 		objDef = nextObjDef
 		obj = objDef.Self().AsObject.Value.Self()
 	}
-	return dagql.ObjectResult[*TypeDef]{}, dagql.ObjectResult[*Function]{}, false
+	return nil
 }
 
 func (mod *Module) patchFunctionArg(
@@ -646,120 +678,141 @@ func (mod *Module) ApplyLegacyCustomizationsToTypeDefs(ctx context.Context, dag 
 		if cust == nil {
 			continue
 		}
-		objDef, fn, constructor := mod.customizationTarget(cust.Function)
-		if !objDef.Self().AsObject.Valid {
-			continue
+		var snapshots [][]string
+		for _, m := range mod.customizationTargets(cust.Function) {
+			if m.constructor {
+				snapshots = append(snapshots, nil)
+				continue
+			}
+			if len(cust.Function) <= 1 {
+				snapshots = append(snapshots, []string{m.fn.Self().OriginalName})
+			} else {
+				snapshots = append(snapshots, cust.Function)
+			}
 		}
-		updatedFn, changed, err := mod.patchFunctionArg(ctx, dag, fn, cust.Argument, func(arg dagql.ObjectResult[*FunctionArg]) (dagql.ObjectResult[*FunctionArg], error) {
-			updatedArg := arg
-			argSelf := arg.Self()
-			setOptional := cust.DefaultPath != "" || cust.DefaultAddress != ""
-			if setOptional && !argSelf.TypeDef.Self().Optional {
-				var updatedTypeDef dagql.ObjectResult[*TypeDef]
-				if err := dag.Select(ctx, argSelf.TypeDef, &updatedTypeDef, dagql.Selector{
-					Field: "withOptional",
-					Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(true)}},
-				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q optional type: %w", argSelf.Name, err)
+		for _, snapshot := range snapshots {
+			fresh := mod.customizationTargets(snapshot)
+			if len(fresh) == 0 {
+				continue
+			}
+			target := fresh[0]
+			objDef := target.objDef
+			fn := target.fn
+			constructor := target.constructor
+			if !objDef.Self().AsObject.Valid {
+				continue
+			}
+			updatedFn, changed, err := mod.patchFunctionArg(ctx, dag, fn, cust.Argument, func(arg dagql.ObjectResult[*FunctionArg]) (dagql.ObjectResult[*FunctionArg], error) {
+				updatedArg := arg
+				argSelf := arg.Self()
+				setOptional := cust.DefaultPath != "" || cust.DefaultAddress != ""
+				if setOptional && !argSelf.TypeDef.Self().Optional {
+					var updatedTypeDef dagql.ObjectResult[*TypeDef]
+					if err := dag.Select(ctx, argSelf.TypeDef, &updatedTypeDef, dagql.Selector{
+						Field: "withOptional",
+						Args:  []dagql.NamedInput{{Name: "optional", Value: dagql.Boolean(true)}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q optional type: %w", argSelf.Name, err)
+					}
+					if !sameAttachedResult(updatedTypeDef, argSelf.TypeDef) {
+						typeDefID, err := ResultIDInput(updatedTypeDef)
+						if err != nil {
+							return updatedArg, fmt.Errorf("legacy customization arg %q optional type id: %w", argSelf.Name, err)
+						}
+						if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+							Field: "__withTypeDef",
+							Args:  []dagql.NamedInput{{Name: "typeDef", Value: typeDefID}},
+						}); err != nil {
+							return updatedArg, fmt.Errorf("legacy customization arg %q optional type apply: %w", argSelf.Name, err)
+						}
+					}
 				}
-				if !sameAttachedResult(updatedTypeDef, argSelf.TypeDef) {
-					typeDefID, err := ResultIDInput(updatedTypeDef)
-					if err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q optional type id: %w", argSelf.Name, err)
+				if jsonValue, ok := legacyArgDefaultValue(argSelf.TypeDef.Self(), cust.Default); ok {
+					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+						Field: "__withDefaultValue",
+						Args:  []dagql.NamedInput{{Name: "defaultValue", Value: jsonValue}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q default value: %w", argSelf.Name, err)
+					}
+				}
+				if cust.DefaultPath != "" {
+					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+						Field: "__withDefaultPath",
+						Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String(cust.DefaultPath)}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q default path: %w", argSelf.Name, err)
 					}
 					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-						Field: "__withTypeDef",
-						Args:  []dagql.NamedInput{{Name: "typeDef", Value: typeDefID}},
+						Field: "__withDefaultAddress",
+						Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String("")}},
 					}); err != nil {
-						return updatedArg, fmt.Errorf("legacy customization arg %q optional type apply: %w", argSelf.Name, err)
+						return updatedArg, fmt.Errorf("legacy customization arg %q clear default address: %w", argSelf.Name, err)
 					}
 				}
+				if cust.DefaultAddress != "" {
+					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+						Field: "__withDefaultAddress",
+						Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String(cust.DefaultAddress)}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q default address: %w", argSelf.Name, err)
+					}
+					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+						Field: "__withDefaultPath",
+						Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String("")}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q clear default path: %w", argSelf.Name, err)
+					}
+				}
+				if len(cust.Ignore) > 0 {
+					if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
+						Field: "__withIgnore",
+						Args:  []dagql.NamedInput{{Name: "ignore", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(cust.Ignore...))}},
+					}); err != nil {
+						return updatedArg, fmt.Errorf("legacy customization arg %q ignore: %w", argSelf.Name, err)
+					}
+				}
+				return updatedArg, nil
+			})
+			if err != nil {
+				return err
 			}
-			if jsonValue, ok := legacyArgDefaultValue(argSelf.TypeDef.Self(), cust.Default); ok {
-				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-					Field: "__withDefaultValue",
-					Args:  []dagql.NamedInput{{Name: "defaultValue", Value: jsonValue}},
+			if !changed {
+				continue
+			}
+			updatedObjectTypeDef := objDef.Self().AsObject.Value
+			fnID, err := ResultIDInput(updatedFn)
+			if err != nil {
+				return fmt.Errorf("legacy customization function id: %w", err)
+			}
+			if constructor {
+				if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
+					Field: "__withConstructor",
+					Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
 				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q default value: %w", argSelf.Name, err)
+					return fmt.Errorf("legacy customization constructor %v: %w", cust.Function, err)
+				}
+			} else {
+				if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
+					Field: "__withFunction",
+					Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
+				}); err != nil {
+					return fmt.Errorf("legacy customization function %v: %w", cust.Function, err)
 				}
 			}
-			if cust.DefaultPath != "" {
-				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-					Field: "__withDefaultPath",
-					Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String(cust.DefaultPath)}},
-				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q default path: %w", argSelf.Name, err)
-				}
-				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-					Field: "__withDefaultAddress",
-					Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String("")}},
-				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q clear default address: %w", argSelf.Name, err)
-				}
+			objectTypeDefID, err := ResultIDInput(updatedObjectTypeDef)
+			if err != nil {
+				return fmt.Errorf("legacy customization object typedef id: %w", err)
 			}
-			if cust.DefaultAddress != "" {
-				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-					Field: "__withDefaultAddress",
-					Args:  []dagql.NamedInput{{Name: "defaultAddress", Value: dagql.String(cust.DefaultAddress)}},
-				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q default address: %w", argSelf.Name, err)
+			for i, existing := range mod.ObjectDefs {
+				if sameAttachedResult(existing, objDef) {
+					if err := dag.Select(ctx, existing, &mod.ObjectDefs[i], dagql.Selector{
+						Field: "__withObjectTypeDef",
+						Args:  []dagql.NamedInput{{Name: "objectTypeDef", Value: objectTypeDefID}},
+					}); err != nil {
+						return fmt.Errorf("legacy customization object typedef: %w", err)
+					}
+					break
 				}
-				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-					Field: "__withDefaultPath",
-					Args:  []dagql.NamedInput{{Name: "defaultPath", Value: dagql.String("")}},
-				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q clear default path: %w", argSelf.Name, err)
-				}
-			}
-			if len(cust.Ignore) > 0 {
-				if err := dag.Select(ctx, updatedArg, &updatedArg, dagql.Selector{
-					Field: "__withIgnore",
-					Args:  []dagql.NamedInput{{Name: "ignore", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(cust.Ignore...))}},
-				}); err != nil {
-					return updatedArg, fmt.Errorf("legacy customization arg %q ignore: %w", argSelf.Name, err)
-				}
-			}
-			return updatedArg, nil
-		})
-		if err != nil {
-			return err
-		}
-		if !changed {
-			continue
-		}
-		updatedObjectTypeDef := objDef.Self().AsObject.Value
-		fnID, err := ResultIDInput(updatedFn)
-		if err != nil {
-			return fmt.Errorf("legacy customization function id: %w", err)
-		}
-		if constructor {
-			if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
-				Field: "__withConstructor",
-				Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
-			}); err != nil {
-				return fmt.Errorf("legacy customization constructor %v: %w", cust.Function, err)
-			}
-		} else {
-			if err := dag.Select(ctx, updatedObjectTypeDef, &updatedObjectTypeDef, dagql.Selector{
-				Field: "__withFunction",
-				Args:  []dagql.NamedInput{{Name: "function", Value: fnID}},
-			}); err != nil {
-				return fmt.Errorf("legacy customization function %v: %w", cust.Function, err)
-			}
-		}
-		objectTypeDefID, err := ResultIDInput(updatedObjectTypeDef)
-		if err != nil {
-			return fmt.Errorf("legacy customization object typedef id: %w", err)
-		}
-		for i, existing := range mod.ObjectDefs {
-			if sameAttachedResult(existing, objDef) {
-				if err := dag.Select(ctx, existing, &mod.ObjectDefs[i], dagql.Selector{
-					Field: "__withObjectTypeDef",
-					Args:  []dagql.NamedInput{{Name: "objectTypeDef", Value: objectTypeDefID}},
-				}); err != nil {
-					return fmt.Errorf("legacy customization object typedef: %w", err)
-				}
-				break
 			}
 		}
 	}

--- a/core/object_test.go
+++ b/core/object_test.go
@@ -281,6 +281,61 @@ func TestModulePersistedTypeDefsRoundTripPreservesNullableValidity(t *testing.T)
 	assert.Equal(t, "Choice", decoded.EnumDefs[0].Self().AsEnum.Value.Self().Name)
 }
 
+func TestModulePersistedRoundTripPreservesAsModuleVariantDigest(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheIface, err := dagql.NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	sc := cacheIface
+
+	root := &Query{}
+	testSrv := &moduleObjectTestServer{
+		mockServer: &mockServer{},
+		cache:      sc,
+		root:       root,
+	}
+	root.Server = testSrv
+	dag := newCoreDagqlServerForTest(t, root)
+	testSrv.dag = dag
+	installTypeDefTestClasses(dag)
+	ctx = dagql.ContextWithCache(ctx, sc)
+	ctx = ContextWithQuery(ctx, root)
+
+	// The digest salts the module's content digest (see moduleImplementationScoped
+	// in core/schema/module.go) so two variants of the same module source — e.g.
+	// the same toolchain loaded with different customizations — don't share cached
+	// results. If it didn't survive the persistence round-trip, a reconstructed
+	// Module would emit no salt and collide with freshly-loaded variants.
+	for _, tc := range []struct {
+		name   string
+		digest string
+	}{
+		{"empty digest round-trips as empty", ""},
+		{"non-empty digest round-trips intact", "variant-abc123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mod := &Module{
+				NameField:             "Test",
+				OriginalName:          "Test",
+				SDKConfig:             &SDKConfig{},
+				Deps:                  NewSchemaBuilder(root, nil),
+				AsModuleVariantDigest: tc.digest,
+			}
+
+			payload, err := mod.EncodePersistedObject(ctx, sc)
+			assert.NilError(t, err)
+
+			decodedTyped, err := (&Module{}).DecodePersistedObject(ctx, dag, 0, nil, payload.JSON)
+			assert.NilError(t, err)
+			decoded, ok := decodedTyped.(*Module)
+			assert.Assert(t, ok)
+
+			assert.Equal(t, tc.digest, decoded.AsModuleVariantDigest)
+		})
+	}
+}
+
 func TestModuleObjectConvertToSDKInputUsesCurrentFieldID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Glob patterns can be used for `function` and `argument` fields.