### PR TITLE
sdk(improvement): support nullable object returns

### DIFF
--- a/.dagger/modules/dotnet-client-dev/main.dang
+++ b/.dagger/modules/dotnet-client-dev/main.dang
@@ -30,6 +30,8 @@ type DotnetClientDev {
   """
   pub sourcePath: String! = "sdk/dotnet/sdk"
 
+  let ws: Workspace!
+
   let originalWorkspace: Directory! = workspaceDir
 
   let baseContainer: Container! {
@@ -37,7 +39,7 @@ type DotnetClientDev {
       .from(dotnetSdkImage)
       .withWorkdir("/src")
 
-    ctr = daggerEngine.installClient(ctr)
+    ctr = daggerEngine(ws: self.ws).installClient(ctr)
   }
 
   ######################################
@@ -69,10 +71,25 @@ type DotnetClientDev {
   """
   pub test: Void @check {
     devContainer
-      .withFile("Dagger.SDK/introspection.json", daggerEngine.introspectionJson)
+      .withFile("Dagger.SDK/introspection.json", daggerEngine(ws: self.ws).introspectionJson)
       .withExec(["dotnet", "restore"])
       .withExec(["dotnet", "build", "--no-restore"])
       .withExec(["dagger", "run", "dotnet", "test", "--no-build"])
+      .sync
+
+    null
+  }
+
+  """
+  Run source generator tests without compiling the generated SDK client.
+  """
+  pub sourceGeneratorTest: Void @check {
+    devContainer
+      .withExec([
+        "dotnet",
+        "test",
+        "Dagger.SDK.SourceGenerator.Tests/Dagger.SDK.SourceGenerator.Tests.csproj",
+      ])
       .sync
 
     null
@@ -117,7 +134,6 @@ type DotnetClientDev {
         devContainer
           .withExec(["dotnet", "tool", "restore"])
           .withExec(["dotnet", "csharpier", "."])
-          .rootfs
           .directory("/src"),
       )
 

--- a/.dagger/modules/java-client-dev/main.dang
+++ b/.dagger/modules/java-client-dev/main.dang
@@ -23,6 +23,7 @@ type JavaClientDev {
     "!sdk/java/README.md",
     "!sdk/java/pom.xml",
     "sdk/java/**/src/test",
+    "!sdk/java/dagger-codegen-maven-plugin/src/test/",
     "sdk/java/**/target",
   ])
 

--- a/cmd/codegen/generator/functions.go
+++ b/cmd/codegen/generator/functions.go
@@ -2,12 +2,17 @@ package generator
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
 	"github.com/dagger/dagger/cmd/codegen/introspection"
 	"golang.org/x/mod/semver"
 )
+
+const nullableObjectSDKCutoverVersion = "v1.0.0-beta.10"
+
+var betaVersion = regexp.MustCompile(`^(v\d+\.\d+\.\d+-beta\.\d+)`)
 
 const (
 	QueryStructName       = "Query"
@@ -257,4 +262,14 @@ func (c *CommonFunctions) formatType(r *introspection.TypeRef, scope string, inp
 
 func (c *CommonFunctions) CheckVersionCompatibility(minVersion string) bool {
 	return semver.Compare(c.schemaVersion, minVersion) >= 0
+}
+
+func SupportsNullableObjects(schemaVersion string) bool {
+	if schemaVersion == "" || !semver.IsValid(schemaVersion) {
+		return true
+	}
+	if version := betaVersion.FindString(schemaVersion); version != "" {
+		schemaVersion = version
+	}
+	return semver.Compare(schemaVersion, nullableObjectSDKCutoverVersion) >= 0
 }

--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -113,6 +113,7 @@ func (funcs goTemplateFuncs) FuncMap() template.FuncMap {
 		// interface support
 		"IsInterfaceType":          funcs.isInterfaceType,
 		"IsInterfaceRef":           funcs.isInterfaceRef,
+		"IsNullableObject":         funcs.isNullableObject,
 		"IsListOfInterface":        funcs.isListOfInterface,
 		"InterfaceClientName":      funcs.interfaceClientName,
 		"InterfaceReturnType":      funcs.interfaceReturnType,
@@ -165,6 +166,10 @@ func (funcs goTemplateFuncs) legacyGoSDKCompat() bool {
 		return false
 	}
 	return !funcs.CheckVersionCompatibility(legacyGoSDKCompatCutoverVersion)
+}
+
+func (funcs goTemplateFuncs) supportsNullableObjects() bool {
+	return generator.SupportsNullableObjects(funcs.schemaVersion)
 }
 
 // fullSchemaTypes returns all types from the full schema, including dependency
@@ -405,7 +410,7 @@ func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool,
 
 	// Generate arguments
 	args := []string{}
-	if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	if f.TypeRef.IsScalar() || f.TypeRef.IsList() || funcs.isNullableObject(f.TypeRef) {
 		args = append(args, "ctx context.Context")
 	}
 	for _, arg := range f.Args {
@@ -457,6 +462,12 @@ func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool,
 		retType = fmt.Sprintf("(*%s, error)", retType)
 	case f.TypeRef.IsScalar() || f.TypeRef.IsList():
 		retType = fmt.Sprintf("(%s, error)", retType)
+	case funcs.isNullableObject(f.TypeRef):
+		if funcs.isInterfaceRef(f.TypeRef) {
+			retType = fmt.Sprintf("(%s, error)", retType)
+		} else {
+			retType = fmt.Sprintf("(*%s, error)", retType)
+		}
 	case funcs.isInterfaceRef(f.TypeRef):
 		retType, err = funcs.interfaceReturnType(funcs.InnerType(f.TypeRef).Name, scopes...)
 		if err != nil {
@@ -490,6 +501,10 @@ func (funcs goTemplateFuncs) isInterfaceRef(t *introspection.TypeRef) bool {
 		}
 	}
 	return false
+}
+
+func (funcs goTemplateFuncs) isNullableObject(t *introspection.TypeRef) bool {
+	return funcs.supportsNullableObjects() && t != nil && t.IsOptional() && (t.IsObject() || funcs.isInterfaceRef(t))
 }
 
 // isListOfInterface returns true if the type ref is a list whose element is an interface.
@@ -581,7 +596,7 @@ func (funcs goTemplateFuncs) interfaceMethodSignature(f introspection.Field) (st
 	sig := formatName(f.Name)
 
 	args := []string{}
-	if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	if f.TypeRef.IsScalar() || f.TypeRef.IsList() || funcs.isNullableObject(f.TypeRef) {
 		args = append(args, "ctx context.Context")
 	}
 	for _, arg := range f.Args {
@@ -622,6 +637,12 @@ func (funcs goTemplateFuncs) interfaceMethodSignature(f introspection.Field) (st
 		sig += fmt.Sprintf(" (%s, error)", retType)
 	case f.TypeRef.IsScalar() || f.TypeRef.IsList():
 		sig += fmt.Sprintf(" (%s, error)", retType)
+	case funcs.isNullableObject(f.TypeRef):
+		if funcs.isInterfaceRef(f.TypeRef) {
+			sig += fmt.Sprintf(" (%s, error)", retType)
+		} else {
+			sig += fmt.Sprintf(" (*%s, error)", retType)
+		}
 	case funcs.isInterfaceRef(f.TypeRef):
 		retType, err = funcs.interfaceReturnType(funcs.InnerType(f.TypeRef).Name)
 		if err != nil {
@@ -643,7 +664,7 @@ func (funcs goTemplateFuncs) interfaceClientMethod(ifaceName string, f introspec
 	sig := "func (r *" + clientName + ") " + formatName(f.Name)
 
 	args := []string{}
-	if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	if f.TypeRef.IsScalar() || f.TypeRef.IsList() || funcs.isNullableObject(f.TypeRef) {
 		args = append(args, "ctx context.Context")
 	}
 	for _, arg := range f.Args {
@@ -684,6 +705,12 @@ func (funcs goTemplateFuncs) interfaceClientMethod(ifaceName string, f introspec
 		sig += fmt.Sprintf(" (%s, error)", retType)
 	case f.TypeRef.IsScalar() || f.TypeRef.IsList():
 		sig += fmt.Sprintf(" (%s, error)", retType)
+	case funcs.isNullableObject(f.TypeRef):
+		if funcs.isInterfaceRef(f.TypeRef) {
+			sig += fmt.Sprintf(" (%s, error)", retType)
+		} else {
+			sig += fmt.Sprintf(" (*%s, error)", retType)
+		}
 	case funcs.isInterfaceRef(f.TypeRef):
 		retType, err = funcs.interfaceReturnType(funcs.InnerType(f.TypeRef).Name)
 		if err != nil {

--- a/cmd/codegen/generator/go/templates/nullable_object_test.go
+++ b/cmd/codegen/generator/go/templates/nullable_object_test.go
@@ -1,0 +1,46 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/cmd/codegen/generator"
+	"github.com/dagger/dagger/cmd/codegen/introspection"
+)
+
+func TestNullableObjectFieldFunction(t *testing.T) {
+	field := introspection.Field{
+		Name:         "latestVersion",
+		TypeRef:      &introspection.TypeRef{Kind: introspection.TypeKindObject, Name: "GitRef"},
+		ParentObject: &introspection.Type{Name: "GitRepository"},
+	}
+
+	for _, test := range []struct {
+		name          string
+		schemaVersion string
+		want          string
+	}{
+		{
+			name:          "current engine",
+			schemaVersion: "v1.0.0-beta.10",
+			want:          "func (r *GitRepository) LatestVersion(ctx context.Context) (*GitRef, error)",
+		},
+		{
+			name:          "older engine",
+			schemaVersion: "v1.0.0-beta.9",
+			want:          "func (r *GitRepository) LatestVersion() *GitRef",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			funcs := goTemplateFuncs{
+				CommonFunctions: generator.NewCommonFunctions(test.schemaVersion, &FormatTypeFunc{}),
+				schemaVersion:   test.schemaVersion,
+			}
+
+			signature, err := funcs.fieldFunction(field, false, true)
+			require.NoError(t, err)
+			require.Equal(t, test.want, signature)
+		})
+	}
+}

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -121,6 +121,25 @@ type {{ $field | FieldOptionsStructName }} struct {
 		query: selectNode(q.Root(), id, "{{ $field.ParentObject.Name }}"),
 	}, nil
 
+	{{- else if IsNullableObject $field.TypeRef }}
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
+	}
+	if objectID == nil {
+		return nil, nil
+	}
+	{{- if IsInterfaceRef $field.TypeRef }}
+	return &{{ $typeName | InterfaceClientName }}{
+		query: selectNode(q.Root(), *objectID, "{{ $typeName }}"),
+	}, nil
+	{{- else }}
+	return &{{ $typeName }}{
+		query: selectNode(q.Root(), *objectID, "{{ $typeName }}"),
+	}, nil
+	{{- end }}
+
 	{{- else if IsInterfaceRef $field.TypeRef }}
 	{{- /* Interface return: wrap in the interface's query-builder struct */ -}}
 	return &{{ $typeName | InterfaceClientName }}{
@@ -253,4 +272,3 @@ func (r *{{ $.Name | FormatName }}) As{{ $iface.Name | FormatName }}() {{ $iface
 	}
 }
 {{ end -}}
-

--- a/cmd/codegen/generator/go/templates/src/dag/dag.gen.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/dag/dag.gen.go.tmpl
@@ -78,7 +78,7 @@ func Close() error {
 {{ FieldFunction $field true $supportsVoid "dagger" }} {
 	client := initClient()
 	return client.{{ .Name | FormatName }}(
-		{{- if not $field.TypeRef.IsObject -}}
+		{{- if or (not $field.TypeRef.IsObject) (IsNullableObject $field.TypeRef) -}}
 		ctx,
 		{{- end -}}
 		{{- range $arg := $field.Args -}}

--- a/cmd/codegen/generator/nullable_object_test.go
+++ b/cmd/codegen/generator/nullable_object_test.go
@@ -1,0 +1,27 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupportsNullableObjects(t *testing.T) {
+	for _, test := range []struct {
+		version string
+		want    bool
+	}{
+		{"", true},
+		{"development", true},
+		{"v0.21.0-dev", false},
+		{"v1.0.0-beta.9-dev", false},
+		{"v1.0.0-beta.10", true},
+		{"v1.0.0-beta.10-dev", true},
+		{"v1.0.0-rc.1", true},
+		{"v1.0.0", true},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			require.Equal(t, test.want, SupportsNullableObjects(test.version))
+		})
+	}
+}

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -133,6 +133,7 @@ func (funcs typescriptTemplateFuncs) FuncMap() template.FuncMap {
 		"IsSelfChainable":           commonFunc.IsSelfChainable,
 		"IsListOfObject":            commonFunc.IsListOfObject,
 		"IsListOfInterface":         funcs.isListOfInterface,
+		"IsNullableObject":          funcs.isNullableObject,
 		"IsListOfEnum":              commonFunc.IsListOfEnum,
 		"GetArrayField":             commonFunc.GetArrayField,
 		"ToLowerCase":               commonFunc.ToLowerCase,
@@ -178,6 +179,10 @@ func (funcs typescriptTemplateFuncs) legacyTypeScriptSDKCompat() bool {
 		return false
 	}
 	return semver.Compare(funcs.schemaVersion, legacyTypeScriptSDKCompatCutoverVersion) < 0
+}
+
+func (funcs typescriptTemplateFuncs) supportsNullableObjects() bool {
+	return generator.SupportsNullableObjects(funcs.schemaVersion)
 }
 
 // isInterface checks if the type is a GraphQL interface.
@@ -336,7 +341,11 @@ func (funcs typescriptTemplateFuncs) solve(field introspection.Field) bool {
 	if field.TypeRef == nil {
 		return false
 	}
-	return field.TypeRef.IsScalar() || field.TypeRef.IsList()
+	return field.TypeRef.IsScalar() || field.TypeRef.IsList() || funcs.isNullableObject(field.TypeRef)
+}
+
+func (funcs typescriptTemplateFuncs) isNullableObject(ref *introspection.TypeRef) bool {
+	return funcs.supportsNullableObjects() && ref != nil && ref.IsOptional() && (ref.IsObject() || ref.IsInterface())
 }
 
 // subtract subtract integer a with integer b.

--- a/cmd/codegen/generator/typescript/templates/src/_method_solve_body.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/_method_solve_body.ts.gtpl
@@ -65,11 +65,21 @@ The dot is an introspection.Field. */ -}}
 		{{- end }}
     ){{- /* Add subfields */ -}}
       {{- if and .TypeRef.IsList (IsListOfObject .TypeRef) }}.select("{{- range $i, $v := . | GetArrayField }}{{if $i }} {{ end }}{{ $v.Name | ToLowerCase }}{{- end }}")
+      {{- else if IsNullableObject .TypeRef }}.select("id")
       {{- end }}
 
-    {{ if not .TypeRef.IsVoid }}const response: Awaited<{{ if $convertID }}{{ . | FormatFieldOutputType }}{{ else }}{{ $promiseRetType }}{{ end }}> = {{ end }}await ctx.execute()
+    {{ if not .TypeRef.IsVoid }}const response: Awaited<{{ if IsNullableObject .TypeRef }}string | null{{ else if $convertID }}{{ . | FormatFieldOutputType }}{{ else }}{{ $promiseRetType }}{{ end }}> = {{ end }}await ctx.execute()
 
-    {{ if $convertID -}}
+    {{ if IsNullableObject .TypeRef -}}
+    if (response === null) {
+      return null
+    }
+      {{- if .TypeRef.IsInterface }}
+    return new _{{ $promiseRetType | FormatProtected | FormatName }}Client(ctx.copy().selectNode(response, "{{ $promiseRetType | FormatProtected }}"))
+      {{- else }}
+    return new {{ $promiseRetType | FormatProtected | FormatName }}(ctx.copy().selectNode(response, "{{ $promiseRetType | FormatProtected }}"))
+      {{- end }}
+    {{- else if $convertID -}}
       {{- if IsInterface .ParentObject }}
     return new _{{ $promiseRetType | FormatProtected | FormatName }}Client(ctx.copy().selectNode(response, "{{ $promiseRetType | FormatProtected }}"))
       {{- else }}

--- a/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
@@ -29,7 +29,7 @@
 	{{- end }}
 
 	{{- /* Write return type */ -}}
-	{{- "" }}): Promise<{{ if .TypeRef.IsVoid }}void{{ else }}{{ . | FormatFieldReturnType }}{{ end }}> => { {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
+	{{- "" }}): Promise<{{ if .TypeRef.IsVoid }}void{{ else }}{{ . | FormatFieldReturnType }}{{ if IsNullableObject .TypeRef }} | null{{ end }}{{ end }}> => { {{- with .Directives.SourceMap }} // {{ .Module }} ({{ .Filelink | ModuleRelPath }}) {{- end }}
 	{{- /* Body is shared with the dep prototype augmentations. */ -}}
 	{{- template "method_solve_body" . }}
   }

--- a/cmd/codegen/generator/typescript/templates/src/object_test.go
+++ b/cmd/codegen/generator/typescript/templates/src/object_test.go
@@ -83,6 +83,39 @@ func TestObjectFieldDeprecated(t *testing.T) {
 	require.Equal(t, want, b.String())
 }
 
+func TestNullableObjectField(t *testing.T) {
+	object := objectInit(t, `{
+      "kind": "OBJECT",
+      "name": "GitRepository",
+      "description": "",
+      "fields": [{
+        "args": [],
+        "description": "",
+        "isDeprecated": false,
+        "name": "latestVersion",
+        "type": {"kind": "OBJECT", "name": "GitRef"}
+      }],
+      "inputFields": null,
+      "interfaces": [],
+      "enumValues": null,
+      "possibleTypes": null
+    }`)
+
+	tmpl := templateHelper(t)
+	var b bytes.Buffer
+	require.NoError(t, tmpl.ExecuteTemplate(&b, "object", object))
+	require.Contains(t, b.String(), "latestVersion = async (): Promise<GitRef | null>")
+	require.Contains(t, b.String(), `"latestVersion",`)
+	require.Contains(t, b.String(), `.select("id")`)
+	require.Contains(t, b.String(), "if (response === null)")
+
+	tmpl = templates.New("v1.0.0-beta.9", nil, "", generator.Config{})
+	b.Reset()
+	require.NoError(t, tmpl.ExecuteTemplate(&b, "object", object))
+	require.Contains(t, b.String(), "latestVersion = (): GitRef")
+	require.NotContains(t, b.String(), "response === null")
+}
+
 func TestInterfaceMethodOptionalArgDeprecated(t *testing.T) {
 	tmpl := templateHelper(t)
 

--- a/cmd/codegen/generator/typescript/templates/src/testdata/objects_test_want.ts
+++ b/cmd/codegen/generator/typescript/templates/src/testdata/objects_test_want.ts
@@ -62,13 +62,18 @@ export class Host extends BaseClient {
   /**
    * Lookup the value of an environment variable. Null if the variable is not available.
    */
-  envVariable = (name: string): HostVariable => {
-
+  envVariable = async (name: string): Promise<HostVariable | null> => {
     const ctx = this._ctx.select(
       "envVariable",
-      { name },
-    )
-    return new HostVariable(ctx)
+      { name},
+    ).select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new HostVariable(ctx.copy().selectNode(response, "HostVariable"))
   }
 
   /**

--- a/core/integration/changeset_test.go
+++ b/core/integration/changeset_test.go
@@ -1442,9 +1442,12 @@ func (ChangesetSuite) testChangeApplying(t *testctx.T, apply func(*dagger.Direct
 
 		resultDir := beforeDir.WithChanges(changes)
 
-		fileType, err := resultDir.Stat("node", dagger.DirectoryStatOpts{
+		stat, err := resultDir.Stat(ctx, "node", dagger.DirectoryStatOpts{
 			DoNotFollowSymlinks: true,
-		}).FileType(ctx)
+		})
+		require.NoError(t, err)
+		require.NotNil(t, stat)
+		fileType, err := stat.FileType(ctx)
 		require.NoError(t, err)
 		require.Equal(t, dagger.FileTypeRegularType, fileType)
 
@@ -1483,9 +1486,12 @@ func (ChangesetSuite) testWithChangesSymlinks(t *testctx.T) {
 		resultDir := beforeDir.WithChanges(afterDir.Changes(beforeDir))
 
 		assertFileType := func(p string, expected dagger.FileType) {
-			fileType, err := resultDir.Stat(p, dagger.DirectoryStatOpts{
+			stat, err := resultDir.Stat(ctx, p, dagger.DirectoryStatOpts{
 				DoNotFollowSymlinks: true,
-			}).FileType(ctx)
+			})
+			require.NoError(t, err)
+			require.NotNil(t, stat)
+			fileType, err := stat.FileType(ctx)
 			require.NoError(t, err)
 			require.Equal(t, expected, fileType, p)
 		}

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -6290,7 +6290,9 @@ func (ContainerSuite) TestStat(ctx context.Context, t *testctx.T) {
 		From(alpineImage).
 		WithWorkdir("/sub").
 		WithNewFile("subdir/data", "contents")
-	stat := ctr.Stat("subdir/data")
+	stat, err := ctr.Stat(ctx, "subdir/data")
+	require.NoError(t, err)
+	require.NotNil(t, stat)
 
 	fileType, err := stat.FileType(ctx)
 	require.NoError(t, err)
@@ -6307,7 +6309,9 @@ func (ContainerSuite) TestStatWithMountedDir(ctx context.Context, t *testctx.T) 
 	ctr := c.Container().
 		From(alpineImage).
 		WithMountedDirectory("/mnt", d)
-	stat := ctr.Stat("/mnt/the-file")
+	stat, err := ctr.Stat(ctx, "/mnt/the-file")
+	require.NoError(t, err)
+	require.NotNil(t, stat)
 
 	fileType, err := stat.FileType(ctx)
 	require.NoError(t, err)
@@ -6324,7 +6328,9 @@ func (ContainerSuite) TestStatWithMountedFile(ctx context.Context, t *testctx.T)
 	ctr := c.Container().
 		From(alpineImage).
 		WithMountedFile("/mnt-file", f)
-	stat := ctr.Stat("/mnt-file")
+	stat, err := ctr.Stat(ctx, "/mnt-file")
+	require.NoError(t, err)
+	require.NotNil(t, stat)
 
 	fileType, err := stat.FileType(ctx)
 	require.NoError(t, err)
@@ -6552,7 +6558,9 @@ func (ContainerSuite) TestHealthcheckIsPublished(ctx context.Context, t *testctx
 	require.Contains(t, pushedRef, "@sha256:")
 
 	pulledCtr := c.Container().From(pushedRef)
-	configuredHealthcheck := pulledCtr.DockerHealthcheck()
+	configuredHealthcheck, err := pulledCtr.DockerHealthcheck(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, configuredHealthcheck)
 
 	healthcheckArgs, err := configuredHealthcheck.Args(ctx)
 	require.NoError(t, err)
@@ -6586,7 +6594,9 @@ func (ContainerSuite) TestHealthcheckDefaults(ctx context.Context, t *testctx.T)
 		From(alpineImage).
 		WithDockerHealthcheck([]string{"/this-will-fail-and-thats-ok"})
 
-	configuredHealthcheck := ctr.DockerHealthcheck()
+	configuredHealthcheck, err := ctr.DockerHealthcheck(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, configuredHealthcheck)
 
 	healthcheckArgs, err := configuredHealthcheck.Args(ctx)
 	require.NoError(t, err)
@@ -6657,11 +6667,9 @@ func (ContainerSuite) TestWithoutHealthcheck(ctx context.Context, t *testctx.T) 
 		WithDockerHealthcheck([]string{"/waiter-check-please"}).
 		WithoutDockerHealthcheck()
 
-	configuredHealthcheck := ctr.DockerHealthcheck()
-
-	healthcheckArgs, err := configuredHealthcheck.Args(ctx)
+	configuredHealthcheck, err := ctr.DockerHealthcheck(ctx)
 	require.NoError(t, err)
-	require.Empty(t, healthcheckArgs)
+	require.Nil(t, configuredHealthcheck)
 }
 
 func (ContainerSuite) TestManifest(ctx context.Context, t *testctx.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -2961,9 +2961,11 @@ func (DirectorySuite) TestExists(ctx context.Context, t *testctx.T) {
 func (DirectorySuite) TestStat(ctx context.Context, t *testctx.T) {
 	t.Run("file-exists", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		stat := c.Directory().
+		stat, err := c.Directory().
 			WithNewFile("f", "data", dagger.DirectoryWithNewFileOpts{Permissions: 0o444}).
-			Stat("f")
+			Stat(ctx, "f")
+		require.NoError(t, err)
+		require.NotNil(t, stat)
 
 		name, err := stat.Name(ctx)
 		require.NoError(t, err)
@@ -2983,9 +2985,11 @@ func (DirectorySuite) TestStat(ctx context.Context, t *testctx.T) {
 	})
 	t.Run("file-dir-exists", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		stat := c.Directory().
+		stat, err := c.Directory().
 			WithNewDirectory("d", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o750}).
-			Stat("d")
+			Stat(ctx, "d")
+		require.NoError(t, err)
+		require.NotNil(t, stat)
 
 		name, err := stat.Name(ctx)
 		require.NoError(t, err)
@@ -3005,9 +3009,7 @@ func (DirectorySuite) TestStat(ctx context.Context, t *testctx.T) {
 	})
 	t.Run("empty-path-fails", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
-		stat := c.Directory().Stat("")
-
-		_, err := stat.Name(ctx)
+		_, err := c.Directory().Stat(ctx, "")
 		require.ErrorContains(t, err, ": no such file or directory")
 	})
 }

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -932,7 +932,9 @@ HEALTHCHECK --interval=21s --timeout=4s --start-period=9s --start-interval=2s --
 `
 		dir := baseDir.WithNewFile("Dockerfile", dockerfile)
 
-		healthcheck := dir.DockerBuild().DockerHealthcheck()
+		healthcheck, err := dir.DockerBuild().DockerHealthcheck(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, healthcheck)
 
 		interval, err := healthcheck.Interval(ctx)
 		require.NoError(t, err)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -1321,23 +1321,37 @@ func (GitSuite) TestGitCommitReleaseTags(ctx context.Context, t *testctx.T) {
 
 	git := ctr.Directory(".").AsGit()
 
-	ancestorStable, err := git.Head().TargetCommit().AncestorReleaseTag().Name(ctx)
+	untaggedRef, err := git.Head().TargetCommit().ReleaseTag(ctx)
+	require.NoError(t, err)
+	require.Nil(t, untaggedRef)
+
+	ancestorStableRef, err := git.Head().TargetCommit().AncestorReleaseTag(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, ancestorStableRef)
+	ancestorStable, err := ancestorStableRef.Name(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "refs/tags/v2.0.0", ancestorStable)
 
-	ancestorPreRelease, err := git.Head().TargetCommit().
-		AncestorReleaseTag(dagger.GitCommitAncestorReleaseTagOpts{IncludePreRelease: true}).
-		Name(ctx)
+	ancestorPreReleaseRef, err := git.Head().TargetCommit().AncestorReleaseTag(ctx,
+		dagger.GitCommitAncestorReleaseTagOpts{IncludePreRelease: true})
+	require.NoError(t, err)
+	require.NotNil(t, ancestorPreReleaseRef)
+	ancestorPreRelease, err := ancestorPreReleaseRef.Name(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "refs/tags/v2.1.0-rc.1", ancestorPreRelease)
 
-	directStable, err := git.Commit(stableSHA).ReleaseTag().Name(ctx)
+	directStableRef, err := git.Commit(stableSHA).ReleaseTag(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, directStableRef)
+	directStable, err := directStableRef.Name(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "refs/tags/v2.0.0", directStable)
 
-	directPreRelease, err := git.Commit(rcSHA).
-		ReleaseTag(dagger.GitCommitReleaseTagOpts{IncludePreRelease: true}).
-		Name(ctx)
+	directPreReleaseRef, err := git.Commit(rcSHA).ReleaseTag(ctx,
+		dagger.GitCommitReleaseTagOpts{IncludePreRelease: true})
+	require.NoError(t, err)
+	require.NotNil(t, directPreReleaseRef)
+	directPreRelease, err := directPreReleaseRef.Name(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "refs/tags/v2.1.0-rc.1", directPreRelease)
 
@@ -1346,7 +1360,10 @@ func (GitSuite) TestGitCommitReleaseTags(ctx context.Context, t *testctx.T) {
 	unreachable := ctr.
 		WithExec([]string{"git", "remote", "add", "origin", "https://invalid.invalid/repo.git"}).
 		Directory(".").AsGit()
-	offlineStable, err := unreachable.Head().TargetCommit().AncestorReleaseTag().Name(ctx)
+	offlineStableRef, err := unreachable.Head().TargetCommit().AncestorReleaseTag(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, offlineStableRef)
+	offlineStable, err := offlineStableRef.Name(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "refs/tags/v2.0.0", offlineStable)
 }
@@ -1396,7 +1413,10 @@ func (GitSuite) TestGitCommitReleaseTagFreshness(ctx context.Context, t *testctx
 		commit := repo.Head().TargetCommit()
 		sha, err = commit.Sha(ctx)
 		require.NoError(t, err)
-		tag, err = commit.ReleaseTag().Name(ctx)
+		tagRef, err := commit.ReleaseTag(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, tagRef)
+		tag, err = tagRef.Name(ctx)
 		require.NoError(t, err)
 		return sha, advertised, tag
 	}

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -515,8 +515,12 @@ func (m *Coolsdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *Coolsdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
+func (m *Coolsdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := modSource.WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithEnvVariable("COOL", "true"), nil
 }
 
 func (m *Coolsdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/core/integration/testdata/modules/go/config-context-defaults-source-root/coolsdk/main.go
+++ b/core/integration/testdata/modules/go/config-context-defaults-source-root/coolsdk/main.go
@@ -27,9 +27,12 @@ func (m *CoolSdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *CoolSdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return modSource.WithSDK("go").AsModule().Runtime().
-		WithMountedDirectory("/da-context", modSource.ContextDirectory())
+func (m *CoolSdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := modSource.WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithMountedDirectory("/da-context", modSource.ContextDirectory()), nil
 }
 
 func (m *CoolSdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/core/integration/testdata/modules/go/config-include-exclude-coolsdk/coolsdk/main.go
+++ b/core/integration/testdata/modules/go/config-include-exclude-coolsdk/coolsdk/main.go
@@ -27,8 +27,12 @@ func (m *Coolsdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *Coolsdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
+func (m *Coolsdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := modSource.WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithEnvVariable("COOL", "true"), nil
 }
 
 func (m *Coolsdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/core/integration/testdata/modules/go/config-sdk-module-no-config-support/coolsdk/main.go
+++ b/core/integration/testdata/modules/go/config-sdk-module-no-config-support/coolsdk/main.go
@@ -53,8 +53,12 @@ func (m *Coolsdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *Coolsdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return m.WithDaggerJson(modSource).WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", m.BarConfig)
+func (m *Coolsdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := m.WithDaggerJson(modSource).WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithEnvVariable("COOL", m.BarConfig), nil
 }
 
 func (m *Coolsdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/core/integration/testdata/modules/go/config-sdk-module-with-config-support/coolsdk/main.go
+++ b/core/integration/testdata/modules/go/config-sdk-module-with-config-support/coolsdk/main.go
@@ -53,8 +53,12 @@ func (m *Coolsdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *Coolsdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return m.WithDaggerJson(modSource).WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", m.BarConfig)
+func (m *Coolsdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := m.WithDaggerJson(modSource).WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithEnvVariable("COOL", m.BarConfig), nil
 }
 
 func (m *Coolsdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/core/integration/testdata/modules/go/custom-sdk-cool-sdk/main.go
+++ b/core/integration/testdata/modules/go/custom-sdk-cool-sdk/main.go
@@ -27,8 +27,12 @@ func (m *CoolSdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *CoolSdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
+func (m *CoolSdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := modSource.WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithEnvVariable("COOL", "true"), nil
 }
 
 func (m *CoolSdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/core/integration/testdata/modules/go/custom-sdk-init-sdk/main.go
+++ b/core/integration/testdata/modules/go/custom-sdk-init-sdk/main.go
@@ -31,8 +31,12 @@ func (m *CoolSdk) ModuleTypes(ctx context.Context, modSource *dagger.ModuleSourc
 		}), nil
 }
 
-func (m *CoolSdk) ModuleRuntime(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.Container {
-	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
+func (m *CoolSdk) ModuleRuntime(ctx context.Context, modSource *dagger.ModuleSource, introspectionJson *dagger.File) (*dagger.Container, error) {
+	runtime, err := modSource.WithSDK("go").AsModule().Runtime(ctx)
+	if err != nil || runtime == nil {
+		return runtime, err
+	}
+	return runtime.WithEnvVariable("COOL", "true"), nil
 }
 
 func (m *CoolSdk) Codegen(modSource *dagger.ModuleSource, introspectionJson *dagger.File) *dagger.GeneratedCode {

--- a/docs/static/reference/php/Dagger/Check.html
+++ b/docs/static/reference/php/Dagger/Check.html
@@ -171,7 +171,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
+                    <abbr title="Dagger\Dagger\Error">Error</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_error">error</a>()
@@ -443,7 +443,7 @@
                     <div class="method-item">
                     <h3 id="method_error">
         <div class="location">at line 43</div>
-        <code>                    <a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\Error">Error</abbr>|null
     <strong>error</strong>()
         </code>
     </h3>
@@ -460,7 +460,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Error.html"><abbr title="Dagger\Error">Error</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Error">Error</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -474,7 +474,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 52</div>
+        <div class="location">at line 57</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -506,7 +506,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 61</div>
+        <div class="location">at line 66</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -538,7 +538,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_originalModule">
-        <div class="location">at line 70</div>
+        <div class="location">at line 75</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>originalModule</strong>()
         </code>
@@ -570,7 +570,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_passed">
-        <div class="location">at line 79</div>
+        <div class="location">at line 84</div>
         <code>                    bool
     <strong>passed</strong>()
         </code>
@@ -602,7 +602,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_path">
-        <div class="location">at line 88</div>
+        <div class="location">at line 93</div>
         <code>                    array
     <strong>path</strong>()
         </code>
@@ -634,7 +634,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_resultEmoji">
-        <div class="location">at line 97</div>
+        <div class="location">at line 102</div>
         <code>                    string
     <strong>resultEmoji</strong>()
         </code>
@@ -666,7 +666,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_run">
-        <div class="location">at line 106</div>
+        <div class="location">at line 111</div>
         <code>                    <a href="../Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a>
     <strong>run</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Client.html
+++ b/docs/static/reference/php/Dagger/Client.html
@@ -168,7 +168,7 @@
                     object
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_loadObjectFromId">loadObjectFromId</a>(string $className, <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
+                    <a href="#method_loadObjectFromId">loadObjectFromId</a>(string $className, <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id, string|null $graphQLTypeName = null)
         
                                             <p><p>Load an object by its ID using node(id:) with an inline fragment.</p></p>                </div>
                 <div class="col-md-2"><small>from&nbsp;<a href="../Dagger/Client/AbstractClient.html#method_loadObjectFromId">
@@ -479,7 +479,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Node.html"><abbr title="Dagger\Node">Node</abbr></a>
+                    <abbr title="Dagger\Dagger\Node">Node</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_node">node</a>(<a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
@@ -720,9 +720,9 @@
                     <div class="method-item">
                     <h3 id="method_loadObjectFromId">
         <div class="location">in <a href="../Dagger/Client/AbstractClient.html#method_loadObjectFromId">
-<abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> at line 66</div>
+<abbr title="Dagger\Client\AbstractClient">AbstractClient</abbr></a> at line 67</div>
         <code>                    object
-    <strong>loadObjectFromId</strong>(string $className, <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
+    <strong>loadObjectFromId</strong>(string $className, <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id, string|null $graphQLTypeName = null)
         </code>
     </h3>
     <div class="details">    
@@ -745,6 +745,11 @@
                 <td><a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a></td>
                 <td>$id</td>
                 <td><p>The object's ID</p></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$graphQLTypeName</td>
+                <td><p>GraphQL type name when it differs from the PHP class name</p></td>
             </tr>
             </table>
 
@@ -2041,7 +2046,7 @@
                     <div class="method-item">
                     <h3 id="method_node">
         <div class="location">at line 406</div>
-        <code>                    <a href="../Dagger/Node.html"><abbr title="Dagger\Node">Node</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\Node">Node</abbr>|null
     <strong>node</strong>(<a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
         </code>
     </h3>
@@ -2068,7 +2073,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Node.html"><abbr title="Dagger\Node">Node</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Node">Node</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -2082,7 +2087,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_schema">
-        <div class="location">at line 416</div>
+        <div class="location">at line 421</div>
         <code>                    <a href="../Dagger/Schema.html"><abbr title="Dagger\Schema">Schema</abbr></a>
     <strong>schema</strong>(<a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a> $json)
         </code>
@@ -2124,7 +2129,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_secret">
-        <div class="location">at line 426</div>
+        <div class="location">at line 431</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>secret</strong>(string $uri, string|null $cacheKey = null)
         </code>
@@ -2171,7 +2176,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecret">
-        <div class="location">at line 441</div>
+        <div class="location">at line 446</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecret</strong>(string $name, string $plaintext)
         </code>
@@ -2218,7 +2223,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceDir">
-        <div class="location">at line 449</div>
+        <div class="location">at line 454</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>sourceDir</strong>()
         </code>
@@ -2251,7 +2256,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceMap">
-        <div class="location">at line 458</div>
+        <div class="location">at line 463</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>sourceMap</strong>(string $filename, int $line, int $column)
         </code>
@@ -2303,7 +2308,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sshfsVolume">
-        <div class="location">at line 470</div>
+        <div class="location">at line 475</div>
         <code>                    <a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a>
     <strong>sshfsVolume</strong>(string $endpoint, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $privateKey, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $knownHosts = null, string|null $cacheKey = null, bool|null $insecureSkipHostKeyCheck = false, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $experimentalServiceHost = null)
         </code>
@@ -2370,7 +2375,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 499</div>
+        <div class="location">at line 504</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>
@@ -2402,7 +2407,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 508</div>
+        <div class="location">at line 513</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -2434,7 +2439,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_with">
-        <div class="location">at line 517</div>
+        <div class="location">at line 522</div>
         <code>                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
     <strong>with</strong>(<abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $sdkSourceDir = null)
         </code>

--- a/docs/static/reference/php/Dagger/Client/AbstractClient.html
+++ b/docs/static/reference/php/Dagger/Client/AbstractClient.html
@@ -161,7 +161,7 @@
                     object
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_loadObjectFromId">loadObjectFromId</a>(string $className, <a href="../../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
+                    <a href="#method_loadObjectFromId">loadObjectFromId</a>(string $className, <a href="../../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id, string|null $graphQLTypeName = null)
         
                                             <p><p>Load an object by its ID using node(id:) with an inline fragment.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -304,9 +304,9 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_loadObjectFromId">
-        <div class="location">at line 66</div>
+        <div class="location">at line 67</div>
         <code>                    object
-    <strong>loadObjectFromId</strong>(string $className, <a href="../../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
+    <strong>loadObjectFromId</strong>(string $className, <a href="../../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id, string|null $graphQLTypeName = null)
         </code>
     </h3>
     <div class="details">    
@@ -329,6 +329,11 @@
                 <td><a href="../../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a></td>
                 <td>$id</td>
                 <td><p>The object's ID</p></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$graphQLTypeName</td>
+                <td><p>GraphQL type name when it differs from the PHP class name</p></td>
             </tr>
             </table>
 

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -193,7 +193,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a>
+                    <abbr title="Dagger\Dagger\HealthcheckConfig">HealthcheckConfig</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_dockerHealthcheck">dockerHealthcheck</a>()
@@ -433,7 +433,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
+                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_stat">stat</a>(string $path, bool|null $doNotFollowSymlinks = false)
@@ -1309,7 +1309,7 @@
                     <div class="method-item">
                     <h3 id="method_dockerHealthcheck">
         <div class="location">at line 110</div>
-        <code>                    <a href="../Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\HealthcheckConfig">HealthcheckConfig</abbr>|null
     <strong>dockerHealthcheck</strong>()
         </code>
     </h3>
@@ -1326,7 +1326,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/HealthcheckConfig.html"><abbr title="Dagger\HealthcheckConfig">HealthcheckConfig</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\HealthcheckConfig">HealthcheckConfig</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -1340,7 +1340,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_entrypoint">
-        <div class="location">at line 119</div>
+        <div class="location">at line 124</div>
         <code>                    array
     <strong>entrypoint</strong>()
         </code>
@@ -1372,7 +1372,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envVariable">
-        <div class="location">at line 128</div>
+        <div class="location">at line 133</div>
         <code>                    string
     <strong>envVariable</strong>(string $name)
         </code>
@@ -1414,7 +1414,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_envVariables">
-        <div class="location">at line 138</div>
+        <div class="location">at line 143</div>
         <code>                    array
     <strong>envVariables</strong>()
         </code>
@@ -1446,7 +1446,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exists">
-        <div class="location">at line 147</div>
+        <div class="location">at line 152</div>
         <code>                    bool
     <strong>exists</strong>(string $path, <abbr title="Dagger\Dagger\ExistsType">ExistsType</abbr>|null $expectedType = null, bool|null $doNotFollowSymlinks = false, bool|null $expand = false)
         </code>
@@ -1503,7 +1503,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exitCode">
-        <div class="location">at line 172</div>
+        <div class="location">at line 177</div>
         <code>                    int
     <strong>exitCode</strong>()
         </code>
@@ -1535,7 +1535,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_experimentalWithAllGPUs">
-        <div class="location">at line 185</div>
+        <div class="location">at line 190</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>experimentalWithAllGPUs</strong>()
         </code>
@@ -1568,7 +1568,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_experimentalWithGPU">
-        <div class="location">at line 198</div>
+        <div class="location">at line 203</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>experimentalWithGPU</strong>(array $devices)
         </code>
@@ -1611,7 +1611,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_export">
-        <div class="location">at line 210</div>
+        <div class="location">at line 215</div>
         <code>                    string
     <strong>export</strong>(string $path, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, bool|null $expand = false)
         </code>
@@ -1673,7 +1673,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exportImage">
-        <div class="location">at line 237</div>
+        <div class="location">at line 242</div>
         <code>                    void
     <strong>exportImage</strong>(string $name, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -1730,7 +1730,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_exposedPorts">
-        <div class="location">at line 262</div>
+        <div class="location">at line 267</div>
         <code>                    array
     <strong>exposedPorts</strong>()
         </code>
@@ -1762,7 +1762,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 273</div>
+        <div class="location">at line 278</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path, bool|null $expand = false)
         </code>
@@ -1809,7 +1809,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_from">
-        <div class="location">at line 286</div>
+        <div class="location">at line 291</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>from</strong>(string $address, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         </code>
@@ -1866,7 +1866,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 309</div>
+        <div class="location">at line 314</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1898,7 +1898,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_imageRef">
-        <div class="location">at line 318</div>
+        <div class="location">at line 323</div>
         <code>                    string
     <strong>imageRef</strong>()
         </code>
@@ -1930,7 +1930,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_import">
-        <div class="location">at line 327</div>
+        <div class="location">at line 332</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>import</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $tag = &#039;&#039;)
         </code>
@@ -1977,7 +1977,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_label">
-        <div class="location">at line 340</div>
+        <div class="location">at line 345</div>
         <code>                    string
     <strong>label</strong>(string $name)
         </code>
@@ -2019,7 +2019,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_labels">
-        <div class="location">at line 350</div>
+        <div class="location">at line 355</div>
         <code>                    array
     <strong>labels</strong>()
         </code>
@@ -2051,7 +2051,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_layer">
-        <div class="location">at line 359</div>
+        <div class="location">at line 364</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>layer</strong>(string $id, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2103,7 +2103,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_manifest">
-        <div class="location">at line 378</div>
+        <div class="location">at line 383</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>manifest</strong>(<abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2150,7 +2150,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_mounts">
-        <div class="location">at line 395</div>
+        <div class="location">at line 400</div>
         <code>                    array
     <strong>mounts</strong>()
         </code>
@@ -2182,7 +2182,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_platform">
-        <div class="location">at line 404</div>
+        <div class="location">at line 409</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>platform</strong>()
         </code>
@@ -2214,7 +2214,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_publish">
-        <div class="location">at line 415</div>
+        <div class="location">at line 420</div>
         <code>                    string
     <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         </code>
@@ -2286,7 +2286,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_rootfs">
-        <div class="location">at line 450</div>
+        <div class="location">at line 455</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>rootfs</strong>()
         </code>
@@ -2318,8 +2318,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stat">
-        <div class="location">at line 459</div>
-        <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
+        <div class="location">at line 464</div>
+        <code>                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
     </h3>
@@ -2351,7 +2351,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Stat">Stat</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -2365,7 +2365,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stderr">
-        <div class="location">at line 474</div>
+        <div class="location">at line 484</div>
         <code>                    string
     <strong>stderr</strong>()
         </code>
@@ -2397,7 +2397,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stdout">
-        <div class="location">at line 485</div>
+        <div class="location">at line 495</div>
         <code>                    string
     <strong>stdout</strong>()
         </code>
@@ -2429,7 +2429,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 496</div>
+        <div class="location">at line 506</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -2461,7 +2461,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 506</div>
+        <div class="location">at line 516</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>terminal</strong>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2513,7 +2513,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_up">
-        <div class="location">at line 529</div>
+        <div class="location">at line 539</div>
         <code>                    void
     <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -2590,7 +2590,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_user">
-        <div class="location">at line 570</div>
+        <div class="location">at line 580</div>
         <code>                    string
     <strong>user</strong>()
         </code>
@@ -2622,7 +2622,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAnnotation">
-        <div class="location">at line 579</div>
+        <div class="location">at line 589</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withAnnotation</strong>(string $name, string $value)
         </code>
@@ -2669,7 +2669,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultArgs">
-        <div class="location">at line 590</div>
+        <div class="location">at line 600</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultArgs</strong>(array $args)
         </code>
@@ -2711,7 +2711,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultTerminalCmd">
-        <div class="location">at line 600</div>
+        <div class="location">at line 610</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2763,7 +2763,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 619</div>
+        <div class="location">at line 629</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false, int|null $permissions = null)
         </code>
@@ -2845,7 +2845,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDockerHealthcheck">
-        <div class="location">at line 660</div>
+        <div class="location">at line 670</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDockerHealthcheck</strong>(array $args, bool|null $shell = null, string|null $interval = null, string|null $timeout = null, string|null $startPeriod = null, string|null $startInterval = null, int|null $retries = null)
         </code>
@@ -2917,7 +2917,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEntrypoint">
-        <div class="location">at line 695</div>
+        <div class="location">at line 705</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
@@ -2964,7 +2964,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvFileVariables">
-        <div class="location">at line 708</div>
+        <div class="location">at line 718</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvFileVariables</strong>(<a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a> $source)
         </code>
@@ -3006,7 +3006,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvVariable">
-        <div class="location">at line 718</div>
+        <div class="location">at line 728</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
@@ -3058,7 +3058,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 732</div>
+        <div class="location">at line 742</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -3100,7 +3100,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExec">
-        <div class="location">at line 742</div>
+        <div class="location">at line 752</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -3192,7 +3192,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExposedPort">
-        <div class="location">at line 799</div>
+        <div class="location">at line 809</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
@@ -3257,7 +3257,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 822</div>
+        <div class="location">at line 832</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3324,7 +3324,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 851</div>
+        <div class="location">at line 861</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3391,7 +3391,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withLabel">
-        <div class="location">at line 880</div>
+        <div class="location">at line 890</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withLabel</strong>(string $name, string $value)
         </code>
@@ -3438,7 +3438,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedCache">
-        <div class="location">at line 891</div>
+        <div class="location">at line 901</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedCache</strong>(string $path, <a href="../Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a> $cache, <abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3510,7 +3510,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 924</div>
+        <div class="location">at line 934</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3577,7 +3577,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 953</div>
+        <div class="location">at line 963</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3639,7 +3639,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedSecret">
-        <div class="location">at line 978</div>
+        <div class="location">at line 988</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedSecret</strong>(string $path, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, int|null $mode = 256, bool|null $expand = false)
         </code>
@@ -3706,7 +3706,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedTemp">
-        <div class="location">at line 1007</div>
+        <div class="location">at line 1017</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
@@ -3758,7 +3758,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedVolume">
-        <div class="location">at line 1023</div>
+        <div class="location">at line 1033</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedVolume</strong>(string $path, <a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a> $volume, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3815,7 +3815,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 1044</div>
+        <div class="location">at line 1054</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3882,7 +3882,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRegistryAuth">
-        <div class="location">at line 1073</div>
+        <div class="location">at line 1083</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRegistryAuth</strong>(string $address, string $username, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -3934,7 +3934,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRootfs">
-        <div class="location">at line 1085</div>
+        <div class="location">at line 1095</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRootfs</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $directory)
         </code>
@@ -3976,7 +3976,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretVariable">
-        <div class="location">at line 1095</div>
+        <div class="location">at line 1105</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSecretVariable</strong>(string $name, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -4023,7 +4023,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceBinding">
-        <div class="location">at line 1112</div>
+        <div class="location">at line 1122</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withServiceBinding</strong>(string $alias, <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a> $service)
         </code>
@@ -4072,7 +4072,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 1123</div>
+        <div class="location">at line 1133</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
@@ -4124,7 +4124,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUnixSocket">
-        <div class="location">at line 1137</div>
+        <div class="location">at line 1147</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUnixSocket</strong>(string $path, <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -4186,7 +4186,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUser">
-        <div class="location">at line 1162</div>
+        <div class="location">at line 1172</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUser</strong>(string $name)
         </code>
@@ -4228,7 +4228,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withVolatileVariable">
-        <div class="location">at line 1174</div>
+        <div class="location">at line 1184</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withVolatileVariable</strong>(string $name, string $value)
         </code>
@@ -4275,7 +4275,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 1185</div>
+        <div class="location">at line 1195</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4322,7 +4322,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 1198</div>
+        <div class="location">at line 1208</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
@@ -4364,7 +4364,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 1208</div>
+        <div class="location">at line 1218</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
@@ -4396,7 +4396,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 1217</div>
+        <div class="location">at line 1227</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4443,7 +4443,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDockerHealthcheck">
-        <div class="location">at line 1230</div>
+        <div class="location">at line 1240</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDockerHealthcheck</strong>()
         </code>
@@ -4475,7 +4475,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1239</div>
+        <div class="location">at line 1249</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
@@ -4517,7 +4517,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1251</div>
+        <div class="location">at line 1261</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
@@ -4559,7 +4559,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1261</div>
+        <div class="location">at line 1271</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
@@ -4606,7 +4606,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1274</div>
+        <div class="location">at line 1284</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4653,7 +4653,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1287</div>
+        <div class="location">at line 1297</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
@@ -4700,7 +4700,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1300</div>
+        <div class="location">at line 1310</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
@@ -4742,7 +4742,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1310</div>
+        <div class="location">at line 1320</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4789,7 +4789,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1323</div>
+        <div class="location">at line 1333</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
@@ -4831,7 +4831,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1333</div>
+        <div class="location">at line 1343</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
@@ -4873,7 +4873,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1343</div>
+        <div class="location">at line 1353</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4920,7 +4920,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1358</div>
+        <div class="location">at line 1368</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
@@ -4952,7 +4952,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutVolatileVariable">
-        <div class="location">at line 1367</div>
+        <div class="location">at line 1377</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutVolatileVariable</strong>(string $name)
         </code>
@@ -4994,7 +4994,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1379</div>
+        <div class="location">at line 1389</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
@@ -5026,7 +5026,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1388</div>
+        <div class="location">at line 1398</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -343,7 +343,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
+                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_stat">stat</a>(string $path, bool|null $doNotFollowSymlinks = false)
@@ -1524,7 +1524,7 @@
                     <div class="method-item">
                     <h3 id="method_stat">
         <div class="location">at line 314</div>
-        <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
     </h3>
@@ -1556,7 +1556,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Stat">Stat</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -1570,7 +1570,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 327</div>
+        <div class="location">at line 332</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1602,7 +1602,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 337</div>
+        <div class="location">at line 342</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>terminal</strong>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -1659,7 +1659,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 362</div>
+        <div class="location">at line 367</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withChanges</strong>(<a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a> $changes)
         </code>
@@ -1701,7 +1701,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 372</div>
+        <div class="location">at line 377</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false, string|null $owner = &#039;&#039;, int|null $permissions = null)
         </code>
@@ -1773,7 +1773,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 405</div>
+        <div class="location">at line 410</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -1815,7 +1815,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 415</div>
+        <div class="location">at line 420</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, int|null $permissions = null, string|null $owner = &#039;&#039;)
         </code>
@@ -1872,7 +1872,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 432</div>
+        <div class="location">at line 437</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null)
         </code>
@@ -1924,7 +1924,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 446</div>
+        <div class="location">at line 451</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewDirectory</strong>(string $path, int|null $permissions = 420)
         </code>
@@ -1971,7 +1971,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 459</div>
+        <div class="location">at line 464</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2023,7 +2023,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatch">
-        <div class="location">at line 473</div>
+        <div class="location">at line 478</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatch</strong>(string $patch, <abbr title="Dagger\Dagger\PatchConflict">PatchConflict</abbr>|null $onConflict = null)
         </code>
@@ -2070,7 +2070,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withPatchFile">
-        <div class="location">at line 486</div>
+        <div class="location">at line 491</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withPatchFile</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $patch, <abbr title="Dagger\Dagger\PatchConflict">PatchConflict</abbr>|null $onConflict = null)
         </code>
@@ -2117,7 +2117,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 499</div>
+        <div class="location">at line 504</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName)
         </code>
@@ -2164,7 +2164,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 510</div>
+        <div class="location">at line 515</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>
@@ -2206,7 +2206,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 520</div>
+        <div class="location">at line 525</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2248,7 +2248,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 530</div>
+        <div class="location">at line 535</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2290,7 +2290,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 540</div>
+        <div class="location">at line 545</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>withoutFiles</strong>(array $paths)
         </code>

--- a/docs/static/reference/php/Dagger/EnumTypeDef.html
+++ b/docs/static/reference/php/Dagger/EnumTypeDef.html
@@ -183,7 +183,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -437,7 +437,7 @@
                     <div class="method-item">
                     <h3 id="method_sourceMap">
         <div class="location">at line 55</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -454,7 +454,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -468,7 +468,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceModuleName">
-        <div class="location">at line 64</div>
+        <div class="location">at line 69</div>
         <code>                    string
     <strong>sourceModuleName</strong>()
         </code>
@@ -500,7 +500,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_values">
-        <div class="location">at line 73</div>
+        <div class="location">at line 78</div>
         <code>                    array
     <strong>values</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/EnumValueTypeDef.html
+++ b/docs/static/reference/php/Dagger/EnumValueTypeDef.html
@@ -183,7 +183,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -427,7 +427,7 @@
                     <div class="method-item">
                     <h3 id="method_sourceMap">
         <div class="location">at line 55</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -444,7 +444,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -458,7 +458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_value">
-        <div class="location">at line 64</div>
+        <div class="location">at line 69</div>
         <code>                    string
     <strong>value</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/FieldTypeDef.html
+++ b/docs/static/reference/php/Dagger/FieldTypeDef.html
@@ -183,7 +183,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -427,7 +427,7 @@
                     <div class="method-item">
                     <h3 id="method_sourceMap">
         <div class="location">at line 57</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -444,7 +444,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -458,7 +458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 66</div>
+        <div class="location">at line 71</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/File.html
+++ b/docs/static/reference/php/Dagger/File.html
@@ -243,7 +243,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
+                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_stat">stat</a>()
@@ -829,7 +829,7 @@
                     <div class="method-item">
                     <h3 id="method_stat">
         <div class="location">at line 170</div>
-        <code>                    <a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
     <strong>stat</strong>()
         </code>
     </h3>
@@ -846,7 +846,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Stat">Stat</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -860,7 +860,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 179</div>
+        <div class="location">at line 184</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -892,7 +892,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withName">
-        <div class="location">at line 189</div>
+        <div class="location">at line 194</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>withName</strong>(string $name)
         </code>
@@ -934,7 +934,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withReplaced">
-        <div class="location">at line 207</div>
+        <div class="location">at line 212</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>withReplaced</strong>(string $search, string $replacement, bool|null $all = false, int|null $firstFrom = null)
         </code>
@@ -994,7 +994,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withTimestamps">
-        <div class="location">at line 228</div>
+        <div class="location">at line 233</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>withTimestamps</strong>(int $timestamp)
         </code>

--- a/docs/static/reference/php/Dagger/FunctionArg.html
+++ b/docs/static/reference/php/Dagger/FunctionArg.html
@@ -223,7 +223,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -595,7 +595,7 @@
                     <div class="method-item">
                     <h3 id="method_sourceMap">
         <div class="location">at line 93</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -612,7 +612,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -626,7 +626,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 102</div>
+        <div class="location">at line 107</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Function_.html
+++ b/docs/static/reference/php/Dagger/Function_.html
@@ -203,7 +203,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -601,7 +601,7 @@
                     <div class="method-item">
                     <h3 id="method_sourceMap">
         <div class="location">at line 75</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -618,7 +618,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -632,7 +632,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceModuleName">
-        <div class="location">at line 84</div>
+        <div class="location">at line 89</div>
         <code>                    string
     <strong>sourceModuleName</strong>()
         </code>
@@ -664,7 +664,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAgent">
-        <div class="location">at line 93</div>
+        <div class="location">at line 98</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withAgent</strong>()
         </code>
@@ -696,7 +696,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withArg">
-        <div class="location">at line 102</div>
+        <div class="location">at line 107</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withArg</strong>(string $name, <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $typeDef, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $defaultValue = null, string|null $defaultPath = &#039;&#039;, array|null $ignore = [], <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null, string|null $deprecated = null, string|null $defaultAddress = &#039;&#039;)
         </code>
@@ -778,7 +778,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCachePolicy">
-        <div class="location">at line 143</div>
+        <div class="location">at line 148</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withCachePolicy</strong>(<abbr title="Dagger\FunctionCachePolicy">FunctionCachePolicy</abbr> $policy, string|null $timeToLive = null)
         </code>
@@ -825,7 +825,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withCheck">
-        <div class="location">at line 156</div>
+        <div class="location">at line 161</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withCheck</strong>()
         </code>
@@ -857,7 +857,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDeprecated">
-        <div class="location">at line 165</div>
+        <div class="location">at line 170</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withDeprecated</strong>(string|null $reason = null)
         </code>
@@ -899,7 +899,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDescription">
-        <div class="location">at line 177</div>
+        <div class="location">at line 182</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withDescription</strong>(string $description)
         </code>
@@ -941,7 +941,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withGenerator">
-        <div class="location">at line 187</div>
+        <div class="location">at line 192</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withGenerator</strong>()
         </code>
@@ -973,7 +973,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSourceMap">
-        <div class="location">at line 196</div>
+        <div class="location">at line 201</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withSourceMap</strong>(<a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a> $sourceMap)
         </code>
@@ -1015,7 +1015,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUp">
-        <div class="location">at line 206</div>
+        <div class="location">at line 211</div>
         <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
     <strong>withUp</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/GitCommit.html
+++ b/docs/static/reference/php/Dagger/GitCommit.html
@@ -143,7 +143,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
+                    <abbr title="Dagger\Dagger\GitRef">GitRef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_ancestorReleaseTag">ancestorReleaseTag</a>(bool|null $includePreRelease = false)
@@ -263,7 +263,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
+                    <abbr title="Dagger\Dagger\GitRef">GitRef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_releaseTag">releaseTag</a>(bool|null $includePreRelease = false)
@@ -399,7 +399,7 @@
                     <div class="method-item">
                     <h3 id="method_ancestorReleaseTag">
         <div class="location">at line 19</div>
-        <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\GitRef">GitRef</abbr>|null
     <strong>ancestorReleaseTag</strong>(bool|null $includePreRelease = false)
         </code>
     </h3>
@@ -426,7 +426,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\GitRef">GitRef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -440,7 +440,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_authorEmail">
-        <div class="location">at line 31</div>
+        <div class="location">at line 36</div>
         <code>                    string
     <strong>authorEmail</strong>()
         </code>
@@ -472,7 +472,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_authorName">
-        <div class="location">at line 40</div>
+        <div class="location">at line 45</div>
         <code>                    string
     <strong>authorName</strong>()
         </code>
@@ -504,7 +504,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_authoredDate">
-        <div class="location">at line 49</div>
+        <div class="location">at line 54</div>
         <code>                    string
     <strong>authoredDate</strong>()
         </code>
@@ -536,7 +536,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_committedDate">
-        <div class="location">at line 58</div>
+        <div class="location">at line 63</div>
         <code>                    string
     <strong>committedDate</strong>()
         </code>
@@ -568,7 +568,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_committerEmail">
-        <div class="location">at line 67</div>
+        <div class="location">at line 72</div>
         <code>                    string
     <strong>committerEmail</strong>()
         </code>
@@ -600,7 +600,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_committerName">
-        <div class="location">at line 76</div>
+        <div class="location">at line 81</div>
         <code>                    string
     <strong>committerName</strong>()
         </code>
@@ -632,7 +632,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 85</div>
+        <div class="location">at line 90</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -664,7 +664,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_message">
-        <div class="location">at line 94</div>
+        <div class="location">at line 99</div>
         <code>                    string
     <strong>message</strong>()
         </code>
@@ -696,7 +696,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_messageBody">
-        <div class="location">at line 103</div>
+        <div class="location">at line 108</div>
         <code>                    string
     <strong>messageBody</strong>()
         </code>
@@ -728,7 +728,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_messageHeadline">
-        <div class="location">at line 112</div>
+        <div class="location">at line 117</div>
         <code>                    string
     <strong>messageHeadline</strong>()
         </code>
@@ -760,7 +760,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_parentShas">
-        <div class="location">at line 121</div>
+        <div class="location">at line 126</div>
         <code>                    array
     <strong>parentShas</strong>()
         </code>
@@ -792,8 +792,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_releaseTag">
-        <div class="location">at line 130</div>
-        <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
+        <div class="location">at line 135</div>
+        <code>                    <abbr title="Dagger\Dagger\GitRef">GitRef</abbr>|null
     <strong>releaseTag</strong>(bool|null $includePreRelease = false)
         </code>
     </h3>
@@ -820,7 +820,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\GitRef">GitRef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -834,7 +834,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sha">
-        <div class="location">at line 142</div>
+        <div class="location">at line 152</div>
         <code>                    string
     <strong>sha</strong>()
         </code>
@@ -866,7 +866,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_shortSha">
-        <div class="location">at line 151</div>
+        <div class="location">at line 161</div>
         <code>                    string
     <strong>shortSha</strong>()
         </code>
@@ -898,7 +898,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tree">
-        <div class="location">at line 160</div>
+        <div class="location">at line 170</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>tree</strong>(bool|null $discardGitDir = false, int|null $depth = 1, bool|null $includeTags = false)
         </code>

--- a/docs/static/reference/php/Dagger/InterfaceTypeDef.html
+++ b/docs/static/reference/php/Dagger/InterfaceTypeDef.html
@@ -183,7 +183,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -427,7 +427,7 @@
                     <div class="method-item">
                     <h3 id="method_sourceMap">
         <div class="location">at line 55</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -444,7 +444,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -458,7 +458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceModuleName">
-        <div class="location">at line 64</div>
+        <div class="location">at line 69</div>
         <code>                    string
     <strong>sourceModuleName</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/Module.html
+++ b/docs/static/reference/php/Dagger/Module.html
@@ -273,7 +273,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
+                    <abbr title="Dagger\Dagger\Container">Container</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_runtime">runtime</a>()
@@ -283,7 +283,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
+                    <abbr title="Dagger\Dagger\SDKConfig">SDKConfig</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sdk">sdk</a>()
@@ -313,7 +313,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+                    <abbr title="Dagger\Dagger\ModuleSource">ModuleSource</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_source">source</a>()
@@ -941,7 +941,7 @@
                     <div class="method-item">
                     <h3 id="method_runtime">
         <div class="location">at line 151</div>
-        <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\Container">Container</abbr>|null
     <strong>runtime</strong>()
         </code>
     </h3>
@@ -958,7 +958,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Container">Container</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -972,8 +972,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 160</div>
-        <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
+        <div class="location">at line 165</div>
+        <code>                    <abbr title="Dagger\Dagger\SDKConfig">SDKConfig</abbr>|null
     <strong>sdk</strong>()
         </code>
     </h3>
@@ -990,7 +990,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SDKConfig">SDKConfig</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -1004,7 +1004,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_serve">
-        <div class="location">at line 171</div>
+        <div class="location">at line 181</div>
         <code>                    void
     <strong>serve</strong>(bool|null $includeDependencies = null, bool|null $entrypoint = null)
         </code>
@@ -1051,7 +1051,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 186</div>
+        <div class="location">at line 196</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1093,8 +1093,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_source">
-        <div class="location">at line 198</div>
-        <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
+        <div class="location">at line 208</div>
+        <code>                    <abbr title="Dagger\Dagger\ModuleSource">ModuleSource</abbr>|null
     <strong>source</strong>()
         </code>
     </h3>
@@ -1111,7 +1111,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\ModuleSource">ModuleSource</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -1125,7 +1125,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 207</div>
+        <div class="location">at line 222</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1157,7 +1157,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_userDefaults">
-        <div class="location">at line 217</div>
+        <div class="location">at line 232</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>userDefaults</strong>()
         </code>
@@ -1189,7 +1189,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDescription">
-        <div class="location">at line 226</div>
+        <div class="location">at line 241</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withDescription</strong>(string $description)
         </code>
@@ -1231,7 +1231,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnum">
-        <div class="location">at line 236</div>
+        <div class="location">at line 251</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withEnum</strong>(<a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $enum)
         </code>
@@ -1273,7 +1273,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInterface">
-        <div class="location">at line 246</div>
+        <div class="location">at line 261</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withInterface</strong>(<a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $iface)
         </code>
@@ -1315,7 +1315,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withObject">
-        <div class="location">at line 256</div>
+        <div class="location">at line 271</div>
         <code>                    <a href="../Dagger/Module.html"><abbr title="Dagger\Module">Module</abbr></a>
     <strong>withObject</strong>(<a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $object)
         </code>

--- a/docs/static/reference/php/Dagger/ModuleSource.html
+++ b/docs/static/reference/php/Dagger/ModuleSource.html
@@ -423,7 +423,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>|null
+                    <abbr title="Dagger\Dagger\SDKConfig">SDKConfig</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sdk">sdk</a>()
@@ -1716,7 +1716,7 @@
                     <div class="method-item">
                     <h3 id="method_sdk">
         <div class="location">at line 284</div>
-        <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>|null
+        <code>                    <abbr title="Dagger\Dagger\SDKConfig">SDKConfig</abbr>|null
     <strong>sdk</strong>()
         </code>
     </h3>
@@ -1733,7 +1733,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SDKConfig">SDKConfig</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -1747,7 +1747,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceRootSubpath">
-        <div class="location">at line 293</div>
+        <div class="location">at line 298</div>
         <code>                    string
     <strong>sourceRootSubpath</strong>()
         </code>
@@ -1779,7 +1779,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceSubpath">
-        <div class="location">at line 302</div>
+        <div class="location">at line 307</div>
         <code>                    string
     <strong>sourceSubpath</strong>()
         </code>
@@ -1811,7 +1811,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 311</div>
+        <div class="location">at line 316</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -1843,7 +1843,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_toolchains">
-        <div class="location">at line 321</div>
+        <div class="location">at line 326</div>
         <code>                    array
     <strong>toolchains</strong>()
         </code>
@@ -1875,7 +1875,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_updatedConfigDirectory">
-        <div class="location">at line 332</div>
+        <div class="location">at line 337</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>updatedConfigDirectory</strong>()
         </code>
@@ -1907,7 +1907,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_userDefaults">
-        <div class="location">at line 341</div>
+        <div class="location">at line 346</div>
         <code>                    <a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a>
     <strong>userDefaults</strong>()
         </code>
@@ -1939,7 +1939,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 350</div>
+        <div class="location">at line 355</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -1971,7 +1971,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withBlueprint">
-        <div class="location">at line 359</div>
+        <div class="location">at line 364</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withBlueprint</strong>(<a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a> $blueprint)
         </code>
@@ -2013,7 +2013,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withClient">
-        <div class="location">at line 369</div>
+        <div class="location">at line 374</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withClient</strong>(string $generator, string $outputDir)
         </code>
@@ -2060,7 +2060,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDependencies">
-        <div class="location">at line 380</div>
+        <div class="location">at line 385</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withDependencies</strong>(array $dependencies)
         </code>
@@ -2102,7 +2102,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEngineVersion">
-        <div class="location">at line 390</div>
+        <div class="location">at line 395</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withEngineVersion</strong>(string $version)
         </code>
@@ -2144,7 +2144,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExperimentalFeatures">
-        <div class="location">at line 400</div>
+        <div class="location">at line 405</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withExperimentalFeatures</strong>(array $features)
         </code>
@@ -2186,7 +2186,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withIncludes">
-        <div class="location">at line 410</div>
+        <div class="location">at line 415</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withIncludes</strong>(array $patterns)
         </code>
@@ -2228,7 +2228,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withName">
-        <div class="location">at line 420</div>
+        <div class="location">at line 425</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withName</strong>(string $name)
         </code>
@@ -2270,7 +2270,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 430</div>
+        <div class="location">at line 435</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withSDK</strong>(string $source)
         </code>
@@ -2312,7 +2312,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSourceSubpath">
-        <div class="location">at line 440</div>
+        <div class="location">at line 445</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withSourceSubpath</strong>(string $path)
         </code>
@@ -2354,7 +2354,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withToolchains">
-        <div class="location">at line 450</div>
+        <div class="location">at line 455</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withToolchains</strong>(array $toolchains)
         </code>
@@ -2396,7 +2396,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateBlueprint">
-        <div class="location">at line 460</div>
+        <div class="location">at line 465</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateBlueprint</strong>()
         </code>
@@ -2428,7 +2428,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateDependencies">
-        <div class="location">at line 469</div>
+        <div class="location">at line 474</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateDependencies</strong>(array $dependencies)
         </code>
@@ -2470,7 +2470,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdateToolchains">
-        <div class="location">at line 479</div>
+        <div class="location">at line 484</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdateToolchains</strong>(array $toolchains)
         </code>
@@ -2512,7 +2512,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedClients">
-        <div class="location">at line 489</div>
+        <div class="location">at line 494</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withUpdatedClients</strong>(array $clients)
         </code>
@@ -2554,7 +2554,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutBlueprint">
-        <div class="location">at line 499</div>
+        <div class="location">at line 504</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutBlueprint</strong>()
         </code>
@@ -2586,7 +2586,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutClient">
-        <div class="location">at line 508</div>
+        <div class="location">at line 513</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutClient</strong>(string $path)
         </code>
@@ -2628,7 +2628,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDependencies">
-        <div class="location">at line 518</div>
+        <div class="location">at line 523</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutDependencies</strong>(array $dependencies)
         </code>
@@ -2670,7 +2670,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExperimentalFeatures">
-        <div class="location">at line 528</div>
+        <div class="location">at line 533</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutExperimentalFeatures</strong>(array $features)
         </code>
@@ -2712,7 +2712,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutToolchains">
-        <div class="location">at line 538</div>
+        <div class="location">at line 543</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>withoutToolchains</strong>(array $toolchains)
         </code>

--- a/docs/static/reference/php/Dagger/ModuleSource.html
+++ b/docs/static/reference/php/Dagger/ModuleSource.html
@@ -423,7 +423,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
+                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sdk">sdk</a>()
@@ -1716,7 +1716,7 @@
                     <div class="method-item">
                     <h3 id="method_sdk">
         <div class="location">at line 284</div>
-        <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>
+        <code>                    <a href="../Dagger/SDKConfig.html"><abbr title="Dagger\SDKConfig">SDKConfig</abbr></a>|null
     <strong>sdk</strong>()
         </code>
     </h3>

--- a/docs/static/reference/php/Dagger/ObjectTypeDef.html
+++ b/docs/static/reference/php/Dagger/ObjectTypeDef.html
@@ -143,7 +143,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
+                    <abbr title="Dagger\Dagger\Function_">Function_</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_constructor">constructor</a>()
@@ -213,7 +213,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_sourceMap">sourceMap</a>()
@@ -329,7 +329,7 @@
                     <div class="method-item">
                     <h3 id="method_constructor">
         <div class="location">at line 19</div>
-        <code>                    <a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\Function_">Function_</abbr>|null
     <strong>constructor</strong>()
         </code>
     </h3>
@@ -346,7 +346,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\Function_">Function_</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -360,7 +360,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_deprecated">
-        <div class="location">at line 28</div>
+        <div class="location">at line 33</div>
         <code>                    string
     <strong>deprecated</strong>()
         </code>
@@ -392,7 +392,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_description">
-        <div class="location">at line 37</div>
+        <div class="location">at line 42</div>
         <code>                    string
     <strong>description</strong>()
         </code>
@@ -424,7 +424,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_fields">
-        <div class="location">at line 46</div>
+        <div class="location">at line 51</div>
         <code>                    array
     <strong>fields</strong>()
         </code>
@@ -456,7 +456,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_functions">
-        <div class="location">at line 55</div>
+        <div class="location">at line 60</div>
         <code>                    array
     <strong>functions</strong>()
         </code>
@@ -488,7 +488,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 64</div>
+        <div class="location">at line 69</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -520,7 +520,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 73</div>
+        <div class="location">at line 78</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -552,8 +552,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceMap">
-        <div class="location">at line 82</div>
-        <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
+        <div class="location">at line 87</div>
+        <code>                    <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null
     <strong>sourceMap</strong>()
         </code>
     </h3>
@@ -570,7 +570,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -584,7 +584,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceModuleName">
-        <div class="location">at line 91</div>
+        <div class="location">at line 101</div>
         <code>                    string
     <strong>sourceModuleName</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/TypeDef.html
+++ b/docs/static/reference/php/Dagger/TypeDef.html
@@ -143,7 +143,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/EnumTypeDef.html"><abbr title="Dagger\EnumTypeDef">EnumTypeDef</abbr></a>
+                    <abbr title="Dagger\Dagger\EnumTypeDef">EnumTypeDef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asEnum">asEnum</a>()
@@ -153,7 +153,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/InputTypeDef.html"><abbr title="Dagger\InputTypeDef">InputTypeDef</abbr></a>
+                    <abbr title="Dagger\Dagger\InputTypeDef">InputTypeDef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asInput">asInput</a>()
@@ -163,7 +163,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/InterfaceTypeDef.html"><abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr></a>
+                    <abbr title="Dagger\Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asInterface">asInterface</a>()
@@ -173,7 +173,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/ListTypeDef.html"><abbr title="Dagger\ListTypeDef">ListTypeDef</abbr></a>
+                    <abbr title="Dagger\Dagger\ListTypeDef">ListTypeDef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asList">asList</a>()
@@ -183,7 +183,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/ObjectTypeDef.html"><abbr title="Dagger\ObjectTypeDef">ObjectTypeDef</abbr></a>
+                    <abbr title="Dagger\Dagger\ObjectTypeDef">ObjectTypeDef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asObject">asObject</a>()
@@ -193,7 +193,7 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
-                    <a href="../Dagger/ScalarTypeDef.html"><abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr></a>
+                    <abbr title="Dagger\Dagger\ScalarTypeDef">ScalarTypeDef</abbr>|null
                 </div>
                 <div class="col-md-8">
                     <a href="#method_asScalar">asScalar</a>()
@@ -459,7 +459,7 @@
                     <div class="method-item">
                     <h3 id="method_asEnum">
         <div class="location">at line 19</div>
-        <code>                    <a href="../Dagger/EnumTypeDef.html"><abbr title="Dagger\EnumTypeDef">EnumTypeDef</abbr></a>
+        <code>                    <abbr title="Dagger\Dagger\EnumTypeDef">EnumTypeDef</abbr>|null
     <strong>asEnum</strong>()
         </code>
     </h3>
@@ -476,7 +476,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/EnumTypeDef.html"><abbr title="Dagger\EnumTypeDef">EnumTypeDef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\EnumTypeDef">EnumTypeDef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -490,8 +490,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asInput">
-        <div class="location">at line 28</div>
-        <code>                    <a href="../Dagger/InputTypeDef.html"><abbr title="Dagger\InputTypeDef">InputTypeDef</abbr></a>
+        <div class="location">at line 33</div>
+        <code>                    <abbr title="Dagger\Dagger\InputTypeDef">InputTypeDef</abbr>|null
     <strong>asInput</strong>()
         </code>
     </h3>
@@ -508,7 +508,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/InputTypeDef.html"><abbr title="Dagger\InputTypeDef">InputTypeDef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\InputTypeDef">InputTypeDef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -522,8 +522,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asInterface">
-        <div class="location">at line 37</div>
-        <code>                    <a href="../Dagger/InterfaceTypeDef.html"><abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr></a>
+        <div class="location">at line 47</div>
+        <code>                    <abbr title="Dagger\Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr>|null
     <strong>asInterface</strong>()
         </code>
     </h3>
@@ -540,7 +540,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/InterfaceTypeDef.html"><abbr title="Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\InterfaceTypeDef">InterfaceTypeDef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -554,8 +554,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asList">
-        <div class="location">at line 46</div>
-        <code>                    <a href="../Dagger/ListTypeDef.html"><abbr title="Dagger\ListTypeDef">ListTypeDef</abbr></a>
+        <div class="location">at line 61</div>
+        <code>                    <abbr title="Dagger\Dagger\ListTypeDef">ListTypeDef</abbr>|null
     <strong>asList</strong>()
         </code>
     </h3>
@@ -572,7 +572,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/ListTypeDef.html"><abbr title="Dagger\ListTypeDef">ListTypeDef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\ListTypeDef">ListTypeDef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -586,8 +586,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asObject">
-        <div class="location">at line 55</div>
-        <code>                    <a href="../Dagger/ObjectTypeDef.html"><abbr title="Dagger\ObjectTypeDef">ObjectTypeDef</abbr></a>
+        <div class="location">at line 75</div>
+        <code>                    <abbr title="Dagger\Dagger\ObjectTypeDef">ObjectTypeDef</abbr>|null
     <strong>asObject</strong>()
         </code>
     </h3>
@@ -604,7 +604,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/ObjectTypeDef.html"><abbr title="Dagger\ObjectTypeDef">ObjectTypeDef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\ObjectTypeDef">ObjectTypeDef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -618,8 +618,8 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_asScalar">
-        <div class="location">at line 64</div>
-        <code>                    <a href="../Dagger/ScalarTypeDef.html"><abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr></a>
+        <div class="location">at line 89</div>
+        <code>                    <abbr title="Dagger\Dagger\ScalarTypeDef">ScalarTypeDef</abbr>|null
     <strong>asScalar</strong>()
         </code>
     </h3>
@@ -636,7 +636,7 @@
 
                     <table class="table table-condensed">
         <tr>
-            <td><a href="../Dagger/ScalarTypeDef.html"><abbr title="Dagger\ScalarTypeDef">ScalarTypeDef</abbr></a></td>
+            <td><abbr title="Dagger\Dagger\ScalarTypeDef">ScalarTypeDef</abbr>|null</td>
             <td></td>
         </tr>
     </table>
@@ -650,7 +650,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 73</div>
+        <div class="location">at line 103</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -682,7 +682,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_kind">
-        <div class="location">at line 82</div>
+        <div class="location">at line 112</div>
         <code>                    <abbr title="Dagger\TypeDefKind">TypeDefKind</abbr>
     <strong>kind</strong>()
         </code>
@@ -714,7 +714,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 91</div>
+        <div class="location">at line 121</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -746,7 +746,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_optional">
-        <div class="location">at line 100</div>
+        <div class="location">at line 130</div>
         <code>                    bool
     <strong>optional</strong>()
         </code>
@@ -778,7 +778,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConstructor">
-        <div class="location">at line 109</div>
+        <div class="location">at line 139</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withConstructor</strong>(<a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a> $function)
         </code>
@@ -820,7 +820,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnum">
-        <div class="location">at line 121</div>
+        <div class="location">at line 151</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withEnum</strong>(string $name, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null)
         </code>
@@ -872,7 +872,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnumMember">
-        <div class="location">at line 137</div>
+        <div class="location">at line 167</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withEnumMember</strong>(string $name, string|null $value = &#039;&#039;, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null, string|null $deprecated = null)
         </code>
@@ -934,7 +934,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnumValue">
-        <div class="location">at line 164</div>
+        <div class="location">at line 194</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withEnumValue</strong>(string $value, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null, string|null $deprecated = null)
         </code>
@@ -991,7 +991,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withField">
-        <div class="location">at line 187</div>
+        <div class="location">at line 217</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withField</strong>(string $name, <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $typeDef, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null, string|null $deprecated = null)
         </code>
@@ -1053,7 +1053,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFunction">
-        <div class="location">at line 212</div>
+        <div class="location">at line 242</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withFunction</strong>(<a href="../Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a> $function)
         </code>
@@ -1095,7 +1095,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInterface">
-        <div class="location">at line 222</div>
+        <div class="location">at line 252</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withInterface</strong>(string $name, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null)
         </code>
@@ -1147,7 +1147,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withKind">
-        <div class="location">at line 238</div>
+        <div class="location">at line 268</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withKind</strong>(<abbr title="Dagger\TypeDefKind">TypeDefKind</abbr> $kind)
         </code>
@@ -1189,7 +1189,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withListOf">
-        <div class="location">at line 248</div>
+        <div class="location">at line 278</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withListOf</strong>(<a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a> $elementType)
         </code>
@@ -1231,7 +1231,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withObject">
-        <div class="location">at line 260</div>
+        <div class="location">at line 290</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withObject</strong>(string $name, string|null $description = &#039;&#039;, <abbr title="Dagger\Dagger\SourceMap">SourceMap</abbr>|null $sourceMap = null, string|null $deprecated = null)
         </code>
@@ -1288,7 +1288,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withOptional">
-        <div class="location">at line 283</div>
+        <div class="location">at line 313</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withOptional</strong>(bool $optional)
         </code>
@@ -1330,7 +1330,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withScalar">
-        <div class="location">at line 293</div>
+        <div class="location">at line 323</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>withScalar</strong>(string $name, string|null $description = &#039;&#039;)
         </code>

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -1142,6 +1142,11 @@ func printID(w io.Writer, response any, typeDef *modTypeDef) error {
 		return nil
 	case typeDef.AsObject != nil:
 		switch v := response.(type) {
+		case nil:
+			// A nullable object field that resolved to null. "null" is both valid
+			// JSON and unambiguous in plain output.
+			_, err := fmt.Fprintln(w, "null")
+			return err
 		case string:
 			return printEncodedID(w, v)
 		case map[string]any:

--- a/internal/cmd/dagger/functions_test.go
+++ b/internal/cmd/dagger/functions_test.go
@@ -3,6 +3,7 @@ package daggercmd
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"testing"
 
@@ -148,6 +149,32 @@ func TestCorePseudoModuleSelection(t *testing.T) {
 	moduleURL = "./core"
 	require.False(t, isCoreModuleSelected())
 	require.True(t, shouldLoadWorkspaceModules(false))
+}
+
+func TestHandleResponseNullableObject(t *testing.T) {
+	oldJSONOutput := jsonOutput
+	t.Cleanup(func() {
+		jsonOutput = oldJSONOutput
+	})
+
+	for _, json := range []bool{false, true} {
+		t.Run(fmt.Sprintf("json=%t", json), func(t *testing.T) {
+			jsonOutput = json
+
+			var out bytes.Buffer
+			err := handleResponse(
+				context.Background(),
+				nil,
+				testObjectTypeDef("Directory", "", ""),
+				nil,
+				&out,
+				io.Discard,
+				false,
+			)
+			require.NoError(t, err)
+			require.Equal(t, "null\n", out.String())
+		})
+	}
 }
 
 func testStringTypeDef() *modTypeDef {

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -1,7 +1,10 @@
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using Dagger.SDK.SourceGenerator.Code;
 using Dagger.SDK.SourceGenerator.Tests.Utils;
+using Dagger.SDK.SourceGenerator.Types;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,6 +14,82 @@ namespace Dagger.SDK.SourceGenerator.Tests;
 [TestClass]
 public class SourceGeneratorTests
 {
+    [TestMethod]
+    [DataRow("v0.21.0-dev")]
+    [DataRow("v1.0.0-beta.9")]
+    [DataRow("v1.0.0-beta.9-dev")]
+    public void NullableObjectsKeepOlderEngineShape(string version)
+    {
+        var introspection = NullableObjectIntrospection(version);
+        var code = new CodeGenerator(new CodeRenderer()).Generate(introspection);
+
+        StringAssert.Contains(code, "public GitRef LatestVersion()");
+        Assert.IsFalse(code.Contains("LatestVersionAsync"));
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("development")]
+    [DataRow("v1.0.0-beta.10")]
+    [DataRow("v1.0.0-beta.10-dev")]
+    [DataRow("v1.0.0-rc.1")]
+    [DataRow("v1.0.0")]
+    public void NullableObjectsUseResolvedShapeFromBeta10(string? version)
+    {
+        var introspection = NullableObjectIntrospection(version);
+        var code = new CodeGenerator(new CodeRenderer()).Generate(introspection);
+
+        StringAssert.Contains(code, "public async Task<GitRef?> LatestVersionAsync");
+    }
+
+    [TestMethod]
+    public void PreservesAcronymsInEnumTypeNames()
+    {
+        var introspection = new Introspection
+        {
+            Schema = new Schema
+            {
+                Types =
+                [
+                    new Dagger.SDK.SourceGenerator.Types.Type
+                    {
+                        Kind = "ENUM",
+                        Name = "LLMMessageRole",
+                        EnumValues = [new EnumValue { Name = "USER" }],
+                    },
+                ],
+            },
+        };
+
+        var code = new CodeGenerator(new CodeRenderer()).Generate(introspection);
+
+        StringAssert.Contains(code, "JsonStringEnumConverter<LLMMessageRole>");
+        StringAssert.Contains(code, "public enum LLMMessageRole");
+    }
+
+    [TestMethod]
+    public void FormatsIdScalarName()
+    {
+        Assert.AreEqual("Id", Formatter.FormatType("ID"));
+    }
+
+    [TestMethod]
+    public void ImplementsInterfacesWithCovariantReturnsAndAdditionalOptionalArguments()
+    {
+        var introspection = InterfaceImplementationIntrospection();
+
+        var code = new CodeGenerator(new CodeRenderer()).Generate(introspection);
+
+        StringAssert.Contains(code, "async Task<Syncer> Syncer.SyncAsync");
+        StringAssert.Contains(code, "return await SyncAsync(cancellationToken: cancellationToken)");
+        StringAssert.Contains(code, "async Task<string> Exportable.ExportAsync");
+        StringAssert.Contains(
+            code,
+            "return await ExportAsync(path: path, cancellationToken: cancellationToken)"
+        );
+    }
+
     [TestMethod]
     [DataRow("introspection.json", TestData.Schema)]
     public void GenerateCodeBasedOnSchema(string path, string text)
@@ -86,4 +165,57 @@ public class SourceGeneratorTests
         // Assert
         Assert.IsTrue(diagnostics.Contains(SourceGenerator.FailedToParseSchemaFile));
     }
+
+    private static Introspection NullableObjectIntrospection(string? version) =>
+        new()
+        {
+            SchemaVersion = version,
+            Schema = new Schema
+            {
+                Types =
+                [
+                    new Dagger.SDK.SourceGenerator.Types.Type
+                    {
+                        Kind = "OBJECT",
+                        Name = "GitRepository",
+                        Fields =
+                        [
+                            new Field
+                            {
+                                Name = "latestVersion",
+                                Type = new TypeRef { Kind = "OBJECT", Name = "GitRef" },
+                            },
+                        ],
+                    },
+                    new Dagger.SDK.SourceGenerator.Types.Type { Kind = "OBJECT", Name = "GitRef" },
+                ],
+            },
+        };
+
+    private static Introspection InterfaceImplementationIntrospection() =>
+        JsonSerializer.Deserialize<Introspection>(InterfaceImplementationSchema)!;
+
+    private const string InterfaceImplementationSchema = """
+        {"__schema":{"types":[
+          {"kind":"INTERFACE","name":"Syncer","fields":[
+            {"name":"sync","type":{"kind":"NON_NULL","ofType":{"kind":"SCALAR","name":"ID"}},
+             "directives":[{"name":"expectedType","args":[{"name":"name","value":"\"Syncer\""}]}]}
+          ]},
+          {"kind":"INTERFACE","name":"Exportable","fields":[
+            {"name":"export","type":{"kind":"NON_NULL","ofType":{"kind":"SCALAR","name":"String"}},
+             "args":[{"name":"path","type":{"kind":"NON_NULL","ofType":{"kind":"SCALAR","name":"String"}}}]}
+          ]},
+          {"kind":"OBJECT","name":"Container",
+           "interfaces":[{"kind":"INTERFACE","name":"Syncer"},{"kind":"INTERFACE","name":"Exportable"}],
+           "fields":[
+             {"name":"sync","type":{"kind":"NON_NULL","ofType":{"kind":"SCALAR","name":"ID"}},
+              "directives":[{"name":"expectedType","args":[{"name":"name","value":"\"Container\""}]}]},
+             {"name":"export","type":{"kind":"NON_NULL","ofType":{"kind":"SCALAR","name":"String"}},
+              "args":[
+                {"name":"path","type":{"kind":"NON_NULL","ofType":{"kind":"SCALAR","name":"String"}}},
+                {"name":"expand","type":{"kind":"SCALAR","name":"Boolean"}}
+              ]}
+           ]}
+        ]}}
+        """;
 }

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Code/CodeGenerator.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Code/CodeGenerator.cs
@@ -17,16 +17,15 @@ public class CodeGenerator(ICodeRenderer renderer)
         // Collect type name sets for the renderer
         if (renderer is CodeRenderer codeRenderer)
         {
+            codeRenderer.SupportsNullableObjects = SupportsNullableObjects(
+                introspection.SchemaVersion
+            );
             codeRenderer.ObjectTypeNames = new HashSet<string>(
-                introspection.Schema.Types
-                    .Where(t => t.Kind == "OBJECT")
-                    .Select(t => t.Name)
+                introspection.Schema.Types.Where(t => t.Kind == "OBJECT").Select(t => t.Name)
             );
-            codeRenderer.InterfaceTypeNames = new HashSet<string>(
-                introspection.Schema.Types
-                    .Where(t => t.Kind == "INTERFACE")
-                    .Select(t => t.Name)
-            );
+            codeRenderer.InterfaceTypes = introspection
+                .Schema.Types.Where(t => t.Kind == "INTERFACE")
+                .ToDictionary(t => t.Name);
         }
 
         var builder = new StringBuilder(renderer.RenderPre());
@@ -40,6 +39,38 @@ public class CodeGenerator(ICodeRenderer renderer)
             .Aggregate(builder, (b, code) => b.Append(code).AppendLine());
 
         return renderer.Format(builder.ToString());
+    }
+
+    private static bool SupportsNullableObjects(string? schemaVersion)
+    {
+        if (string.IsNullOrWhiteSpace(schemaVersion))
+        {
+            return true;
+        }
+
+        var version = schemaVersion!.TrimStart('v');
+        var parts = version.Split(new[] { '-' }, 2);
+        if (!Version.TryParse(parts[0], out var core))
+        {
+            return true;
+        }
+
+        var cutover = new Version(1, 0, 0);
+        if (core != cutover)
+        {
+            return core > cutover;
+        }
+        if (parts.Length == 1)
+        {
+            return true;
+        }
+
+        const string betaPrefix = "beta.";
+        return
+            parts[1].StartsWith(betaPrefix)
+            && int.TryParse(parts[1].Substring(betaPrefix.Length).Split('-', '+')[0], out var beta)
+            ? beta >= 10
+            : string.CompareOrdinal(parts[1], "beta") > 0;
     }
 
     private bool NotInternalTypes(Type type) => !type.Name.StartsWith("_");

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Code/CodeRenderer.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Code/CodeRenderer.cs
@@ -12,6 +12,8 @@ namespace Dagger.SDK.SourceGenerator.Code;
 
 public class CodeRenderer : ICodeRenderer
 {
+    public bool SupportsNullableObjects { get; set; } = true;
+
     /// <summary>
     /// Set of all known OBJECT type names in the schema (for resolving @expectedType).
     /// Must be set before calling Render methods.
@@ -19,9 +21,9 @@ public class CodeRenderer : ICodeRenderer
     public HashSet<string> ObjectTypeNames { get; set; } = new();
 
     /// <summary>
-    /// Set of all known INTERFACE type names in the schema.
+    /// Interface definitions keyed by GraphQL type name.
     /// </summary>
-    public HashSet<string> InterfaceTypeNames { get; set; } = new();
+    public Dictionary<string, Type> InterfaceTypes { get; set; } = new();
 
     public string RenderPre()
     {
@@ -40,11 +42,12 @@ public class CodeRenderer : ICodeRenderer
 
     public string RenderEnum(Type type)
     {
+        var typeName = Formatter.FormatType(type.Name);
         var evs = type.EnumValues.Select(ev => ev.Name);
         return $$"""
             {{RenderDocComment(type)}}
-            [JsonConverter(typeof(JsonStringEnumConverter<{{type.Name}}>))]
-            public enum {{Formatter.FormatType(type.Name)}}
+            [JsonConverter(typeof(JsonStringEnumConverter<{{typeName}}>))]
+            public enum {{typeName}}
             {
                 {{string.Join(",", evs)}}
             }
@@ -108,39 +111,31 @@ public class CodeRenderer : ICodeRenderer
 
         // Generate the C# interface
         // Skip the "id" field since IId already declares IdAsync
-        var interfaceMethods = type.Fields
-            .Where(field => field.Name != "id")
+        var interfaceMethods = type
+            .Fields.Where(field => field.Name != "id")
             .Select(field =>
-        {
-            var isAsync = IsAsyncField(field, type.Name);
-            var methodName = Formatter.FormatMethod(field.Name);
-
-            if (type.Name.Equals(field.Name, StringComparison.CurrentCultureIgnoreCase))
             {
-                methodName = $"{methodName}_";
-            }
+                var isAsync = IsAsyncField(field, type.Name);
+                var methodName = FormatMethodName(field, type.Name);
 
-            if (isAsync)
-            {
-                methodName = $"{methodName}Async";
-            }
+                var requiredArgs = field.RequiredArgs();
+                var optionalArgs = field.OptionalArgs();
+                var args = requiredArgs
+                    .Select(RenderArgument)
+                    .Concat(optionalArgs.Select(RenderOptionalArgument))
+                    .Concat(
+                        isAsync ? new[] { "CancellationToken cancellationToken = default" } : []
+                    );
 
-            var requiredArgs = field.RequiredArgs();
-            var optionalArgs = field.OptionalArgs();
-            var args = requiredArgs
-                .Select(RenderArgument)
-                .Concat(optionalArgs.Select(RenderOptionalArgument))
-                .Concat(isAsync ? new[] { "CancellationToken cancellationToken = default" } : []);
+                // Interface methods can't use 'async' — just declare the Task<T> return type
+                var returnType = RenderReturnType(field, type.Name).Replace("async ", "");
 
-            // Interface methods can't use 'async' — just declare the Task<T> return type
-            var returnType = RenderReturnType(field, type.Name).Replace("async ", "");
-
-            return $$"""
-            {{RenderDocComment(field)}}
-            {{RenderObsolete(field)}}
-            {{returnType}} {{methodName}}({{string.Join(",", args)}});
-            """;
-        });
+                return $$"""
+                {{RenderDocComment(field)}}
+                {{RenderObsolete(field)}}
+                {{returnType}} {{methodName}}({{string.Join(",", args)}});
+                """;
+            });
 
         var interfaceCode = $$"""
             {{RenderDocComment(type)}}
@@ -165,17 +160,7 @@ public class CodeRenderer : ICodeRenderer
         var methods = type.Fields.Select(field =>
         {
             var isAsync = IsAsyncField(field, type.Name);
-            var methodName = Formatter.FormatMethod(field.Name);
-
-            if (type.Name.Equals(field.Name, StringComparison.CurrentCultureIgnoreCase))
-            {
-                methodName = $"{methodName}_";
-            }
-
-            if (isAsync)
-            {
-                methodName = $"{methodName}Async";
-            }
+            var methodName = FormatMethodName(field, type.Name);
 
             var requiredArgs = field.RequiredArgs();
             var optionalArgs = field.OptionalArgs();
@@ -224,15 +209,16 @@ public class CodeRenderer : ICodeRenderer
         }
 
         var baseClass = "Object(queryBuilder, gqlClient)";
-        var implementsClause = implementsList.Count > 0
-            ? $", {string.Join(", ", implementsList)}"
-            : "";
+        var implementsClause =
+            implementsList.Count > 0 ? $", {string.Join(", ", implementsList)}" : "";
+        var interfaceAdapters = isInterface ? [] : RenderInterfaceAdapters(type).ToArray();
 
         return $$"""
             {{RenderDocComment(type)}}
             public class {{className}}(QueryBuilder queryBuilder, GraphQLClient gqlClient) : {{baseClass}}{{implementsClause}}
             {
                 {{string.Join("\n\n", methods)}}
+                {{string.Join("\n\n", interfaceAdapters)}}
             }
             """;
     }
@@ -271,7 +257,12 @@ public class CodeRenderer : ICodeRenderer
             return true;
         }
 
-        return field.Type.IsLeaf() || field.Type.IsList();
+        return field.Type.IsLeaf() || field.Type.IsList() || IsNullableObject(field.Type);
+    }
+
+    private bool IsNullableObject(TypeRef type)
+    {
+        return SupportsNullableObjects && type.Kind != "NON_NULL" && type.IsObjectOrInterface();
     }
 
     /// <summary>
@@ -326,7 +317,7 @@ public class CodeRenderer : ICodeRenderer
     /// </summary>
     private bool IsIdableType(string typeName)
     {
-        return ObjectTypeNames.Contains(typeName) || InterfaceTypeNames.Contains(typeName);
+        return ObjectTypeNames.Contains(typeName) || InterfaceTypes.ContainsKey(typeName);
     }
 
     private static string RenderObsolete(Field field)
@@ -441,14 +432,17 @@ public class CodeRenderer : ICodeRenderer
         if (IsSyncLikeField(field, parentTypeName))
         {
             var formatted = Formatter.FormatType(parentTypeName);
-            var className = InterfaceTypeNames.Contains(parentTypeName)
-                ? $"{formatted}Client" : formatted;
-            return $"async Task<{className}>";
+            return $"async Task<{formatted}>";
         }
 
         if (type.IsLeaf() || type.IsList())
         {
             return $"async Task<{type.GetTypeName()}>";
+        }
+
+        if (IsNullableObject(type))
+        {
+            return $"async Task<{type.GetTypeName()}?>";
         }
 
         return type.GetTypeName();
@@ -462,8 +456,9 @@ public class CodeRenderer : ICodeRenderer
         if (IsSyncLikeField(field, parentTypeName))
         {
             var formatted = Formatter.FormatType(parentTypeName);
-            var className = InterfaceTypeNames.Contains(parentTypeName)
-                ? $"{formatted}Client" : formatted;
+            var className = InterfaceTypes.ContainsKey(parentTypeName)
+                ? $"{formatted}Client"
+                : formatted;
             return $"new {className}(Object.NodeQueryBuilder((await QueryExecutor.ExecuteAsync<Id>(GraphQLClient, queryBuilder, cancellationToken)).Value, \"{parentTypeName}\"), GraphQLClient)";
         }
 
@@ -477,7 +472,7 @@ public class CodeRenderer : ICodeRenderer
             var typeName = type.GetType_().OfType!.GetType_().Name;
             var formattedName = Formatter.FormatType(typeName);
             // Use the client class for interface types
-            var clientClassName = InterfaceTypeNames.Contains(typeName)
+            var clientClassName = InterfaceTypes.ContainsKey(typeName)
                 ? $"{formattedName}Client"
                 : formattedName;
             return $"""
@@ -498,6 +493,16 @@ public class CodeRenderer : ICodeRenderer
             return $"await QueryExecutor.ExecuteListAsync<{typeName}>(GraphQLClient, queryBuilder, cancellationToken)";
         }
 
+        if (IsNullableObject(type))
+        {
+            var typeName = type.GetType_().Name;
+            var formattedName = Formatter.FormatType(typeName);
+            var clientClassName = InterfaceTypes.ContainsKey(typeName)
+                ? $"{formattedName}Client"
+                : formattedName;
+            return $"await QueryExecutor.ExecuteNullableObjectAsync(GraphQLClient, queryBuilder, id => new {clientClassName}(Object.NodeQueryBuilder(id.Value, \"{typeName}\"), GraphQLClient), cancellationToken)";
+        }
+
         // For interface return types, use the client class
         if (type.IsInterface())
         {
@@ -507,6 +512,76 @@ public class CodeRenderer : ICodeRenderer
         }
 
         return $"new {field.Type.GetTypeName()}(queryBuilder, GraphQLClient)";
+    }
+
+    private IEnumerable<string> RenderInterfaceAdapters(Type type)
+    {
+        foreach (var interfaceRef in type.Interfaces)
+        {
+            var interfaceName = interfaceRef.GetType_().Name;
+            if (
+                interfaceName == "Node"
+                || !InterfaceTypes.TryGetValue(interfaceName, out var iface)
+            )
+            {
+                continue;
+            }
+
+            foreach (var interfaceField in iface.Fields.Where(field => field.Name != "id"))
+            {
+                var objectField = type.Fields.FirstOrDefault(field =>
+                    field.Name == interfaceField.Name
+                );
+                if (objectField is null)
+                {
+                    continue;
+                }
+
+                var isAsync = IsAsyncField(interfaceField, interfaceName);
+                var methodName = FormatMethodName(interfaceField, interfaceName);
+                var objectMethodName = FormatMethodName(objectField, type.Name);
+
+                var args = interfaceField
+                    .RequiredArgs()
+                    .Select(RenderArgument)
+                    .Concat(
+                        interfaceField
+                            .OptionalArgs()
+                            .Select(arg => $"{GetArgTypeName(arg)}? {arg.GetVarName()}")
+                    )
+                    .Concat(isAsync ? new[] { "CancellationToken cancellationToken" } : []);
+                var forwardedArgs = interfaceField
+                    .Args.Select(arg => $"{arg.GetVarName()}: {arg.GetVarName()}")
+                    .Concat(isAsync ? new[] { "cancellationToken: cancellationToken" } : []);
+                var returnType = RenderReturnType(interfaceField, interfaceName)
+                    .Replace("async ", "");
+                var awaitKeyword = isAsync ? "await " : "";
+                var asyncKeyword = isAsync ? "async " : "";
+
+                yield return $$"""
+                    {{asyncKeyword}}{{returnType}} {{Formatter.FormatType(
+                        interfaceName
+                    )}}.{{methodName}}({{string.Join(",", args)}})
+                    {
+                        return {{awaitKeyword}}{{objectMethodName}}({{string.Join(
+                        ",",
+                        forwardedArgs
+                    )}});
+                    }
+                    """;
+            }
+        }
+    }
+
+    private string FormatMethodName(Field field, string parentTypeName)
+    {
+        var methodName = Formatter.FormatMethod(field.Name);
+        if (parentTypeName.Equals(field.Name, StringComparison.CurrentCultureIgnoreCase))
+        {
+            methodName = $"{methodName}_";
+        }
+
+        return IsAsyncField(field, parentTypeName) ? $"{methodName}Async" : methodName;
     }
 
     private string RenderArgumentBuilder(Field field)
@@ -545,9 +620,7 @@ public class CodeRenderer : ICodeRenderer
                     (sb, arg) =>
                     {
                         var varName = arg.GetVarName();
-                        return sb.Append(
-                                $"""if ({varName} is {GetArgTypeName(arg)} {varName}_)"""
-                            )
+                        return sb.Append($"""if ({varName} is {GetArgTypeName(arg)} {varName}_)""")
                             .Append("{\n")
                             .Append(
                                 $$"""    arguments = arguments.Add(new Argument("{{arg.Name}}", {{RenderArgumentValue(arg, addVarSuffix: true)}}));"""

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Code/Formatter.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Code/Formatter.cs
@@ -20,7 +20,8 @@ public static class Formatter
             "Boolean" => SyntaxFacts.GetText(SyntaxKind.BoolKeyword),
             "Int" => SyntaxFacts.GetText(SyntaxKind.IntKeyword),
             "Float" => SyntaxFacts.GetText(SyntaxKind.FloatKeyword),
-            _ => typeName.ToPascalCase(),
+            "ID" => "Id",
+            _ => typeName,
         };
     }
 }

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/Directive.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/Directive.cs
@@ -24,7 +24,8 @@ public class Directive
     /// </summary>
     public string? GetExpectedType()
     {
-        if (Name != "expectedType") return null;
+        if (Name != "expectedType")
+            return null;
         foreach (var arg in Args)
         {
             if (arg.Name == "name")

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/Field.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/Field.cs
@@ -48,7 +48,8 @@ public class Field
         foreach (var d in Directives)
         {
             var et = d.GetExpectedType();
-            if (et != null) return et;
+            if (et != null)
+                return et;
         }
         return null;
     }

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/InputValue.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/InputValue.cs
@@ -27,7 +27,8 @@ public class InputValue
         foreach (var d in Directives)
         {
             var et = d.GetExpectedType();
-            if (et != null) return et;
+            if (et != null)
+                return et;
         }
         return null;
     }

--- a/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/Introspection.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.SourceGenerator/Types/Introspection.cs
@@ -4,6 +4,9 @@ namespace Dagger.SDK.SourceGenerator.Types;
 
 public class Introspection
 {
+    [JsonPropertyName("__schemaVersion")]
+    public string? SchemaVersion { get; set; }
+
     [JsonPropertyName("__schema")]
     public required Schema Schema { get; set; }
 }

--- a/sdk/dotnet/sdk/Dagger.SDK.Tests/GraphQL/QueryBuilderTest.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK.Tests/GraphQL/QueryBuilderTest.cs
@@ -109,8 +109,8 @@ public class QueryBuilderTest
     [TestMethod]
     public void TestNodeQueryBuilder()
     {
-        var query = global::Dagger.SDK.Object
-            .NodeQueryBuilder("some-id", "EnvVariable")
+        var query = global::Dagger
+            .SDK.Object.NodeQueryBuilder("some-id", "EnvVariable")
             .Select("name")
             .Build();
 

--- a/sdk/dotnet/sdk/Dagger.SDK/IId.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK/IId.cs
@@ -1,5 +1,5 @@
-using Dagger.SDK.JsonConverters;
 using System.Text.Json.Serialization;
+using Dagger.SDK.JsonConverters;
 
 namespace Dagger.SDK;
 
@@ -7,9 +7,7 @@ namespace Dagger.SDK;
 /// The unified ID scalar type. All Dagger objects have an ID of this type.
 /// </summary>
 [JsonConverter(typeof(ScalarIdConverter<Id>))]
-public class Id : Scalar
-{
-}
+public class Id : Scalar { }
 
 /// <summary>
 /// Interface for objects that have a unique ID.

--- a/sdk/dotnet/sdk/Dagger.SDK/Object.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK/Object.cs
@@ -13,7 +13,8 @@ public class Object(QueryBuilder queryBuilder, GraphQLClient gqlClient)
     /// </summary>
     public static QueryBuilder NodeQueryBuilder(string id, string graphQLTypeName)
     {
-        return QueryBuilder.Builder()
+        return QueryBuilder
+            .Builder()
             .Select("node", ImmutableList.Create<Argument>(new Argument("id", new StringValue(id))))
             .InlineFragment(graphQLTypeName);
     }

--- a/sdk/dotnet/sdk/Dagger.SDK/QueryExecutor.cs
+++ b/sdk/dotnet/sdk/Dagger.SDK/QueryExecutor.cs
@@ -48,6 +48,37 @@ public static class QueryExecutor
             .ToArray();
     }
 
+    /// <summary>
+    /// Execute a nullable object selection and load the returned object by ID.
+    /// </summary>
+    public static async Task<T?> ExecuteNullableObjectAsync<T>(
+        GraphQLClient client,
+        QueryBuilder queryBuilder,
+        Func<Id, T> objectFactory,
+        CancellationToken cancellationToken = default
+    )
+        where T : class
+    {
+        var idQueryBuilder = queryBuilder.Select("id");
+        var jsonElement = await RequestAsync(client, idQueryBuilder, cancellationToken);
+
+        foreach (var field in idQueryBuilder.Path)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            jsonElement = jsonElement.GetProperty(field.Name);
+        }
+
+        if (jsonElement.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        return objectFactory(jsonElement.Deserialize<Id>()!);
+    }
+
     private static async Task<JsonElement> RequestAsync(
         GraphQLClient client,
         QueryBuilder queryBuilder,
@@ -62,8 +93,7 @@ public static class QueryExecutor
         // Check for GraphQL errors
         if (jsonElement.TryGetProperty("errors", out var errors))
         {
-            throw new InvalidOperationException(
-                $"GraphQL errors: {errors}");
+            throw new InvalidOperationException($"GraphQL errors: {errors}");
         }
 
         return jsonElement.GetProperty("data");
@@ -81,8 +111,9 @@ public static class QueryExecutor
             if (json.ValueKind == JsonValueKind.Null)
             {
                 throw new InvalidOperationException(
-                    $"Cannot traverse property '{fieldName}': parent element is null. " +
-                    $"The node(id:) query may have returned null.");
+                    $"Cannot traverse property '{fieldName}': parent element is null. "
+                        + $"The node(id:) query may have returned null."
+                );
             }
             json = json.GetProperty(fieldName);
         }

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen.ex
@@ -5,11 +5,32 @@ defmodule Dagger.Codegen do
 
   alias Dagger.Codegen.Introspection.Types.Schema
 
+  @nullable_objects_version Version.parse!("1.0.0-beta.10")
+
   def generate(generator, introspection_schema) do
+    supports_nullable_objects = supports_nullable_objects?(introspection_schema.version)
+
     visit(introspection_schema, fn type ->
-      code = do_generate(type, generator)
+      code = do_generate(%{type | supports_nullable_objects: supports_nullable_objects}, generator)
       {generator.filename(type), generator.format(code)}
     end)
+  end
+
+  defp supports_nullable_objects?(nil), do: true
+
+  defp supports_nullable_objects?(version) do
+    version = String.trim_leading(version, "v")
+
+    version =
+      case Regex.run(~r/^\d+\.\d+\.\d+-beta\.\d+/, version) do
+        [beta_version] -> beta_version
+        nil -> version
+      end
+
+    case Version.parse(version) do
+      {:ok, version} -> Version.compare(version, @nullable_objects_version) != :lt
+      :error -> true
+    end
   end
 
   defp visit(%Schema{types: types}, generate) do

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/formatter.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/formatter.ex
@@ -170,6 +170,11 @@ defmodule Dagger.Codegen.ElixirGenerator.Formatter do
     "{:ok, #{format_type(type)}} | {:error, term()}"
   end
 
+  def format_typespec_output_type(%TypeRef{kind: kind} = type)
+      when kind in ["OBJECT", "INTERFACE"] do
+    "{:ok, #{format_type(type)}} | {:error, term()}"
+  end
+
   def format_typespec_output_type(type) do
     format_type(type)
   end

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/object_renderer.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/object_renderer.ex
@@ -123,7 +123,7 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRenderer do
       ?\n,
       "  query_builder = ",
       ?\n,
-      render_query_builder_chain(field, module_var, required_args, optional_args),
+      render_query_builder_chain(type, field, module_var, required_args, optional_args),
       ?\n,
       render_return_value(type, field, module_var),
       ?\n,
@@ -215,6 +215,27 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRenderer do
         """
         case Client.execute(#{module_var}.client, query_builder) do
           {:ok, enum} -> {:ok, #{output_type}.from_string(enum)}
+          error -> error
+        end
+        """
+
+      type.supports_nullable_objects and field.type.kind in ["OBJECT", "INTERFACE"] ->
+        output_type = Formatter.format_output_type(field.type)
+        type_name = field.type.name
+
+        """
+        case Client.execute(#{module_var}.client, query_builder) do
+          {:ok, nil} -> {:ok, nil}
+          {:ok, id} ->
+            {:ok,
+             %#{output_type}{
+               query_builder:
+                 QB.query()
+                 |> QB.select("node")
+                 |> QB.put_arg("id", id)
+                 |> QB.inline_fragment("#{type_name}"),
+               client: #{module_var}.client
+             }}
           error -> error
         end
         """
@@ -336,6 +357,9 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRenderer do
             Formatter.format_typespec_output_type(field.type)
           end
 
+        not type.supports_nullable_objects and field.type.kind in ["OBJECT", "INTERFACE"] ->
+          "#{Formatter.format_output_type(field.type)}.t()"
+
         true ->
           Formatter.format_typespec_output_type(field.type)
       end
@@ -420,7 +444,7 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRenderer do
     Enum.any?(fields, &(&1.name == "id"))
   end
 
-  def render_query_builder_chain(field, module_var, required_args, optional_args) do
+  def render_query_builder_chain(type, field, module_var, required_args, optional_args) do
     [
       "#{module_var}.query_builder",
       "|> QB.select(\"#{field.name}\")",
@@ -430,7 +454,8 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRenderer do
       for arg <- optional_args do
         ["|> QB.maybe_put_arg(", ?", arg.name, ?", ~c",", render_maybe_put_arg(arg), ")"]
       end,
-      if TypeRef.is_list_of?(field.type, "OBJECT") or
+      if (type.supports_nullable_objects and field.type.kind in ["OBJECT", "INTERFACE"]) or
+           TypeRef.is_list_of?(field.type, "OBJECT") or
            TypeRef.is_list_of?(field.type, "INTERFACE") do
         ["|> QB.select(\"id\")"]
       else

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/schema.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/schema.ex
@@ -1,5 +1,6 @@
 defmodule Dagger.Codegen.Introspection.Types.Schema do
   defstruct [
+    :version,
     :query_type,
     :types
   ]
@@ -11,8 +12,15 @@ defmodule Dagger.Codegen.Introspection.Types.Schema do
   @doc """
   Convert a schema map from introspection.json into module.
   """
-  def from_map(%{"queryType" => query_type, "types" => types}) do
+  def from_map(%{"__schema" => schema} = response) do
+    schema
+    |> Map.put("__schemaVersion", response["__schemaVersion"])
+    |> from_map()
+  end
+
+  def from_map(%{"queryType" => query_type, "types" => types} = schema) do
     %__MODULE__{
+      version: schema["__schemaVersion"],
       query_type: Dagger.Codegen.Introspection.Types.QueryType.from_map(query_type),
       types: Enum.map(types, &Dagger.Codegen.Introspection.Types.Type.from_map/1)
     }

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type.ex
@@ -7,7 +7,8 @@ defmodule Dagger.Codegen.Introspection.Types.Type do
     :interfaces,
     :kind,
     :name,
-    :possible_types
+    :possible_types,
+    supports_nullable_objects: true
   ]
 
   def from_map(

--- a/sdk/elixir/dagger_codegen/lib/mix/tasks/dagger.codegen.ex
+++ b/sdk/elixir/dagger_codegen/lib/mix/tasks/dagger.codegen.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Dagger.Codegen do
   end
 
   def handle_generate(%{outdir: outdir, introspection: introspection}) do
-    %{"__schema" => schema} = introspection |> File.read!() |> JSON.decode!()
+    schema = introspection |> File.read!() |> JSON.decode!()
 
     IO.puts("Generate code to #{outdir}")
 

--- a/sdk/elixir/dagger_codegen/test/dagger/codegen/elixir_generator/object_renderer_test.exs
+++ b/sdk/elixir/dagger_codegen/test/dagger/codegen/elixir_generator/object_renderer_test.exs
@@ -516,29 +516,57 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRendererTest do
         @doc \"""
         The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
         \"""
-        @spec runtime(t()) :: Dagger.Container.t() | nil
+        @spec runtime(t()) :: {:ok, Dagger.Container.t() | nil} | {:error, term()}
         def runtime(%__MODULE__{} = module) do
           query_builder =
-            module.query_builder |> QB.select("runtime")
+            module.query_builder |> QB.select("runtime") |> QB.select("id")
 
-          %Dagger.Container{
-            query_builder: query_builder,
-            client: module.client
-          }
+          case Client.execute(module.client, query_builder) do
+            {:ok, nil} ->
+              {:ok, nil}
+
+            {:ok, id} ->
+              {:ok,
+               %Dagger.Container{
+                 query_builder:
+                   QB.query()
+                   |> QB.select("node")
+                   |> QB.put_arg("id", id)
+                   |> QB.inline_fragment("Container"),
+                 client: module.client
+               }}
+
+            error ->
+              error
+          end
         end
 
         @doc \"""
         The SDK config used by this module.
         \"""
-        @spec sdk(t()) :: Dagger.SDKConfig.t() | nil
+        @spec sdk(t()) :: {:ok, Dagger.SDKConfig.t() | nil} | {:error, term()}
         def sdk(%__MODULE__{} = module) do
           query_builder =
-            module.query_builder |> QB.select("sdk")
+            module.query_builder |> QB.select("sdk") |> QB.select("id")
 
-          %Dagger.SDKConfig{
-            query_builder: query_builder,
-            client: module.client
-          }
+          case Client.execute(module.client, query_builder) do
+            {:ok, nil} ->
+              {:ok, nil}
+
+            {:ok, id} ->
+              {:ok,
+               %Dagger.SDKConfig{
+                 query_builder:
+                   QB.query()
+                   |> QB.select("node")
+                   |> QB.put_arg("id", id)
+                   |> QB.inline_fragment("SDKConfig"),
+                 client: module.client
+               }}
+
+            error ->
+              error
+          end
         end
 
         @doc \"""
@@ -564,15 +592,29 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRendererTest do
         @doc \"""
         The source for the module.
         \"""
-        @spec source(t()) :: Dagger.ModuleSource.t() | nil
+        @spec source(t()) :: {:ok, Dagger.ModuleSource.t() | nil} | {:error, term()}
         def source(%__MODULE__{} = module) do
           query_builder =
-            module.query_builder |> QB.select("source")
+            module.query_builder |> QB.select("source") |> QB.select("id")
 
-          %Dagger.ModuleSource{
-            query_builder: query_builder,
-            client: module.client
-          }
+          case Client.execute(module.client, query_builder) do
+            {:ok, nil} ->
+              {:ok, nil}
+
+            {:ok, id} ->
+              {:ok,
+               %Dagger.ModuleSource{
+                 query_builder:
+                   QB.query()
+                   |> QB.select("node")
+                   |> QB.put_arg("id", id)
+                   |> QB.inline_fragment("ModuleSource"),
+                 client: module.client
+               }}
+
+            error ->
+              error
+          end
         end
 
         @doc \"""

--- a/sdk/elixir/dagger_codegen/test/dagger/codegen_test.exs
+++ b/sdk/elixir/dagger_codegen/test/dagger/codegen_test.exs
@@ -1,4 +1,50 @@
 defmodule Dagger.CodegenTest do
   use ExUnit.Case
   doctest Dagger.Codegen
+
+  alias Dagger.Codegen.Introspection.Types.Schema
+
+  defmodule VersionGenerator do
+    def generate_object(type), do: type.supports_nullable_objects
+    def filename(_type), do: "type"
+    def format(value), do: value
+  end
+
+  test "reads the schema version" do
+    schema =
+      Schema.from_map(%{
+        "__schemaVersion" => "v1.0.0-beta.9",
+        "__schema" => %{
+          "queryType" => %{"name" => "Query"},
+          "types" => []
+        }
+      })
+
+    assert schema.version == "v1.0.0-beta.9"
+  end
+
+  test "nullable object version gate handles boundaries and development versions" do
+    for {version, expected} <- [
+          {nil, true},
+          {"development", true},
+          {"v0.21.0-dev", false},
+          {"v1.0.0-beta.9-dev", false},
+          {"v1.0.0-beta.10", true},
+          {"v1.0.0-beta.10-dev", true},
+          {"v1.0.0-rc.1", true},
+          {"v1.0.0", true}
+        ] do
+      schema =
+        Schema.from_map(%{
+          "__schemaVersion" => version,
+          "__schema" => %{
+            "queryType" => %{"name" => "Query"},
+            "types" => [%{"kind" => "OBJECT", "name" => "Query"}]
+          }
+        })
+
+      assert [ok: {"type", ^expected}] =
+               Dagger.Codegen.generate(VersionGenerator, schema) |> Enum.to_list()
+    end
+  end
 end

--- a/sdk/elixir/lib/dagger/gen/check.ex
+++ b/sdk/elixir/lib/dagger/gen/check.ex
@@ -51,15 +51,29 @@ defmodule Dagger.Check do
   @doc """
   If the check failed, this is the error
   """
-  @spec error(t()) :: Dagger.Error.t() | nil
+  @spec error(t()) :: {:ok, Dagger.Error.t() | nil} | {:error, term()}
   def error(%__MODULE__{} = check) do
     query_builder =
-      check.query_builder |> QB.select("error")
+      check.query_builder |> QB.select("error") |> QB.select("id")
 
-    %Dagger.Error{
-      query_builder: query_builder,
-      client: check.client
-    }
+    case Client.execute(check.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Error{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Error"),
+           client: check.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -523,15 +523,29 @@ defmodule Dagger.Client do
   @doc """
   Load any object by its ID.
   """
-  @spec node(t(), String.t()) :: Dagger.Node.t() | nil
+  @spec node(t(), String.t()) :: {:ok, Dagger.Node.t() | nil} | {:error, term()}
   def node(%__MODULE__{} = client, id) do
     query_builder =
-      client.query_builder |> QB.select("node") |> QB.put_arg("id", id)
+      client.query_builder |> QB.select("node") |> QB.put_arg("id", id) |> QB.select("id")
 
-    %Dagger.Node{
-      query_builder: query_builder,
-      client: client.client
-    }
+    case Client.execute(client.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Node{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Node"),
+           client: client.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -122,15 +122,29 @@ defmodule Dagger.Container do
   @doc """
   Retrieves this container's configured docker healthcheck.
   """
-  @spec docker_healthcheck(t()) :: Dagger.HealthcheckConfig.t() | nil
+  @spec docker_healthcheck(t()) :: {:ok, Dagger.HealthcheckConfig.t() | nil} | {:error, term()}
   def docker_healthcheck(%__MODULE__{} = container) do
     query_builder =
-      container.query_builder |> QB.select("dockerHealthcheck")
+      container.query_builder |> QB.select("dockerHealthcheck") |> QB.select("id")
 
-    %Dagger.HealthcheckConfig{
-      query_builder: query_builder,
-      client: container.client
-    }
+    case Client.execute(container.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.HealthcheckConfig{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("HealthcheckConfig"),
+           client: container.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
@@ -575,18 +589,33 @@ defmodule Dagger.Container do
   Return file status
   """
   @spec stat(t(), String.t(), [{:do_not_follow_symlinks, boolean() | nil}]) ::
-          Dagger.Stat.t() | nil
+          {:ok, Dagger.Stat.t() | nil} | {:error, term()}
   def stat(%__MODULE__{} = container, path, optional_args \\ []) do
     query_builder =
       container.query_builder
       |> QB.select("stat")
       |> QB.put_arg("path", path)
       |> QB.maybe_put_arg("doNotFollowSymlinks", optional_args[:do_not_follow_symlinks])
+      |> QB.select("id")
 
-    %Dagger.Stat{
-      query_builder: query_builder,
-      client: container.client
-    }
+    case Client.execute(container.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Stat{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Stat"),
+           client: container.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -370,18 +370,33 @@ defmodule Dagger.Directory do
   Return file status
   """
   @spec stat(t(), String.t(), [{:do_not_follow_symlinks, boolean() | nil}]) ::
-          Dagger.Stat.t() | nil
+          {:ok, Dagger.Stat.t() | nil} | {:error, term()}
   def stat(%__MODULE__{} = directory, path, optional_args \\ []) do
     query_builder =
       directory.query_builder
       |> QB.select("stat")
       |> QB.put_arg("path", path)
       |> QB.maybe_put_arg("doNotFollowSymlinks", optional_args[:do_not_follow_symlinks])
+      |> QB.select("id")
 
-    %Dagger.Stat{
-      query_builder: query_builder,
-      client: directory.client
-    }
+    case Client.execute(directory.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Stat{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Stat"),
+           client: directory.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/enum_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_type_def.ex
@@ -74,15 +74,29 @@ defmodule Dagger.EnumTypeDef do
   @doc """
   The location of this enum declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = enum_type_def) do
     query_builder =
-      enum_type_def.query_builder |> QB.select("sourceMap")
+      enum_type_def.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: enum_type_def.client
-    }
+    case Client.execute(enum_type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: enum_type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
@@ -62,15 +62,29 @@ defmodule Dagger.EnumValueTypeDef do
   @doc """
   The location of this enum member declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = enum_value_type_def) do
     query_builder =
-      enum_value_type_def.query_builder |> QB.select("sourceMap")
+      enum_value_type_def.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: enum_value_type_def.client
-    }
+    case Client.execute(enum_value_type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: enum_value_type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/field_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/field_type_def.ex
@@ -64,15 +64,29 @@ defmodule Dagger.FieldTypeDef do
   @doc """
   The location of this field declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = field_type_def) do
     query_builder =
-      field_type_def.query_builder |> QB.select("sourceMap")
+      field_type_def.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: field_type_def.client
-    }
+    case Client.execute(field_type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: field_type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/file.ex
+++ b/sdk/elixir/lib/dagger/gen/file.ex
@@ -188,15 +188,29 @@ defmodule Dagger.File do
   @doc """
   Return file status
   """
-  @spec stat(t()) :: Dagger.Stat.t() | nil
+  @spec stat(t()) :: {:ok, Dagger.Stat.t() | nil} | {:error, term()}
   def stat(%__MODULE__{} = file) do
     query_builder =
-      file.query_builder |> QB.select("stat")
+      file.query_builder |> QB.select("stat") |> QB.select("id")
 
-    %Dagger.Stat{
-      query_builder: query_builder,
-      client: file.client
-    }
+    case Client.execute(file.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Stat{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Stat"),
+           client: file.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -101,15 +101,29 @@ defmodule Dagger.Function do
   @doc """
   The location of this function declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = function) do
     query_builder =
-      function.query_builder |> QB.select("sourceMap")
+      function.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: function.client
-    }
+    case Client.execute(function.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: function.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/function_arg.ex
+++ b/sdk/elixir/lib/dagger/gen/function_arg.ex
@@ -108,15 +108,29 @@ defmodule Dagger.FunctionArg do
   @doc """
   The location of this arg declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = function_arg) do
     query_builder =
-      function_arg.query_builder |> QB.select("sourceMap")
+      function_arg.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: function_arg.client
-    }
+    case Client.execute(function_arg.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: function_arg.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/git_commit.ex
+++ b/sdk/elixir/lib/dagger/gen/git_commit.ex
@@ -19,17 +19,32 @@ defmodule Dagger.GitCommit do
   The latest semver release tag reachable from this commit.
   """
   @spec ancestor_release_tag(t(), [{:include_pre_release, boolean() | nil}]) ::
-          Dagger.GitRef.t() | nil
+          {:ok, Dagger.GitRef.t() | nil} | {:error, term()}
   def ancestor_release_tag(%__MODULE__{} = git_commit, optional_args \\ []) do
     query_builder =
       git_commit.query_builder
       |> QB.select("ancestorReleaseTag")
       |> QB.maybe_put_arg("includePreRelease", optional_args[:include_pre_release])
+      |> QB.select("id")
 
-    %Dagger.GitRef{
-      query_builder: query_builder,
-      client: git_commit.client
-    }
+    case Client.execute(git_commit.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.GitRef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("GitRef"),
+           client: git_commit.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
@@ -156,17 +171,33 @@ defmodule Dagger.GitCommit do
   @doc """
   The latest semver release tag that points directly at this commit.
   """
-  @spec release_tag(t(), [{:include_pre_release, boolean() | nil}]) :: Dagger.GitRef.t() | nil
+  @spec release_tag(t(), [{:include_pre_release, boolean() | nil}]) ::
+          {:ok, Dagger.GitRef.t() | nil} | {:error, term()}
   def release_tag(%__MODULE__{} = git_commit, optional_args \\ []) do
     query_builder =
       git_commit.query_builder
       |> QB.select("releaseTag")
       |> QB.maybe_put_arg("includePreRelease", optional_args[:include_pre_release])
+      |> QB.select("id")
 
-    %Dagger.GitRef{
-      query_builder: query_builder,
-      client: git_commit.client
-    }
+    case Client.execute(git_commit.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.GitRef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("GitRef"),
+           client: git_commit.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/interface_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/interface_type_def.ex
@@ -74,15 +74,29 @@ defmodule Dagger.InterfaceTypeDef do
   @doc """
   The location of this interface declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = interface_type_def) do
     query_builder =
-      interface_type_def.query_builder |> QB.select("sourceMap")
+      interface_type_def.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: interface_type_def.client
-    }
+    case Client.execute(interface_type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: interface_type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -253,29 +253,57 @@ defmodule Dagger.Module do
   @doc """
   The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
   """
-  @spec runtime(t()) :: Dagger.Container.t() | nil
+  @spec runtime(t()) :: {:ok, Dagger.Container.t() | nil} | {:error, term()}
   def runtime(%__MODULE__{} = module) do
     query_builder =
-      module.query_builder |> QB.select("runtime")
+      module.query_builder |> QB.select("runtime") |> QB.select("id")
 
-    %Dagger.Container{
-      query_builder: query_builder,
-      client: module.client
-    }
+    case Client.execute(module.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Container{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Container"),
+           client: module.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
   The SDK config used by this module.
   """
-  @spec sdk(t()) :: Dagger.SDKConfig.t() | nil
+  @spec sdk(t()) :: {:ok, Dagger.SDKConfig.t() | nil} | {:error, term()}
   def sdk(%__MODULE__{} = module) do
     query_builder =
-      module.query_builder |> QB.select("sdk")
+      module.query_builder |> QB.select("sdk") |> QB.select("id")
 
-    %Dagger.SDKConfig{
-      query_builder: query_builder,
-      client: module.client
-    }
+    case Client.execute(module.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SDKConfig{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SDKConfig"),
+           client: module.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
@@ -321,15 +349,29 @@ defmodule Dagger.Module do
   @doc """
   The source for the module.
   """
-  @spec source(t()) :: Dagger.ModuleSource.t() | nil
+  @spec source(t()) :: {:ok, Dagger.ModuleSource.t() | nil} | {:error, term()}
   def source(%__MODULE__{} = module) do
     query_builder =
-      module.query_builder |> QB.select("source")
+      module.query_builder |> QB.select("source") |> QB.select("id")
 
-    %Dagger.ModuleSource{
-      query_builder: query_builder,
-      client: module.client
-    }
+    case Client.execute(module.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.ModuleSource{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("ModuleSource"),
+           client: module.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source.ex
@@ -400,15 +400,29 @@ defmodule Dagger.ModuleSource do
   @doc """
   The SDK configuration of the module.
   """
-  @spec sdk(t()) :: Dagger.SDKConfig.t() | nil
+  @spec sdk(t()) :: {:ok, Dagger.SDKConfig.t() | nil} | {:error, term()}
   def sdk(%__MODULE__{} = module_source) do
     query_builder =
-      module_source.query_builder |> QB.select("sdk")
+      module_source.query_builder |> QB.select("sdk") |> QB.select("id")
 
-    %Dagger.SDKConfig{
-      query_builder: query_builder,
-      client: module_source.client
-    }
+    case Client.execute(module_source.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SDKConfig{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SDKConfig"),
+           client: module_source.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/object_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/object_type_def.ex
@@ -18,15 +18,29 @@ defmodule Dagger.ObjectTypeDef do
   @doc """
   The function used to construct new instances of this object, if any.
   """
-  @spec constructor(t()) :: Dagger.Function.t() | nil
+  @spec constructor(t()) :: {:ok, Dagger.Function.t() | nil} | {:error, term()}
   def constructor(%__MODULE__{} = object_type_def) do
     query_builder =
-      object_type_def.query_builder |> QB.select("constructor")
+      object_type_def.query_builder |> QB.select("constructor") |> QB.select("id")
 
-    %Dagger.Function{
-      query_builder: query_builder,
-      client: object_type_def.client
-    }
+    case Client.execute(object_type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.Function{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("Function"),
+           client: object_type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
@@ -122,15 +136,29 @@ defmodule Dagger.ObjectTypeDef do
   @doc """
   The location of this object declaration.
   """
-  @spec source_map(t()) :: Dagger.SourceMap.t() | nil
+  @spec source_map(t()) :: {:ok, Dagger.SourceMap.t() | nil} | {:error, term()}
   def source_map(%__MODULE__{} = object_type_def) do
     query_builder =
-      object_type_def.query_builder |> QB.select("sourceMap")
+      object_type_def.query_builder |> QB.select("sourceMap") |> QB.select("id")
 
-    %Dagger.SourceMap{
-      query_builder: query_builder,
-      client: object_type_def.client
-    }
+    case Client.execute(object_type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.SourceMap{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("SourceMap"),
+           client: object_type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/lib/dagger/gen/type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/type_def.ex
@@ -18,85 +18,169 @@ defmodule Dagger.TypeDef do
   @doc """
   If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.
   """
-  @spec as_enum(t()) :: Dagger.EnumTypeDef.t() | nil
+  @spec as_enum(t()) :: {:ok, Dagger.EnumTypeDef.t() | nil} | {:error, term()}
   def as_enum(%__MODULE__{} = type_def) do
     query_builder =
-      type_def.query_builder |> QB.select("asEnum")
+      type_def.query_builder |> QB.select("asEnum") |> QB.select("id")
 
-    %Dagger.EnumTypeDef{
-      query_builder: query_builder,
-      client: type_def.client
-    }
+    case Client.execute(type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.EnumTypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("EnumTypeDef"),
+           client: type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
   If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
   """
-  @spec as_input(t()) :: Dagger.InputTypeDef.t() | nil
+  @spec as_input(t()) :: {:ok, Dagger.InputTypeDef.t() | nil} | {:error, term()}
   def as_input(%__MODULE__{} = type_def) do
     query_builder =
-      type_def.query_builder |> QB.select("asInput")
+      type_def.query_builder |> QB.select("asInput") |> QB.select("id")
 
-    %Dagger.InputTypeDef{
-      query_builder: query_builder,
-      client: type_def.client
-    }
+    case Client.execute(type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.InputTypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("InputTypeDef"),
+           client: type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
   If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
   """
-  @spec as_interface(t()) :: Dagger.InterfaceTypeDef.t() | nil
+  @spec as_interface(t()) :: {:ok, Dagger.InterfaceTypeDef.t() | nil} | {:error, term()}
   def as_interface(%__MODULE__{} = type_def) do
     query_builder =
-      type_def.query_builder |> QB.select("asInterface")
+      type_def.query_builder |> QB.select("asInterface") |> QB.select("id")
 
-    %Dagger.InterfaceTypeDef{
-      query_builder: query_builder,
-      client: type_def.client
-    }
+    case Client.execute(type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.InterfaceTypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("InterfaceTypeDef"),
+           client: type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
   If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
   """
-  @spec as_list(t()) :: Dagger.ListTypeDef.t() | nil
+  @spec as_list(t()) :: {:ok, Dagger.ListTypeDef.t() | nil} | {:error, term()}
   def as_list(%__MODULE__{} = type_def) do
     query_builder =
-      type_def.query_builder |> QB.select("asList")
+      type_def.query_builder |> QB.select("asList") |> QB.select("id")
 
-    %Dagger.ListTypeDef{
-      query_builder: query_builder,
-      client: type_def.client
-    }
+    case Client.execute(type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.ListTypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("ListTypeDef"),
+           client: type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
   If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
   """
-  @spec as_object(t()) :: Dagger.ObjectTypeDef.t() | nil
+  @spec as_object(t()) :: {:ok, Dagger.ObjectTypeDef.t() | nil} | {:error, term()}
   def as_object(%__MODULE__{} = type_def) do
     query_builder =
-      type_def.query_builder |> QB.select("asObject")
+      type_def.query_builder |> QB.select("asObject") |> QB.select("id")
 
-    %Dagger.ObjectTypeDef{
-      query_builder: query_builder,
-      client: type_def.client
-    }
+    case Client.execute(type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.ObjectTypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("ObjectTypeDef"),
+           client: type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """
   If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.
   """
-  @spec as_scalar(t()) :: Dagger.ScalarTypeDef.t() | nil
+  @spec as_scalar(t()) :: {:ok, Dagger.ScalarTypeDef.t() | nil} | {:error, term()}
   def as_scalar(%__MODULE__{} = type_def) do
     query_builder =
-      type_def.query_builder |> QB.select("asScalar")
+      type_def.query_builder |> QB.select("asScalar") |> QB.select("id")
 
-    %Dagger.ScalarTypeDef{
-      query_builder: query_builder,
-      client: type_def.client
-    }
+    case Client.execute(type_def.client, query_builder) do
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:ok, id} ->
+        {:ok,
+         %Dagger.ScalarTypeDef{
+           query_builder:
+             QB.query()
+             |> QB.select("node")
+             |> QB.put_arg("id", id)
+             |> QB.inline_fragment("ScalarTypeDef"),
+           client: type_def.client
+         }}
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/sdk/elixir/test/dagger/mod/module_test.exs
+++ b/sdk/elixir/test/dagger/mod/module_test.exs
@@ -114,7 +114,10 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, :OBJECT_KIND} = Dagger.TypeDef.kind(arg_type_def)
 
       assert {:ok, "Container"} =
-               arg_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+               arg_type_def
+               |> Dagger.TypeDef.as_object()
+               |> unwrap_ok()
+               |> Dagger.ObjectTypeDef.name()
     end
 
     test "list arguments", %{dag: dag} do
@@ -130,7 +133,10 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, :LIST_KIND} = Dagger.TypeDef.kind(arg_type_def)
 
       sub_type_def =
-        arg_type_def |> Dagger.TypeDef.as_list() |> Dagger.ListTypeDef.element_type_def()
+        arg_type_def
+        |> Dagger.TypeDef.as_list()
+        |> unwrap_ok()
+        |> Dagger.ListTypeDef.element_type_def()
 
       assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(sub_type_def)
 
@@ -143,7 +149,10 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, :LIST_KIND} = Dagger.TypeDef.kind(arg_type_def)
 
       sub_type_def =
-        arg_type_def |> Dagger.TypeDef.as_list() |> Dagger.ListTypeDef.element_type_def()
+        arg_type_def
+        |> Dagger.TypeDef.as_list()
+        |> unwrap_ok()
+        |> Dagger.ListTypeDef.element_type_def()
 
       assert {:ok, :STRING_KIND} = Dagger.TypeDef.kind(sub_type_def)
     end
@@ -176,7 +185,10 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, :OBJECT_KIND} = Dagger.TypeDef.kind(arg_type_def)
 
       assert {:ok, "Directory"} =
-               arg_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+               arg_type_def
+               |> Dagger.TypeDef.as_object()
+               |> unwrap_ok()
+               |> Dagger.ObjectTypeDef.name()
 
       assert {:ok, true} = Dagger.TypeDef.optional(arg_type_def)
     end
@@ -218,7 +230,7 @@ defmodule Dagger.Mod.ModuleTest do
       # No any functions because `init` register as a function.
       assert {:ok, []} = Dagger.ObjectTypeDef.functions(root)
 
-      init = Dagger.ObjectTypeDef.constructor(root)
+      init = Dagger.ObjectTypeDef.constructor(root) |> unwrap_ok()
       assert {:ok, ""} = Dagger.Function.name(init)
       assert {:ok, [arg]} = Dagger.Function.args(init)
       assert {:ok, "name"} = Dagger.FunctionArg.name(arg)
@@ -231,7 +243,10 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, :OBJECT_KIND} = Dagger.TypeDef.kind(return_type_def)
 
       assert {:ok, "ConstructorFunction"} =
-               return_type_def |> Dagger.TypeDef.as_object() |> Dagger.ObjectTypeDef.name()
+               return_type_def
+               |> Dagger.TypeDef.as_object()
+               |> unwrap_ok()
+               |> Dagger.ObjectTypeDef.name()
     end
 
     test "accept and return scalar", %{dag: dag} do
@@ -246,6 +261,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, "Platform"} =
                arg_type_def
                |> Dagger.TypeDef.as_scalar()
+               |> unwrap_ok()
                |> Dagger.ScalarTypeDef.name()
 
       return_type_def = Dagger.Function.return_type(accept)
@@ -254,6 +270,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, "Platform"} =
                return_type_def
                |> Dagger.TypeDef.as_scalar()
+               |> unwrap_ok()
                |> Dagger.ScalarTypeDef.name()
     end
 
@@ -269,6 +286,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, "NetworkProtocol"} =
                arg_type_def
                |> Dagger.TypeDef.as_enum()
+               |> unwrap_ok()
                |> Dagger.EnumTypeDef.name()
 
       return_type_def = Dagger.Function.return_type(accept)
@@ -277,6 +295,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, "NetworkProtocol"} =
                return_type_def
                |> Dagger.TypeDef.as_enum()
+               |> unwrap_ok()
                |> Dagger.EnumTypeDef.name()
     end
 
@@ -292,6 +311,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, "SimpleEnum"} =
                arg_type_def
                |> Dagger.TypeDef.as_enum()
+               |> unwrap_ok()
                |> Dagger.EnumTypeDef.name()
 
       return_type_def = Dagger.Function.return_type(scan)
@@ -300,6 +320,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, "SimpleEnum"} =
                return_type_def
                |> Dagger.TypeDef.as_enum()
+               |> unwrap_ok()
                |> Dagger.EnumTypeDef.name()
 
       assert {:ok, [arg]} = Dagger.Function.args(scan)
@@ -311,7 +332,7 @@ defmodule Dagger.Mod.ModuleTest do
       assert {:ok, :ENUM_KIND} =
                Dagger.TypeDef.kind(type_def)
 
-      enum_type_def = type_def |> Dagger.TypeDef.as_enum()
+      enum_type_def = type_def |> Dagger.TypeDef.as_enum() |> unwrap_ok()
 
       Dagger.EnumTypeDef.description(enum_type_def)
       Dagger.EnumTypeDef.name(enum_type_def)
@@ -331,6 +352,7 @@ defmodule Dagger.Mod.ModuleTest do
         |> Enum.map(fn enum ->
           enum
           |> Dagger.TypeDef.as_enum()
+          |> unwrap_ok()
           |> Dagger.EnumTypeDef.name()
         end)
         |> Enum.map(fn {:ok, name} -> name end)
@@ -377,6 +399,8 @@ defmodule Dagger.Mod.ModuleTest do
   defp root_object(dag, module) do
     module = Module.define(dag, module)
     {:ok, [root_object]} = Dagger.Module.objects(module)
-    Dagger.TypeDef.as_object(root_object)
+    Dagger.TypeDef.as_object(root_object) |> unwrap_ok()
   end
+
+  defp unwrap_ok({:ok, value}), do: value
 end

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -217,9 +217,9 @@ func ModuleSource(refString string, opts ...dagger.ModuleSourceOpts) *dagger.Mod
 }
 
 // Load any object by its ID.
-func Node(id dagger.ID) dagger.Node {
+func Node(ctx context.Context, id dagger.ID) (dagger.Node, error) {
 	client := initClient()
-	return client.Node(id)
+	return client.Node(ctx, id)
 }
 
 // Load a GraphQL introspection schema for merging.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1048,12 +1048,20 @@ func (r *Check) Description(ctx context.Context) (string, error) {
 }
 
 // If the check failed, this is the error
-func (r *Check) Error() *Error {
+func (r *Check) Error(ctx context.Context) (*Error, error) {
 	q := r.query.Select("error")
 
-	return &Error{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &Error{
+		query: selectNode(q.Root(), *objectID, "Error"),
+	}, nil
 }
 
 // A unique identifier for this Check.
@@ -1623,12 +1631,20 @@ func (r *Container) Directory(path string, opts ...ContainerDirectoryOpts) *Dire
 }
 
 // Retrieves this container's configured docker healthcheck.
-func (r *Container) DockerHealthcheck() *HealthcheckConfig {
+func (r *Container) DockerHealthcheck(ctx context.Context) (*HealthcheckConfig, error) {
 	q := r.query.Select("dockerHealthcheck")
 
-	return &HealthcheckConfig{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &HealthcheckConfig{
+		query: selectNode(q.Root(), *objectID, "HealthcheckConfig"),
+	}, nil
 }
 
 // Return the container's OCI entrypoint.
@@ -2257,7 +2273,7 @@ type ContainerStatOpts struct {
 }
 
 // Return file status
-func (r *Container) Stat(path string, opts ...ContainerStatOpts) *Stat {
+func (r *Container) Stat(ctx context.Context, path string, opts ...ContainerStatOpts) (*Stat, error) {
 	q := r.query.Select("stat")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `doNotFollowSymlinks` optional argument
@@ -2267,9 +2283,17 @@ func (r *Container) Stat(path string, opts ...ContainerStatOpts) *Stat {
 	}
 	q = q.Arg("path", path)
 
-	return &Stat{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &Stat{
+		query: selectNode(q.Root(), *objectID, "Stat"),
+	}, nil
 }
 
 // The buffered standard error stream of the last executed command
@@ -4852,7 +4876,7 @@ type DirectoryStatOpts struct {
 }
 
 // Return file status
-func (r *Directory) Stat(path string, opts ...DirectoryStatOpts) *Stat {
+func (r *Directory) Stat(ctx context.Context, path string, opts ...DirectoryStatOpts) (*Stat, error) {
 	q := r.query.Select("stat")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `doNotFollowSymlinks` optional argument
@@ -4862,9 +4886,17 @@ func (r *Directory) Stat(path string, opts ...DirectoryStatOpts) *Stat {
 	}
 	q = q.Arg("path", path)
 
-	return &Stat{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &Stat{
+		query: selectNode(q.Root(), *objectID, "Stat"),
+	}, nil
 }
 
 // Force evaluation in the engine.
@@ -5923,12 +5955,20 @@ func (r *EnumTypeDef) Name(ctx context.Context) (string, error) {
 }
 
 // The location of this enum declaration.
-func (r *EnumTypeDef) SourceMap() *SourceMap {
+func (r *EnumTypeDef) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -6084,12 +6124,20 @@ func (r *EnumValueTypeDef) Name(ctx context.Context) (string, error) {
 }
 
 // The location of this enum member declaration.
-func (r *EnumValueTypeDef) SourceMap() *SourceMap {
+func (r *EnumValueTypeDef) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // The value of the enum member
@@ -6710,12 +6758,20 @@ func (r *FieldTypeDef) Name(ctx context.Context) (string, error) {
 }
 
 // The location of this field declaration.
-func (r *FieldTypeDef) SourceMap() *SourceMap {
+func (r *FieldTypeDef) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // The type of the field.
@@ -7054,12 +7110,20 @@ func (r *File) Size(ctx context.Context) (int, error) {
 }
 
 // Return file status
-func (r *File) Stat() *Stat {
+func (r *File) Stat(ctx context.Context) (*Stat, error) {
 	q := r.query.Select("stat")
 
-	return &Stat{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &Stat{
+		query: selectNode(q.Root(), *objectID, "Stat"),
+	}, nil
 }
 
 // Force evaluation in the engine.
@@ -7305,12 +7369,20 @@ func (r *Function) ReturnType() *TypeDef {
 }
 
 // The location of this function declaration.
-func (r *Function) SourceMap() *SourceMap {
+func (r *Function) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // If this function is provided by a module, the name of the module. Unset otherwise.
@@ -7644,12 +7716,20 @@ func (r *FunctionArg) Name(ctx context.Context) (string, error) {
 }
 
 // The location of this arg declaration.
-func (r *FunctionArg) SourceMap() *SourceMap {
+func (r *FunctionArg) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // The type of the argument.
@@ -8392,7 +8472,7 @@ type GitCommitAncestorReleaseTagOpts struct {
 }
 
 // The latest semver release tag reachable from this commit.
-func (r *GitCommit) AncestorReleaseTag(opts ...GitCommitAncestorReleaseTagOpts) *GitRef {
+func (r *GitCommit) AncestorReleaseTag(ctx context.Context, opts ...GitCommitAncestorReleaseTagOpts) (*GitRef, error) {
 	q := r.query.Select("ancestorReleaseTag")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `includePreRelease` optional argument
@@ -8401,9 +8481,17 @@ func (r *GitCommit) AncestorReleaseTag(opts ...GitCommitAncestorReleaseTagOpts) 
 		}
 	}
 
-	return &GitRef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &GitRef{
+		query: selectNode(q.Root(), *objectID, "GitRef"),
+	}, nil
 }
 
 // Git author email.
@@ -8580,7 +8668,7 @@ type GitCommitReleaseTagOpts struct {
 }
 
 // The latest semver release tag that points directly at this commit.
-func (r *GitCommit) ReleaseTag(opts ...GitCommitReleaseTagOpts) *GitRef {
+func (r *GitCommit) ReleaseTag(ctx context.Context, opts ...GitCommitReleaseTagOpts) (*GitRef, error) {
 	q := r.query.Select("releaseTag")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `includePreRelease` optional argument
@@ -8589,9 +8677,17 @@ func (r *GitCommit) ReleaseTag(opts ...GitCommitReleaseTagOpts) *GitRef {
 		}
 	}
 
-	return &GitRef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &GitRef{
+		query: selectNode(q.Root(), *objectID, "GitRef"),
+	}, nil
 }
 
 // The full commit SHA.
@@ -9811,12 +9907,20 @@ func (r *InterfaceTypeDef) Name(ctx context.Context) (string, error) {
 }
 
 // The location of this interface declaration.
-func (r *InterfaceTypeDef) SourceMap() *SourceMap {
+func (r *InterfaceTypeDef) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -11657,21 +11761,37 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 }
 
 // The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-func (r *Module) Runtime() *Container {
+func (r *Module) Runtime(ctx context.Context) (*Container, error) {
 	q := r.query.Select("runtime")
 
-	return &Container{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &Container{
+		query: selectNode(q.Root(), *objectID, "Container"),
+	}, nil
 }
 
 // The SDK config used by this module.
-func (r *Module) SDK() *SDKConfig {
+func (r *Module) SDK(ctx context.Context) (*SDKConfig, error) {
 	q := r.query.Select("sdk")
 
-	return &SDKConfig{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SDKConfig{
+		query: selectNode(q.Root(), *objectID, "SDKConfig"),
+	}, nil
 }
 
 // ModuleServeOpts contains options for Module.Serve
@@ -11728,12 +11848,20 @@ func (r *Module) Services(opts ...ModuleServicesOpts) *UpGroup {
 }
 
 // The source for the module.
-func (r *Module) Source() *ModuleSource {
+func (r *Module) Source(ctx context.Context) (*ModuleSource, error) {
 	q := r.query.Select("source")
 
-	return &ModuleSource{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &ModuleSource{
+		query: selectNode(q.Root(), *objectID, "ModuleSource"),
+	}, nil
 }
 
 // Forces evaluation of the module, including any loading into the engine and associated validation.
@@ -12355,12 +12483,20 @@ func (r *ModuleSource) RepoRootPath(ctx context.Context) (string, error) {
 }
 
 // The SDK configuration of the module.
-func (r *ModuleSource) SDK() *SDKConfig {
+func (r *ModuleSource) SDK(ctx context.Context) (*SDKConfig, error) {
 	q := r.query.Select("sdk")
 
-	return &SDKConfig{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SDKConfig{
+		query: selectNode(q.Root(), *objectID, "SDKConfig"),
+	}, nil
 }
 
 // The path, relative to the context directory, that contains the module config.
@@ -12706,12 +12842,20 @@ func (r *ObjectTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *ObjectTypeD
 }
 
 // The function used to construct new instances of this object, if any.
-func (r *ObjectTypeDef) Constructor() *Function {
+func (r *ObjectTypeDef) Constructor(ctx context.Context) (*Function, error) {
 	q := r.query.Select("constructor")
 
-	return &Function{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &Function{
+		query: selectNode(q.Root(), *objectID, "Function"),
+	}, nil
 }
 
 // The reason this enum member is deprecated, if any.
@@ -12860,12 +13004,20 @@ func (r *ObjectTypeDef) Name(ctx context.Context) (string, error) {
 }
 
 // The location of this object declaration.
-func (r *ObjectTypeDef) SourceMap() *SourceMap {
+func (r *ObjectTypeDef) SourceMap(ctx context.Context) (*SourceMap, error) {
 	q := r.query.Select("sourceMap")
 
-	return &SourceMap{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &SourceMap{
+		query: selectNode(q.Root(), *objectID, "SourceMap"),
+	}, nil
 }
 
 // If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -13575,12 +13727,21 @@ func (r *Query) ModuleSource(refString string, opts ...ModuleSourceOpts) *Module
 }
 
 // Load any object by its ID.
-func (r *Query) Node(id ID) Node {
+func (r *Query) Node(ctx context.Context, id ID) (Node, error) {
 	q := r.query.Select("node")
 	q = q.Arg("id", id)
-	return &NodeClient{
-		query: q,
+
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &NodeClient{
+		query: selectNode(q.Root(), *objectID, "Node"),
+	}, nil
 }
 
 // Load a GraphQL introspection schema for merging.
@@ -15109,57 +15270,105 @@ func (r *TypeDef) WithGraphQLQuery(q *querybuilder.Selection) *TypeDef {
 }
 
 // If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.
-func (r *TypeDef) AsEnum() *EnumTypeDef {
+func (r *TypeDef) AsEnum(ctx context.Context) (*EnumTypeDef, error) {
 	q := r.query.Select("asEnum")
 
-	return &EnumTypeDef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &EnumTypeDef{
+		query: selectNode(q.Root(), *objectID, "EnumTypeDef"),
+	}, nil
 }
 
 // If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
-func (r *TypeDef) AsInput() *InputTypeDef {
+func (r *TypeDef) AsInput(ctx context.Context) (*InputTypeDef, error) {
 	q := r.query.Select("asInput")
 
-	return &InputTypeDef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &InputTypeDef{
+		query: selectNode(q.Root(), *objectID, "InputTypeDef"),
+	}, nil
 }
 
 // If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
-func (r *TypeDef) AsInterface() *InterfaceTypeDef {
+func (r *TypeDef) AsInterface(ctx context.Context) (*InterfaceTypeDef, error) {
 	q := r.query.Select("asInterface")
 
-	return &InterfaceTypeDef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &InterfaceTypeDef{
+		query: selectNode(q.Root(), *objectID, "InterfaceTypeDef"),
+	}, nil
 }
 
 // If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
-func (r *TypeDef) AsList() *ListTypeDef {
+func (r *TypeDef) AsList(ctx context.Context) (*ListTypeDef, error) {
 	q := r.query.Select("asList")
 
-	return &ListTypeDef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &ListTypeDef{
+		query: selectNode(q.Root(), *objectID, "ListTypeDef"),
+	}, nil
 }
 
 // If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
-func (r *TypeDef) AsObject() *ObjectTypeDef {
+func (r *TypeDef) AsObject(ctx context.Context) (*ObjectTypeDef, error) {
 	q := r.query.Select("asObject")
 
-	return &ObjectTypeDef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &ObjectTypeDef{
+		query: selectNode(q.Root(), *objectID, "ObjectTypeDef"),
+	}, nil
 }
 
 // If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.
-func (r *TypeDef) AsScalar() *ScalarTypeDef {
+func (r *TypeDef) AsScalar(ctx context.Context) (*ScalarTypeDef, error) {
 	q := r.query.Select("asScalar")
 
-	return &ScalarTypeDef{
-		query: q,
+	q = q.Select("id")
+	var objectID *ID
+	if err := q.Bind(&objectID).Execute(ctx); err != nil {
+		return nil, err
 	}
+	if objectID == nil {
+		return nil, nil
+	}
+	return &ScalarTypeDef{
+		query: selectNode(q.Root(), *objectID, "ScalarTypeDef"),
+	}, nil
 }
 
 // A unique identifier for this TypeDef.

--- a/sdk/java/dagger-codegen-maven-plugin/pom.xml
+++ b/sdk/java/dagger-codegen-maven-plugin/pom.xml
@@ -57,6 +57,16 @@
             <groupId>com.ongres</groupId>
             <artifactId>fluent-process</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/InterfaceVisitor.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/InterfaceVisitor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import javax.lang.model.element.Modifier;
 
@@ -51,6 +52,11 @@ class InterfaceVisitor extends AbstractVisitor {
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT);
 
         TypeName returnType = resolveReturnType(field);
+        if (getSchema().supportsNullableObjects()
+            && field.getTypeRef().isOptional()
+            && field.getTypeRef().isObjectOrInterface()) {
+          returnType = ParameterizedTypeName.get(ClassName.get(Optional.class), returnType);
+        }
         methodBuilder.returns(returnType);
 
         // Add parameters for required args
@@ -128,6 +134,12 @@ class InterfaceVisitor extends AbstractVisitor {
             .addAnnotation(Override.class);
 
     TypeName returnType = resolveReturnType(field);
+    TypeName objectReturnType = returnType;
+    if (getSchema().supportsNullableObjects()
+        && field.getTypeRef().isOptional()
+        && field.getTypeRef().isObjectOrInterface()) {
+      returnType = ParameterizedTypeName.get(ClassName.get(Optional.class), returnType);
+    }
     fieldMethodBuilder.returns(returnType);
 
     List<ParameterSpec> mandatoryParams =
@@ -192,8 +204,26 @@ class InterfaceVisitor extends AbstractVisitor {
           .addException(InterruptedException.class)
           .addException(ExecutionException.class)
           .addException(ClassName.get("io.dagger.client.exception", "DaggerQueryException"));
+    } else if (getSchema().supportsNullableObjects()
+        && field.getTypeRef().isOptional()
+        && field.getTypeRef().isObjectOrInterface()) {
+      String graphqlTypeName = field.getTypeRef().getTypeName();
+      String clientClassName =
+          field.getTypeRef().isInterface()
+              ? graphqlTypeName + "Client"
+              : objectReturnType.toString();
+      fieldMethodBuilder.addStatement(
+          "QueryBuilder objectQueryBuilder = nextQueryBuilder.executeNullableObjectQuery($S)",
+          graphqlTypeName);
+      fieldMethodBuilder.addStatement(
+          "return Optional.ofNullable(objectQueryBuilder).map(qb -> new $L(qb))",
+          ClassName.bestGuess(clientClassName));
+      fieldMethodBuilder
+          .addException(InterruptedException.class)
+          .addException(ExecutionException.class)
+          .addException(ClassName.get("io.dagger.client.exception", "DaggerQueryException"));
     } else if (field.getTypeRef().isObjectOrInterface()) {
-      TypeName objectType = resolveReturnType(field);
+      TypeName objectType = objectReturnType;
       // For interface return types, instantiate the client class
       if (field.getTypeRef().isInterface()) {
         fieldMethodBuilder.addStatement(
@@ -241,7 +271,7 @@ class InterfaceVisitor extends AbstractVisitor {
       return true;
     }
     if (field.getTypeRef().isObjectOrInterface()) {
-      return false;
+      return getSchema().supportsNullableObjects() && field.getTypeRef().isOptional();
     }
     return true; // scalar fields need exceptions
   }

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/ObjectVisitor.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/ObjectVisitor.java
@@ -11,6 +11,7 @@ import jakarta.json.stream.JsonParser;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.UnaryOperator;
 import javax.lang.model.element.Modifier;
@@ -213,6 +214,12 @@ class ObjectVisitor extends AbstractVisitor {
     MethodSpec.Builder fieldMethodBuilder =
         MethodSpec.methodBuilder(Helpers.formatName(field)).addModifiers(Modifier.PUBLIC);
     TypeName returnType = resolveReturnType(field);
+    TypeName objectReturnType = returnType;
+    if (getSchema().supportsNullableObjects()
+        && field.getTypeRef().isOptional()
+        && field.getTypeRef().isObjectOrInterface()) {
+      returnType = ParameterizedTypeName.get(ClassName.get(Optional.class), returnType);
+    }
     fieldMethodBuilder.returns(returnType);
     List<ParameterSpec> mandatoryParams =
         field.getRequiredArgs().stream()
@@ -290,6 +297,24 @@ class ObjectVisitor extends AbstractVisitor {
     } else if (Helpers.isIdToConvert(field)) {
       fieldMethodBuilder.addStatement("nextQueryBuilder.executeQuery()");
       fieldMethodBuilder.addStatement("return this");
+      fieldMethodBuilder
+          .addException(InterruptedException.class)
+          .addException(ExecutionException.class)
+          .addException(ClassName.get("io.dagger.client.exception", "DaggerQueryException"));
+    } else if (getSchema().supportsNullableObjects()
+        && field.getTypeRef().isOptional()
+        && field.getTypeRef().isObjectOrInterface()) {
+      String graphqlTypeName = field.getTypeRef().getTypeName();
+      String clientClassName =
+          field.getTypeRef().isInterface()
+              ? graphqlTypeName + "Client"
+              : objectReturnType.toString();
+      fieldMethodBuilder.addStatement(
+          "QueryBuilder objectQueryBuilder = nextQueryBuilder.executeNullableObjectQuery($S)",
+          graphqlTypeName);
+      fieldMethodBuilder.addStatement(
+          "return Optional.ofNullable(objectQueryBuilder).map(qb -> new $L(qb))",
+          ClassName.bestGuess(clientClassName));
       fieldMethodBuilder
           .addException(InterruptedException.class)
           .addException(ExecutionException.class)

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Schema.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/introspection/Schema.java
@@ -8,8 +8,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 
 public class Schema {
+
+  private static final ComparableVersion NULLABLE_OBJECTS_VERSION =
+      new ComparableVersion("1.0.0-beta.10");
 
   public static class SchemaContainer {
 
@@ -67,6 +71,19 @@ public class Schema {
 
   public String getVersion() {
     return version;
+  }
+
+  public boolean supportsNullableObjects() {
+    if (version == null || version.isBlank()) {
+      return true;
+    }
+
+    if (!version.matches("^v?\\d+\\.\\d+\\.\\d+.*$")) {
+      return true;
+    }
+
+    String normalized = version.startsWith("v") ? version.substring(1) : version;
+    return new ComparableVersion(normalized).compareTo(NULLABLE_OBJECTS_VERSION) >= 0;
   }
 
   public Type query() {

--- a/sdk/java/dagger-codegen-maven-plugin/src/test/java/io/dagger/codegen/introspection/InterfaceVisitorTest.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/test/java/io/dagger/codegen/introspection/InterfaceVisitorTest.java
@@ -1,0 +1,74 @@
+package io.dagger.codegen.introspection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InterfaceVisitorTest {
+  @Test
+  void nullableObjectVersionGateHandlesBoundariesAndDevelopmentVersions() throws Exception {
+    assertThat(schemaAtVersion(null).supportsNullableObjects()).isTrue();
+    assertThat(schemaAtVersion("").supportsNullableObjects()).isTrue();
+    assertThat(schemaAtVersion("development").supportsNullableObjects()).isTrue();
+    assertThat(schemaAtVersion("v0.21.0-dev").supportsNullableObjects()).isFalse();
+    assertThat(schemaAtVersion("v1.0.0-beta.9-dev").supportsNullableObjects()).isFalse();
+    assertThat(schemaAtVersion("v1.0.0-beta.10").supportsNullableObjects()).isTrue();
+    assertThat(schemaAtVersion("v1.0.0-beta.10-dev").supportsNullableObjects()).isTrue();
+    assertThat(schemaAtVersion("v1.0.0-rc.1").supportsNullableObjects()).isTrue();
+    assertThat(schemaAtVersion("v1.0.0").supportsNullableObjects()).isTrue();
+  }
+
+  @Test
+  void optionalObjectMethodsOnlyDeclareExceptionsWhenNullableObjectsAreSupported()
+      throws Exception {
+    Type type = interfaceWithOptionalObjectField();
+
+    String legacyInterface = generateInterface(type, "v1.0.0-beta.9");
+    String nullableInterface = generateInterface(type, "v1.0.0-beta.10");
+
+    assertThat(legacyInterface)
+        .contains("Directory child();")
+        .doesNotContain("DaggerQueryException");
+    assertThat(nullableInterface)
+        .contains("Optional<Directory> child()")
+        .contains("DaggerQueryException");
+  }
+
+  private static String generateInterface(Type type, String version) throws Exception {
+    Schema schema = schemaAtVersion(version);
+    return new InterfaceVisitor(schema, Path.of("."), StandardCharsets.UTF_8)
+        .generateType(type)
+        .toString();
+  }
+
+  private static Schema schemaAtVersion(String version) throws Exception {
+    byte[] introspection = "{\"__schema\":{\"types\":[]}}".getBytes(StandardCharsets.UTF_8);
+    return Schema.initialize(new ByteArrayInputStream(introspection), version);
+  }
+
+  private static Type interfaceWithOptionalObjectField() {
+    TypeRef returnType = new TypeRef();
+    returnType.setKind(TypeKind.OBJECT);
+    returnType.setName("Directory");
+
+    Type parent = new Type();
+    parent.setKind(TypeKind.INTERFACE);
+    parent.setName("Parent");
+    parent.setDescription("");
+
+    Field field = new Field();
+    field.setName("child");
+    field.setDescription("");
+    field.setTypeRef(returnType);
+    field.setArgs(List.of());
+    field.setDirectives(List.of());
+    field.setParentObject(parent);
+
+    parent.setFields(List.of(field));
+    return parent;
+  }
+}

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/QueryBuilder.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/QueryBuilder.java
@@ -235,6 +235,15 @@ class QueryBuilder {
     return rv;
   }
 
+  QueryBuilder executeNullableObjectQuery(String graphqlTypeName)
+      throws ExecutionException, InterruptedException, DaggerQueryException {
+    String id = chain(List.of("id")).executeQuery(String.class);
+    if (id == null) {
+      return null;
+    }
+    return new QueryBuilder(this.client).chainNode(graphqlTypeName, id);
+  }
+
   /**
    * Execute a list query for objects, returning QueryBuilders that load each element via node(id:).
    *

--- a/sdk/php/generated/Check.php
+++ b/sdk/php/generated/Check.php
@@ -40,10 +40,15 @@ class Check extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * If the check failed, this is the error
      */
-    public function error(): Error
+    public function error(): ?Error
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('error');
-        return new \Dagger\Error($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('error');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\Error::class, new \Dagger\Id((string)$id), 'Error');
     }
 
     /**

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -403,11 +403,16 @@ class Client extends Client\AbstractClient implements Client\IdAble, Node
     /**
      * Load any object by its ID.
      */
-    public function node(Id $id): Node
+    public function node(Id $id): ?Node
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('node');
-        $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\NodeClient($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('node');
+        $objectQueryBuilder->setArgument('id', $id);
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\NodeClient::class, new \Dagger\Id((string)$id), 'Node');
     }
 
     /**

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -107,10 +107,15 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
     /**
      * Retrieves this container's configured docker healthcheck.
      */
-    public function dockerHealthcheck(): HealthcheckConfig
+    public function dockerHealthcheck(): ?HealthcheckConfig
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('dockerHealthcheck');
-        return new \Dagger\HealthcheckConfig($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('dockerHealthcheck');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\HealthcheckConfig::class, new \Dagger\Id((string)$id), 'HealthcheckConfig');
     }
 
     /**
@@ -456,14 +461,19 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
     /**
      * Return file status
      */
-    public function stat(string $path, ?bool $doNotFollowSymlinks = false): Stat
+    public function stat(string $path, ?bool $doNotFollowSymlinks = false): ?Stat
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('stat');
-        $innerQueryBuilder->setArgument('path', $path);
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('stat');
+        $objectQueryBuilder->setArgument('path', $path);
         if (null !== $doNotFollowSymlinks) {
-        $innerQueryBuilder->setArgument('doNotFollowSymlinks', $doNotFollowSymlinks);
+        $objectQueryBuilder->setArgument('doNotFollowSymlinks', $doNotFollowSymlinks);
         }
-        return new \Dagger\Stat($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\Stat::class, new \Dagger\Id((string)$id), 'Stat');
     }
 
     /**

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -311,14 +311,19 @@ class Directory extends Client\AbstractObject implements Client\IdAble, Exportab
     /**
      * Return file status
      */
-    public function stat(string $path, ?bool $doNotFollowSymlinks = false): Stat
+    public function stat(string $path, ?bool $doNotFollowSymlinks = false): ?Stat
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('stat');
-        $innerQueryBuilder->setArgument('path', $path);
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('stat');
+        $objectQueryBuilder->setArgument('path', $path);
         if (null !== $doNotFollowSymlinks) {
-        $innerQueryBuilder->setArgument('doNotFollowSymlinks', $doNotFollowSymlinks);
+        $objectQueryBuilder->setArgument('doNotFollowSymlinks', $doNotFollowSymlinks);
         }
-        return new \Dagger\Stat($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\Stat::class, new \Dagger\Id((string)$id), 'Stat');
     }
 
     /**

--- a/sdk/php/generated/EnumTypeDef.php
+++ b/sdk/php/generated/EnumTypeDef.php
@@ -52,10 +52,15 @@ class EnumTypeDef extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The location of this enum declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/EnumValueTypeDef.php
+++ b/sdk/php/generated/EnumValueTypeDef.php
@@ -52,10 +52,15 @@ class EnumValueTypeDef extends Client\AbstractObject implements Client\IdAble, N
     /**
      * The location of this enum member declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/FieldTypeDef.php
+++ b/sdk/php/generated/FieldTypeDef.php
@@ -54,10 +54,15 @@ class FieldTypeDef extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The location of this field declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/File.php
+++ b/sdk/php/generated/File.php
@@ -167,10 +167,15 @@ class File extends Client\AbstractObject implements Client\IdAble, Exportable, N
     /**
      * Return file status
      */
-    public function stat(): Stat
+    public function stat(): ?Stat
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('stat');
-        return new \Dagger\Stat($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('stat');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\Stat::class, new \Dagger\Id((string)$id), 'Stat');
     }
 
     /**

--- a/sdk/php/generated/FunctionArg.php
+++ b/sdk/php/generated/FunctionArg.php
@@ -90,10 +90,15 @@ class FunctionArg extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The location of this arg declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/Function_.php
+++ b/sdk/php/generated/Function_.php
@@ -72,10 +72,15 @@ class Function_ extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The location of this function declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/GitCommit.php
+++ b/sdk/php/generated/GitCommit.php
@@ -16,13 +16,18 @@ class GitCommit extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The latest semver release tag reachable from this commit.
      */
-    public function ancestorReleaseTag(?bool $includePreRelease = false): GitRef
+    public function ancestorReleaseTag(?bool $includePreRelease = false): ?GitRef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('ancestorReleaseTag');
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('ancestorReleaseTag');
         if (null !== $includePreRelease) {
-        $innerQueryBuilder->setArgument('includePreRelease', $includePreRelease);
+        $objectQueryBuilder->setArgument('includePreRelease', $includePreRelease);
         }
-        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\GitRef::class, new \Dagger\Id((string)$id), 'GitRef');
     }
 
     /**
@@ -127,13 +132,18 @@ class GitCommit extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The latest semver release tag that points directly at this commit.
      */
-    public function releaseTag(?bool $includePreRelease = false): GitRef
+    public function releaseTag(?bool $includePreRelease = false): ?GitRef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('releaseTag');
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('releaseTag');
         if (null !== $includePreRelease) {
-        $innerQueryBuilder->setArgument('includePreRelease', $includePreRelease);
+        $objectQueryBuilder->setArgument('includePreRelease', $includePreRelease);
         }
-        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\GitRef::class, new \Dagger\Id((string)$id), 'GitRef');
     }
 
     /**

--- a/sdk/php/generated/InterfaceTypeDef.php
+++ b/sdk/php/generated/InterfaceTypeDef.php
@@ -52,10 +52,15 @@ class InterfaceTypeDef extends Client\AbstractObject implements Client\IdAble, N
     /**
      * The location of this interface declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -148,19 +148,29 @@ class Module extends Client\AbstractObject implements Client\IdAble, Node, Synce
     /**
      * The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
      */
-    public function runtime(): Container
+    public function runtime(): ?Container
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('runtime');
-        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('runtime');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\Container::class, new \Dagger\Id((string)$id), 'Container');
     }
 
     /**
      * The SDK config used by this module.
      */
-    public function sdk(): SDKConfig
+    public function sdk(): ?SDKConfig
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');
-        return new \Dagger\SDKConfig($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SDKConfig::class, new \Dagger\Id((string)$id), 'SDKConfig');
     }
 
     /**
@@ -195,10 +205,15 @@ class Module extends Client\AbstractObject implements Client\IdAble, Node, Synce
     /**
      * The source for the module.
      */
-    public function source(): ModuleSource
+    public function source(): ?ModuleSource
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('source');
-        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('source');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\ModuleSource::class, new \Dagger\Id((string)$id), 'ModuleSource');
     }
 
     /**

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -281,10 +281,15 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble, Node,
     /**
      * The SDK configuration of the module.
      */
-    public function sdk(): SDKConfig
+    public function sdk(): ?SDKConfig
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');
-        return new \Dagger\SDKConfig($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SDKConfig::class, new \Dagger\Id((string)$id), 'SDKConfig');
     }
 
     /**

--- a/sdk/php/generated/ObjectTypeDef.php
+++ b/sdk/php/generated/ObjectTypeDef.php
@@ -16,10 +16,15 @@ class ObjectTypeDef extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The function used to construct new instances of this object, if any.
      */
-    public function constructor(): Function_
+    public function constructor(): ?Function_
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('constructor');
-        return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('constructor');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\Function_::class, new \Dagger\Id((string)$id), 'Function');
     }
 
     /**
@@ -79,10 +84,15 @@ class ObjectTypeDef extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * The location of this object declaration.
      */
-    public function sourceMap(): SourceMap
+    public function sourceMap(): ?SourceMap
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
-        return new \Dagger\SourceMap($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('sourceMap');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\SourceMap::class, new \Dagger\Id((string)$id), 'SourceMap');
     }
 
     /**

--- a/sdk/php/generated/TypeDef.php
+++ b/sdk/php/generated/TypeDef.php
@@ -16,55 +16,85 @@ class TypeDef extends Client\AbstractObject implements Client\IdAble, Node
     /**
      * If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.
      */
-    public function asEnum(): EnumTypeDef
+    public function asEnum(): ?EnumTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asEnum');
-        return new \Dagger\EnumTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('asEnum');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\EnumTypeDef::class, new \Dagger\Id((string)$id), 'EnumTypeDef');
     }
 
     /**
      * If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
      */
-    public function asInput(): InputTypeDef
+    public function asInput(): ?InputTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asInput');
-        return new \Dagger\InputTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('asInput');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\InputTypeDef::class, new \Dagger\Id((string)$id), 'InputTypeDef');
     }
 
     /**
      * If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
      */
-    public function asInterface(): InterfaceTypeDef
+    public function asInterface(): ?InterfaceTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asInterface');
-        return new \Dagger\InterfaceTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('asInterface');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\InterfaceTypeDef::class, new \Dagger\Id((string)$id), 'InterfaceTypeDef');
     }
 
     /**
      * If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
      */
-    public function asList(): ListTypeDef
+    public function asList(): ?ListTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asList');
-        return new \Dagger\ListTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('asList');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\ListTypeDef::class, new \Dagger\Id((string)$id), 'ListTypeDef');
     }
 
     /**
      * If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
      */
-    public function asObject(): ObjectTypeDef
+    public function asObject(): ?ObjectTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asObject');
-        return new \Dagger\ObjectTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('asObject');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\ObjectTypeDef::class, new \Dagger\Id((string)$id), 'ObjectTypeDef');
     }
 
     /**
      * If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.
      */
-    public function asScalar(): ScalarTypeDef
+    public function asScalar(): ?ScalarTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asScalar');
-        return new \Dagger\ScalarTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $objectQueryBuilder = new \Dagger\Client\QueryBuilder('asScalar');
+        $objectQueryBuilder->selectField('id');
+        $id = $this->queryLeaf($objectQueryBuilder, 'id');
+        if ($id === null) {
+            return null;
+        }
+        return $this->client->loadObjectFromId(\Dagger\ScalarTypeDef::class, new \Dagger\Id((string)$id), 'ScalarTypeDef');
     }
 
     /**

--- a/sdk/php/src/Client/AbstractClient.php
+++ b/sdk/php/src/Client/AbstractClient.php
@@ -61,14 +61,15 @@ abstract class AbstractClient
      * @template T of object
      * @param class-string<T> $className Fully-qualified PHP class name (e.g. \Dagger\Container)
      * @param Id $id The object's ID
+     * @param ?string $graphQLTypeName GraphQL type name when it differs from the PHP class name
      * @return T
      */
-    public function loadObjectFromId(string $className, Id $id): object
+    public function loadObjectFromId(string $className, Id $id, ?string $graphQLTypeName = null): object
     {
         $shortName = (new ReflectionClass($className))->getShortName();
 
         // Reverse the PHP class name → GraphQL type name mapping
-        $graphQLTypeName = match ($shortName) {
+        $graphQLTypeName ??= match ($shortName) {
             'Function_' => 'Function',
             'Client' => 'Query',
             default => $shortName,

--- a/sdk/php/src/Codegen/Codegen.php
+++ b/sdk/php/src/Codegen/Codegen.php
@@ -18,7 +18,7 @@ class Codegen
 
     public function generate(): void
     {
-        $visitor = new NewCodegenVisitor($this->writeDir);
+        $visitor = new NewCodegenVisitor($this->writeDir, $this->schema->supportsNullableObjects());
 
         $filteredTypes = array_filter($this->schema->types, function (IntrospectionType $type) {
             return !str_starts_with($type->name, '_')

--- a/sdk/php/src/Codegen/Introspection/IntrospectionSchema.php
+++ b/sdk/php/src/Codegen/Introspection/IntrospectionSchema.php
@@ -6,16 +6,36 @@ namespace Dagger\Codegen\Introspection;
 
 class IntrospectionSchema
 {
+    public ?string $version = null;
+
     /** @var IntrospectionType[] */
     public array $types = [];
 
     public static function fromArray(array $data): self
     {
         $schema = new self();
+        $schema->version = $data['__schemaVersion'] ?? null;
         foreach ($data['__schema']['types'] ?? [] as $typeData) {
             $schema->types[] = IntrospectionType::fromArray($typeData);
         }
         return $schema;
+    }
+
+    public function supportsNullableObjects(): bool
+    {
+        if ($this->version === null || $this->version === '') {
+            return true;
+        }
+
+        $version = ltrim($this->version, 'v');
+        if (preg_match('/^\d+\.\d+\.\d+/', $version) !== 1) {
+            return true;
+        }
+        if (preg_match('/^(\d+\.\d+\.\d+-beta\.\d+)/', $version, $matches) === 1) {
+            $version = $matches[1];
+        }
+
+        return version_compare($version, '1.0.0-beta.10', '>=');
     }
 
     public function getType(string $name): ?IntrospectionType

--- a/sdk/php/src/Codegen/Introspection/NewCodegenVisitor.php
+++ b/sdk/php/src/Codegen/Introspection/NewCodegenVisitor.php
@@ -23,7 +23,8 @@ use Nette\PhpGenerator\Method;
 class NewCodegenVisitor extends CodeWriter
 {
     public function __construct(
-        string $targetDirectory
+        string $targetDirectory,
+        private readonly bool $supportsNullableObjects = true,
     ) {
         parent::__construct($targetDirectory);
     }
@@ -190,6 +191,8 @@ class NewCodegenVisitor extends CodeWriter
             $phpReturnType = $this->resolveReturnType($returnType, $field);
             if ($returnType->isNonNull()) {
                 $method->setReturnNullable(false);
+            } elseif ($this->supportsNullableObjects && ($returnType->isObject() || $returnType->isInterface())) {
+                $method->setReturnNullable(true);
             }
             $method->setReturnType($phpReturnType);
         }
@@ -210,6 +213,25 @@ class NewCodegenVisitor extends CodeWriter
                 [$field->name]
             );
             $method->addBody('return $this;');
+        } elseif (
+            $this->supportsNullableObjects
+            && !$returnType->isNonNull()
+            && ($returnType->isObject() || $returnType->isInterface())
+        ) {
+            $method->addBody('$objectQueryBuilder = new \Dagger\Client\QueryBuilder(?);', [$field->name]);
+            $this->generateMethodArgsBody($method, $sortedArgs, 'objectQueryBuilder');
+            $method->addBody('$objectQueryBuilder->selectField(?);', ['id']);
+            $method->addBody('$id = $this->queryLeaf($objectQueryBuilder, ?);', ['id']);
+            $method->addBody('if ($id === null) {');
+            $method->addBody('    return null;');
+            $method->addBody('}');
+            $returnClassName = $this->resolveReturnClassName($returnType, $field);
+            $graphQLTypeName = $this->unwrapNonNull($returnType)->leafName();
+            $method->addBody(
+                'return $this->client->loadObjectFromId(' . $returnClassName
+                . '::class, new \Dagger\Id((string)$id), ?);',
+                [$graphQLTypeName]
+            );
         } elseif ($this->isLeafReturn($returnType, $field)) {
             // Scalar/list/enum return: use queryLeaf
             $method->addBody('$leafQueryBuilder = new \Dagger\Client\QueryBuilder(?);', [$field->name]);
@@ -287,6 +309,8 @@ class NewCodegenVisitor extends CodeWriter
             $phpReturnType = $this->resolveReturnType($returnType, $field);
             if ($returnType->isNonNull()) {
                 $method->setReturnNullable(false);
+            } elseif ($this->supportsNullableObjects && ($returnType->isObject() || $returnType->isInterface())) {
+                $method->setReturnNullable(true);
             }
             $method->setReturnType($phpReturnType);
         }

--- a/sdk/php/tests/Integration/ClientTest.php
+++ b/sdk/php/tests/Integration/ClientTest.php
@@ -70,4 +70,15 @@ class ClientTest extends TestCase
 
         $this->assertEquals('3.16.2', trim($contents));
     }
+
+    public function testNode(): void
+    {
+        $client = $this->newClient();
+        $containerId = $client->container()->id();
+
+        $node = $client->node($containerId);
+
+        self::assertNotNull($node);
+        self::assertEquals($containerId, $node->id());
+    }
 }

--- a/sdk/php/tests/Unit/Codegen/IntrospectionSchemaTest.php
+++ b/sdk/php/tests/Unit/Codegen/IntrospectionSchemaTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Tests\Unit\Codegen;
+
+use Dagger\Codegen\Introspection\IntrospectionSchema;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+#[CoversClass(IntrospectionSchema::class)]
+class IntrospectionSchemaTest extends TestCase
+{
+    #[Test]
+    public function itReadsTheSchemaVersion(): void
+    {
+        $schema = IntrospectionSchema::fromArray([
+            '__schemaVersion' => 'v1.0.0-beta.9',
+            '__schema' => ['types' => []],
+        ]);
+
+        self::assertSame('v1.0.0-beta.9', $schema->version);
+    }
+
+    #[Test]
+    #[DataProvider('nullableObjectVersions')]
+    public function itChecksNullableObjectVersionSupport(?string $version, bool $expected): void
+    {
+        $schema = IntrospectionSchema::fromArray([
+            '__schemaVersion' => $version,
+            '__schema' => ['types' => []],
+        ]);
+
+        self::assertSame($expected, $schema->supportsNullableObjects());
+    }
+
+    public static function nullableObjectVersions(): iterable
+    {
+        yield 'missing version' => [null, true];
+        yield 'development version' => ['development', true];
+        yield 'old development version' => ['v0.21.0-dev', false];
+        yield 'beta 9 development version' => ['v1.0.0-beta.9-dev', false];
+        yield 'beta 10' => ['v1.0.0-beta.10', true];
+        yield 'beta 10 development version' => ['v1.0.0-beta.10-dev', true];
+        yield 'release candidate' => ['v1.0.0-rc.1', true];
+        yield 'stable version' => ['v1.0.0', true];
+    }
+}

--- a/sdk/python/codegen/src/codegen/generator.py
+++ b/sdk/python/codegen/src/codegen/generator.py
@@ -131,6 +131,11 @@ class Context:
         """Generate the pre-v0.21 ID/load helper source facade."""
         return legacy_sdk_compat(self.schema_version)
 
+    @property
+    def supports_nullable_objects(self) -> bool:
+        """Expose nullable object fields as values that must be resolved."""
+        return supports_nullable_objects(self.schema_version)
+
     def process_type(self, name: str):
         # This is only needed to keep track of remaining types because
         # of forward references.
@@ -366,6 +371,7 @@ def id_from_type(t: GraphQLType) -> IDName | None:
 
 
 LEGACY_SDK_COMPAT_CUTOVER = (0, 21, 0)
+NULLABLE_OBJECT_SDK_CUTOVER = (1, 0, 0, "beta", 10)
 
 
 def legacy_sdk_compat(schema_version: str) -> bool:
@@ -384,6 +390,31 @@ def parse_version(version: str) -> tuple[int, int, int] | None:
     if match is None:
         return None
     return tuple(int(part) for part in match.groups())
+
+
+def supports_nullable_objects(schema_version: str) -> bool:
+    """Whether nullable object fields use the new resolved return shape."""
+    if not schema_version:
+        return True
+
+    match = re.match(
+        r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+)(?:\.(\d+))?)?",
+        schema_version,
+    )
+    if match is None:
+        return True
+
+    core = tuple(int(part) for part in match.groups()[:3])
+    cutover_core = NULLABLE_OBJECT_SDK_CUTOVER[:3]
+    if core != cutover_core:
+        return core > cutover_core
+
+    prerelease, number = match.groups()[3:]
+    if prerelease is None:
+        return True
+    if prerelease == "beta" and number is not None:
+        return int(number) >= NULLABLE_OBJECT_SDK_CUTOVER[4]
+    return prerelease > NULLABLE_OBJECT_SDK_CUTOVER[3]
 
 
 def legacy_id_name(type_name: TypeName) -> IDName:
@@ -512,13 +543,27 @@ def format_output_type(
     t: GraphQLOutputType,
     expected_type: TypeName | None = None,
     legacy_ids: bool = False,
+    nullable_objects: bool = True,
 ) -> str:
     """May be used as the output type of an object field."""
-    # When returning objects we're in query building mode, so don't return
-    # None even if the field's return is optional.
-    if not is_output_leaf_type(t) and not is_required_type(t):
+    # Lists of objects already execute eagerly and keep their established
+    # return shape. A directly nullable object must expose None because its
+    # accessor now executes to determine whether the object exists.
+    if (
+        (
+            not nullable_objects
+            or not isinstance(t, (GraphQLObjectType, GraphQLInterfaceType))
+        )
+        and not is_output_leaf_type(t)
+        and not is_required_type(t)
+    ):
         t = GraphQLNonNull(t)
-    return format_input_type(t, False, expected_type, legacy_ids)
+    return format_input_type(
+        cast(GraphQLInputType, t),
+        False,
+        expected_type,
+        legacy_ids,
+    )
 
 
 def output_type_description(t: GraphQLOutputType) -> str:
@@ -690,7 +735,13 @@ class _ObjectField:
 
         self.is_leaf = is_output_leaf_type(field.type)
         self.is_list = is_list_of_objects_type(field.type)
-        self.is_exec = self.is_leaf or self.is_list
+        self.is_nullable_object = (
+            ctx.supports_nullable_objects
+            and not self.is_leaf
+            and not self.is_list
+            and not is_required_type(field.type)
+        )
+        self.is_exec = self.is_leaf or self.is_list or self.is_nullable_object
         self.is_void = self.is_leaf and self.named_type.name == "Void"
 
         # Read @expectedType directive from the field's AST node.
@@ -707,6 +758,7 @@ class _ObjectField:
             field.type,
             legacy_output_id_type,
             ctx.legacy_sdk_compat,
+            ctx.supports_nullable_objects,
         )
 
         # Any field in the API that returns an ID for its parent object should
@@ -804,6 +856,9 @@ class _ObjectField:
             # Use the concrete client class for interface types
             t = self._iface_client_name(self.type)
             yield f"return {t}(_ctx)"
+        elif self.is_nullable_object:
+            t = self._iface_client_name(self.named_type.name)
+            yield f"return await _ctx.execute_object({t})"
         elif self.is_list:
             n = self.named_type.name
             t = self._iface_client_name(n)

--- a/sdk/python/src/dagger/client/_core.py
+++ b/sdk/python/src/dagger/client/_core.py
@@ -248,6 +248,15 @@ class Context:
         gql_name = element_type._graphql_name()  # noqa: SLF001
         return [element_type(ctx.select_id(gql_name, v.id)) for v in ids]
 
+    async def execute_object(self, object_type: type[Obj_T]) -> Obj_T | None:
+        ctx = self.select("id", [])
+        id_ = await ctx.execute(str | None)
+        if id_ is None:
+            return None
+
+        gql_name = object_type._graphql_name()  # noqa: SLF001
+        return object_type(ctx.select_id(gql_name, id_))
+
     async def execute_sync(
         self,
         obj: Obj_T,

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1204,11 +1204,11 @@ class Check(Type):
         _ctx = self._select("description", _args)
         return await _ctx.execute(str)
 
-    def error(self) -> "Error":
+    async def error(self) -> "Error | None":
         """If the check failed, this is the error"""
         _args: list[Arg] = []
         _ctx = self._select("error", _args)
-        return Error(_ctx)
+        return await _ctx.execute_object(Error)
 
     async def id(self) -> str:
         """A unique identifier for this Check.
@@ -1660,11 +1660,11 @@ class Container(Type):
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
 
-    def docker_healthcheck(self) -> "HealthcheckConfig":
+    async def docker_healthcheck(self) -> "HealthcheckConfig | None":
         """Retrieves this container's configured docker healthcheck."""
         _args: list[Arg] = []
         _ctx = self._select("dockerHealthcheck", _args)
-        return HealthcheckConfig(_ctx)
+        return await _ctx.execute_object(HealthcheckConfig)
 
     async def entrypoint(self) -> list[str]:
         """Return the container's OCI entrypoint.
@@ -2318,12 +2318,12 @@ class Container(Type):
         _ctx = self._select("rootfs", _args)
         return Directory(_ctx)
 
-    def stat(
+    async def stat(
         self,
         path: str,
         *,
         do_not_follow_symlinks: bool | None = False,
-    ) -> "Stat":
+    ) -> "Stat | None":
         """Return file status
 
         Parameters
@@ -2338,7 +2338,7 @@ class Container(Type):
             Arg("doNotFollowSymlinks", do_not_follow_symlinks, False),
         ]
         _ctx = self._select("stat", _args)
-        return Stat(_ctx)
+        return await _ctx.execute_object(Stat)
 
     async def stderr(self) -> str:
         """The buffered standard error stream of the last executed command
@@ -4890,12 +4890,12 @@ class Directory(Type):
         _ctx = self._select("search", _args)
         return await _ctx.execute_object_list(SearchResult)
 
-    def stat(
+    async def stat(
         self,
         path: str,
         *,
         do_not_follow_symlinks: bool | None = False,
-    ) -> "Stat":
+    ) -> "Stat | None":
         """Return file status
 
         Parameters
@@ -4910,7 +4910,7 @@ class Directory(Type):
             Arg("doNotFollowSymlinks", do_not_follow_symlinks, False),
         ]
         _ctx = self._select("stat", _args)
-        return Stat(_ctx)
+        return await _ctx.execute_object(Stat)
 
     async def sync(self) -> Self:
         """Force evaluation in the engine.
@@ -5933,11 +5933,11 @@ class EnumTypeDef(Type):
         _ctx = self._select("name", _args)
         return await _ctx.execute(str)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this enum declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     async def source_module_name(self) -> str:
         """If this EnumTypeDef is associated with a Module, the name of the
@@ -6072,11 +6072,11 @@ class EnumValueTypeDef(Type):
         _ctx = self._select("name", _args)
         return await _ctx.execute(str)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this enum member declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     async def value(self) -> str:
         """The value of the enum member
@@ -6600,11 +6600,11 @@ class FieldTypeDef(Type):
         _ctx = self._select("name", _args)
         return await _ctx.execute(str)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this field declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     def type_def(self) -> "TypeDef":
         """The type of the field."""
@@ -6894,11 +6894,11 @@ class File(Type):
         _ctx = self._select("size", _args)
         return await _ctx.execute(int)
 
-    def stat(self) -> "Stat":
+    async def stat(self) -> "Stat | None":
         """Return file status"""
         _args: list[Arg] = []
         _ctx = self._select("stat", _args)
-        return Stat(_ctx)
+        return await _ctx.execute_object(Stat)
 
     async def sync(self) -> Self:
         """Force evaluation in the engine.
@@ -7103,11 +7103,11 @@ class Function(Type):
         _ctx = self._select("returnType", _args)
         return TypeDef(_ctx)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this function declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     async def source_module_name(self) -> str:
         """If this function is provided by a module, the name of the module.
@@ -7465,11 +7465,11 @@ class FunctionArg(Type):
         _ctx = self._select("name", _args)
         return await _ctx.execute(str)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this arg declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     def type_def(self) -> "TypeDef":
         """The type of the argument."""
@@ -8099,11 +8099,11 @@ class GeneratorGroup(Type):
 class GitCommit(Type):
     """An immutable git commit."""
 
-    def ancestor_release_tag(
+    async def ancestor_release_tag(
         self,
         *,
         include_pre_release: bool | None = False,
-    ) -> "GitRef":
+    ) -> "GitRef | None":
         """The latest semver release tag reachable from this commit.
 
         Parameters
@@ -8115,7 +8115,7 @@ class GitCommit(Type):
             Arg("includePreRelease", include_pre_release, False),
         ]
         _ctx = self._select("ancestorReleaseTag", _args)
-        return GitRef(_ctx)
+        return await _ctx.execute_object(GitRef)
 
     async def author_email(self) -> str:
         """Git author email.
@@ -8355,11 +8355,11 @@ class GitCommit(Type):
         _ctx = self._select("parentShas", _args)
         return await _ctx.execute(list[str])
 
-    def release_tag(
+    async def release_tag(
         self,
         *,
         include_pre_release: bool | None = False,
-    ) -> "GitRef":
+    ) -> "GitRef | None":
         """The latest semver release tag that points directly at this commit.
 
         Parameters
@@ -8371,7 +8371,7 @@ class GitCommit(Type):
             Arg("includePreRelease", include_pre_release, False),
         ]
         _ctx = self._select("releaseTag", _args)
-        return GitRef(_ctx)
+        return await _ctx.execute_object(GitRef)
 
     async def sha(self) -> str:
         """The full commit SHA.
@@ -9456,11 +9456,11 @@ class InterfaceTypeDef(Type):
         _ctx = self._select("name", _args)
         return await _ctx.execute(str)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this interface declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     async def source_module_name(self) -> str:
         """If this InterfaceTypeDef is associated with a Module, the name of the
@@ -11142,19 +11142,19 @@ class Module(Type):
         _ctx = self._select("objects", _args)
         return await _ctx.execute_object_list(TypeDef)
 
-    def runtime(self) -> Container:
+    async def runtime(self) -> Container | None:
         """The container that runs the module's entrypoint. It will fail to
         execute if the module doesn't compile.
         """
         _args: list[Arg] = []
         _ctx = self._select("runtime", _args)
-        return Container(_ctx)
+        return await _ctx.execute_object(Container)
 
-    def sdk(self) -> "SDKConfig":
+    async def sdk(self) -> "SDKConfig | None":
         """The SDK config used by this module."""
         _args: list[Arg] = []
         _ctx = self._select("sdk", _args)
-        return SDKConfig(_ctx)
+        return await _ctx.execute_object(SDKConfig)
 
     async def serve(
         self,
@@ -11217,11 +11217,11 @@ class Module(Type):
         _ctx = self._select("services", _args)
         return UpGroup(_ctx)
 
-    def source(self) -> "ModuleSource":
+    async def source(self) -> "ModuleSource | None":
         """The source for the module."""
         _args: list[Arg] = []
         _ctx = self._select("source", _args)
-        return ModuleSource(_ctx)
+        return await _ctx.execute_object(ModuleSource)
 
     async def sync(self) -> Self:
         """Forces evaluation of the module, including any loading into the engine
@@ -11865,11 +11865,11 @@ class ModuleSource(Type):
         _ctx = self._select("repoRootPath", _args)
         return await _ctx.execute(str)
 
-    def sdk(self) -> "SDKConfig":
+    async def sdk(self) -> "SDKConfig | None":
         """The SDK configuration of the module."""
         _args: list[Arg] = []
         _ctx = self._select("sdk", _args)
-        return SDKConfig(_ctx)
+        return await _ctx.execute_object(SDKConfig)
 
     async def source_root_subpath(self) -> str:
         """The path, relative to the context directory, that contains the module
@@ -12320,11 +12320,11 @@ class ModuleSource(Type):
 class ObjectTypeDef(Type):
     """A definition of a custom object defined in a Module."""
 
-    def constructor(self) -> Function:
+    async def constructor(self) -> Function | None:
         """The function used to construct new instances of this object, if any."""
         _args: list[Arg] = []
         _ctx = self._select("constructor", _args)
-        return Function(_ctx)
+        return await _ctx.execute_object(Function)
 
     async def deprecated(self) -> str | None:
         """The reason this enum member is deprecated, if any.
@@ -12429,11 +12429,11 @@ class ObjectTypeDef(Type):
         _ctx = self._select("name", _args)
         return await _ctx.execute(str)
 
-    def source_map(self) -> "SourceMap":
+    async def source_map(self) -> "SourceMap | None":
         """The location of this object declaration."""
         _args: list[Arg] = []
         _ctx = self._select("sourceMap", _args)
-        return SourceMap(_ctx)
+        return await _ctx.execute_object(SourceMap)
 
     async def source_module_name(self) -> str:
         """If this ObjectTypeDef is associated with a Module, the name of the
@@ -13061,13 +13061,13 @@ class Query(Root):
         _ctx = self._select("moduleSource", _args)
         return ModuleSource(_ctx)
 
-    def node(self, id: Type) -> Node:
+    async def node(self, id: Type) -> Node | None:
         """Load any object by its ID."""
         _args = [
             Arg("id", id),
         ]
         _ctx = self._select("node", _args)
-        return _NodeClient(_ctx)
+        return await _ctx.execute_object(_NodeClient)
 
     def schema(self, json: JSON) -> "Schema":
         """Load a GraphQL introspection schema for merging.
@@ -14395,53 +14395,53 @@ class Terminal(Type):
 class TypeDef(Type):
     """A definition of a parameter or return type in a Module."""
 
-    def as_enum(self) -> EnumTypeDef:
+    async def as_enum(self) -> EnumTypeDef | None:
         """If kind is ENUM, the enum-specific type definition. If kind is not
         ENUM, this will be null.
         """
         _args: list[Arg] = []
         _ctx = self._select("asEnum", _args)
-        return EnumTypeDef(_ctx)
+        return await _ctx.execute_object(EnumTypeDef)
 
-    def as_input(self) -> InputTypeDef:
+    async def as_input(self) -> InputTypeDef | None:
         """If kind is INPUT, the input-specific type definition. If kind is not
         INPUT, this will be null.
         """
         _args: list[Arg] = []
         _ctx = self._select("asInput", _args)
-        return InputTypeDef(_ctx)
+        return await _ctx.execute_object(InputTypeDef)
 
-    def as_interface(self) -> InterfaceTypeDef:
+    async def as_interface(self) -> InterfaceTypeDef | None:
         """If kind is INTERFACE, the interface-specific type definition. If kind
         is not INTERFACE, this will be null.
         """
         _args: list[Arg] = []
         _ctx = self._select("asInterface", _args)
-        return InterfaceTypeDef(_ctx)
+        return await _ctx.execute_object(InterfaceTypeDef)
 
-    def as_list(self) -> ListTypeDef:
+    async def as_list(self) -> ListTypeDef | None:
         """If kind is LIST, the list-specific type definition. If kind is not
         LIST, this will be null.
         """
         _args: list[Arg] = []
         _ctx = self._select("asList", _args)
-        return ListTypeDef(_ctx)
+        return await _ctx.execute_object(ListTypeDef)
 
-    def as_object(self) -> ObjectTypeDef:
+    async def as_object(self) -> ObjectTypeDef | None:
         """If kind is OBJECT, the object-specific type definition. If kind is not
         OBJECT, this will be null.
         """
         _args: list[Arg] = []
         _ctx = self._select("asObject", _args)
-        return ObjectTypeDef(_ctx)
+        return await _ctx.execute_object(ObjectTypeDef)
 
-    def as_scalar(self) -> ScalarTypeDef:
+    async def as_scalar(self) -> ScalarTypeDef | None:
         """If kind is SCALAR, the scalar-specific type definition. If kind is not
         SCALAR, this will be null.
         """
         _args: list[Arg] = []
         _ctx = self._select("asScalar", _args)
-        return ScalarTypeDef(_ctx)
+        return await _ctx.execute_object(ScalarTypeDef)
 
     async def id(self) -> str:
         """A unique identifier for this TypeDef.

--- a/sdk/python/tests/codegen/test_generator.py
+++ b/sdk/python/tests/codegen/test_generator.py
@@ -57,6 +57,7 @@ from codegen.generator import (
     format_name,
     format_output_type,
     generate,
+    supports_nullable_objects,
 )
 from codegen.generator import (
     Enum as EnumHandler,
@@ -155,7 +156,7 @@ cache_volume = Object(
         (NonNull(Scalar("FileID")), "FileID"),
         (Scalar("FileID"), "FileID | None"),
         (NonNull(cache_volume), "CacheVolume"),
-        (cache_volume, "CacheVolume"),
+        (cache_volume, "CacheVolume | None"),
         (List(NonNull(cache_volume)), "list[CacheVolume]"),
         (List(cache_volume), "list[CacheVolume | None]"),
     ],
@@ -284,6 +285,53 @@ def test_core_sync(ctx: Context):
     assert str(handler.func_body()).endswith(
         'return await self._ctx.execute_sync(self, "sync", _args)'
     )
+
+
+def test_nullable_object_field():
+    git_ref = Object("GitRef", {"id": Field(NonNull(GraphQLID))})
+    repository = Object("GitRepository", {})
+    handler = _ObjectField(
+        Context(),
+        "latestVersion",
+        Field(git_ref),
+        repository,
+    )
+
+    assert handler.func_signature() == (
+        "async def latest_version(self) -> GitRef | None:"
+    )
+    assert str(handler.func_body()).endswith("return await _ctx.execute_object(GitRef)")
+
+
+def test_nullable_object_field_older_engine():
+    git_ref = Object("GitRef", {"id": Field(NonNull(GraphQLID))})
+    repository = Object("GitRepository", {})
+    handler = _ObjectField(
+        Context(schema_version="v1.0.0-beta.9"),
+        "latestVersion",
+        Field(git_ref),
+        repository,
+    )
+
+    assert handler.func_signature() == "def latest_version(self) -> GitRef:"
+    assert str(handler.func_body()).endswith("return GitRef(_ctx)")
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("", True),
+        ("development", True),
+        ("v0.21.0-dev", False),
+        ("v1.0.0-beta.9-dev", False),
+        ("v1.0.0-beta.10", True),
+        ("v1.0.0-beta.10-dev", True),
+        ("v1.0.0-rc.1", True),
+        ("v1.0.0", True),
+    ],
+)
+def test_nullable_object_version_gate(version: str, expected: bool):
+    assert supports_nullable_objects(version) is expected
 
 
 def test_generate_modern_id_surface():

--- a/sdk/rust/crates/dagger-codegen/src/functions.rs
+++ b/sdk/rust/crates/dagger-codegen/src/functions.rs
@@ -29,13 +29,19 @@ pub type DynFormatTypeFuncs = Arc<dyn FormatTypeFuncs + Send + Sync>;
 
 pub struct CommonFunctions {
     format_type_funcs: DynFormatTypeFuncs,
+    supports_nullable_objects: bool,
 }
 
 impl CommonFunctions {
-    pub fn new(funcs: DynFormatTypeFuncs) -> Self {
+    pub fn new(funcs: DynFormatTypeFuncs, schema_version: Option<&str>) -> Self {
         Self {
             format_type_funcs: funcs,
+            supports_nullable_objects: supports_nullable_objects(schema_version),
         }
+    }
+
+    pub fn supports_nullable_objects(&self) -> bool {
+        self.supports_nullable_objects
     }
 
     pub fn format_input_type(&self, t: &TypeRef) -> String {
@@ -157,6 +163,61 @@ impl CommonFunctions {
         }
 
         representation
+    }
+}
+
+fn supports_nullable_objects(schema_version: Option<&str>) -> bool {
+    let Some(version) = schema_version.filter(|version| !version.is_empty()) else {
+        return true;
+    };
+    let version = version.trim_start_matches('v');
+    let Some((core, prerelease)) = version.split_once('-') else {
+        return version
+            .split('.')
+            .take(3)
+            .map(|part| part.parse::<u64>())
+            .collect::<Result<Vec<_>, _>>()
+            .map(|core| core.as_slice() >= &[1, 0, 0])
+            .unwrap_or(true);
+    };
+    let Ok(core) = core
+        .split('.')
+        .take(3)
+        .map(|part| part.parse::<u64>())
+        .collect::<Result<Vec<_>, _>>()
+    else {
+        return true;
+    };
+    if core.as_slice() != [1, 0, 0] {
+        return core.as_slice() > &[1, 0, 0];
+    }
+    prerelease
+        .strip_prefix("beta.")
+        .and_then(|number| number.split(|c: char| !c.is_ascii_digit()).next())
+        .and_then(|number| number.parse::<u64>().ok())
+        .map(|number| number >= 10)
+        .unwrap_or(prerelease > "beta")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supports_nullable_objects;
+
+    #[test]
+    fn nullable_object_version_gate_handles_boundaries_and_development_versions() {
+        for (version, expected) in [
+            (None, true),
+            (Some(""), true),
+            (Some("development"), true),
+            (Some("v0.21.0-dev"), false),
+            (Some("v1.0.0-beta.9-dev"), false),
+            (Some("v1.0.0-beta.10"), true),
+            (Some("v1.0.0-beta.10-dev"), true),
+            (Some("v1.0.0-rc.1"), true),
+            (Some("v1.0.0"), true),
+        ] {
+            assert_eq!(supports_nullable_objects(version), expected, "{version:?}");
+        }
     }
 }
 

--- a/sdk/rust/crates/dagger-codegen/src/lib.rs
+++ b/sdk/rust/crates/dagger-codegen/src/lib.rs
@@ -44,6 +44,15 @@ mod tests {
         .unwrap()
     }
 
+    fn generate_from_json_at_version(json: &str, schema_version: &str) -> String {
+        let json = json.replacen(
+            '{',
+            &format!(r#"{{"__schemaVersion":"{schema_version}","#),
+            1,
+        );
+        generate_from_json(&json)
+    }
+
     /// Minimal schema with an interface, two implementing objects, and a
     /// Query root that returns the interface via node(id:).
     fn interface_schema() -> &'static str {
@@ -255,11 +264,25 @@ mod tests {
     #[test]
     fn interface_return_type_uses_client() {
         let code = generate_from_json(interface_schema());
-        // Query.node() should return NodeClient, not Node
+        // Query.node() should return an optional NodeClient, not Node.
         assert!(
-            code.contains("-> NodeClient"),
-            "expected node() to return NodeClient, not Node"
+            code.contains("Result<Option<NodeClient>, DaggerError>"),
+            "expected node() to return an optional NodeClient, not Node"
         );
+    }
+
+    #[test]
+    fn nullable_interface_keeps_older_engine_shape() {
+        let code = generate_from_json_at_version(interface_schema(), "v1.0.0-beta.9");
+        assert!(
+            code.contains("pub fn node(") && code.contains("-> NodeClient"),
+            "expected node() to remain chainable for older engines, got:\n{}",
+            code.lines()
+                .filter(|line| line.contains("fn node"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        assert!(!code.contains("Result<Option<NodeClient>, DaggerError>"));
     }
 
     #[test]

--- a/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
@@ -38,7 +38,10 @@ pub fn field_options_struct_name(field: &FullTypeFields) -> Option<String> {
 pub fn format_function(funcs: &CommonFunctions, field: &FullTypeFields) -> Option<rust::Tokens> {
     let is_convert_id = CommonFunctions::convert_id(field);
     let is_async = field.type_.pipe(|t| &t.type_ref).pipe(|t| {
-        if !is_convert_id && t.is_object() {
+        if !is_convert_id
+            && t.is_object()
+            && (!t.is_optional() || !funcs.supports_nullable_objects())
+        {
             None
         } else {
             Some(quote! {
@@ -232,6 +235,12 @@ fn render_output_type(funcs: &CommonFunctions, type_ref: &TypeRef) -> rust::Toke
     let output_type = funcs.format_output_type(type_ref);
 
     if type_ref.is_object() {
+        if funcs.supports_nullable_objects() && type_ref.is_optional() {
+            let dagger_error = rust::import("crate::errors", "DaggerError");
+            return quote! {
+                Result<Option<$output_type>, $dagger_error>
+            };
+        }
         return quote! {
             $(output_type)
         };
@@ -285,6 +294,23 @@ fn render_execution(funcs: &CommonFunctions, field: &FullTypeFields) -> rust::To
                 selection: query.root().select("node").arg("id", &id.0).inline_fragment($(quoted(graphql_name))),
                 graphql_client: self.graphql_client.clone(),
             })
+        };
+    }
+
+    if let Some(true) = field.type_.pipe(|t| {
+        funcs.supports_nullable_objects() && t.type_ref.is_object() && t.type_ref.is_optional()
+    }) {
+        let type_ref = &field.type_.as_ref().unwrap().type_ref;
+        let output_type = funcs.format_output_type(type_ref);
+        let graphql_name = type_ref.get_non_null().name.clone().unwrap_or_default();
+        return quote! {
+            let query = query.select("id");
+            let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+            Ok(id.map(|id| $(output_type) {
+                proc: self.proc.clone(),
+                selection: query.root().select("node").arg("id", &id.0).inline_fragment($(quoted(graphql_name))),
+                graphql_client: self.graphql_client.clone(),
+            }))
         };
     }
 

--- a/sdk/rust/crates/dagger-codegen/src/rust/mod.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/mod.rs
@@ -25,7 +25,10 @@ pub struct RustGenerator {}
 impl Generator for RustGenerator {
     fn generate(&self, schema: Schema) -> eyre::Result<String> {
         let render = Arc::new(Mutex::new(rust::Tokens::new()));
-        let common_funcs = Arc::new(CommonFunctions::new(Arc::new(FormatTypeFunc {})));
+        let common_funcs = Arc::new(CommonFunctions::new(
+            Arc::new(FormatTypeFunc {}),
+            schema.schema_version.as_deref(),
+        ));
 
         tracing::info!("generating dagger for rust");
 

--- a/sdk/rust/crates/dagger-codegen/src/rust/templates/interface_tmpl.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/templates/interface_tmpl.rs
@@ -100,7 +100,12 @@ fn render_trait_method(
     // Build argument list (required args only for trait signatures)
     let args = render_trait_method_args(funcs, field);
 
-    if is_object {
+    if funcs.supports_nullable_objects() && type_ref.is_object() && type_ref.is_optional() {
+        Some(quote! {
+            $(field.description.pipe(|d| format_struct_comment(d)))
+            fn $fn_name(&self$(if let Some(a) = &args => , $a)) -> impl core::future::Future<Output = Result<Option<$output_type>, $dagger_error>> + Send;
+        })
+    } else if is_object {
         Some(quote! {
             $(field.description.pipe(|d| format_struct_comment(d)))
             fn $fn_name(&self$(if let Some(a) = &args => , $a)) -> $output_type;
@@ -192,7 +197,26 @@ fn render_trait_impl_method(
 
     let (arg_sig, _arg_pass) = render_trait_impl_arg_parts(funcs, field);
 
-    if is_object {
+    if funcs.supports_nullable_objects() && type_ref.is_object() && type_ref.is_optional() {
+        let graphql_name = type_ref.get_non_null().name.clone().unwrap_or_default();
+        Some(quote! {
+            fn $fn_name(&self$(if let Some(a) = &arg_sig => , $a)) -> impl core::future::Future<Output = Result<Option<$(&output_type)>, $dagger_error>> + Send {
+                let mut query = self.selection.select($(genco::tokens::quoted(name)));
+                $(render_required_args(funcs, field))
+                let query = query.select("id");
+                let proc = self.proc.clone();
+                let graphql_client = self.graphql_client.clone();
+                async move {
+                    let id: Option<Id> = query.execute(graphql_client.clone()).await?;
+                    Ok(id.map(|id| $(&output_type) {
+                        proc,
+                        selection: query.root().select("node").arg("id", &id.0).inline_fragment($(genco::tokens::quoted(graphql_name))),
+                        graphql_client,
+                    }))
+                }
+            }
+        })
+    } else if is_object {
         Some(quote! {
             fn $fn_name(&self$(if let Some(a) = &arg_sig => , $a)) -> $(&output_type) {
                 let mut query = self.selection.select($(genco::tokens::quoted(name)));

--- a/sdk/rust/crates/dagger-sdk/src/core/graphql/introspection_query.graphql
+++ b/sdk/rust/crates/dagger-sdk/src/core/graphql/introspection_query.graphql
@@ -1,4 +1,5 @@
 query IntrospectionQuery {
+  __schemaVersion
   __schema {
     queryType {
       name

--- a/sdk/rust/crates/dagger-sdk/src/core/graphql/introspection_schema.graphql
+++ b/sdk/rust/crates/dagger-sdk/src/core/graphql/introspection_schema.graphql
@@ -3,6 +3,7 @@ schema {
 }
 
 type Query {
+  __schemaVersion: String!
   __schema: __Schema
 }
 

--- a/sdk/rust/crates/dagger-sdk/src/core/introspection.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/introspection.rs
@@ -266,6 +266,8 @@ pub struct SchemaDirectives {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Schema {
+    #[serde(skip)]
+    pub schema_version: Option<String>,
     pub query_type: Option<SchemaQueryType>,
     pub mutation_type: Option<SchemaMutationType>,
     pub subscription_type: Option<SchemaSubscriptionType>,
@@ -308,6 +310,8 @@ impl DirectivesExt for Option<Vec<DirectiveApplication>> {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct SchemaContainer {
+    #[serde(rename = "__schemaVersion", default)]
+    pub schema_version: Option<String>,
     #[serde(rename = "__schema")]
     pub schema: Option<Schema>,
 }
@@ -333,9 +337,13 @@ impl IntrospectionResponse {
     }
 
     pub fn into_schema(self) -> SchemaContainer {
-        match self {
+        let mut container = match self {
             IntrospectionResponse::FullResponse(full_response) => full_response.data,
             IntrospectionResponse::Schema(schema) => schema,
+        };
+        if let Some(schema) = container.schema.as_mut() {
+            schema.schema_version = container.schema_version.clone();
         }
+        container
     }
 }

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1011,13 +1011,19 @@ impl Check {
         query.execute(self.graphql_client.clone()).await
     }
     /// If the check failed, this is the error
-    pub fn error(&self) -> Error {
+    pub async fn error(&self) -> Result<Option<Error>, DaggerError> {
         let query = self.selection.select("error");
-        Error {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Error {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Error"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// A unique identifier for this Check.
     pub async fn id(&self) -> Result<Id, DaggerError> {
@@ -1960,13 +1966,19 @@ impl Container {
         }
     }
     /// Retrieves this container's configured docker healthcheck.
-    pub fn docker_healthcheck(&self) -> HealthcheckConfig {
+    pub async fn docker_healthcheck(&self) -> Result<Option<HealthcheckConfig>, DaggerError> {
         let query = self.selection.select("dockerHealthcheck");
-        HealthcheckConfig {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| HealthcheckConfig {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("HealthcheckConfig"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Return the container's OCI entrypoint.
     pub async fn entrypoint(&self) -> Result<Vec<String>, DaggerError> {
@@ -2474,14 +2486,20 @@ impl Container {
     ///
     /// * `path` - Path to check (e.g., "/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn stat(&self, path: impl Into<String>) -> Stat {
+    pub async fn stat(&self, path: impl Into<String>) -> Result<Option<Stat>, DaggerError> {
         let mut query = self.selection.select("stat");
         query = query.arg("path", path.into());
-        Stat {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Stat {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Stat"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Return file status
     ///
@@ -2489,17 +2507,27 @@ impl Container {
     ///
     /// * `path` - Path to check (e.g., "/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn stat_opts(&self, path: impl Into<String>, opts: ContainerStatOpts) -> Stat {
+    pub async fn stat_opts(
+        &self,
+        path: impl Into<String>,
+        opts: ContainerStatOpts,
+    ) -> Result<Option<Stat>, DaggerError> {
         let mut query = self.selection.select("stat");
         query = query.arg("path", path.into());
         if let Some(do_not_follow_symlinks) = opts.do_not_follow_symlinks {
             query = query.arg("doNotFollowSymlinks", do_not_follow_symlinks);
         }
-        Stat {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Stat {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Stat"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The buffered standard error stream of the last executed command
     /// Returns an error if no command was executed
@@ -5512,14 +5540,20 @@ impl Directory {
     ///
     /// * `path` - Path to stat (e.g., "/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn stat(&self, path: impl Into<String>) -> Stat {
+    pub async fn stat(&self, path: impl Into<String>) -> Result<Option<Stat>, DaggerError> {
         let mut query = self.selection.select("stat");
         query = query.arg("path", path.into());
-        Stat {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Stat {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Stat"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Return file status
     ///
@@ -5527,17 +5561,27 @@ impl Directory {
     ///
     /// * `path` - Path to stat (e.g., "/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn stat_opts(&self, path: impl Into<String>, opts: DirectoryStatOpts) -> Stat {
+    pub async fn stat_opts(
+        &self,
+        path: impl Into<String>,
+        opts: DirectoryStatOpts,
+    ) -> Result<Option<Stat>, DaggerError> {
         let mut query = self.selection.select("stat");
         query = query.arg("path", path.into());
         if let Some(do_not_follow_symlinks) = opts.do_not_follow_symlinks {
             query = query.arg("doNotFollowSymlinks", do_not_follow_symlinks);
         }
-        Stat {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Stat {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Stat"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Force evaluation in the engine.
     pub async fn sync(&self) -> Result<Directory, DaggerError> {
@@ -6516,13 +6560,19 @@ impl EnumTypeDef {
         query.execute(self.graphql_client.clone()).await
     }
     /// The location of this enum declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise.
     pub async fn source_module_name(&self) -> Result<String, DaggerError> {
@@ -6605,13 +6655,19 @@ impl EnumValueTypeDef {
         query.execute(self.graphql_client.clone()).await
     }
     /// The location of this enum member declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The value of the enum member
     pub async fn value(&self) -> Result<String, DaggerError> {
@@ -7059,13 +7115,19 @@ impl FieldTypeDef {
         query.execute(self.graphql_client.clone()).await
     }
     /// The location of this field declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The type of the field.
     pub fn type_def(&self) -> TypeDef {
@@ -7412,13 +7474,19 @@ impl File {
         query.execute(self.graphql_client.clone()).await
     }
     /// Return file status
-    pub fn stat(&self) -> Stat {
+    pub async fn stat(&self) -> Result<Option<Stat>, DaggerError> {
         let query = self.selection.select("stat");
-        Stat {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Stat {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Stat"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Force evaluation in the engine.
     pub async fn sync(&self) -> Result<File, DaggerError> {
@@ -7665,13 +7733,19 @@ impl Function {
         }
     }
     /// The location of this function declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If this function is provided by a module, the name of the module. Unset otherwise.
     pub async fn source_module_name(&self) -> Result<String, DaggerError> {
@@ -7965,13 +8039,19 @@ impl FunctionArg {
         query.execute(self.graphql_client.clone()).await
     }
     /// The location of this arg declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The type of the argument.
     pub fn type_def(&self) -> TypeDef {
@@ -8505,29 +8585,44 @@ impl GitCommit {
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn ancestor_release_tag(&self) -> GitRef {
+    pub async fn ancestor_release_tag(&self) -> Result<Option<GitRef>, DaggerError> {
         let query = self.selection.select("ancestorReleaseTag");
-        GitRef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| GitRef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("GitRef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The latest semver release tag reachable from this commit.
     ///
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn ancestor_release_tag_opts(&self, opts: GitCommitAncestorReleaseTagOpts) -> GitRef {
+    pub async fn ancestor_release_tag_opts(
+        &self,
+        opts: GitCommitAncestorReleaseTagOpts,
+    ) -> Result<Option<GitRef>, DaggerError> {
         let mut query = self.selection.select("ancestorReleaseTag");
         if let Some(include_pre_release) = opts.include_pre_release {
             query = query.arg("includePreRelease", include_pre_release);
         }
-        GitRef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| GitRef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("GitRef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Git author email.
     pub async fn author_email(&self) -> Result<String, DaggerError> {
@@ -8589,29 +8684,44 @@ impl GitCommit {
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn release_tag(&self) -> GitRef {
+    pub async fn release_tag(&self) -> Result<Option<GitRef>, DaggerError> {
         let query = self.selection.select("releaseTag");
-        GitRef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| GitRef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("GitRef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The latest semver release tag that points directly at this commit.
     ///
     /// # Arguments
     ///
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn release_tag_opts(&self, opts: GitCommitReleaseTagOpts) -> GitRef {
+    pub async fn release_tag_opts(
+        &self,
+        opts: GitCommitReleaseTagOpts,
+    ) -> Result<Option<GitRef>, DaggerError> {
         let mut query = self.selection.select("releaseTag");
         if let Some(include_pre_release) = opts.include_pre_release {
             query = query.arg("includePreRelease", include_pre_release);
         }
-        GitRef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| GitRef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("GitRef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The full commit SHA.
     pub async fn sha(&self) -> Result<String, DaggerError> {
@@ -9694,13 +9804,19 @@ impl InterfaceTypeDef {
         query.execute(self.graphql_client.clone()).await
     }
     /// The location of this interface declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
     pub async fn source_module_name(&self) -> Result<String, DaggerError> {
@@ -11166,22 +11282,34 @@ impl Module {
             .collect())
     }
     /// The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-    pub fn runtime(&self) -> Container {
+    pub async fn runtime(&self) -> Result<Option<Container>, DaggerError> {
         let query = self.selection.select("runtime");
-        Container {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Container {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Container"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The SDK config used by this module.
-    pub fn sdk(&self) -> SdkConfig {
+    pub async fn sdk(&self) -> Result<Option<SdkConfig>, DaggerError> {
         let query = self.selection.select("sdk");
-        SdkConfig {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SdkConfig {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SDKConfig"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Serve a module's API in the current session.
     /// Note: this can only be called once per session. In the future, it could return a stream or service to remove the side effect.
@@ -11239,13 +11367,19 @@ impl Module {
         }
     }
     /// The source for the module.
-    pub fn source(&self) -> ModuleSource {
+    pub async fn source(&self) -> Result<Option<ModuleSource>, DaggerError> {
         let query = self.selection.select("source");
-        ModuleSource {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| ModuleSource {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("ModuleSource"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Forces evaluation of the module, including any loading into the engine and associated validation.
     pub async fn sync(&self) -> Result<Module, DaggerError> {
@@ -11672,13 +11806,19 @@ impl ModuleSource {
         query.execute(self.graphql_client.clone()).await
     }
     /// The SDK configuration of the module.
-    pub fn sdk(&self) -> SdkConfig {
+    pub async fn sdk(&self) -> Result<Option<SdkConfig>, DaggerError> {
         let query = self.selection.select("sdk");
-        SdkConfig {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SdkConfig {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SDKConfig"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The path, relative to the context directory, that contains the module config.
     pub async fn source_root_subpath(&self) -> Result<String, DaggerError> {
@@ -12106,13 +12246,19 @@ impl Loadable for ObjectTypeDef {
 }
 impl ObjectTypeDef {
     /// The function used to construct new instances of this object, if any.
-    pub fn constructor(&self) -> Function {
+    pub async fn constructor(&self) -> Result<Option<Function>, DaggerError> {
         let query = self.selection.select("constructor");
-        Function {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| Function {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Function"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// The reason this enum member is deprecated, if any.
     pub async fn deprecated(&self) -> Result<String, DaggerError> {
@@ -12169,13 +12315,19 @@ impl ObjectTypeDef {
         query.execute(self.graphql_client.clone()).await
     }
     /// The location of this object declaration.
-    pub fn source_map(&self) -> SourceMap {
+    pub async fn source_map(&self) -> Result<Option<SourceMap>, DaggerError> {
         let query = self.selection.select("sourceMap");
-        SourceMap {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| SourceMap {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("SourceMap"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
     pub async fn source_module_name(&self) -> Result<String, DaggerError> {
@@ -13008,7 +13160,7 @@ impl Query {
         }
     }
     /// Load any object by its ID.
-    pub fn node(&self, id: impl IntoID<Id>) -> NodeClient {
+    pub async fn node(&self, id: impl IntoID<Id>) -> Result<Option<NodeClient>, DaggerError> {
         let mut query = self.selection.select("node");
         query = query.arg_lazy(
             "id",
@@ -13017,11 +13169,17 @@ impl Query {
                 Box::pin(async move { id.into_id().await.unwrap().quote() })
             }),
         );
-        NodeClient {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| NodeClient {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("Node"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// Load a GraphQL introspection schema for merging.
     ///
@@ -14223,58 +14381,94 @@ impl Loadable for TypeDef {
 }
 impl TypeDef {
     /// If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.
-    pub fn as_enum(&self) -> EnumTypeDef {
+    pub async fn as_enum(&self) -> Result<Option<EnumTypeDef>, DaggerError> {
         let query = self.selection.select("asEnum");
-        EnumTypeDef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| EnumTypeDef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("EnumTypeDef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
-    pub fn as_input(&self) -> InputTypeDef {
+    pub async fn as_input(&self) -> Result<Option<InputTypeDef>, DaggerError> {
         let query = self.selection.select("asInput");
-        InputTypeDef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| InputTypeDef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("InputTypeDef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
-    pub fn as_interface(&self) -> InterfaceTypeDef {
+    pub async fn as_interface(&self) -> Result<Option<InterfaceTypeDef>, DaggerError> {
         let query = self.selection.select("asInterface");
-        InterfaceTypeDef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| InterfaceTypeDef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("InterfaceTypeDef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
-    pub fn as_list(&self) -> ListTypeDef {
+    pub async fn as_list(&self) -> Result<Option<ListTypeDef>, DaggerError> {
         let query = self.selection.select("asList");
-        ListTypeDef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| ListTypeDef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("ListTypeDef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
-    pub fn as_object(&self) -> ObjectTypeDef {
+    pub async fn as_object(&self) -> Result<Option<ObjectTypeDef>, DaggerError> {
         let query = self.selection.select("asObject");
-        ObjectTypeDef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| ObjectTypeDef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("ObjectTypeDef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.
-    pub fn as_scalar(&self) -> ScalarTypeDef {
+    pub async fn as_scalar(&self) -> Result<Option<ScalarTypeDef>, DaggerError> {
         let query = self.selection.select("asScalar");
-        ScalarTypeDef {
+        let query = query.select("id");
+        let id: Option<Id> = query.execute(self.graphql_client.clone()).await?;
+        Ok(id.map(|id| ScalarTypeDef {
             proc: self.proc.clone(),
-            selection: query,
+            selection: query
+                .root()
+                .select("node")
+                .arg("id", &id.0)
+                .inline_fragment("ScalarTypeDef"),
             graphql_client: self.graphql_client.clone(),
-        }
+        }))
     }
     /// A unique identifier for this TypeDef.
     pub async fn id(&self) -> Result<Id, DaggerError> {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -4015,9 +4015,15 @@ export class Check extends BaseClient {
   /**
    * If the check failed, this is the error
    */
-  error = (): Error => {
-    const ctx = this._ctx.select("error")
-    return new Error(ctx)
+  error = async (): Promise<Error | null> => {
+    const ctx = this._ctx.select("error").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new Error(ctx.copy().selectNode(response, "Error"))
   }
 
   /**
@@ -4419,9 +4425,17 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container's configured docker healthcheck.
    */
-  dockerHealthcheck = (): HealthcheckConfig => {
-    const ctx = this._ctx.select("dockerHealthcheck")
-    return new HealthcheckConfig(ctx)
+  dockerHealthcheck = async (): Promise<HealthcheckConfig | null> => {
+    const ctx = this._ctx.select("dockerHealthcheck").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new HealthcheckConfig(
+      ctx.copy().selectNode(response, "HealthcheckConfig"),
+    )
   }
 
   /**
@@ -4864,9 +4878,18 @@ export class Container extends BaseClient {
    * @param path Path to check (e.g., "/file.txt").
    * @param opts.doNotFollowSymlinks If specified, do not follow symlinks.
    */
-  stat = (path: string, opts?: ContainerStatOpts): Stat => {
-    const ctx = this._ctx.select("stat", { path, ...opts })
-    return new Stat(ctx)
+  stat = async (
+    path: string,
+    opts?: ContainerStatOpts,
+  ): Promise<Stat | null> => {
+    const ctx = this._ctx.select("stat", { path, ...opts }).select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new Stat(ctx.copy().selectNode(response, "Stat"))
   }
 
   /**
@@ -6504,9 +6527,18 @@ export class Directory extends BaseClient {
    * @param path Path to stat (e.g., "/file.txt").
    * @param opts.doNotFollowSymlinks If specified, do not follow symlinks.
    */
-  stat = (path: string, opts?: DirectoryStatOpts): Stat => {
-    const ctx = this._ctx.select("stat", { path, ...opts })
-    return new Stat(ctx)
+  stat = async (
+    path: string,
+    opts?: DirectoryStatOpts,
+  ): Promise<Stat | null> => {
+    const ctx = this._ctx.select("stat", { path, ...opts }).select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new Stat(ctx.copy().selectNode(response, "Stat"))
   }
 
   /**
@@ -7291,9 +7323,15 @@ export class EnumTypeDef extends BaseClient {
   /**
    * The location of this enum declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -7424,9 +7462,15 @@ export class EnumValueTypeDef extends BaseClient {
   /**
    * The location of this enum member declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -7923,9 +7967,15 @@ export class FieldTypeDef extends BaseClient {
   /**
    * The location of this field declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -8132,9 +8182,15 @@ export class File extends BaseClient {
   /**
    * Return file status
    */
-  stat = (): Stat => {
-    const ctx = this._ctx.select("stat")
-    return new Stat(ctx)
+  stat = async (): Promise<Stat | null> => {
+    const ctx = this._ctx.select("stat").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new Stat(ctx.copy().selectNode(response, "Stat"))
   }
 
   /**
@@ -8326,9 +8382,15 @@ export class Function_ extends BaseClient {
   /**
    * The location of this function declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -8613,9 +8675,15 @@ export class FunctionArg extends BaseClient {
   /**
    * The location of this arg declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -9249,9 +9317,17 @@ export class GitCommit extends BaseClient {
    * The latest semver release tag reachable from this commit.
    * @param opts.includePreRelease Include pre-release tags when choosing the latest tag.
    */
-  ancestorReleaseTag = (opts?: GitCommitAncestorReleaseTagOpts): GitRef => {
-    const ctx = this._ctx.select("ancestorReleaseTag", { ...opts })
-    return new GitRef(ctx)
+  ancestorReleaseTag = async (
+    opts?: GitCommitAncestorReleaseTagOpts,
+  ): Promise<GitRef | null> => {
+    const ctx = this._ctx.select("ancestorReleaseTag", { ...opts }).select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new GitRef(ctx.copy().selectNode(response, "GitRef"))
   }
 
   /**
@@ -9404,9 +9480,17 @@ export class GitCommit extends BaseClient {
    * The latest semver release tag that points directly at this commit.
    * @param opts.includePreRelease Include pre-release tags when choosing the latest tag.
    */
-  releaseTag = (opts?: GitCommitReleaseTagOpts): GitRef => {
-    const ctx = this._ctx.select("releaseTag", { ...opts })
-    return new GitRef(ctx)
+  releaseTag = async (
+    opts?: GitCommitReleaseTagOpts,
+  ): Promise<GitRef | null> => {
+    const ctx = this._ctx.select("releaseTag", { ...opts }).select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new GitRef(ctx.copy().selectNode(response, "GitRef"))
   }
 
   /**
@@ -10233,9 +10317,15 @@ export class InterfaceTypeDef extends BaseClient {
   /**
    * The location of this interface declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -11650,17 +11740,29 @@ export class Module_ extends BaseClient {
   /**
    * The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
    */
-  runtime = (): Container => {
-    const ctx = this._ctx.select("runtime")
-    return new Container(ctx)
+  runtime = async (): Promise<Container | null> => {
+    const ctx = this._ctx.select("runtime").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new Container(ctx.copy().selectNode(response, "Container"))
   }
 
   /**
    * The SDK config used by this module.
    */
-  sdk = (): SDKConfig => {
-    const ctx = this._ctx.select("sdk")
-    return new SDKConfig(ctx)
+  sdk = async (): Promise<SDKConfig | null> => {
+    const ctx = this._ctx.select("sdk").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SDKConfig(ctx.copy().selectNode(response, "SDKConfig"))
   }
 
   /**
@@ -11693,9 +11795,15 @@ export class Module_ extends BaseClient {
   /**
    * The source for the module.
    */
-  source = (): ModuleSource => {
-    const ctx = this._ctx.select("source")
-    return new ModuleSource(ctx)
+  source = async (): Promise<ModuleSource | null> => {
+    const ctx = this._ctx.select("source").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new ModuleSource(ctx.copy().selectNode(response, "ModuleSource"))
   }
 
   /**
@@ -12281,9 +12389,15 @@ export class ModuleSource extends BaseClient {
   /**
    * The SDK configuration of the module.
    */
-  sdk = (): SDKConfig => {
-    const ctx = this._ctx.select("sdk")
-    return new SDKConfig(ctx)
+  sdk = async (): Promise<SDKConfig | null> => {
+    const ctx = this._ctx.select("sdk").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SDKConfig(ctx.copy().selectNode(response, "SDKConfig"))
   }
 
   /**
@@ -12647,9 +12761,15 @@ export class ObjectTypeDef extends BaseClient {
   /**
    * The function used to construct new instances of this object, if any.
    */
-  constructor_ = (): Function_ => {
-    const ctx = this._ctx.select("constructor")
-    return new Function_(ctx)
+  constructor_ = async (): Promise<Function_ | null> => {
+    const ctx = this._ctx.select("constructor").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new Function_(ctx.copy().selectNode(response, "Function"))
   }
 
   /**
@@ -12734,9 +12854,15 @@ export class ObjectTypeDef extends BaseClient {
   /**
    * The location of this object declaration.
    */
-  sourceMap = (): SourceMap => {
-    const ctx = this._ctx.select("sourceMap")
-    return new SourceMap(ctx)
+  sourceMap = async (): Promise<SourceMap | null> => {
+    const ctx = this._ctx.select("sourceMap").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new SourceMap(ctx.copy().selectNode(response, "SourceMap"))
   }
 
   /**
@@ -13203,9 +13329,15 @@ export class Client extends BaseClient {
   /**
    * Load any object by its ID.
    */
-  node = (id: ID): Node => {
-    const ctx = this._ctx.select("node", { id })
-    return new _NodeClient(ctx)
+  node = async (id: ID): Promise<Node | null> => {
+    const ctx = this._ctx.select("node", { id }).select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new _NodeClient(ctx.copy().selectNode(response, "Node"))
   }
 
   /**
@@ -14413,49 +14545,87 @@ export class TypeDef extends BaseClient {
   /**
    * If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null.
    */
-  asEnum = (): EnumTypeDef => {
-    const ctx = this._ctx.select("asEnum")
-    return new EnumTypeDef(ctx)
+  asEnum = async (): Promise<EnumTypeDef | null> => {
+    const ctx = this._ctx.select("asEnum").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new EnumTypeDef(ctx.copy().selectNode(response, "EnumTypeDef"))
   }
 
   /**
    * If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
    */
-  asInput = (): InputTypeDef => {
-    const ctx = this._ctx.select("asInput")
-    return new InputTypeDef(ctx)
+  asInput = async (): Promise<InputTypeDef | null> => {
+    const ctx = this._ctx.select("asInput").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new InputTypeDef(ctx.copy().selectNode(response, "InputTypeDef"))
   }
 
   /**
    * If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
    */
-  asInterface = (): InterfaceTypeDef => {
-    const ctx = this._ctx.select("asInterface")
-    return new InterfaceTypeDef(ctx)
+  asInterface = async (): Promise<InterfaceTypeDef | null> => {
+    const ctx = this._ctx.select("asInterface").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new InterfaceTypeDef(
+      ctx.copy().selectNode(response, "InterfaceTypeDef"),
+    )
   }
 
   /**
    * If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
    */
-  asList = (): ListTypeDef => {
-    const ctx = this._ctx.select("asList")
-    return new ListTypeDef(ctx)
+  asList = async (): Promise<ListTypeDef | null> => {
+    const ctx = this._ctx.select("asList").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new ListTypeDef(ctx.copy().selectNode(response, "ListTypeDef"))
   }
 
   /**
    * If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
    */
-  asObject = (): ObjectTypeDef => {
-    const ctx = this._ctx.select("asObject")
-    return new ObjectTypeDef(ctx)
+  asObject = async (): Promise<ObjectTypeDef | null> => {
+    const ctx = this._ctx.select("asObject").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new ObjectTypeDef(ctx.copy().selectNode(response, "ObjectTypeDef"))
   }
 
   /**
    * If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null.
    */
-  asScalar = (): ScalarTypeDef => {
-    const ctx = this._ctx.select("asScalar")
-    return new ScalarTypeDef(ctx)
+  asScalar = async (): Promise<ScalarTypeDef | null> => {
+    const ctx = this._ctx.select("asScalar").select("id")
+
+    const response: Awaited<string | null> = await ctx.execute()
+
+    if (response === null) {
+      return null
+    }
+    return new ScalarTypeDef(ctx.copy().selectNode(response, "ScalarTypeDef"))
   }
 
   /**


### PR DESCRIPTION
#### What

Support nullable GraphQL object and interface results in generated clients and module SDKs.

Nullable methods now resolve the object's ID before returning. A missing ID becomes the language's empty value; a present ID is rebuilt as a normal client. Non-null object methods stay lazy.

#### Client APIs

Each SDK uses its normal optional value: `Nullable` in Go, `null` in TypeScript, PHP, and .NET, `None` in Python, `Option` in Rust, `Optional` in Java, and `{:ok, value | nil}` in Elixir.

For example, Go callers can handle `GitCommit.releaseTag` explicitly:

```go
result, err := commit.ReleaseTag(ctx)
if err != nil {
	return err
}

tag, ok := result.Get()
if !ok {
	return nil
}

name, err := tag.Name(ctx)
```

#### Module APIs

Module authors can declare nullable object returns with their SDK's existing syntax:

- TypeScript: `Promise<User | null>`
- PHP: `?Directory`
- Java: `Optional<Directory>`
- Go: `dagger.Nullable[*dagger.Directory]`
- Python: `User | None`
- Elixir: `User.t() | nil`

Rust and .NET do not currently support modules. Dang already supports nullable return types.

#### Compatibility and tests

Generated templates use the schema version to keep the old lazy method shape before `v1.0.0-beta.10`. From beta.10 onward, nullable object methods use the resolved optional result.

Tests cover both sides of the version boundary, object and interface results, and both present and null module returns. Java and .NET also exercise the runtime null path directly.
