### PR TITLE
[backport-0.21] fix(engine): take session teardown off the client shutdown path

### DIFF
--- a/.changes/unreleased/Fixed-20260810-150651.yaml
+++ b/.changes/unreleased/Fixed-20260810-150651.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Engine client enumeration no longer blocks behind another session's
+  initialization or teardown, preventing Cloud keeper heartbeats from stalling
+  and live engines from being suspended.
+time: 2026-08-10T15:06:51Z
+custom:
+  Author: sipsma
+  PR: 13542

--- a/.changes/unreleased/Fixed-20260812-212429.yaml
+++ b/.changes/unreleased/Fixed-20260812-212429.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Session teardown now runs in the background after the main client disconnects,
+  preventing shutdown responses from timing out while the engine releases
+  session-owned cache results.
+time: 2026-08-12T21:24:29Z
+custom:
+  Author: sipsma
+  PR: 13681

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -943,9 +943,12 @@ import (
 
 type Secreter struct {}
 
-func (*Secreter) Fn(cacheBust string, tokenPlaintext string) *dagger.Container {
+func (*Secreter) Fn(cacheBust, username, tokenPlaintext string) *dagger.Container {
 	authSecret := dag.SetSecret("GIT_AUTH", tokenPlaintext)
-	gitRepo := dag.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private", dagger.GitOpts{HTTPAuthToken: authSecret}).
+	gitRepo := dag.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private", dagger.GitOpts{
+		HTTPAuthUsername: username,
+		HTTPAuthToken:    authSecret,
+	}).
 		Branch("main").
 		Tree()
 
@@ -959,6 +962,7 @@ func (*Secreter) Fn(cacheBust string, tokenPlaintext string) *dagger.Container {
 				With(daggerCall(
 					"fn",
 					"--cache-bust", cacheBust,
+					"--username", authTokenTestCase.httpAuthUsername,
 					"--token-plaintext", authTokenTestCase.token(),
 					"stdout",
 				)).
@@ -1711,7 +1715,7 @@ func (m *Test) Fn(ctx context.Context, dir *dagger.Directory, rand string) ([]st
 	gitConfigFile1 := filepath.Join(gitConfigDir1, "config")
 	err = os.WriteFile(
 		gitConfigFile1,
-		[]byte(makeGitCredentials("https://"+tc.expectedHost, "git", decodedGitToken(tc.encodedToken))),
+		[]byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, decodedGitToken(tc.encodedToken))),
 		0644,
 	)
 	require.NoError(t, err)
@@ -1735,7 +1739,7 @@ func (m *Test) Fn(ctx context.Context, dir *dagger.Directory, rand string) ([]st
 	gitConfigFile2 := filepath.Join(gitConfigDir2, "config")
 	err = os.WriteFile(
 		gitConfigFile2,
-		[]byte(makeGitCredentials("https://"+tc.expectedHost, "git", decodedGitToken(tc.encodedToken2))),
+		[]byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername2, decodedGitToken(tc.encodedToken2))),
 		0644,
 	)
 	require.NoError(t, err)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -778,13 +778,11 @@ func (GitSuite) TestAuthProviders(ctx context.Context, t *testctx.T) {
 	// })
 
 	t.Run("GitLab auth", func(ctx context.Context, t *testctx.T) {
-		// Base64-encoded read-only PAT for test repo
-		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := decodeAndTrimPAT(pat)
-		require.NoError(t, err)
+		tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
-		_, err = c.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git", dagger.GitOpts{
-			HTTPAuthToken: c.SetSecret("gitlab_pat", token),
+		_, err := c.Git(tc.gitTestRepoRef, dagger.GitOpts{
+			HTTPAuthUsername: tc.httpAuthUsername,
+			HTTPAuthToken:    c.SetSecret("gitlab_deploy_token", tc.token()),
 		}).
 			Branch("main").
 			Tree().

--- a/core/integration/gitcredential_test.go
+++ b/core/integration/gitcredential_test.go
@@ -20,7 +20,7 @@ func TestGitCredential(t *testing.T) {
 }
 
 // TestGitCredentialErrors verifies Git authentication for private modules across different providers
-// using host-specific PATs and isolated Git credentials per test.
+// using host-specific credentials and isolated Git configuration per test.
 func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testctx.T) {
 	// Decode base64-encoded PATs used in CI
 	decodeAndTrimPAT := func(encoded string) (string, error) {
@@ -32,9 +32,9 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 	}
 
 	// Creates isolated Git credentials per host to allow parallel test execution
-	setupGitCredentials := func(host, token, workDir string) []string {
+	setupGitCredentials := func(host, username, token, workDir string) []string {
 		gitConfigPath := filepath.Join(workDir, ".gitconfig")
-		err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials(host, "x-token-auth", token)), 0600)
+		err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials(host, username, token)), 0600)
 		require.NoError(t, err)
 		return []string{"GIT_CONFIG_GLOBAL=" + gitConfigPath}
 	}
@@ -81,7 +81,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 
-		env := setupGitCredentials("github.com", token, workDir)
+		env := setupGitCredentials("github.com", "x-token-auth", token, workDir)
 		modDir := filepath.Join(workDir, "module")
 		err = os.MkdirAll(modDir, 0755)
 		require.NoError(t, err)
@@ -110,14 +110,11 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 
 	t.Run("gitlab private module", func(ctx context.Context, t *testctx.T) {
 		workDir := t.TempDir()
+		tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
-		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := decodeAndTrimPAT(pat)
-		require.NoError(t, err)
-
-		env := setupGitCredentials("gitlab.com", token, workDir)
+		env := setupGitCredentials(tc.expectedHost, tc.httpAuthUsername, tc.token(), workDir)
 		modDir := filepath.Join(workDir, "module")
-		err = os.MkdirAll(modDir, 0755)
+		err := os.MkdirAll(modDir, 0755)
 		require.NoError(t, err)
 
 		out, err := execWithEnv(ctx, t, modDir, env, "-m", "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git", "functions")
@@ -133,7 +130,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 
-		env := setupGitCredentials("github.com", token, workDir)
+		env := setupGitCredentials("github.com", "x-token-auth", token, workDir)
 
 		// Create the root directory for the main module
 		rootDir := filepath.Join(workDir, "main")

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1193,10 +1193,13 @@ type vcsTestCase struct {
 	isPrivateRepo      bool
 	skipProxyTest      bool
 
-	// encodedToken is a based64 encoded read-only PAT
-	encodedToken string
+	// HTTP credentials for private repositories. Tokens are base64 encoded to
+	// avoid storing token-shaped strings directly in the source.
+	httpAuthUsername string
+	encodedToken     string
 	// encodedToken2 is an optional second token to test cases of using different tokens for the same repo
-	encodedToken2 string
+	httpAuthUsername2 string
+	encodedToken2     string
 	// sshKey determines whether to propagate the host's ssh-key
 	sshKey bool
 }
@@ -1274,7 +1277,7 @@ var vcsTestCases = []vcsTestCase{
 		skipProxyTest:            true,
 		sshKey:                   true,
 	},
-	// GitLab private repository using PAT
+	// GitLab private repository using project-scoped deploy tokens
 	{
 		name:                     "Private GitLab",
 		gitTestRepoRef:           "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git",
@@ -1284,10 +1287,11 @@ var vcsTestCases = []vcsTestCase{
 		expectedURLPathComponent: "tree",
 		expectedPathPrefix:       "",
 		isPrivateRepo:            true,
-		// NOTE: this is not a security vulnerability, these tokens are read-only and scoped to a test repository
-		// with no actual private code
-		encodedToken:  "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx",
-		encodedToken2: "Z2xwYXQtcFVIWDVmZmVCUmdjZ2FYTHdndjNPVzg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxa2oyMHJi",
+		// NOTE: these tokens are read-only and scoped to a test repository with no actual private code.
+		httpAuthUsername:  "dagger-read-only",
+		encodedToken:      "Z2xkdC1ucHU2TTFGRkF3WXFoUnFrcHhXdA==",
+		httpAuthUsername2: "dagger-read-only-2",
+		encodedToken2:     "Z2xkdC1LN3p3Q3I3RW1HclFocmJSZmcteg==",
 	},
 	// BitBucket private repository using SCP-like SSH reference format
 	{

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -8093,7 +8093,7 @@ func privateRepoSetup(c *dagger.Client, t *testctx.T, tc vcsTestCase) (dagger.Wi
 		}
 		if token := tc.token(); token != "" {
 			ctr = ctr.
-				WithNewFile("/tmp/git-config", makeGitCredentials("https://"+tc.expectedHost, "git", token)).
+				WithNewFile("/tmp/git-config", makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, token)).
 				WithEnvVariable("GIT_CONFIG_GLOBAL", "/tmp/git-config")
 		}
 

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -391,6 +391,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					run: func(t *testctx.T, c *dagger.Client, _ proxyTestFixtures) {
 						opts := dagger.GitOpts{}
 						if token := tc.token(); token != "" {
+							opts.HTTPAuthUsername = tc.httpAuthUsername
 							opts.HTTPAuthToken = c.SetSecret("TOKEN", token)
 						}
 						gitURL := "https://" + strings.TrimPrefix(tc.gitTestRepoRef, "https://")
@@ -432,6 +433,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					run: func(t *testctx.T, c *dagger.Client, _ proxyTestFixtures) {
 						opts := dagger.GitOpts{}
 						if token := tc.token(); token != "" {
+							opts.HTTPAuthUsername = tc.httpAuthUsername
 							opts.HTTPAuthToken = c.SetSecret("TOKEN", token)
 						}
 

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -690,11 +690,11 @@ func (srv *Server) EngineName() string {
 }
 
 func (srv *Server) Clients() []string {
-	// Snapshot under daggerSessionsMu, then read mainClientCallerID under
-	// stateMu (it is set during initialization). Releasing daggerSessionsMu
-	// before taking stateMu avoids inverting removeDaggerSession's
-	// stateMu->daggerSessionsMu lock order; skip sessions that aren't
-	// initialized yet.
+	// Snapshot the session pointers under daggerSessionsMu, then read each
+	// session's liveness and identity WITHOUT any per-session lock: state is
+	// atomic and mainClientCallerID is immutable (set at construction). This is
+	// what keeps the active-clients API (polled by the cloud keepalive) from ever
+	// blocking on a session that is initializing or tearing down.
 	srv.daggerSessionsMu.RLock()
 	sessions := make([]*daggerSession, 0, len(srv.daggerSessions))
 	for _, sess := range srv.daggerSessions {
@@ -704,13 +704,10 @@ func (srv *Server) Clients() []string {
 
 	clients := map[string]struct{}{}
 	for _, sess := range sessions {
-		sess.stateMu.RLock()
-		if sess.state != sessionStateInitialized {
-			sess.stateMu.RUnlock()
+		if sess.state.Load() != sessionStateInitialized {
 			continue
 		}
 		clients[sess.mainClientCallerID] = struct{}{}
-		sess.stateMu.RUnlock()
 	}
 
 	return slices.Collect(maps.Keys(clients))
@@ -725,8 +722,14 @@ func (srv *Server) GracefulStop(ctx context.Context) error {
 
 	// note this *could* cause a panic in Session if it was still running, so
 	// the server should be shutdown first
+	// snapshot the session pointers into a slice (not an alias of the live map)
+	// so concurrent pointer-conditional deleteSession calls can't race this
+	// iteration.
 	srv.daggerSessionsMu.Lock()
-	daggerSessions := srv.daggerSessions
+	daggerSessions := make([]*daggerSession, 0, len(srv.daggerSessions))
+	for _, s := range srv.daggerSessions {
+		daggerSessions = append(daggerSessions, s)
+	}
 	srv.daggerSessionsMu.Unlock()
 
 	if srv.engineCache != nil {
@@ -735,9 +738,15 @@ func (srv *Server) GracefulStop(ctx context.Context) error {
 	}
 
 	for _, s := range daggerSessions {
-		s.stateMu.Lock()
-		err = errors.Join(err, srv.removeDaggerSession(ctx, s))
-		s.stateMu.Unlock()
+		s.lifecycleMu.Lock()
+		// Wait out any in-flight init (lifecycleMu serializes it), then tear down
+		// only if the session actually initialized; an already-removed tombstone
+		// or a still-uninitialized session has nothing (more) to remove here.
+		if s.state.Load() == sessionStateInitialized {
+			err = errors.Join(err, srv.removeDaggerSession(ctx, s))
+		}
+		s.lifecycleMu.Unlock()
+		srv.deleteSession(s)
 	}
 
 	if srv.engineCache != nil && len(srv.workerGCPolicies) > 0 {
@@ -921,11 +930,10 @@ func (srv *Server) gcClientDBs() {
 func (srv *Server) activeClientIDs() map[string]bool {
 	keep := map[string]bool{}
 
-	// Snapshot the sessions under daggerSessionsMu, then drop it before taking
-	// per-session locks: clients is written by getOrInitClient under clientMu
-	// (so must be read under clientMu), and removeDaggerSession takes
-	// daggerSessionsMu while holding stateMu, so holding daggerSessionsMu while
-	// acquiring stateMu here would risk a lock-order inversion.
+	// Snapshot session pointers under daggerSessionsMu, then per session read
+	// state atomically (lock-free) and the clients map under clientMu. No
+	// per-session lifecycle lock is taken, so the client-DB GC ticker can never
+	// block on a session that is initializing or tearing down.
 	srv.daggerSessionsMu.RLock()
 	sessions := make([]*daggerSession, 0, len(srv.daggerSessions))
 	for _, sess := range srv.daggerSessions {
@@ -934,12 +942,10 @@ func (srv *Server) activeClientIDs() map[string]bool {
 	srv.daggerSessionsMu.RUnlock()
 
 	for _, sess := range sessions {
-		sess.stateMu.RLock()
-		// clients is only populated once a session is initialized, and a
-		// removed session's client DBs are already being torn down, so only
-		// initialized sessions contribute IDs worth keeping.
-		if sess.state != sessionStateInitialized {
-			sess.stateMu.RUnlock()
+		// clients is only populated once a session is initialized, and a removed
+		// session's client DBs are already being torn down, so only initialized
+		// sessions contribute IDs worth keeping.
+		if sess.state.Load() != sessionStateInitialized {
 			continue
 		}
 		sess.clientMu.RLock()
@@ -947,7 +953,6 @@ func (srv *Server) activeClientIDs() map[string]bool {
 			keep[id] = true
 		}
 		sess.clientMu.RUnlock()
-		sess.stateMu.RUnlock()
 	}
 
 	return keep

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1094,59 +1094,81 @@ func (srv *Server) getOrInitClient(
 	}
 
 	return client, func() error {
-		if clientID != sess.mainClientCallerID {
-			client.stateMu.Lock()
-			client.activeCount--
-			activeCount := client.activeCount
-			client.stateMu.Unlock()
-
-			if activeCount > 0 {
-				return nil
-			}
-
-			slog.With(
-				"sessionID", sess.sessionID,
-				"clientID", client.clientID,
-			).Info("all client connections closed")
-			return nil
-		}
-
-		// Main client cleanup. Take lifecycleMu BEFORE client.stateMu (matching
-		// getOrInitClient's order) and hold it across the activeCount zero-check
-		// and the teardown decision, so a concurrent getOrInitClient (which bumps
-		// activeCount under lifecycleMu) cannot slip a new connection in between
-		// the check and removeDaggerSession.
-		sess.lifecycleMu.Lock()
-
-		client.stateMu.Lock()
-		client.activeCount--
-		activeCount := client.activeCount
-		client.stateMu.Unlock()
-
-		if activeCount > 0 {
-			sess.lifecycleMu.Unlock()
-			return nil
-		}
-
-		slog.With(
-			"sessionID", sess.sessionID,
-			"clientID", client.clientID,
-		).Info("all client connections closed")
-
-		if sess.state.Load() != sessionStateInitialized {
-			// Already removed, or never fully initialized: nothing to tear down.
-			sess.lifecycleMu.Unlock()
-			return nil
-		}
-
-		err := srv.removeDaggerSession(ctx, sess)
-		sess.lifecycleMu.Unlock()
-		// Drop the tombstone now that teardown is complete and lifecycleMu is
-		// released (pointer-conditional, so a fresh same-id session is never
-		// deleted).
-		srv.deleteSession(sess)
-		return err
+		return srv.releaseClientConnection(ctx, sess, client)
 	}, nil
+}
+
+// releaseClientConnection is the per-request cleanup for a connection obtained
+// via getOrInitClient. When the main client's last connection closes it only
+// SCHEDULES teardown (reapDaggerSession) rather than running it: this cleanup
+// runs in the request handler before the response is flushed — typically the
+// main client's /shutdown POST — and the client enforces a hard budget
+// (default 10s) on that response, while teardown is unbounded (the dagql cache
+// release alone is proportional to the session's cache footprint).
+func (srv *Server) releaseClientConnection(ctx context.Context, sess *daggerSession, client *daggerClient) error {
+	client.stateMu.Lock()
+	client.activeCount--
+	activeCount := client.activeCount
+	client.stateMu.Unlock()
+
+	if activeCount > 0 {
+		return nil
+	}
+
+	slog.With(
+		"sessionID", sess.sessionID,
+		"clientID", client.clientID,
+	).Info("all client connections closed")
+
+	if client.clientID != sess.mainClientCallerID {
+		return nil
+	}
+
+	// The teardown decision itself is (re-)made inside reapDaggerSession under
+	// lifecycleMu, so a concurrent getOrInitClient (which bumps activeCount
+	// under lifecycleMu) either lands before the reap and aborts it, or
+	// observes the removed tombstone and retries against a fresh session.
+	go srv.reapDaggerSession(context.WithoutCancel(ctx), sess, client)
+	return nil
+}
+
+// reapDaggerSession tears down a session in the background after the main
+// client's last connection closed. It re-checks the teardown conditions under
+// lifecycleMu because the session may have changed since the disconnect that
+// scheduled it: a reconnected main client abandons the reap (the next last
+// disconnect schedules a fresh one), and an already-removed session (a
+// concurrent reap or GracefulStop won the race) is left alone.
+func (srv *Server) reapDaggerSession(ctx context.Context, sess *daggerSession, mainClient *daggerClient) {
+	sess.lifecycleMu.Lock()
+
+	if sess.state.Load() != sessionStateInitialized {
+		// Already removed, or never fully initialized: nothing to tear down.
+		sess.lifecycleMu.Unlock()
+		return
+	}
+
+	mainClient.stateMu.RLock()
+	activeCount := mainClient.activeCount
+	mainClient.stateMu.RUnlock()
+	if activeCount > 0 {
+		// The main client reconnected before this reap ran; the session is
+		// live again.
+		sess.lifecycleMu.Unlock()
+		return
+	}
+
+	err := srv.removeDaggerSession(ctx, sess)
+	sess.lifecycleMu.Unlock()
+	// Drop the tombstone now that teardown is complete and lifecycleMu is
+	// released (pointer-conditional, so a fresh same-id session is never
+	// deleted).
+	srv.deleteSession(sess)
+	if err != nil {
+		slog.Error("session teardown failed",
+			"sessionID", sess.sessionID,
+			"error", err,
+		)
+	}
 }
 
 // ServeHTTP serves clients directly hitting the engine API (i.e. main client callers, not nested execs like module functions)

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -61,8 +62,16 @@ type daggerSession struct {
 	sessionID          string
 	mainClientCallerID string
 
-	state   daggerSessionState
-	stateMu sync.RWMutex
+	// state is read lock-free by observer paths and written only under
+	// lifecycleMu. The zero value is sessionStateUninitialized.
+	state atomicSessionState
+
+	// lifecycleMu serializes this session's initialization and teardown. It is
+	// held across the (potentially slow, up to ~60s) init and teardown work, but
+	// NO observer path (Clients/activeClientIDs/clientFromIDs) ever acquires it,
+	// so a session stuck initializing or tearing down can never stall the
+	// active-clients API or the client-DB GC.
+	lifecycleMu sync.Mutex
 
 	clients  map[string]*daggerClient // clientID -> client
 	clientMu sync.RWMutex
@@ -123,13 +132,40 @@ type workspaceLockState struct {
 	dirty    bool
 }
 
-type daggerSessionState string
+// daggerSessionState is the lifecycle state of a session. It is intentionally
+// int-backed (rather than string) so it can be stored in an atomic and read by
+// observers without locking; the zero value is sessionStateUninitialized.
+type daggerSessionState int32
 
 const (
-	sessionStateUninitialized daggerSessionState = "uninitialized"
-	sessionStateInitialized   daggerSessionState = "initialized"
-	sessionStateRemoved       daggerSessionState = "removed"
+	sessionStateUninitialized daggerSessionState = iota
+	sessionStateInitialized
+	sessionStateRemoved
 )
+
+func (s daggerSessionState) String() string {
+	switch s {
+	case sessionStateUninitialized:
+		return "uninitialized"
+	case sessionStateInitialized:
+		return "initialized"
+	case sessionStateRemoved:
+		return "removed"
+	default:
+		return fmt.Sprintf("unknown(%d)", int32(s))
+	}
+}
+
+// atomicSessionState wraps the session's lifecycle state so it can be read
+// lock-free by observer paths (Clients/activeClientIDs/clientFromIDs). Writes
+// only ever happen while holding the session's lifecycleMu, which serializes
+// state transitions; the atomic is what makes concurrent lock-free reads safe.
+type atomicSessionState struct {
+	v atomic.Int32
+}
+
+func (a *atomicSessionState) Load() daggerSessionState   { return daggerSessionState(a.v.Load()) }
+func (a *atomicSessionState) Store(s daggerSessionState) { a.v.Store(int32(s)) }
 
 type daggerClient struct {
 	daggerSession  *daggerSession
@@ -310,7 +346,7 @@ func (sess *daggerSession) FlushTelemetry(ctx context.Context) error {
 	return eg.Wait()
 }
 
-// requires that sess.stateMu is held
+// requires that sess.lifecycleMu is held
 func (srv *Server) initializeDaggerSession(
 	clientMetadata *engine.ClientMetadata,
 	sess *daggerSession,
@@ -319,9 +355,9 @@ func (srv *Server) initializeDaggerSession(
 	slog.Info("initializing new session", "session", clientMetadata.SessionID)
 	defer slog.Debug("initialized new session", "session", clientMetadata.SessionID)
 
-	sess.sessionID = clientMetadata.SessionID
-	sess.mainClientCallerID = clientMetadata.ClientID
-	sess.clients = map[string]*daggerClient{}
+	// NOTE: sessionID, mainClientCallerID and the clients map are set at
+	// construction (before the session is published) and are immutable /
+	// clientMu-protected thereafter; they are deliberately not assigned here.
 	sess.attachables = newSessionAttachableManager()
 	sess.endpoints = map[string]http.Handler{}
 	sess.closingCtx, sess.cancelClosing = context.WithCancelCause(context.Background())
@@ -360,7 +396,10 @@ func (srv *Server) initializeDaggerSession(
 	})
 	failureCleanups.Add("close session analytics", sess.analytics.Close)
 
-	sess.state = sessionStateInitialized
+	// NOTE: state is NOT set to sessionStateInitialized here. getOrInitClient
+	// performs that atomic transition as its last step, after the main client is
+	// initialized and inserted, so observers never see an initialized session
+	// whose fields/clients aren't ready yet.
 	return nil
 }
 
@@ -386,12 +425,27 @@ func (sess *daggerSession) withClosingCancel(ctx context.Context) context.Contex
 	return ctx
 }
 
-// requires that sess.stateMu is held
+// requires that sess.lifecycleMu is held.
+//
+// removeDaggerSession does NOT remove the session from srv.daggerSessions; it
+// leaves it in place as a "removed" tombstone so observers see the removed state
+// and a concurrent same-id getOrInitClient bails out instead of resurrecting the
+// session while its cache is still being released. The caller must call
+// deleteSession (after releasing lifecycleMu) to drop the tombstone once
+// teardown is complete.
 func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession) error {
 	slog := slog.With("session", sess.sessionID)
 
 	slog.Info("removing session; stopping client services and flushing")
 	defer slog.Debug("session removed")
+
+	// Publish the removed state first (atomic) so observers holding a stale
+	// snapshot pointer, and any concurrent same-id getOrInitClient, observe it
+	// immediately and skip/bail instead of using a tearing-down session. The
+	// session is intentionally left in srv.daggerSessions as a tombstone until
+	// the caller drops it via deleteSession after lifecycleMu is released.
+	sess.state.Store(sessionStateRemoved)
+	sess.beginClosing()
 
 	// check if the local cache needs pruning after session is removed, prune if so
 	defer func() {
@@ -400,13 +454,6 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 		}
 		time.AfterFunc(time.Second, srv.throttledGC)
 	}()
-
-	srv.daggerSessionsMu.Lock()
-	delete(srv.daggerSessions, sess.sessionID)
-	srv.daggerSessionsMu.Unlock()
-
-	sess.state = sessionStateRemoved
-	sess.beginClosing()
 
 	var errs error
 
@@ -504,6 +551,18 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	})
 
 	return errs
+}
+
+// deleteSession drops a session from the registry, but only if the map entry is
+// still this exact session pointer. Pointer-conditional deletion ensures a slow
+// teardown can't delete a freshly created same-id session. Call only after the
+// session's teardown is complete and lifecycleMu has been released.
+func (srv *Server) deleteSession(sess *daggerSession) {
+	srv.daggerSessionsMu.Lock()
+	if srv.daggerSessions[sess.sessionID] == sess {
+		delete(srv.daggerSessions, sess.sessionID)
+	}
+	srv.daggerSessionsMu.Unlock()
 }
 
 type ClientInitOpts struct {
@@ -777,13 +836,11 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 		return nil, err
 	}
 
-	// The session pointer is published before initializeDaggerSession populates
-	// its fields, so gate on state under stateMu before reading them. stateMu is
-	// taken only after releasing daggerSessionsMu to avoid inverting
-	// removeDaggerSession's stateMu->daggerSessionsMu lock order.
-	sess.stateMu.RLock()
-	defer sess.stateMu.RUnlock()
-	switch sess.state {
+	// Gate on the session's lifecycle state via a lock-free atomic read (never
+	// lifecycleMu), so this lookup can't block on a session that is initializing
+	// or tearing down. A client is inserted into sess.clients only after it is
+	// fully initialized, so a clientMu read can't observe a half-initialized one.
+	switch st := sess.state.Load(); st {
 	case sessionStateInitialized:
 		// continue
 	case sessionStateRemoved:
@@ -792,14 +849,21 @@ func (srv *Server) clientFromIDs(sessID, clientID string) (*daggerClient, error)
 	case sessionStateUninitialized:
 		return nil, fmt.Errorf("session %q not initialized", sessID)
 	default:
-		return nil, fmt.Errorf("session %q has unknown state %q", sessID, sess.state)
+		return nil, fmt.Errorf("session %q has unknown state %s", sessID, st)
 	}
 
 	sess.clientMu.RLock()
-	defer sess.clientMu.RUnlock()
 	client, ok := sess.clients[clientID]
+	sess.clientMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("client %q not found", clientID)
+	}
+
+	// Re-check state: if the session flipped to removed while we read the clients
+	// map, treat it as not-found rather than handing back a client whose session
+	// is tearing down. This is a lock-free atomic read, so it never blocks.
+	if sess.state.Load() == sessionStateRemoved {
+		return nil, flightcontrol.RetryableError{Err: fmt.Errorf("session %q not found", sessID)}
 	}
 
 	return client, nil
@@ -831,13 +895,10 @@ func (srv *Server) getOrInitClient(
 		return nil, nil, fmt.Errorf("client secret token is required")
 	}
 
-	// cleanup to do if this method fails
+	// cleanup to do if this method fails; the failure handler that runs these is
+	// installed below, once we hold the session's lifecycleMu (so it can publish
+	// the removed tombstone before unlocking, then drop it only after cleanups).
 	failureCleanups := &cleanups.Cleanups{}
-	defer func() {
-		if rerr != nil {
-			rerr = errors.Join(rerr, failureCleanups.Run())
-		}
-	}()
 
 	// get or initialize the session as a whole
 
@@ -847,35 +908,75 @@ func (srv *Server) getOrInitClient(
 		return nil, nil, errServerShuttingDown
 	}
 	sess, sessionExists := srv.daggerSessions[sessionID]
-	stateMuLocked := false
+	createdSession := false
 	if !sessionExists {
+		// Construct with immutable identity and a non-nil clients map, and lock
+		// the new session's lifecycleMu BEFORE publishing it, so this goroutine
+		// is guaranteed to be the session's initializer: any concurrent caller
+		// that finds the published-but-uninitialized session blocks on
+		// lifecycleMu until initialization completes (or sees the removed
+		// tombstone if init fails). The session is still unreachable here, so this
+		// acquisition never contends and can't invert the lock order even though
+		// we currently hold daggerSessionsMu (the one "unpublished object"
+		// exception to "lifecycleMu and daggerSessionsMu are never nested").
 		sess = &daggerSession{
-			state: sessionStateUninitialized,
+			sessionID:          sessionID,
+			mainClientCallerID: clientID,
+			clients:            map[string]*daggerClient{},
 		}
-		// Lock stateMu before publishing the session below so a concurrent
-		// clientFromIDs that looks it up blocks until initialization finishes
-		// instead of observing uninitialized fields. The session is still
-		// unreachable by other goroutines here, so this never blocks and can't
-		// invert removeDaggerSession's stateMu->daggerSessionsMu order even
-		// though we currently hold daggerSessionsMu.
-		sess.stateMu.Lock()
-		stateMuLocked = true
+		sess.lifecycleMu.Lock()
+		createdSession = true
 		srv.daggerSessions[sessionID] = sess
-
-		failureCleanups.Add("delete session ID", func() error {
-			srv.daggerSessionsMu.Lock()
-			delete(srv.daggerSessions, sessionID)
-			srv.daggerSessionsMu.Unlock()
-			return nil
-		})
 	}
 	srv.daggerSessionsMu.Unlock()
 
-	if !stateMuLocked {
-		sess.stateMu.Lock()
+	if !createdSession {
+		// Fast, lock-free check: if the session is already a removed tombstone,
+		// bail immediately rather than blocking on lifecycleMu for the (possibly
+		// ~60s) teardown. A same-id reconnect then retries and gets a fresh
+		// session once the tombstone is dropped.
+		if sess.state.Load() == sessionStateRemoved {
+			return nil, nil, flightcontrol.RetryableError{Err: fmt.Errorf("session %q removed", sessionID)}
+		}
+		sess.lifecycleMu.Lock()
 	}
-	defer sess.stateMu.Unlock()
-	switch sess.state {
+
+	// We now hold sess.lifecycleMu. The deferred handler below manages the unlock
+	// for both success and failure. On failure of a session WE created it:
+	// publishes the removed tombstone (while still holding lifecycleMu, so a
+	// waiting same-id caller observes removed and bails instead of resurrecting a
+	// half-built session), releases the lock, runs resource cleanups, and only
+	// THEN drops the tombstone from the registry — so no fresh same-id session can
+	// be created while this one's resources are still being released.
+	lifecycleHeld := true
+	unlockLifecycle := func() {
+		if lifecycleHeld {
+			lifecycleHeld = false
+			sess.lifecycleMu.Unlock()
+		}
+	}
+	defer func() {
+		if rerr == nil {
+			unlockLifecycle()
+			return
+		}
+		if createdSession {
+			sess.state.Store(sessionStateRemoved)
+		}
+		unlockLifecycle()
+		rerr = errors.Join(rerr, failureCleanups.Run())
+		// No engineCache.ReleaseSession is needed here: session-scoped cache refs
+		// are only attached (via AttachResult) during nested-client init carrying
+		// Env/Module context, which always targets an already-existing session
+		// (createdSession=false). In current in-tree call paths a created session
+		// is always a main-client session that has attached nothing session-scoped,
+		// so there is nothing to release before dropping the tombstone.
+		if createdSession {
+			srv.deleteSession(sess)
+		}
+	}()
+
+	switch sess.state.Load() {
 	case sessionStateUninitialized:
 		if err := srv.initializeDaggerSession(opts.ClientMetadata, sess, failureCleanups); err != nil {
 			return nil, nil, fmt.Errorf("initialize session: %w", err)
@@ -883,13 +984,20 @@ func (srv *Server) getOrInitClient(
 	case sessionStateInitialized:
 		// nothing to do
 	case sessionStateRemoved:
-		return nil, nil, fmt.Errorf("session %q removed", sess.sessionID)
+		return nil, nil, flightcontrol.RetryableError{Err: fmt.Errorf("session %q removed", sessionID)}
 	}
 
-	// get or initialize the client itself
-
-	sess.clientMu.Lock()
+	// get or initialize the client itself.
+	//
+	// A client is inserted into sess.clients only AFTER it is fully initialized,
+	// so observer paths (clientFromIDs/activeClientIDs) can never see a
+	// half-initialized client. We hold lifecycleMu here, so no other goroutine
+	// can be creating the same client concurrently; a brief clientMu read to find
+	// an existing client is therefore sufficient (no double-checked locking).
+	sess.clientMu.RLock()
 	client, clientExists := sess.clients[clientID]
+	sess.clientMu.RUnlock()
+
 	if !clientExists {
 		client = &daggerClient{
 			state:          clientStateUninitialized,
@@ -900,9 +1008,9 @@ func (srv *Server) getOrInitClient(
 			shutdownCh:     make(chan struct{}),
 			clientMetadata: opts.ClientMetadata,
 		}
-		sess.clients[clientID] = client
 
-		// initialize SQLite DB early so we can subscribe to it immediately
+		// Open the SQLite DB outside clientMu (its busy_timeout is 10s) so a slow
+		// open can never block observers reading the clients map under clientMu.
 		if db, err := srv.clientDBs.Open(ctx, client.clientID); err != nil {
 			slog.Warn("failed to open client DB; continuing without keepalive",
 				"sessionID", sessionID,
@@ -916,20 +1024,14 @@ func (srv *Server) getOrInitClient(
 			})
 		}
 
+		sess.clientMu.RLock()
 		parent, parentExists := sess.clients[opts.CallerClientID]
+		sess.clientMu.RUnlock()
 		if parentExists {
 			client.parents = slices.Clone(parent.parents)
 			client.parents = append(client.parents, parent)
 		}
-
-		failureCleanups.Add("delete client ID", func() error {
-			sess.clientMu.Lock()
-			delete(sess.clients, clientID)
-			sess.clientMu.Unlock()
-			return nil
-		})
 	}
-	sess.clientMu.Unlock()
 
 	client.stateMu.Lock()
 	defer client.stateMu.Unlock()
@@ -938,6 +1040,11 @@ func (srv *Server) getOrInitClient(
 		if err := srv.initializeDaggerClient(ctx, client, opts); err != nil {
 			return nil, nil, fmt.Errorf("initialize client: %w", err)
 		}
+		// Now that the client is fully initialized, publish it into the session.
+		// (We hold lifecycleMu, so this is the only goroutine creating it.)
+		sess.clientMu.Lock()
+		sess.clients[clientID] = client
+		sess.clientMu.Unlock()
 	case clientStateInitialized:
 		// verify token matches existing client
 		if token != client.secretToken {
@@ -979,6 +1086,13 @@ func (srv *Server) getOrInitClient(
 	// increment the number of active connections from this client
 	client.activeCount++
 
+	// If this call initialized the session, mark it initialized now — as the
+	// LAST step, after the main client has been initialized and inserted — so
+	// observers never see an initialized session whose main client isn't present.
+	if sess.state.Load() == sessionStateUninitialized {
+		sess.state.Store(sessionStateInitialized)
+	}
+
 	return client, func() error {
 		if clientID != sess.mainClientCallerID {
 			client.stateMu.Lock()
@@ -990,46 +1104,48 @@ func (srv *Server) getOrInitClient(
 				return nil
 			}
 
-			slog := slog.With(
+			slog.With(
 				"sessionID", sess.sessionID,
 				"clientID", client.clientID,
-			)
-			slog.Info("all client connections closed")
+			).Info("all client connections closed")
 			return nil
 		}
 
-		sess.stateMu.Lock()
-		defer sess.stateMu.Unlock()
+		// Main client cleanup. Take lifecycleMu BEFORE client.stateMu (matching
+		// getOrInitClient's order) and hold it across the activeCount zero-check
+		// and the teardown decision, so a concurrent getOrInitClient (which bumps
+		// activeCount under lifecycleMu) cannot slip a new connection in between
+		// the check and removeDaggerSession.
+		sess.lifecycleMu.Lock()
 
-		// Keep the lock order consistent with getOrInitClient (session before
-		// client). If cleanup took client.stateMu first, a new request could
-		// hold stateMu while waiting on client.stateMu, while cleanup waited
-		// on stateMu.
 		client.stateMu.Lock()
 		client.activeCount--
 		activeCount := client.activeCount
 		client.stateMu.Unlock()
 
 		if activeCount > 0 {
+			sess.lifecycleMu.Unlock()
 			return nil
 		}
 
-		slog := slog.With(
+		slog.With(
 			"sessionID", sess.sessionID,
 			"clientID", client.clientID,
-		)
-		slog.Info("all client connections closed")
+		).Info("all client connections closed")
 
-		switch sess.state {
-		case sessionStateInitialized:
-			return srv.removeDaggerSession(ctx, sess)
-		default:
-			// this should never happen unless there's a bug
-			slog.Error("session state being removed not in initialized state",
-				"state", sess.state,
-			)
+		if sess.state.Load() != sessionStateInitialized {
+			// Already removed, or never fully initialized: nothing to tear down.
+			sess.lifecycleMu.Unlock()
 			return nil
 		}
+
+		err := srv.removeDaggerSession(ctx, sess)
+		sess.lifecycleMu.Unlock()
+		// Drop the tombstone now that teardown is complete and lifecycleMu is
+		// released (pointer-conditional, so a fresh same-id session is never
+		// deleted).
+		srv.deleteSession(sess)
+		return err
 	}, nil
 }
 

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
@@ -347,6 +348,204 @@ func TestSessionLifecycleObserverConcurrency(t *testing.T) {
 		_ = srv.Clients()
 		_ = srv.activeClientIDs()
 		_, _ = srv.clientFromIDs("s0", "c")
+	}
+}
+
+// newTeardownTestServer builds a Server with just enough real state for
+// removeDaggerSession to run: an empty in-memory dagql cache, a live wcprof
+// counter, and a stubbed GC callback (scheduled via time.AfterFunc at the end
+// of teardown).
+func newTeardownTestServer(t *testing.T) *Server {
+	t.Helper()
+	cache, err := dagql.NewCache(context.Background(), "", nil, nil)
+	require.NoError(t, err)
+	return &Server{
+		daggerSessions:  map[string]*daggerSession{},
+		engineCache:     cache,
+		wcprofSpanCount: newWcprofSpanCounter(),
+		throttledGC:     func() {},
+	}
+}
+
+// newTeardownTestSession publishes an initialized session whose main client
+// has the given number of active connections. dagqlInFlight starts at 1 so
+// teardown deterministically blocks in the in-flight drain until
+// releaseTeardownDrain is called.
+func newTeardownTestSession(srv *Server, sessionID, mainClientID string, activeCount int) (*daggerSession, *daggerClient) {
+	client := &daggerClient{
+		clientID:    mainClientID,
+		activeCount: activeCount,
+	}
+	sess := &daggerSession{
+		sessionID:          sessionID,
+		mainClientCallerID: mainClientID,
+		clients:            map[string]*daggerClient{mainClientID: client},
+		services:           core.NewServices(),
+		analytics:          analytics.New(analytics.Config{DoNotTrack: true}),
+		shutdownCh:         make(chan struct{}),
+	}
+	client.daggerSession = sess
+	sess.dagqlCond = sync.NewCond(&sess.dagqlMu)
+	sess.dagqlInFlight = 1
+	sess.closingCtx, sess.cancelClosing = context.WithCancelCause(context.Background())
+	sess.state.Store(sessionStateInitialized)
+
+	srv.daggerSessionsMu.Lock()
+	srv.daggerSessions[sessionID] = sess
+	srv.daggerSessionsMu.Unlock()
+	return sess, client
+}
+
+func releaseTeardownDrain(sess *daggerSession) {
+	sess.dagqlMu.Lock()
+	sess.dagqlInFlight = 0
+	sess.dagqlCond.Broadcast()
+	sess.dagqlMu.Unlock()
+}
+
+func sessionInRegistry(srv *Server, sessionID string) bool {
+	srv.daggerSessionsMu.RLock()
+	defer srv.daggerSessionsMu.RUnlock()
+	_, ok := srv.daggerSessions[sessionID]
+	return ok
+}
+
+func TestMainClientLastDisconnectDoesNotBlockOnTeardown(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the client-side `shutdown: ... context deadline exceeded`
+	// timeout: the main client's last connection cleanup runs in the request
+	// handler before the /shutdown response is flushed, so it must only
+	// SCHEDULE teardown, never run it. Teardown here is deterministically
+	// blocked in the in-flight dagql drain; the cleanup must return anyway.
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.releaseClientConnection(context.Background(), sess, client)
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("last-connection cleanup blocked on session teardown")
+	}
+
+	// The background reap marks the session removed (tombstone) but stays
+	// blocked in the drain, so the registry entry must survive for now.
+	require.Eventually(t, func() bool {
+		return sess.state.Load() == sessionStateRemoved
+	}, 10*time.Second, 10*time.Millisecond, "background teardown never started")
+	require.True(t, sessionInRegistry(srv, "s"), "tombstone dropped before teardown finished")
+
+	releaseTeardownDrain(sess)
+
+	require.Eventually(t, func() bool {
+		return !sessionInRegistry(srv, "s")
+	}, 10*time.Second, 10*time.Millisecond, "session never finished background teardown")
+	select {
+	case <-sess.shutdownCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("session shutdownCh never closed by background teardown")
+	}
+}
+
+func TestSameIDConnectDuringBackgroundTeardownGetsRetryable(t *testing.T) {
+	t.Parallel()
+
+	// While a background reap is mid-teardown (removed tombstone in the
+	// registry, lifecycleMu held), a same-id getOrInitClient must bail out
+	// fast with a retryable error instead of blocking on the teardown.
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 1)
+
+	require.NoError(t, srv.releaseClientConnection(context.Background(), sess, client))
+	require.Eventually(t, func() bool {
+		return sess.state.Load() == sessionStateRemoved
+	}, 10*time.Second, 10*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := srv.getOrInitClient(context.Background(), &ClientInitOpts{
+			ClientMetadata: &engine.ClientMetadata{
+				SessionID:         "s",
+				ClientID:          "m",
+				ClientSecretToken: "token",
+			},
+		})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		var retryable flightcontrol.RetryableError
+		require.ErrorAs(t, err, &retryable)
+	case <-time.After(10 * time.Second):
+		t.Fatal("same-id getOrInitClient blocked on background teardown")
+	}
+
+	releaseTeardownDrain(sess)
+	require.Eventually(t, func() bool {
+		return !sessionInRegistry(srv, "s")
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestReapAbandonedWhenMainClientReconnects(t *testing.T) {
+	t.Parallel()
+
+	// A new main-client connection can land between the last disconnect and
+	// the scheduled reap running. The reap re-checks activeCount under
+	// lifecycleMu and must leave the now-live session alone.
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 1)
+
+	// Simulate the reconnect winning the race: activeCount is back above zero
+	// by the time the reap runs.
+	client.stateMu.Lock()
+	client.activeCount = 1
+	client.stateMu.Unlock()
+
+	srv.reapDaggerSession(context.Background(), sess, client)
+
+	require.Equal(t, sessionStateInitialized, sess.state.Load())
+	require.True(t, sessionInRegistry(srv, "s"))
+	select {
+	case <-sess.shutdownCh:
+		t.Fatal("reap tore down a session with a live main client")
+	default:
+	}
+}
+
+func TestConcurrentReapsSingleTeardown(t *testing.T) {
+	t.Parallel()
+
+	// Duplicate reaps can be scheduled (disconnect, reconnect, disconnect).
+	// Whichever acquires lifecycleMu first tears down; the loser must observe
+	// the removed state and no-op (double teardown would double-close
+	// shutdownCh and panic).
+	srv := newTeardownTestServer(t)
+	sess, client := newTeardownTestSession(srv, "s", "m", 0)
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			srv.reapDaggerSession(context.Background(), sess, client)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		return sess.state.Load() == sessionStateRemoved
+	}, 10*time.Second, 10*time.Millisecond)
+	releaseTeardownDrain(sess)
+	wg.Wait()
+
+	require.False(t, sessionInRegistry(srv, "s"))
+	select {
+	case <-sess.shutdownCh:
+	default:
+		t.Fatal("session shutdownCh not closed after teardown")
 	}
 }
 

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -3,17 +3,20 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
+	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -38,11 +41,11 @@ func TestActiveClientIDsConcurrentSessionClientMutation(t *testing.T) {
 	// Without the lock, ranging the map while another goroutine writes it is a
 	// fatal "concurrent map iteration and map write" (caught here under -race).
 	sess := &daggerSession{
-		state: sessionStateInitialized,
 		clients: map[string]*daggerClient{
 			"client-a": {clientID: "client-a"},
 		},
 	}
+	sess.state.Store(sessionStateInitialized)
 	srv := &Server{
 		daggerSessions: map[string]*daggerSession{
 			"session-a": sess,
@@ -85,13 +88,12 @@ func TestActiveClientIDsConcurrentSessionClientMutation(t *testing.T) {
 func TestClientFromIDsConcurrentSessionInitialization(t *testing.T) {
 	t.Parallel()
 
-	// Regression test: clientFromIDs must read sess.state/sess.clients under
-	// stateMu while another goroutine reassigns those fields during session
-	// initialization. Without the stateMu gate this is a data race (caught
+	// Regression test: clientFromIDs must read sess.state (atomically) and
+	// sess.clients (under clientMu) while another goroutine mutates them during
+	// session initialization. Without that discipline this is a data race (caught
 	// here under -race).
-	sess := &daggerSession{
-		state: sessionStateUninitialized,
-	}
+	sess := &daggerSession{}
+	sess.state.Store(sessionStateUninitialized)
 	srv := &Server{
 		daggerSessions: map[string]*daggerSession{
 			"session-a": sess,
@@ -124,29 +126,228 @@ func TestClientFromIDsConcurrentSessionInitialization(t *testing.T) {
 	<-started
 
 	for i := 0; i < 1000; i++ {
-		sess.stateMu.Lock()
+		sess.clientMu.Lock()
 		sess.clients = map[string]*daggerClient{
 			"client-a": {clientID: "client-a"},
 		}
-		sess.state = sessionStateInitialized
-		sess.state = sessionStateUninitialized
+		sess.clientMu.Unlock()
+		sess.state.Store(sessionStateInitialized)
+		sess.state.Store(sessionStateUninitialized)
+		sess.clientMu.Lock()
 		sess.clients = nil
-		sess.stateMu.Unlock()
+		sess.clientMu.Unlock()
 	}
 
 	client := &daggerClient{clientID: "client-a"}
-	sess.stateMu.Lock()
 	sess.clientMu.Lock()
 	sess.clients = map[string]*daggerClient{
 		client.clientID: client,
 	}
 	sess.clientMu.Unlock()
-	sess.state = sessionStateInitialized
-	sess.stateMu.Unlock()
+	sess.state.Store(sessionStateInitialized)
 
 	got, err := srv.clientFromIDs("session-a", client.clientID)
 	require.NoError(t, err)
 	require.Same(t, client, got)
+}
+
+func TestClientsDoesNotBlockWhileSessionLifecycleLocked(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the >15s active-clients stall (Discord: "Session lock might
+	// be causing unwanted session shutdowns"): Clients() must never acquire a
+	// session's lifecycleMu. A session stuck initializing or tearing down holds
+	// lifecycleMu for a long time (teardown has a 60s safeguard), but that must
+	// not stall the active-clients API the cloud keepalive polls.
+	live := &daggerSession{sessionID: "live", mainClientCallerID: "main-live"}
+	live.state.Store(sessionStateInitialized)
+	busy := &daggerSession{sessionID: "busy", mainClientCallerID: "main-busy"}
+	busy.state.Store(sessionStateInitialized)
+	srv := &Server{daggerSessions: map[string]*daggerSession{
+		"live": live,
+		"busy": busy,
+	}}
+
+	// Simulate an in-progress init/teardown holding busy's lifecycleMu.
+	busy.lifecycleMu.Lock()
+	defer busy.lifecycleMu.Unlock()
+
+	done := make(chan []string, 1)
+	go func() { done <- srv.Clients() }()
+
+	select {
+	case clients := <-done:
+		require.ElementsMatch(t, []string{"main-live", "main-busy"}, clients)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Clients() blocked while a session's lifecycleMu was held")
+	}
+}
+
+func TestActiveClientIDsDoesNotBlockWhileSessionLifecycleLocked(t *testing.T) {
+	t.Parallel()
+
+	// activeClientIDs() (the client-DB GC ticker) must also never acquire a
+	// session's lifecycleMu, for the same reason as Clients().
+	live := &daggerSession{
+		sessionID: "live",
+		clients:   map[string]*daggerClient{"c-live": {clientID: "c-live"}},
+	}
+	live.state.Store(sessionStateInitialized)
+	busy := &daggerSession{
+		sessionID: "busy",
+		clients:   map[string]*daggerClient{"c-busy": {clientID: "c-busy"}},
+	}
+	busy.state.Store(sessionStateInitialized)
+	srv := &Server{daggerSessions: map[string]*daggerSession{
+		"live": live,
+		"busy": busy,
+	}}
+
+	busy.lifecycleMu.Lock()
+	defer busy.lifecycleMu.Unlock()
+
+	done := make(chan map[string]bool, 1)
+	go func() { done <- srv.activeClientIDs() }()
+
+	select {
+	case keep := <-done:
+		require.True(t, keep["c-live"], "expected live session's client to be kept")
+		require.True(t, keep["c-busy"], "expected initialized busy session's client to be kept")
+	case <-time.After(10 * time.Second):
+		t.Fatal("activeClientIDs() blocked while a session's lifecycleMu was held")
+	}
+}
+
+func TestGetOrInitClientReturnsFastForRemovedTombstone(t *testing.T) {
+	t.Parallel()
+
+	// A session mid-teardown holds lifecycleMu and is marked removed (a tombstone
+	// left in the registry until cleanup completes). A same-id getOrInitClient
+	// must bail immediately via the lock-free removed pre-check rather than block
+	// on lifecycleMu for the (possibly ~60s) teardown.
+	tombstone := &daggerSession{sessionID: "s", mainClientCallerID: "m"}
+	tombstone.state.Store(sessionStateRemoved)
+	srv := &Server{daggerSessions: map[string]*daggerSession{"s": tombstone}}
+
+	// Hold lifecycleMu to simulate an in-progress teardown.
+	tombstone.lifecycleMu.Lock()
+	defer tombstone.lifecycleMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := srv.getOrInitClient(context.Background(), &ClientInitOpts{
+			ClientMetadata: &engine.ClientMetadata{
+				SessionID:         "s",
+				ClientID:          "m",
+				ClientSecretToken: "token",
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		var retryable flightcontrol.RetryableError
+		require.ErrorAs(t, err, &retryable, "removed tombstone should yield a retryable error")
+	case <-time.After(10 * time.Second):
+		t.Fatal("getOrInitClient blocked on lifecycleMu for a removed tombstone")
+	}
+}
+
+func TestClientFromIDsStateGating(t *testing.T) {
+	t.Parallel()
+
+	// clientFromIDs gates on the session's (atomic) lifecycle state without ever
+	// taking lifecycleMu, and never returns a client whose session isn't usable.
+	client := &daggerClient{clientID: "c"}
+	sess := &daggerSession{
+		sessionID: "s",
+		clients:   map[string]*daggerClient{"c": client},
+	}
+	srv := &Server{daggerSessions: map[string]*daggerSession{"s": sess}}
+
+	// uninitialized: not yet usable.
+	sess.state.Store(sessionStateUninitialized)
+	_, err := srv.clientFromIDs("s", "c")
+	require.ErrorContains(t, err, "not initialized")
+
+	// removed: retryable not-found (session is tearing down).
+	sess.state.Store(sessionStateRemoved)
+	_, err = srv.clientFromIDs("s", "c")
+	var retryable flightcontrol.RetryableError
+	require.ErrorAs(t, err, &retryable)
+
+	// initialized: returns the client.
+	sess.state.Store(sessionStateInitialized)
+	got, err := srv.clientFromIDs("s", "c")
+	require.NoError(t, err)
+	require.Same(t, client, got)
+}
+
+func TestSessionLifecycleObserverConcurrency(t *testing.T) {
+	t.Parallel()
+
+	// Stress the observer paths (Clients/activeClientIDs/clientFromIDs) against
+	// concurrent session churn. The churners exercise the observer-visible state
+	// the way the real lifecycle does — registry writes under daggerSessionsMu,
+	// the clients map under clientMu, the lifecycle state via the atomic, and a
+	// pointer-conditional deleteSession on teardown — but deliberately do NOT take
+	// lifecycleMu, since the whole point of the redesign is that observers don't
+	// depend on it. Run under -race to catch data races; the observers must also
+	// never block (completing while churn runs is the liveness assertion).
+	srv := &Server{daggerSessions: map[string]*daggerSession{}}
+
+	const (
+		churners         = 4
+		cyclesPerChurner = 1000
+	)
+	var wg sync.WaitGroup
+	for i := range churners {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := fmt.Sprintf("s%d", n)
+			for range cyclesPerChurner {
+				sess := &daggerSession{
+					sessionID:          id,
+					mainClientCallerID: "m" + id,
+					clients:            map[string]*daggerClient{},
+				}
+				// publish, then populate clients, then flip to initialized last.
+				srv.daggerSessionsMu.Lock()
+				srv.daggerSessions[id] = sess
+				srv.daggerSessionsMu.Unlock()
+				sess.clientMu.Lock()
+				sess.clients["c"] = &daggerClient{clientID: "c"}
+				sess.clientMu.Unlock()
+				sess.state.Store(sessionStateInitialized)
+
+				// teardown: removed first, then pointer-conditional delete.
+				sess.state.Store(sessionStateRemoved)
+				srv.deleteSession(sess)
+			}
+		}(i)
+	}
+
+	churnDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(churnDone)
+	}()
+
+	// Hammer the observers concurrently until every churner has finished its
+	// fixed workload, so the race window is exercised deterministically rather
+	// than depending on scheduler timing.
+	for {
+		select {
+		case <-churnDone:
+			return
+		default:
+		}
+		_ = srv.Clients()
+		_ = srv.activeClientIDs()
+		_, _ = srv.clientFromIDs("s0", "c")
+	}
 }
 
 func TestPendingLegacyModule(t *testing.T) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/engineutil"
 	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
@@ -352,18 +353,16 @@ func TestSessionLifecycleObserverConcurrency(t *testing.T) {
 }
 
 // newTeardownTestServer builds a Server with just enough real state for
-// removeDaggerSession to run: an empty in-memory dagql cache, a live wcprof
-// counter, and a stubbed GC callback (scheduled via time.AfterFunc at the end
-// of teardown).
+// removeDaggerSession to run: an empty in-memory dagql cache and a stubbed GC
+// callback (scheduled via time.AfterFunc at the end of teardown).
 func newTeardownTestServer(t *testing.T) *Server {
 	t.Helper()
 	cache, err := dagql.NewCache(context.Background(), "", nil, nil)
 	require.NoError(t, err)
 	return &Server{
-		daggerSessions:  map[string]*daggerSession{},
-		engineCache:     cache,
-		wcprofSpanCount: newWcprofSpanCounter(),
-		throttledGC:     func() {},
+		daggerSessions: map[string]*daggerSession{},
+		engineCache:    cache,
+		throttledGC:    func() {},
 	}
 }
 


### PR DESCRIPTION
## Summary

Backports https://github.com/dagger/dagger/pull/13681 to the v0.21 maintenance line for v0.21.9.

When the main client's final connection closes, engine-internal session teardown is now scheduled on a background reaper. This keeps the `/shutdown` response from waiting on unbounded cache and resource reclamation, while the client-critical workspace/service/telemetry drain remains synchronous.

This draft also carries the exact proven v0.21 private-GitLab CI-fixture backport from https://github.com/dagger/dagger/pull/13849. It replaces revoked GitLab user PAT usage with project deploy tokens and their required usernames in six integration-test files; it does not change product behavior.

The shutdown change addresses shutdown-path teardown scheduling. It does not claim to fix the newly reported startup/egraph contention, and it does not redesign cache release or lifecycle locking.

## Source PR and commits

Shutdown-path backport:

- Source PR: https://github.com/dagger/dagger/pull/13681
- Exact source commit: https://github.com/dagger/dagger/commit/b3953091561d53b2eb57b1493c116c89551abeb5
- Traceable `cherry-pick -x` backport commit: `a5eb16e5efb93794ba31eb08b84a81f56590874d`
- v0.21 test-fixture adaptation: `a75c147aa640348ac3a03b2739e8f60a60ddf56b`
- v0.21.9 release-note commit: `ce47b2b336e49e37302d05e6abe8195c8ac6ff52`

GitLab CI-fixture backport:

- Source PR: https://github.com/dagger/dagger/pull/13849
- Source PR commit: https://github.com/dagger/dagger/commit/0c656b9ca6395fdec1f051d34987bb4f8864196a
- Main merge commit: https://github.com/dagger/dagger/commit/66337ba5d3d01ae10a0d7fb97ebe4dec9326e8bc
- Proven v0.21 canary backport: `becaa3a33542ccc7e96dbf3f430d887f41958e52` on https://github.com/dagger/dagger/pull/13885
- Exact clean cherry-pick on this branch: `da8c39fb37947ffb4ee304e799b5e09e4c3e3b16`

## Dependency / stacked diff

This draft intentionally and temporarily includes and depends on https://github.com/dagger/dagger/pull/13865. PR #13681 relies on the lifecycle-state and removed-tombstone behavior backported there.

The branch starts from the exact current #13865 PR head, `35afbde0013e6c40937fedfa67434c801427762f`, but this PR still targets `dagger/dagger:backport-0.21`. It must be rebased or otherwise updated after #13865 merges so that the prerequisite commits disappear from this PR's diff. The stacked diff is expected while #13865 remains open.

Since the fixture was propagated here, #13885 merged into `backport-0.21` as `269c47d7708b4623c3fbfdcd2440d19a055dc7e0`, so the target branch now contains the same six-file fixture patch. A clean local three-way merge against that base collapses the identical fixture content: the effective merge delta contains only the #13865 prerequisite and #13681 backport files. The exact fixture cherry-pick remains in this branch's history for provenance.

## v0.21 adaptations

Shutdown-path backport:

- The production `engine/server/session.go` change cherry-picked cleanly; its patch is identical to the source commit's production patch.
- The source regression-test helper relied on a `dagql` import and `wcprofSpanCount` fixture already present on main. v0.21 needs an explicit `dagql` import and has no `wcprofSpanCount` field, so the fixture omits that main-only field. The four regression scenarios and assertions are unchanged.
- Added the v0.21.9 unreleased change entry at `.changes/unreleased/Fixed-20260812-212429.yaml`, attributed to source PR #13681.

GitLab CI fixture:

- Cherry-picked the proven v0.21 commit without conflict or adaptation; the resulting commit has the same stable patch ID as `becaa3a33542ccc7e96dbf3f430d887f41958e52`.
- The delta is exactly six existing integration-test files: `cross_session_test.go`, `git_test.go`, `gitcredential_test.go`, `module_config_test.go`, `module_test.go`, and `proxy_test.go`.
- No engine/product code, diagnostics, local-worktree workaround, or release note was added by the fixture backport.

No teardown, cache-release, or locking behavior was opportunistically redesigned.

## Validation

Shutdown-path validation passed locally:

- `dagger --progress=plain call engine-dev test --pkg=./engine/server --run='^(TestMainClientLastDisconnectDoesNotBlockOnTeardown|TestSameIDConnectDuringBackgroundTeardownGetsRetryable|TestReapAbandonedWhenMainClientReconnects|TestConcurrentReapsSingleTeardown)$' --race --count=1 --test-verbose` — 4/4 passed (trace `886bbe0b885eadd71e68918a20194ccd`)
- `dagger --progress=plain call engine-dev test --pkg=./engine/server --count=1` — 56/56 passed (trace `ac8e829ffe4a031b53a25e5176e4c983`)
- `dagger --progress=plain call engine-dev test --pkg=./engine/server --race --count=1` — 56/56 passed (trace `63c38bec3799ed278a72b79ff5305185`)
- `dagger --progress=plain check go:lint changelog:generate` — passed (trace `52c8f0caf2bfebc849034933083594a8`)

GitLab fixture validation and provenance:

- Canary PR #13885 passed all 75 applicable checks on `becaa3a33542ccc7e96dbf3f430d887f41958e52`, including all five formerly failing shards and `TestPrivateGitRepoArgCaching` in real CI.
- Fresh CI on this PR's current head passed all 75 applicable checks: 74 Dagger Cloud contexts plus DCO. The five formerly failing shards passed with traces: `test-base` (`2460fc75505f4043c73494f2f9504ba4`), `test-call-and-shell` (`6a40c909805c2ca65b8733650c2daa63`), `test-cli-engine` (`09c7f1aaa19a385f71b973f574042f59`), `test-container` (`4fb6d68d4ea869e4065304ecb7e36cb2`), and `test-modules` (`2eea881d02a2065a40344008d4612f4f`).
- Stable patch IDs for `becaa3a33542ccc7e96dbf3f430d887f41958e52` and `da8c39fb37947ffb4ee304e799b5e09e4c3e3b16` match: `c5ece8f8d50919d36bdb6abad1e312d65ae8a2bf`.
- The post-cherry-pick delta is exactly six files with 35 insertions and 30 deletions.
- `gofmt -d` produced no diff for all six fixture files.
- `git diff --check` passed for both the six-file cherry-pick and the complete stacked PR diff.

## Release note

The unreleased v0.21.9 `Fixed` entry says that session teardown now runs in the background after the main client disconnects, preventing shutdown responses from timing out while the engine releases session-owned cache results. It attributes the change to source PR #13681.

The GitLab fixture update is test-only and does not add a release note.

## Remaining risks / work

- Update this branch after #13865 merges to remove the prerequisite from the stacked diff.
- Manual playground validation was not run locally.
