### PR TITLE
feat(engine): optional IPv6 CIDR for the container network

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -223,6 +223,10 @@ func addFlags(app *cli.App) {
 			Usage: "address range to use for networked containers",
 			Value: network.DefaultCIDR,
 		},
+		cli.StringFlag{
+			Name:  "network-cidr6",
+			Usage: "optional IPv6 address range to additionally assign to networked containers (dual-stack); empty disables IPv6",
+		},
 		cli.StringSliceFlag{
 			Name:  "oci-worker-labels",
 			Usage: "user-specific annotation labels (com.example.foo=bar)",
@@ -365,6 +369,7 @@ func main() { //nolint:gocyclo
 		netConf, err := setupNetwork(networkContext,
 			c.GlobalString("network-name"),
 			c.GlobalString("network-cidr"),
+			c.GlobalString("network-cidr6"),
 		)
 		if err != nil {
 			return err
@@ -914,11 +919,16 @@ func attrMap(sl []string) (map[string]string, error) {
 type networkConfig struct {
 	NetName       string
 	NetCIDR       string
+	NetCIDR6      string
 	Bridge        net.IP
 	CNIConfigPath string
 }
 
-func setupNetwork(ctx context.Context, netName, netCIDR string) (*networkConfig, error) {
+// setupNetwork configures the engine's container network. netCIDR6 is
+// optional: when set, containers additionally receive an address from it,
+// making the bridge dual-stack. The bridge address handed to resolv.conf
+// stays IPv4 so DNS is reachable either way.
+func setupNetwork(ctx context.Context, netName, netCIDR, netCIDR6 string) (*networkConfig, error) {
 	bridge, err := network.BridgeFromCIDR(netCIDR)
 	if err != nil {
 		return nil, fmt.Errorf("bridge from cidr: %w", err)
@@ -940,7 +950,7 @@ func setupNetwork(ctx context.Context, netName, netCIDR string) (*networkConfig,
 		return nil, fmt.Errorf("install dnsmasq: %w", err)
 	}
 
-	cniConfigPath, err := netinst.InstallCNIConfig(ctx, netName, netCIDR)
+	cniConfigPath, err := netinst.InstallCNIConfig(ctx, netName, netCIDR, netCIDR6)
 	if err != nil {
 		return nil, fmt.Errorf("install cni: %w", err)
 	}
@@ -948,6 +958,7 @@ func setupNetwork(ctx context.Context, netName, netCIDR string) (*networkConfig,
 	return &networkConfig{
 		NetName:       netName,
 		NetCIDR:       netCIDR,
+		NetCIDR6:      netCIDR6,
 		Bridge:        bridge,
 		CNIConfigPath: cniConfigPath,
 	}, nil

--- a/network/netinst/cni.go
+++ b/network/netinst/cni.go
@@ -14,8 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func InstallCNIConfig(ctx context.Context, name, subnet string) (string, error) {
-	cni, err := cniConfig(ctx, name, subnet)
+// InstallCNIConfig writes the engine's generated CNI config. subnets is
+// ordered; each entry becomes its own IPAM range set, so passing an IPv6
+// range alongside the IPv4 one yields a dual-stack bridge.
+func InstallCNIConfig(ctx context.Context, name string, subnets ...string) (string, error) {
+	cni, err := cniConfig(ctx, name, subnets...)
 	if err != nil {
 		return "", err
 	}
@@ -44,7 +47,15 @@ func detectIPMasqBackend() string {
 	return "iptables"
 }
 
-func cniConfig(ctx context.Context, name, subnet string) ([]byte, error) {
+func cniConfig(ctx context.Context, name string, subnets ...string) ([]byte, error) {
+	ranges := make([]any, 0, len(subnets))
+	for _, subnet := range subnets {
+		if subnet == "" {
+			continue
+		}
+		ranges = append(ranges, []any{map[string]any{"subnet": subnet}})
+	}
+
 	bridgePlugin := map[string]any{
 		"type":             "bridge",
 		"bridge":           name + "0",
@@ -52,10 +63,8 @@ func cniConfig(ctx context.Context, name, subnet string) ([]byte, error) {
 		"ipMasq":           true,
 		"hairpinMode":      true,
 		"ipam": map[string]any{
-			"type": "host-local",
-			"ranges": []any{
-				[]any{map[string]any{"subnet": subnet}},
-			},
+			"type":   "host-local",
+			"ranges": ranges,
 		},
 	}
 

--- a/network/netinst/cni_test.go
+++ b/network/netinst/cni_test.go
@@ -1,0 +1,51 @@
+package netinst
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func ipamRanges(t *testing.T, cfg []byte) []any {
+	t.Helper()
+	var parsed struct {
+		Plugins []struct {
+			Type string `json:"type"`
+			IPAM struct {
+				Ranges []any `json:"ranges"`
+			} `json:"ipam"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(cfg, &parsed); err != nil {
+		t.Fatalf("unmarshal cni config: %v", err)
+	}
+	for _, p := range parsed.Plugins {
+		if p.Type == "bridge" {
+			return p.IPAM.Ranges
+		}
+	}
+	t.Fatal("no bridge plugin in generated cni config")
+	return nil
+}
+
+func TestCNIConfigRanges(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		subnets    []string
+		wantRanges int
+	}{
+		{"ipv4 only", []string{"10.87.0.0/16"}, 1},
+		{"dual stack", []string{"10.87.0.0/16", "fdaa:dag::/64"}, 2},
+		{"empty ipv6 is skipped", []string{"10.87.0.0/16", ""}, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := cniConfig(context.Background(), "dagger", tc.subnets...)
+			if err != nil {
+				t.Fatalf("cniConfig: %v", err)
+			}
+			if got := len(ipamRanges(t, cfg)); got != tc.wantRanges {
+				t.Errorf("ipam ranges = %d, want %d", got, tc.wantRanges)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Relates to #13868 (whose original premise I've since corrected there).

## Correction up front

My initial framing — "engine users have no equivalent to BuildKit's `cniprovider.Opt.ConfigPath`" — **was wrong**. `--oci-cni-config-path` is exposed and it wins over the generated config: `setNetworkDefaults` only fills `CNIConfigPath` when empty, and `applyMainFlags` runs after it. So dual-stack is already achievable today with a hand-written conflist, no code change required.

This PR is therefore **not a capability fix**. It's ergonomics, and I'd understand entirely if you'd rather close it.

## The residual argument

Supplying your own conflist means giving up what the generated one does dynamically:

- **MTU** discovered from the host interface.
- **`ipMasqBackend`** detected for kernels without legacy xtables (#11731) — a static conflist works until someone moves to 6.17+, then breaks.

It also means keeping the bridge name and IPv4 subnet in sync by hand with `InstallResolvconf` (which points containers at the bridge address derived from `--network-cidr`) and dnsmasq (`interface={{.NetworkInterface}}`). Diverge on either and DNS breaks non-obviously.

So the narrow ask: let an operator add a v6 range *without* opting out of the generated config.

## Change

Optional `--network-cidr6`. When set, its range is appended as a second `host-local` IPAM range set. When unset — the default — the generated config is **byte-identical to today's**. The `ranges` key was already CNI's dual-stack shape, so this is an append, not a restructure.

- `network/netinst/cni.go` — `InstallCNIConfig`/`cniConfig` take variadic subnets, one range set per non-empty entry.
- `cmd/engine/main.go` — new flag, threaded through `setupNetwork`.

Deliberately unchanged: `BridgeFromCIDR` stays IPv4-only and still feeds `InstallResolvconf`, so DNS is reachable regardless of families; dnsmasq needs nothing since it binds an interface rather than an address.

## Testing

`network/netinst/cni_test.go` — one IPAM range for IPv4-only, two for dual-stack, empty IPv6 skipped. Passes on linux:

```
--- PASS: TestCNIConfigRanges/ipv4_only
--- PASS: TestCNIConfigRanges/dual_stack
--- PASS: TestCNIConfigRanges/empty_ipv6_is_skipped
ok  github.com/dagger/dagger/network/netinst
```

`go build ./cmd/engine ./network/...` clean for `GOOS=linux`.

Still draft: **runtime-unverified**. I'm currently validating dual-stack address assignment against a real engine via the `--oci-cni-config-path` route and will report the result on #13868 — if that shows `ipMasq` doesn't do what's needed for v6, this PR needs more than a second IPAM range and I'll say so.
