### PR TITLE
[backport-0.21] fix: hide registry HTTP probe errors

### DIFF
--- a/.changes/unreleased/Fixed-20260812-213333.yaml
+++ b/.changes/unreleased/Fixed-20260812-213333.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Registry protocol probes no longer appear as scary errors in progress output
+  when image pulls or publishes succeed, while genuine registry failures remain
+  visible.
+time: 2026-08-12T21:33:33Z
+custom:
+  Author: vito
+  PR: 13410

--- a/core/integration/cross_session_test.go
+++ b/core/integration/cross_session_test.go
@@ -943,9 +943,12 @@ import (
 
 type Secreter struct {}
 
-func (*Secreter) Fn(cacheBust string, tokenPlaintext string) *dagger.Container {
+func (*Secreter) Fn(cacheBust, username, tokenPlaintext string) *dagger.Container {
 	authSecret := dag.SetSecret("GIT_AUTH", tokenPlaintext)
-	gitRepo := dag.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private", dagger.GitOpts{HTTPAuthToken: authSecret}).
+	gitRepo := dag.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private", dagger.GitOpts{
+		HTTPAuthUsername: username,
+		HTTPAuthToken:    authSecret,
+	}).
 		Branch("main").
 		Tree()
 
@@ -959,6 +962,7 @@ func (*Secreter) Fn(cacheBust string, tokenPlaintext string) *dagger.Container {
 				With(daggerCall(
 					"fn",
 					"--cache-bust", cacheBust,
+					"--username", authTokenTestCase.httpAuthUsername,
 					"--token-plaintext", authTokenTestCase.token(),
 					"stdout",
 				)).
@@ -1711,7 +1715,7 @@ func (m *Test) Fn(ctx context.Context, dir *dagger.Directory, rand string) ([]st
 	gitConfigFile1 := filepath.Join(gitConfigDir1, "config")
 	err = os.WriteFile(
 		gitConfigFile1,
-		[]byte(makeGitCredentials("https://"+tc.expectedHost, "git", decodedGitToken(tc.encodedToken))),
+		[]byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, decodedGitToken(tc.encodedToken))),
 		0644,
 	)
 	require.NoError(t, err)
@@ -1735,7 +1739,7 @@ func (m *Test) Fn(ctx context.Context, dir *dagger.Directory, rand string) ([]st
 	gitConfigFile2 := filepath.Join(gitConfigDir2, "config")
 	err = os.WriteFile(
 		gitConfigFile2,
-		[]byte(makeGitCredentials("https://"+tc.expectedHost, "git", decodedGitToken(tc.encodedToken2))),
+		[]byte(makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername2, decodedGitToken(tc.encodedToken2))),
 		0644,
 	)
 	require.NoError(t, err)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -778,13 +778,11 @@ func (GitSuite) TestAuthProviders(ctx context.Context, t *testctx.T) {
 	// })
 
 	t.Run("GitLab auth", func(ctx context.Context, t *testctx.T) {
-		// Base64-encoded read-only PAT for test repo
-		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := decodeAndTrimPAT(pat)
-		require.NoError(t, err)
+		tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
-		_, err = c.Git("https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git", dagger.GitOpts{
-			HTTPAuthToken: c.SetSecret("gitlab_pat", token),
+		_, err := c.Git(tc.gitTestRepoRef, dagger.GitOpts{
+			HTTPAuthUsername: tc.httpAuthUsername,
+			HTTPAuthToken:    c.SetSecret("gitlab_deploy_token", tc.token()),
 		}).
 			Branch("main").
 			Tree().

--- a/core/integration/gitcredential_test.go
+++ b/core/integration/gitcredential_test.go
@@ -20,7 +20,7 @@ func TestGitCredential(t *testing.T) {
 }
 
 // TestGitCredentialErrors verifies Git authentication for private modules across different providers
-// using host-specific PATs and isolated Git credentials per test.
+// using host-specific credentials and isolated Git configuration per test.
 func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testctx.T) {
 	// Decode base64-encoded PATs used in CI
 	decodeAndTrimPAT := func(encoded string) (string, error) {
@@ -32,9 +32,9 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 	}
 
 	// Creates isolated Git credentials per host to allow parallel test execution
-	setupGitCredentials := func(host, token, workDir string) []string {
+	setupGitCredentials := func(host, username, token, workDir string) []string {
 		gitConfigPath := filepath.Join(workDir, ".gitconfig")
-		err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials(host, "x-token-auth", token)), 0600)
+		err := os.WriteFile(gitConfigPath, []byte(makeGitCredentials(host, username, token)), 0600)
 		require.NoError(t, err)
 		return []string{"GIT_CONFIG_GLOBAL=" + gitConfigPath}
 	}
@@ -81,7 +81,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 
-		env := setupGitCredentials("github.com", token, workDir)
+		env := setupGitCredentials("github.com", "x-token-auth", token, workDir)
 		modDir := filepath.Join(workDir, "module")
 		err = os.MkdirAll(modDir, 0755)
 		require.NoError(t, err)
@@ -110,14 +110,11 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 
 	t.Run("gitlab private module", func(ctx context.Context, t *testctx.T) {
 		workDir := t.TempDir()
+		tc := getVCSTestCase(t, "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git")
 
-		pat := "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx"
-		token, err := decodeAndTrimPAT(pat)
-		require.NoError(t, err)
-
-		env := setupGitCredentials("gitlab.com", token, workDir)
+		env := setupGitCredentials(tc.expectedHost, tc.httpAuthUsername, tc.token(), workDir)
 		modDir := filepath.Join(workDir, "module")
-		err = os.MkdirAll(modDir, 0755)
+		err := os.MkdirAll(modDir, 0755)
 		require.NoError(t, err)
 
 		out, err := execWithEnv(ctx, t, modDir, env, "-m", "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git", "functions")
@@ -133,7 +130,7 @@ func (GitCredentialSuite) TestGitCredentialErrors(ctx context.Context, t *testct
 		token, err := decodeAndTrimPAT(pat)
 		require.NoError(t, err)
 
-		env := setupGitCredentials("github.com", token, workDir)
+		env := setupGitCredentials("github.com", "x-token-auth", token, workDir)
 
 		// Create the root directory for the main module
 		rootDir := filepath.Join(workDir, "main")

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1193,10 +1193,13 @@ type vcsTestCase struct {
 	isPrivateRepo      bool
 	skipProxyTest      bool
 
-	// encodedToken is a based64 encoded read-only PAT
-	encodedToken string
+	// HTTP credentials for private repositories. Tokens are base64 encoded to
+	// avoid storing token-shaped strings directly in the source.
+	httpAuthUsername string
+	encodedToken     string
 	// encodedToken2 is an optional second token to test cases of using different tokens for the same repo
-	encodedToken2 string
+	httpAuthUsername2 string
+	encodedToken2     string
 	// sshKey determines whether to propagate the host's ssh-key
 	sshKey bool
 }
@@ -1274,7 +1277,7 @@ var vcsTestCases = []vcsTestCase{
 		skipProxyTest:            true,
 		sshKey:                   true,
 	},
-	// GitLab private repository using PAT
+	// GitLab private repository using project-scoped deploy tokens
 	{
 		name:                     "Private GitLab",
 		gitTestRepoRef:           "https://gitlab.com/dagger-modules/private/test/more/dagger-test-modules-private.git",
@@ -1284,10 +1287,11 @@ var vcsTestCases = []vcsTestCase{
 		expectedURLPathComponent: "tree",
 		expectedPathPrefix:       "",
 		isPrivateRepo:            true,
-		// NOTE: this is not a security vulnerability, these tokens are read-only and scoped to a test repository
-		// with no actual private code
-		encodedToken:  "Z2xwYXQtMGF2bWZBbHBxWENwOXpuazZfZ2JmbTg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxbWF0b2Rx",
-		encodedToken2: "Z2xwYXQtcFVIWDVmZmVCUmdjZ2FYTHdndjNPVzg2TVFwMU9tTjRhV3BqQ3cuMDEuMTIxa2oyMHJi",
+		// NOTE: these tokens are read-only and scoped to a test repository with no actual private code.
+		httpAuthUsername:  "dagger-read-only",
+		encodedToken:      "Z2xkdC1ucHU2TTFGRkF3WXFoUnFrcHhXdA==",
+		httpAuthUsername2: "dagger-read-only-2",
+		encodedToken2:     "Z2xkdC1LN3p3Q3I3RW1HclFocmJSZmcteg==",
 	},
 	// BitBucket private repository using SCP-like SSH reference format
 	{

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -8093,7 +8093,7 @@ func privateRepoSetup(c *dagger.Client, t *testctx.T, tc vcsTestCase) (dagger.Wi
 		}
 		if token := tc.token(); token != "" {
 			ctr = ctr.
-				WithNewFile("/tmp/git-config", makeGitCredentials("https://"+tc.expectedHost, "git", token)).
+				WithNewFile("/tmp/git-config", makeGitCredentials("https://"+tc.expectedHost, tc.httpAuthUsername, token)).
 				WithEnvVariable("GIT_CONFIG_GLOBAL", "/tmp/git-config")
 		}
 

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -391,6 +391,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					run: func(t *testctx.T, c *dagger.Client, _ proxyTestFixtures) {
 						opts := dagger.GitOpts{}
 						if token := tc.token(); token != "" {
+							opts.HTTPAuthUsername = tc.httpAuthUsername
 							opts.HTTPAuthToken = c.SetSecret("TOKEN", token)
 						}
 						gitURL := "https://" + strings.TrimPrefix(tc.gitTestRepoRef, "https://")
@@ -432,6 +433,7 @@ func (ContainerSuite) TestSystemProxies(ctx context.Context, t *testctx.T) {
 					run: func(t *testctx.T, c *dagger.Client, _ proxyTestFixtures) {
 						opts := dagger.GitOpts{}
 						if token := tc.token(); token != "" {
+							opts.HTTPAuthUsername = tc.httpAuthUsername
 							opts.HTTPAuthToken = c.SetSecret("TOKEN", token)
 						}
 

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -95,8 +95,11 @@ func (opts FrontendOpts) ShouldShow(db *DB, span *Span) bool {
 		// _still_ not interesting
 		return false
 	}
-	if span.IsFailedOrCausedFailure() && verbosity > HideErrorsVerbosity {
-		// prioritize showing failed things, even if they're internal
+	if span.IsFailedOrCausedFailure() && verbosity > HideErrorsVerbosity &&
+		!span.EncapsulationHidden(opts) {
+		// prioritize showing failed things, even if they're internal - but not
+		// encapsulated failures whose parent succeeded (e.g. a registry's
+		// routine 401 auth challenge); those are handled internal details
 		return true
 	}
 	if span.Call() != nil {

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -771,14 +771,22 @@ func (span *Span) Hidden(opts FrontendOpts) bool {
 		// internal spans are hidden by default
 		return true
 	}
-	if span.ParentSpan != nil &&
+	return span.EncapsulationHidden(opts)
+}
+
+// EncapsulationHidden reports whether the span is hidden as an encapsulated
+// internal detail of a parent that didn't fail. Encapsulated steps are
+// hidden - even on error, e.g. a registry's routine 401 auth challenge -
+// unless their parent errors.
+func (span *Span) EncapsulationHidden(opts FrontendOpts) bool {
+	verbosity := opts.Verbosity
+	if v, ok := opts.SpanVerbosity[span.ID]; ok {
+		verbosity = v
+	}
+	return span.ParentSpan != nil &&
 		(span.Encapsulated || span.ParentSpan.Encapsulate) &&
 		!span.ParentSpan.IsFailed() &&
-		verbosity < ShowEncapsulatedVerbosity {
-		// encapsulated steps are hidden (even on error) unless their parent errors
-		return true
-	}
-	return false
+		verbosity < ShowEncapsulatedVerbosity
 }
 
 func (span *Span) IsRunning() bool {

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -22,8 +22,6 @@ $ viztest: Viztest! X.Xs CACHED
   │ ! stat .dockerignore: no such file or directory
   │
   ├╴✔ resolving docker.io/library/busybox:1.34 X.Xs
-  │ ╰╴✔ remotes.docker.resolver.HTTPRequest X.Xs
-  │   ╰╴✔ HTTP HEAD X.Xs
   │
   ├╴$ Container.from(address: "docker.io/library/busybox:1.34@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"): Container! X.Xs CACHED
   │

--- a/engine/server/resolver/resolver.go
+++ b/engine/server/resolver/resolver.go
@@ -157,7 +157,7 @@ func (r *Resolver) ResolveImageConfig(
 	ref string,
 	opts ResolveImageConfigOpts,
 ) (_ string, _ digest.Digest, _ []byte, rerr error) {
-	span, ctx := tracing.StartSpan(ctx, "resolving "+ref, telemetry.Encapsulated())
+	span, ctx := tracing.StartSpan(ctx, "resolving "+ref, telemetry.Encapsulated(), telemetry.Encapsulate())
 	defer func() {
 		tracing.FinishWithError(span, rerr)
 	}()
@@ -239,7 +239,7 @@ func (r *Resolver) ResolveImageConfig(
 }
 
 func (r *Resolver) Pull(ctx context.Context, ref string, opts PullOpts) (_ *PulledImage, rerr error) {
-	span, ctx := tracing.StartSpan(ctx, "pulling "+ref, telemetry.Encapsulated())
+	span, ctx := tracing.StartSpan(ctx, "pulling "+ref, telemetry.Encapsulated(), telemetry.Encapsulate())
 	defer func() {
 		tracing.FinishWithError(span, rerr)
 	}()
@@ -575,7 +575,7 @@ func (r *Resolver) localCanonicalRootDescriptor(ctx context.Context, dgst digest
 }
 
 func (r *Resolver) PushImage(ctx context.Context, img *PushedImage, ref string, opts PushOpts) (rerr error) {
-	span, ctx := tracing.StartSpan(ctx, "pushing "+ref, telemetry.Encapsulated())
+	span, ctx := tracing.StartSpan(ctx, "pushing "+ref, telemetry.Encapsulated(), telemetry.Encapsulate())
 	defer func() {
 		tracing.FinishWithError(span, rerr)
 	}()


### PR DESCRIPTION
## Summary

Backport the scoped telemetry fix that hides normal registry-protocol HTTP probe failures from successful pull and publish progress. Registry HEAD 404s and auth challenges still occur as expected, but they no longer render as scary failed child rows when the enclosing registry operation succeeds.

Also backport the shared private-GitLab test fixture update from #13849. GitLab revoked the committed user PATs used by the v0.21 integration tests; the fixture now uses read-only project deploy tokens and forwards their required usernames through each existing authentication path.

## Source provenance

Registry progress fix:

- Source PR: https://github.com/dagger/dagger/pull/13410
- Exact semantic source commit: https://github.com/dagger/dagger/commit/b9cdb6656036d6efd176fcda8e615332c81cb554
- Merged squash commit for source PR: https://github.com/dagger/dagger/commit/0bb84dde94beb8174d17222f33b782adeb6f8ee9
- Backported with `cherry-pick -x`, preserving Alex Suraci as author.

GitLab CI fixture fix:

- Source PR: https://github.com/dagger/dagger/pull/13849
- Source PR commit: https://github.com/dagger/dagger/commit/0c656b9ca6395fdec1f051d34987bb4f8864196a
- Merged main commit: https://github.com/dagger/dagger/commit/66337ba5d3d01ae10a0d7fb97ebe4dec9326e8bc
- Backported as `becaa3a33542ccc7e96dbf3f430d887f41958e52` with `cherry-pick -x`, preserving Guillaume de Rouville as author.

## Root cause and user impact

containerd instruments registry HTTP requests through OpenTelemetry. Normal protocol behavior includes failed probes such as HEAD 404 responses for blobs or manifests that are not present yet, plus authentication challenges. The progress frontend forced every failed span visible, even when that span was encapsulated and its parent registry operation completed successfully. As a result, successful `Container.publish` calls could show prominent `remotes.docker.resolver.HTTPRequest` and `HTTP HEAD ERROR` rows, especially in plain progress.

The fix encapsulates registry resolve, pull, and push internals and only reveals failed encapsulated children when the enclosing operation itself fails. Genuine registry failures therefore retain their diagnostic HTTP spans.

Separately, GitLab automatically revoked the user PATs committed for the disposable private-repository integration fixture. That made five otherwise unrelated CI shards fail wherever they exercised the shared HTTPS fixture. Project deploy tokens require a username/token pair, so changing only the token is insufficient; every fixture consumer must propagate the matching username.

## v0.21 adaptations

Registry progress fix:

- Cherry-picked the complete scoped semantic fix and its golden regression coverage.
- Kept the existing v0.21 golden-fixture hostname; the source commit included unrelated hostname churn in the same fixture.
- Excluded the broader transfer-progress row architecture from the remainder of #13410.
- No BuildKit, containerd, OpenTelemetry, or other dependency changes.

GitLab fixture fix:

- Limited to six existing v0.21 integration-test files; no engine or product code changed.
- Mapped main's extracted `module_helpers_test.go` change to the equivalent helper in v0.21's `module_test.go`.
- Preserved v0.21's existing CLI assertion form in `gitcredential_test.go`.
- Omitted main-only workspace/private-dependency coverage and its extracted fixture because those tests and layouts do not exist on v0.21.

## Validation

Registry progress fix passed:

- `dagger call engine-dev test --pkg='./dagql/idtui' --run='^TestTelemetry/TestGolden/docker-build-fail$'` — 3 tests
- `dagger --progress=plain call engine-dev test --pkg='./core/integration' --run='^TestContainer/TestPublish$'` — 2 tests, using the local test registry; expected HEAD 404 probes occurred without HTTP HEAD ERROR progress rows
- `dagger call engine-dev test --pkg='./dagql/dagui'` — 22 tests
- `dagger call engine-dev test --pkg='./engine/server/resolver'` — 1 test
- `dagger --progress=plain -m ./toolchains/go call --source=. lint-module --module=dagql`
- `dagger --progress=plain -m ./toolchains/go call --source=. lint-module --module=engine`
- `git diff --check upstream/backport-0.21...HEAD`

GitLab fixture adaptation passed locally:

- `TestGit/TestAuthProviders/GitLab_auth` — direct username/token API path
- `TestGitCredential/TestGitCredentialErrors/gitlab_private_module` — host credential-helper/module path
- `TestModule/TestCrossSessionSecrets/contenthash_cache_hit_with_secrets` — nested secret path
- `TestConfig/TestDaggerGitRefs/Private_GitLab` — six module-reference assertions
- `git diff --check`

Fresh Dagger Cloud checks on canary head `becaa3a33542ccc7e96dbf3f430d887f41958e52` passed all five shards that previously exposed the revoked GitLab credentials:

- `test-split:test-base`
- `test-split:test-cli-engine`
- `test-split:test-call-and-shell`
- `test-split:test-container`
- `test-split:test-modules`

That run also passed `TestPrivateGitRepoArgCaching`, confirming the earlier linked-worktree `.git` failure was local-state-only. The first fresh `test-split:test-base` run independently hit `TestChangeset/TestWithChangesets/comparison_with_sequential_merge` with `fatal: stash failed`, the exact unrelated snapshot-hardlink/ctime baseline defect documented by main PR #13773. Its isolated supported Dagger Cloud rerun passed in 13m34s (trace `91b9bc8f3a602d14f0e6e8b5627e93c6`). The final PR ledger is 75 successful checks and one intentionally skipped changelog gate.

The repository-root lint entrypoint was also attempted for the registry fix. It failed on an unrelated generated import in `docs/versioned_docs/version-0.21.4/getting-started/types/snippets/default-address/go/main.go`; the scoped lints for both changed source trees pass.

## Release note

Added a v0.21.9 unreleased `Fixed` entry attributed to source PR #13410:

> Registry protocol probes no longer appear as scary errors in progress output when image pulls or publishes succeed, while genuine registry failures remain visible.

The GitLab fixture update is test-only and does not add a release note.

## Remaining risks

The registry change is a presentation-only policy change scoped to Dagger registry resolve, pull, and push spans. Failed enclosing registry operations still reveal their failed children, and higher verbosity can still expose encapsulated details. The broad progress and transfer-row changes from the rest of #13410 are intentionally not included.

The GitLab change depends on the deliberately public, read-only deploy-token fixture remaining valid. Fresh CI on this canary commit verified all five affected shards; propagation to other backport PRs remains a separate lead decision.
