### PR TITLE
cli: name the SDK in install hints for full refs

### DIFF
--- a/core/integration/command_hints_test.go
+++ b/core/integration/command_hints_test.go
@@ -70,6 +70,22 @@ func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t
 		"client init generates the bindings, so it must not send the user to `dagger generate`")
 }
 
+// TestSDKInstallFullRefHints verifies that installing an SDK by full ref names
+// the SDK in the capability hints. The install name of a full ref is derived
+// engine-side, so the CLI only learns it back from the install.
+func (CommandHintsSuite) TestSDKInstallFullRefHints(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+
+	installOut, err := hostDaggerExecRaw(ctx, t, workdir, "sdk", "install", "github.com/dagger/go-sdk")
+	require.NoError(t, err, "%s", string(installOut))
+
+	got := string(installOut)
+	require.Contains(t, got, `Installed SDK "go-sdk". This SDK can`)
+	require.Contains(t, got, "dagger module init go-sdk")
+	require.Contains(t, got, "dagger api client init go-sdk")
+}
+
 // TestUninstalledSDKInitHint verifies that `dagger module init <sdk> <name>`
 // for a registry-known but uninstalled SDK, in a workspace with no dagger.toml,
 // fails with a hint to install the SDK rather than a generic unknown-command

--- a/internal/cmd/dagger/sdk.go
+++ b/internal/cmd/dagger/sdk.go
@@ -152,20 +152,22 @@ func runSDKInstall(cmd *cobra.Command, args []string) error {
 	if name == "" {
 		name = defaultName
 	}
-	// The name the authoring commands dispatch on: the as-sdk alias if the
-	// registry set one, otherwise the install name.
-	hintName := asSDKName
-	if hintName == "" {
-		hintName = name
-	}
 
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,
 	}, func(ctx context.Context, ec *client.Client) error {
 		dag := ec.Dagger()
-		if err := installWorkspaceSDK(ctx, dag, cmd.OutOrStdout(), canonicalRef, name, asSDKName, sdkInstallHere); err != nil {
+		installedName, err := installWorkspaceSDK(ctx, dag, cmd.OutOrStdout(), canonicalRef, name, asSDKName, sdkInstallHere)
+		if err != nil {
 			return err
+		}
+		// The name the authoring commands dispatch on: the as-sdk alias if the
+		// registry set one, otherwise the name the install resolved to — which
+		// for a full ref is only known once the engine derived it.
+		hintName := asSDKName
+		if hintName == "" {
+			hintName = installedName
 		}
 		printSDKInstallCapabilityHints(ctx, dag, cmd, hintName, canonicalRef)
 		return nil
@@ -238,11 +240,14 @@ func printSDKInstallCapabilityHints(ctx context.Context, dag *dagger.Client, cmd
 	}
 }
 
-func installWorkspaceSDK(ctx context.Context, dag *dagger.Client, out io.Writer, ref, name, asSDKName string, here bool) error {
+// installWorkspaceSDK installs the SDK and returns the workspace name it ended
+// up installed under — for a full ref that name is derived engine-side, so
+// callers can only learn it from here.
+func installWorkspaceSDK(ctx context.Context, dag *dagger.Client, out io.Writer, ref, name, asSDKName string, here bool) (string, error) {
 	current := dag.CurrentWorkspace()
 	previousConfig, err := current.ConfigFile(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	updated, err := materializeWorkspace(ctx, dag, current.WithSDK(ref, dagger.WorkspaceWithSDKOpts{
 		Name:      name,
@@ -250,38 +255,38 @@ func installWorkspaceSDK(ctx context.Context, dag *dagger.Client, out io.Writer,
 		AsSDKName: asSDKName,
 	}))
 	if err != nil {
-		return err
+		return "", err
 	}
 	resolvedName, err := workspaceInstalledModuleName(ctx, current, updated, ref, name)
 	if err != nil {
-		return err
+		return "", err
 	}
 	configPath, err := workspaceConfigHostPath(ctx, updated)
 	if err != nil {
-		return err
+		return "", err
 	}
 	updatedConfig, err := updated.ConfigFile(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	isEmpty, err := updated.Changes().IsEmpty(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := updated.Export(ctx); err != nil {
-		return err
+		return "", err
 	}
 	if isEmpty {
 		_, err = fmt.Fprintf(out, "SDK %q is already installed\n", resolvedName)
-		return err
+		return resolvedName, err
 	}
 	if previousConfig != updatedConfig {
 		if _, err := fmt.Fprintf(out, "Created workspace config in %s\n", filepath.Dir(configPath)); err != nil {
-			return err
+			return "", err
 		}
 	}
 	_, err = fmt.Fprintf(out, "Installed SDK %q in %s\n", resolvedName, configPath)
-	return err
+	return resolvedName, err
 }
 
 func runSDKUninstall(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
`dagger sdk install github.com/eunomie/python-sdk@test-template` printed a **blank SDK name** in the post-install capability-hints block:

```
Installed SDK "python-sdk" in /tmp/.../dagger.toml
  Installed SDK "". This SDK can:
    • Create a new module:
        dagger module init  <name>
```

**Root cause:** `sdkResolveInstall` returns an empty install name for full refs by design (the name is derived engine-side in `Workspace.withSDK`), and `runSDKInstall` computed the hint name from that empty CLI-side name. The correct name was already computed inside `installWorkspaceSDK` (`workspaceInstalledModuleName`, after the `WithSDK` call) but wasn't returned to the caller.

**Fix** (`internal/cmd/dagger/sdk.go`, +test):
- `installWorkspaceSDK` now returns `(string, error)` — the resolved install name.
- `runSDKInstall` uses it as the hint name when the registry set no as-sdk alias; registry installs still dispatch on their alias.

## Verification

- Before: reproduced the blank name exactly; after: `Installed SDK "python-sdk". This SDK can:` / `dagger module init python-sdk <name>`.
- Registry alias `sdk install ts` unchanged (hints say "typescript", install line still "dagger-typescript-sdk"); `--name mypy` full ref → hints say "mypy"; re-install ("already installed") path still named.
- New integration test `CommandHintsSuite.TestSDKInstallFullRefHints`; full `TestCommandHints` suite passes (4/4) against a dev engine. `go vet` / staticcheck / gofmt / `go test ./internal/cmd/dagger/` all clean.
