### PR TITLE
fix(check): align @check with @generate on required arguments

### DIFF
--- a/core/integration/checks_test.go
+++ b/core/integration/checks_test.go
@@ -468,3 +468,36 @@ source = "../%s"
 		})
 	}
 }
+
+// A @check that declares a required argument breaks the marker's contract: no
+// caller supplies one when `dagger check` runs. Like @up and @generate, that is
+// a module load failure rather than a check quietly missing from the list.
+func (ChecksSuite) TestChecksValidationRejectsRequiredArg(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	t.Run("required arg", func(ctx context.Context, t *testctx.T) {
+		modGen, err := checksTestEnv(t, c)
+		require.NoError(t, err)
+
+		// badcheck-arg's @check declares a required `name: String!`, which must be
+		// rejected at module load.
+		out, err := modGen.WithWorkdir("badcheck-arg").
+			With(daggerExecFail("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "@check functions must be callable with no arguments")
+	})
+
+	t.Run("workspace arg", func(ctx context.Context, t *testctx.T) {
+		modGen, err := checksTestEnv(t, c)
+		require.NoError(t, err)
+
+		// A Workspace! argument is injected rather than supplied by the caller, so
+		// it is not a required argument as far as the contract is concerned.
+		out, err := modGen.WithWorkdir("check-workspace-arg").
+			With(daggerExec("check", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "check-workspace-arg:verify")
+	})
+}

--- a/core/integration/testdata/checks/badcheck-arg/dagger.json
+++ b/core/integration/testdata/checks/badcheck-arg/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "badcheck-arg",
+  "engineVersion": "v1.0.0",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/checks/badcheck-arg/main.dang
+++ b/core/integration/testdata/checks/badcheck-arg/main.dang
@@ -1,0 +1,7 @@
+"""A deliberately malformed check module (@check with a required arg) for validation tests."""
+type BadcheckArg {
+  """@check with a required arg, which the contract forbids."""
+  pub verify(name: String!): Void @check {
+    null
+  }
+}

--- a/core/integration/testdata/checks/check-workspace-arg/dagger.json
+++ b/core/integration/testdata/checks/check-workspace-arg/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-workspace-arg",
+  "engineVersion": "v1.0.0",
+  "sdk": "dang"
+}

--- a/core/integration/testdata/checks/check-workspace-arg/main.dang
+++ b/core/integration/testdata/checks/check-workspace-arg/main.dang
@@ -1,0 +1,9 @@
+"""A module whose @check takes the auto-injected Workspace, which the no-argument
+contract must not reject."""
+type CheckWorkspaceArg {
+  """A check that reads the workspace it runs against."""
+  pub verify(ws: Workspace!): Void @check {
+    ws.file("dagger.json").contents
+    null
+  }
+}

--- a/core/module.go
+++ b/core/module.go
@@ -191,6 +191,21 @@ func returnsCoreObject(fn *Function, name string) bool {
 		ret.AsObject.Value.Self().SourceModuleName == ""
 }
 
+// validateCheckFunction enforces the @check contract: the function must be
+// callable with no caller-supplied arguments, since `dagger check` runs checks
+// without any. Unlike @up and @generate there is no return-type constraint — a
+// check reports itself however it likes.
+func validateCheckFunction(obj *ObjectTypeDef, fn *Function) error {
+	for _, argRes := range fn.Args {
+		arg := argRes.Self()
+		if argRequired(arg) {
+			return fmt.Errorf("object %q function %q is marked @check but declares required argument %q; @check functions must be callable with no arguments",
+				obj.OriginalName, fn.OriginalName, arg.OriginalName)
+		}
+	}
+	return nil
+}
+
 // validateUpFunction enforces the @up contract: the function must return the
 // core Service! type and must be callable with no caller-supplied arguments,
 // since `dagger up` starts services without any.
@@ -1361,6 +1376,11 @@ func (mod *Module) validateObjectField(ctx context.Context, obj *ObjectTypeDef, 
 func (mod *Module) validateObjectFunction(ctx context.Context, obj *ObjectTypeDef, fn *Function, state *moduleValidationState) error {
 	if gqlFieldName(fn.Name) == "id" {
 		return fmt.Errorf("cannot define function with reserved name %q on object %q", fn.Name, obj.Name)
+	}
+	if fn.IsCheck {
+		if err := validateCheckFunction(obj, fn); err != nil {
+			return err
+		}
 	}
 	if fn.IsUp {
 		if err := validateUpFunction(obj, fn); err != nil {


### PR DESCRIPTION
`@up`, `@generate` and `@agent` all refuse to load a module whose marked function demands an argument the caller never supplies. `@check` didn't, so the same mistake showed up as one fewer entry in `dagger check -l` — indistinguishable from a check that passed, while `dagger functions` still listed the function.

Before:

```
$ dagger functions
needs-arg   A @check with a required argument
runnable    A check a rollup can run

$ dagger check -l
my-module:runnable        ← needs-arg is simply gone, no warning
```

After, matching what `@generate` already does:

```
$ dagger check -l
✘ ERROR object "MyModule" function "needsArg" is marked @check but declares required argument "name";
        @check functions must be callable with no arguments
```

**Scope.** One validator plus its dispatch, mirroring `validateGeneratorFunction`. No return-type constraint — unlike `@up`/`@generate`, a check reports itself however it likes (`Void`, an error, a `Container` to run). An auto-injected `Workspace!` is not a caller-supplied argument, so checks taking one keep loading; there's a fixture pinning that.

**Compatibility.** A module with a `@check` that declares a required argument now fails to load instead of quietly losing that check. Verified against this repo and its published dependencies: `dagger check -l` lists the same 84 checks before and after (`ci:bootstrap` takes `source: Workspace!`, `python-client:lint` takes `paths` with a default — both unaffected).

**Testing.** `dagger api call engine-dev test --pkg ./core/integration --run='^TestChecks$|^TestGenerators$|^TestUp$|^TestAgents$'` → 213 passed, 0 failed. New `TestChecksValidationRejectsRequiredArg` covers both the rejection and the Workspace-argument case, alongside the existing `badgenerate-arg`/`badup-arg` tests.

**Not included.** A check whose *owning object* is only reachable through a function that requires an argument (`suite(name: String!): Suite!`) is still silently dropped from rollups. Making that a load error was tried and rejected: `github.com/dagger/go` has exactly that shape (`GoModule.lint` behind `module(path:)`), so it would break `dagger check` for this repo and every user of that module. Surfacing it needs a warning rather than an error, which is left for a follow-up.
