### PR TITLE
feat(workspace): include another config in dagger.toml

### DIFF
--- a/.changes/unreleased/Added-20260812-153000.yaml
+++ b/.changes/unreleased/Added-20260812-153000.yaml
@@ -1,0 +1,38 @@
+kind: Added
+body: |
+  Workspaces can include another config file.
+
+  A new top-level `[[include]]` block in `dagger.toml` names a config whose
+  contents are merged underneath the current one, so a team can publish one
+  base config — shared tool versions, settings, environments — and have many
+  repositories point at it instead of duplicating it:
+
+  ```toml
+  [[include]]
+  source = "github.com/acme/dagger-base@v1.2.0"
+
+  [modules.go.settings]
+  goVersion = "1.24"
+  ```
+
+  `source` addresses a config file, either as a path (`common/base.toml` or
+  `./base.toml` next to the including config, `/common/base.toml` from the
+  workspace root) or as a Git ref (`github.com/acme/dagger-base@v1.2.0`,
+  `https://host/repo.git#main:dagger/base.toml`). A source with no extension
+  names a directory and reaches the `dagger.toml` inside it. The workspace
+  naming the include wins every conflict, and a module entry may omit `source`
+  to override just the settings of a module the include installs.
+
+  Only one include is resolved for now — a config with more is an error — and
+  an included config that includes something in turn is rejected rather than
+  followed. Module entries whose source is a local path are dropped with a
+  warning: an include shares configuration, not code.
+
+  Reads report the merged result (`dagger workspace config` and the module and
+  env listings); writes still only touch the local `dagger.toml`. A Git
+  include's resolved commit is recorded in `dagger.lock` like any other Git
+  reference, so later runs reuse the pin and `dagger update` refreshes it.
+time: 2026-08-12T15:30:00.000000000+00:00
+custom:
+    Author: eunomie
+    PR: "13882"

--- a/.changes/unreleased/Added-20260812-153000.yaml
+++ b/.changes/unreleased/Added-20260812-153000.yaml
@@ -23,10 +23,20 @@ body: |
   naming the include wins every conflict, and a module entry may omit `source`
   to override just the settings of a module the include installs.
 
+  An included config brings its own modules. A module entry there whose source
+  is a local path names a directory beside *that* config, so it is re-addressed
+  rather than resolved as written: within one workspace the path simply changes
+  what it is relative to, and for a Git include `modules/ci` becomes
+  `<repo>/modules/ci@<commit>`, pinned to the commit the config was read at.
+  That is what makes a monorepo work — `common/dagger.toml` installs
+  `../shared/tester`, `project-a/dagger.toml` includes `../common`, and
+  `dagger module list` in `project-a` shows `tester`. What has no address on this
+  side is left out with a warning naming it: built-in SDK installs, absolute
+  paths, and paths escaping the tree the config came from.
+
   Only one include is resolved for now — a config with more is an error — and
   an included config that includes something in turn is rejected rather than
-  followed. Module entries whose source is a local path are dropped with a
-  warning: an include shares configuration, not code.
+  followed.
 
   Reads report the merged result (`dagger workspace config` and the module and
   env listings); writes still only touch the local `dagger.toml`. A Git

--- a/.changes/unreleased/Changed-20260825-120000.yaml
+++ b/.changes/unreleased/Changed-20260825-120000.yaml
@@ -1,0 +1,16 @@
+kind: Changed
+body: |
+  A `[modules.<name>]` entry in `dagger.toml` may now omit `source`, so it can
+  override the settings of a module an `[[include]]` installs. Because the file
+  format alone can no longer require a source, an effective config is validated
+  after the include is merged instead — and that check runs on every config,
+  include or not.
+
+  A `dagger.toml` with a source-less module entry and no `[[include]]` at all
+  therefore now fails every config read, naming the module, where it previously
+  loaded as a module with an empty reference and failed later or silently. Give
+  the entry a `source`, or add an `[[include]]` that provides one.
+time: 2026-08-25T12:00:00.000000000+00:00
+custom:
+    Author: eunomie
+    PR: "13882"

--- a/.changes/unreleased/Fixed-20260902-120000.yaml
+++ b/.changes/unreleased/Fixed-20260902-120000.yaml
@@ -1,0 +1,12 @@
+kind: Fixed
+body: |
+  An explicit HTTP(S) port survives a remote ref round trip. `gitref.Parse`
+  rebuilt the clone ref without the port for `http://` and `https://` refs —
+  only SSH put it back — so `https://host:8443/acme/repo` came back addressing
+  port 443: a different remote, with different credentials and different cache
+  keys. Every such ref is affected, whether it names a module source or a
+  workspace passed to `dagger -W`.
+time: 2026-09-02T12:00:00.000000000+00:00
+custom:
+  Author: eunomie
+  PR: "13882"

--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -77,6 +77,13 @@ func (s SchemeType) IsSSH() bool {
 	return s == SchemeSSH
 }
 
+// HasExplicitPort reports whether a ref of this scheme can carry a port that
+// must be preserved in the clone ref. A schemeless or SCP-like ref cannot: its
+// colon is the path separator, not a port.
+func (s SchemeType) HasExplicitPort() bool {
+	return s == SchemeSSH || s == SchemeHTTP || s == SchemeHTTPS
+}
+
 // RefString builds a module ref string from a clone ref, an optional source
 // root subpath and an optional version.
 func RefString(cloneRef, sourceRootSubpath, version string) string {
@@ -270,9 +277,13 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 		cloneUser += "@"
 	}
 
-	// For SSH URLs, inject port after host if it is defined: ssh://user@host:port/path
+	// Inject the port back after the host when one was given:
+	// <scheme>://user@host:port/path. The port never reaches ModPath, because
+	// repo-root discovery matches on host and path alone, so it has to be
+	// restored here or the clone ref would address the scheme's default port —
+	// a different remote, with different credentials and cache keys.
 	repoRootWithPort := gitParsed.RepoRoot.Root
-	if gitParsed.Scheme == SchemeSSH && endpoint.Port > 0 {
+	if endpoint.Port > 0 && gitParsed.Scheme.HasExplicitPort() {
 		if host, rest, ok := strings.Cut(repoRootWithPort, "/"); ok {
 			repoRootWithPort = fmt.Sprintf("%s:%d/%s", host, endpoint.Port, rest)
 		}

--- a/core/gitref/gitref_test.go
+++ b/core/gitref/gitref_test.go
@@ -325,6 +325,19 @@ func TestParse(t *testing.T) {
 				SourceUser:     "git",
 			},
 		},
+		// An HTTP remote on a custom port: the port is part of the remote's
+		// identity, so it has to survive into the clone ref.
+		{
+			urlStr: "http://github.com:8080/shykes/daggerverse/ci",
+			want: Parsed{
+				ModPath:        "github.com/shykes/daggerverse/ci",
+				RepoRoot:       &vcs.RepoRoot{Root: "github.com/shykes/daggerverse", Repo: "https://github.com/shykes/daggerverse"},
+				Scheme:         SchemeHTTP,
+				RepoRootSubdir: "ci",
+				CloneRef:       "http://github.com:8080/shykes/daggerverse",
+				SourceCloneRef: "http://github.com:8080/shykes/daggerverse",
+			},
+		},
 		// Gerrit codereview on custom port
 		{
 			urlStr: "ssh://someuser@golang.org:29418/x/review/git-codereview",

--- a/core/integration/workspace_include_test.go
+++ b/core/integration/workspace_include_test.go
@@ -255,6 +255,46 @@ platform = "arm64"
 	})
 }
 
+func (WorkspaceIncludeSuite) TestIncludedModulesReachTheCommandTree(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// `module list` reads the config; the command tree is built from the API
+	// schema, which needs the modules actually attached to Query. A workspace
+	// can therefore list an inherited module and still not offer it as a
+	// command — reported from the field against an earlier build, so it is
+	// pinned here rather than left to the config read alone.
+	monorepo := workspaceBase(t, c).
+		WithNewFile("/work/shared/tester/dagger.json", `{"name":"tester","sdk":{"source":"dang"}}`).
+		WithNewFile("/work/shared/tester/main.dang", workspaceSelectionDangSource("Tester", "identify", "shared tester")).
+		WithNewFile("/work/common/dagger.toml", `[modules.tester]
+source = "../shared/tester"
+`).
+		WithNewFile("/work/project-a/dagger.toml", `[[include]]
+source = "../common"
+
+[modules.tester.settings]
+greeting = "hello"
+`)
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "functions", args: []string{"--silent", "functions"}},
+		{name: "call --help", args: []string{"--silent", "call", "--help"}},
+		{name: "api functions", args: []string{"--silent", "api", "functions"}},
+		{name: "api call --help", args: []string{"--silent", "api", "call", "--help"}},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			out, err := monorepo.
+				With(workspaceIncludeMonorepoIn("/work/project-a", tc.args...)).
+				Stdout(ctx)
+			require.NoError(t, err)
+			require.Contains(t, out, "tester", "an inherited module has to be callable, not just listed")
+		})
+	}
+}
+
 func (WorkspaceIncludeSuite) TestLocalModulesOfAGitIncludeAreInherited(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/workspace_include_test.go
+++ b/core/integration/workspace_include_test.go
@@ -53,7 +53,7 @@ func workspaceIncludeConsumer(t *testctx.T, c *dagger.Client, configTOML string)
 func workspaceIncludeConfig(args ...string) dagger.WithContainerFunc {
 	return func(ctr *dagger.Container) *dagger.Container {
 		return ctr.WithExec(
-			append([]string{"dagger", "--progress=report", "--silent", "workspace", "config"}, args...),
+			append([]string{"dagger", "workspace", "config"}, args...),
 			dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 		)
 	}
@@ -62,7 +62,7 @@ func workspaceIncludeConfig(args ...string) dagger.WithContainerFunc {
 func workspaceIncludeConfigFail(args ...string) dagger.WithContainerFunc {
 	return func(ctr *dagger.Container) *dagger.Container {
 		return ctr.WithExec(
-			append([]string{"dagger", "--progress=report", "workspace", "config"}, args...),
+			append([]string{"dagger", "workspace", "config"}, args...),
 			dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 				Expect:                        dagger.ReturnTypeFailure,
@@ -158,10 +158,13 @@ source = "`+baseRef+`"
 // workspaceIncludeMonorepoIn runs a command from dir inside the consuming
 // repository, which is what a monorepo's per-project workspace looks like: the
 // git root is the workspace, and each project's dagger.toml sits below it.
+//
+// No --progress: the commands exercised here include `workspace config`, which
+// renders no pipeline and so does not accept the flag.
 func workspaceIncludeMonorepoIn(dir string, args ...string) dagger.WithContainerFunc {
 	return func(ctr *dagger.Container) *dagger.Container {
 		return ctr.WithWorkdir(dir).WithExec(
-			append([]string{"dagger", "--progress=report"}, args...),
+			append([]string{"dagger"}, args...),
 			dagger.ContainerWithExecOpts{
 				UseEntrypoint:                 true,
 				ExperimentalPrivilegedNesting: true,
@@ -236,7 +239,7 @@ platform = "arm64"
 
 	t.Run("the effective config addresses them from the including project", func(ctx context.Context, t *testctx.T) {
 		out, err := monorepo.
-			With(workspaceIncludeMonorepoIn("/work/project-a", "--silent", "workspace", "config")).
+			With(workspaceIncludeMonorepoIn("/work/project-a", "workspace", "config")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		// Relative to project-a, not to common, and dot-prefixed so it can
@@ -247,7 +250,7 @@ platform = "arm64"
 
 	t.Run("a project overrides a shared module's settings without repeating its source", func(ctx context.Context, t *testctx.T) {
 		out, err := monorepo.
-			With(workspaceIncludeMonorepoIn("/work/project-b", "--silent", "workspace", "config")).
+			With(workspaceIncludeMonorepoIn("/work/project-b", "workspace", "config")).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, `platform = "arm64"`)
@@ -280,10 +283,10 @@ greeting = "hello"
 		name string
 		args []string
 	}{
-		{name: "functions", args: []string{"--silent", "functions"}},
-		{name: "call --help", args: []string{"--silent", "call", "--help"}},
-		{name: "api functions", args: []string{"--silent", "api", "functions"}},
-		{name: "api call --help", args: []string{"--silent", "api", "call", "--help"}},
+		{name: "functions", args: []string{"functions"}},
+		{name: "call --help", args: []string{"call", "--help"}},
+		{name: "api functions", args: []string{"api", "functions"}},
+		{name: "api call --help", args: []string{"api", "call", "--help"}},
 	} {
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			out, err := monorepo.
@@ -417,11 +420,13 @@ source = "`+baseRef+`"
 	})
 
 	t.Run("and the run says so", func(ctx context.Context, t *testctx.T) {
-		// Reported without --silent, which suppresses progress output. The
+		// Reported without --silent, which suppresses progress output.
+		// --progress cannot be set on this command: it does not render a
+		// pipeline, so the flag is not among its capabilities. The
 		// warning has to reach a command that skips workspace modules
 		// entirely, which is exactly what `workspace config` does.
 		out, err := ctr.WithExec(
-			[]string{"dagger", "--progress=plain", "workspace", "config"},
+			[]string{"dagger", "workspace", "config"},
 			dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 		).CombinedOutput(ctx)
 		require.NoError(t, err)
@@ -590,7 +595,7 @@ source = "`+baseRef+`"
 	// disabled across commands upstream. What matters here is that the env the
 	// included config defines crossed the boundary at all.
 	out, err := ctr.WithExec(
-		[]string{"dagger", "--progress=report", "--silent", "workspace", "config", "env.ci.modules.greeter.settings.greeting"},
+		[]string{"dagger", "workspace", "config", "env.ci.modules.greeter.settings.greeting"},
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	).Stdout(ctx)
 	require.NoError(t, err)
@@ -657,7 +662,7 @@ source = "`+baseRef+`"
 
 	t.Run("uninstalling an included module names the include", func(ctx context.Context, t *testctx.T) {
 		stderr, err := ctr.WithExec(
-			[]string{"dagger", "--progress=report", "uninstall", "greeter"},
+			[]string{"dagger", "uninstall", "greeter"},
 			dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 				Expect:                        dagger.ReturnTypeFailure,
@@ -704,7 +709,7 @@ source = "`+baseRef+`"
 	// A later run reuses the recorded pin rather than re-resolving: the lock is
 	// left exactly as it was, and the merged config still resolves.
 	replayed := resolved.WithExec(
-		[]string{"dagger", "--progress=report", "--silent", "workspace", "config"},
+		[]string{"dagger", "workspace", "config"},
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	out, err := replayed.Stdout(ctx)

--- a/core/integration/workspace_include_test.go
+++ b/core/integration/workspace_include_test.go
@@ -155,7 +155,107 @@ source = "`+baseRef+`"
 	require.Equal(t, "false", strings.TrimSpace(out))
 }
 
-func (WorkspaceIncludeSuite) TestLocalModulesAreNotInherited(ctx context.Context, t *testctx.T) {
+// workspaceIncludeMonorepoIn runs a command from dir inside the consuming
+// repository, which is what a monorepo's per-project workspace looks like: the
+// git root is the workspace, and each project's dagger.toml sits below it.
+func workspaceIncludeMonorepoIn(dir string, args ...string) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		return ctr.WithWorkdir(dir).WithExec(
+			append([]string{"dagger", "--progress=report"}, args...),
+			dagger.ContainerWithExecOpts{
+				UseEntrypoint:                 true,
+				ExperimentalPrivilegedNesting: true,
+			},
+		)
+	}
+}
+
+func (WorkspaceIncludeSuite) TestMonorepoProjectsShareModulesThroughAnInclude(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// The shape this feature exists for: shared/ holds the modules, common/
+	// packages them as configuration, and each project includes common/. Every
+	// config lives in one workspace — the git root — so common's own relative
+	// paths only have to change what they are relative to.
+	monorepo := workspaceBase(t, c).
+		// shared/ is a workspace in its own right — that is where someone
+		// authoring the modules works. Nothing includes it, and it must not
+		// interfere with a project that includes common/.
+		WithNewFile("/work/shared/dagger.toml", `[modules.dagger-dang-sdk]
+source = "github.com/dagger/dang-sdk"
+
+[sdks.dang]
+module = "dagger-dang-sdk"
+
+[sdks.dang.scopes.tester]
+is-module = true
+
+[sdks.dang.scopes.builder]
+is-module = true
+`).
+		WithNewFile("/work/shared/tester/dagger.json", `{"name":"tester","sdk":{"source":"dang"}}`).
+		WithNewFile("/work/shared/tester/main.dang", workspaceSelectionDangSource("Tester", "identify", "shared tester")).
+		WithNewFile("/work/shared/builder/dagger.json", `{"name":"builder","sdk":{"source":"dang"}}`).
+		WithNewFile("/work/shared/builder/main.dang", workspaceSelectionDangSource("Builder", "identify", "shared builder")).
+		WithNewFile("/work/common/dagger.toml", `[modules.tester]
+source = "../shared/tester"
+
+[modules.builder]
+source = "../shared/builder"
+`).
+		WithNewFile("/work/project-a/dagger.toml", `[[include]]
+source = "../common"
+`).
+		WithNewFile("/work/project-b/dagger.toml", `[[include]]
+source = "../common"
+
+[modules.builder.settings]
+platform = "arm64"
+`)
+
+	t.Run("dagger module list shows the shared modules", func(ctx context.Context, t *testctx.T) {
+		out, err := monorepo.With(workspaceIncludeMonorepoIn("/work/project-a", "module", "list")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "tester")
+		require.Contains(t, out, "builder")
+	})
+
+	t.Run("they can be called", func(ctx context.Context, t *testctx.T) {
+		for _, tc := range []struct{ project, module, want string }{
+			{project: "/work/project-a", module: "tester", want: "shared tester"},
+			{project: "/work/project-a", module: "builder", want: "shared builder"},
+			{project: "/work/project-b", module: "tester", want: "shared tester"},
+		} {
+			out, err := monorepo.
+				With(workspaceIncludeMonorepoIn(tc.project, "call", tc.module, "identify")).
+				Stdout(ctx)
+			require.NoError(t, err, "%s %s", tc.project, tc.module)
+			require.Equal(t, tc.want, strings.TrimSpace(out))
+		}
+	})
+
+	t.Run("the effective config addresses them from the including project", func(ctx context.Context, t *testctx.T) {
+		out, err := monorepo.
+			With(workspaceIncludeMonorepoIn("/work/project-a", "--silent", "workspace", "config")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		// Relative to project-a, not to common, and dot-prefixed so it can
+		// never read back as a git ref.
+		require.Contains(t, out, `source = "../shared/tester"`)
+		require.Contains(t, out, "# included: ../common")
+	})
+
+	t.Run("a project overrides a shared module's settings without repeating its source", func(ctx context.Context, t *testctx.T) {
+		out, err := monorepo.
+			With(workspaceIncludeMonorepoIn("/work/project-b", "--silent", "workspace", "config")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, `platform = "arm64"`)
+		require.Contains(t, out, `source = "../shared/builder"`)
+	})
+}
+
+func (WorkspaceIncludeSuite) TestLocalModulesOfAGitIncludeAreInherited(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
@@ -168,8 +268,9 @@ source = "github.com/acme/tool@v1"
 		WithNewFile(".dagger/modules/local-ci/dagger.json", `{"name":"local-ci","sdk":{"source":"dang"}}`).
 		WithNewFile(".dagger/modules/local-ci/main.dang", workspaceSelectionDangSource("LocalCi", "identify", "base local module")))
 
-	// The consuming workspace has a directory at the very same path: without
-	// the drop, the inherited source would resolve here instead.
+	// The consuming workspace holds a different module at the very same path,
+	// which is what the rewrite has to get right: the entry must reach the
+	// included repository's module, not the one next to the consumer.
 	ctr := workspaceIncludeConsumer(t, c, `
 [[include]]
 source = "`+baseRef+`"
@@ -177,14 +278,105 @@ source = "`+baseRef+`"
 		WithNewFile("/work/.dagger/modules/local-ci/dagger.json", `{"name":"local-ci","sdk":{"source":"dang"}}`).
 		WithNewFile("/work/.dagger/modules/local-ci/main.dang", workspaceSelectionDangSource("LocalCi", "identify", "consumer local module"))
 
-	t.Run("drops the entry", func(ctx context.Context, t *testctx.T) {
+	t.Run("the entry becomes a ref into the included repository", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, out, "local-ci", "a local module of the included config must not be usable here")
-		require.Contains(t, out, `source = "github.com/acme/tool@v1"`, "remote entries still come through")
+		require.Contains(t, out, "/.dagger/modules/local-ci@", "addressed in the repository the config came from")
+		require.NotContains(t, out, `source = ".dagger/modules/local-ci"`, "not left as a path the consumer would resolve")
+		require.Contains(t, out, `source = "github.com/acme/tool@v1"`, "remote entries are untouched")
 	})
 
-	t.Run("says so", func(ctx context.Context, t *testctx.T) {
+	t.Run("it is pinned to the commit the config was read at", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+		require.NoError(t, err)
+		ref := ""
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, "/.dagger/modules/local-ci@") {
+				ref = line
+			}
+		}
+		require.NotEmpty(t, ref)
+		_, version, _ := strings.Cut(ref, "/.dagger/modules/local-ci@")
+		version = strings.Trim(strings.TrimSpace(version), `"`)
+		require.Len(t, version, 40, "a full commit SHA, not the symbolic version: %q", version)
+	})
+
+	t.Run("calling it reaches the included repository's module", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceSelectionDaggerCall("local-ci", "identify")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "base local module", strings.TrimSpace(out))
+	})
+}
+
+func (WorkspaceIncludeSuite) TestGitIncludeNamesAConfigInsideTheRepository(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// The fragment spelling the reference page advertises, and the one place
+	// the file-versus-directory rule meets a parsed subdir: the config is not
+	// at the repository root, so the modules beside it have to be re-addressed
+	// against its directory rather than against the clone.
+	moduleRef := workspaceIncludeModuleRepo(ctx, t, c, "greeter", "Greeter", "hello from the base")
+	baseRepo := c.Directory().
+		WithNewFile("dagger/base.toml", `[modules.greeter]
+source = "`+moduleRef+`"
+
+[modules.local-ci]
+source = "modules/ci"
+`).
+		WithNewFile("dagger/modules/ci/dagger.json", `{"name":"local-ci","sdk":{"source":"dang"}}`).
+		WithNewFile("dagger/modules/ci/main.dang", workspaceSelectionDangSource("LocalCi", "identify", "ci beside the base config"))
+	baseRef := strings.TrimSuffix(workspaceSelectionRemoteRef(ctx, t, c, baseRepo), "@main") + "#main:dagger/base.toml"
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "`+moduleRef+`"`, "a remote entry comes through untouched")
+	require.Contains(t, out, "/dagger/modules/ci@", "a local entry is addressed against the config's own directory")
+
+	out, err = ctr.With(workspaceSelectionDaggerCall("local-ci", "identify")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ci beside the base config", strings.TrimSpace(out))
+}
+
+func (WorkspaceIncludeSuite) TestModulesWithNoAddressAreDropped(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// A built-in SDK install is the shape that is easiest to get wrong: its
+	// source is a runtime name the engine resolves in-process, not a path, so
+	// it has no address in the included repository. An entry escaping that
+	// repository has none either.
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
+		WithNewFile("dagger.toml", `[modules.dagger-dang-sdk]
+source = "dang"
+
+[modules.escaping]
+source = "../outside/ci"
+
+[modules.remote-tool]
+source = "github.com/acme/tool@v1"
+
+[sdks.dang]
+module = "dagger-dang-sdk"
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	t.Run("they do not appear in the effective config", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "dagger-dang-sdk")
+		require.NotContains(t, out, "escaping")
+		require.Contains(t, out, `source = "github.com/acme/tool@v1"`)
+	})
+
+	t.Run("and the run says so", func(ctx context.Context, t *testctx.T) {
 		// Reported without --silent, which suppresses progress output. The
 		// warning has to reach a command that skips workspace modules
 		// entirely, which is exactly what `workspace config` does.
@@ -193,13 +385,8 @@ source = "`+baseRef+`"
 			dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 		).CombinedOutput(ctx)
 		require.NoError(t, err)
-		require.Contains(t, out, "local-ci")
-		require.Contains(t, out, "Only its remote modules are inherited")
-	})
-
-	t.Run("does not resolve the same-named local directory", func(ctx context.Context, t *testctx.T) {
-		_, err := ctr.With(workspaceSelectionDaggerCallFail("local-ci", "identify")).Sync(ctx)
-		require.NoError(t, err)
+		require.Contains(t, out, "dagger-dang-sdk (built-in SDK runtime)")
+		require.Contains(t, out, "escaping (no address outside the config it came from)")
 	})
 }
 

--- a/core/integration/workspace_include_test.go
+++ b/core/integration/workspace_include_test.go
@@ -1,0 +1,490 @@
+package core
+
+// These tests cover [[include]] in dagger.toml: a workspace naming another
+// config whose contents are merged underneath its own. A source is either a
+// path next to the including config or a git ref.
+//
+// A git include's repository is served by workspaceSelectionRemoteRef, at an
+// IP-addressed URL, because the engine resolves the include itself — there is
+// no client-side service binding to attach.
+//
+// See also:
+// - workspace_config_test.go: reads and writes of the local config.
+// - workspace_selection_test.go: the remote-workspace machinery a git include
+//   reuses.
+// - lockfile_test.go: the git-sha lock entries a git include records.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+type WorkspaceIncludeSuite struct{}
+
+func TestWorkspaceInclude(t *testing.T) {
+	testctx.New(t, Middleware()...).RunTests(WorkspaceIncludeSuite{})
+}
+
+// workspaceIncludeModuleRepo serves a repository holding a single dang module,
+// so an include workspace can install it the way a published base config
+// would: by remote ref.
+func workspaceIncludeModuleRepo(ctx context.Context, t *testctx.T, c *dagger.Client, name, typeName, result string) string {
+	t.Helper()
+
+	return workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
+		WithNewFile("dagger.json", `{"name":"`+name+`","sdk":{"source":"dang"}}`).
+		WithNewFile("main.dang", workspaceSelectionDangSource(typeName, "identify", result)))
+}
+
+// workspaceIncludeConsumer is the consuming workspace: a git-rooted /work — the
+// boundary local workspace detection walks up to — whose dagger.toml declares
+// the include.
+func workspaceIncludeConsumer(t *testctx.T, c *dagger.Client, configTOML string) *dagger.Container {
+	t.Helper()
+
+	return workspaceBase(t, c).WithNewFile("/work/dagger.toml", configTOML)
+}
+
+func workspaceIncludeConfig(args ...string) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		return ctr.WithExec(
+			append([]string{"dagger", "--progress=report", "--silent", "workspace", "config"}, args...),
+			dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+		)
+	}
+}
+
+func workspaceIncludeConfigFail(args ...string) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		return ctr.WithExec(
+			append([]string{"dagger", "--progress=report", "workspace", "config"}, args...),
+			dagger.ContainerWithExecOpts{
+				ExperimentalPrivilegedNesting: true,
+				Expect:                        dagger.ReturnTypeFailure,
+			},
+		)
+	}
+}
+
+func (WorkspaceIncludeSuite) TestMergesIncludedConfig(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	moduleRef := workspaceIncludeModuleRepo(ctx, t, c, "greeter", "Greeter", "hello from the base")
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `[modules.greeter]
+source = "`+moduleRef+`"
+entrypoint = true
+
+[modules.greeter.settings]
+greeting = "hello"
+tone = "formal"
+`))
+
+	// The overriding entry carries no source: it inherits the module's ref from
+	// the include config and only changes one setting.
+	ctr := workspaceIncludeConsumer(t, c, `
+[modules.greeter.settings]
+greeting = "hola"
+
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	t.Run("reports the merged config", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+		require.NoError(t, err)
+
+		require.Contains(t, out, `source = "`+moduleRef+`"`, "the module ref is inherited")
+		require.Contains(t, out, `greeting = "hola"`, "the local override wins")
+		require.Contains(t, out, `tone = "formal"`, "settings merge key by key")
+		require.Contains(t, out, "entrypoint = true", "other fields are inherited")
+
+		require.Contains(t, out, "# included: "+baseRef)
+		require.NotContains(t, out, "[[include]]", "the applied layer must not be re-applicable from this output")
+	})
+
+	t.Run("reads the include list from the local config", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceIncludeConfig("include")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, baseRef, strings.TrimSpace(out))
+	})
+
+	// The include entry is the workspace entrypoint, so its functions are
+	// proxied onto the root rather than namespaced under the module name.
+	t.Run("loads a module the include contributes", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceSelectionDaggerCall("identify")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from the base", strings.TrimSpace(out))
+	})
+}
+
+func (WorkspaceIncludeSuite) TestCurrentWorkspaceWins(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `ignore = ["base-dist"]
+
+[modules.greeter]
+source = "github.com/acme/base-greeter@v1"
+pin = "1111111111111111111111111111111111111111"
+entrypoint = true
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `ignore = ["dist"]
+
+[modules.greeter]
+source = "github.com/acme/local-greeter@v2"
+entrypoint = false
+
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "github.com/acme/local-greeter@v2"`)
+	require.NotContains(t, out, "1111111111111111111111111111111111111111", "a replaced source drops the pin that belonged to it")
+	require.Contains(t, out, `ignore = ["dist"]`)
+
+	// entrypoint = false is an override, not an absent key.
+	out, err = ctr.With(workspaceIncludeConfig("modules.greeter.entrypoint")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "false", strings.TrimSpace(out))
+}
+
+func (WorkspaceIncludeSuite) TestLocalModulesAreNotInherited(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
+		WithNewFile("dagger.toml", `[modules.local-ci]
+source = ".dagger/modules/local-ci"
+
+[modules.remote-tool]
+source = "github.com/acme/tool@v1"
+`).
+		WithNewFile(".dagger/modules/local-ci/dagger.json", `{"name":"local-ci","sdk":{"source":"dang"}}`).
+		WithNewFile(".dagger/modules/local-ci/main.dang", workspaceSelectionDangSource("LocalCi", "identify", "base local module")))
+
+	// The consuming workspace has a directory at the very same path: without
+	// the drop, the inherited source would resolve here instead.
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`).
+		WithNewFile("/work/.dagger/modules/local-ci/dagger.json", `{"name":"local-ci","sdk":{"source":"dang"}}`).
+		WithNewFile("/work/.dagger/modules/local-ci/main.dang", workspaceSelectionDangSource("LocalCi", "identify", "consumer local module"))
+
+	t.Run("drops the entry", func(ctx context.Context, t *testctx.T) {
+		out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, "local-ci", "a local module of the included config must not be usable here")
+		require.Contains(t, out, `source = "github.com/acme/tool@v1"`, "remote entries still come through")
+	})
+
+	t.Run("says so", func(ctx context.Context, t *testctx.T) {
+		// Reported without --silent, which suppresses progress output. The
+		// warning has to reach a command that skips workspace modules
+		// entirely, which is exactly what `workspace config` does.
+		out, err := ctr.WithExec(
+			[]string{"dagger", "--progress=plain", "workspace", "config"},
+			dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+		).CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "local-ci")
+		require.Contains(t, out, "Only its remote modules are inherited")
+	})
+
+	t.Run("does not resolve the same-named local directory", func(ctx context.Context, t *testctx.T) {
+		_, err := ctr.With(workspaceSelectionDaggerCallFail("local-ci", "identify")).Sync(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func (WorkspaceIncludeSuite) TestRejectsNestedInclude(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// The nested ref is never followed — the error fires on its presence — so a
+	// literal one saves standing up a second git service.
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `
+[[include]]
+source = "github.com/acme/deeper@v1"
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	stderr, err := ctr.With(workspaceIncludeConfigFail()).Stderr(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stderr, "nested includes are not supported")
+}
+
+func (WorkspaceIncludeSuite) TestRejectsMissingIncludeTarget(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// A repository with no config where the include points.
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
+		WithNewFile("README.md", "no config here"))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	stderr, err := ctr.With(workspaceIncludeConfigFail()).Stderr(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stderr, "dagger.toml")
+	require.Contains(t, stderr, "no such file")
+}
+
+func (WorkspaceIncludeSuite) TestIncludesAConfigFileInTheSameWorkspace(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// A monorepo shape: the shared config sits next to the workspace that
+	// includes it, addressed as a path rather than a git ref.
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "common/base.toml"
+`).
+		WithNewFile("/work/common/base.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+
+[modules.greeter.settings]
+greeting = "hello"
+tone = "formal"
+`)
+
+	out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "github.com/acme/greeter@v1"`)
+	require.Contains(t, out, `tone = "formal"`)
+	require.Contains(t, out, "# included: common/base.toml")
+}
+
+func (WorkspaceIncludeSuite) TestIncludesARootRelativeConfig(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// A leading "/" means the workspace root, the same rule every other path a
+	// workspace resolves follows — which is the spelling that works unchanged
+	// from a config in a subdirectory.
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "/common/base.toml"
+`).
+		WithNewFile("/work/common/base.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+`)
+
+	out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "github.com/acme/greeter@v1"`)
+}
+
+func (WorkspaceIncludeSuite) TestIncludesADirectoryConfig(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// A source that names a directory reaches the dagger.toml inside it.
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "common"
+`).
+		WithNewFile("/work/common/dagger.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+`)
+
+	out, err := ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "github.com/acme/greeter@v1"`)
+}
+
+func (WorkspaceIncludeSuite) TestRejectsMoreThanOneInclude(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// The shape allows several; resolving several does not, for now.
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "common/base.toml"
+
+[[include]]
+source = "common/extra.toml"
+`).
+		WithNewFile("/work/common/base.toml", "[modules]\n").
+		WithNewFile("/work/common/extra.toml", "[modules]\n")
+
+	stderr, err := ctr.With(workspaceIncludeConfigFail()).Stderr(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stderr, "declares 2 includes")
+	require.Contains(t, stderr, "only 1 is supported")
+}
+
+func (WorkspaceIncludeSuite) TestRejectsOverrideOfAModuleTheIncludeDoesNotProvide(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[modules.missing.settings]
+greeting = "hola"
+
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	stderr, err := ctr.With(workspaceIncludeConfigFail()).Stderr(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stderr, `module "missing" has no source`)
+}
+
+func (WorkspaceIncludeSuite) TestIncludedEnvIsSelectable(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+
+[modules.greeter.settings]
+greeting = "hello"
+
+[env.ci.modules.greeter.settings]
+greeting = "ci hello"
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	// Read the overlay itself rather than selecting it: --env is temporarily
+	// disabled across commands upstream. What matters here is that the env the
+	// included config defines crossed the boundary at all.
+	out, err := ctr.WithExec(
+		[]string{"dagger", "--progress=report", "--silent", "workspace", "config", "env.ci.modules.greeter.settings.greeting"},
+		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+	).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ci hello", strings.TrimSpace(out))
+}
+
+func (WorkspaceIncludeSuite) TestSetsTheIncludeThroughTheCLI(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	// The config shape is an array of tables, but the CLI addresses the single
+	// supported include as one value — which is the only way a user sets one
+	// without hand-editing dagger.toml.
+	ctr := workspaceIncludeConsumer(t, c, "ignore = [\"node_modules\"]\n").
+		WithNewFile("/work/common/base.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+`).
+		With(workspaceIncludeConfig("include", "common/base.toml"))
+
+	written, err := ctr.File("/work/dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Contains(t, written, "[[include]]")
+	require.Contains(t, written, `source = "common/base.toml"`)
+	require.Contains(t, written, `ignore = ["node_modules"]`, "a bare key must not be swallowed by the include table")
+
+	// Reading it back reports this workspace's own value, and the effective
+	// view now carries what the include provides.
+	out, err := ctr.With(workspaceIncludeConfig("include")).Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "common/base.toml", strings.TrimSpace(out))
+
+	out, err = ctr.With(workspaceIncludeConfig()).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "github.com/acme/greeter@v1"`)
+	require.Contains(t, out, "# included: common/base.toml")
+}
+
+func (WorkspaceIncludeSuite) TestWritesStayLocal(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `[modules.greeter]
+source = "github.com/acme/greeter@v1"
+
+[modules.greeter.settings]
+greeting = "hello"
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	t.Run("a setting write records only the override", func(ctx context.Context, t *testctx.T) {
+		written, err := ctr.
+			With(workspaceIncludeConfig("modules.greeter.settings.greeting", "hola")).
+			File("/work/dagger.toml").
+			Contents(ctx)
+		require.NoError(t, err)
+
+		require.Contains(t, written, `source = "`+baseRef+`"`)
+		require.Contains(t, written, `greeting = "hola"`)
+		require.NotContains(t, written, `source = ""`, "an override must not write out an empty source")
+		require.NotContains(t, written, "github.com/acme/greeter", "the inherited ref stays in the included config")
+	})
+
+	t.Run("uninstalling an included module names the include", func(ctx context.Context, t *testctx.T) {
+		stderr, err := ctr.WithExec(
+			[]string{"dagger", "--progress=report", "uninstall", "greeter"},
+			dagger.ContainerWithExecOpts{
+				ExperimentalPrivilegedNesting: true,
+				Expect:                        dagger.ReturnTypeFailure,
+			},
+		).Stderr(ctx)
+		require.NoError(t, err)
+		require.Contains(t, stderr, "comes from the included config")
+	})
+}
+
+func (WorkspaceIncludeSuite) TestGitIncludeIsPinnedInTheLockfile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	moduleRef := workspaceIncludeModuleRepo(ctx, t, c, "greeter", "Greeter", "hello from the base")
+	baseRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().WithNewFile("dagger.toml", `[modules.greeter]
+source = "`+moduleRef+`"
+entrypoint = true
+`))
+
+	ctr := workspaceIncludeConsumer(t, c, `
+[[include]]
+source = "`+baseRef+`"
+`)
+
+	// Locking is on by default, so an ordinary run resolves the include's ref
+	// and records it like any other git lookup.
+	resolved := ctr.WithExec(
+		[]string{"dagger", "--progress=report", "--silent", "call", "identify"},
+		dagger.ContainerWithExecOpts{
+			UseEntrypoint:                 true,
+			ExperimentalPrivilegedNesting: true,
+		},
+	)
+	lock, err := resolved.File("/work/dagger.lock").Contents(ctx)
+	require.NoError(t, err)
+	// "git-sha" is the immutable-resolution operation the lockfile records for
+	// a git lookup; the include gets one because it resolves like any other.
+	require.Contains(t, lock, `"git-sha"`, "the include is pinned like any other git ref")
+	// The lock entry names the repository as the resolver canonicalizes it:
+	// no scheme, no .git suffix.
+	repo := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSuffix(baseRef, "@main"), "http://"), ".git")
+	require.Contains(t, lock, repo, "the entry names the include repository")
+
+	// A later run reuses the recorded pin rather than re-resolving: the lock is
+	// left exactly as it was, and the merged config still resolves.
+	replayed := resolved.WithExec(
+		[]string{"dagger", "--progress=report", "--silent", "workspace", "config"},
+		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
+	)
+	out, err := replayed.Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `source = "`+moduleRef+`"`)
+
+	after, err := replayed.File("/work/dagger.lock").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, lock, after, "a pinned include is not re-resolved on the next run")
+}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -466,6 +466,35 @@ func (s *moduleSourceSchema) workspaceModuleSourceByName(
 	if err != nil {
 		return inst, false, fmt.Errorf("failed to parse workspace config: %w", err)
 	}
+	// This path reads dagger.toml directly rather than through the Workspace
+	// object, so it has to apply the includes itself; without it a module an
+	// included config contributes would not resolve by name.
+	includeSource := core.IncludeSource{}
+	explicitKeys := map[string]bool{}
+	if len(cfg.Include) > 0 {
+		dag, err := core.CurrentDagqlServer(ctx)
+		if err != nil {
+			return inst, false, err
+		}
+		includeSource = core.IncludeSource{
+			Dag:       dag,
+			ConfigDir: filepath.Dir(ws.ConfigFile),
+			ReadWorkspaceFile: func(ctx context.Context, wsPath string) ([]byte, error) {
+				return bk.ReadCallerHostFile(ctx, filepath.Join(ws.Root, wsPath))
+			},
+		}
+		explicitKeys, err = workspace.ExplicitConfigKeys(contents)
+		if err != nil {
+			return inst, false, fmt.Errorf("failed to parse workspace config: %w", err)
+		}
+	}
+	// ApplyIncludes also runs the effective-config validation, without which a
+	// config every other read path rejects would be reported here as a plain
+	// "not found".
+	cfg, err = core.ApplyIncludes(ctx, includeSource, cfg, explicitKeys)
+	if err != nil {
+		return inst, false, err
+	}
 	entry, ok := cfg.Modules[name]
 	if !ok || entry.Source == "" {
 		return inst, false, nil

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -212,9 +212,44 @@ func (s *workspaceSchema) withoutConfigValue(
 
 	updated, err := workspace.DeleteConfigValue(staged.Data, unsetKey)
 	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
+		return dagql.ObjectResult[*core.Workspace]{}, unsetIncludedValueError(ctx, parent.Self(), staged, unsetKey, err)
 	}
 	return s.stageWorkspaceConfigBytes(ctx, parent, staged, updated)
+}
+
+// unsetIncludedValueError names the include when the key being unset is one the
+// workspace inherits rather than one it set. Unsetting only ever edits the
+// local file, and an inherited value has nothing local to remove — "key is not
+// set" is true but says nothing about where the value the user sees came from.
+func unsetIncludedValueError(
+	ctx context.Context,
+	ws *core.Workspace,
+	staged *stagedWorkspaceConfig,
+	key string,
+	cause error,
+) error {
+	if len(staged.Config.Include) == 0 {
+		return cause
+	}
+	// A key the local file does spell out was not refused for being inherited —
+	// unsetting a protected key such as modules.<name>.source fails with the
+	// entry right there in dagger.toml.
+	if _, err := workspace.ReadConfigValue(staged.Data, key); err == nil {
+		return cause
+	}
+	effective, err := readWorkspaceConfig(ctx, ws)
+	if err != nil {
+		// An include that cannot be read is the answer, not a reason to fall
+		// back to reporting the key as unset.
+		return err
+	}
+	if _, err := workspace.ReadConfigValue(workspace.SerializeConfig(effective), key); err != nil {
+		return cause
+	}
+	return fmt.Errorf(
+		"%w: it comes from the included config %q, which can be overridden here but not unset",
+		cause, staged.Config.Include[0].Source,
+	)
 }
 
 func (s *workspaceSchema) withConfigEnv(
@@ -416,7 +451,10 @@ func (s *workspaceSchema) withoutModule(
 	configDir, cwd := moduleSelectionDirectories(parent.Self(), staged.ConfigDir)
 	selection, err := workspace.SelectModule(modules, configDir, cwd, args.Name, false)
 	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
+		// A module the include provides is absent from the local config, so
+		// selection misses it. Say where it comes from rather than that it is
+		// not installed.
+		return dagql.ObjectResult[*core.Workspace]{}, uninstallUnavailableError(ctx, parent.Self(), staged, args.Name, err)
 	}
 	args.Name = selection.Name
 	if envName, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok {
@@ -428,8 +466,26 @@ func (s *workspaceSchema) withoutModule(
 		return s.withoutEnvModule(ctx, parent, staged, envName, args.Name)
 	}
 	entry, ok := staged.Config.Modules[args.Name]
-	if !ok {
-		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("module %q is not installed in the workspace", args.Name)
+	overridesIncluded := false
+	if ok && entry.Source == "" {
+		overridesIncluded, err = workspaceIncludeProvidesModule(ctx, parent.Self(), staged, args.Name)
+		if err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+	}
+	if overridesIncluded {
+		// A source-less entry only overrides a module an include provides:
+		// removing it drops those overrides and the inherited module comes
+		// back. There is no local module directory to remove with it.
+		delete(staged.Config.Modules, args.Name)
+		updated, err := workspace.UpdateConfigBytes(staged.Data, staged.Config)
+		if err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+		return s.stageWorkspaceConfigBytes(ctx, parent, staged, updated)
+	}
+	if !ok || entry.Source == "" {
+		return dagql.ObjectResult[*core.Workspace]{}, uninstallUnavailableError(ctx, parent.Self(), staged, args.Name, nil)
 	}
 
 	managedModulePath, removeManagedModuleDir, err := removeSDKManagedModuleReference(staged.Config, staged.ConfigDir, args.Name, entry)
@@ -472,6 +528,56 @@ func (s *workspaceSchema) withoutModule(
 	}, func(ws *core.Workspace) {
 		setWorkspaceConfigSelection(ws, staged.ConfigDir)
 	})
+}
+
+// uninstallUnavailableError explains why a module cannot be uninstalled here.
+// A module an included config provides is not installed by this config, so
+// there is nothing local to remove.
+func uninstallUnavailableError(
+	ctx context.Context,
+	ws *core.Workspace,
+	staged *stagedWorkspaceConfig,
+	name string,
+	cause error,
+) error {
+	provided, err := workspaceIncludeProvidesModule(ctx, ws, staged, name)
+	if err != nil {
+		return err
+	}
+	if !provided {
+		if cause != nil {
+			return cause
+		}
+		return fmt.Errorf("module %q is not installed in the workspace", name)
+	}
+	return fmt.Errorf(
+		"module %q comes from the included config %q and cannot be uninstalled here",
+		name, staged.Config.Include[0].Source,
+	)
+}
+
+// workspaceIncludeProvidesModule reports whether an included config supplies
+// name, which is what tells an override apart from an install and a missing
+// module apart from an inherited one.
+//
+// A failure to read the effective config is returned rather than answered as
+// "no": an unreachable or invalid include would otherwise be reported as the
+// module simply not being installed.
+func workspaceIncludeProvidesModule(
+	ctx context.Context,
+	ws *core.Workspace,
+	staged *stagedWorkspaceConfig,
+	name string,
+) (bool, error) {
+	if len(staged.Config.Include) == 0 {
+		return false, nil
+	}
+	effective, err := readWorkspaceConfig(ctx, ws)
+	if err != nil {
+		return false, err
+	}
+	_, provided := effective.Modules[name]
+	return provided, nil
 }
 
 // withoutEnvModule removes a module from the selected env's overlay only; the

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -100,9 +100,15 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	return readWorkspaceFileBytes(ctx, ws, configFile)
+}
 
+// readWorkspaceFileBytes reads a workspace-relative file whichever way this
+// workspace is backed: a synthetic source directory, a host path (with any
+// overlay edit taking precedence), or a remote rootfs.
+func readWorkspaceFileBytes(ctx context.Context, ws *core.Workspace, wsPath string) ([]byte, error) {
 	if rootfs, ok := ws.SourceDirectory(); ok && rootfs.Self() != nil {
-		data, err := core.DirectoryReadFile(ctx, rootfs, configFile)
+		data, err := core.DirectoryReadFile(ctx, rootfs, wsPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading config: %w", err)
 		}
@@ -110,22 +116,22 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 	}
 
 	if ws.HostPath() != "" {
-		// Host overlay edits to the config live only in the changeset's delta
-		// side (host overlays store no full read root — see overlayEdit);
-		// untouched configs read straight from the host file below.
-		if deltaRoot, ok := ws.OverlayDeltaRoot(); ok && ws.OverlayPathTouched(configFile) {
-			data, err := core.DirectoryReadFile(ctx, deltaRoot, configFile)
+		// Host overlay edits live only in the changeset's delta side (host
+		// overlays store no full read root — see overlayEdit); untouched files
+		// read straight from the host below.
+		if deltaRoot, ok := ws.OverlayDeltaRoot(); ok && ws.OverlayPathTouched(wsPath) {
+			data, err := core.DirectoryReadFile(ctx, deltaRoot, wsPath)
 			if err != nil {
 				return nil, fmt.Errorf("reading config: %w", err)
 			}
 			return data, nil
 		}
 
-		ctx, err = withWorkspaceClientContext(ctx, ws)
+		ctx, err := withWorkspaceClientContext(ctx, ws)
 		if err != nil {
 			return nil, err
 		}
-		configPath, err := workspaceHostPath(ws, configFile)
+		hostPath, err := workspaceHostPath(ws, wsPath)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +140,7 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 			return nil, err
 		}
 
-		data, err := bk.ReadCallerHostFile(ctx, configPath)
+		data, err := bk.ReadCallerHostFile(ctx, hostPath)
 		if err != nil {
 			return nil, fmt.Errorf("reading config: %w", err)
 		}
@@ -145,7 +151,7 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 	if rootfs.Self() == nil {
 		return nil, fmt.Errorf("workspace has no host path or rootfs")
 	}
-	data, err := core.DirectoryReadFile(ctx, rootfs, configFile)
+	data, err := core.DirectoryReadFile(ctx, rootfs, wsPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading config: %w", err)
 	}
@@ -153,19 +159,89 @@ func readConfigBytes(ctx context.Context, ws *core.Workspace) ([]byte, error) {
 }
 
 func readWorkspaceConfig(ctx context.Context, ws *core.Workspace) (*workspace.Config, error) {
+	cfg, _, err := readEffectiveWorkspaceConfig(ctx, ws)
+	return cfg, err
+}
+
+// readEffectiveWorkspaceConfig also returns the raw local config bytes, for
+// callers that need to answer about the file itself as well.
+func readEffectiveWorkspaceConfig(ctx context.Context, ws *core.Workspace) (*workspace.Config, []byte, error) {
 	data, err := readConfigBytes(ctx, ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	cfg, err := workspace.ParseConfigAt(ctx, data, filepath.Dir(ws.ConfigFile))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if cfg.Modules == nil {
 		cfg.Modules = map[string]workspace.ModuleEntry{}
 	}
-	return cfg, nil
+
+	cfg, err = applyWorkspaceIncludes(ctx, ws, cfg, data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cfg, data, nil
+}
+
+// applyWorkspaceIncludes merges the config's includes underneath it. data is
+// the raw config bytes cfg was parsed from, which is what tells an explicitly
+// set key from an absent one.
+//
+// The include resolves in the workspace owner's client context: a git lookup
+// records its pin in that workspace's lockfile, which is the wrong one when the
+// receiver is not the caller's own workspace, and a local include reads through
+// that workspace's filesystem.
+func applyWorkspaceIncludes(
+	ctx context.Context,
+	ws *core.Workspace,
+	cfg *workspace.Config,
+	data []byte,
+) (*workspace.Config, error) {
+	if cfg == nil || len(cfg.Include) == 0 {
+		return core.ApplyIncludes(ctx, core.IncludeSource{}, cfg, nil)
+	}
+
+	if ws.ClientID != "" {
+		clientCtx, err := withWorkspaceClientContext(ctx, ws)
+		if err != nil {
+			return nil, err
+		}
+		ctx = clientCtx
+	}
+
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	source, err := workspaceIncludeSource(ws, dag)
+	if err != nil {
+		return nil, err
+	}
+	explicitKeys, err := workspace.ExplicitConfigKeys(data)
+	if err != nil {
+		return nil, err
+	}
+	return core.ApplyIncludes(ctx, source, cfg, explicitKeys)
+}
+
+// workspaceIncludeSource lets an include address a config in this workspace,
+// whichever way the workspace reads its own files.
+func workspaceIncludeSource(ws *core.Workspace, dag *dagql.Server) (core.IncludeSource, error) {
+	configFile, err := workspaceConfigFile(ws)
+	if err != nil {
+		return core.IncludeSource{}, err
+	}
+
+	return core.IncludeSource{
+		Dag:       dag,
+		ConfigDir: filepath.Dir(configFile),
+		ReadWorkspaceFile: func(ctx context.Context, wsPath string) ([]byte, error) {
+			return readWorkspaceFileBytes(ctx, ws, wsPath)
+		},
+	}, nil
 }
 
 type configReadArgs struct {
@@ -182,6 +258,40 @@ func (s *workspaceSchema) configRead(
 			return "", fmt.Errorf("workspace env %q requires dagger.toml", envName)
 		}
 		result, err := workspace.ReadConfigValue(nil, args.Key)
+		if err != nil {
+			return "", err
+		}
+		return dagql.String(result), nil
+	}
+
+	// The include list is answered from the local file whatever else is layered
+	// on: it is this workspace's own declaration, and every effective view (env,
+	// user overlay, merged include) strips it, so reading it from one of those
+	// would report "key is not set" — and would resolve the include just to
+	// return something the local file already says.
+	//
+	// `include` reports one source per line rather than the raw array of
+	// tables, matching how it is written: `config include <source>`.
+	if isIncludeConfigKey(args.Key) {
+		data, err := readConfigBytes(ctx, parent)
+		if err != nil {
+			return "", err
+		}
+		if args.Key == "include" {
+			cfg, err := workspace.ParseConfig(data)
+			if err != nil {
+				return "", err
+			}
+			if len(cfg.Include) == 0 {
+				return "", fmt.Errorf("key %q is not set", args.Key)
+			}
+			sources := make([]string, 0, len(cfg.Include))
+			for _, include := range cfg.Include {
+				sources = append(sources, include.Source)
+			}
+			return dagql.String(strings.Join(sources, "\n")), nil
+		}
+		result, err := workspace.ReadConfigValue(data, args.Key)
 		if err != nil {
 			return "", err
 		}
@@ -224,16 +334,22 @@ func (s *workspaceSchema) configRead(
 			return "", err
 		}
 
-		result, err := workspace.ReadConfigValue(workspace.SerializeConfig(merged), args.Key)
+		result, err := workspace.ReadConfigValue(effectiveConfigBytes(merged), args.Key)
 		if err != nil {
 			return "", err
 		}
 		return dagql.String(result), nil
 	}
 
-	data, err := readConfigBytes(ctx, parent)
+	cfg, data, err := readEffectiveWorkspaceConfig(ctx, parent)
 	if err != nil {
 		return "", err
+	}
+	// An include turns reads into the effective view, the same way an env
+	// selection or a user overlay already does. Without one the file is
+	// returned verbatim, comments and formatting included.
+	if len(cfg.Include) > 0 {
+		data = effectiveConfigBytes(cfg)
 	}
 
 	result, err := workspace.ReadConfigValue(data, args.Key)
@@ -241,6 +357,35 @@ func (s *workspaceSchema) configRead(
 		return "", err
 	}
 	return dagql.String(result), nil
+}
+
+func isIncludeConfigKey(key string) bool {
+	return key == "include" || strings.HasPrefix(key, "include.")
+}
+
+// effectiveConfigBytes serializes an effective config as a standalone snapshot:
+// the include that produced the inherited values is named in a comment rather
+// than left as a live key. Keeping the key would make the output a config that
+// inlines the included values *and* names the include again underneath.
+//
+// Same reasoning as effectiveWorkspaceConfigBytes clearing Env: the layer is
+// applied, so it should not be re-applicable.
+func effectiveConfigBytes(cfg *workspace.Config) []byte {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Include) == 0 {
+		return workspace.SerializeConfig(cfg)
+	}
+
+	snapshot := *cfg
+	snapshot.Include = nil
+	header := &strings.Builder{}
+	for _, include := range cfg.Include {
+		fmt.Fprintf(header, "# included: %s\n", include.Source)
+	}
+	header.WriteString("\n")
+	return append([]byte(header.String()), workspace.SerializeConfig(&snapshot)...)
 }
 
 type workspaceConfigValueArgs struct {
@@ -287,7 +432,7 @@ func effectiveWorkspaceConfigBytes(ws *core.Workspace, cfg *workspace.Config, en
 		return nil, err
 	}
 	applied.Env = nil
-	return workspace.SerializeConfig(applied), nil
+	return effectiveConfigBytes(applied), nil
 }
 
 // envScopedConfigKey maps a modules.<name>.settings.* key into the selected

--- a/core/schema/workspace_install.go
+++ b/core/schema/workspace_install.go
@@ -60,7 +60,18 @@ func planWorkspaceInstallConfig(
 	}
 
 	if existing, ok := cfg.Modules[name]; ok {
-		if !workspace.SameModuleRequest(existing.Source, ".", sourcePath, ".") {
+		switch {
+		case existing.Source == "":
+			// An entry with no source overrides a module an included config
+			// provides; installing under that name is not a conflict, it fills
+			// the source in and keeps the overrides. A pin recorded for the
+			// inherited ref goes with it — same source/pin coupling the merge
+			// uses.
+			existing.Source = sourcePath
+			existing.Pin = ""
+			cfg.Modules[name] = existing
+			plan.Changed = true
+		case !workspace.SameModuleRequest(existing.Source, ".", sourcePath, "."):
 			if workspace.ModuleSourceIdentity(existing.Source, ".") == workspace.ModuleSourceIdentity(sourcePath, ".") {
 				return plan, fmt.Errorf("module %q is already installed from %q; use dagger mod update %s --version VERSION to change its version", name, existing.Source, name)
 			}

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -1005,6 +1005,27 @@ func TestPlanWorkspaceInstallConfigSDKNames(t *testing.T) {
 	require.Equal(t, "go-sdk", cfg.SDKs["custom-go"].Module)
 }
 
+func TestPlanWorkspaceInstallConfigOverSourcelessOverride(t *testing.T) {
+	cfg := &workspace.Config{
+		Include: []workspace.IncludeEntry{{Source: "github.com/acme/base@v1"}},
+		Modules: map[string]workspace.ModuleEntry{
+			"dep": {
+				Pin:      "1111111111111111111111111111111111111111",
+				Settings: map[string]any{"region": "eu"},
+			},
+		},
+	}
+
+	plan, err := planWorkspaceInstallConfig(cfg, workspaceInstallArgs{}, "dep", "github.com/acme/dep@v2")
+	require.NoError(t, err)
+	require.True(t, plan.Changed)
+
+	entry := cfg.Modules["dep"]
+	require.Equal(t, "github.com/acme/dep@v2", entry.Source)
+	require.Empty(t, entry.Pin, "a pin recorded for the inherited ref must not travel to a different source")
+	require.Equal(t, map[string]any{"region": "eu"}, entry.Settings, "the overrides survive the install")
+}
+
 func TestEnvScopedConfigKeyMissingEnv(t *testing.T) {
 	cfg := &workspace.Config{
 		Modules: map[string]workspace.ModuleEntry{

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -79,6 +79,11 @@ func ValidateSDKs(cfg *Config) error {
 
 // Config represents a parsed dagger.toml workspace configuration.
 type Config struct {
+	// Include lists the workspace configs this one builds on: each entry's
+	// config is merged underneath this one. The shape allows several, but only
+	// one is accepted for now, and an included config's own includes are never
+	// followed.
+	Include            []IncludeEntry         `json:"include,omitempty" toml:"include,omitempty"`
 	Modules            map[string]ModuleEntry `json:"modules,omitempty" toml:"modules"`
 	SDKs               map[string]SDKEntry    `json:"sdks,omitempty" toml:"sdks"`
 	Ignore             []string               `json:"ignore,omitempty" toml:"ignore"`
@@ -100,9 +105,26 @@ type PortMapping struct {
 	BackendPort    int    `json:"backendPort" toml:"backendPort"`
 }
 
+// IncludeEntry is one included workspace config. Source addresses the config
+// file itself — not the workspace holding it — either as a path relative to the
+// including config's directory, or as a git ref with the file as its subpath:
+//
+//	[[include]]
+//	source = "../../common/dagger.toml"
+//
+//	[[include]]
+//	source = "https://github.com/acme/platform#:dagger/common/app-base.toml"
+type IncludeEntry struct {
+	Source string `json:"source" toml:"source"`
+}
+
 // ModuleEntry represents a single module entry in the workspace config.
+//
+// Source is optional in the file: with an [[include]], an entry may carry only
+// overrides and inherit its source from the included config. Every entry in an
+// *effective* config still needs one — see ValidateEffectiveConfig.
 type ModuleEntry struct {
-	Source            string         `json:"source" toml:"source"`
+	Source            string         `json:"source,omitempty" toml:"source"`
 	Pin               string         `json:"pin,omitempty" toml:"pin,omitempty"`
 	Settings          map[string]any `json:"settings,omitempty" toml:"settings,omitempty"`
 	Entrypoint        bool           `json:"entrypoint,omitempty" toml:"entrypoint,omitempty"`
@@ -404,6 +426,12 @@ func SerializeConfig(cfg *Config) []byte {
 		fmt.Fprintf(&b, "check-generated = %t\n\n", *cfg.CheckGenerated)
 	}
 
+	// After the top-level scalars: every bare key in a TOML document has to
+	// precede the first table header, and [[include]] is one.
+	for _, include := range cfg.Include {
+		fmt.Fprintf(&b, "[[include]]\nsource = %q\n\n", include.Source)
+	}
+
 	wrote := writeModuleEntries(&b, cfg.Modules)
 	if wrote && len(cfg.SDKs) > 0 {
 		b.WriteString("\n")
@@ -431,6 +459,7 @@ func cloneConfig(cfg *Config) *Config {
 	}
 
 	cloned := &Config{
+		Include:            append([]IncludeEntry(nil), cfg.Include...),
 		Ignore:             append([]string(nil), cfg.Ignore...),
 		DefaultsFromDotEnv: cfg.DefaultsFromDotEnv,
 	}
@@ -453,24 +482,7 @@ func cloneConfig(cfg *Config) *Config {
 			}
 		}
 	}
-	if len(cfg.SDKs) > 0 {
-		cloned.SDKs = make(map[string]SDKEntry, len(cfg.SDKs))
-		for name, sdk := range cfg.SDKs {
-			clonedSDK := SDKEntry{Module: sdk.Module}
-			if len(sdk.Scopes) > 0 {
-				clonedSDK.Scopes = make(map[string]SDKScope, len(sdk.Scopes))
-				for scopePath, scope := range sdk.Scopes {
-					clonedSDK.Scopes[scopePath] = SDKScope{
-						IsModule: scope.IsModule,
-						Name:     scope.Name,
-						Clients:  append([]string(nil), scope.Clients...),
-						Settings: cloneConfigMap(scope.Settings),
-					}
-				}
-			}
-			cloned.SDKs[name] = clonedSDK
-		}
-	}
+	cloned.SDKs = cloneSDKs(cfg.SDKs)
 	if len(cfg.Env) > 0 {
 		cloned.Env = make(map[string]EnvOverlay, len(cfg.Env))
 		for envName, env := range cfg.Env {
@@ -493,6 +505,32 @@ func cloneConfig(cfg *Config) *Config {
 		for host, pm := range cfg.Ports {
 			cloned.Ports[host] = pm
 		}
+	}
+	return cloned
+}
+
+// cloneSDKs deep-copies a config's SDK declarations. It is separate from
+// cloneConfig because the include merge replaces them wholesale rather than
+// inheriting them.
+func cloneSDKs(sdks map[string]SDKEntry) map[string]SDKEntry {
+	if len(sdks) == 0 {
+		return nil
+	}
+	cloned := make(map[string]SDKEntry, len(sdks))
+	for name, sdk := range sdks {
+		clonedSDK := SDKEntry{Module: sdk.Module}
+		if len(sdk.Scopes) > 0 {
+			clonedSDK.Scopes = make(map[string]SDKScope, len(sdk.Scopes))
+			for scopePath, scope := range sdk.Scopes {
+				clonedSDK.Scopes[scopePath] = SDKScope{
+					IsModule: scope.IsModule,
+					Name:     scope.Name,
+					Clients:  append([]string(nil), scope.Clients...),
+					Settings: cloneConfigMap(scope.Settings),
+				}
+			}
+		}
+		cloned[name] = clonedSDK
 	}
 	return cloned
 }
@@ -527,7 +565,11 @@ func writeModuleEntries(b *strings.Builder, modules map[string]ModuleEntry) bool
 		entry := modules[name]
 		modulePath := "modules." + formatConfigPathSegment(name)
 		fmt.Fprintf(b, "[%s]\n", modulePath)
-		fmt.Fprintf(b, "source = %q\n", entry.Source)
+		// An entry with no source is an override of an included module; writing
+		// source = "" back would turn it into an entry that names nothing.
+		if entry.Source != "" {
+			fmt.Fprintf(b, "source = %q\n", entry.Source)
+		}
 		if entry.Pin != "" {
 			fmt.Fprintf(b, "pin = %q\n", entry.Pin)
 		}
@@ -803,8 +845,26 @@ func writeConfigValueAtKey(existingData []byte, key string, valueFor func(parts 
 	if err != nil {
 		return nil, err
 	}
+
 	// The requested key is explicit, even if its value equals an implicit
 	// default and therefore produces no difference between typed configs.
+	// [[include]] is an array of tables, which the document editor declines to
+	// edit; it is rewritten as a block instead.
+	if parts[0] == "include" {
+		existingCfg, err := ParseConfig(existingData)
+		if err != nil && len(existingData) > 0 {
+			return nil, err
+		}
+		var existingIncludes []IncludeEntry
+		if existingCfg != nil {
+			existingIncludes = existingCfg.Include
+		}
+		updated := rewriteIncludeBlocks(existingData, existingIncludes, cfg.Include)
+		if _, err := ParseConfig(updated); err != nil {
+			return nil, fmt.Errorf("validate edited config: %w", err)
+		}
+		return updated, nil
+	}
 	doc, err := parseConfigText(existingData)
 	if err != nil {
 		return nil, err
@@ -1185,6 +1245,21 @@ func setConfigValue(cfg *Config, parts []string, value any) error { //nolint:goc
 	}
 
 	switch parts[0] {
+	case "include":
+		// The config shape is an array of tables, but only one include is
+		// accepted for now, so the CLI addresses it as a single value: setting
+		// it replaces whatever was there.
+		if len(parts) == 2 && parts[1] == "source" || len(parts) == 1 {
+			source := fmt.Sprint(value)
+			if strings.TrimSpace(source) == "" {
+				// Writing it empty would leave a block naming nothing, which
+				// every later read rejects. Refuse at the write instead.
+				return fmt.Errorf("include source is required; remove the include rather than emptying it")
+			}
+			cfg.Include = []IncludeEntry{{Source: source}}
+			return nil
+		}
+		return fmt.Errorf("invalid key %q; expected include or include.source", strings.Join(parts, "."))
 	case "ignore":
 		if len(parts) != 1 {
 			return fmt.Errorf("invalid key %q; ignore does not have sub-keys", strings.Join(parts, "."))

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"sort"
 	"strings"
+
+	toml "github.com/pelletier/go-toml"
 )
 
 // UpdateConfigBytes applies the differences between the old and new typed
@@ -28,6 +30,7 @@ func UpdateConfigBytes(existingData []byte, cfg *Config) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	updated = rewriteIncludeBlocks(updated, existing.Include, cfg.Include)
 	if _, err := ParseConfig(updated); err != nil {
 		return nil, fmt.Errorf("validate edited config: %w", err)
 	}
@@ -236,6 +239,42 @@ func configDocumentMap(cfg *Config) map[string]any {
 		values["sdks"] = sdks
 	}
 	return values
+}
+
+// ExplicitConfigKeys returns the dotted paths of every leaf key the config file
+// actually spells out. Merging an included config needs presence, not the Go
+// zero value: `entrypoint = false` and `ignore = []` are overrides of what the
+// include provides, and both parse to the same value as an absent key.
+//
+// Array-of-tables blocks are skipped: the only one a config can carry is
+// [[include]], which is replaced wholesale rather than merged, so its presence
+// decides nothing.
+func ExplicitConfigKeys(data []byte) (map[string]bool, error) {
+	keys := map[string]bool{}
+	if len(data) == 0 {
+		return keys, nil
+	}
+	tree, err := toml.LoadBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse config keys: %w", err)
+	}
+	collectExplicitConfigKeys(tree, nil, keys)
+	return keys, nil
+}
+
+func collectExplicitConfigKeys(tree *toml.Tree, prefix []string, keys map[string]bool) {
+	for _, key := range tree.Keys() {
+		path := append(append([]string(nil), prefix...), key)
+		// GetPath, not Get: Get re-splits a dotted key, so a quoted table name
+		// like [modules."my.mod"] would look up my -> mod and miss.
+		switch value := tree.GetPath([]string{key}).(type) {
+		case *toml.Tree:
+			collectExplicitConfigKeys(value, path, keys)
+		case []*toml.Tree:
+		default:
+			keys[JoinConfigPath(path...)] = true
+		}
+	}
 }
 
 // FormatConfigPathSegment formats one TOML dotted-key path segment.

--- a/core/workspace/include.go
+++ b/core/workspace/include.go
@@ -1,0 +1,336 @@
+package workspace
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// MaxIncludes is how many [[include]] entries a config may carry. The shape is
+// an array so several can be expressed, but resolving more than one raises
+// questions this feature deliberately does not answer yet — ordering between
+// includes, and what happens when two of them disagree. One is enough to share
+// a base config, so the limit stays until there is a reason to lift it.
+const MaxIncludes = 1
+
+// TooManyIncludesError reports a config with more includes than are supported.
+type TooManyIncludesError struct {
+	Count int
+}
+
+func (e *TooManyIncludesError) Error() string {
+	return fmt.Sprintf(
+		"workspace config declares %d includes; only %d is supported for now",
+		e.Count, MaxIncludes,
+	)
+}
+
+// NestedIncludeError reports an included config that includes something in
+// turn. Includes are one level deep: following the chain would turn a basic
+// inheritance feature into config composition.
+type NestedIncludeError struct {
+	// Include is the source the current config includes.
+	Include string
+	// Nested is the source that included config names in turn.
+	Nested string
+}
+
+func (e *NestedIncludeError) Error() string {
+	return fmt.Sprintf(
+		"included config %q includes %q in turn; nested includes are not supported",
+		e.Include, e.Nested,
+	)
+}
+
+// ValidateIncludes checks a config's own include list before anything is
+// resolved, so an unsupported shape is reported against the file the user
+// wrote rather than as a failure deeper in loading.
+func ValidateIncludes(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Include) > MaxIncludes {
+		return &TooManyIncludesError{Count: len(cfg.Include)}
+	}
+	for i, include := range cfg.Include {
+		// An [[include]] with nothing to resolve would otherwise be a silent
+		// no-op: the block is there, the config it promises is not.
+		if strings.TrimSpace(include.Source) == "" {
+			return fmt.Errorf("workspace include %d has no source", i+1)
+		}
+	}
+	return nil
+}
+
+func MergeIncludedConfig(included, current *Config, currentKeys map[string]bool) (*Config, error) {
+	if current == nil {
+		current = &Config{}
+	}
+	if included == nil {
+		return cloneConfig(current), nil
+	}
+	if len(included.Include) > 0 {
+		return nil, &NestedIncludeError{
+			Include: currentIncludeSource(current),
+			Nested:  included.Include[0].Source,
+		}
+	}
+
+	merged := cloneConfig(included)
+	merged.Include = append([]IncludeEntry(nil), current.Include...)
+	// SDK declarations are never inherited: an SDK's scopes are paths into the
+	// tree its config came from, so one declared over there names project roots
+	// that do not exist here. The current workspace's own declarations stand
+	// alone rather than merging with them.
+	merged.SDKs = cloneSDKs(current.SDKs)
+
+	// legacy-default-path is migration state for a specific local module tree,
+	// so it is not inherited either.
+	for name, entry := range merged.Modules {
+		entry.LegacyDefaultPath = false
+		merged.Modules[name] = entry
+	}
+
+	if currentKeys[keyIgnore] {
+		merged.Ignore = append([]string(nil), current.Ignore...)
+	}
+	if currentKeys[keyDefaultsFromDotEnv] {
+		merged.DefaultsFromDotEnv = current.DefaultsFromDotEnv
+	}
+	if current.CheckGenerated != nil {
+		checkGenerated := *current.CheckGenerated
+		merged.CheckGenerated = &checkGenerated
+	}
+
+	mergeIncludedModules(merged, current, currentKeys)
+	mergeIncludedEnvs(merged, current)
+	mergeIncludedPorts(merged, current)
+
+	return merged, nil
+}
+
+const (
+	keyIgnore             = "ignore"
+	keyDefaultsFromDotEnv = "defaults_from_dotenv"
+)
+
+func mergeIncludedModules(merged, current *Config, currentKeys map[string]bool) {
+	if len(current.Modules) == 0 {
+		return
+	}
+	if merged.Modules == nil {
+		merged.Modules = map[string]ModuleEntry{}
+	}
+	for name, overlay := range current.Modules {
+		entry, inherited := merged.Modules[name]
+		if !inherited {
+			merged.Modules[name] = cloneModuleEntry(overlay)
+			continue
+		}
+
+		// A source replaces the inherited one and its pin travels with it; a
+		// lone pin updates the inherited pin in place. Same coupling env
+		// overlays already use.
+		if overlay.Source != "" {
+			entry.Source = overlay.Source
+			entry.Pin = overlay.Pin
+		} else if overlay.Pin != "" {
+			entry.Pin = overlay.Pin
+		}
+		if len(overlay.Settings) > 0 {
+			if entry.Settings == nil {
+				entry.Settings = map[string]any{}
+			}
+			for key, value := range overlay.Settings {
+				entry.Settings[key] = value
+			}
+		}
+		prefix := JoinConfigPath("modules", name)
+		if currentKeys[prefix+".entrypoint"] {
+			entry.Entrypoint = overlay.Entrypoint
+		}
+		entry.LegacyDefaultPath = overlay.LegacyDefaultPath
+		if currentKeys[prefix+".up.skip"] {
+			entry.Up = ModuleSkip{Skip: append([]string(nil), overlay.Up.Skip...)}
+		}
+		if currentKeys[prefix+".generate.skip"] {
+			entry.Generate = ModuleSkip{Skip: append([]string(nil), overlay.Generate.Skip...)}
+		}
+		if currentKeys[prefix+".check.skip"] {
+			entry.Check = ModuleSkip{Skip: append([]string(nil), overlay.Check.Skip...)}
+		}
+		merged.Modules[name] = entry
+	}
+}
+
+// mergeIncludedEnvs layers the current config's envs over the inherited ones
+// with mergeEnvOverlay, the same merge the user-level overlay uses: per env,
+// per module, source/pin coupled and settings key by key — exactly the rules
+// the merge table states for env.<name>.modules.<mod>.
+func mergeIncludedEnvs(merged, current *Config) {
+	if len(current.Env) == 0 {
+		return
+	}
+	if merged.Env == nil {
+		merged.Env = map[string]EnvOverlay{}
+	}
+	for envName, currentEnv := range current.Env {
+		merged.Env[envName] = mergeEnvOverlay(merged.Env[envName], currentEnv)
+	}
+}
+
+// mergeIncludedPorts replaces an inherited mapping wholesale per host port. A
+// service and its backend port are one unit, and the config serializer writes
+// both keys unconditionally, so a per-field merge would read a written-out
+// `backendPort = 0` as a deliberate override.
+func mergeIncludedPorts(merged, current *Config) {
+	if len(current.Ports) == 0 {
+		return
+	}
+	if merged.Ports == nil {
+		merged.Ports = map[string]PortMapping{}
+	}
+	for host, mapping := range current.Ports {
+		merged.Ports[host] = mapping
+	}
+}
+
+func cloneModuleEntry(entry ModuleEntry) ModuleEntry {
+	return ModuleEntry{
+		Source:            entry.Source,
+		Pin:               entry.Pin,
+		Settings:          cloneConfigMap(entry.Settings),
+		Entrypoint:        entry.Entrypoint,
+		LegacyDefaultPath: entry.LegacyDefaultPath,
+		Up:                ModuleSkip{Skip: append([]string(nil), entry.Up.Skip...)},
+		Generate:          ModuleSkip{Skip: append([]string(nil), entry.Generate.Skip...)},
+		Check:             ModuleSkip{Skip: append([]string(nil), entry.Check.Skip...)},
+	}
+}
+
+// ValidateEffectiveConfig checks the invariant the file format alone no longer
+// guarantees, on the config that will actually be used: every module entry
+// names a source.
+//
+// A module entry may omit its source in the file — that is how a workspace
+// overrides one setting of an included module without repeating its ref — so
+// the completeness check moved here, and runs for every config, whether or not
+// it includes one. Gating it on an include being present would mean removing
+// the include silently turns a valid override into an entry that names
+// nothing.
+//
+// Port mappings are deliberately not checked, even though they merge wholesale:
+// `dagger workspace config ports.3000.backendService web` writes one key while
+// the serializers always write both, so a partial mapping is a state the CLI
+// itself produces, and validating it here would make configs that load today
+// start failing on every read.
+func ValidateEffectiveConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	var problems []string
+	for _, name := range sortedKeys(cfg.Modules) {
+		if cfg.Modules[name].Source == "" {
+			problems = append(problems, fmt.Sprintf("module %q has no source", name))
+		}
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+
+	detail := strings.Join(problems, "; ")
+	if source := currentIncludeSource(cfg); source != "" {
+		return fmt.Errorf("invalid workspace config after merging include %q: %s (an entry with no source must be provided by the included config)", source, detail)
+	}
+	return fmt.Errorf("invalid workspace config: %s (name a source, or add an [[include]] whose config provides it)", detail)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// currentIncludeSource names the include a config declares, for error messages.
+func currentIncludeSource(cfg *Config) string {
+	if cfg == nil || len(cfg.Include) == 0 {
+		return ""
+	}
+	return cfg.Include[0].Source
+}
+
+// rewriteIncludeBlocks replaces the document's [[include]] blocks with the ones
+// in desired, leaving the rest of the text untouched.
+//
+// It exists because [[include]] is the only array of tables a workspace config
+// carries, and the document editor declines to edit those — so an include is
+// rewritten as text rather than as a key. When the list did not change the
+// document is returned verbatim, which is what keeps a comment inside the block,
+// and the position its author chose, across an unrelated write.
+func rewriteIncludeBlocks(data []byte, existing, desired []IncludeEntry) []byte {
+	if slices.Equal(existing, desired) {
+		return data
+	}
+
+	lines := strings.Split(string(data), "\n")
+	kept := make([]string, 0, len(lines))
+	// The first table header is where bare keys stop being legal, so a new
+	// block has to go in ahead of it.
+	insertAt := -1
+	inInclude := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inInclude = trimmed == "[[include]]"
+			if insertAt < 0 {
+				insertAt = len(kept)
+			}
+		}
+		if !inInclude {
+			kept = append(kept, line)
+		}
+	}
+	if insertAt < 0 {
+		insertAt = len(kept)
+	}
+
+	if len(desired) == 0 {
+		return []byte(trimBlankRun(kept))
+	}
+
+	var block strings.Builder
+	for _, include := range desired {
+		fmt.Fprintf(&block, "[[include]]\nsource = %q\n\n", include.Source)
+	}
+	rendered := strings.Split(strings.TrimSuffix(block.String(), "\n"), "\n")
+	merged := append(append(append([]string{}, kept[:insertAt]...), rendered...), kept[insertAt:]...)
+	return []byte(trimBlankRun(merged))
+}
+
+// trimBlankRun joins lines, collapsing the runs of blank lines that removing a
+// block leaves behind.
+func trimBlankRun(lines []string) string {
+	out := make([]string, 0, len(lines))
+	blank := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			blank++
+			if blank > 1 {
+				continue
+			}
+		} else {
+			blank = 0
+		}
+		out = append(out, line)
+	}
+	text := strings.Join(out, "\n")
+	return strings.TrimLeft(text, "\n")
+}

--- a/core/workspace/include_test.go
+++ b/core/workspace/include_test.go
@@ -1,0 +1,602 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mergeIncluded parses both configs from their TOML source, so every case
+// exercises the same explicit-key detection the engine uses.
+func mergeIncluded(t *testing.T, includedTOML, currentTOML string) (*Config, error) {
+	t.Helper()
+
+	included, err := ParseConfig([]byte(includedTOML))
+	require.NoError(t, err)
+	current, err := ParseConfig([]byte(currentTOML))
+	require.NoError(t, err)
+	currentKeys, err := ExplicitConfigKeys([]byte(currentTOML))
+	require.NoError(t, err)
+
+	return MergeIncludedConfig(included, current, currentKeys)
+}
+
+func mustMergeIncluded(t *testing.T, includedTOML, currentTOML string) *Config {
+	t.Helper()
+
+	merged, err := mergeIncluded(t, includedTOML, currentTOML)
+	require.NoError(t, err)
+	return merged
+}
+
+func TestMergeIncludedConfigInheritsAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	included := `ignore = ["base-dist"]
+defaults_from_dotenv = true
+check-generated = false
+
+[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+pin = "aaa"
+entrypoint = true
+up.skip = ["base-service"]
+
+[modules.go.settings]
+version = "1.22"
+strict = true
+
+[modules.node]
+source = "github.com/acme/node-toolchain@v2"
+`
+
+	current := `[modules.go.settings]
+version = "1.24"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	require.Equal(t, []IncludeEntry{{Source: "github.com/acme/base@v1"}}, merged.Include)
+	require.Equal(t, []string{"base-dist"}, merged.Ignore)
+	require.True(t, merged.DefaultsFromDotEnv)
+	require.NotNil(t, merged.CheckGenerated)
+	require.False(t, *merged.CheckGenerated)
+
+	// The source-less entry inherits its ref, pin, entrypoint and skips, and
+	// overrides one setting while keeping the others.
+	goEntry := merged.Modules["go"]
+	require.Equal(t, "github.com/acme/go-toolchain@v1", goEntry.Source)
+	require.Equal(t, "aaa", goEntry.Pin)
+	require.True(t, goEntry.Entrypoint)
+	require.Equal(t, []string{"base-service"}, goEntry.Up.Skip)
+	require.Equal(t, map[string]any{"version": "1.24", "strict": true}, goEntry.Settings)
+
+	require.Equal(t, "github.com/acme/node-toolchain@v2", merged.Modules["node"].Source)
+}
+
+func TestMergeIncludedConfigCurrentWins(t *testing.T) {
+	t.Parallel()
+
+	included := `ignore = ["base-dist"]
+
+[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+pin = "aaa"
+
+[modules.go.settings]
+version = "1.22"
+
+[ports.3000]
+backendService = "base:web"
+backendPort = 8080
+`
+
+	current := `ignore = ["dist"]
+
+[modules.go]
+source = "github.com/acme/go-toolchain@v2"
+
+[ports.3000]
+backendService = "app:web"
+backendPort = 9090
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	require.Equal(t, []string{"dist"}, merged.Ignore)
+	// A replacing source drops the inherited pin, which belonged to the ref it
+	// replaced.
+	require.Equal(t, "github.com/acme/go-toolchain@v2", merged.Modules["go"].Source)
+	require.Empty(t, merged.Modules["go"].Pin)
+	require.Equal(t, map[string]any{"version": "1.22"}, merged.Modules["go"].Settings)
+	require.Equal(t, PortMapping{BackendService: "app:web", BackendPort: 9090}, merged.Ports["3000"])
+}
+
+func TestMergeIncludedConfigLonePinUpdatesInheritedSource(t *testing.T) {
+	t.Parallel()
+
+	included := `[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+pin = "aaa"
+`
+	current := `[modules.go]
+pin = "bbb"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	require.Equal(t, "github.com/acme/go-toolchain@v1", merged.Modules["go"].Source)
+	require.Equal(t, "bbb", merged.Modules["go"].Pin)
+}
+
+func TestMergeIncludedConfigExplicitZeroOverrides(t *testing.T) {
+	t.Parallel()
+
+	included := `ignore = ["base-dist"]
+defaults_from_dotenv = true
+check-generated = true
+
+[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+entrypoint = true
+check.skip = ["lint"]
+`
+
+	current := `ignore = []
+defaults_from_dotenv = false
+check-generated = false
+
+[modules.go]
+entrypoint = false
+check.skip = []
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	require.Empty(t, merged.Ignore)
+	require.False(t, merged.DefaultsFromDotEnv)
+	require.NotNil(t, merged.CheckGenerated)
+	require.False(t, *merged.CheckGenerated)
+	require.False(t, merged.Modules["go"].Entrypoint)
+	require.Empty(t, merged.Modules["go"].Check.Skip)
+}
+
+func TestMergeIncludedConfigExplicitEmptySkipsOverride(t *testing.T) {
+	t.Parallel()
+
+	included := `[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+up.skip = ["base-service"]
+generate.skip = ["base-client"]
+check.skip = ["lint"]
+`
+
+	current := `[modules.go]
+up.skip = []
+generate.skip = []
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	entry := merged.Modules["go"]
+	require.Empty(t, entry.Up.Skip)
+	require.Empty(t, entry.Generate.Skip)
+	require.Equal(t, []string{"lint"}, entry.Check.Skip, "a skip list the current config leaves alone is inherited")
+}
+
+func TestMergeIncludedConfigEnvSourcePinCoupling(t *testing.T) {
+	t.Parallel()
+
+	included := `[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+
+[env.ci.modules.go]
+source = "github.com/acme/go-toolchain@v2"
+pin = "aaa"
+settings.version = "1.22"
+`
+
+	current := `[env.ci.modules.go]
+source = "github.com/acme/go-toolchain@v3"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	overlay := merged.Env["ci"].Modules["go"]
+	require.Equal(t, "github.com/acme/go-toolchain@v3", overlay.Source)
+	require.Empty(t, overlay.Pin, "the inherited pin belonged to the ref the current source replaced")
+	require.Equal(t, map[string]any{"version": "1.22"}, overlay.Settings)
+}
+
+func TestMergeIncludedConfigKeepsInheritedWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	included := `ignore = ["base-dist"]
+defaults_from_dotenv = true
+
+[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+entrypoint = true
+check.skip = ["lint"]
+`
+
+	current := `[modules.go.settings]
+version = "1.24"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	require.Equal(t, []string{"base-dist"}, merged.Ignore)
+	require.True(t, merged.DefaultsFromDotEnv)
+	require.True(t, merged.Modules["go"].Entrypoint)
+	require.Equal(t, []string{"lint"}, merged.Modules["go"].Check.Skip)
+}
+
+func TestMergeIncludedConfigDropsSDKsAndLegacyDefaultPath(t *testing.T) {
+	t.Parallel()
+
+	included := `[modules.go-sdk]
+source = "github.com/acme/go-sdk@v1"
+legacy-default-path = true
+
+[sdks.go]
+module = "go-sdk"
+
+[sdks.go.scopes."modules/ci"]
+is-module = true
+`
+
+	current := `
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	entry := merged.Modules["go-sdk"]
+	require.Equal(t, "github.com/acme/go-sdk@v1", entry.Source, "the provider module is still inherited")
+	require.False(t, entry.LegacyDefaultPath)
+	require.Empty(t, merged.SDKs, "an included SDK's scopes are paths into the base tree")
+}
+
+func TestMergeIncludedConfigKeepsCurrentSDKs(t *testing.T) {
+	t.Parallel()
+
+	included := `[modules.go-sdk]
+source = "github.com/acme/go-sdk@v1"
+
+[sdks.base-go]
+module = "go-sdk"
+`
+
+	// The provider is installed locally: ValidateSDKs runs when the file is
+	// parsed, so an SDK whose provider only exists in the included config
+	// cannot be declared here. See the design doc's SDK section.
+	current := `[modules.go-sdk]
+source = "github.com/acme/local-go-sdk@v2"
+
+[sdks.go]
+module = "go-sdk"
+
+[sdks.go.scopes."modules/ci"]
+is-module = true
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	// Wholesale, not merged: the current workspace's declarations are the only
+	// ones whose scopes name paths that exist here.
+	require.Equal(t, map[string]SDKEntry{
+		"go": {
+			Module: "go-sdk",
+			Scopes: map[string]SDKScope{"modules/ci": {IsModule: true}},
+		},
+	}, merged.SDKs)
+}
+
+func TestMergeIncludedConfigEnvs(t *testing.T) {
+	t.Parallel()
+
+	included := `[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+
+[env.ci.modules.go.settings]
+version = "1.22"
+strict = true
+
+[env.base-only.modules.go.settings]
+version = "1.20"
+`
+
+	current := `[env.ci.modules.go.settings]
+version = "1.24"
+
+[env.local.modules.go.settings]
+version = "1.25"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`
+
+	merged := mustMergeIncluded(t, included, current)
+
+	require.Equal(t, map[string]any{"version": "1.24", "strict": true}, merged.Env["ci"].Modules["go"].Settings)
+	require.Equal(t, map[string]any{"version": "1.20"}, merged.Env["base-only"].Modules["go"].Settings)
+	require.Equal(t, map[string]any{"version": "1.25"}, merged.Env["local"].Modules["go"].Settings)
+}
+
+func TestMergeIncludedConfigRejectsNestedInclude(t *testing.T) {
+	t.Parallel()
+
+	_, err := mergeIncluded(t,
+		`[[include]]
+source = "github.com/acme/deeper@v1"`,
+		`[[include]]
+source = "github.com/acme/base@v1"`,
+	)
+
+	var nested *NestedIncludeError
+	require.ErrorAs(t, err, &nested)
+	require.Equal(t, "github.com/acme/base@v1", nested.Include)
+	require.Equal(t, "github.com/acme/deeper@v1", nested.Nested)
+	require.Contains(t, err.Error(), "nested includes are not supported")
+}
+
+func TestMergeIncludedConfigWithoutIncludedConfig(t *testing.T) {
+	t.Parallel()
+
+	current, err := ParseConfig([]byte(`[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+`))
+	require.NoError(t, err)
+
+	merged, err := MergeIncludedConfig(nil, current, nil)
+	require.NoError(t, err)
+	require.Equal(t, "github.com/acme/go-toolchain@v1", merged.Modules["go"].Source)
+}
+
+func TestValidateEffectiveConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts a complete config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte(`[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+
+[ports.3000]
+backendService = "app:web"
+backendPort = 8080
+`))
+		require.NoError(t, err)
+		require.NoError(t, ValidateEffectiveConfig(cfg))
+	})
+
+	t.Run("rejects a source-less module with no include", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := ParseConfig([]byte(`[modules.go.settings]
+version = "1.24"
+`))
+		require.NoError(t, err)
+
+		err = ValidateEffectiveConfig(cfg)
+		require.ErrorContains(t, err, `module "go" has no source`)
+		require.ErrorContains(t, err, "name a source, or add an [[include]]")
+		require.NotContains(t, err.Error(), "after merging include", "there is no include to blame")
+	})
+
+	t.Run("rejects a source-less module left over by an include", func(t *testing.T) {
+		t.Parallel()
+
+		merged := mustMergeIncluded(t,
+			`[modules.node]
+source = "github.com/acme/node-toolchain@v1"
+`,
+			`[modules.go.settings]
+version = "1.24"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`)
+
+		err := ValidateEffectiveConfig(merged)
+		require.ErrorContains(t, err, `module "go" has no source`)
+		require.ErrorContains(t, err, "github.com/acme/base@v1")
+	})
+
+	t.Run("accepts a partial port mapping", func(t *testing.T) {
+		t.Parallel()
+
+		// `dagger workspace config ports.3000.backendService web` writes one key
+		// at a time, so a half-written mapping is a state the CLI produces and
+		// existing configs are in; rejecting it would break reads that work.
+		cfg, err := ParseConfig([]byte(`[ports.3000]
+backendService = "app:web"
+`))
+		require.NoError(t, err)
+		require.NoError(t, ValidateEffectiveConfig(cfg))
+
+		cfg, err = ParseConfig([]byte(`[ports.3000]
+backendPort = 8080
+`))
+		require.NoError(t, err)
+		require.NoError(t, ValidateEffectiveConfig(cfg))
+	})
+}
+
+func TestExplicitConfigKeys(t *testing.T) {
+	t.Parallel()
+
+	keys, err := ExplicitConfigKeys([]byte(`ignore = []
+
+[modules.go]
+entrypoint = false
+check.skip = []
+
+[modules."my.mod"]
+source = "github.com/acme/mod@v1"
+
+[modules.go.settings]
+version = "1.24"
+
+[ports.3000]
+backendPort = 8080
+
+[sdks.go]
+module = "go"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`))
+	require.NoError(t, err)
+
+	for _, key := range []string{
+		"ignore",
+		"modules.go.entrypoint",
+		"modules.go.check.skip",
+		"modules.go.settings.version",
+		`modules."my.mod".source`,
+		"ports.3000.backendPort",
+	} {
+		require.True(t, keys[key], "expected explicit key %q in %v", key, keys)
+	}
+	require.False(t, keys["modules.go.source"], "absent keys must not be reported as explicit")
+	require.True(t, keys["sdks.go.module"], "ordinary keys under a new top-level table are still explicit")
+	require.False(t, keys["include"], "the include list is carried over wholesale, so its presence decides nothing")
+}
+
+func TestConfigIncludeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseConfig([]byte(`[modules.go.settings]
+version = "1.24"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`))
+	require.NoError(t, err)
+	require.Equal(t, []IncludeEntry{{Source: "github.com/acme/base@v1"}}, cfg.Include)
+
+	serialized := SerializeConfig(cfg)
+	require.Contains(t, string(serialized), `[[include]]
+source = "github.com/acme/base@v1"`)
+	require.NotContains(t, string(serialized), `source = ""`)
+
+	reparsed, err := ParseConfig(serialized)
+	require.NoError(t, err)
+	require.Equal(t, cfg.Include, reparsed.Include)
+	require.Equal(t, cfg.Modules, reparsed.Modules)
+}
+
+func TestValidateIncludesRejectsAnEmptySource(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseConfig([]byte(`[[include]]
+source = ""
+`))
+	require.NoError(t, err)
+	require.ErrorContains(t, ValidateIncludes(cfg), "workspace include 1 has no source")
+
+	// And the CLI refuses to write one in the first place.
+	_, err = WriteConfigValue(nil, "include", "")
+	require.ErrorContains(t, err, "include source is required")
+}
+
+func TestConfigIncludeWriteReadDelete(t *testing.T) {
+	t.Parallel()
+
+	// The config shape is an array of tables, but the CLI addresses the single
+	// supported include as one value.
+	written, err := WriteConfigValue(nil, "include", "github.com/acme/base@v1")
+	require.NoError(t, err)
+	require.Contains(t, string(written), "[[include]]")
+
+	cfg, err := ParseConfig(written)
+	require.NoError(t, err)
+	require.Equal(t, []IncludeEntry{{Source: "github.com/acme/base@v1"}}, cfg.Include)
+
+	// Setting it again replaces rather than appends: only one is supported.
+	rewritten, err := WriteConfigValue(written, "include", "github.com/acme/other@v2")
+	require.NoError(t, err)
+	cfg, err = ParseConfig(rewritten)
+	require.NoError(t, err)
+	require.Equal(t, []IncludeEntry{{Source: "github.com/acme/other@v2"}}, cfg.Include)
+}
+
+func TestUpdateConfigBytesKeepsSourcelessOverride(t *testing.T) {
+	t.Parallel()
+
+	existing := []byte(`# base config
+[modules.go]
+settings.version = "1.24"
+
+[[include]]
+source = "github.com/acme/base@v1"
+`)
+
+	updated, err := WriteConfigValue(existing, "modules.go.settings.strict", "true")
+	require.NoError(t, err)
+
+	require.NotContains(t, string(updated), `source = ""`)
+	require.Contains(t, string(updated), "# base config")
+
+	cfg, err := ParseConfig(updated)
+	require.NoError(t, err)
+	require.Equal(t, []IncludeEntry{{Source: "github.com/acme/base@v1"}}, cfg.Include)
+	require.Equal(t, map[string]any{"version": "1.24", "strict": true}, cfg.Modules["go"].Settings)
+}
+
+func TestUpdateConfigBytesLeavesAnUntouchedIncludeAlone(t *testing.T) {
+	t.Parallel()
+
+	existing := []byte(`ignore = ["node_modules"]
+
+[modules.go]
+source = "github.com/acme/go-toolchain@v1"
+
+# the team's shared base, pinned by dagger.lock
+[[include]]
+source = "github.com/acme/base@v1"
+`)
+
+	updated, err := WriteConfigValue(existing, "modules.go.settings.strict", "true")
+	require.NoError(t, err)
+
+	// A write that has nothing to do with the include must not move the block
+	// or drop the comment above it.
+	require.Contains(t, string(updated), "# the team's shared base, pinned by dagger.lock\n[[include]]")
+	require.Greater(t, strings.Index(string(updated), "[[include]]"), strings.Index(string(updated), "[modules.go]"))
+
+	cfg, err := ParseConfig(updated)
+	require.NoError(t, err)
+	require.Equal(t, []IncludeEntry{{Source: "github.com/acme/base@v1"}}, cfg.Include)
+	require.Equal(t, []string{"node_modules"}, cfg.Ignore)
+	require.Equal(t, map[string]any{"strict": true}, cfg.Modules["go"].Settings)
+}

--- a/core/workspace_include.go
+++ b/core/workspace_include.go
@@ -1,0 +1,361 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/slog"
+	telemetry "github.com/dagger/otel-go"
+	"github.com/iancoleman/strcase"
+)
+
+// IncludeSource is what an [[include]] entry needs to be resolved: where the
+// including config sits inside its workspace, how to read files there, and how
+// to resolve a git ref. ConfigDir and the paths handed to ReadWorkspaceFile are
+// workspace-relative; the reader may be nil for a caller that can only resolve
+// git includes.
+type IncludeSource struct {
+	Dag               *dagql.Server
+	ConfigDir         string
+	ReadWorkspaceFile func(ctx context.Context, wsPath string) ([]byte, error)
+}
+
+// resolveIncludePath turns an include source into a workspace-relative path,
+// following the same rule as every other path a workspace resolves
+// (resolveWorkspacePath): a leading "/" means the workspace root, anything else
+// is relative — here to the directory of the config that declares the include,
+// because that is what the path sits next to.
+func (s IncludeSource) resolveIncludePath(source string) (string, error) {
+	// filepath.ToSlash is a no-op on the engine reading this, so a path spelled
+	// with Windows separators is normalized explicitly, as ResolveSDKManagedPath
+	// and resolveWorkspacePath both do.
+	clean := path.Clean(strings.ReplaceAll(source, `\`, "/"))
+	var resolved string
+	if path.IsAbs(clean) {
+		resolved = strings.TrimPrefix(clean, "/")
+	} else {
+		resolved = path.Join(filepath.ToSlash(s.ConfigDir), clean)
+	}
+	resolved = path.Clean(resolved)
+	if resolved == "" {
+		resolved = "."
+	}
+	if resolved != "." && !filepath.IsLocal(filepath.FromSlash(resolved)) {
+		return "", fmt.Errorf("%q escapes the workspace root", source)
+	}
+	return resolved, nil
+}
+
+// DefaultIncludeConfigFile is appended to an include source that names a
+// directory rather than a config file.
+const DefaultIncludeConfigFile = workspace.ConfigFileName
+
+// ApplyIncludes layers cfg on top of the config it includes and returns what
+// the workspace will actually use. Every path that builds an effective config
+// goes through here, validation included, so a new one cannot resolve an
+// include and then skip a step the others take.
+//
+// explicitKeys are the keys cfg's own file spells out, which is what tells an
+// explicit `entrypoint = false` from an absent one; workspace.ExplicitConfigKeys
+// reads them from the bytes cfg was parsed from. src is consulted only when cfg
+// declares an include, so a caller that has none may pass the zero value rather
+// than build a resolver it will not use.
+func ApplyIncludes(
+	ctx context.Context,
+	src IncludeSource,
+	cfg *workspace.Config,
+	explicitKeys map[string]bool,
+) (*workspace.Config, error) {
+	if cfg != nil && len(cfg.Include) > 0 {
+		if err := workspace.ValidateIncludes(cfg); err != nil {
+			return nil, err
+		}
+		included, err := LoadIncludedConfig(ctx, src, cfg.Include[0].Source)
+		if err != nil {
+			return nil, err
+		}
+		cfg, err = workspace.MergeIncludedConfig(included, cfg, explicitKeys)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := workspace.ValidateEffectiveConfig(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadIncludedConfig resolves one [[include]] source and returns the config it
+// names, with everything that cannot cross the include boundary removed.
+//
+// The source addresses a config *file*, not a workspace: either a path relative
+// to the including config's directory, or a git ref whose fragment names the
+// file inside the repository. A source that names a directory gets
+// dagger.toml appended.
+//
+// The caller merges the result underneath its own config. A git include
+// resolves through the normal git selectors, so its commit lands in the
+// consuming workspace's dagger.lock like any other git lookup.
+func LoadIncludedConfig(
+	ctx context.Context,
+	source IncludeSource,
+	include string,
+) (_ *workspace.Config, rerr error) {
+	if include == "" {
+		return nil, nil
+	}
+
+	// The warning below is written to the caller's context, not the span's:
+	// progress renderers surface top-level logs, and a notice about modules
+	// that silently went missing has to be seen.
+	callerCtx := ctx
+	ctx, span := Tracer(ctx).Start(ctx, fmt.Sprintf("including workspace config: %s", include))
+	defer telemetry.EndWithCause(span, &rerr)
+
+	var (
+		cfg *workspace.Config
+		err error
+	)
+	if IncludeSourceIsGit(include) {
+		cfg, err = source.loadGitInclude(ctx, include)
+	} else {
+		cfg, err = source.loadLocalInclude(ctx, include)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("workspace include %q: %w", include, err)
+	}
+
+	warnDroppedIncludedModules(callerCtx, include, dropLocalIncludedModules(cfg))
+
+	return cfg, nil
+}
+
+// IncludeSourceIsGit reports whether an include source addresses a git
+// repository rather than a path next to the including config.
+//
+// This is workspace.IsLocalRef, the classifier every other ref in a workspace
+// config is read with: only the segment ahead of the first separator can be a
+// host, so common/base.toml is a path and github.com/acme/base@v1 is a ref,
+// neither needing a scheme. Answering the same question the same way
+// everywhere is worth more than a rule tuned for the file paths an include
+// happens to favour — the one place they differ, a dotted filename directly
+// beside the config, is spelled ./base.toml.
+func IncludeSourceIsGit(source string) bool {
+	return !workspace.IsLocalRef(source, "")
+}
+
+func (s IncludeSource) loadGitInclude(
+	ctx context.Context,
+	include string,
+) (*workspace.Config, error) {
+	if s.Dag == nil {
+		return nil, fmt.Errorf("git includes cannot be resolved here")
+	}
+
+	parsedRef, err := ParseWorkspaceRemoteRef(ctx, include)
+	if err != nil {
+		if looksLikeSiblingConfigFile(include) {
+			// The source read as a ref only because its first segment has a
+			// dot, which is also true of a filename. Say so, since the file it
+			// names is otherwise reported as a repository nobody can find.
+			return nil, fmt.Errorf("parsing git ref: %w (a config file beside this one is spelled %q)", err, "./"+include)
+		}
+		return nil, fmt.Errorf("parsing git ref: %w", err)
+	}
+
+	tree, _, err := CloneWorkspaceGitTree(ctx, s.Dag, parsedRef)
+	if err != nil {
+		return nil, err
+	}
+
+	configPath := includeConfigPath(parsedRef.WorkspaceSubdir)
+	data, err := DirectoryReadFile(ctx, tree, configPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", configPath, err)
+	}
+	return workspace.ParseConfig(data)
+}
+
+func (s IncludeSource) loadLocalInclude(
+	ctx context.Context,
+	include string,
+) (*workspace.Config, error) {
+	if s.ReadWorkspaceFile == nil {
+		return nil, fmt.Errorf("path includes cannot be resolved here")
+	}
+
+	resolved, err := s.resolveIncludePath(include)
+	if err != nil {
+		return nil, err
+	}
+	configPath := includeConfigPath(resolved)
+	data, err := s.ReadWorkspaceFile(ctx, configPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", configPath, err)
+	}
+	return workspace.ParseConfig(data)
+}
+
+// looksLikeSiblingConfigFile reports whether a source that failed to parse as a
+// git ref is more plausibly a file below the including config: nothing that
+// only a ref carries — scheme, fragment, version — and a config file's name at
+// the end. Deliberately narrower than the file rule includeConfigPath applies,
+// so a genuine ref that happens to end in .git is never told it is a path.
+func looksLikeSiblingConfigFile(source string) bool {
+	return !strings.ContainsAny(source, "#@:") && path.Ext(source) == ".toml"
+}
+
+// includeConfigPath appends the default config filename to a source that names
+// a directory, so a `…#main:dagger/common` fragment and `../common` both reach
+// the config inside.
+//
+// Which one a source names is decided from its spelling — an extension means a
+// file — because the two filesystems an include is read through, a local
+// workspace and a cloned git tree, have no statting in common. That keeps a
+// mistyped dagger.tml a file rather than a directory to look inside; a
+// directory whose own name has an extension is reached by naming the config
+// in it.
+func includeConfigPath(p string) string {
+	p = path.Clean(strings.ReplaceAll(p, `\`, "/"))
+	if p == "." || p == "/" {
+		return DefaultIncludeConfigFile
+	}
+	if path.Ext(p) != "" {
+		return p
+	}
+	return path.Join(p, DefaultIncludeConfigFile)
+}
+
+// dropLocalIncludedModules removes the module entries a workspace must not load
+// through an include: the included config's own local modules. It returns the
+// dropped entries, labelled the way the config spells them — including dotted
+// `env.<name>.modules.<mod>` paths for env overlays.
+//
+// A local source in an included config means a directory next to *that* config,
+// and resolving it as written would resolve it against the consuming workspace
+// instead — a different module, or none. Addressing them properly is possible
+// (an included git config's modules are reachable as refs into its repository)
+// but is deliberately left for later; for now an include shares configuration,
+// not code.
+func dropLocalIncludedModules(cfg *workspace.Config) []string {
+	// The labels name config paths, so they cannot be used to match ports: the
+	// module names the dropped entries denote are tracked separately.
+	var dropped, droppedModules []string
+	for name, entry := range cfg.Modules {
+		if !includedSourceIsLocal(entry.Source) {
+			continue
+		}
+		delete(cfg.Modules, name)
+		dropped = append(dropped, name)
+		droppedModules = append(droppedModules, name)
+	}
+
+	for envName, env := range cfg.Env {
+		for moduleName, overlay := range env.Modules {
+			_, installed := cfg.Modules[moduleName]
+			switch {
+			case includedSourceIsLocal(overlay.Source):
+				// An overlay that installs a local module is the same
+				// violation as a base entry that does.
+				delete(env.Modules, moduleName)
+				dropped = append(dropped, workspace.JoinConfigPath("env", envName, "modules", moduleName))
+				if !installed {
+					// Nothing installs the module any more, so a port
+					// forwarding to it has nothing left to reach.
+					droppedModules = append(droppedModules, moduleName)
+				}
+			case overlay.Source == "" && !installed:
+				// Settings for a module that was just dropped configure
+				// nothing. An overlay with its own remote source stands on its
+				// own and stays.
+				delete(env.Modules, moduleName)
+			}
+		}
+		if len(env.Modules) == 0 {
+			env.Modules = nil
+		}
+		cfg.Env[envName] = env
+	}
+
+	dropPortsForDroppedModules(cfg, droppedModules)
+	sort.Strings(dropped)
+	return dropped
+}
+
+// includedSourceIsLocal reports whether a module source in an included config
+// addresses something next to that config.
+//
+// This is workspace.IsLocalRef, the same classifier the module loader reaches
+// through ResolveModuleEntrySource, and with the same empty pin: agreeing with
+// it is the whole correctness criterion here, because anything this keeps is
+// something the loader will then resolve. Passing the entry's own pin would
+// disagree — any non-empty pin reads as git — and let `source = "./ci",
+// pin = "…"` through to be resolved against the consuming workspace.
+func includedSourceIsLocal(source string) bool {
+	return source != "" && workspace.IsLocalRef(source, "")
+}
+
+// dropPortsForDroppedModules removes included port mappings that forward to a
+// module that no longer exists here. BackendService is a colon-joined service
+// path whose first segment is the module's CLI-cased name.
+func dropPortsForDroppedModules(cfg *workspace.Config, droppedNames []string) {
+	if len(cfg.Ports) == 0 || len(droppedNames) == 0 {
+		return
+	}
+	droppedModules := make(map[string]bool, len(droppedNames))
+	for _, name := range droppedNames {
+		droppedModules[strcase.ToKebab(name)] = true
+	}
+	for host, mapping := range cfg.Ports {
+		module, _, _ := strings.Cut(mapping.BackendService, ":")
+		if droppedModules[strcase.ToKebab(module)] {
+			delete(cfg.Ports, host)
+		}
+	}
+}
+
+// warnDroppedIncludedModules reports dropped entries once per client and
+// include source. It lives here rather than in the callers because the surfaces
+// that most need it — `dagger workspace config` and the other config reads —
+// connect with workspace module loading skipped entirely.
+func warnDroppedIncludedModules(ctx context.Context, include string, dropped []string) {
+	if len(dropped) == 0 || !shouldWarnDroppedIncludedModules(ctx, include) {
+		return
+	}
+
+	msg := fmt.Sprintf(
+		"Included config %s declares local modules that cannot be used here: %s. Only its remote modules are inherited.",
+		include, strings.Join(dropped, ", "),
+	)
+	slog.Warn(msg, "include", include, "dropped", dropped)
+	fmt.Fprintln(telemetry.GlobalWriter(ctx, ""), msg)
+}
+
+// shouldWarnDroppedIncludedModules dedups the warning, because every read path
+// resolves the include and they would otherwise repeat the same line several
+// times for one command. Scoping is per client rather than per session: a
+// nested CLI shares its parent's session, so session scope would silence every
+// command after the first. Without a store to dedup against, warn rather than
+// risk swallowing the only warning a run gets.
+func shouldWarnDroppedIncludedModules(ctx context.Context, include string) bool {
+	query, err := CurrentQuery(ctx)
+	if err != nil {
+		return true
+	}
+	seenKeys, err := query.TelemetrySeenKeyStore(ctx)
+	if err != nil {
+		return true
+	}
+	key := "workspace.include.dropped:" + include
+	if clientMetadata, err := engine.ClientMetadataFromContext(ctx); err == nil && clientMetadata.ClientID != "" {
+		key += ":" + clientMetadata.ClientID
+	}
+	return dagql.ShouldEmitTelemetry(ctx, seenKeys, key, false)
+}

--- a/core/workspace_include.go
+++ b/core/workspace_include.go
@@ -8,10 +8,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dagger/dagger/core/sdk/sdkmeta"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/dagger/dagger/util/gitutil"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/iancoleman/strcase"
 )
@@ -120,19 +122,20 @@ func LoadIncludedConfig(
 	defer telemetry.EndWithCause(span, &rerr)
 
 	var (
-		cfg *workspace.Config
-		err error
+		cfg     *workspace.Config
+		address includedModuleAddresser
+		err     error
 	)
 	if IncludeSourceIsGit(include) {
-		cfg, err = source.loadGitInclude(ctx, include)
+		cfg, address, err = source.loadGitInclude(ctx, include)
 	} else {
-		cfg, err = source.loadLocalInclude(ctx, include)
+		cfg, address, err = source.loadLocalInclude(ctx, include)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("workspace include %q: %w", include, err)
 	}
 
-	warnDroppedIncludedModules(callerCtx, include, dropLocalIncludedModules(cfg))
+	warnDroppedIncludedModules(callerCtx, include, addressIncludedModules(address, cfg))
 
 	return cfg, nil
 }
@@ -154,9 +157,9 @@ func IncludeSourceIsGit(source string) bool {
 func (s IncludeSource) loadGitInclude(
 	ctx context.Context,
 	include string,
-) (*workspace.Config, error) {
+) (*workspace.Config, includedModuleAddresser, error) {
 	if s.Dag == nil {
-		return nil, fmt.Errorf("git includes cannot be resolved here")
+		return nil, nil, fmt.Errorf("git includes cannot be resolved here")
 	}
 
 	parsedRef, err := ParseWorkspaceRemoteRef(ctx, include)
@@ -165,42 +168,70 @@ func (s IncludeSource) loadGitInclude(
 			// The source read as a ref only because its first segment has a
 			// dot, which is also true of a filename. Say so, since the file it
 			// names is otherwise reported as a repository nobody can find.
-			return nil, fmt.Errorf("parsing git ref: %w (a config file beside this one is spelled %q)", err, "./"+include)
+			return nil, nil, fmt.Errorf("parsing git ref: %w (a config file beside this one is spelled %q)", err, "./"+include)
 		}
-		return nil, fmt.Errorf("parsing git ref: %w", err)
+		return nil, nil, fmt.Errorf("parsing git ref: %w", err)
 	}
 
-	tree, _, err := CloneWorkspaceGitTree(ctx, s.Dag, parsedRef)
+	tree, gitRef, err := CloneWorkspaceGitTree(ctx, s.Dag, parsedRef)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	commit, err := includedGitCommit(gitRef)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	configPath := includeConfigPath(parsedRef.WorkspaceSubdir)
 	data, err := DirectoryReadFile(ctx, tree, configPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("reading %s: %w", configPath, err)
 	}
-	return workspace.ParseConfig(data)
+	cfg, err := workspace.ParseConfig(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cfg, gitIncludedModuleAddresser(parsedRef.CloneRef, commit, path.Dir(configPath)), nil
 }
 
 func (s IncludeSource) loadLocalInclude(
 	ctx context.Context,
 	include string,
-) (*workspace.Config, error) {
+) (*workspace.Config, includedModuleAddresser, error) {
 	if s.ReadWorkspaceFile == nil {
-		return nil, fmt.Errorf("path includes cannot be resolved here")
+		return nil, nil, fmt.Errorf("path includes cannot be resolved here")
 	}
 
 	resolved, err := s.resolveIncludePath(include)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	configPath := includeConfigPath(resolved)
 	data, err := s.ReadWorkspaceFile(ctx, configPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("reading %s: %w", configPath, err)
 	}
-	return workspace.ParseConfig(data)
+	cfg, err := workspace.ParseConfig(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cfg, pathIncludedModuleAddresser(path.Dir(configPath), s.ConfigDir), nil
+}
+
+// includedGitCommit is the commit an included config was read at. Every module
+// re-addressed into its repository is pinned to it, so the config and the
+// modules it names always come from one revision even if the branch moves
+// mid-run — and a commit SHA short-circuits the lock lookup, so no per-module
+// lock entry appears.
+func includedGitCommit(gitRef dagql.ObjectResult[*GitRef]) (string, error) {
+	if gitRef.Self() == nil || gitRef.Self().Ref == nil {
+		return "", fmt.Errorf("resolving the included commit: no git ref")
+	}
+	commit := gitRef.Self().Ref.SHA
+	if !gitutil.IsCommitSHA(commit) {
+		return "", fmt.Errorf("resolving the included commit: %q is not a commit SHA", commit)
+	}
+	return commit, nil
 }
 
 // looksLikeSiblingConfigFile reports whether a source that failed to parse as a
@@ -233,49 +264,90 @@ func includeConfigPath(p string) string {
 	return path.Join(p, DefaultIncludeConfigFile)
 }
 
-// dropLocalIncludedModules removes the module entries a workspace must not load
-// through an include: the included config's own local modules. It returns the
-// dropped entries, labelled the way the config spells them — including dotted
-// `env.<name>.modules.<mod>` paths for env overlays.
+// includedModuleAddresser re-addresses one local module source of an included
+// config so that it names the same module from the consuming workspace, or
+// reports that it cannot be named from here at all.
+type includedModuleAddresser func(source string) (string, bool)
+
+// addressIncludedModules makes the included config's own modules usable here,
+// and removes the ones that cannot be. It returns what was removed, labelled
+// the way the config spells it — including dotted `env.<name>.modules.<mod>`
+// paths for env overlays.
 //
-// A local source in an included config means a directory next to *that* config,
-// and resolving it as written would resolve it against the consuming workspace
-// instead — a different module, or none. Addressing them properly is possible
-// (an included git config's modules are reachable as refs into its repository)
-// but is deliberately left for later; for now an include shares configuration,
-// not code.
-func dropLocalIncludedModules(cfg *workspace.Config) []string {
-	// The labels name config paths, so they cannot be used to match ports: the
-	// module names the dropped entries denote are tracked separately.
-	var dropped, droppedModules []string
-	for name, entry := range cfg.Modules {
-		if !includedSourceIsLocal(entry.Source) {
-			continue
+// A local source in an included config names a directory next to *that* config,
+// so resolving it as written would resolve it against the consuming workspace
+// instead — a different module, or none. Re-addressing is what makes the
+// primary monorepo shape work: a shared config installs the modules beside it,
+// and the projects that include it get them.
+func addressIncludedModules(address includedModuleAddresser, cfg *workspace.Config) []string {
+	// The labels carry a reason and name config paths, so they can match
+	// neither modules nor ports: what each set is keyed by is tracked
+	// separately.
+	var dropped []string
+	droppedModules := map[string]bool{}
+	readdressedModules := map[string]bool{}
+	// Being some SDK's provider is what makes a bare runtime name a built-in
+	// install rather than a directory that happens to be called "go". Read
+	// from the config the entries came from, since that is where the claim was
+	// made — the merge discards these declarations straight afterwards.
+	sdkProviders := make(map[string]bool, len(cfg.SDKs))
+	for _, sdk := range cfg.SDKs {
+		if sdk.Module != "" {
+			sdkProviders[sdk.Module] = true
 		}
-		delete(cfg.Modules, name)
-		dropped = append(dropped, name)
-		droppedModules = append(droppedModules, name)
+	}
+	for name, entry := range cfg.Modules {
+		readdressed, verdict, why := addressIncludedSource(address, entry.Source, sdkProviders[name])
+		switch verdict {
+		case includedSourceKeep:
+		case includedSourceReaddress:
+			// The pin described the source that was just replaced; what the new
+			// ref resolves to is fixed by the ref itself.
+			entry.Source = readdressed
+			entry.Pin = ""
+			cfg.Modules[name] = entry
+			readdressedModules[name] = true
+		case includedSourceDrop:
+			delete(cfg.Modules, name)
+			dropped = append(dropped, name+" ("+why+")")
+			droppedModules[name] = true
+		}
 	}
 
 	for envName, env := range cfg.Env {
 		for moduleName, overlay := range env.Modules {
 			_, installed := cfg.Modules[moduleName]
+			// An overlay never carries as-sdk state, so a runtime name there is
+			// an ordinary source.
+			readdressed, verdict, why := addressIncludedSource(address, overlay.Source, false)
 			switch {
-			case includedSourceIsLocal(overlay.Source):
-				// An overlay that installs a local module is the same
-				// violation as a base entry that does.
+			case verdict == includedSourceReaddress:
+				overlay.Source = readdressed
+				overlay.Pin = ""
+				env.Modules[moduleName] = overlay
+				// The overlay installs the module even where the base entry
+				// could not be addressed, so a port forwarding to it still has
+				// something to reach.
+				delete(droppedModules, moduleName)
+			case verdict == includedSourceDrop:
+				// An overlay that installs a module with no address here is the
+				// same problem as a base entry that does.
 				delete(env.Modules, moduleName)
-				dropped = append(dropped, workspace.JoinConfigPath("env", envName, "modules", moduleName))
+				dropped = append(dropped, workspace.JoinConfigPath("env", envName, "modules", moduleName)+" ("+why+")")
 				if !installed {
 					// Nothing installs the module any more, so a port
 					// forwarding to it has nothing left to reach.
-					droppedModules = append(droppedModules, moduleName)
+					droppedModules[moduleName] = true
 				}
 			case overlay.Source == "" && !installed:
 				// Settings for a module that was just dropped configure
-				// nothing. An overlay with its own remote source stands on its
-				// own and stays.
+				// nothing. An overlay with its own source stands on its own.
 				delete(env.Modules, moduleName)
+			case overlay.Source == "" && readdressedModules[moduleName] && overlay.Pin != "":
+				// A lone pin updates the base entry's pin, and that entry now
+				// names something else entirely.
+				overlay.Pin = ""
+				env.Modules[moduleName] = overlay
 			}
 		}
 		if len(env.Modules) == 0 {
@@ -289,33 +361,151 @@ func dropLocalIncludedModules(cfg *workspace.Config) []string {
 	return dropped
 }
 
+type includedSourceVerdict int
+
+const (
+	// includedSourceKeep is a source that already addresses something outside
+	// the included config's own tree: a remote ref, or nothing at all.
+	includedSourceKeep includedSourceVerdict = iota
+	// includedSourceReaddress is one of the included config's own modules,
+	// nameable from the consuming workspace.
+	includedSourceReaddress
+	// includedSourceDrop is local to the included config and has no address
+	// here.
+	includedSourceDrop
+)
+
+// addressIncludedSource decides what becomes of one source string. It returns
+// the re-addressed ref when the verdict is includedSourceReaddress, and why the
+// source has no address here when it is includedSourceDrop.
+//
+// sdkInstall says the entry carries as-sdk state, which is what makes a bare
+// runtime name a built-in install rather than a directory that happens to be
+// called "go". The loader draws the line in the same place, so an entry without
+// it is an ordinary path however it is spelled.
+func addressIncludedSource(address includedModuleAddresser, source string, sdkInstall bool) (string, includedSourceVerdict, string) {
+	if source == "" {
+		return "", includedSourceKeep, ""
+	}
+	// Ahead of the path check, because "go@v1.2.3" carries a dot and so reads
+	// as a ref rather than a path. The runtime resolves in-engine either way,
+	// not by fetching, and the as-sdk state that gave the entry its purpose
+	// does not survive the merge.
+	if name, _, _ := strings.Cut(source, "@"); sdkInstall && sdkmeta.IsBuiltin(name) {
+		return "", includedSourceDrop, "built-in SDK runtime"
+	}
+	if !includedSourceIsLocal(source) {
+		return "", includedSourceKeep, ""
+	}
+	if readdressed, ok := address(source); ok {
+		return readdressed, includedSourceReaddress, ""
+	}
+	return "", includedSourceDrop, "no address outside the config it came from"
+}
+
 // includedSourceIsLocal reports whether a module source in an included config
 // addresses something next to that config.
 //
 // This is workspace.IsLocalRef, the same classifier the module loader reaches
 // through ResolveModuleEntrySource, and with the same empty pin: agreeing with
-// it is the whole correctness criterion here, because anything this keeps is
-// something the loader will then resolve. Passing the entry's own pin would
-// disagree — any non-empty pin reads as git — and let `source = "./ci",
-// pin = "…"` through to be resolved against the consuming workspace.
+// it is the whole correctness criterion here, because anything this leaves
+// alone is something the loader will then resolve as written. Passing the
+// entry's own pin would disagree — any non-empty pin reads as git — and let
+// `source = "./ci", pin = "…"` through to be resolved against the consuming
+// workspace.
 func includedSourceIsLocal(source string) bool {
 	return source != "" && workspace.IsLocalRef(source, "")
+}
+
+// gitIncludedModuleAddresser names an included config's own modules as refs
+// into the repository the config came from, pinned to the commit it was read
+// at: `modules/ci` beside a config at the repository root becomes
+// `<clone-ref>/modules/ci@<commit>`. That is the same rewrite remote workspace
+// selection already performs for a workspace loaded with -W.
+func gitIncludedModuleAddresser(cloneRef, commit, configDir string) includedModuleAddresser {
+	return func(source string) (string, bool) {
+		treePath, ok := includedModulePath(configDir, source)
+		if !ok {
+			return "", false
+		}
+		if strings.ContainsAny(treePath, "@#") {
+			// Both spell "version" in a ref, so a path carrying either would be
+			// cut short by the parser and resolve somewhere else entirely.
+			return "", false
+		}
+		return GitRefString(cloneRef, treePath, commit), true
+	}
+}
+
+// pathIncludedModuleAddresser names an included config's own modules the way
+// the consuming config would have written them itself. Both configs live in one
+// workspace, so only what the path is relative to changes.
+//
+// The result is always dot-prefixed, because a bare rewritten path whose first
+// segment carries a dot ("shared.v2/ci") would otherwise read back as a git
+// ref — the very confusion between a path and a ref this exists to prevent.
+func pathIncludedModuleAddresser(includedDir, consumerDir string) includedModuleAddresser {
+	if consumerDir == "" {
+		consumerDir = "."
+	}
+	return func(source string) (string, bool) {
+		wsPath, ok := includedModulePath(includedDir, source)
+		if !ok {
+			return "", false
+		}
+		rel, err := filepath.Rel(filepath.FromSlash(consumerDir), filepath.FromSlash(wsPath))
+		if err != nil {
+			return "", false
+		}
+		rel = filepath.ToSlash(rel)
+		if !strings.HasPrefix(rel, ".") {
+			rel = "./" + rel
+		}
+		return rel, true
+	}
+}
+
+// includedModulePath turns a local module source in an included config into the
+// path it names inside that config's own tree, or reports that it names nothing
+// addressable from outside it.
+func includedModulePath(configDir, source string) (string, bool) {
+	// Normalize separators first: a path spelled on Windows reaches a Linux
+	// engine with backslashes, and \\server\share would otherwise read as
+	// relative and be rebased under the config's directory.
+	source = strings.ReplaceAll(source, `\`, "/")
+	if path.IsAbs(source) || filepath.IsAbs(source) {
+		// An absolute path addresses the machine the config was authored on.
+		// Nothing in a shared tree corresponds to it.
+		return "", false
+	}
+	treePath := path.Clean(path.Join(filepath.ToSlash(configDir), source))
+	if treePath == "." {
+		// The tree's own root is a workspace, not a module.
+		return "", false
+	}
+	if !filepath.IsLocal(filepath.FromSlash(treePath)) {
+		// Escapes the tree it came from. GitRefString would quietly normalize
+		// this to a root-level path, resolving the wrong module rather than
+		// failing.
+		return "", false
+	}
+	return treePath, true
 }
 
 // dropPortsForDroppedModules removes included port mappings that forward to a
 // module that no longer exists here. BackendService is a colon-joined service
 // path whose first segment is the module's CLI-cased name.
-func dropPortsForDroppedModules(cfg *workspace.Config, droppedNames []string) {
+func dropPortsForDroppedModules(cfg *workspace.Config, droppedNames map[string]bool) {
 	if len(cfg.Ports) == 0 || len(droppedNames) == 0 {
 		return
 	}
-	droppedModules := make(map[string]bool, len(droppedNames))
-	for _, name := range droppedNames {
-		droppedModules[strcase.ToKebab(name)] = true
+	kebab := make(map[string]bool, len(droppedNames))
+	for name := range droppedNames {
+		kebab[strcase.ToKebab(name)] = true
 	}
 	for host, mapping := range cfg.Ports {
 		module, _, _ := strings.Cut(mapping.BackendService, ":")
-		if droppedModules[strcase.ToKebab(module)] {
+		if kebab[strcase.ToKebab(module)] {
 			delete(cfg.Ports, host)
 		}
 	}
@@ -331,7 +521,7 @@ func warnDroppedIncludedModules(ctx context.Context, include string, dropped []s
 	}
 
 	msg := fmt.Sprintf(
-		"Included config %s declares local modules that cannot be used here: %s. Only its remote modules are inherited.",
+		"Included config %s declares modules that were left out, with the reason for each: %s.",
 		include, strings.Join(dropped, ", "),
 	)
 	slog.Warn(msg, "include", include, "dropped", dropped)

--- a/core/workspace_include_test.go
+++ b/core/workspace_include_test.go
@@ -1,0 +1,269 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropLocalIncludedModules(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := workspace.ParseConfig([]byte(`[modules.ci]
+source = "modules/ci"
+
+[modules.pinned-local]
+source = "./ci"
+pin = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+[modules.dotted-local]
+source = "modules/foo.bar"
+
+[modules.toolchain]
+source = "github.com/acme/toolchain@v1"
+
+[modules.scheme]
+source = "https://example.com/acme/mod.git"
+
+[env.ci.modules.ci.settings]
+greeting = "hello"
+
+[env.ci.modules.toolchain.settings]
+version = "1.24"
+
+[env.ci.modules.extra-local]
+source = "modules/ci"
+
+[ports.3000]
+backendService = "ci:web"
+backendPort = 8080
+
+[ports.4000]
+backendService = "toolchain:api"
+backendPort = 9090
+`))
+	require.NoError(t, err)
+
+	dropped := dropLocalIncludedModules(cfg)
+
+	require.Equal(t, []string{
+		"ci",
+		"dotted-local",
+		"env.ci.modules.extra-local",
+		"pinned-local",
+	}, dropped)
+
+	require.NotContains(t, cfg.Modules, "ci")
+	require.NotContains(t, cfg.Modules, "pinned-local", "a pin must not launder a local source")
+	require.NotContains(t, cfg.Modules, "dotted-local", "an ambiguous ref that is a directory in the included tree is local")
+	require.Contains(t, cfg.Modules, "toolchain")
+	require.Contains(t, cfg.Modules, "scheme")
+
+	// The dropped module's env overlay goes with it; the surviving module's
+	// overlay stays.
+	require.NotContains(t, cfg.Env["ci"].Modules, "ci")
+	require.NotContains(t, cfg.Env["ci"].Modules, "extra-local")
+	require.Contains(t, cfg.Env["ci"].Modules, "toolchain")
+
+	// Ports forwarding to a dropped module go too; the others stay.
+	require.NotContains(t, cfg.Ports, "3000")
+	require.Contains(t, cfg.Ports, "4000")
+}
+
+func TestDropLocalIncludedModulesKeepsAVanityRemote(t *testing.T) {
+	t.Parallel()
+
+	// A schemeless remote whose host carries the dot: kept, and without asking
+	// the network — classification is syntactic, so it cannot depend on
+	// reachability.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.toolchain]
+source = "vanity.example.com/acme/toolchain"
+`))
+	require.NoError(t, err)
+
+	dropped := dropLocalIncludedModules(cfg)
+	require.Empty(t, dropped)
+	require.Contains(t, cfg.Modules, "toolchain")
+}
+
+func TestDropLocalIncludedModulesDropsBareShortNameSource(t *testing.T) {
+	t.Parallel()
+
+	// The shape `dagger setup` writes for a migrated SDK. Nothing named php
+	// exists in the included tree, so this pins the classification rather than
+	// the stat — and with it the reasoning that lets setupResolveMigratedSDKs
+	// keep writing back what configRead returned: it only rewrites entries of
+	// this shape, and an entry of this shape is never inherited from an include.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.php]
+source = "php"
+`))
+	require.NoError(t, err)
+
+	dropped := dropLocalIncludedModules(cfg)
+	require.Equal(t, []string{"php"}, dropped)
+	require.NotContains(t, cfg.Modules, "php")
+}
+
+func TestDropLocalIncludedModulesCascadesToPortsOfNonCanonicalNames(t *testing.T) {
+	t.Parallel()
+
+	// backendService names the module CLI-cased, which is not how the config
+	// spells the key it was declared under.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.MyTool]
+source = "modules/my-tool"
+
+[ports.3000]
+backendService = "my-tool:web"
+backendPort = 8080
+`))
+	require.NoError(t, err)
+
+	dropped := dropLocalIncludedModules(cfg)
+	require.Equal(t, []string{"MyTool"}, dropped)
+	require.NotContains(t, cfg.Ports, "3000")
+}
+
+func TestDropLocalIncludedModulesCascadesToPortsOfEnvOnlyInstalls(t *testing.T) {
+	t.Parallel()
+
+	// The module is installed by an env overlay only, so dropping that overlay
+	// leaves nothing for the port to forward to.
+	cfg, err := workspace.ParseConfig([]byte(`[env.ci.modules.local-ci]
+source = "modules/ci"
+
+[ports.3000]
+backendService = "local-ci:web"
+backendPort = 8080
+
+[ports.4000]
+backendService = "toolchain:api"
+backendPort = 9090
+`))
+	require.NoError(t, err)
+
+	dropped := dropLocalIncludedModules(cfg)
+	require.Equal(t, []string{"env.ci.modules.local-ci"}, dropped)
+	require.NotContains(t, cfg.Ports, "3000")
+	require.Contains(t, cfg.Ports, "4000")
+}
+
+func TestDropLocalIncludedModulesDropsADottedPath(t *testing.T) {
+	t.Parallel()
+
+	// The dot is in a path segment rather than the host, so this is a path.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.nested]
+source = "modules/foo.bar"
+`))
+	require.NoError(t, err)
+
+	dropped := dropLocalIncludedModules(cfg)
+	require.Equal(t, []string{"nested"}, dropped)
+}
+
+func TestIncludedSourceIsLocal(t *testing.T) {
+	t.Parallel()
+
+	// The classifier is workspace.IsLocalRef, the same one the module loader
+	// reaches through ResolveModuleEntrySource. These cases pin the agreement,
+	// including the dotted path that only reads as local because the dot is not
+	// in the host segment.
+	for _, tc := range []struct {
+		source string
+		local  bool
+	}{
+		{source: "", local: false},
+		{source: "modules/ci", local: true},
+		{source: "./ci", local: true},
+		{source: "../shared/ci", local: true},
+		{source: "common/.dagger/mymod", local: true},
+		{source: "github.com/acme/toolchain@v1", local: false},
+		{source: "https://example.com/acme/mod.git", local: false},
+		{source: "vanity.example.com/acme/toolchain", local: false},
+	} {
+		require.Equal(t, tc.local, includedSourceIsLocal(tc.source), "source %q", tc.source)
+	}
+}
+
+func TestIncludedSourceIsLocalIgnoresThePin(t *testing.T) {
+	t.Parallel()
+
+	// A pin makes the shared classifier read any ref as git, so the sanitizer
+	// deliberately never passes one: otherwise `source = "./ci", pin = "…"`
+	// would survive and then resolve against the consuming workspace.
+	require.True(t, includedSourceIsLocal("./ci"))
+	require.False(t, workspace.IsLocalRef("./ci", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+}
+
+func TestIncludeSourceIsGit(t *testing.T) {
+	t.Parallel()
+
+	// The rule is workspace.IsLocalRef, the classifier every other ref in a
+	// workspace config is read with. These cases pin the spellings the
+	// reference page advertises, in both directions.
+	for _, tc := range []struct {
+		source string
+		git    bool
+	}{
+		{source: "github.com/acme/base@v1.2.0", git: true},
+		{source: "github.com/acme/base/common/base.toml@v1.2.0", git: true},
+		{source: "github.com/acme/base", git: true},
+		{source: "https://example.com/acme/base.git#main:base.toml", git: true},
+		{source: "ssh://git@example.com/acme/base.git#v1:base.toml", git: true},
+		{source: "git@github.com:acme/base.git", git: true},
+		{source: "vanity.example.com/acme/base", git: true},
+		{source: "common/base.toml", git: false},
+		{source: "dagger/base.toml", git: false},
+		{source: "./base.toml", git: false},
+		{source: "../shared/base.toml", git: false},
+		{source: "/common/base.toml", git: false},
+		{source: "common", git: false},
+	} {
+		require.Equal(t, tc.git, IncludeSourceIsGit(tc.source), "source %q", tc.source)
+	}
+}
+
+func TestResolveIncludePath(t *testing.T) {
+	t.Parallel()
+
+	src := IncludeSource{ConfigDir: "services/payment"}
+
+	for _, tc := range []struct {
+		source string
+		want   string
+	}{
+		{source: "base.toml", want: "services/payment/base.toml"},
+		{source: "./base.toml", want: "services/payment/base.toml"},
+		{source: "../shared/base.toml", want: "services/shared/base.toml"},
+		{source: "/common/base.toml", want: "common/base.toml"},
+		// A path typed on Windows: filepath.ToSlash is a no-op on the engine
+		// reading it, so the separators are normalized explicitly.
+		{source: `common\base.toml`, want: "services/payment/common/base.toml"},
+		{source: `\common\base.toml`, want: "common/base.toml"},
+	} {
+		got, err := src.resolveIncludePath(tc.source)
+		require.NoError(t, err, "source %q", tc.source)
+		require.Equal(t, tc.want, got, "source %q", tc.source)
+	}
+
+	_, err := src.resolveIncludePath("../../../etc/base.toml")
+	require.ErrorContains(t, err, "escapes the workspace root")
+}
+
+func TestIncludeConfigPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		source string
+		want   string
+	}{
+		{source: ".", want: "dagger.toml"},
+		{source: "common", want: "common/dagger.toml"},
+		{source: "common/base.toml", want: "common/base.toml"},
+		// A mistyped extension still names a file: appending dagger.toml to it
+		// would report a missing directory rather than the typo.
+		{source: "dagger.tml", want: "dagger.tml"},
+	} {
+		require.Equal(t, tc.want, includeConfigPath(tc.source), "source %q", tc.source)
+	}
+}

--- a/core/workspace_include_test.go
+++ b/core/workspace_include_test.go
@@ -7,7 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropLocalIncludedModules(t *testing.T) {
+const testIncludeCommit = "0123456789abcdef0123456789abcdef01234567"
+
+// testGitAddresser stands in for an include resolved from
+// https://github.com/acme/base, whose config sits at the repository root.
+func testGitAddresser() includedModuleAddresser {
+	return gitIncludedModuleAddresser("https://github.com/acme/base", testIncludeCommit, ".")
+}
+
+func TestAddressIncludedModules(t *testing.T) {
 	t.Parallel()
 
 	cfg, err := workspace.ParseConfig([]byte(`[modules.ci]
@@ -19,6 +27,9 @@ pin = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 [modules.dotted-local]
 source = "modules/foo.bar"
+
+[modules.escaping]
+source = "../outside/ci"
 
 [modules.toolchain]
 source = "github.com/acme/toolchain@v1"
@@ -33,7 +44,7 @@ greeting = "hello"
 version = "1.24"
 
 [env.ci.modules.extra-local]
-source = "modules/ci"
+source = "modules/extra"
 
 [ports.3000]
 backendService = "ci:web"
@@ -42,76 +53,227 @@ backendPort = 8080
 [ports.4000]
 backendService = "toolchain:api"
 backendPort = 9090
+
+[ports.5000]
+backendService = "escaping:web"
+backendPort = 7070
 `))
 	require.NoError(t, err)
 
-	dropped := dropLocalIncludedModules(cfg)
+	dropped := addressIncludedModules(testGitAddresser(), cfg)
 
-	require.Equal(t, []string{
-		"ci",
-		"dotted-local",
-		"env.ci.modules.extra-local",
-		"pinned-local",
-	}, dropped)
+	// Only what has no address in the included repository is left out.
+	require.Equal(t, []string{"escaping (no address outside the config it came from)"}, dropped)
 
-	require.NotContains(t, cfg.Modules, "ci")
-	require.NotContains(t, cfg.Modules, "pinned-local", "a pin must not launder a local source")
-	require.NotContains(t, cfg.Modules, "dotted-local", "an ambiguous ref that is a directory in the included tree is local")
-	require.Contains(t, cfg.Modules, "toolchain")
-	require.Contains(t, cfg.Modules, "scheme")
+	// The included config's own modules become refs into its repository, at the
+	// commit its config was read from.
+	require.Equal(t, "https://github.com/acme/base/modules/ci@"+testIncludeCommit, cfg.Modules["ci"].Source)
+	require.Equal(t, "https://github.com/acme/base/ci@"+testIncludeCommit, cfg.Modules["pinned-local"].Source)
+	require.Empty(t, cfg.Modules["pinned-local"].Pin, "the pin described the source that was replaced")
+	require.Equal(t, "https://github.com/acme/base/modules/foo.bar@"+testIncludeCommit, cfg.Modules["dotted-local"].Source,
+		"a dot outside the host segment is a path, not a ref")
 
-	// The dropped module's env overlay goes with it; the surviving module's
-	// overlay stays.
-	require.NotContains(t, cfg.Env["ci"].Modules, "ci")
-	require.NotContains(t, cfg.Env["ci"].Modules, "extra-local")
+	// Sources that already address something outside the tree are untouched.
+	require.Equal(t, "github.com/acme/toolchain@v1", cfg.Modules["toolchain"].Source)
+	require.Equal(t, "https://example.com/acme/mod.git", cfg.Modules["scheme"].Source)
+
+	// Env overlays follow their module, whether they install one or only
+	// configure it.
+	require.Equal(t, "https://github.com/acme/base/modules/extra@"+testIncludeCommit, cfg.Env["ci"].Modules["extra-local"].Source)
+	require.Contains(t, cfg.Env["ci"].Modules, "ci")
 	require.Contains(t, cfg.Env["ci"].Modules, "toolchain")
 
-	// Ports forwarding to a dropped module go too; the others stay.
-	require.NotContains(t, cfg.Ports, "3000")
+	// Ports keep pointing at modules that survived, and lose the one whose
+	// module did not.
+	require.Contains(t, cfg.Ports, "3000")
 	require.Contains(t, cfg.Ports, "4000")
+	require.NotContains(t, cfg.Ports, "5000")
 }
 
-func TestDropLocalIncludedModulesKeepsAVanityRemote(t *testing.T) {
+func TestAddressIncludedModulesFromAConfigInASubdirectory(t *testing.T) {
 	t.Parallel()
 
-	// A schemeless remote whose host carries the dot: kept, and without asking
-	// the network — classification is syntactic, so it cannot depend on
-	// reachability.
+	// The included config is not at the repository root, so its own paths are
+	// relative to where it sits rather than to the clone.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.ci]
+source = "ci"
+
+[modules.sibling]
+source = "../tools/lint"
+`))
+	require.NoError(t, err)
+
+	address := gitIncludedModuleAddresser("https://github.com/acme/base", testIncludeCommit, "dagger/common")
+	require.Empty(t, addressIncludedModules(address, cfg))
+
+	require.Equal(t, "https://github.com/acme/base/dagger/common/ci@"+testIncludeCommit, cfg.Modules["ci"].Source)
+	require.Equal(t, "https://github.com/acme/base/dagger/tools/lint@"+testIncludeCommit, cfg.Modules["sibling"].Source)
+}
+
+func TestAddressIncludedModulesKeepsAVanityRemote(t *testing.T) {
+	t.Parallel()
+
+	// A schemeless remote whose host carries the dot: kept as written, and
+	// without asking the network — classification is syntactic, so it cannot
+	// depend on reachability.
 	cfg, err := workspace.ParseConfig([]byte(`[modules.toolchain]
 source = "vanity.example.com/acme/toolchain"
 `))
 	require.NoError(t, err)
 
-	dropped := dropLocalIncludedModules(cfg)
-	require.Empty(t, dropped)
-	require.Contains(t, cfg.Modules, "toolchain")
+	require.Empty(t, addressIncludedModules(testGitAddresser(), cfg))
+	require.Equal(t, "vanity.example.com/acme/toolchain", cfg.Modules["toolchain"].Source)
 }
 
-func TestDropLocalIncludedModulesDropsBareShortNameSource(t *testing.T) {
+func TestAddressIncludedModulesDropsABuiltinSDKInstall(t *testing.T) {
 	t.Parallel()
 
-	// The shape `dagger setup` writes for a migrated SDK. Nothing named php
-	// exists in the included tree, so this pins the classification rather than
-	// the stat — and with it the reasoning that lets setupResolveMigratedSDKs
-	// keep writing back what configRead returned: it only rewrites entries of
-	// this shape, and an entry of this shape is never inherited from an include.
+	// The shape `dagger setup` writes for a migrated SDK: a runtime name the
+	// engine resolves in-process, not a path. It is also the reasoning that
+	// lets setupResolveMigratedSDKs keep writing back what configRead
+	// returned: it only rewrites entries of this shape, and an entry of this
+	// shape is never inherited from an include.
 	cfg, err := workspace.ParseConfig([]byte(`[modules.php]
 source = "php"
+
+[modules.go]
+source = "go@v1.2.3"
+
+[sdks.php]
+module = "php"
+
+[sdks.go]
+module = "go"
 `))
 	require.NoError(t, err)
 
-	dropped := dropLocalIncludedModules(cfg)
-	require.Equal(t, []string{"php"}, dropped)
+	dropped := addressIncludedModules(testGitAddresser(), cfg)
+	require.Len(t, dropped, 2)
+	require.Contains(t, dropped[0], "built-in SDK runtime")
 	require.NotContains(t, cfg.Modules, "php")
+	require.NotContains(t, cfg.Modules, "go")
 }
 
-func TestDropLocalIncludedModulesCascadesToPortsOfNonCanonicalNames(t *testing.T) {
+func TestAddressIncludedModulesKeepsADirectoryNamedAfterAnSDK(t *testing.T) {
+	t.Parallel()
+
+	// With no [sdks.*] naming it as a provider, the entry is an ordinary module
+	// that happens to live in a directory called "go", and the loader reads it
+	// that way too. Dropping it on the name alone would lose a module nobody
+	// said was a runtime.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.compiler]
+source = "go"
+`))
+	require.NoError(t, err)
+
+	require.Empty(t, addressIncludedModules(testGitAddresser(), cfg))
+	require.Equal(t, "https://github.com/acme/base/go@"+testIncludeCommit, cfg.Modules["compiler"].Source)
+}
+
+func TestAddressIncludedModulesDropsAPathAGitRefCannotSpell(t *testing.T) {
+	t.Parallel()
+
+	// "@" and "#" both mean "version" in a ref, so a path carrying either
+	// would be cut short by the parser and resolve somewhere else entirely.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.scoped]
+source = "modules/@scope/tool"
+
+[modules.fragment]
+source = "modules/a#b"
+`))
+	require.NoError(t, err)
+
+	require.Len(t, addressIncludedModules(testGitAddresser(), cfg), 2)
+	require.NotContains(t, cfg.Modules, "scoped")
+	require.NotContains(t, cfg.Modules, "fragment")
+}
+
+func TestAddressIncludedModulesDropsAWindowsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	// A UNC path reaches a Linux engine with backslashes: normalizing after the
+	// absolute check would read it as relative and rebase it under the included
+	// config's directory.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.unc]
+source = '\\server\share\mod'
+`))
+	require.NoError(t, err)
+
+	require.Len(t, addressIncludedModules(testGitAddresser(), cfg), 1)
+	require.NotContains(t, cfg.Modules, "unc")
+}
+
+func TestAddressIncludedModulesKeepsAPortAnEnvOverlayStillInstalls(t *testing.T) {
+	t.Parallel()
+
+	// The base entry has no address here, but the env overlay installs the same
+	// module with one that does — so the port still has something to reach.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.api]
+source = "../../outside"
+
+[env.ci.modules.api]
+source = "modules/api"
+
+[ports.3000]
+backendService = "api:web"
+backendPort = 8080
+`))
+	require.NoError(t, err)
+
+	require.Len(t, addressIncludedModules(testGitAddresser(), cfg), 1)
+	require.Equal(t, "https://github.com/acme/base/modules/api@"+testIncludeCommit, cfg.Env["ci"].Modules["api"].Source)
+	require.Contains(t, cfg.Ports, "3000")
+}
+
+func TestAddressIncludedModulesClearsAPinOnlyOverlayOfAReaddressedModule(t *testing.T) {
+	t.Parallel()
+
+	// A lone pin updates the base entry's pin, and that entry now names
+	// something else entirely.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.ci]
+source = "./ci"
+
+[env.prod.modules.ci]
+pin = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+`))
+	require.NoError(t, err)
+
+	require.Empty(t, addressIncludedModules(testGitAddresser(), cfg))
+	require.Equal(t, "https://github.com/acme/base/ci@"+testIncludeCommit, cfg.Modules["ci"].Source)
+	require.Empty(t, cfg.Env["prod"].Modules["ci"].Pin, "the pin described the source that was replaced")
+}
+
+func TestAddressIncludedModulesDropsTheIncludedRootItself(t *testing.T) {
+	t.Parallel()
+
+	// The tree the config came from is a workspace, not a module.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.self]
+source = "."
+`))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"self (no address outside the config it came from)"}, addressIncludedModules(testGitAddresser(), cfg))
+}
+
+func TestAddressIncludedModulesDropsAnAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	// An absolute path addresses the machine the config was authored on.
+	cfg, err := workspace.ParseConfig([]byte(`[modules.abs]
+source = "/opt/ci"
+`))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"abs (no address outside the config it came from)"}, addressIncludedModules(testGitAddresser(), cfg))
+}
+
+func TestAddressIncludedModulesCascadesToPortsOfNonCanonicalNames(t *testing.T) {
 	t.Parallel()
 
 	// backendService names the module CLI-cased, which is not how the config
 	// spells the key it was declared under.
 	cfg, err := workspace.ParseConfig([]byte(`[modules.MyTool]
-source = "modules/my-tool"
+source = "../../my-tool"
 
 [ports.3000]
 backendService = "my-tool:web"
@@ -119,18 +281,17 @@ backendPort = 8080
 `))
 	require.NoError(t, err)
 
-	dropped := dropLocalIncludedModules(cfg)
-	require.Equal(t, []string{"MyTool"}, dropped)
+	require.Equal(t, []string{"MyTool (no address outside the config it came from)"}, addressIncludedModules(testGitAddresser(), cfg))
 	require.NotContains(t, cfg.Ports, "3000")
 }
 
-func TestDropLocalIncludedModulesCascadesToPortsOfEnvOnlyInstalls(t *testing.T) {
+func TestAddressIncludedModulesCascadesToPortsOfEnvOnlyInstalls(t *testing.T) {
 	t.Parallel()
 
 	// The module is installed by an env overlay only, so dropping that overlay
 	// leaves nothing for the port to forward to.
 	cfg, err := workspace.ParseConfig([]byte(`[env.ci.modules.local-ci]
-source = "modules/ci"
+source = "/opt/ci"
 
 [ports.3000]
 backendService = "local-ci:web"
@@ -142,23 +303,52 @@ backendPort = 9090
 `))
 	require.NoError(t, err)
 
-	dropped := dropLocalIncludedModules(cfg)
-	require.Equal(t, []string{"env.ci.modules.local-ci"}, dropped)
+	require.Equal(t, []string{"env.ci.modules.local-ci (no address outside the config it came from)"}, addressIncludedModules(testGitAddresser(), cfg))
 	require.NotContains(t, cfg.Ports, "3000")
 	require.Contains(t, cfg.Ports, "4000")
 }
 
-func TestDropLocalIncludedModulesDropsADottedPath(t *testing.T) {
+func TestPathIncludedModuleAddresser(t *testing.T) {
 	t.Parallel()
 
-	// The dot is in a path segment rather than the host, so this is a path.
-	cfg, err := workspace.ParseConfig([]byte(`[modules.nested]
-source = "modules/foo.bar"
-`))
-	require.NoError(t, err)
+	// The monorepo shape: common/dagger.toml installs the modules under
+	// shared/, and project-a/dagger.toml includes it. Both paths are
+	// workspace-relative, so only what they are relative to changes.
+	address := pathIncludedModuleAddresser("common", "project-a")
 
-	dropped := dropLocalIncludedModules(cfg)
-	require.Equal(t, []string{"nested"}, dropped)
+	for _, tc := range []struct {
+		source string
+		want   string
+		ok     bool
+	}{
+		{source: "../shared/tester", want: "../shared/tester", ok: true},
+		{source: "modules/ci", want: "../common/modules/ci", ok: true},
+		// Dot-prefixed even when the target sits below the consumer, so the
+		// result can never read back as a git ref.
+		{source: "../project-a/ci", want: "./ci", ok: true},
+		{source: "../shared.v2/ci", want: "../shared.v2/ci", ok: true},
+		{source: "../../elsewhere", ok: false},
+		{source: "/opt/ci", ok: false},
+		{source: "..", ok: false},
+	} {
+		got, ok := address(tc.source)
+		require.Equal(t, tc.ok, ok, "source %q", tc.source)
+		if tc.ok {
+			require.Equal(t, tc.want, got, "source %q", tc.source)
+			require.True(t, workspace.IsLocalRef(got, ""), "%q must read back as a path", got)
+		}
+	}
+}
+
+func TestPathIncludedModuleAddresserFromTheWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	// A consuming config at the workspace root: the rewritten path is the
+	// workspace-relative one, still dot-prefixed.
+	address := pathIncludedModuleAddresser("common", "")
+	got, ok := address("../shared/tester")
+	require.True(t, ok)
+	require.Equal(t, "./shared/tester", got)
 }
 
 func TestIncludedSourceIsLocal(t *testing.T) {

--- a/core/workspace_remote.go
+++ b/core/workspace_remote.go
@@ -1,0 +1,191 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/core/gitref"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
+)
+
+// WorkspaceRemoteRef is a git ref that denotes a workspace: a clone ref, an
+// optional version, the subdirectory the workspace root sits in, and which
+// selector syntax named it.
+type WorkspaceRemoteRef struct {
+	CloneRef        string
+	Version         string
+	WorkspaceSubdir string
+	Selector        gitref.SelectorType
+}
+
+// ParseWorkspaceRemoteRef parses a remote workspace ref, in either the
+// explicit `#` selector form or the Go-like `@` form, following a dagger-get
+// redirect when the host publishes one.
+//
+// Both the `-W <ref>` selection path and an [[include]] whose source is a git
+// ref come through here, so a vanity ref means the same thing in a dagger.toml
+// as it does on the command line.
+func ParseWorkspaceRemoteRef(ctx context.Context, remoteRef string) (WorkspaceRemoteRef, error) {
+	return ParseWorkspaceRemoteRefWithResolver(ctx, remoteRef, ResolveDaggerGetRedirect)
+}
+
+// ParseWorkspaceRemoteRefWithResolver is ParseWorkspaceRemoteRef with the
+// redirect lookup injected, so tests can parse without reaching the network.
+func ParseWorkspaceRemoteRefWithResolver(
+	ctx context.Context,
+	remoteRef string,
+	resolve func(context.Context, string) (string, error),
+) (WorkspaceRemoteRef, error) {
+	// A # selector is the explicit Git URL form: protocol://repo#ref:subpath.
+	if strings.Contains(remoteRef, "#") {
+		parsedRef, err := ParseGitRefString(ctx, remoteRef)
+		if err != nil {
+			return WorkspaceRemoteRef{}, err
+		}
+		workspaceSubdir, err := NormalizeWorkspaceRemoteSubdir(parsedRef.RepoRootSubdir)
+		if err != nil {
+			return WorkspaceRemoteRef{}, fmt.Errorf("invalid git subdir in workspace ref %q: %w", remoteRef, err)
+		}
+		cloneRef := parsedRef.SourceCloneRef
+		resolvedRef, err := resolve(ctx, cloneRef)
+		if err != nil {
+			return WorkspaceRemoteRef{}, err
+		}
+		if resolvedRef != cloneRef {
+			// A redirect may point into a subdirectory of the repository it
+			// names, so the fragment's own subdir hangs off that one.
+			redirected, err := ParseGitRefString(ctx, resolvedRef)
+			if err != nil {
+				return WorkspaceRemoteRef{}, err
+			}
+			cloneRef = redirected.SourceCloneRef
+			resolvedSubdir := redirected.RepoRootSubdir
+			if resolvedSubdir == "/" {
+				resolvedSubdir = "."
+			}
+			workspaceSubdir, err = NormalizeWorkspaceRemoteSubdir(filepath.Join(resolvedSubdir, workspaceSubdir))
+			if err != nil {
+				return WorkspaceRemoteRef{}, err
+			}
+		}
+		return WorkspaceRemoteRef{
+			CloneRef:        cloneRef,
+			Version:         parsedRef.ModVersion,
+			WorkspaceSubdir: workspaceSubdir,
+			Selector:        parsedRef.Selector,
+		}, nil
+	}
+
+	// The @ selector uses Go-like import path semantics, with any path after the
+	// repository root identifying the workspace subdirectory.
+	remoteRef, err := resolve(ctx, remoteRef)
+	if err != nil {
+		return WorkspaceRemoteRef{}, err
+	}
+	parsedRef, err := ParseGitRefString(ctx, remoteRef)
+	if err != nil {
+		return WorkspaceRemoteRef{}, err
+	}
+	workspaceSubdir := "."
+	if parsedRef.RepoRootSubdir != "/" && parsedRef.RepoRootSubdir != "." {
+		workspaceSubdir = parsedRef.RepoRootSubdir
+	}
+	return WorkspaceRemoteRef{
+		CloneRef:        parsedRef.SourceCloneRef,
+		Version:         parsedRef.ModVersion,
+		WorkspaceSubdir: workspaceSubdir,
+		Selector:        parsedRef.Selector,
+	}, nil
+}
+
+// NormalizeWorkspaceRemoteSubdir cleans a workspace subdirectory and refuses
+// one that escapes the repository.
+func NormalizeWorkspaceRemoteSubdir(subdir string) (string, error) {
+	if subdir == "" {
+		return ".", nil
+	}
+	subdir = filepath.Clean(subdir)
+	subdir = strings.TrimPrefix(subdir, string(filepath.Separator))
+	if subdir == "" || subdir == "." {
+		return ".", nil
+	}
+	if !filepath.IsLocal(subdir) {
+		return "", fmt.Errorf("path points outside repository: %q", subdir)
+	}
+	return subdir, nil
+}
+
+// workspaceGitRefSelector picks how a remote workspace ref resolves. HEAD
+// without a selector and literal ref resolution, unless an @ selector carries a
+// SemVer query this API version supports.
+func workspaceGitRefSelector(remote WorkspaceRemoteRef, supportsVersionQueries bool) dagql.Selector {
+	refSelector := dagql.Selector{Field: "head"}
+	if remote.Version == "" {
+		return refSelector
+	}
+	refSelector = dagql.Selector{
+		Field: "ref",
+		Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(remote.Version)}},
+	}
+	if remote.Selector != gitref.ModuleVersionSelector ||
+		!supportsVersionQueries ||
+		!IsReleaseVersionQuery(remote.Version) {
+		return refSelector
+	}
+	refSelector = dagql.Selector{
+		Field: "latest",
+		Args: []dagql.NamedInput{{
+			Name:  "version",
+			Value: dagql.String(remote.Version),
+		}},
+	}
+	if remote.WorkspaceSubdir != "." {
+		refSelector.Args = append(refSelector.Args, dagql.NamedInput{
+			Name:  "tagPrefix",
+			Value: dagql.String(remote.WorkspaceSubdir),
+		})
+	}
+	return refSelector
+}
+
+// CloneWorkspaceGitTree resolves a remote workspace ref and returns its tree.
+// Going through the ordinary git(url).head / .ref(name) / .latest(version)
+// selectors is what records the resolved commit in the workspace lockfile.
+func CloneWorkspaceGitTree(
+	ctx context.Context,
+	dag *dagql.Server,
+	remote WorkspaceRemoteRef,
+) (dagql.ObjectResult[*Directory], dagql.ObjectResult[*GitRef], error) {
+	supportsVersionQueries := AfterVersion(workspace.VersionQueriesVersion).Contains(dag.View)
+
+	var gitRef dagql.ObjectResult[*GitRef]
+	err := dag.Select(ctx, dag.Root(), &gitRef,
+		dagql.Selector{
+			Field: "git",
+			Args: []dagql.NamedInput{
+				{Name: "url", Value: dagql.String(remote.CloneRef)},
+			},
+		},
+		workspaceGitRefSelector(remote, supportsVersionQueries),
+	)
+	if err != nil {
+		return dagql.ObjectResult[*Directory]{}, gitRef, fmt.Errorf("resolving repo ref: %w", err)
+	}
+
+	var tree dagql.ObjectResult[*Directory]
+	err = dag.Select(ctx, gitRef, &tree,
+		dagql.Selector{
+			Field: "tree",
+			Args: []dagql.NamedInput{
+				{Name: "discardGitDir", Value: dagql.NewBoolean(true)},
+			},
+		},
+	)
+	if err != nil {
+		return tree, gitRef, fmt.Errorf("cloning repo: %w", err)
+	}
+	return tree, gitRef, nil
+}

--- a/core/workspace_remote_test.go
+++ b/core/workspace_remote_test.go
@@ -1,0 +1,134 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/core/gitref"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWorkspaceRemoteRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supports address fragment ref at repository root", func(t *testing.T) {
+		t.Parallel()
+
+		for _, address := range []string{
+			"https://github.com/dagger/dagger#main",
+			"https://github.com/dagger/dagger#main:.",
+		} {
+			ref, err := ParseWorkspaceRemoteRef(context.Background(), address)
+			require.NoError(t, err)
+			require.Equal(t, "https://github.com/dagger/dagger", ref.CloneRef)
+			require.Equal(t, "main", ref.Version)
+			require.Equal(t, ".", ref.WorkspaceSubdir)
+			require.Equal(t, gitref.GitRefSelector, ref.Selector)
+		}
+	})
+
+	t.Run("supports address fragment ref and subdir", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := ParseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger#main:toolchains/changelog")
+		require.NoError(t, err)
+		require.Equal(t, "https://github.com/dagger/dagger", ref.CloneRef)
+		require.Equal(t, "main", ref.Version)
+		require.Equal(t, "toolchains/changelog", ref.WorkspaceSubdir)
+		require.Equal(t, gitref.GitRefSelector, ref.Selector)
+	})
+
+	t.Run("supports legacy at-ref syntax", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := ParseWorkspaceRemoteRef(context.Background(), "github.com/dagger/dagger/toolchains/changelog@main")
+		require.NoError(t, err)
+		require.Equal(t, "main", ref.Version)
+		require.Equal(t, "toolchains/changelog", ref.WorkspaceSubdir)
+		require.Equal(t, gitref.ModuleVersionSelector, ref.Selector)
+	})
+
+	t.Run("preserves legacy https at-ref syntax", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := ParseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger@main")
+		require.NoError(t, err)
+		require.Equal(t, "main", ref.Version)
+		require.Equal(t, ".", ref.WorkspaceSubdir)
+		require.Equal(t, gitref.ModuleVersionSelector, ref.Selector)
+	})
+
+	t.Run("resolves legacy vanity ref", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := ParseWorkspaceRemoteRefWithResolver(
+			context.Background(),
+			"dagger.io/go@main",
+			func(_ context.Context, got string) (string, error) {
+				require.Equal(t, "dagger.io/go@main", got)
+				return "https://github.com/dagger/dagger/sdk/go@main", nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "https://github.com/dagger/dagger", ref.CloneRef)
+		require.Equal(t, "main", ref.Version)
+		require.Equal(t, "sdk/go", ref.WorkspaceSubdir)
+	})
+
+	t.Run("resolves fragment clone ref and preserves subdir", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := ParseWorkspaceRemoteRefWithResolver(
+			context.Background(),
+			"https://github.com/dagger/python#main:docs",
+			func(_ context.Context, got string) (string, error) {
+				require.Equal(t, "https://github.com/dagger/python", got)
+				return "https://github.com/dagger/dagger/sdk/go", nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "https://github.com/dagger/dagger", ref.CloneRef)
+		require.Equal(t, "main", ref.Version)
+		require.Equal(t, "sdk/go/docs", ref.WorkspaceSubdir)
+		require.Equal(t, gitref.GitRefSelector, ref.Selector)
+	})
+
+	for _, invalid := range []string{
+		"github.com/dagger/python/ruff#main",
+		"https://github.com/dagger/python/ruff#main",
+		"https://github.com/dagger/python#main:",
+		"github.com/dagger/python@main:ruff",
+		"https://github.com/dagger/python@main:ruff",
+		"github.com/dagger/python#main:ruff",
+	} {
+		t.Run("rejects "+invalid, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseWorkspaceRemoteRef(context.Background(), invalid)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNormalizeWorkspaceRemoteSubdir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty becomes dot", func(t *testing.T) {
+		t.Parallel()
+		got, err := NormalizeWorkspaceRemoteSubdir("")
+		require.NoError(t, err)
+		require.Equal(t, ".", got)
+	})
+
+	t.Run("absolute gets normalized to relative", func(t *testing.T) {
+		t.Parallel()
+		got, err := NormalizeWorkspaceRemoteSubdir("/toolchains/changelog")
+		require.NoError(t, err)
+		require.Equal(t, "toolchains/changelog", got)
+	})
+
+	t.Run("rejects escaping paths", func(t *testing.T) {
+		t.Parallel()
+		_, err := NormalizeWorkspaceRemoteSubdir("../outside")
+		require.ErrorContains(t, err, "outside repository")
+	})
+}

--- a/docs/current_docs/config/includes.mdx
+++ b/docs/current_docs/config/includes.mdx
@@ -38,7 +38,7 @@ dagger workspace config include ../common
 
 The included config's own modules come with it. A module entry there whose source is a local path names a directory beside *that* config, not beside yours, so it is re-addressed rather than resolved as written:
 
-```
+```text
 shared/tester/          the module
 common/dagger.toml      [modules.tester] source = "../shared/tester"
 project-a/dagger.toml   [[include]] source = "../common"

--- a/docs/current_docs/config/includes.mdx
+++ b/docs/current_docs/config/includes.mdx
@@ -1,0 +1,72 @@
+---
+title: "Includes"
+slug: /config/includes
+description: "Inherit workspace configuration from a shared config file"
+---
+
+# Includes
+
+An include points your workspace at another config file and inherits what it declares. Use one when several repositories — or several projects in one repository — need the same tool versions, module settings, and environments, so they are written down once instead of copied into each `dagger.toml`.
+
+```toml
+[[include]]
+source = "github.com/acme/dagger-base@v1.2.0"
+
+# Only the difference from the included config:
+[modules.go.settings]
+goVersion = "1.24"
+```
+
+## Name a config to inherit from
+
+`source` addresses a config **file**, written either as a path or as a Git ref:
+
+- a path — `common/base.toml` or `./base.toml` relative to your config's directory, `../shared/base.toml` beside it, or `/common/base.toml` from the workspace root.
+- a Git ref — `github.com/acme/dagger-base@v1.2.0`, `https://host/repo.git#main:dagger/base.toml`, or `git@github.com:acme/base.git`.
+
+A source is a path when it starts with `/`, `./` or `../`, or when its first segment contains neither a dot nor a colon — the same rule that tells a local module source from a remote one. One consequence: a file with a dotted name sitting directly beside your config, such as `base.toml`, reads as a Git ref, so write it as `./base.toml`.
+
+A source with no file extension names a **directory** and reaches the `dagger.toml` inside it, so `common` reaches `common/dagger.toml`.
+
+Set it with `dagger workspace config`:
+
+```shell
+dagger workspace config include ../common
+```
+
+## Configuration, not code
+
+A module entry in the included config whose source is a local path names a directory beside *that* config, not beside yours, so it is dropped with a warning naming it. Its remote module refs come through normally.
+
+## Override what you inherit
+
+The included config is merged **underneath** yours, so your workspace wins every conflict. The effective configuration is merged in a fixed order: the included config, then your `dagger.toml`, then your [user configuration](./user.mdx).
+
+Merging is per key, so a module entry may omit `source` and override only a setting of a module the include installs:
+
+```toml
+[modules.go.settings]
+goVersion = "1.24"
+```
+
+Module settings merge key by key; a `source` you set replaces the inherited one and its pin travels with it; an explicit `false` or `[]` overrides an inherited value, and an absent key inherits. `[ports.<host>]` replaces the inherited mapping as a unit. An included config's `[sdks.*]` declarations and its modules' `legacy-default-path` flags are never inherited: they describe the tree that config came from.
+
+## Reads are effective, writes are local
+
+`dagger workspace config` prints the merged configuration as a standalone snapshot, with a `# included: <source>` comment in place of the `[[include]]` block:
+
+```shell
+dagger workspace config
+```
+
+Every write — `dagger install`, `dagger settings`, `dagger workspace config <key> <value>` — only ever touches your own `dagger.toml`. An inherited entry can be overridden but not deleted: uninstalling a module the include provides, or unsetting a value it supplies, tells you where the value comes from instead.
+
+## Limits
+
+Only one `[[include]]` is resolved for now — a config with more is an error. With two includes, the order they apply in and what happens when they disagree are questions this version doesn't answer, so the limit stays until it does. The shape is an array so several can be expressed later, without changing what people write today.
+
+If the included config includes something in turn, that's an error. Includes do not compose.
+
+## Pinning
+
+A Git include's ref is resolved and recorded in `dagger.lock` like any other Git reference: later runs reuse the recorded pin, and `dagger update` refreshes it. A path include is read from the workspace as it is on disk, so there is nothing to pin.

--- a/docs/current_docs/config/includes.mdx
+++ b/docs/current_docs/config/includes.mdx
@@ -34,9 +34,19 @@ Set it with `dagger workspace config`:
 dagger workspace config include ../common
 ```
 
-## Configuration, not code
+## Share modules across a monorepo
 
-A module entry in the included config whose source is a local path names a directory beside *that* config, not beside yours, so it is dropped with a warning naming it. Its remote module refs come through normally.
+The included config's own modules come with it. A module entry there whose source is a local path names a directory beside *that* config, not beside yours, so it is re-addressed rather than resolved as written:
+
+```
+shared/tester/          the module
+common/dagger.toml      [modules.tester] source = "../shared/tester"
+project-a/dagger.toml   [[include]] source = "../common"
+```
+
+From `project-a`, `dagger module list` shows `tester` and `dagger call tester …` runs it. For a Git include the same entry is addressed in the repository the config came from — `modules/ci` becomes `<repo>/modules/ci@<commit>`, pinned to the commit the config itself was read at, so the config and the modules it names always come from one revision.
+
+What has no address on your side is left out, with a warning naming it: built-in SDK installs, absolute paths, and paths escaping the tree the config came from.
 
 ## Override what you inherit
 

--- a/docs/current_docs/config/index.mdx
+++ b/docs/current_docs/config/index.mdx
@@ -8,6 +8,7 @@ description: "Configure a Dagger workspace: module settings, wiring, and persona
 
 How a workspace is configured: the settings in `dagger.toml` and how modules connect to each other.
 
+- [Includes](./includes.mdx) inherit configuration from a shared config file, so it is written down once.
 - [User configuration](./user.mdx) holds personal overrides that stay out of the repository.
 - [Module wiring](./module-wiring.mdx) connects one module's output to another module's settings.
 - [Migrate from dagger.json](./migrate-dagger-json.mdx) converts a legacy project to a workspace.

--- a/docs/current_docs/config/user.mdx
+++ b/docs/current_docs/config/user.mdx
@@ -18,7 +18,7 @@ profile = "alice-dev"
 
 ## Merge order
 
-Dagger merges your user-level overrides on top of the repository's `dagger.toml`. User-level values shadow repository values key by key, without modifying `dagger.toml`.
+Dagger merges your user-level overrides on top of the repository's `dagger.toml`, which in turn sits on top of any config the repository [includes](./includes.mdx). User-level values shadow repository values key by key, without modifying `dagger.toml`.
 
 ## Writing values
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2451,6 +2451,13 @@ With one argument and --unset, removes the value at the given key.
 
 Explicit env.* keys address raw overlay storage.
 
+An include is set with "dagger workspace config include &lt;source&gt;", where source
+is a git ref (github.com/acme/base@v1) or a path to a config file next to this
+one ("./base.toml", or "/common/base.toml" from the workspace root). Reads then
+show the merged view — the included configuration with this workspace's own on
+top — while writes still only touch this workspace's dagger.toml. Reading the
+include key itself reports this workspace's own value.
+
 Local module source values are stored relative to dagger.toml.
 
 ```

--- a/docs/current_docs/reference/config-files/dagger-toml.mdx
+++ b/docs/current_docs/reference/config-files/dagger-toml.mdx
@@ -35,7 +35,7 @@ source = "../common"
 | --- | --- | --- |
 | `source` | string | Config file to inherit from — a workspace-relative path, or a Git ref such as `github.com/org/base@version`. A source with no file extension names a directory and reaches the `dagger.toml` inside it. |
 
-The included config is merged **underneath** this one, so this workspace wins every conflict. Only one `[[include]]` is resolved for now. See [Includes](../../config/includes.mdx).
+The included config is merged **underneath** this one, so this workspace wins every conflict, and its own modules come with it. Only one `[[include]]` is resolved for now. See [Includes](../../config/includes.mdx).
 
 ## `[modules.<name>]`
 

--- a/docs/current_docs/reference/config-files/dagger-toml.mdx
+++ b/docs/current_docs/reference/config-files/dagger-toml.mdx
@@ -20,8 +20,22 @@ The machine-readable schema is published at [dagger-workspace.schema.json](/refe
 | `ignore` | array | Path patterns excluded when loading the workspace. |
 | `defaults_from_dotenv` | bool | Read module constructor defaults from a `.env` file. |
 | `check-generated` | bool | Run generators as checks during `dagger check`, failing when generated files are stale. Defaults to `true`; CLI flags override it. |
+| `include` | array of tables | Another config file whose contents are merged underneath this one. See [`[[include]]`](#include). |
 
 Resolved image and Git lookups are pinned in `dagger.lock` alongside the config, and refreshed with `dagger workspace update`.
+
+## `[[include]]`
+
+```toml
+[[include]]
+source = "../common"
+```
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `source` | string | Config file to inherit from — a workspace-relative path, or a Git ref such as `github.com/org/base@version`. A source with no file extension names a directory and reaches the `dagger.toml` inside it. |
+
+The included config is merged **underneath** this one, so this workspace wins every conflict. Only one `[[include]]` is resolved for now. See [Includes](../../config/includes.mdx).
 
 ## `[modules.<name>]`
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -88,6 +88,7 @@ module.exports = {
       collapsible: true,
       collapsed: true,
       items: [
+        "config/includes",
         "config/user",
         "config/module-wiring",
         "config/migrate-dagger-json",

--- a/docs/static/reference/dagger-workspace.schema.json
+++ b/docs/static/reference/dagger-workspace.schema.json
@@ -5,6 +5,13 @@
   "$defs": {
     "Config": {
       "properties": {
+        "include": {
+          "items": {
+            "$ref": "#/$defs/IncludeEntry"
+          },
+          "type": "array",
+          "description": "Include lists the workspace configs this one builds on: each entry's config is merged underneath this one. The shape allows several, but only one is accepted for now, and an included config's own includes are never followed."
+        },
         "modules": {
           "additionalProperties": {
             "$ref": "#/$defs/ModuleEntry"
@@ -78,6 +85,19 @@
       "type": "object",
       "description": "EnvOverlay is a named workspace environment overlay."
     },
+    "IncludeEntry": {
+      "properties": {
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "source"
+      ],
+      "description": "IncludeEntry is one included workspace config."
+    },
     "ModuleEntry": {
       "properties": {
         "source": {
@@ -107,9 +127,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "source"
-      ],
       "description": "ModuleEntry represents a single module entry in the workspace config."
     },
     "ModuleSkip": {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/core"
-	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
@@ -2102,136 +2101,6 @@ func TestRemoteWorkspaceAddress(t *testing.T) {
 	require.Equal(t, "https://github.com/dagger/dagger/services/payment@main", remoteWorkspaceAddress("https://github.com/dagger/dagger", "services/payment", "main"))
 }
 
-func TestParseWorkspaceRemoteRef(t *testing.T) {
-	t.Parallel()
-
-	t.Run("supports address fragment ref at repository root", func(t *testing.T) {
-		t.Parallel()
-
-		for _, address := range []string{
-			"https://github.com/dagger/dagger#main",
-			"https://github.com/dagger/dagger#main:.",
-		} {
-			ref, err := parseWorkspaceRemoteRef(context.Background(), address)
-			require.NoError(t, err)
-			require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
-			require.Equal(t, "main", ref.version)
-			require.Equal(t, ".", ref.workspaceSubdir)
-			require.Equal(t, gitref.GitRefSelector, ref.selector)
-		}
-	})
-
-	t.Run("supports address fragment ref and subdir", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := parseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger#main:toolchains/changelog")
-		require.NoError(t, err)
-		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
-		require.Equal(t, "main", ref.version)
-		require.Equal(t, "toolchains/changelog", ref.workspaceSubdir)
-		require.Equal(t, gitref.GitRefSelector, ref.selector)
-	})
-
-	t.Run("supports legacy at-ref syntax", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := parseWorkspaceRemoteRef(context.Background(), "github.com/dagger/dagger/toolchains/changelog@main")
-		require.NoError(t, err)
-		require.Equal(t, "main", ref.version)
-		require.Equal(t, "toolchains/changelog", ref.workspaceSubdir)
-		require.Equal(t, gitref.ModuleVersionSelector, ref.selector)
-	})
-
-	t.Run("preserves legacy https at-ref syntax", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := parseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger@main")
-		require.NoError(t, err)
-		require.Equal(t, "main", ref.version)
-		require.Equal(t, ".", ref.workspaceSubdir)
-		require.Equal(t, gitref.ModuleVersionSelector, ref.selector)
-	})
-
-	t.Run("resolves legacy vanity ref", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := parseWorkspaceRemoteRefWithResolver(
-			context.Background(),
-			"dagger.io/go@main",
-			func(_ context.Context, got string) (string, error) {
-				require.Equal(t, "dagger.io/go@main", got)
-				return "https://github.com/dagger/dagger/sdk/go@main", nil
-			},
-		)
-		require.NoError(t, err)
-		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
-		require.Equal(t, "main", ref.version)
-		require.Equal(t, "sdk/go", ref.workspaceSubdir)
-	})
-
-	t.Run("resolves fragment clone ref and preserves subdir", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := parseWorkspaceRemoteRefWithResolver(
-			context.Background(),
-			"https://github.com/dagger/python#main:docs",
-			func(_ context.Context, got string) (string, error) {
-				require.Equal(t, "https://github.com/dagger/python", got)
-				return "https://github.com/dagger/dagger/sdk/go", nil
-			},
-		)
-		require.NoError(t, err)
-		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
-		require.Equal(t, "main", ref.version)
-		require.Equal(t, "sdk/go/docs", ref.workspaceSubdir)
-		require.Equal(t, gitref.GitRefSelector, ref.selector)
-	})
-
-	for _, invalid := range []string{
-		"github.com/dagger/python/ruff#main",
-		"https://github.com/dagger/python/ruff#main",
-		"https://github.com/dagger/python#main:",
-		"github.com/dagger/python@main:ruff",
-		"https://github.com/dagger/python@main:ruff",
-		"github.com/dagger/python#main:ruff",
-	} {
-		t.Run("rejects "+invalid, func(t *testing.T) {
-			t.Parallel()
-			_, err := parseWorkspaceRemoteRef(context.Background(), invalid)
-			require.Error(t, err)
-		})
-	}
-}
-
-func TestWorkspaceGitRefSelectorSemverSemantics(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name                   string
-		selector               gitref.SelectorType
-		supportsVersionQueries bool
-		wantField              string
-	}{
-		{name: "at selector uses semver query", selector: gitref.ModuleVersionSelector, supportsVersionQueries: true, wantField: "latest"},
-		{name: "old client uses literal git ref", selector: gitref.ModuleVersionSelector, supportsVersionQueries: false, wantField: "ref"},
-		{name: "fragment selector uses literal git ref", selector: gitref.GitRefSelector, supportsVersionQueries: true, wantField: "ref"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			selector := workspaceGitRefSelector(workspaceRemoteRef{
-				version:         "v1.2",
-				workspaceSubdir: "ruff",
-				selector:        tc.selector,
-			}, tc.supportsVersionQueries)
-			require.Equal(t, tc.wantField, selector.Field)
-			if tc.wantField == "latest" {
-				require.Equal(t, "version", selector.Args[0].Name)
-				require.Equal(t, "tagPrefix", selector.Args[1].Name)
-			}
-		})
-	}
-}
-
 func TestGatherModuleLoadRequests(t *testing.T) {
 	t.Parallel()
 
@@ -2462,30 +2331,6 @@ func TestArbitrateResolvedModuleLoads(t *testing.T) {
 
 		err := arbitrateResolvedModuleLoads(loads, resolved)
 		require.EqualError(t, err, "invalid extra-module request: multiple distinct extra-module entrypoints: extra1, extra2")
-	})
-}
-
-func TestNormalizeWorkspaceRemoteSubdir(t *testing.T) {
-	t.Parallel()
-
-	t.Run("empty becomes dot", func(t *testing.T) {
-		t.Parallel()
-		got, err := normalizeWorkspaceRemoteSubdir("")
-		require.NoError(t, err)
-		require.Equal(t, ".", got)
-	})
-
-	t.Run("absolute gets normalized to relative", func(t *testing.T) {
-		t.Parallel()
-		got, err := normalizeWorkspaceRemoteSubdir("/toolchains/changelog")
-		require.NoError(t, err)
-		require.Equal(t, "toolchains/changelog", got)
-	})
-
-	t.Run("rejects escaping paths", func(t *testing.T) {
-		t.Parallel()
-		_, err := normalizeWorkspaceRemoteSubdir("../outside")
-		require.ErrorContains(t, err, "outside repository")
 	})
 }
 

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/dagger/dagger/core"
-	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/schema"
 	coresdk "github.com/dagger/dagger/core/sdk"
@@ -296,112 +295,21 @@ func isWorkspaceNotFound(err error) bool {
 	return errors.Is(err, os.ErrNotExist) || status.Code(err) == codes.NotFound
 }
 
-type workspaceRemoteRef struct {
-	cloneRef        string
-	version         string
-	workspaceSubdir string
-	selector        gitref.SelectorType
-}
-
-func parseWorkspaceRemoteRef(ctx context.Context, remoteRef string) (workspaceRemoteRef, error) {
-	return parseWorkspaceRemoteRefWithResolver(ctx, remoteRef, core.ResolveDaggerGetRedirect)
-}
-
-func parseWorkspaceRemoteRefWithResolver(
-	ctx context.Context,
-	remoteRef string,
-	resolve func(context.Context, string) (string, error),
-) (workspaceRemoteRef, error) {
-	// A # selector is the explicit Git URL form: protocol://repo#ref:subpath.
-	if strings.Contains(remoteRef, "#") {
-		parsedRef, err := core.ParseGitRefString(ctx, remoteRef)
-		if err != nil {
-			return workspaceRemoteRef{}, err
-		}
-		workspaceSubdir, err := normalizeWorkspaceRemoteSubdir(parsedRef.RepoRootSubdir)
-		if err != nil {
-			return workspaceRemoteRef{}, fmt.Errorf("invalid git subdir in workspace ref %q: %w", remoteRef, err)
-		}
-		cloneRef := parsedRef.SourceCloneRef
-		resolvedRef, err := resolve(ctx, cloneRef)
-		if err != nil {
-			return workspaceRemoteRef{}, err
-		}
-		if resolvedRef != cloneRef {
-			parsedRef, err := core.ParseGitRefString(ctx, resolvedRef)
-			if err != nil {
-				return workspaceRemoteRef{}, err
-			}
-			cloneRef = parsedRef.SourceCloneRef
-			resolvedSubdir := parsedRef.RepoRootSubdir
-			if resolvedSubdir == "/" {
-				resolvedSubdir = "."
-			}
-			workspaceSubdir, err = normalizeWorkspaceRemoteSubdir(filepath.Join(resolvedSubdir, workspaceSubdir))
-			if err != nil {
-				return workspaceRemoteRef{}, err
-			}
-		}
-		return workspaceRemoteRef{
-			cloneRef:        cloneRef,
-			version:         parsedRef.ModVersion,
-			workspaceSubdir: workspaceSubdir,
-			selector:        parsedRef.Selector,
-		}, nil
-	}
-
-	// The @ selector uses Go-like import path semantics, with any path after the
-	// repository root identifying the workspace subdirectory.
-	remoteRef, err := resolve(ctx, remoteRef)
-	if err != nil {
-		return workspaceRemoteRef{}, err
-	}
-	parsedRef, err := core.ParseGitRefString(ctx, remoteRef)
-	if err != nil {
-		return workspaceRemoteRef{}, err
-	}
-	workspaceSubdir := "."
-	if parsedRef.RepoRootSubdir != "/" && parsedRef.RepoRootSubdir != "." {
-		workspaceSubdir = parsedRef.RepoRootSubdir
-	}
-	return workspaceRemoteRef{
-		cloneRef:        parsedRef.SourceCloneRef,
-		version:         parsedRef.ModVersion,
-		workspaceSubdir: workspaceSubdir,
-		selector:        parsedRef.Selector,
-	}, nil
-}
-
-func normalizeWorkspaceRemoteSubdir(subdir string) (string, error) {
-	if subdir == "" {
-		return ".", nil
-	}
-	subdir = filepath.Clean(subdir)
-	subdir = strings.TrimPrefix(subdir, string(filepath.Separator))
-	if subdir == "" || subdir == "." {
-		return ".", nil
-	}
-	if !filepath.IsLocal(subdir) {
-		return "", fmt.Errorf("path points outside repository: %q", subdir)
-	}
-	return subdir, nil
-}
-
 // loadWorkspaceFromRemote clones a git repo and detects/loads the workspace from it.
 func (srv *Server) loadWorkspaceFromRemote(ctx context.Context, client *daggerClient, remoteRef string) error {
-	parsedRef, err := parseWorkspaceRemoteRef(ctx, remoteRef)
+	parsedRef, err := core.ParseWorkspaceRemoteRef(ctx, remoteRef)
 	if err != nil {
 		return fmt.Errorf("remote workspace %q: parsing git ref: %w", remoteRef, err)
 	}
 
-	tree, gitRef, err := srv.cloneGitTree(ctx, client.dag, parsedRef)
+	tree, gitRef, err := core.CloneWorkspaceGitTree(ctx, client.dag, parsedRef)
 	if err != nil {
 		return fmt.Errorf("remote workspace %q: %w", remoteRef, err)
 	}
 
 	resolveLocalRef := func(ws *workspace.Workspace, relPath string) string {
 		subPath := filepath.Join(ws.Root, relPath)
-		return core.GitRefString(parsedRef.cloneRef, subPath, parsedRef.version)
+		return core.GitRefString(parsedRef.CloneRef, subPath, parsedRef.Version)
 	}
 
 	return srv.detectAndLoadWorkspaceWithRootfs(ctx, client,
@@ -409,18 +317,18 @@ func (srv *Server) loadWorkspaceFromRemote(ctx context.Context, client *daggerCl
 		func(ctx context.Context, path string) ([]byte, error) {
 			return core.DirectoryReadFile(ctx, tree, path)
 		},
-		parsedRef.workspaceSubdir,
+		parsedRef.WorkspaceSubdir,
 		resolveLocalRef,
 		func(ws *workspace.Workspace) string {
-			return remoteWorkspaceAddress(parsedRef.cloneRef, ws.Cwd, parsedRef.version)
+			return remoteWorkspaceAddress(parsedRef.CloneRef, ws.Cwd, parsedRef.Version)
 		},
 		false, // isLocal
 		tree,  // pre-built rootfs for remote
-		core.NewWorkspaceSourceGitRef(gitRef.Result, gitutil.IsCommitSHA(parsedRef.version)),
+		core.NewWorkspaceSourceGitRef(gitRef.Result, gitutil.IsCommitSHA(parsedRef.Version)),
 		// The workspace tree is remote, but user-level config still comes from
 		// the caller's host; the key is the declared remote itself.
 		client.engineUtilClient.ReadCallerHostFile,
-		workspace.NormalizeGitRemote(parsedRef.cloneRef),
+		workspace.NormalizeGitRemote(parsedRef.CloneRef),
 	)
 }
 
@@ -1105,70 +1013,6 @@ func localWorkspaceAddress(root, workspaceCwd string) string {
 
 func remoteWorkspaceAddress(cloneRef, workspaceCwd, version string) string {
 	return core.GitRefString(cloneRef, workspaceCwd, version)
-}
-
-// cloneGitTree clones a git repository and returns its selected ref and tree.
-func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, remote workspaceRemoteRef) (dagql.ObjectResult[*core.Directory], dagql.ObjectResult[*core.GitRef], error) {
-	supportsVersionQueries := core.AfterVersion(workspace.VersionQueriesVersion).Contains(dag.View)
-	refSelector := workspaceGitRefSelector(remote, supportsVersionQueries)
-
-	var gitRef dagql.ObjectResult[*core.GitRef]
-	err := dag.Select(ctx, dag.Root(), &gitRef,
-		dagql.Selector{
-			Field: "git",
-			Args: []dagql.NamedInput{
-				{Name: "url", Value: dagql.String(remote.cloneRef)},
-			},
-		},
-		refSelector,
-	)
-	if err != nil {
-		return dagql.ObjectResult[*core.Directory]{}, gitRef, fmt.Errorf("resolving repo ref: %w", err)
-	}
-
-	var tree dagql.ObjectResult[*core.Directory]
-	err = dag.Select(ctx, gitRef, &tree,
-		dagql.Selector{
-			Field: "tree",
-			Args: []dagql.NamedInput{
-				{Name: "discardGitDir", Value: dagql.NewBoolean(true)},
-			},
-		},
-	)
-	if err != nil {
-		return tree, gitRef, fmt.Errorf("cloning repo: %w", err)
-	}
-	return tree, gitRef, nil
-}
-
-func workspaceGitRefSelector(remote workspaceRemoteRef, supportsVersionQueries bool) dagql.Selector {
-	// Use HEAD without a selector and literal ref resolution unless an @
-	// selector contains a SemVer query supported by this API version.
-	refSelector := dagql.Selector{Field: "head"}
-	if remote.version != "" {
-		refSelector = dagql.Selector{
-			Field: "ref",
-			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(remote.version)}},
-		}
-		if remote.selector == gitref.ModuleVersionSelector &&
-			supportsVersionQueries &&
-			core.IsReleaseVersionQuery(remote.version) {
-			refSelector = dagql.Selector{
-				Field: "latest",
-				Args: []dagql.NamedInput{{
-					Name:  "version",
-					Value: dagql.String(remote.version),
-				}},
-			}
-			if remote.workspaceSubdir != "." {
-				refSelector.Args = append(refSelector.Args, dagql.NamedInput{
-					Name:  "tagPrefix",
-					Value: dagql.String(remote.workspaceSubdir),
-				})
-			}
-		}
-	}
-	return refSelector
 }
 
 // ensureModulesLoaded loads pending modules (workspace, compat, and -m) on

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -434,31 +434,38 @@ const (
 
 const maxParallelModuleResolves = 8
 
+// loadWorkspaceConfig parses the workspace config and returns the keys the file
+// spells out alongside it. Merging an included config needs that presence information,
+// and re-reading the file to compute it later would be a second host round trip.
 func loadWorkspaceConfig(
 	ctx context.Context,
 	readFile func(context.Context, string) ([]byte, error),
 	ws *workspace.Workspace,
-) (*workspace.Config, error) {
+) (*workspace.Config, map[string]bool, error) {
 	if ws.ConfigFile == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	configPath := filepath.Join(ws.Root, ws.ConfigFile)
 	data, err := readFile(ctx, configPath)
 	if err != nil {
 		if isWorkspaceNotFound(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, fmt.Errorf("reading workspace config %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("reading workspace config %s: %w", configPath, err)
 	}
 
 	cfg, err := workspace.ParseConfigAt(ctx, data, filepath.Dir(ws.ConfigFile))
 	if err != nil {
-		return nil, fmt.Errorf("parsing workspace config %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("parsing workspace config %s: %w", configPath, err)
 	}
 	if cfg.Modules == nil {
 		cfg.Modules = map[string]workspace.ModuleEntry{}
 	}
-	return cfg, nil
+	explicitKeys, err := workspace.ExplicitConfigKeys(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing workspace config %s: %w", configPath, err)
+	}
+	return cfg, explicitKeys, nil
 }
 
 func workspaceConfigPendingModules(
@@ -640,8 +647,9 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 	}
 
 	var wsConfig *workspace.Config
+	var wsConfigKeys map[string]bool
 	if ws != nil && ws.ConfigFile != "" {
-		wsConfig, err = loadWorkspaceConfig(ctx, readFile, ws)
+		wsConfig, wsConfigKeys, err = loadWorkspaceConfig(ctx, readFile, ws)
 		if err != nil {
 			return err
 		}
@@ -736,6 +744,24 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 
 	if !loadModules {
 		return nil
+	}
+
+	// An included config is the bottom layer: it applies before the user-level
+	// overlay and the env overlay, so the current workspace always wins.
+	//
+	// Resolving here, after client.workspace is set, is what makes a git
+	// include's pin land in this workspace's dagger.lock: the lock binding
+	// reads the client's workspace.
+	includeSource := core.IncludeSource{
+		Dag:       client.dag,
+		ConfigDir: filepath.Dir(ws.ConfigFile),
+		ReadWorkspaceFile: func(ctx context.Context, wsPath string) ([]byte, error) {
+			return readFile(ctx, filepath.Join(ws.Root, wsPath))
+		},
+	}
+	wsConfig, err = core.ApplyIncludes(ctx, includeSource, wsConfig, wsConfigKeys)
+	if err != nil {
+		return err
 	}
 
 	// User-level overrides merge over the repository config before any env

--- a/future/done/workspace-include.md
+++ b/future/done/workspace-include.md
@@ -1,0 +1,690 @@
+# Workspace Config Include
+
+author: eunomie
+created: 2026-08-12
+status: implemented
+
+PR: [#13882](https://github.com/dagger/dagger/pull/13882)
+
+## Problem
+
+Teams that run Dagger across many repositories duplicate the same `dagger.toml`
+in every one of them: the same toolchain modules, the same pinned tool versions,
+the same module settings, the same env definitions. When a version moves, every
+repository has to be edited.
+
+This is a confirmed want, not a hypothetical one. From Discord:
+
+- _vindico_: "I'm currently putting duplicated workspace config in a lot of repos."
+- _chrisp6229_: asked to publish standard workspace configs per project type
+  (go / node / terraform) and have downstream repos point at one, so tool
+  versions are managed in one place.
+- _shykes_: "As long as we don't go crazy with the config layering and other
+  complications, it seems reasonable. Like a basic import feature in dagger.toml."
+
+There is no mechanism today. `dagger.toml` is read from exactly one file; the
+only layering that exists is the user-level overlay (`[workspaces.*]` in the
+user config) and env overlays (`[env.<name>]`), both of which are local to the
+machine or to the file itself.
+
+## Goals
+
+- A workspace can name another config file — by path or by git ref — whose
+  contents are loaded and merged **underneath** its own config.
+- The current workspace wins on every conflict, with a merge rule that is
+  written down per config section rather than left to whatever the code does.
+  "Wins" means _explicitly set_, including an explicit `false` or an explicit
+  empty list — not merely "non-zero".
+- A git include is pinned in `dagger.lock` like every other git ref this repo
+  resolves: later runs reuse the recorded pin, and `dagger update` refreshes it.
+  A path include has nothing to pin.
+- Only _remote_ module references survive the include. A local module reference
+  in the included config must not become loadable in the workspace.
+- The merged result is what read surfaces (`dagger workspace config`, module
+  listing, env listing) report, so the effect is visible rather than silent.
+
+## Non-goals (YAGNI)
+
+- **No multi-include composition.** The `[[include]]` shape allows several
+  entries, but resolving more than one is an error for now: no ordered layer
+  stack, no diamond resolution. The limit lives in `workspace.MaxIncludes` and
+  can lift without changing what anyone has written.
+- **No transitive includes.** If the included config itself declares an
+  include, that is an error (see
+  [Limitation 1](#limitation-1--one-include-no-chain)), not a second layer.
+- **No new lock operation kind.** The include reuses the existing git lock
+  operations (`git-latest` for a mutable selection, `git-sha` for the
+  immutable resolution).
+- **No inheriting the included config's local module tree**, generated clients,
+  or SDK-managed authoring state — see
+  [Limitation 2](#limitation-2--configuration-not-code) for why, and for the
+  sketch of what a later version would do.
+- **No tombstones.** An inherited entry can be overridden but not deleted. See
+  [Inherited entries cannot be removed](#inherited-entries-cannot-be-removed).
+- **No write-through.** `dagger install`, `dagger workspace config <key> <value>`
+  and every other mutation keep writing the _local_ `dagger.toml` only. The
+  include is read-only input.
+
+## Proposed approach
+
+### Config surface
+
+A top-level array of tables in `dagger.toml`:
+
+```toml
+[[include]]
+source = "github.com/acme/dagger-base@v1.2.0"
+
+[modules.go]
+settings.goVersion = "1.24"
+```
+
+`source` addresses a config **file**, not a workspace root, and comes in two
+forms:
+
+- **a path**: `common/base.toml` relative to the including config's directory,
+  `./base.toml` or `../shared/base.toml` next to it, or `/common/base.toml` from
+  the workspace root — the same rule `resolveWorkspacePath` applies to every
+  other path a workspace resolves, so a root-anchored include reads the same
+  from any subdirectory.
+- **a git ref**: `github.com/acme/dagger-base@v1.2.0`,
+  `github.com/acme/dagger-base/common/base.toml@v1.2.0`, or the fragment form
+  that names the file inside the repository,
+  `https://host/repo.git#main:dagger/base.toml`,
+  `ssh://git@host/repo.git#v1:base.toml`, `git@github.com:acme/base.git`.
+
+**Which of the two a source is, is decided by `workspace.IsLocalRef`** — the
+classifier every other ref in a workspace config is read with. A leading `/`,
+`./` or `../`, or a first path segment carrying neither a dot nor a colon, means
+a path; anything else is a git ref. Answering the same question the same way
+everywhere is worth more than a rule tuned for the paths an include happens to
+favour, and it needs no scheme, no `#` fragment and no filesystem. The one place
+the two readings differ is a dotted filename sitting directly beside the config:
+`base.toml` on its own reads as a git ref, so it is spelled `./base.toml`.
+
+A source naming a **directory** reaches the `dagger.toml` inside it, decided by
+extension alone — path cleaning eats a trailing `/`, so it carries no signal. A
+source with a file extension is a file, one without is a directory: `common` and
+`https://host/repo.git#main:dagger/common` reach the `dagger.toml` inside,
+`common/base.toml` is read as written, and a directory whose own name has an
+extension is reached by naming the config inside it (`common.d/dagger.toml`).
+
+**An array, with one entry allowed.** The shape is `[[include]]` so several can
+be expressed, but resolving more than one is rejected: ordering between includes
+and what happens when two of them disagree are questions this feature does not
+answer yet. One entry is enough to share a base config, and the limit can lift
+without changing what anyone has written. `workspace.MaxIncludes` is the single
+place that says so.
+
+**A file, not a workspace.** The earlier design resolved the ref to a workspace
+_root_ and read the `dagger.toml` it detected there. Naming the file directly is
+what makes `common/base.toml` and `https://host/repo.git#main:dagger/app-base.toml`
+work: a
+repository can publish several base configs side by side without each needing
+its own workspace.
+
+### Naming
+
+The key is `include`, after two earlier names. `import` was rejected upstream as
+confusing next to module imports; `blueprint` was tried and dropped because it
+revived a retired `dagger.json` term for a different meaning. `include` says
+what the feature does with no vocabulary to learn — this file, in that one — and
+reads the same way in every config format people already use.
+
+### Where it happens
+
+```mermaid
+graph TD
+    A["dagger.toml (current workspace)"] -->|"[[include]] source"| B{"IsLocalRef?"}
+    B -->|"git ref"| C["git tree @ commit<br/>lock: git-sha entry"]
+    B -->|"path"| C2["the workspace's own files"]
+    C --> D["read the named config file<br/>(dagger.toml when it names a directory)"]
+    C2 --> D
+    D --> E{"included config<br/>declares an include?"}
+    E -->|yes| F["error: nested includes<br/>are not supported"]
+    E -->|no| G["sanitize: classify every included<br/>module source with IsLocalRef"]
+    G --> H["drop local entries + their env<br/>overlays and ports, warn once"]
+    H --> I[merge]
+    A --> I
+    I --> J{"merged entry<br/>without a source?"}
+    J -->|yes| K["error: override of a module<br/>the include does not provide"]
+    J -->|no| L[effective workspace config]
+```
+
+Layering, lowest to highest — the include slots in _below_ everything that
+exists today, so no current precedence changes:
+
+```mermaid
+graph BT
+    I["include dagger.toml"] --> R["repo dagger.toml"]
+    R --> U["user-level overlay<br/>(~/.config [workspaces.*])"]
+    U --> E["--env overlay"]
+    E --> F["effective config"]
+```
+
+Consumers of the merged config:
+
+1. `engine/server/session_workspaces.go` — workspace module loading, merged
+   before the user overlay and the env overlay are applied.
+2. `core/schema/workspace_config.go:readWorkspaceConfig` — the shared read path
+   behind `Workspace.modules`, `Workspace.envList`, `Workspace.sdks`,
+   `currentModule.asSDK` and the SDK-ownership lookup in `modulesource.go`.
+3. `core/schema/workspace_config.go:configRead` — **its base path too**.
+   `configRead` only calls `readWorkspaceConfig` in its env-selected and
+   user-overlay branches; with neither overlay it returns raw `readConfigBytes`
+   output. Patching only `readWorkspaceConfig` would leave plain
+   `dagger workspace config` unmerged, which is the headline surface. The
+   `[[include]]` block is the one exception, and it is handled **above** the branch
+   split: every effective view strips it, so answering it from a merged view
+   would report "key is not set" under `--env` or a user overlay — and would
+   resolve the include just to report what the local file already says.
+4. `core/schema/modulesource.go:workspaceModuleSourceByName` — a separate raw
+   read of `dagger.toml` from the caller's cwd, used to resolve
+   `--load-module <installed-name>`.
+
+`workspaceConfigWithCompatFallback` (checks, generate, up, port mappings, and
+address demand-loading) sits on top of `readWorkspaceConfig` and inherits the
+merge without its own change.
+
+The three that resolve an include for themselves — 1, 2/3 and 4 — go through
+one `core.ApplyIncludes`: validate the include list, load, merge, validate the
+result. Only building the `IncludeSource` genuinely differs between them, and
+the sequence is exactly the kind that drifts when it is written out three
+times; the last step in particular, since a caller that skipped it would accept
+a config every other read path rejects.
+
+Include resolution must run under the **workspace owner's client context**
+(`withWorkspaceClientContext`), the same way `readConfigBytes` and
+`withUpdatedLock` do. Resolving in the caller's context would bind the git
+lookup to the wrong workspace lock when the `Workspace` receiver is not the
+caller's own.
+
+Config **writers** (`loadWorkspaceConfigForOverlay`) keep parsing the raw local
+file. Reads are effective; writes are local. That is the same split the env
+overlay already uses.
+
+### Merge semantics, per section
+
+`current` is the workspace's own `dagger.toml`; `include` is the
+resolved and sanitized one. **"Set" means explicitly present in the current
+`dagger.toml`**, decided from the parsed TOML document, not from the Go zero
+value: `entrypoint = false`, `ignore = []` and `check.skip = []` are overrides,
+not absences.
+
+| Section / key | Rule |
+| --- | --- |
+| `include` | Never inherited. The current workspace's own value survives the merge, so the merged `Config` still knows what it includes; the printed effective view replaces the block with a `# included: <source>` comment (see [CLI-visible behavior](#cli-visible-behavior)). An `include` in the included config is an error. |
+| `ignore` | Current replaces when present, including `ignore = []` to clear. No union — a union would make it impossible to drop an inherited pattern. |
+| `defaults_from_dotenv` | Current replaces when present, including `false`. |
+| `check-generated` | `*bool`; current wins when non-nil. |
+| `modules.<name>` | Merged **per field**, not wholesale, so a downstream repo can override one setting without repeating `source`. |
+| `modules.<name>.source` | Current wins when set. When the current entry sets `source`, its `pin` travels with it and the included config's `pin` is discarded — the same coupling `applyModuleOverlays` already uses for env overlays. |
+| `modules.<name>.pin` | Current wins when set, unless overridden by the source coupling above. |
+| `modules.<name>.settings.<key>` | Merged key by key; current wins per key. An inherited key cannot be deleted, only overridden. |
+| `modules.<name>.entrypoint` | Current replaces when present, including `false`. Presence matters here more than anywhere: an inherited `entrypoint = true` that could not be switched off would collide with the downstream repo's own entrypoint, and the loader rejects two ambient entrypoints. |
+| `modules.<name>.legacy-default-path` | **Never inherited.** It is migration-compat state for a specific local module tree, not reusable configuration. A current entry keeps its own value. |
+| `modules.<name>.{up,generate,check}.skip` | Current replaces when present, including an explicit empty list. |
+| `modules.<name>.as-sdk` | **Never inherited** — marker, `name`, `modules` and `clients` are all dropped from the include. `modules`/`clients` are workspace-root-relative paths into the base repo; keeping the marker alone would advertise an SDK that no init flow can use, since init writes SDK-managed paths and reads only the local config. A current entry keeps its own `as-sdk` wholesale. |
+| `env.<name>` | Merged per env name; an env that only the include defines is selectable downstream. |
+| `env.<name>.modules.<mod>` | Same field rules as `modules.<name>` (source/pin coupling, settings key by key). |
+| `ports.<host>` | Current replaces **wholesale** per host port. Per-field merge was tried and reverted: `writePortEntries` always serializes both keys, so setting one through `dagger workspace config` writes `backendPort = 0` into the file, which a presence-aware merge would then read as an explicit override to port 0. A service and its port are one unit; overriding one means repeating the other. Completeness is deliberately **not** validated — `dagger workspace config ports.3000.backendService web` writes one key at a time, so a partial mapping is a state the CLI itself produces and configs that load today would start failing on every read. Ports keep their pre-existing behavior. |
+
+### Module entries become patches, and validation moves after the merge
+
+With an include present, `[modules.<name>]` may omit `source` when the included
+config supplies that module. This is the mechanism behind the primary use case
+("bump one setting, inherit the module ref"), and it is a real change to the
+config contract, not an implementation detail:
+
+- **Generated JSON schema**: `docs/static/reference/dagger-workspace.schema.json`
+  is reflected from `workspace.Config` by `cmd/json-schema`, and marked `source`
+  required. `ModuleEntry.Source` gains `omitempty` so the schema stops rejecting
+  a valid patch entry.
+- **Serialization**: `SerializeConfig` and the document editor both stop
+  writing `source = ""` for an entry with no source — otherwise the first
+  `dagger workspace config` write over a patch entry re-introduces the empty
+  key that the schema change just made unnecessary.
+- **`ValidateEffectiveConfig(cfg) error`** takes over what the schema no longer
+  guarantees, and it runs **unconditionally on every effective config**, not only
+  when an include is present: every module entry has a non-empty source (a patch
+  entry whose include was removed, or that names a module the include does not
+  provide, is an error naming the module — not a `pendingModule` with an empty
+  `Ref`). Port completeness is **not** checked, for the reason in the merge
+  table's `ports.<host>` row.
+
+  Running it only inside the include branch would be worse than not relaxing the
+  schema at all: unsetting `include` would silently turn a valid patch into an
+  unloadable entry. It is called after the optional merge in the load path and
+  in the effective-read path.
+
+Install and uninstall have to learn the same distinction, because they plan
+against the raw local config:
+
+- `planWorkspaceInstallConfig` compares a new ref against the existing entry's
+  source and reports a conflict when they differ; an empty source must read as
+  "not installed locally" so `dagger install` fills it in instead of failing.
+- `withoutModule` deleting a source-less patch entry removes an **override**,
+  not an installation — the inherited module comes back, and no managed-module
+  directory is removed with it, because there is no local module. The CLI checks
+  whether the module is still listed after the write and says the overrides were
+  removed, rather than "Uninstalled module".
+
+### Limitation 1 — one include, no chain
+
+**Decision: an `[[include]]` block in the included config is an error**, reported at
+workspace load with both refs named.
+
+Silently ignoring it would hand the downstream user a config that is missing
+whatever the base author expected to inherit, with no signal — the failure would
+surface much later as a missing module or a wrong setting. An error is
+actionable and fails closed, which is what this repo does elsewhere. The cost is
+that an include author cannot themselves build on an include; that is the scope control
+being asked for, and the error says so.
+
+### Limitation 2 — configuration, not code
+
+**Decision: module entries in the included config whose source is a local path
+are dropped, with a warning naming them.**
+
+A local source in an included config means a directory next to _that_ config,
+and resolving it as written resolves it against the **consuming** workspace, via
+`workspace.ResolveModuleEntrySource(configDir, …)` in
+`workspaceConfigPendingModules` — loading a different module or failing with a
+path the user never wrote. Dropping prevents that, and keeps an include to
+sharing configuration.
+
+Erroring instead was the first choice and is wrong: a normal repository keeps
+project-specific modules under `modules/`, so erroring would make an ordinary
+repo unusable as an include target because of a `ci` module the consuming user
+never asked for.
+
+**This is a deliberate stopping point, not the end state.** Inheriting the
+included config's own local modules is not implemented in this version. It is
+buildable: a git include's modules _are_ addressable, because the config came
+from a repository at a known commit, so `source = "modules/ci"` could be
+inherited as `<clone-ref>/modules/ci@<commit>`, exactly the rewrite remote
+workspace selection already performs through `core.GitRefString`. Two findings
+from prototyping it are worth keeping:
+
+- `gitref.Parse` drops an explicit HTTP(S) port when rebuilding a clone ref
+  (only SSH puts it back), which would send a rewritten module to the wrong
+  remote — with different credentials and cache keys;
+- a rewrite must skip built-in SDK runtimes (`source = "dang"` is a name the
+  engine resolves in-process), absolute paths, and paths that escape the
+  repository, which `GitRefString` would silently normalize to a root-level
+  path.
+
+**Classification is `workspace.IsLocalRef`, the classifier the loader itself
+uses**, with an **empty pin**. Agreeing with the loader is the whole correctness
+criterion: anything sanitization keeps is something the loader will then
+resolve, so the two must not disagree.
+
+The empty pin is the one deliberate difference from a naive call. `IsLocalRef`
+reads _any_ ref carrying a pin as git, so passing the entry's own pin would let
+`source = "./ci", pin = "…"` survive and then be resolved against the consuming
+workspace. `ResolveModuleEntrySource`, which the loader reaches for the same
+decision, passes an empty pin for the same reason.
+
+This is the same classifier that decides whether the **include source itself**
+is a git ref or a path ([Config surface](#config-surface)). The two questions
+are distinct — one reads a source in the current config, the other a module
+entry inside the included one — but both are ref-vs-path, and answering them
+differently is how a config comes to mean one thing when it is read and another
+when it is loaded. Both replaced two-step rules of this feature's own that
+paired `FastKindCheck` with a filesystem stat to settle `KindUnknown`. Since
+`12d34c468` the shared classifier settles that case syntactically: only the
+segment ahead of the first separator can be a host, so `common/.dagger/mymod`
+reads as local while `vanity.example.com/acme/toolchain` reads as remote,
+neither needing a filesystem. Converging removed the stat plumbing from the
+include loader and its callers, and closed a real gap — where no filesystem was
+available the old rule fell back to "remote", exactly the mis-resolution this
+limitation exists to prevent.
+
+`core.ParseRefString` remains the wrong helper for either: for an ambiguous ref
+it attempts a git parse and **falls back to `Local` on `EndpointError`**, so a
+vanity-domain remote would be classified local whenever endpoint discovery is
+unavailable. Classification must not depend on network reachability.
+
+The warning is emitted **inside the shared loader**, deduplicated per **client**
+and include source through the query's telemetry seen-key store (the mechanism
+`shouldRecordWorkspaceMigrationProgress` already uses), and written through the
+same global-writer + `slog.Warn` path the legacy compat notice uses. Per client,
+not per session: a nested CLI shares its parent's session, so session scope
+would silence every command after the first. Not in the load path:
+`dagger workspace config` connects with `SkipWorkspaceModules`, so a warning
+wired into module loading would never fire on exactly the surface where the
+modules appear to be missing.
+
+The warning names entries as the config spells them, so a dropped env overlay
+appears as a dotted path (`env.ci.modules.local-ci`) rather than a bare module
+name.
+
+Dropping cascades, so no orphan state survives:
+
+- `env.<name>.modules.<dropped>` overlays from the included config are dropped;
+- included `ports.<host>` entries whose `backendService` names a dropped module
+  are dropped. `backendService` is a colon-joined service path
+  (`hello-with-services:web`) whose first segment is the module's **CLI-cased**
+  name, matched at runtime against `Up.Name()` — so the cascade compares the
+  segment before the first colon to the dropped module's kebab-cased name, not
+  to its raw config key;
+- an env overlay in the included config that _installs_ a local module is
+  dropped the same way.
+
+**A residual hole the earlier rule had is now closed.** While classification
+depended on statting the tree the config came from, a dotted source that existed
+in neither tree was kept and then resolved locally downstream. The syntactic
+rule has no such gap: the same string classifies the same way for sanitization
+and for the loader, whatever either can see.
+
+### Inherited entries cannot be removed
+
+The merge is additive per map key and writes only touch the local file, so an
+inherited module, env, port or setting can be overridden but not deleted. No
+tombstone syntax is introduced.
+
+What this must _not_ do is fail confusingly:
+
+- `dagger uninstall <name>` for a module that exists only in the include reports
+  that the module comes from the include and cannot be uninstalled locally,
+  instead of "module is not installed in the workspace". When the workspace does
+  have a source-less entry for it, that entry is an override rather than an
+  install, so uninstalling removes it and says the module is still provided by
+  the include.
+- `dagger workspace config <key> --unset` on an inherited-only value says the
+  value comes from the include instead of "key is not set". The check lives in
+  the schema wrapper (`unsetIncludedValueError` in
+  `core/schema/workspace_builders.go`, called from `withoutConfigValue`), which
+  re-reads the effective config to decide — writers only ever hold the local
+  one; `core/workspace`'s document editor stays include-free. A key the local
+  file does spell out is never blamed on the include.
+
+### Lockfile
+
+No new lock entry kind. The include ref is resolved through the ordinary
+`git(url).head` / `git(url).ref(name)` dagql path, which already:
+
+- writes a `git-sha` entry into `dagger.lock` (namespace `""`,
+  inputs `[remote, ref name]`) the first time the lookup resolves. Locking is
+  pinned by default, so an ordinary run is what records it;
+- is refreshed afterwards by `core.UpdateWorkspaceLock` — `dagger update`
+  refreshes entries that are already recorded; it does not discover an include
+  that has never been resolved, so the first recording comes from an ordinary
+  run;
+- reuses the stored pin on later runs rather than re-resolving the symbolic
+  ref. Reusing a pin does **not** mean offline — materializing the pinned tree
+  may still fetch from the remote;
+- follows whatever policy the lock subsystem applies to git refs generally; this
+  feature adds no rule of its own.
+
+Round trip: an ordinary run resolves the ref and writes the `git-sha` entry on
+session flush; the next run reads the pin back and does not re-resolve the
+symbolic ref — the integration test asserts the lockfile is byte-identical after
+that second run. `dagger update` refreshes the pin.
+
+**Remote workspaces** (`dagger -W <ref>` where that workspace declares an
+include) resolve the include the same way, but their lock behavior is the one
+remote workspaces already have: a remote workspace has no writable host lock
+binding (`workspaceLockPath` needs a host path), so the include's pin has
+nowhere to be recorded and the ref is resolved on each run. Inherited, not
+redesigned.
+
+### CLI-visible behavior
+
+The command is `dagger workspace config`; the hidden top-level `dagger config`
+alias was removed in CLI 1.0 (`future/cli-1.0.md`).
+
+- `dagger workspace config` (no key) prints the **merged** config as a
+  standalone snapshot: the merged `Config` still carries the current
+  workspace's own `include` — the merge never drops it, see the
+  [merge table](#merge-semantics-per-section) — but this printed view
+  **strips** the `[[include]]` block and replaces it with a leading
+  `# included: <source>` comment. This follows the existing env precedent
+  exactly — `effectiveWorkspaceConfigBytes` already
+  clears `Env` from the effective view rather than printing the layer that
+  produced it. Keeping the line in would make the output actively dangerous:
+  pasted back into `dagger.toml`, it would inline every inherited value _and_
+  name the include again underneath them.
+- `dagger workspace config <key>` reads the merged value, same rule.
+  `dagger workspace config include` still reports the local sources, one per
+  line, which is how the include stays addressable.
+- `dagger workspace config include <source>` sets it. The stored shape is an
+  array of tables, but with one entry allowed the CLI addresses it as a single
+  value, and setting it replaces rather than appends.
+- Include resolution runs inside a telemetry span named
+  `including workspace config: <ref>`, mirroring the existing
+  `applying env: <name>` span, so it is visible in the TUI and in traces and any
+  fetch latency is attributed.
+- Dropped local modules from the include produce one warning line naming them,
+  on every command that resolves the include — including
+  `dagger workspace config`, which skips workspace modules entirely.
+- `dagger workspace config --help` gains the effective-read / local-write rule
+  for includes, next to the `--env` wording it already carries.
+- The raw local file remains available: `dagger workspace config-file` prints
+  its path, and it is what every write touches.
+
+## Alternatives considered
+
+**A general `extends`/layer list.** Explicitly rejected upstream ("as long as we
+don't go crazy with the config layering"). Multi-layer merge forces an ordering
+model, conflict-precedence rules across layers, and diamond resolution — all
+before anyone has asked for a second layer.
+
+**An include at the module level (`[modules.X] from = "…"`)**. Solves nothing the
+existing remote module source doesn't; the duplication complained about is the
+_set_ of modules and their settings, not one entry.
+
+**Store the include pin inline in `dagger.toml` (`include-pin = "sha"`).** The
+include is a workspace-level git lookup that the lock subsystem already models; a
+parallel inline pin would duplicate that state and would not be refreshed by
+`dagger update`. (`dagger.toml` does carry `pin` for module and client entries —
+the older "no resolved versions in dagger.toml" rule from
+`hack/designs/workspace.md` is no longer categorical, so it is not the argument.)
+
+**Merge wholesale per module entry instead of per field.** Simpler rule, and it
+would avoid the source-optional change to the config contract, but it forces a
+downstream repo that wants to bump one setting to copy the module's `source`
+too — re-introducing exactly the duplication this feature removes.
+
+**Erroring on local module entries in the include** instead of dropping them.
+Rejected after review: it makes ordinary repositories unusable as includes. See [Limitation 2](#limitation-2--configuration-not-code).
+
+**Classifying refs with `gitref.FastKindCheck` alone**, leaving `KindUnknown` to
+a filesystem stat. Rejected for both the include source and the included
+config's module entries: `IsLocalRef` settles the ambiguous case syntactically,
+so the stat bought nothing and failed open to "remote" where no filesystem was
+reachable. See the same section.
+
+**Resolve the include in the CLI** rather than the engine. The CLI has no git
+resolution or lockfile machinery; the engine has both, and the merged config has
+to be right for module loading, which is engine-side anyway.
+
+## Affected components
+
+| Area | Change |
+| --- | --- |
+| `core/workspace/config.go` | `Config.Include` as `[]IncludeEntry`; `ModuleEntry.Source` gains `omitempty`; serialization; `cloneConfig`; `setConfigValue` case |
+| `core/workspace/config_document.go` | `restoreIncludeSections` puts the `[[include]]` blocks back after the map application, which drops every array of tables it was not given — `configDocumentMap` deliberately does not carry them, since ApplyMap would render one inline. An unchanged list is restored verbatim so an unrelated write keeps its comments and position; explicit-key presence helper |
+| `core/workspace/include.go` (new) | the one-include limit, pure merge, post-merge validation |
+| `core/workspace_include.go` (new, package `core`) | classify the source, load and sanitize the included config; `ApplyIncludes`, the one sequence — validate, load, merge, validate again — that every effective-config path goes through |
+| `core/workspace_remote.go` (new, package `core`) | remote-workspace ref parsing and cloning, shared with workspace selection |
+| `engine/server/session_workspaces.go` | the remote-workspace ref helpers **move** to `core`, with their tests moving out of `engine/server/session_test.go`; resolve and merge during workspace load |
+| `core/schema/workspace_config.go` | merge in `readWorkspaceConfig` **and** in `configRead`'s base path; answer `include` from the local file whatever is layered on; strip `include` from the effective view; owner-client context |
+| `core/schema/modulesource.go` | merge **and validate** in `workspaceModuleSourceByName` |
+| `core/schema/workspace_builders.go` | uninstalling a source-less override removes the override; include-aware errors for uninstalling an inherited module and for `--unset` of an inherited value |
+| `core/schema/workspace_install.go` | an empty source reads as "not installed locally" when planning an install |
+| `internal/cmd/dagger/workspace.go` | `dagger workspace config --help` text; `dagger uninstall` reports the override case instead of "Uninstalled module" |
+| `core/integration/workspace_include_test.go` (new) | multi-workspace fixture over a git service |
+| `docs/current_docs/config/includes.mdx` (new) | the user-facing page, next to Environments |
+| `docs/current_docs/config/reference/dagger-toml.mdx` | the `include` key and its `[[include]]` section |
+| `docs/static/reference/dagger-workspace.schema.json` | regenerated |
+| `.changes/unreleased/Added-*.yaml` | changelog entry |
+
+Untouched on purpose: every config **write** path, the lockfile format, and the
+`Workspace` GraphQL surface (no new field — the merged config flows through
+existing fields).
+
+## Testing
+
+Unit (`core/workspace`), on the pure merge:
+
+- every row of the merge table, including the source/pin coupling;
+- explicit-zero overrides: `entrypoint = false`, `ignore = []`,
+  `defaults_from_dotenv = false`, `check.skip = []` each beat an inherited value;
+- `legacy-default-path` and `as-sdk` never inherited;
+- ports replace wholesale per host port;
+- included config declaring `include` → error;
+- `ValidateEffectiveConfig`: a module entry with no source errors **with and
+  without** an include present, and a partial port mapping is accepted;
+- an `[[include]]` with an empty source is rejected, and a write that would
+  create one is refused;
+- config round trip: `Include` survives `SerializeConfig` → `ParseConfig`,
+  `WriteConfigValue` / `ReadConfigValue` / `DeleteConfigValue` on `include`, a
+  document-preserving update over a source-less patch entry that neither
+  re-introduces `source = ""` nor duplicates the key, and an unrelated write
+  that leaves an untouched `[[include]]` block where it was, comment included.
+
+Unit (`core`), on classifying an include source, one case per spelling the
+reference page advertises in either direction, plus the path resolver (Windows
+separators, root anchoring, refused escapes) and the file-versus-directory rule.
+
+Unit (`core`), on sanitization, against config text alone — the syntactic
+classifier needs no tree:
+
+- `source = "modules/ci"` → dropped;
+- `source = "./ci", pin = "abc"` → dropped, proving the pin does not launder a
+  local source;
+- `source = "modules/foo.bar"` → dropped, the dotted-path case the earlier stat
+  rule got wrong;
+- `source = "github.com/acme/toolchain@v1"` and
+  `source = "vanity.example.com/acme/toolchain"` → kept, the vanity domain
+  **with no network in play at all**, pinning the reason `ParseRefString` is not
+  used;
+- `source = "php"` — the bare short name `dagger setup` writes for a migrated
+  SDK — → dropped, which is the reasoning the `setupResolveMigratedSDKs` risk
+  below rests on;
+- dropping cascades to the module's env overlays in the included config and to ports whose
+  `backendService` prefix is the module's kebab-cased name (covered with a
+  non-canonical module key such as `MyTool`, and for a module an env overlay
+  alone installs).
+
+Integration (`core/integration/workspace_include_test.go`). A git include's
+repository is served by `gitSmartHTTPServiceDirAuth` at an IP-addressable URL —
+the pattern `workspaceSelectionRemoteRef` already uses, which is reachable from
+the engine that resolves the include itself (no `ExperimentalServiceHost`); a
+path include needs no fixture beyond a second file in the workspace.
+
+1. **Merge**: the workspace declares an include plus one setting override with
+   no `source`; `dagger workspace config` shows the included module with its ref
+   inherited and the override applied, the output names the include in a comment
+   instead of carrying the block, `dagger workspace config include` still reports
+   the local source, and the module the include contributes loads.
+2. **Conflict**: same module name in both → the current workspace's `source`
+   wins and the inherited pin goes with the ref it belonged to; `ignore`
+   replaces; `entrypoint = false` downstream beats an inherited
+   `entrypoint = true`.
+3. **Path include**: `source = "common/base.toml"` next to the including config
+   is merged with no git service in play, and `source = "/common/base.toml"`
+   resolves from the workspace root.
+4. **Directory include**: `source = "common"` reaches `common/dagger.toml`.
+5. **More than one include**: two `[[include]]` blocks → error naming the count
+   and the limit.
+6. **Local module blocked**: the included config declares a local module _and_
+   the consuming repo contains a same-named directory. The module does not
+   appear in the merged config, and the warning names it under plain
+   `dagger workspace config`, which skips workspace modules entirely.
+7. **No chain**: the included config includes something in turn → explicit error.
+8. **Missing target**: the include points where no config exists → error naming
+   the file.
+9. **Dangling override**: a `[modules.x]` patch entry with no source and an
+   include that does not provide `x` → clear error.
+10. **Env from the include**: an env defined only in the included config is
+    selectable with `--env` downstream.
+11. **Setting the include through the CLI**:
+    `dagger workspace config include common/base.toml` writes the block without
+    swallowing the bare keys above it, reads back the local source, and the
+    effective view then carries what the include provides.
+12. **Writes stay local**: a setting write records only the override — no
+    inherited ref, no `source = ""` — and uninstalling a module the include
+    provides names the include.
+13. **Lockfile**: an ordinary run records a `git-sha` entry naming the included
+    repository, and a later run resolves the same merged config while leaving
+    the lockfile byte-identical.
+
+Two cases are deliberately absent:
+
+- **Lock refresh** (`dagger update` after the base branch moves)
+  is not expressible with this fixture: the git service serves a fixed tree, and
+  re-serving moves the URL, which changes the lock inputs. The entry is the
+  ordinary git entry whose refresh `core/integration/lockfile_test.go`
+  already covers.
+- **"A missing lock entry fails the run"** turned out to assert engine behavior
+  this feature does not own: with the tree already resolved in the same engine,
+  the dagql cache can satisfy `git().ref()` without the resolver — and therefore
+  without any lock check — running at all.
+
+Error-message assertions use stable substrings.
+
+## Risks
+
+- **Workspace load grows a network round trip** when an include is declared: a
+  ref resolution plus a git tree fetch, both dagql-cached and both skipped
+  entirely when no `[[include]]` block exists. Once pinned, the ref resolution
+  is replaced by the stored pin, though the tree may still be fetched.
+- **A failed include can read as "module not installed".** Address resolution
+  demand-loads workspace modules and deliberately discards config errors
+  (`demandLoadInstalledModule` in `core/schema/address.go`), so an unreachable
+  include degrades to a not-found on that path. The module-loading path and `dagger workspace config`
+  still report it properly. Accepted; noted in the PR.
+- **`dagger workspace config` becomes an effective view** for the base case as
+  well, which may surprise someone expecting a `cat` of the file. Mitigated by
+  the same behavior already existing for `--env` and user overlays, and by
+  `dagger workspace config-file`.
+- **The uninstall and unset error paths re-resolve the include** to decide what
+  to say: they run in a writer, which only holds the local config, so naming the
+  include costs another effective read. Only on the error and override paths, and
+  the resolution is dagql-cached within the session.
+- **`ValidateEffectiveConfig` rejects a source-less module entry in a workspace
+  with no include.** Such a config loads on `main` today — the entry becomes a
+  `pendingModule` with an empty `Ref` — and now fails every read with an error
+  naming the module. That is the point of moving the check off the JSON schema,
+  but it is a behavior change for a config nobody writes deliberately.
+- **One CLI path writes from what `configRead` returned**:
+  `setupResolveMigratedSDKs` (`internal/cmd/dagger/setup.go`) parses
+  `Workspace.configRead` and writes fixups back. It only rewrites entries whose
+  source is a bare short name (e.g. `php`), which classify as local and are
+  therefore always dropped from an include — so an inherited entry can never
+  reach it. A unit test pins that reasoning; if it ever stops holding, that call
+  site must read the local file instead.
+- **Inherited entries cannot be deleted.** Covered above; the mitigation is
+  error-message quality, not a mechanism.
+- **An explicit clear reads as "not set".** `SerializeConfig` omits zero values,
+  so a current `ignore = []` or `check.skip = []` that clears an inherited list
+  does not appear in the effective view, and
+  `dagger workspace config ignore` answers "key is not set". The _value_ it
+  implies is right (the effective list is empty) and `entrypoint` /
+  `defaults_from_dotenv` already resolve to `false` through
+  `readMissingConfigDefault`; only the phrasing is off for explicitly-cleared
+  lists. Fixing it properly needs a presence-preserving serializer, which is
+  more machinery than the wording is worth. Documented.
+- **Relaxing `source` to optional in the generated schema** weakens static
+  validation for configs that have no include. The engine's post-merge check
+  covers both cases, and is what actually gates loading.
+- **Init flows against an included SDK.** `loadWorkspaceConfigForOverlay` is a
+  write path and stays unmerged, and include `as-sdk` data is dropped entirely,
+  so an SDK can only be authored against from the local config. Deliberate: init
+  writes SDK-managed paths into the config that owns them.
+
+## Related prior art
+
+- `hack/designs/workspace.md` — `dagger.toml` shape, env overlays, entrypoint
+  arbitration.
+- `hack/designs/lockfile.md` — lookup entries and pinning policy, reused
+  verbatim here.
+- `future/cli-1.0.md` — `dagger workspace config` surface, `[modules.*.as-sdk]`
+  semantics, and inline pins in `dagger.toml`.
+- `future/done/2026-05-27-workspace-disable-inheritance.md` — a _different_
+  inheritance: runtime workspace authority across module calls. Unrelated
+  mechanism, but the same instinct — inheritance must be explicit and bounded.
+- `future/synthetic-workspace.md` — `GitRef.asWorkspace`; the same "a git ref can
+  denote a workspace" idea the include ref relies on.

--- a/future/done/workspace-include.md
+++ b/future/done/workspace-include.md
@@ -40,7 +40,7 @@ machine or to the file itself.
   A path include has nothing to pin.
 - A module the included config installs is usable here, whether it named a
   remote ref or a directory beside itself. What it must never do is resolve a
-  path of the included config's against the *consuming* workspace.
+  path of the included config's against the _consuming_ workspace.
 - The merged result is what read surfaces (`dagger workspace config`, module
   listing, env listing) report, so the effect is visible rather than silent.
 
@@ -295,7 +295,7 @@ Resolving it as written resolves it against the **consuming** workspace, via
 path the user never wrote. So it cannot be passed through untouched. It also
 must not simply be dropped, because sharing the modules is the point:
 
-```
+```text
 monorepo/
   shared/tester/          the module
   common/dagger.toml      [modules.tester] source = "../shared/tester"
@@ -667,7 +667,7 @@ path include needs no fixture beyond a second file in the workspace.
    installs them by relative path, `project-a/` and `project-b/` include
    `../common`. From either project, `dagger module list` shows the shared
    modules, `dagger call <module> …` runs them, the effective config shows them
-   addressed relative to the *including* project, and `project-b` overrides one
+   addressed relative to the _including_ project, and `project-b` overrides one
    of their settings without repeating a source.
 7. **An inherited module reaches the command tree**: a module a path include
    contributes appears in `dagger functions`, `dagger call --help`,

--- a/future/done/workspace-include.md
+++ b/future/done/workspace-include.md
@@ -669,30 +669,35 @@ path include needs no fixture beyond a second file in the workspace.
    modules, `dagger call <module> …` runs them, the effective config shows them
    addressed relative to the *including* project, and `project-b` overrides one
    of their settings without repeating a source.
-7. **A git include's own modules**: the consuming workspace holds a different
+7. **An inherited module reaches the command tree**: a module a path include
+   contributes appears in `dagger functions`, `dagger call --help`,
+   `dagger api functions` and `dagger api call --help`. The command tree is
+   built from the API schema rather than from the config, so a workspace can
+   list an inherited module and still not offer it as a command.
+8. **A git include's own modules**: the consuming workspace holds a different
    module at the very same path the included entry names, which is what the
    re-addressing has to get right. The effective config shows the entry as a ref
    into the included repository at a full commit SHA rather than the path it was
    written as, and the call reaches the included repository's module.
-8. **Modules with no address are left out**: a built-in SDK install and an entry
+9. **Modules with no address are left out**: a built-in SDK install and an entry
    escaping the included repository. Neither appears in the merged config, and
    the warning names both under plain `dagger workspace config`, which skips
    workspace modules entirely.
-9. **No chain**: the included config includes something in turn → explicit error.
-10. **Missing target**: the include points where no config exists → error naming
+10. **No chain**: the included config includes something in turn → explicit error.
+11. **Missing target**: the include points where no config exists → error naming
     the file.
-11. **Dangling override**: a `[modules.x]` patch entry with no source and an
+12. **Dangling override**: a `[modules.x]` patch entry with no source and an
     include that does not provide `x` → clear error.
-12. **Env from the include**: an env defined only in the included config is
+13. **Env from the include**: an env defined only in the included config is
     selectable with `--env` downstream.
-13. **Setting the include through the CLI**:
+14. **Setting the include through the CLI**:
     `dagger workspace config include common/base.toml` writes the block without
     swallowing the bare keys above it, reads back the local source, and the
     effective view then carries what the include provides.
-14. **Writes stay local**: a setting write records only the override — no
+15. **Writes stay local**: a setting write records only the override — no
     inherited ref, no `source = ""` — and uninstalling a module the include
     provides names the include.
-15. **Lockfile**: an ordinary run records a `git-sha` entry naming the included
+16. **Lockfile**: an ordinary run records a `git-sha` entry naming the included
     repository, and a later run resolves the same merged config while leaving
     the lockfile byte-identical.
 

--- a/future/done/workspace-include.md
+++ b/future/done/workspace-include.md
@@ -38,8 +38,9 @@ machine or to the file itself.
 - A git include is pinned in `dagger.lock` like every other git ref this repo
   resolves: later runs reuse the recorded pin, and `dagger update` refreshes it.
   A path include has nothing to pin.
-- Only _remote_ module references survive the include. A local module reference
-  in the included config must not become loadable in the workspace.
+- A module the included config installs is usable here, whether it named a
+  remote ref or a directory beside itself. What it must never do is resolve a
+  path of the included config's against the *consuming* workspace.
 - The merged result is what read surfaces (`dagger workspace config`, module
   listing, env listing) report, so the effect is visible rather than silent.
 
@@ -51,14 +52,14 @@ machine or to the file itself.
   can lift without changing what anyone has written.
 - **No transitive includes.** If the included config itself declares an
   include, that is an error (see
-  [Limitation 1](#limitation-1--one-include-no-chain)), not a second layer.
+  [One include, no chain](#one-include-no-chain)), not a second layer.
 - **No new lock operation kind.** The include reuses the existing git lock
   operations (`git-latest` for a mutable selection, `git-sha` for the
   immutable resolution).
-- **No inheriting the included config's local module tree**, generated clients,
-  or SDK-managed authoring state — see
-  [Limitation 2](#limitation-2--configuration-not-code) for why, and for the
-  sketch of what a later version would do.
+- **No inheriting generated clients or SDK-managed authoring state.** The
+  modules an included config installs come with it, but its `[sdks.*]`
+  declarations and the client trees they imply do not — see
+  [The included config's own modules](#the-included-configs-own-modules).
 - **No tombstones.** An inherited entry can be overridden but not deleted. See
   [Inherited entries cannot be removed](#inherited-entries-cannot-be-removed).
 - **No write-through.** `dagger install`, `dagger workspace config <key> <value>`
@@ -142,8 +143,8 @@ graph TD
     C2 --> D
     D --> E{"included config<br/>declares an include?"}
     E -->|yes| F["error: nested includes<br/>are not supported"]
-    E -->|no| G["sanitize: classify every included<br/>module source with IsLocalRef"]
-    G --> H["drop local entries + their env<br/>overlays and ports, warn once"]
+    E -->|no| G["classify every included module<br/>source with IsLocalRef"]
+    G --> H["re-address its own modules;<br/>drop what has no address here,<br/>with their env overlays and ports"]
     H --> I[merge]
     A --> I
     I --> J{"merged entry<br/>without a source?"}
@@ -224,7 +225,7 @@ not absences.
 | `modules.<name>.entrypoint` | Current replaces when present, including `false`. Presence matters here more than anywhere: an inherited `entrypoint = true` that could not be switched off would collide with the downstream repo's own entrypoint, and the loader rejects two ambient entrypoints. |
 | `modules.<name>.legacy-default-path` | **Never inherited.** It is migration-compat state for a specific local module tree, not reusable configuration. A current entry keeps its own value. |
 | `modules.<name>.{up,generate,check}.skip` | Current replaces when present, including an explicit empty list. |
-| `modules.<name>.as-sdk` | **Never inherited** — marker, `name`, `modules` and `clients` are all dropped from the include. `modules`/`clients` are workspace-root-relative paths into the base repo; keeping the marker alone would advertise an SDK that no init flow can use, since init writes SDK-managed paths and reads only the local config. A current entry keeps its own `as-sdk` wholesale. |
+| `sdks.<name>` | **Never inherited** — the whole table is replaced by the current config's own. An SDK's `scopes` are project roots relative to the config that declares it, so an inherited declaration names paths that do not exist here, and init writes SDK-managed paths while reading only the local config. Note the interaction with `ValidateSDKs`, which runs when a file is parsed: an SDK's provider module must be installed in the same file, so an SDK cannot name a provider the include supplies. |
 | `env.<name>` | Merged per env name; an env that only the include defines is selectable downstream. |
 | `env.<name>.modules.<mod>` | Same field rules as `modules.<name>` (source/pin coupling, settings key by key). |
 | `ports.<host>` | Current replaces **wholesale** per host port. Per-field merge was tried and reverted: `writePortEntries` always serializes both keys, so setting one through `dagger workspace config` writes `backendPort = 0` into the file, which a presence-aware merge would then read as an explicit override to port 0. A service and its port are one unit; overriding one means repeating the other. Completeness is deliberately **not** validated — `dagger workspace config ports.3000.backendService web` writes one key at a time, so a partial mapping is a state the CLI itself produces and configs that load today would start failing on every read. Ports keep their pre-existing behavior. |
@@ -269,7 +270,7 @@ against the raw local config:
   whether the module is still listed after the write and says the overrides were
   removed, rather than "Uninstalled module".
 
-### Limitation 1 — one include, no chain
+### One include, no chain
 
 **Decision: an `[[include]]` block in the included config is an error**, reported at
 workspace load with both refs named.
@@ -281,49 +282,105 @@ actionable and fails closed, which is what this repo does elsewhere. The cost is
 that an include author cannot themselves build on an include; that is the scope control
 being asked for, and the error says so.
 
-### Limitation 2 — configuration, not code
+### The included config's own modules
 
-**Decision: module entries in the included config whose source is a local path
-are dropped, with a warning naming them.**
+**Decision: a module entry whose source is a local path is re-addressed so it
+names the same module from here, and only what has no address on this side is
+left out.**
 
-A local source in an included config means a directory next to _that_ config,
-and resolving it as written resolves it against the **consuming** workspace, via
+A local source in an included config names a directory beside _that_ config.
+Resolving it as written resolves it against the **consuming** workspace, via
 `workspace.ResolveModuleEntrySource(configDir, …)` in
-`workspaceConfigPendingModules` — loading a different module or failing with a
-path the user never wrote. Dropping prevents that, and keeps an include to
-sharing configuration.
+`workspaceConfigPendingModules` — loading a different module, or failing with a
+path the user never wrote. So it cannot be passed through untouched. It also
+must not simply be dropped, because sharing the modules is the point:
 
-Erroring instead was the first choice and is wrong: a normal repository keeps
-project-specific modules under `modules/`, so erroring would make an ordinary
-repo unusable as an include target because of a `ci` module the consuming user
-never asked for.
+```
+monorepo/
+  shared/tester/          the module
+  common/dagger.toml      [modules.tester] source = "../shared/tester"
+  project-a/dagger.toml   [[include]] source = "../common"
+```
 
-**This is a deliberate stopping point, not the end state.** Inheriting the
-included config's own local modules is not implemented in this version. It is
-buildable: a git include's modules _are_ addressable, because the config came
-from a repository at a known commit, so `source = "modules/ci"` could be
-inherited as `<clone-ref>/modules/ci@<commit>`, exactly the rewrite remote
-workspace selection already performs through `core.GitRefString`. Two findings
-from prototyping it are worth keeping:
+`dagger module list` in `project-a` has to show `tester`, and `dagger call tester`
+has to run it. A config that could only pass on modules it had itself installed
+from elsewhere would leave every monorepo re-declaring them per project, which
+is the duplication this feature exists to remove.
 
-- `gitref.Parse` drops an explicit HTTP(S) port when rebuilding a clone ref
-  (only SSH puts it back), which would send a rewritten module to the wrong
-  remote — with different credentials and cache keys;
-- a rewrite must skip built-in SDK runtimes (`source = "dang"` is a name the
-  engine resolves in-process), absolute paths, and paths that escape the
-  repository, which `GitRefString` would silently normalize to a root-level
-  path.
+Re-addressing differs by how the config was reached, because that is what
+decides where its modules live:
+
+```mermaid
+graph TD
+    A["module entry in the included config"] --> B{"IsLocalRef?"}
+    B -->|"a ref already"| K["keep as written"]
+    B -->|"a path"| C{"how was the config reached?"}
+    C -->|"path include"| D["same workspace:<br/>rebase the path onto<br/>the consuming config's dir"]
+    C -->|"git include"| E["same repository:<br/>&lt;clone-ref&gt;/&lt;path&gt;@&lt;commit&gt;"]
+    D --> F{"addressable?"}
+    E --> F
+    F -->|no| G["drop + warn"]
+    F -->|yes| H["re-addressed entry,<br/>pin cleared"]
+```
+
+**A path include re-bases the path.** Both configs live in one workspace, so
+only what the path is relative to changes: `../shared/tester` written beside
+`common/dagger.toml` becomes `../shared/tester` read beside
+`project-a/dagger.toml` — the same directory, named from a different place. The
+result is always dot-prefixed. A bare rewritten path whose first segment carries
+a dot (`shared.v2/ci`) would otherwise read back as a git ref under
+`IsLocalRef`, which is exactly the path-versus-ref confusion this exists to
+prevent.
+
+**A git include addresses the module in its repository.** The config came from a
+repository at a known commit, so `modules/ci` becomes
+`<clone-ref>/modules/ci@<commit>` — the same rewrite remote workspace selection
+already performs for a workspace loaded with `-W`, through the same
+`core.GitRefString`. The **commit**, not the include's symbolic version, for two
+reasons: the config and the modules it names then always come from one revision
+even if the branch moves mid-run, and a commit SHA short-circuits the lock
+lookup, so no per-module lock entry appears. The entry's own pin is cleared —
+it described the source that was just replaced.
+
+Getting the clone ref back out intact is what the rewrite rests on, and it was
+already broken: `gitref.Parse` dropped an explicit HTTP(S) port when rebuilding
+the ref (only SSH put it back), so a re-addressed module on a custom-port remote
+would be sent to a different remote, with different credentials and cache keys.
+A pre-existing round-tripping bug in `core/gitref`, carried here because
+re-addressing would inherit it — nothing on this branch exercises it, since the
+integration fixture serves git on port 80.
+
+**What is left out, and why each one:**
+
+- **built-in SDK runtimes.** `source = "dang"` is a name the engine resolves
+  in-process, not a path — even where the included tree has a directory by that
+  name. Checked _before_ the path classification, because `go@v1.2.3` carries a
+  dot and would otherwise read as a ref. Such an entry only ever appears
+  alongside an `[sdks.*]` declaration, which the merge strips, so nothing on
+  this side could use it anyway.
+- **absolute paths.** They address the machine the config was authored on;
+  nothing in a shared tree corresponds to them.
+- **paths that escape the tree they came from.** `GitRefString` would quietly
+  normalize `../../elsewhere` into a root-level path and resolve the wrong
+  module instead of failing; for a path include the same escape leaves the
+  workspace.
+- **the included config's own root.** A workspace, not a module.
+
+Erroring on these instead was the first choice and is wrong: an ordinary
+repository keeps project-specific modules under `modules/`, so erroring would
+make it unusable as an include target because of a `ci` module the consuming
+user never asked for.
 
 **Classification is `workspace.IsLocalRef`, the classifier the loader itself
 uses**, with an **empty pin**. Agreeing with the loader is the whole correctness
-criterion: anything sanitization keeps is something the loader will then
-resolve, so the two must not disagree.
+criterion: anything left alone here is something the loader will then resolve as
+written, so the two must not disagree.
 
 The empty pin is the one deliberate difference from a naive call. `IsLocalRef`
 reads _any_ ref carrying a pin as git, so passing the entry's own pin would let
-`source = "./ci", pin = "…"` survive and then be resolved against the consuming
-workspace. `ResolveModuleEntrySource`, which the loader reaches for the same
-decision, passes an empty pin for the same reason.
+`source = "./ci", pin = "…"` through untouched and then be resolved against the
+consuming workspace. `ResolveModuleEntrySource`, which the loader reaches for
+the same decision, passes an empty pin for the same reason.
 
 This is the same classifier that decides whether the **include source itself**
 is a git ref or a path ([Config surface](#config-surface)). The two questions
@@ -335,47 +392,45 @@ paired `FastKindCheck` with a filesystem stat to settle `KindUnknown`. Since
 `12d34c468` the shared classifier settles that case syntactically: only the
 segment ahead of the first separator can be a host, so `common/.dagger/mymod`
 reads as local while `vanity.example.com/acme/toolchain` reads as remote,
-neither needing a filesystem. Converging removed the stat plumbing from the
-include loader and its callers, and closed a real gap — where no filesystem was
-available the old rule fell back to "remote", exactly the mis-resolution this
-limitation exists to prevent.
+neither needing a filesystem. That matters twice over here, because the two
+trees an include is read through — a local workspace and a cloned git tree —
+have no statting in common.
 
 `core.ParseRefString` remains the wrong helper for either: for an ambiguous ref
 it attempts a git parse and **falls back to `Local` on `EndpointError`**, so a
 vanity-domain remote would be classified local whenever endpoint discovery is
 unavailable. Classification must not depend on network reachability.
 
-The warning is emitted **inside the shared loader**, deduplicated per **client**
-and include source through the query's telemetry seen-key store (the mechanism
-`shouldRecordWorkspaceMigrationProgress` already uses), and written through the
-same global-writer + `slog.Warn` path the legacy compat notice uses. Per client,
-not per session: a nested CLI shares its parent's session, so session scope
-would silence every command after the first. Not in the load path:
-`dagger workspace config` connects with `SkipWorkspaceModules`, so a warning
-wired into module loading would never fire on exactly the surface where the
-modules appear to be missing.
+**Existence is not checked.** A re-addressed path that names nothing fails at
+module load, with the address it failed on in the message. Verifying it here
+would mean a stat per entry against whichever tree the config came from, to turn
+one clear failure into a different one.
+
+The warning for what was left out is emitted **inside the shared loader**,
+deduplicated per **client** and include source through the query's telemetry
+seen-key store (the mechanism `shouldRecordWorkspaceMigrationProgress` already
+uses), and written through the same global-writer + `slog.Warn` path the legacy
+compat notice uses. Per client, not per session: a nested CLI shares its
+parent's session, so session scope would silence every command after the first.
+Not in the load path: `dagger workspace config` connects with
+`SkipWorkspaceModules`, so a warning wired into module loading would never fire
+on exactly the surface where the modules appear to be missing.
 
 The warning names entries as the config spells them, so a dropped env overlay
 appears as a dotted path (`env.ci.modules.local-ci`) rather than a bare module
 name.
 
-Dropping cascades, so no orphan state survives:
+Re-addressing and dropping both cascade, so no stale state survives:
 
-- `env.<name>.modules.<dropped>` overlays from the included config are dropped;
+- `env.<name>.modules.<mod>` overlays are re-addressed or dropped by the same
+  rule as base entries; an overlay whose module was dropped and that installs
+  nothing itself goes with it;
 - included `ports.<host>` entries whose `backendService` names a dropped module
   are dropped. `backendService` is a colon-joined service path
   (`hello-with-services:web`) whose first segment is the module's **CLI-cased**
   name, matched at runtime against `Up.Name()` — so the cascade compares the
   segment before the first colon to the dropped module's kebab-cased name, not
-  to its raw config key;
-- an env overlay in the included config that _installs_ a local module is
-  dropped the same way.
-
-**A residual hole the earlier rule had is now closed.** While classification
-depended on statting the tree the config came from, a dotted source that existed
-in neither tree was kept and then resolved locally downstream. The syntactic
-rule has no such gap: the same string classifies the same way for sanitization
-and for the loader, whatever either can see.
+  to its raw config key.
 
 ### Inherited entries cannot be removed
 
@@ -417,6 +472,11 @@ No new lock entry kind. The include ref is resolved through the ordinary
 - follows whatever policy the lock subsystem applies to git refs generally; this
   feature adds no rule of its own.
 
+The modules an include contributes add nothing to the lockfile. A git include's
+own modules are re-addressed at the commit its config was read at, and a commit
+SHA short-circuits the lock lookup, so no per-module entry appears; a path
+include's modules are directories in this workspace, with nothing to pin.
+
 Round trip: an ordinary run resolves the ref and writes the `git-sha` entry on
 session flush; the next run reads the pin back and does not re-resolve the
 symbolic ref — the integration test asserts the lockfile is byte-identical after
@@ -455,8 +515,8 @@ alias was removed in CLI 1.0 (`future/cli-1.0.md`).
   `including workspace config: <ref>`, mirroring the existing
   `applying env: <name>` span, so it is visible in the TUI and in traces and any
   fetch latency is attributed.
-- Dropped local modules from the include produce one warning line naming them,
-  on every command that resolves the include — including
+- Modules the include declares that have no address here produce one warning
+  line naming them, on every command that resolves the include — including
   `dagger workspace config`, which skips workspace modules entirely.
 - `dagger workspace config --help` gains the effective-read / local-write rule
   for includes, next to the `--env` wording it already carries.
@@ -486,8 +546,12 @@ would avoid the source-optional change to the config contract, but it forces a
 downstream repo that wants to bump one setting to copy the module's `source`
 too — re-introducing exactly the duplication this feature removes.
 
-**Erroring on local module entries in the include** instead of dropping them.
-Rejected after review: it makes ordinary repositories unusable as includes. See [Limitation 2](#limitation-2--configuration-not-code).
+**Erroring on local module entries in the include**, and later **dropping them
+outright**. Both rejected: erroring makes an ordinary repository unusable as an
+include target because of a `ci` module the consumer never asked for, and
+dropping leaves every monorepo project re-declaring the modules its shared
+config already installs. Re-addressing them is what both were standing in for.
+See [The included config's own modules](#the-included-configs-own-modules).
 
 **Classifying refs with `gitref.FastKindCheck` alone**, leaving `KindUnknown` to
 a filesystem stat. Rejected for both the include source and the included
@@ -504,9 +568,11 @@ to be right for module loading, which is engine-side anyway.
 | Area | Change |
 | --- | --- |
 | `core/workspace/config.go` | `Config.Include` as `[]IncludeEntry`; `ModuleEntry.Source` gains `omitempty`; serialization; `cloneConfig`; `setConfigValue` case |
-| `core/workspace/config_document.go` | `restoreIncludeSections` puts the `[[include]]` blocks back after the map application, which drops every array of tables it was not given — `configDocumentMap` deliberately does not carry them, since ApplyMap would render one inline. An unchanged list is restored verbatim so an unrelated write keeps its comments and position; explicit-key presence helper |
+| `core/workspace/config_document.go` | `ExplicitConfigKeys`, the presence helper the merge needs. `configDocumentMap` deliberately leaves `include` out: the document editor works by diffing that map and declines to edit an array of tables, and leaving it out is also what keeps an untouched block, comments and position included, across an unrelated write |
+| `core/workspace/include.go` | `rewriteIncludeBlocks` rewrites the `[[include]]` blocks as text, which is how an include is written at all given the editor above |
 | `core/workspace/include.go` (new) | the one-include limit, pure merge, post-merge validation |
-| `core/workspace_include.go` (new, package `core`) | classify the source, load and sanitize the included config; `ApplyIncludes`, the one sequence — validate, load, merge, validate again — that every effective-config path goes through |
+| `core/workspace_include.go` (new, package `core`) | classify the source, load the included config and re-address the modules it installs; `ApplyIncludes`, the one sequence — validate, load, merge, validate again — that every effective-config path goes through |
+| `core/gitref/gitref.go` | keep an explicit HTTP(S) port in the clone ref, so a re-addressed module reaches the remote its config came from |
 | `core/workspace_remote.go` (new, package `core`) | remote-workspace ref parsing and cloning, shared with workspace selection |
 | `engine/server/session_workspaces.go` | the remote-workspace ref helpers **move** to `core`, with their tests moving out of `engine/server/session_test.go`; resolve and merge during workspace load |
 | `core/schema/workspace_config.go` | merge in `readWorkspaceConfig` **and** in `configRead`'s base path; answer `include` from the local file whatever is layered on; strip `include` from the effective view; owner-client context |
@@ -516,9 +582,9 @@ to be right for module loading, which is engine-side anyway.
 | `internal/cmd/dagger/workspace.go` | `dagger workspace config --help` text; `dagger uninstall` reports the override case instead of "Uninstalled module" |
 | `core/integration/workspace_include_test.go` (new) | multi-workspace fixture over a git service |
 | `docs/current_docs/config/includes.mdx` (new) | the user-facing page, next to Environments |
-| `docs/current_docs/config/reference/dagger-toml.mdx` | the `include` key and its `[[include]]` section |
+| `docs/current_docs/reference/config-files/dagger-toml.mdx` | the `include` key and its `[[include]]` section |
 | `docs/static/reference/dagger-workspace.schema.json` | regenerated |
-| `.changes/unreleased/Added-*.yaml` | changelog entry |
+| `.changes/unreleased/*.yaml` | changelog entries for the feature and for the `core/gitref` fix |
 
 Untouched on purpose: every config **write** path, the lockfile format, and the
 `Workspace` GraphQL surface (no new field — the merged config flows through
@@ -531,7 +597,8 @@ Unit (`core/workspace`), on the pure merge:
 - every row of the merge table, including the source/pin coupling;
 - explicit-zero overrides: `entrypoint = false`, `ignore = []`,
   `defaults_from_dotenv = false`, `check.skip = []` each beat an inherited value;
-- `legacy-default-path` and `as-sdk` never inherited;
+- `legacy-default-path` never inherited, and `[sdks.*]` replaced wholesale by
+  the current config's own;
 - ports replace wholesale per host port;
 - included config declaring `include` → error;
 - `ValidateEffectiveConfig`: a module entry with no source errors **with and
@@ -548,25 +615,32 @@ Unit (`core`), on classifying an include source, one case per spelling the
 reference page advertises in either direction, plus the path resolver (Windows
 separators, root anchoring, refused escapes) and the file-versus-directory rule.
 
-Unit (`core`), on sanitization, against config text alone — the syntactic
-classifier needs no tree:
+Unit (`core`), on re-addressing the included config's modules, against config
+text alone — the syntactic classifier needs no tree:
 
-- `source = "modules/ci"` → dropped;
-- `source = "./ci", pin = "abc"` → dropped, proving the pin does not launder a
-  local source;
-- `source = "modules/foo.bar"` → dropped, the dotted-path case the earlier stat
-  rule got wrong;
+- `source = "modules/ci"` → `<clone-ref>/modules/ci@<commit>`, and the same from
+  a config in a subdirectory, where the entry's path is relative to the config
+  rather than to the clone;
+- `source = "./ci", pin = "abc"` → re-addressed with the pin cleared, proving
+  the pin neither launders a local source nor survives the source it described;
+- `source = "modules/foo.bar"` → re-addressed, the dotted-path case that only
+  reads as a path because the dot is not in the host segment;
 - `source = "github.com/acme/toolchain@v1"` and
-  `source = "vanity.example.com/acme/toolchain"` → kept, the vanity domain
-  **with no network in play at all**, pinning the reason `ParseRefString` is not
-  used;
-- `source = "php"` — the bare short name `dagger setup` writes for a migrated
-  SDK — → dropped, which is the reasoning the `setupResolveMigratedSDKs` risk
-  below rests on;
-- dropping cascades to the module's env overlays in the included config and to ports whose
-  `backendService` prefix is the module's kebab-cased name (covered with a
-  non-canonical module key such as `MyTool`, and for a module an env overlay
-  alone installs).
+  `source = "vanity.example.com/acme/toolchain"` → kept exactly as written, the
+  vanity domain **with no network in play at all**, pinning the reason
+  `ParseRefString` is not used;
+- dropped: `source = "php"` and `source = "go@v1.2.3"` (the shapes
+  `dagger setup` writes for a migrated SDK, and the reasoning the
+  `setupResolveMigratedSDKs` risk below rests on), `source = "/opt/ci"`,
+  `source = "."`, and a path escaping the tree;
+- the path addresser on the monorepo shape: re-based onto the consuming
+  config's directory, always dot-prefixed, refusing an escape — and each result
+  asserted to read back as a path under `IsLocalRef`, which is the property the
+  dot-prefix exists for;
+- dropping cascades to the module's env overlays in the included config and to
+  ports whose `backendService` prefix is the module's kebab-cased name (covered
+  with a non-canonical module key such as `MyTool`, and for a module an env
+  overlay alone installs).
 
 Integration (`core/integration/workspace_include_test.go`). A git include's
 repository is served by `gitSmartHTTPServiceDirAuth` at an IP-addressable URL —
@@ -589,25 +663,36 @@ path include needs no fixture beyond a second file in the workspace.
 4. **Directory include**: `source = "common"` reaches `common/dagger.toml`.
 5. **More than one include**: two `[[include]]` blocks → error naming the count
    and the limit.
-6. **Local module blocked**: the included config declares a local module _and_
-   the consuming repo contains a same-named directory. The module does not
-   appear in the merged config, and the warning names it under plain
-   `dagger workspace config`, which skips workspace modules entirely.
-7. **No chain**: the included config includes something in turn → explicit error.
-8. **Missing target**: the include points where no config exists → error naming
-   the file.
-9. **Dangling override**: a `[modules.x]` patch entry with no source and an
-   include that does not provide `x` → clear error.
-10. **Env from the include**: an env defined only in the included config is
+6. **The monorepo shape**, end to end: `shared/` holds the modules, `common/`
+   installs them by relative path, `project-a/` and `project-b/` include
+   `../common`. From either project, `dagger module list` shows the shared
+   modules, `dagger call <module> …` runs them, the effective config shows them
+   addressed relative to the *including* project, and `project-b` overrides one
+   of their settings without repeating a source.
+7. **A git include's own modules**: the consuming workspace holds a different
+   module at the very same path the included entry names, which is what the
+   re-addressing has to get right. The effective config shows the entry as a ref
+   into the included repository at a full commit SHA rather than the path it was
+   written as, and the call reaches the included repository's module.
+8. **Modules with no address are left out**: a built-in SDK install and an entry
+   escaping the included repository. Neither appears in the merged config, and
+   the warning names both under plain `dagger workspace config`, which skips
+   workspace modules entirely.
+9. **No chain**: the included config includes something in turn → explicit error.
+10. **Missing target**: the include points where no config exists → error naming
+    the file.
+11. **Dangling override**: a `[modules.x]` patch entry with no source and an
+    include that does not provide `x` → clear error.
+12. **Env from the include**: an env defined only in the included config is
     selectable with `--env` downstream.
-11. **Setting the include through the CLI**:
+13. **Setting the include through the CLI**:
     `dagger workspace config include common/base.toml` writes the block without
     swallowing the bare keys above it, reads back the local source, and the
     effective view then carries what the include provides.
-12. **Writes stay local**: a setting write records only the override — no
+14. **Writes stay local**: a setting write records only the override — no
     inherited ref, no `source = ""` — and uninstalling a module the include
     provides names the include.
-13. **Lockfile**: an ordinary run records a `git-sha` entry naming the included
+15. **Lockfile**: an ordinary run records a `git-sha` entry naming the included
     repository, and a later run resolves the same merged config while leaving
     the lockfile byte-identical.
 
@@ -631,6 +716,12 @@ Error-message assertions use stable substrings.
   ref resolution plus a git tree fetch, both dagql-cached and both skipped
   entirely when no `[[include]]` block exists. Once pinned, the ref resolution
   is replaced by the stored pin, though the tree may still be fetched.
+- **A git include's own modules are fetched as refs**, not read out of the tree
+  already cloned to read its config. They resolve at the same commit, so the
+  content is the same and the fetch is cache-shared with any other consumer of
+  that ref — but it is a second addressing of a tree already in hand. Reading
+  them out of the clone would mean synthesizing a local module source with no
+  path on this filesystem, which the loader has no notion of.
 - **A failed include can read as "module not installed".** Address resolution
   demand-loads workspace modules and deliberately discards config errors
   (`demandLoadInstalledModule` in `core/schema/address.go`), so an unreachable
@@ -652,10 +743,11 @@ Error-message assertions use stable substrings.
 - **One CLI path writes from what `configRead` returned**:
   `setupResolveMigratedSDKs` (`internal/cmd/dagger/setup.go`) parses
   `Workspace.configRead` and writes fixups back. It only rewrites entries whose
-  source is a bare short name (e.g. `php`), which classify as local and are
-  therefore always dropped from an include — so an inherited entry can never
-  reach it. A unit test pins that reasoning; if it ever stops holding, that call
-  site must read the local file instead.
+  source is a bare runtime name (e.g. `php`), which is exactly the shape an
+  include never contributes — a built-in runtime is dropped rather than
+  re-addressed — so an inherited entry can never reach it. A unit test pins that
+  reasoning; if it ever stops holding, that call site must read the local file
+  instead.
 - **Inherited entries cannot be deleted.** Covered above; the mitigation is
   error-message quality, not a mechanism.
 - **An explicit clear reads as "not set".** `SerializeConfig` omits zero values,
@@ -671,7 +763,8 @@ Error-message assertions use stable substrings.
   validation for configs that have no include. The engine's post-merge check
   covers both cases, and is what actually gates loading.
 - **Init flows against an included SDK.** `loadWorkspaceConfigForOverlay` is a
-  write path and stays unmerged, and include `as-sdk` data is dropped entirely,
+  write path and stays unmerged, and an included config's `[sdks.*]` data is
+  dropped entirely,
   so an SDK can only be authored against from the local config. Deliberate: init
   writes SDK-managed paths into the config that owns them.
 

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -215,6 +215,13 @@ With one argument and --unset, removes the value at the given key.
 
 Explicit env.* keys address raw overlay storage.
 
+An include is set with "dagger workspace config include <source>", where source
+is a git ref (github.com/acme/base@v1) or a path to a config file next to this
+one ("./base.toml", or "/common/base.toml" from the workspace root). Reads then
+show the merged view — the included configuration with this workspace's own on
+top — while writes still only touch this workspace's dagger.toml. Reading the
+include key itself reports this workspace's own value.
+
 Local module source values are stored relative to dagger.toml.`,
 	Args: cobra.MaximumNArgs(2),
 	RunE: runWorkspaceConfig,
@@ -601,6 +608,24 @@ func uninstallWorkspaceModule(ctx context.Context, out io.Writer, dag *dagger.Cl
 		_, err = fmt.Fprintf(out, "Uninstalled module %q from env %q in %s\n", name, workspaceEnv, configPath)
 		return err
 	}
+
+	// A module that survives the write was never installed here: what went away
+	// is the local entry overriding the module an included config provides.
+	modules, err := updated.Modules(ctx)
+	if err != nil {
+		return err
+	}
+	for _, module := range modules {
+		moduleName, err := module.Name(ctx)
+		if err != nil {
+			return err
+		}
+		if moduleName == name {
+			_, err = fmt.Fprintf(out, "Removed local overrides for module %q from %s; the module is still provided by an included config\n", name, configPath)
+			return err
+		}
+	}
+
 	_, err = fmt.Fprintf(out, "Uninstalled module %q from %s\n", name, configPath)
 	return err
 }


### PR DESCRIPTION
## What

> **Reviewing this?** There is a rendered walkthrough that follows the real call chain
> rather than the diff order, with the relevant hunks embedded at the point in the story
> where each one matters: **[PR walkthrough](https://gistpreview.github.io/?1faea9aa6cd6ea5ac74debbd326e01e4)**
> ([source gist](https://gist.github.com/eunomie/1faea9aa6cd6ea5ac74debbd326e01e4)).
> It is a snapshot of `837545b2`, not a living document.

Adds a top-level `[[include]]` block to `dagger.toml`: a config file whose contents are merged **underneath** the current workspace's own config.

```toml
[[include]]
source = "github.com/acme/dagger-base@v1.2.0"

# Only the difference from the included config:
[modules.go.settings]
goVersion = "1.24"
```

A team can publish one base config — shared tool versions, module refs, settings, environments — and have many repositories point at it instead of copying it into each one. Asked for on Discord (vindico: "I'm currently putting duplicated workspace config in a lot of repos"; chrisp6229 asked for exactly this, per project type), and shaped by shykes' proposal of `[[include]] source = …` over the earlier `import` and `blueprint` spellings.

## The source

`source` addresses a config **file**, not a workspace root, which lets one repository publish several base configs side by side:

- **a path**: `common/base.toml` relative to the including config's directory, `./base.toml` or `../shared/base.toml` next to it, or `/common/base.toml` from the workspace root — the same rule every other path a workspace resolves follows, so a root-anchored include reads the same from any subdirectory.
- **a git ref**: `github.com/acme/dagger-base@v1.2.0`, `github.com/acme/dagger-base/common/base.toml@v1.2.0`, `https://host/repo.git#main:dagger/base.toml`, `ssh://git@host/repo.git#v1:base.toml`, `git@github.com:acme/base.git`.

**Which of the two a source is comes from `workspace.IsLocalRef`**, the classifier every other ref in a workspace config is read with: a leading `/`, `./` or `../`, or a first segment carrying neither a dot nor a colon, is a path; anything else is a git ref, with no scheme or `#` fragment needed. An include-specific rule tuned for file paths would read better in isolation and worse everywhere else. The one spelling that suffers is a dotted filename directly beside the config — `base.toml` on its own reads as a ref, so it is written `./base.toml`, and a source that fails to parse as a ref says so.

A source with a file extension names a file; one without names a directory and reaches the `dagger.toml` inside it. Statting is not an option — a local workspace and a cloned git tree have no filesystem in common — so a mistyped `dagger.tml` stays a file rather than a directory to look inside.

Design doc: `future/done/workspace-include.md`. User docs: a new **Includes** page next to Environments, plus the `[[include]]` entry in the `dagger.toml` reference.

**The array holds one entry for now.** `[[include]]` is a table array so several can be expressed, but resolving more than one is an error: ordering between includes, and what happens when two disagree, are questions this doesn't answer yet. `workspace.MaxIncludes` is the single place that says so, and lifting it later changes no config anyone has written.

## Merge semantics

The workspace naming the include wins every conflict. Layering, lowest first: the included config → this repo's `dagger.toml` → user-level overrides → `--env` overlay. Nothing about the existing three layers changes.

- **Module entries merge per field**, so a repo can override one setting without repeating the module's ref. That makes `source` optional in the file — an entry may be a pure override of a module the include installs.
- **"Set" means explicitly present**, not non-zero: `entrypoint = false` and `ignore = []` override an inherited value. Presence comes from the raw TOML, not the parsed struct.
- `as-sdk` and `legacy-default-path` are **never inherited** — both describe the tree the included config came from.
- `[ports.<host>]` replaces the inherited mapping as a unit.
- Envs merge by name; an env only the included config defines is selectable downstream.

The full per-section table is in the design doc.

Three call sites build an effective config — workspace load, the shared schema read, and the by-name module lookup. All three go through one `core.ApplyIncludes`: validate the include list, load, merge, validate the result. Only building the `IncludeSource` genuinely differs, and the sequence had already drifted apart once.

## An include brings its own modules

A module entry in the included config whose source is a local path names a directory beside *that* config. Resolving it as written would resolve it against the consuming workspace — a different module, or none — so it is **re-addressed**, by whichever route the config was reached:

- **Path include** — both configs live in one workspace, so only what the path is relative to changes. The result is always dot-prefixed: a bare rewritten path whose first segment carries a dot (`shared.v2/ci`) would otherwise read back as a git ref under `IsLocalRef`, the very path-versus-ref confusion this exists to prevent.
- **Git include** — `modules/ci` becomes `<clone-ref>/modules/ci@<commit>`, the same rewrite `-W <git ref>` already performs through `GitRefString`. The commit, not the include's symbolic version: the config and the modules it names then come from one revision even if the branch moves mid-run, and a commit SHA short-circuits the lock lookup, so no per-module lock entry appears. The entry's own pin is cleared, since it described the source just replaced.

That is what makes a monorepo work. Given `shared/` holding the modules, `common/dagger.toml` installing them by relative path, and `project-a/dagger.toml` declaring `[[include]] source = "../common"`, `dagger installed` in `project-a` lists them and `dagger call` runs them. Verified against a real repository, [eunomie/dagger-monorepo-include](https://github.com/eunomie/dagger-monorepo-include), not only the test fixture.

What has no address on the consuming side is dropped, with a warning naming it — along with its env overlays and any port mapping that forwards to it: built-in SDK runtimes (a name the engine resolves in-process, checked *ahead* of the path classification because `go@v1.2.3` carries a dot and would otherwise read as a ref), absolute paths, the included config's own root, and paths escaping the tree they came from, which `GitRefString` would quietly normalize into a root-level path and resolve the wrong module rather than fail.

Classification is `workspace.IsLocalRef` again, with a deliberately empty pin. Agreeing with the module loader is the whole correctness criterion — anything left alone here is something the loader will then resolve as written — and `IsLocalRef` reads any pinned ref as git, so passing the entry's own pin would let `source = "./ci", pin = "…"` through untouched.

Existence is deliberately not checked: a re-addressed path that names nothing fails at module load with the address it failed on, and verifying it here would mean a stat per entry against whichever tree the config came from.

## The one deliberate limit

**One level, no chain.** An included config that includes something in turn is an error, not a second layer.

## Lockfile

No new lock operation kind. A git include resolves through the ordinary `git(url).head` / `.ref(name)` selectors, so it records the standard `git-sha` entry in `dagger.lock`. Resolution runs after the client's workspace is bound, which puts the entry in the right lockfile: an ordinary run records it, a later run reuses it (the integration test asserts the lockfile is left byte-identical), and `dagger update` refreshes it. A path include is read from the workspace as it is on disk, so there is nothing to pin.

## Reads are effective, writes are local

`readWorkspaceConfig` — behind module/env/SDK listings and `currentModule.asSDK` — returns the merged config, as does `configRead`, **including its base path**, which is the plain `dagger workspace config` case. `--load-module <name>` resolves modules an included config contributes.

The no-argument output is a standalone snapshot: the `[[include]]` block is stripped and named in a `# included: <source>` comment, the same way the env-effective view already clears `Env`. Keeping it would make the printed config one that inlines the inherited values *and* names the include again underneath. `dagger workspace config include` still reports the local sources, one per line, and `dagger workspace config include <source>` sets it.

Writes never touch the included config, and now say so when that would be confusing: unsetting a value it supplies names it instead of reporting that nothing is set; `dagger uninstall` on a module that exists only there says it cannot be uninstalled here; on a source-less override it removes the override and reports that the module is still provided by the include. An unrelated write also leaves the `[[include]]` block exactly where it was, comments and all.

## Judgment calls worth a second opinion

- **`ModuleEntry.Source` is now `omitempty`**, so the generated JSON schema no longer requires it. `ValidateEffectiveConfig` replaces that check on the *effective* config and runs whether or not an include is present — gating it on an include would mean removing the include silently turns a valid override into an entry naming nothing. This is the one thing here that can break a config working on `main` today: a source-less module entry with no include now fails every read instead of loading as a module with an empty ref. It has its own `Changed` changelog entry.
- Port mappings are deliberately *not* validated: `dagger workspace config ports.3000.backendService web` writes one key while the serializer writes both, so a partial mapping is a state the CLI itself produces.
- **No tombstones.** An inherited entry can be overridden but not deleted.

## Patches

| Patch | Scope |
| --- | --- |
| `future: design workspace config include` | the design doc, in `future/done` alongside the other shipped ones |
| `core/workspace: add the dagger.toml include key and its merge` | the key, presence detection, pure merge, `ValidateEffectiveConfig` |
| `core: resolve an included workspace config` | resolving a path or git source, `ApplyIncludes`, and sanitizing what crosses the boundary |
| `engine/server: apply workspace includes during workspace load` | merge during workspace load |
| `core/schema: report the effective config on every read path` | effective reads, override-aware install/uninstall |
| `core/integration: cover workspace includes end to end` | fixtures for both source forms |
| `docs: document workspace includes` | the Includes page, `dagger.toml` reference, regenerated schema, changelog, CLI help |
| `core/gitref: keep an explicit HTTP(S) port in the clone ref` | prerequisite: a re-addressed module would otherwise reach a different remote |
| `core: address an included config's own modules` | the re-addressing, plus unit coverage |
| `core/integration: cover an include's own modules` | the monorepo shape end to end, a git include's own modules, and what stays dropped |
| `docs: an include brings its own modules` | the four surfaces that said otherwise |

## Verification

- `dagger check golang:lint-all` — passing
- unit: `./core/workspace`, `./core`, `./core/schema`, `./engine/server`, `./internal/cmd/dagger` — passing
- integration: `TestWorkspaceInclude` — 37 passing
- end to end against [eunomie/dagger-monorepo-include](https://github.com/eunomie/dagger-monorepo-include): `dagger installed`, `dagger call`, and `dagger check` all reach the shared modules from `project-a` and `project-b`

