### PR TITLE
engine: support manual metadata pruning

### DIFF
--- a/.changes/unreleased/Added-20260812-224458.yaml
+++ b/.changes/unreleased/Added-20260812-224458.yaml
@@ -1,0 +1,11 @@
+kind: Added
+body: |
+  Add explicit structural-memory controls to `Engine.localCache.prune`. Manual
+  pruning can now apply absolute `maxEstimatedBytes` and
+  `targetEstimatedBytes` limits without enabling automatic garbage collection,
+  and `useDefaultPolicy` applies both enabled disk and structural policies in
+  the same request.
+time: 2026-08-12T22:44:58Z
+custom:
+  Author: sipsma
+  PR: ""

--- a/core/engine.go
+++ b/core/engine.go
@@ -29,11 +29,13 @@ type EngineCache struct {
 }
 
 type EngineCachePruneOptions struct {
-	UseDefaultPolicy bool
-	MaxUsedSpace     string
-	ReservedSpace    string
-	MinFreeSpace     string
-	TargetSpace      string
+	UseDefaultPolicy     bool
+	MaxUsedSpace         string
+	ReservedSpace        string
+	MinFreeSpace         string
+	TargetSpace          string
+	MaxEstimatedBytes    *int64
+	TargetEstimatedBytes *int64
 }
 
 func (*EngineCache) Type() *ast.Type {

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -752,6 +752,22 @@ sleep 30`,
 	require.NotEmpty(t, strings.TrimSpace(version))
 }
 
+func (LocalCacheSuite) TestLocalCacheManualMetadataPruneCLI(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	engine := devEngineContainer(c, engineWithConfig(ctx, t, engineConfigWithEnabled(false)))
+	devEngine := devEngineContainerAsService(engine)
+
+	_, err := engineClientContainer(ctx, t, c, devEngine).
+		WithExec([]string{
+			"dagger", "-m", "core", "api", "call",
+			"engine", "local-cache", "prune",
+			"--max-estimated-bytes=4294967296",
+			"--target-estimated-bytes=3221225472",
+		}).
+		Sync(ctx)
+	require.NoError(t, err, "explicit structural pruning must remain available when automatic GC is disabled")
+}
+
 func (LocalCacheSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	setup := func(ctx context.Context, t *testctx.T) (endpoint string, c2 *dagger.Client, addCacheBlock func(*testctx.T, string, int), getUsedBytes func(*testctx.T) int) {

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -765,7 +765,7 @@ func (LocalCacheSuite) TestLocalCacheManualMetadataPruneCLI(ctx context.Context,
 			"--target-estimated-bytes=3221225472",
 		}).
 		Sync(ctx)
-	require.NoError(t, err, "explicit structural pruning must remain available when automatic GC is disabled")
+	require.NoError(t, err, "the CLI must accept 64-bit structural thresholds when automatic GC is disabled")
 }
 
 func (LocalCacheSuite) TestLocalCachePruneSpaceOverrides(ctx context.Context, t *testctx.T) {

--- a/core/query.go
+++ b/core/query.go
@@ -150,9 +150,8 @@ type Server interface {
 	// Return all the cache entries in the local cache. No support for filtering yet.
 	EngineLocalCacheEntries(context.Context) (*EngineCacheEntrySet, error)
 
-	// Prune the local cache of releaseable entries. If UseDefaultPolicy is true,
-	// use the engine-wide default pruning policy, otherwise prune the whole cache
-	// of any releasable entries.
+	// Prune releaseable local-cache entries using explicit disk and/or structural
+	// controls, or the enabled engine-wide default policies when requested.
 	PruneEngineLocalCacheEntries(context.Context, EngineCachePruneOptions) (*EngineCacheEntrySet, error)
 
 	// The default local cache policy to use for automatic local cache GC.

--- a/core/schema/engine.go
+++ b/core/schema/engine.go
@@ -38,16 +38,21 @@ func (s *engineSchema) Install(srv *dagql.Server) {
 			DoNotCache("Mutates mutable state").
 			Doc("Prune the cache of releaseable entries").
 			Args(
-				dagql.Arg("useDefaultPolicy").Doc("Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries."),
+				dagql.Arg("useDefaultPolicy").
+					Doc("Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.").
+					View(BeforeVersion("v1.0.0-0")),
+				dagql.Arg("useDefaultPolicy").
+					Doc("Use enabled engine-wide default disk and structural policies. If no default disk policy is enabled, the disk stage falls back to pruning all releasable disk-cache entries. If false, explicit options select stages; with no options, all releasable disk-cache entries are pruned.").
+					View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("maxUsedSpace").Doc("Override the maximum disk space to keep before pruning (e.g. \"200GB\" or \"80%\")."),
 				dagql.Arg("reservedSpace").Doc("Override the minimum disk space to retain during pruning (e.g. \"500GB\" or \"10%\")."),
 				dagql.Arg("minFreeSpace").Doc("Override the minimum free disk space target during pruning (e.g. \"20GB\" or \"20%\")."),
 				dagql.Arg("targetSpace").Doc("Override the target disk space to keep after pruning (e.g. \"200GB\" or \"50%\")."),
 				dagql.Arg("maxEstimatedBytes").
-					Doc("Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.").
+					Doc("Override the maximum structural metadata estimate in absolute bytes. Explicit values must be positive; the configured/default value is used when omitted.").
 					View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("targetEstimatedBytes").
-					Doc("Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.").
+					Doc("Override the structural metadata estimate to target in absolute bytes. Explicit values must be positive and lower than the resolved maximum; the configured/default value is used when omitted.").
 					View(AfterVersion("v1.0.0-0")),
 			),
 	}.Install(srv)

--- a/core/schema/engine.go
+++ b/core/schema/engine.go
@@ -43,6 +43,12 @@ func (s *engineSchema) Install(srv *dagql.Server) {
 				dagql.Arg("reservedSpace").Doc("Override the minimum disk space to retain during pruning (e.g. \"500GB\" or \"10%\")."),
 				dagql.Arg("minFreeSpace").Doc("Override the minimum free disk space target during pruning (e.g. \"20GB\" or \"20%\")."),
 				dagql.Arg("targetSpace").Doc("Override the target disk space to keep after pruning (e.g. \"200GB\" or \"50%\")."),
+				dagql.Arg("maxEstimatedBytes").
+					Doc("Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.").
+					View(AfterVersion("v1.0.0-0")),
+				dagql.Arg("targetEstimatedBytes").
+					Doc("Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.").
+					View(AfterVersion("v1.0.0-0")),
 			),
 	}.Install(srv)
 
@@ -131,11 +137,13 @@ func (s *engineSchema) cacheEntrySet(ctx context.Context, parent dagql.ObjectRes
 }
 
 func (s *engineSchema) cachePrune(ctx context.Context, parent *core.EngineCache, args struct {
-	UseDefaultPolicy bool   `default:"false"`
-	MaxUsedSpace     string `default:""`
-	ReservedSpace    string `default:""`
-	MinFreeSpace     string `default:""`
-	TargetSpace      string `default:""`
+	UseDefaultPolicy     bool   `default:"false"`
+	MaxUsedSpace         string `default:""`
+	ReservedSpace        string `default:""`
+	MinFreeSpace         string `default:""`
+	TargetSpace          string `default:""`
+	MaxEstimatedBytes    dagql.Optional[dagql.Int]
+	TargetEstimatedBytes dagql.Optional[dagql.Int]
 }) (dagql.Nullable[core.Void], error) {
 	void := dagql.Null[core.Void]()
 	query, err := core.CurrentQuery(ctx)
@@ -147,17 +155,27 @@ func (s *engineSchema) cachePrune(ctx context.Context, parent *core.EngineCache,
 	}
 
 	_, err = query.PruneEngineLocalCacheEntries(ctx, core.EngineCachePruneOptions{
-		UseDefaultPolicy: args.UseDefaultPolicy,
-		MaxUsedSpace:     args.MaxUsedSpace,
-		ReservedSpace:    args.ReservedSpace,
-		MinFreeSpace:     args.MinFreeSpace,
-		TargetSpace:      args.TargetSpace,
+		UseDefaultPolicy:     args.UseDefaultPolicy,
+		MaxUsedSpace:         args.MaxUsedSpace,
+		ReservedSpace:        args.ReservedSpace,
+		MinFreeSpace:         args.MinFreeSpace,
+		TargetSpace:          args.TargetSpace,
+		MaxEstimatedBytes:    optionalInt64(args.MaxEstimatedBytes),
+		TargetEstimatedBytes: optionalInt64(args.TargetEstimatedBytes),
 	})
 	if err != nil {
 		return void, fmt.Errorf("failed to prune cache entries: %w", err)
 	}
 
 	return void, nil
+}
+
+func optionalInt64(value dagql.Optional[dagql.Int]) *int64 {
+	if !value.Valid {
+		return nil
+	}
+	resolved := value.Value.Int64()
+	return &resolved
 }
 
 func (s *engineSchema) cacheEntrySetEntries(ctx context.Context, parent *core.EngineCacheEntrySet, args struct{}) (dagql.Array[*core.EngineCacheEntry], error) {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -832,21 +832,34 @@ func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
 }
 
 func (c *Cache) snapshotSessionResultIDs() map[sharedResultID]struct{} {
+	roots, _ := c.snapshotSessionResultIDsCancelable(nil)
+	return roots
+}
+
+func (c *Cache) snapshotSessionResultIDsCancelable(checker *pruneCancellationChecker) (map[sharedResultID]struct{}, error) {
 	if c == nil {
-		return nil
+		return nil, nil
 	}
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
+	if err := checker.checkNow(); err != nil {
+		return nil, err
+	}
 	if len(c.sessionResultIDsBySession) == 0 {
-		return nil
+		return nil, nil
 	}
 	roots := make(map[sharedResultID]struct{})
 	for _, resultIDs := range c.sessionResultIDsBySession {
 		for resultID := range resultIDs {
+			if checker != nil {
+				if err := checker.check(); err != nil {
+					return nil, err
+				}
+			}
 			roots[resultID] = struct{}{}
 		}
 	}
-	return roots
+	return roots, nil
 }
 
 func (c *Cache) upsertPersistedEdgeLocked(ctx context.Context, res *sharedResult, expiresAtUnix int64, unpruneable bool) {

--- a/dagql/cache_metadata_prune_test.go
+++ b/dagql/cache_metadata_prune_test.go
@@ -15,6 +15,20 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
+type cancelOnErrCheckContext struct {
+	context.Context
+	cancel   context.CancelFunc
+	cancelAt int32
+	checks   atomic.Int32
+}
+
+func (ctx *cancelOnErrCheckContext) Err() error {
+	if ctx.checks.Add(1) == ctx.cancelAt {
+		ctx.cancel()
+	}
+	return ctx.Context.Err()
+}
+
 func TestCacheMetadataEstimateFormula(t *testing.T) {
 	t.Parallel()
 
@@ -149,6 +163,28 @@ func TestCacheMetadataPruneCandidateOrder(t *testing.T) {
 		ids = append(ids, candidate.resultID)
 	}
 	assert.DeepEqual(t, ids, []sharedResultID{2, 1, 3, 4})
+}
+
+func TestCacheMetadataPruneCandidateSortCancellation(t *testing.T) {
+	t.Parallel()
+
+	const candidateCount = pruneCancellationCheckInterval + 44
+	candidates := make([]pruneCandidate, 0, candidateCount)
+	for i := candidateCount; i > 0; i-- {
+		candidates = append(candidates, pruneCandidate{resultID: sharedResultID(i)})
+	}
+
+	base, cancel := context.WithCancel(t.Context())
+	cancelingCtx := &cancelOnErrCheckContext{
+		Context:  base,
+		cancel:   cancel,
+		cancelAt: 2,
+	}
+	defer cancel()
+
+	err := sortPruneCandidatesCancelable(candidates, time.Now(), newPruneCancellationChecker(cancelingCtx))
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(2), cancelingCtx.checks.Load())
 }
 
 func TestCachePruneMetadataEstimateSkipsPhysicalMeasurementAndUsesColdOrder(t *testing.T) {
@@ -434,4 +470,46 @@ func TestCachePruneMetadataEstimateCancellationDoesNotMutate(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.DeepEqual(t, before, c.MetadataEstimate())
 	assert.Equal(t, 1, c.EntryStats().RetainedCalls)
+}
+
+func TestCachePruneMetadataEstimateCancellationDuringPlanningDoesNotMutate(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+	const resultCount = pruneCancellationCheckInterval + 44
+	for i := range resultCount {
+		call := cacheTestIntCall(fmt.Sprintf("metadata-prune-canceled-during-planning-%d", i))
+		_, err := c.GetOrInitCall(ctx, "test-session", noopTypeResolver{}, &CallRequest{
+			ResultCall:    call,
+			IsPersistable: true,
+		}, func(context.Context) (AnyResult, error) {
+			return cacheTestIntResult(call, i), nil
+		})
+		assert.NilError(t, err)
+	}
+	cacheTestReleaseSession(t, c, ctx)
+
+	// PruneMetadataEstimate checks Err twice before structural planning. The
+	// cancelable active-root and graph snapshots perform checks three and four,
+	// then the graph walk performs check five on its first item and check six
+	// after a bounded amount of work. Cancel there to exercise in-flight
+	// cancellation deterministically, without sleeps or scheduling races.
+	base, cancel := context.WithCancel(ctx)
+	planningCtx := &cancelOnErrCheckContext{
+		Context:  base,
+		cancel:   cancel,
+		cancelAt: 6,
+	}
+	defer cancel()
+
+	before := c.MetadataEstimate()
+	report, err := c.PruneMetadataEstimate(planningCtx, before.EstimatedBytes-1, 1)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Assert(t, report.Triggered)
+	assert.Equal(t, int32(6), planningCtx.checks.Load())
+	assert.Equal(t, 0, report.RemovedPersistedRootCount)
+	assert.Equal(t, resultCount, c.EntryStats().RetainedCalls)
+	assert.DeepEqual(t, before, c.MetadataEstimate())
 }

--- a/dagql/cache_metadata_prune_test.go
+++ b/dagql/cache_metadata_prune_test.go
@@ -187,6 +187,45 @@ func TestCacheMetadataPruneCandidateSortCancellation(t *testing.T) {
 	assert.Equal(t, int32(2), cancelingCtx.checks.Load())
 }
 
+func TestCacheMetadataPruneDependencySortCancellation(t *testing.T) {
+	t.Parallel()
+
+	const dependencyCount = pruneCancellationCheckInterval + 44
+	deps := make(map[sharedResultID]struct{}, dependencyCount)
+	for i := 1; i <= dependencyCount; i++ {
+		deps[sharedResultID(i)] = struct{}{}
+	}
+	c := &Cache{resultsByID: map[sharedResultID]*sharedResult{
+		dependencyCount + 1: {
+			id:   dependencyCount + 1,
+			deps: deps,
+		},
+	}}
+
+	base, cancel := context.WithCancel(t.Context())
+	cancelingCtx := &cancelOnErrCheckContext{
+		Context: base,
+		cancel:  cancel,
+		// The first three checks occur at snapshot start, on the result,
+		// and while copying its dependencies. The fourth occurs after a
+		// bounded number of comparisons inside dependency ordering.
+		cancelAt: 4,
+	}
+	defer cancel()
+
+	snapshot, err := c.snapshotPruneStateCancelable(
+		nil,
+		pruneSnapshotMetadata,
+		cacheMetadataResultEstimatedBytes,
+		newPruneCancellationChecker(cancelingCtx),
+	)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Assert(t, snapshot.results == nil)
+	assert.Assert(t, snapshot.usageIdentities == nil)
+	assert.Equal(t, int64(0), snapshot.usedBytes)
+	assert.Equal(t, int32(4), cancelingCtx.checks.Load())
+}
+
 func TestCachePruneMetadataEstimateSkipsPhysicalMeasurementAndUsesColdOrder(t *testing.T) {
 	t.Parallel()
 

--- a/dagql/cache_prune.go
+++ b/dagql/cache_prune.go
@@ -428,8 +428,7 @@ func (c *Cache) snapshotPruneStateCancelable(
 			deps = append(deps, depID)
 		}
 		if len(deps) > 1 {
-			slices.Sort(deps)
-			if err := checker.checkNow(); err != nil {
+			if err := sortPruneResultIDsCancelable(deps, checker); err != nil {
 				return pruneSnapshot{}, err
 			}
 		}
@@ -648,11 +647,32 @@ type pruneSortCancellation struct {
 	err error
 }
 
-func sortPruneCandidatesCancelable(candidates []pruneCandidate, now time.Time, checker *pruneCancellationChecker) (rerr error) {
+func sortPruneResultIDsCancelable(resultIDs []sharedResultID, checker *pruneCancellationChecker) error {
 	if checker == nil {
-		slices.SortFunc(candidates, func(a, b pruneCandidate) int {
-			return comparePruneCandidates(a, b, now)
-		})
+		slices.Sort(resultIDs)
+		return nil
+	}
+	return sortPruneSliceCancelable(resultIDs, checker, func(a, b sharedResultID) int {
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	})
+}
+
+func sortPruneCandidatesCancelable(candidates []pruneCandidate, now time.Time, checker *pruneCancellationChecker) error {
+	return sortPruneSliceCancelable(candidates, checker, func(a, b pruneCandidate) int {
+		return comparePruneCandidates(a, b, now)
+	})
+}
+
+func sortPruneSliceCancelable[S ~[]E, E any](items S, checker *pruneCancellationChecker, compare func(E, E) int) (rerr error) {
+	if checker == nil {
+		slices.SortFunc(items, compare)
 		return nil
 	}
 
@@ -669,11 +689,11 @@ func sortPruneCandidatesCancelable(candidates []pruneCandidate, now time.Time, c
 		}
 	}()
 
-	slices.SortFunc(candidates, func(a, b pruneCandidate) int {
+	slices.SortFunc(items, func(a, b E) int {
 		if err := checker.check(); err != nil {
 			panic(pruneSortCancellation{err: err})
 		}
-		return comparePruneCandidates(a, b, now)
+		return compare(a, b)
 	})
 	return checker.checkNow()
 }

--- a/dagql/cache_prune.go
+++ b/dagql/cache_prune.go
@@ -61,7 +61,35 @@ type pruneSnapshotMode uint8
 const (
 	pruneSnapshotDisk pruneSnapshotMode = iota
 	pruneSnapshotMetadata
+	pruneCancellationCheckInterval = 256
 )
+
+type pruneCancellationChecker struct {
+	ctx  context.Context
+	work uint64
+}
+
+func newPruneCancellationChecker(ctx context.Context) *pruneCancellationChecker {
+	if ctx.Done() == nil {
+		return nil
+	}
+	return &pruneCancellationChecker{ctx: ctx}
+}
+
+func (checker *pruneCancellationChecker) checkNow() error {
+	if checker == nil {
+		return nil
+	}
+	return checker.ctx.Err()
+}
+
+func (checker *pruneCancellationChecker) check() error {
+	checker.work++
+	if checker.work == 1 || checker.work%pruneCancellationCheckInterval == 0 {
+		return checker.ctx.Err()
+	}
+	return nil
+}
 
 func metadataDirectResultBytes(estimate CacheMetadataEstimate) int64 {
 	if estimate.ResultCount <= 0 {
@@ -124,22 +152,39 @@ func (c *Cache) PruneMetadataEstimate(ctx context.Context, maximumBytes, targetB
 	}
 
 	pruneCtx := withMetadataPruneContext(ctx)
-	activeRoots := c.snapshotSessionResultIDs()
+	checker := newPruneCancellationChecker(pruneCtx)
+	activeRoots, err := c.snapshotSessionResultIDsCancelable(checker)
+	if err != nil {
+		return report, err
+	}
 	directResultBytes := metadataDirectResultBytes(report.AfterInitialCompaction)
-	snapshot := c.snapshotPruneState(activeRoots, pruneSnapshotMetadata, directResultBytes)
-	activeClosure := pruneActiveClosure(snapshot, activeRoots)
-	candidates := c.collectPruneCandidates(
+	snapshot, err := c.snapshotPruneStateCancelable(activeRoots, pruneSnapshotMetadata, directResultBytes, checker)
+	if err != nil {
+		return report, err
+	}
+	activeClosure, err := pruneActiveClosureCancelable(snapshot, activeRoots, checker)
+	if err != nil {
+		return report, err
+	}
+	candidates, err := c.collectPruneCandidatesCancelable(
 		pruneCtx,
 		-1,
 		snapshot,
 		activeClosure,
 		CachePrunePolicy{All: true},
 		time.Now(),
+		checker,
 	)
+	if err != nil {
+		return report, err
+	}
 	report.CandidateCount = len(candidates)
 
 	reclaimTarget := report.AfterInitialCompaction.EstimatedBytes - targetBytes
-	plan, simulatedReclaimed, simulatedCollected := buildPrunePlan(snapshot, candidates, reclaimTarget)
+	plan, simulatedReclaimed, simulatedCollected, err := buildPrunePlanCancelable(snapshot, candidates, reclaimTarget, checker)
+	if err != nil {
+		return report, err
+	}
 	report.PlannedRootCount = len(plan)
 	report.SimulatedStructuralBytes = simulatedReclaimed
 	report.SimulatedCollectedResultCount = simulatedCollected
@@ -323,6 +368,16 @@ func (c *Cache) Prune(ctx context.Context, policies []CachePrunePolicy) (CachePr
 }
 
 func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}, mode pruneSnapshotMode, directResultBytes int64) pruneSnapshot {
+	snapshot, _ := c.snapshotPruneStateCancelable(activeRoots, mode, directResultBytes, nil)
+	return snapshot
+}
+
+func (c *Cache) snapshotPruneStateCancelable(
+	activeRoots map[sharedResultID]struct{},
+	mode pruneSnapshotMode,
+	directResultBytes int64,
+	checker *pruneCancellationChecker,
+) (pruneSnapshot, error) {
 	c.egraphMu.RLock()
 	defer c.egraphMu.RUnlock()
 
@@ -330,30 +385,25 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}, mode
 		results:         make(map[sharedResultID]pruneSnapshotResult, len(c.resultsByID)),
 		usageIdentities: make(map[string]pruneUsageIdentityState),
 	}
+	if err := checker.checkNow(); err != nil {
+		return pruneSnapshot{}, err
+	}
 	if len(c.resultsByID) == 0 {
-		return snapshot
+		return snapshot, nil
 	}
 
 	if mode == pruneSnapshotDisk {
-		for resID, res := range c.resultsByID {
-			if res == nil {
-				continue
-			}
-			for _, usageIdentity := range cacheUsageIdentities(res) {
-				identityState := snapshot.usageIdentities[usageIdentity]
-				if identityState.ownerID == 0 || resID < identityState.ownerID {
-					identityState.ownerID = resID
-				}
-				if sizeBytes, ok := res.cacheUsageSizeByIdentity[usageIdentity]; ok && sizeBytes > identityState.sizeBytes {
-					identityState.sizeBytes = sizeBytes
-				}
-				identityState.aliveMembers++
-				snapshot.usageIdentities[usageIdentity] = identityState
-			}
+		if err := c.snapshotPruneDiskUsageIdentitiesLocked(&snapshot, checker); err != nil {
+			return pruneSnapshot{}, err
 		}
 	}
 
 	for resID, res := range c.resultsByID {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return pruneSnapshot{}, err
+			}
+		}
 		if res == nil {
 			continue
 		}
@@ -370,9 +420,19 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}, mode
 
 		deps := make([]sharedResultID, 0, len(res.deps))
 		for depID := range res.deps {
+			if checker != nil {
+				if err := checker.check(); err != nil {
+					return pruneSnapshot{}, err
+				}
+			}
 			deps = append(deps, depID)
 		}
-		slices.Sort(deps)
+		if len(deps) > 1 {
+			slices.Sort(deps)
+			if err := checker.checkNow(); err != nil {
+				return pruneSnapshot{}, err
+			}
+		}
 
 		edge, hasPersistedEdge := c.persistedEdgesByResult[resID]
 		snapshotResult := pruneSnapshotResult{
@@ -395,6 +455,11 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}, mode
 			usageIdentities := cacheUsageIdentities(res)
 			sizeBytes := int64(0)
 			for _, measured := range res.cacheUsageSizeByIdentity {
+				if checker != nil {
+					if err := checker.check(); err != nil {
+						return pruneSnapshot{}, err
+					}
+				}
 				if measured > 0 {
 					sizeBytes += measured
 				}
@@ -421,20 +486,75 @@ func (c *Cache) snapshotPruneState(activeRoots map[sharedResultID]struct{}, mode
 		snapshot.results[resID] = snapshotResult
 	}
 
-	return snapshot
+	if err := checker.checkNow(); err != nil {
+		return pruneSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (c *Cache) snapshotPruneDiskUsageIdentitiesLocked(snapshot *pruneSnapshot, checker *pruneCancellationChecker) error {
+	for resID, res := range c.resultsByID {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return err
+			}
+		}
+		if res == nil {
+			continue
+		}
+		for _, usageIdentity := range cacheUsageIdentities(res) {
+			if checker != nil {
+				if err := checker.check(); err != nil {
+					return err
+				}
+			}
+			identityState := snapshot.usageIdentities[usageIdentity]
+			if identityState.ownerID == 0 || resID < identityState.ownerID {
+				identityState.ownerID = resID
+			}
+			if sizeBytes, ok := res.cacheUsageSizeByIdentity[usageIdentity]; ok && sizeBytes > identityState.sizeBytes {
+				identityState.sizeBytes = sizeBytes
+			}
+			identityState.aliveMembers++
+			snapshot.usageIdentities[usageIdentity] = identityState
+		}
+	}
+	return nil
 }
 
 func pruneActiveClosure(snapshot pruneSnapshot, activeRoots map[sharedResultID]struct{}) map[sharedResultID]struct{} {
+	closure, _ := pruneActiveClosureCancelable(snapshot, activeRoots, nil)
+	return closure
+}
+
+func pruneActiveClosureCancelable(
+	snapshot pruneSnapshot,
+	activeRoots map[sharedResultID]struct{},
+	checker *pruneCancellationChecker,
+) (map[sharedResultID]struct{}, error) {
+	if err := checker.checkNow(); err != nil {
+		return nil, err
+	}
 	if len(activeRoots) == 0 {
-		return nil
+		return nil, nil
 	}
 	closure := make(map[sharedResultID]struct{}, len(activeRoots))
 	stack := make([]sharedResultID, 0, len(activeRoots))
 	for resultID := range activeRoots {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return nil, err
+			}
+		}
 		stack = append(stack, resultID)
 	}
 
 	for len(stack) > 0 {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return nil, err
+			}
+		}
 		n := len(stack) - 1
 		curID := stack[n]
 		stack = stack[:n]
@@ -446,13 +566,39 @@ func pruneActiveClosure(snapshot pruneSnapshot, activeRoots map[sharedResultID]s
 		if !ok {
 			continue
 		}
-		stack = append(stack, cur.deps...)
+		for _, depID := range cur.deps {
+			if checker != nil {
+				if err := checker.check(); err != nil {
+					return nil, err
+				}
+			}
+			stack = append(stack, depID)
+		}
 	}
 
-	return closure
+	if err := checker.checkNow(); err != nil {
+		return nil, err
+	}
+	return closure, nil
 }
 
 func (c *Cache) collectPruneCandidates(ctx context.Context, policyIndex int, snapshot pruneSnapshot, activeClosure map[sharedResultID]struct{}, policy CachePrunePolicy, now time.Time) []pruneCandidate {
+	candidates, _ := c.collectPruneCandidatesCancelable(ctx, policyIndex, snapshot, activeClosure, policy, now, nil)
+	return candidates
+}
+
+func (c *Cache) collectPruneCandidatesCancelable(
+	ctx context.Context,
+	policyIndex int,
+	snapshot pruneSnapshot,
+	activeClosure map[sharedResultID]struct{},
+	policy CachePrunePolicy,
+	now time.Time,
+	checker *pruneCancellationChecker,
+) ([]pruneCandidate, error) {
+	if err := checker.checkNow(); err != nil {
+		return nil, err
+	}
 	cutoffUnixNano := int64(0)
 	if policy.KeepDuration > 0 {
 		cutoffUnixNano = now.Add(-policy.KeepDuration).UnixNano()
@@ -460,6 +606,11 @@ func (c *Cache) collectPruneCandidates(ctx context.Context, policyIndex int, sna
 
 	candidates := make([]pruneCandidate, 0, len(snapshot.results))
 	for resultID, res := range snapshot.results {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return nil, err
+			}
+		}
 		if !res.hasPersistedEdge {
 			c.tracePruneCandidateSkipped(ctx, policyIndex, "no_persisted_edge", res)
 			continue
@@ -486,58 +637,120 @@ func (c *Cache) collectPruneCandidates(ctx context.Context, policyIndex int, sna
 		})
 	}
 
-	slices.SortFunc(candidates, func(a, b pruneCandidate) int {
-		if aExpired, bExpired := persistedEdgeExpired(now, persistedEdge{expiresAtUnix: a.expiresAtUnix}), persistedEdgeExpired(now, persistedEdge{expiresAtUnix: b.expiresAtUnix}); aExpired != bExpired {
-			if aExpired {
-				return -1
-			}
-			return 1
-		}
-		if a.entry.MostRecentUseTimeUnixNano != b.entry.MostRecentUseTimeUnixNano {
-			if a.entry.MostRecentUseTimeUnixNano < b.entry.MostRecentUseTimeUnixNano {
-				return -1
-			}
-			return 1
-		}
-		if a.entry.CreatedTimeUnixNano != b.entry.CreatedTimeUnixNano {
-			if a.entry.CreatedTimeUnixNano < b.entry.CreatedTimeUnixNano {
-				return -1
-			}
-			return 1
-		}
-		if a.entry.SizeBytes != b.entry.SizeBytes {
-			if a.entry.SizeBytes > b.entry.SizeBytes {
-				return -1
-			}
-			return 1
-		}
-		switch {
-		case a.entry.ID < b.entry.ID:
-			return -1
-		case a.entry.ID > b.entry.ID:
-			return 1
-		case a.resultID < b.resultID:
-			return -1
-		case a.resultID > b.resultID:
-			return 1
-		default:
-			return 0
-		}
-	})
+	if err := sortPruneCandidatesCancelable(candidates, now, checker); err != nil {
+		return nil, err
+	}
 
-	return candidates
+	return candidates, nil
+}
+
+type pruneSortCancellation struct {
+	err error
+}
+
+func sortPruneCandidatesCancelable(candidates []pruneCandidate, now time.Time, checker *pruneCancellationChecker) (rerr error) {
+	if checker == nil {
+		slices.SortFunc(candidates, func(a, b pruneCandidate) int {
+			return comparePruneCandidates(a, b, now)
+		})
+		return nil
+	}
+
+	// slices.SortFunc cannot return an error from its comparator. Use a private
+	// sentinel to stop it immediately on cancellation, while preserving every
+	// unrelated panic. The partially ordered slice is discarded by the caller.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			canceled, ok := recovered.(pruneSortCancellation)
+			if !ok {
+				panic(recovered)
+			}
+			rerr = canceled.err
+		}
+	}()
+
+	slices.SortFunc(candidates, func(a, b pruneCandidate) int {
+		if err := checker.check(); err != nil {
+			panic(pruneSortCancellation{err: err})
+		}
+		return comparePruneCandidates(a, b, now)
+	})
+	return checker.checkNow()
+}
+
+func comparePruneCandidates(a, b pruneCandidate, now time.Time) int {
+	if aExpired, bExpired := persistedEdgeExpired(now, persistedEdge{expiresAtUnix: a.expiresAtUnix}), persistedEdgeExpired(now, persistedEdge{expiresAtUnix: b.expiresAtUnix}); aExpired != bExpired {
+		if aExpired {
+			return -1
+		}
+		return 1
+	}
+	if a.entry.MostRecentUseTimeUnixNano != b.entry.MostRecentUseTimeUnixNano {
+		if a.entry.MostRecentUseTimeUnixNano < b.entry.MostRecentUseTimeUnixNano {
+			return -1
+		}
+		return 1
+	}
+	if a.entry.CreatedTimeUnixNano != b.entry.CreatedTimeUnixNano {
+		if a.entry.CreatedTimeUnixNano < b.entry.CreatedTimeUnixNano {
+			return -1
+		}
+		return 1
+	}
+	if a.entry.SizeBytes != b.entry.SizeBytes {
+		if a.entry.SizeBytes > b.entry.SizeBytes {
+			return -1
+		}
+		return 1
+	}
+	switch {
+	case a.entry.ID < b.entry.ID:
+		return -1
+	case a.entry.ID > b.entry.ID:
+		return 1
+	case a.resultID < b.resultID:
+		return -1
+	case a.resultID > b.resultID:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func buildPrunePlan(snapshot pruneSnapshot, candidates []pruneCandidate, targetBytes int64) ([]prunePlanEntry, int64, int) {
-	if len(candidates) == 0 {
-		return nil, 0, 0
+	plan, reclaimed, collected, _ := buildPrunePlanCancelable(snapshot, candidates, targetBytes, nil)
+	return plan, reclaimed, collected
+}
+
+func buildPrunePlanCancelable(
+	snapshot pruneSnapshot,
+	candidates []pruneCandidate,
+	targetBytes int64,
+	checker *pruneCancellationChecker,
+) ([]prunePlanEntry, int64, int, error) {
+	if err := checker.checkNow(); err != nil {
+		return nil, 0, 0, err
 	}
-	sim := newPruneSimulationState(snapshot)
+	if len(candidates) == 0 {
+		return nil, 0, 0, nil
+	}
+	sim, err := newPruneSimulationStateCancelable(snapshot, checker)
+	if err != nil {
+		return nil, 0, 0, err
+	}
 	plan := make([]prunePlanEntry, 0, len(candidates))
 	var reclaimed int64
 	var collected int
 	for _, candidate := range candidates {
-		immediateReclaim, immediateCollected := sim.applyCandidate(snapshot, candidate.resultID)
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return nil, 0, 0, err
+			}
+		}
+		immediateReclaim, immediateCollected, err := sim.applyCandidateCancelable(snapshot, candidate.resultID, checker)
+		if err != nil {
+			return nil, 0, 0, err
+		}
 		plan = append(plan, prunePlanEntry{
 			candidate:    candidate,
 			reclaimBytes: immediateReclaim,
@@ -548,10 +761,13 @@ func buildPrunePlan(snapshot pruneSnapshot, candidates []pruneCandidate, targetB
 			break
 		}
 	}
-	return plan, reclaimed, collected
+	if err := checker.checkNow(); err != nil {
+		return nil, 0, 0, err
+	}
+	return plan, reclaimed, collected, nil
 }
 
-func newPruneSimulationState(snapshot pruneSnapshot) pruneSimulationState {
+func newPruneSimulationStateCancelable(snapshot pruneSnapshot, checker *pruneCancellationChecker) (pruneSimulationState, error) {
 	state := pruneSimulationState{
 		remainingIncomingCount:    make(map[sharedResultID]int64, len(snapshot.results)),
 		aliveCountByUsageIdentity: make(map[string]int, len(snapshot.usageIdentities)),
@@ -559,19 +775,38 @@ func newPruneSimulationState(snapshot pruneSnapshot) pruneSimulationState {
 		collected:                 make(map[sharedResultID]struct{}),
 	}
 	for resultID, res := range snapshot.results {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return pruneSimulationState{}, err
+			}
+		}
 		state.remainingIncomingCount[resultID] = res.incomingCount
 	}
 	for identity, identityState := range snapshot.usageIdentities {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return pruneSimulationState{}, err
+			}
+		}
 		state.aliveCountByUsageIdentity[identity] = identityState.aliveMembers
 		state.sizeBytesByUsageIdentity[identity] = identityState.sizeBytes
 	}
-	return state
+	return state, nil
 }
 
-func (s *pruneSimulationState) applyCandidate(snapshot pruneSnapshot, resultID sharedResultID) (int64, int) {
+func (s *pruneSimulationState) applyCandidateCancelable(
+	snapshot pruneSnapshot,
+	resultID sharedResultID,
+	checker *pruneCancellationChecker,
+) (int64, int, error) {
+	if checker != nil {
+		if err := checker.check(); err != nil {
+			return 0, 0, err
+		}
+	}
 	curCount, ok := s.remainingIncomingCount[resultID]
 	if !ok {
-		return 0, 0
+		return 0, 0, nil
 	}
 	s.remainingIncomingCount[resultID] = curCount - 1
 
@@ -583,6 +818,11 @@ func (s *pruneSimulationState) applyCandidate(snapshot pruneSnapshot, resultID s
 	var reclaimed int64
 	var collected int
 	for len(queue) > 0 {
+		if checker != nil {
+			if err := checker.check(); err != nil {
+				return 0, 0, err
+			}
+		}
 		curID := queue[len(queue)-1]
 		queue = queue[:len(queue)-1]
 
@@ -601,6 +841,11 @@ func (s *pruneSimulationState) applyCandidate(snapshot pruneSnapshot, resultID s
 		}
 		reclaimed += cur.directResultBytes
 		for _, identity := range cur.usageIdentities {
+			if checker != nil {
+				if err := checker.check(); err != nil {
+					return 0, 0, err
+				}
+			}
 			alive := s.aliveCountByUsageIdentity[identity] - 1
 			s.aliveCountByUsageIdentity[identity] = alive
 			if alive == 0 {
@@ -609,6 +854,11 @@ func (s *pruneSimulationState) applyCandidate(snapshot pruneSnapshot, resultID s
 		}
 
 		for _, depID := range cur.deps {
+			if checker != nil {
+				if err := checker.check(); err != nil {
+					return 0, 0, err
+				}
+			}
 			depCount, ok := s.remainingIncomingCount[depID]
 			if !ok {
 				continue
@@ -621,7 +871,7 @@ func (s *pruneSimulationState) applyCandidate(snapshot pruneSnapshot, resultID s
 		}
 	}
 
-	return reclaimed, collected
+	return reclaimed, collected, nil
 }
 
 func resultInActiveClosure(activeClosure map[sharedResultID]struct{}, resultID sharedResultID) bool {

--- a/docs/current_docs/reference/configuration/cache.mdx
+++ b/docs/current_docs/reference/configuration/cache.mdx
@@ -57,8 +57,11 @@ policy](./engine.mdx), use the following command:
 dagger -m core api call engine local-cache prune --use-default-policy
 ```
 
-If automatic garbage collection is disabled, `--use-default-policy` does not
-re-enable its policies.
+If automatic garbage collection is disabled, no default disk policies are
+active. For compatibility, `--use-default-policy` then falls back to the same
+all-releasable disk prune as a request with no options; it does not enable the
+structural stage. Use explicit structural options to run that stage while
+automatic garbage collection is disabled.
 
 Structural metadata can also be pruned explicitly with absolute byte limits:
 
@@ -68,13 +71,20 @@ dagger -m core api call engine local-cache prune \
   --target-estimated-bytes=3221225472
 ```
 
+These example values match the built-in 4 GiB maximum and 3 GiB target. A
+structural pass removes roots only when the current estimate exceeds the
+maximum.
+
 Supplying either structural option enables structural pruning for that request,
 even when automatic garbage collection is disabled. An omitted option inherits
 the engine's resolved configured/default value. Explicit values must be
 positive, and the resolved target must be lower than the resolved maximum.
 Percentages and size strings are not accepted.
 
-A request containing only structural options does not prune disk cache entries.
-Disk options and structural options can be combined; the disk stage runs first,
-followed by the structural stage in the same serialized request. Active session
-closures and engine-lifetime unpruneable roots remain protected in both stages.
+A request containing only structural options does not run the disk-policy
+stage. Structural pruning can still release cache entries and trigger snapshot
+garbage collection, which may reclaim disk; disk-policy retention rules and
+filters do not constrain that structural pass. Disk options and structural
+options can be combined; the disk stage runs first, followed by the structural
+stage in the same serialized request. Active session closures and
+engine-lifetime unpruneable roots remain protected in both stages.

--- a/docs/current_docs/reference/configuration/cache.mdx
+++ b/docs/current_docs/reference/configuration/cache.mdx
@@ -49,8 +49,32 @@ dagger -m core api call engine local-cache prune
 
 That will remove *all* cache entries not currently being used by connected clients from the disk.
 
-To instead trigger a prune that follows the same rules as specified in the engine's [configured cache garbage collection policy](./engine.mdx), use the following command:
+To instead trigger a prune that follows the enabled disk and structural
+metadata rules in the engine's [configured cache garbage collection
+policy](./engine.mdx), use the following command:
 
 ```shell
 dagger -m core api call engine local-cache prune --use-default-policy
 ```
+
+If automatic garbage collection is disabled, `--use-default-policy` does not
+re-enable its policies.
+
+Structural metadata can also be pruned explicitly with absolute byte limits:
+
+```shell
+dagger -m core api call engine local-cache prune \
+  --max-estimated-bytes=4294967296 \
+  --target-estimated-bytes=3221225472
+```
+
+Supplying either structural option enables structural pruning for that request,
+even when automatic garbage collection is disabled. An omitted option inherits
+the engine's resolved configured/default value. Explicit values must be
+positive, and the resolved target must be lower than the resolved maximum.
+Percentages and size strings are not accepted.
+
+A request containing only structural options does not prune disk cache entries.
+Disk options and structural options can be combined; the disk stage runs first,
+followed by the structural stage in the same serialized request. Active session
+closures and engine-lifetime unpruneable roots remain protected in both stages.

--- a/docs/current_docs/reference/configuration/engine.mdx
+++ b/docs/current_docs/reference/configuration/engine.mdx
@@ -249,8 +249,9 @@ The limits can be changed in `engine.json` using absolute integer bytes:
 `targetEstimatedBytes` must be positive and lower than
 `maxEstimatedBytes`. Omitting either field, or setting it to `0`, uses its
 built-in default. These fields do not accept percentages or size strings.
-Setting `gc.enabled` to `false` disables both disk and operation-metadata
-garbage collection.
+Setting `gc.enabled` to `false` disables automatic disk and operation-metadata
+garbage collection. Explicit manual structural pruning remains available, while
+manual `useDefaultPolicy` does not re-enable a disabled automatic policy.
 
 The metadata value is a coarse structural estimate based on the number of live
 cached results, symbolic operation terms, and allocated equivalence-class

--- a/docs/current_docs/reference/configuration/engine.mdx
+++ b/docs/current_docs/reference/configuration/engine.mdx
@@ -250,8 +250,10 @@ The limits can be changed in `engine.json` using absolute integer bytes:
 `maxEstimatedBytes`. Omitting either field, or setting it to `0`, uses its
 built-in default. These fields do not accept percentages or size strings.
 Setting `gc.enabled` to `false` disables automatic disk and operation-metadata
-garbage collection. Explicit manual structural pruning remains available, while
-manual `useDefaultPolicy` does not re-enable a disabled automatic policy.
+garbage collection. Explicit manual structural pruning remains available.
+Manual `useDefaultPolicy` does not enable the structural stage in this case;
+because no default disk policies are active, its existing disk path falls back
+to pruning all releasable disk-cache entries.
 
 The metadata value is a coarse structural estimate based on the number of live
 cached results, symbolic operation terms, and allocated equivalence-class

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2405,6 +2405,17 @@ type EngineCache implements Node {
     Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
     """
     targetSpace: String = ""
+
+    """
+    Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+    """
+    maxEstimatedBytes: Int
+
+    """
+    Override the structural metadata estimate to target in absolute bytes. The
+    configured/default value is used when omitted.
+    """
+    targetEstimatedBytes: Int
   ): Void
 
   """The minimum amount of disk space this policy is guaranteed to retain."""

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2382,7 +2382,10 @@ type EngineCache implements Node {
   """Prune the cache of releaseable entries"""
   prune(
     """
-    Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
+    Use enabled engine-wide default disk and structural policies. If no default
+    disk policy is enabled, the disk stage falls back to pruning all releasable
+    disk-cache entries. If false, explicit options select stages; with no
+    options, all releasable disk-cache entries are pruned.
     """
     useDefaultPolicy: Boolean = false
 
@@ -2407,12 +2410,15 @@ type EngineCache implements Node {
     targetSpace: String = ""
 
     """
-    Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+    Override the maximum structural metadata estimate in absolute bytes.
+    Explicit values must be positive; the configured/default value is used when
+    omitted.
     """
     maxEstimatedBytes: Int
 
     """
-    Override the structural metadata estimate to target in absolute bytes. The
+    Override the structural metadata estimate to target in absolute bytes.
+    Explicit values must be positive and lower than the resolved maximum; the
     configured/default value is used when omitted.
     """
     targetEstimatedBytes: Int

--- a/docs/static/reference/php/Dagger/EngineCache.html
+++ b/docs/static/reference/php/Dagger/EngineCache.html
@@ -186,7 +186,7 @@
                     void
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_prune">prune</a>(bool|null $useDefaultPolicy = false, string|null $maxUsedSpace = &#039;&#039;, string|null $reservedSpace = &#039;&#039;, string|null $minFreeSpace = &#039;&#039;, string|null $targetSpace = &#039;&#039;)
+                    <a href="#method_prune">prune</a>(bool|null $useDefaultPolicy = false, string|null $maxUsedSpace = &#039;&#039;, string|null $reservedSpace = &#039;&#039;, string|null $minFreeSpace = &#039;&#039;, string|null $targetSpace = &#039;&#039;, int|null $maxEstimatedBytes = null, int|null $targetEstimatedBytes = null)
         
                                             <p><p>Prune the cache of releaseable entries</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -448,7 +448,7 @@
                     <h3 id="method_prune">
         <div class="location">at line 58</div>
         <code>                    void
-    <strong>prune</strong>(bool|null $useDefaultPolicy = false, string|null $maxUsedSpace = &#039;&#039;, string|null $reservedSpace = &#039;&#039;, string|null $minFreeSpace = &#039;&#039;, string|null $targetSpace = &#039;&#039;)
+    <strong>prune</strong>(bool|null $useDefaultPolicy = false, string|null $maxUsedSpace = &#039;&#039;, string|null $reservedSpace = &#039;&#039;, string|null $minFreeSpace = &#039;&#039;, string|null $targetSpace = &#039;&#039;, int|null $maxEstimatedBytes = null, int|null $targetEstimatedBytes = null)
         </code>
     </h3>
     <div class="details">    
@@ -487,6 +487,16 @@
                 <td>$targetSpace</td>
                 <td></td>
             </tr>
+                    <tr>
+                <td>int|null</td>
+                <td>$maxEstimatedBytes</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>int|null</td>
+                <td>$targetEstimatedBytes</td>
+                <td></td>
+            </tr>
             </table>
 
             
@@ -508,7 +518,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_reservedSpace">
-        <div class="location">at line 87</div>
+        <div class="location">at line 95</div>
         <code>                    int
     <strong>reservedSpace</strong>()
         </code>
@@ -540,7 +550,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_targetSpace">
-        <div class="location">at line 96</div>
+        <div class="location">at line 104</div>
         <code>                    int
     <strong>targetSpace</strong>()
         </code>

--- a/engine/server/gc.go
+++ b/engine/server/gc.go
@@ -79,31 +79,105 @@ func (srv *Server) EngineLocalCacheEntries(ctx context.Context) (*core.EngineCac
 	return engineCacheEntrySetFromUsage(entries), nil
 }
 
-// Prune the local cache of releaseable entries. If UseDefaultPolicy is true,
-// use the engine-wide default pruning policy, otherwise prune the whole cache
-// of any releasable entries.
+// Prune the local cache of releaseable entries. With no options, preserve the
+// legacy behavior of pruning all releasable disk cache entries. Explicit disk
+// and structural controls run only their respective stages; UseDefaultPolicy
+// runs both configured stages when automatic GC is enabled.
 func (srv *Server) PruneEngineLocalCacheEntries(ctx context.Context, opts core.EngineCachePruneOptions) (*core.EngineCacheEntrySet, error) {
 	srv.gcmu.Lock()
 	defer srv.gcmu.Unlock()
 	srv.metadataPruneMonitorBlocked.Store(false)
 
-	dstat, _ := disk.GetDiskStat(srv.rootDir)
-	prunePolicies, err := resolveEngineLocalCachePrunePolicies(
-		srv.workerGCPolicies,
-		opts,
-		dstat,
-	)
-	if err != nil {
-		return nil, err
+	pruneDisk, pruneMetadata := engineLocalCachePruneModes(opts, srv.localCacheGCEnabled)
+	var maximumEstimatedBytes, targetEstimatedBytes int64
+	if pruneMetadata {
+		var err error
+		maximumEstimatedBytes, targetEstimatedBytes, err = resolveEngineLocalCacheMetadataPruneOptions(
+			srv.dagqlCacheMaxEstimatedBytes,
+			srv.dagqlCacheTargetEstimatedBytes,
+			opts,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
-	report, err := srv.engineCache.Prune(ctx, prunePolicies)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prune dagql cache: %w", err)
+
+	var (
+		report dagql.CachePruneReport
+		rerr   error
+	)
+	if pruneDisk {
+		dstat, _ := disk.GetDiskStat(srv.rootDir)
+		prunePolicies, err := resolveEngineLocalCachePrunePolicies(
+			srv.workerGCPolicies,
+			opts,
+			dstat,
+		)
+		if err != nil {
+			return nil, err
+		}
+		report, err = srv.engineCache.Prune(ctx, prunePolicies)
+		if err != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("failed to prune dagql cache: %w", err))
+		}
+	}
+
+	if pruneMetadata {
+		_, err := srv.engineCache.PruneMetadataEstimate(ctx, maximumEstimatedBytes, targetEstimatedBytes)
+		if err != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("failed to prune dagql cache metadata: %w", err))
+		}
+	}
+	if rerr != nil {
+		return nil, rerr
 	}
 	if len(report.Entries) == 0 {
 		return &core.EngineCacheEntrySet{}, nil
 	}
 	return engineCacheEntrySetFromUsage(report.Entries), nil
+}
+
+func engineLocalCachePruneModes(opts core.EngineCachePruneOptions, automaticGCEnabled bool) (disk, metadata bool) {
+	explicitMetadata := opts.MaxEstimatedBytes != nil || opts.TargetEstimatedBytes != nil
+	metadata = explicitMetadata || (opts.UseDefaultPolicy && automaticGCEnabled)
+	maxUsedSpace, reservedSpace, minFreeSpace, targetSpace := trimmedPruneOpts(opts)
+	hasDiskOptions := maxUsedSpace != "" || reservedSpace != "" || minFreeSpace != "" || targetSpace != ""
+
+	// Preserve the legacy no-option prune-all behavior, while ensuring that a
+	// structural-only request does not run that implicit disk stage first.
+	disk = opts.UseDefaultPolicy || hasDiskOptions || !explicitMetadata
+	return disk, metadata
+}
+
+func resolveEngineLocalCacheMetadataPruneOptions(
+	defaultMaximumBytes,
+	defaultTargetBytes int64,
+	opts core.EngineCachePruneOptions,
+) (maximumBytes, targetBytes int64, _ error) {
+	maximumBytes = defaultMaximumBytes
+	targetBytes = defaultTargetBytes
+	if opts.MaxEstimatedBytes != nil {
+		maximumBytes = *opts.MaxEstimatedBytes
+	}
+	if opts.TargetEstimatedBytes != nil {
+		targetBytes = *opts.TargetEstimatedBytes
+	}
+
+	if maximumBytes <= 0 {
+		return 0, 0, fmt.Errorf(
+			"maxEstimatedBytes must be positive (resolved maxEstimatedBytes=%d, targetEstimatedBytes=%d)",
+			maximumBytes,
+			targetBytes,
+		)
+	}
+	if targetBytes <= 0 || targetBytes >= maximumBytes {
+		return 0, 0, fmt.Errorf(
+			"targetEstimatedBytes must be positive and lower than maxEstimatedBytes (resolved maxEstimatedBytes=%d, targetEstimatedBytes=%d)",
+			maximumBytes,
+			targetBytes,
+		)
+	}
+	return maximumBytes, targetBytes, nil
 }
 
 func trimmedPruneOpts(opts core.EngineCachePruneOptions) (maxUsedSpace, reservedSpace, minFreeSpace, targetSpace string) {

--- a/engine/server/gc_test.go
+++ b/engine/server/gc_test.go
@@ -244,6 +244,16 @@ func TestEngineLocalCachePruneModes(t *testing.T) {
 			opts:     core.EngineCachePruneOptions{UseDefaultPolicy: true},
 			wantDisk: true,
 		},
+		{
+			name: "disabled default policy with explicit metadata",
+			opts: core.EngineCachePruneOptions{
+				UseDefaultPolicy:     true,
+				MaxEstimatedBytes:    &maximum,
+				TargetEstimatedBytes: &target,
+			},
+			wantDisk:     true,
+			wantMetadata: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			disk, metadata := engineLocalCachePruneModes(tc.opts, tc.automaticGC)
@@ -262,6 +272,7 @@ func TestResolveEngineLocalCacheMetadataPruneOptions(t *testing.T) {
 	maximumOverride := int64(1200)
 	targetOverride := int64(600)
 	zero := int64(0)
+	negative := int64(-1)
 	conflictingMaximum := int64(600)
 	conflictingTarget := int64(1000)
 
@@ -307,6 +318,16 @@ func TestResolveEngineLocalCacheMetadataPruneOptions(t *testing.T) {
 		{
 			name:      "zero target",
 			opts:      core.EngineCachePruneOptions{TargetEstimatedBytes: &zero},
+			wantError: "targetEstimatedBytes must be positive and lower",
+		},
+		{
+			name:      "negative maximum",
+			opts:      core.EngineCachePruneOptions{MaxEstimatedBytes: &negative},
+			wantError: "maxEstimatedBytes must be positive",
+		},
+		{
+			name:      "negative target",
+			opts:      core.EngineCachePruneOptions{TargetEstimatedBytes: &negative},
 			wantError: "targetEstimatedBytes must be positive and lower",
 		},
 		{
@@ -374,6 +395,32 @@ func TestManualMetadataPruneOnlySkipsDiskAndProtectsRoots(t *testing.T) {
 	require.NoError(t, cache.ReleaseSession(activeCtx, "manual-metadata-active"))
 }
 
+func TestManualMetadataPruneBelowMaximumIsNoOp(t *testing.T) {
+	cache := newGCTestCache(t)
+	sizeCalls := &atomic.Int32{}
+	ctx := addGCTestPersistable(t, cache, "manual-metadata-below-maximum", "manualMetadataBelowMaximum", gcTestTrackedInt{
+		Int:       dagql.NewInt(1),
+		sizeBytes: 100,
+		identity:  "manual-metadata-below-maximum",
+		sizeCalls: sizeCalls,
+	})
+	require.NoError(t, cache.ReleaseSession(ctx, "manual-metadata-below-maximum"))
+
+	before := cache.MetadataEstimate()
+	maximum := before.EstimatedBytes + 1
+	target := int64(1)
+	srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+	set, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+		MaxEstimatedBytes:    &maximum,
+		TargetEstimatedBytes: &target,
+	})
+	require.NoError(t, err)
+	require.Zero(t, set.EntryCount)
+	require.Zero(t, sizeCalls.Load(), "metadata-only pruning must not measure physical disk usage")
+	require.Equal(t, 1, cache.EntryStats().RetainedCalls, "an estimate below the maximum must not be pruned toward the target")
+	require.Equal(t, before, cache.MetadataEstimate())
+}
+
 func TestManualCombinedDiskAndMetadataPrune(t *testing.T) {
 	cache := newGCTestCache(t)
 	sizeCalls := &atomic.Int32{}
@@ -398,7 +445,10 @@ func TestManualCombinedDiskAndMetadataPrune(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, set.EntryCount, "the detailed response contains only the disk-stage removal")
-	require.Greater(t, sizeCalls.Load(), int32(0), "the disk stage must run before the structural stage")
+	require.Greater(t, sizeCalls.Load(), int32(0), "the combined request must run the disk stage")
+	// The disk report contains the physically sized root while no roots remain,
+	// proving that disk pruning ran before structural pruning removed the
+	// zero-disk root left behind by the disk stage.
 	require.Zero(t, cache.EntryStats().RetainedCalls, "both stages must complete before the manual call returns")
 }
 
@@ -481,20 +531,47 @@ func TestManualMetadataPruneCancellationAndReleaseError(t *testing.T) {
 }
 
 func TestManualCombinedPruneValidatesBeforeMutation(t *testing.T) {
-	cache := newGCTestCache(t)
-	ctx := addGCTestPersistable(t, cache, "manual-combined-invalid", "manualCombinedInvalid", dagql.NewInt(1))
-	require.NoError(t, cache.ReleaseSession(ctx, "manual-combined-invalid"))
-	maximum := cache.MetadataEstimate().EstimatedBytes - 1
-	target := int64(1)
+	t.Run("disk options before metadata mutation", func(t *testing.T) {
+		cache := newGCTestCache(t)
+		ctx := addGCTestPersistable(t, cache, "manual-combined-invalid-disk", "manualCombinedInvalidDisk", dagql.NewInt(1))
+		require.NoError(t, cache.ReleaseSession(ctx, "manual-combined-invalid-disk"))
+		maximum := cache.MetadataEstimate().EstimatedBytes - 1
+		target := int64(1)
 
-	srv := &Server{rootDir: t.TempDir(), engineCache: cache}
-	_, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
-		MaxUsedSpace:         "not-a-size",
-		MaxEstimatedBytes:    &maximum,
-		TargetEstimatedBytes: &target,
+		srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+		_, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+			MaxUsedSpace:         "not-a-size",
+			MaxEstimatedBytes:    &maximum,
+			TargetEstimatedBytes: &target,
+		})
+		require.ErrorContains(t, err, "invalid maxUsedSpace value")
+		require.Equal(t, 1, cache.EntryStats().RetainedCalls, "neither stage may mutate before the complete request validates")
 	})
-	require.ErrorContains(t, err, "invalid maxUsedSpace value")
-	require.Equal(t, 1, cache.EntryStats().RetainedCalls, "neither stage may mutate before the complete request validates")
+
+	t.Run("metadata options before disk mutation", func(t *testing.T) {
+		cache := newGCTestCache(t)
+		sizeCalls := &atomic.Int32{}
+		ctx := addGCTestPersistable(t, cache, "manual-combined-invalid-metadata", "manualCombinedInvalidMetadata", gcTestTrackedInt{
+			Int:       dagql.NewInt(1),
+			sizeBytes: 100,
+			identity:  "manual-combined-invalid-metadata",
+			sizeCalls: sizeCalls,
+		})
+		require.NoError(t, cache.ReleaseSession(ctx, "manual-combined-invalid-metadata"))
+		maximum := int64(0)
+		target := int64(1)
+
+		srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+		_, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+			MaxUsedSpace:         "1",
+			TargetSpace:          "1",
+			MaxEstimatedBytes:    &maximum,
+			TargetEstimatedBytes: &target,
+		})
+		require.ErrorContains(t, err, "maxEstimatedBytes must be positive")
+		require.Zero(t, sizeCalls.Load(), "disk pruning must not measure physical usage before metadata options validate")
+		require.Equal(t, 1, cache.EntryStats().RetainedCalls, "neither stage may mutate before the complete request validates")
+	})
 }
 
 func TestLocalCacheDiskPressureGCNeeded(t *testing.T) {

--- a/engine/server/gc_test.go
+++ b/engine/server/gc_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,7 +42,36 @@ func (v gcTestSizedInt) CacheUsageSize(context.Context, dagql.CacheUsageSizeProv
 	return v.sizeBytes, true, nil
 }
 
+type gcTestTrackedInt struct {
+	dagql.Int
+	sizeBytes  int64
+	identity   string
+	sizeCalls  *atomic.Int32
+	releaseErr error
+}
+
+func (v gcTestTrackedInt) CacheUsageIdentities() []string {
+	return []string{v.identity}
+}
+
+func (v gcTestTrackedInt) CacheUsageSize(context.Context, dagql.CacheUsageSizeProvider, string) (int64, bool, error) {
+	if v.sizeCalls != nil {
+		v.sizeCalls.Add(1)
+	}
+	return v.sizeBytes, true, nil
+}
+
+func (v gcTestTrackedInt) OnRelease(context.Context) error {
+	return v.releaseErr
+}
+
 func addGCTestPersistable(t *testing.T, cache *dagql.Cache, sessionID, name string, value dagql.Typed) context.Context {
+	t.Helper()
+	ctx, _ := addGCTestPersistableResult(t, cache, sessionID, name, value)
+	return ctx
+}
+
+func addGCTestPersistableResult(t *testing.T, cache *dagql.Cache, sessionID, name string, value dagql.Typed) (context.Context, dagql.AnyResult) {
 	t.Helper()
 	ctx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
 		ClientID:  sessionID,
@@ -51,14 +82,14 @@ func addGCTestPersistable(t *testing.T, cache *dagql.Cache, sessionID, name stri
 		Type:  dagql.NewResultCallType(value.Type()),
 		Field: name,
 	}
-	_, err := cache.GetOrInitCall(ctx, sessionID, gcTestTypeResolver{}, &dagql.CallRequest{
+	res, err := cache.GetOrInitCall(ctx, sessionID, gcTestTypeResolver{}, &dagql.CallRequest{
 		ResultCall:    frame,
 		IsPersistable: true,
 	}, func(context.Context) (dagql.AnyResult, error) {
 		return dagql.NewResultForCall(value, frame)
 	})
 	require.NoError(t, err)
-	return ctx
+	return ctx, res
 }
 
 func newGCTestCache(t *testing.T) *dagql.Cache {
@@ -164,6 +195,306 @@ func TestResolveEngineLocalCachePrunePoliciesUsesAvailableSpaceForMinFree(t *tes
 	require.Equal(t, dstat.Available, prunePolicies[0].CurrentFreeSpace)
 	require.Less(t, prunePolicies[0].CurrentFreeSpace, prunePolicies[0].MinFreeSpace)
 	require.GreaterOrEqual(t, dstat.Free, prunePolicies[0].MinFreeSpace)
+}
+
+func TestEngineLocalCachePruneModes(t *testing.T) {
+	maximum := int64(100)
+	target := int64(50)
+
+	for _, tc := range []struct {
+		name         string
+		opts         core.EngineCachePruneOptions
+		automaticGC  bool
+		wantDisk     bool
+		wantMetadata bool
+	}{
+		{name: "no options", wantDisk: true},
+		{
+			name:     "disk only",
+			opts:     core.EngineCachePruneOptions{MaxUsedSpace: "1GB"},
+			wantDisk: true,
+		},
+		{
+			name: "metadata only",
+			opts: core.EngineCachePruneOptions{
+				MaxEstimatedBytes:    &maximum,
+				TargetEstimatedBytes: &target,
+			},
+			wantMetadata: true,
+		},
+		{
+			name: "combined",
+			opts: core.EngineCachePruneOptions{
+				MaxUsedSpace:         "1GB",
+				MaxEstimatedBytes:    &maximum,
+				TargetEstimatedBytes: &target,
+			},
+			wantDisk:     true,
+			wantMetadata: true,
+		},
+		{
+			name:         "enabled default policy",
+			opts:         core.EngineCachePruneOptions{UseDefaultPolicy: true},
+			automaticGC:  true,
+			wantDisk:     true,
+			wantMetadata: true,
+		},
+		{
+			name:     "disabled default policy",
+			opts:     core.EngineCachePruneOptions{UseDefaultPolicy: true},
+			wantDisk: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			disk, metadata := engineLocalCachePruneModes(tc.opts, tc.automaticGC)
+			require.Equal(t, tc.wantDisk, disk)
+			require.Equal(t, tc.wantMetadata, metadata)
+		})
+	}
+}
+
+func TestResolveEngineLocalCacheMetadataPruneOptions(t *testing.T) {
+	const (
+		defaultMaximum = int64(1000)
+		defaultTarget  = int64(700)
+	)
+
+	maximumOverride := int64(1200)
+	targetOverride := int64(600)
+	zero := int64(0)
+	conflictingMaximum := int64(600)
+	conflictingTarget := int64(1000)
+
+	for _, tc := range []struct {
+		name        string
+		opts        core.EngineCachePruneOptions
+		wantMaximum int64
+		wantTarget  int64
+		wantError   string
+	}{
+		{
+			name:        "default policy",
+			opts:        core.EngineCachePruneOptions{UseDefaultPolicy: true},
+			wantMaximum: defaultMaximum,
+			wantTarget:  defaultTarget,
+		},
+		{
+			name:        "maximum only inherits target",
+			opts:        core.EngineCachePruneOptions{MaxEstimatedBytes: &maximumOverride},
+			wantMaximum: maximumOverride,
+			wantTarget:  defaultTarget,
+		},
+		{
+			name:        "target only inherits maximum",
+			opts:        core.EngineCachePruneOptions{TargetEstimatedBytes: &targetOverride},
+			wantMaximum: defaultMaximum,
+			wantTarget:  targetOverride,
+		},
+		{
+			name: "explicit pair overrides defaults",
+			opts: core.EngineCachePruneOptions{
+				MaxEstimatedBytes:    &maximumOverride,
+				TargetEstimatedBytes: &targetOverride,
+			},
+			wantMaximum: maximumOverride,
+			wantTarget:  targetOverride,
+		},
+		{
+			name:      "zero maximum",
+			opts:      core.EngineCachePruneOptions{MaxEstimatedBytes: &zero},
+			wantError: "maxEstimatedBytes must be positive",
+		},
+		{
+			name:      "zero target",
+			opts:      core.EngineCachePruneOptions{TargetEstimatedBytes: &zero},
+			wantError: "targetEstimatedBytes must be positive and lower",
+		},
+		{
+			name:      "partial maximum conflicts with inherited target",
+			opts:      core.EngineCachePruneOptions{MaxEstimatedBytes: &conflictingMaximum},
+			wantError: "targetEstimatedBytes must be positive and lower",
+		},
+		{
+			name:      "partial target conflicts with inherited maximum",
+			opts:      core.EngineCachePruneOptions{TargetEstimatedBytes: &conflictingTarget},
+			wantError: "targetEstimatedBytes must be positive and lower",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			maximum, target, err := resolveEngineLocalCacheMetadataPruneOptions(
+				defaultMaximum,
+				defaultTarget,
+				tc.opts,
+			)
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMaximum, maximum)
+			require.Equal(t, tc.wantTarget, target)
+		})
+	}
+}
+
+func TestManualMetadataPruneOnlySkipsDiskAndProtectsRoots(t *testing.T) {
+	cache := newGCTestCache(t)
+	sizeCalls := &atomic.Int32{}
+	activeCtx := addGCTestPersistable(t, cache, "manual-metadata-active", "manualMetadataActive", gcTestTrackedInt{
+		Int:       dagql.NewInt(1),
+		sizeBytes: 100,
+		identity:  "manual-metadata-active",
+		sizeCalls: sizeCalls,
+	})
+	coldCtx := addGCTestPersistable(t, cache, "manual-metadata-cold", "manualMetadataCold", dagql.NewInt(2))
+	require.NoError(t, cache.ReleaseSession(coldCtx, "manual-metadata-cold"))
+	unpruneableCtx, unpruneable := addGCTestPersistableResult(t, cache, "manual-metadata-unpruneable", "manualMetadataUnpruneable", dagql.NewInt(3))
+	require.NoError(t, cache.MakeResultUnpruneable(unpruneableCtx, unpruneable))
+	require.NoError(t, cache.ReleaseSession(unpruneableCtx, "manual-metadata-unpruneable"))
+
+	before := cache.MetadataEstimate()
+	maximum := before.EstimatedBytes - 1
+	target := int64(1)
+	srv := &Server{
+		rootDir:                        t.TempDir(),
+		engineCache:                    cache,
+		localCacheGCEnabled:            false,
+		dagqlCacheMaxEstimatedBytes:    1000,
+		dagqlCacheTargetEstimatedBytes: 700,
+	}
+	set, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+		MaxEstimatedBytes:    &maximum,
+		TargetEstimatedBytes: &target,
+	})
+	require.NoError(t, err)
+	require.Zero(t, set.EntryCount)
+	require.Zero(t, sizeCalls.Load(), "metadata-only pruning must not measure physical disk usage")
+	require.Equal(t, 2, cache.EntryStats().RetainedCalls, "active and unpruneable roots must survive while the cold root is removed")
+	require.Less(t, cache.MetadataEstimate().EstimatedBytes, before.EstimatedBytes)
+	require.NoError(t, cache.ReleaseSession(activeCtx, "manual-metadata-active"))
+}
+
+func TestManualCombinedDiskAndMetadataPrune(t *testing.T) {
+	cache := newGCTestCache(t)
+	sizeCalls := &atomic.Int32{}
+	diskCtx := addGCTestPersistable(t, cache, "manual-combined-disk", "manualCombinedDisk", gcTestTrackedInt{
+		Int:       dagql.NewInt(1),
+		sizeBytes: 100,
+		identity:  "manual-combined-disk",
+		sizeCalls: sizeCalls,
+	})
+	require.NoError(t, cache.ReleaseSession(diskCtx, "manual-combined-disk"))
+	metadataCtx := addGCTestPersistable(t, cache, "manual-combined-metadata", "manualCombinedMetadata", dagql.NewInt(2))
+	require.NoError(t, cache.ReleaseSession(metadataCtx, "manual-combined-metadata"))
+
+	maximum := int64(2)
+	target := int64(1)
+	srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+	set, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+		MaxUsedSpace:         "1",
+		TargetSpace:          "1",
+		MaxEstimatedBytes:    &maximum,
+		TargetEstimatedBytes: &target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, set.EntryCount, "the detailed response contains only the disk-stage removal")
+	require.Greater(t, sizeCalls.Load(), int32(0), "the disk stage must run before the structural stage")
+	require.Zero(t, cache.EntryStats().RetainedCalls, "both stages must complete before the manual call returns")
+}
+
+func TestManualUseDefaultPolicyIncludesMetadata(t *testing.T) {
+	cache := newGCTestCache(t)
+	ctx := addGCTestPersistable(t, cache, "manual-default-metadata", "manualDefaultMetadata", dagql.NewInt(1))
+	require.NoError(t, cache.ReleaseSession(ctx, "manual-default-metadata"))
+
+	srv := &Server{
+		rootDir:                        t.TempDir(),
+		engineCache:                    cache,
+		workerGCPolicies:               []dagqlCachePrunePolicy{{All: true, MaxUsedSpace: 1 << 40}},
+		localCacheGCEnabled:            true,
+		dagqlCacheMaxEstimatedBytes:    2,
+		dagqlCacheTargetEstimatedBytes: 1,
+	}
+	_, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{UseDefaultPolicy: true})
+	require.NoError(t, err)
+	require.Zero(t, cache.EntryStats().RetainedCalls, "configured structural pruning must occur in the same manual call")
+}
+
+func TestManualNoOptionPrunePreservesDiskPruneAll(t *testing.T) {
+	cache := newGCTestCache(t)
+	sizeCalls := &atomic.Int32{}
+	ctx := addGCTestPersistable(t, cache, "manual-no-options", "manualNoOptions", gcTestTrackedInt{
+		Int:       dagql.NewInt(1),
+		sizeBytes: 100,
+		identity:  "manual-no-options",
+		sizeCalls: sizeCalls,
+	})
+	require.NoError(t, cache.ReleaseSession(ctx, "manual-no-options"))
+
+	srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+	set, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, set.EntryCount)
+	require.Greater(t, sizeCalls.Load(), int32(0))
+	require.Zero(t, cache.EntryStats().RetainedCalls)
+}
+
+func TestManualMetadataPruneCancellationAndReleaseError(t *testing.T) {
+	t.Run("cancellation", func(t *testing.T) {
+		cache := newGCTestCache(t)
+		ctx := addGCTestPersistable(t, cache, "manual-metadata-canceled", "manualMetadataCanceled", dagql.NewInt(1))
+		require.NoError(t, cache.ReleaseSession(ctx, "manual-metadata-canceled"))
+		maximum := cache.MetadataEstimate().EstimatedBytes - 1
+		target := int64(1)
+		canceled, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+		_, err := srv.PruneEngineLocalCacheEntries(canceled, core.EngineCachePruneOptions{
+			MaxEstimatedBytes:    &maximum,
+			TargetEstimatedBytes: &target,
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, cache.EntryStats().RetainedCalls)
+	})
+
+	t.Run("release error", func(t *testing.T) {
+		cache := newGCTestCache(t)
+		releaseErr := errors.New("manual metadata release failed")
+		ctx := addGCTestPersistable(t, cache, "manual-metadata-release-error", "manualMetadataReleaseError", gcTestTrackedInt{
+			Int:        dagql.NewInt(1),
+			identity:   "manual-metadata-release-error",
+			releaseErr: releaseErr,
+		})
+		require.NoError(t, cache.ReleaseSession(ctx, "manual-metadata-release-error"))
+		maximum := cache.MetadataEstimate().EstimatedBytes - 1
+		target := int64(1)
+
+		srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+		_, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+			MaxEstimatedBytes:    &maximum,
+			TargetEstimatedBytes: &target,
+		})
+		require.ErrorIs(t, err, releaseErr)
+		require.Zero(t, cache.EntryStats().RetainedCalls, "the underlying release error must be returned after the root is cut")
+	})
+}
+
+func TestManualCombinedPruneValidatesBeforeMutation(t *testing.T) {
+	cache := newGCTestCache(t)
+	ctx := addGCTestPersistable(t, cache, "manual-combined-invalid", "manualCombinedInvalid", dagql.NewInt(1))
+	require.NoError(t, cache.ReleaseSession(ctx, "manual-combined-invalid"))
+	maximum := cache.MetadataEstimate().EstimatedBytes - 1
+	target := int64(1)
+
+	srv := &Server{rootDir: t.TempDir(), engineCache: cache}
+	_, err := srv.PruneEngineLocalCacheEntries(t.Context(), core.EngineCachePruneOptions{
+		MaxUsedSpace:         "not-a-size",
+		MaxEstimatedBytes:    &maximum,
+		TargetEstimatedBytes: &target,
+	})
+	require.ErrorContains(t, err, "invalid maxUsedSpace value")
+	require.Equal(t, 1, cache.EntryStats().RetainedCalls, "neither stage may mutate before the complete request validates")
 }
 
 func TestLocalCacheDiskPressureGCNeeded(t *testing.T) {

--- a/internal-docs/cache_pruning.md
+++ b/internal-docs/cache_pruning.md
@@ -284,10 +284,10 @@ That layer:
 So `dagql` owns the prune implementation, while `engine/server` owns policy
 construction and triggering.
 
-The automatic structural-memory pass does not create another policy language.
-It always uses `KeepDuration=0`, no filters, and the current deterministic
-candidate order. Its only controls are an absolute maximum estimate and a lower
-target estimate.
+The structural-memory pass does not create another policy language. It always
+uses `KeepDuration=0`, no filters, and the current deterministic candidate
+order. Its only controls are an absolute maximum estimate and a lower target
+estimate.
 
 ## Local-Cache GC Scheduling
 
@@ -312,8 +312,33 @@ pressure or disk policies. Session completion and other explicit lifecycle
 entries bypass or clear it, and any successful removal or return below maximum
 clears it.
 
-`gc.enabled=false` disables both disk and structural pruning. Legacy BuildKit GC
-disablement has the same effect.
+`gc.enabled=false` disables automatic disk and structural pruning. Legacy
+BuildKit GC disablement has the same effect on automatic scheduling. An explicit
+manual structural request remains allowed.
+
+## Manual Pruning Modes
+
+`Engine.localCache.prune` selects disk and structural stages independently while
+holding the existing server `gcmu` for the complete request:
+
+- no options preserves the legacy all-eligible disk prune
+- disk options run disk pruning
+- structural `maxEstimatedBytes` or `targetEstimatedBytes` options run
+  structural pruning without an implicit disk prune
+- combined disk and structural controls run disk first and structural second,
+  matching automatic GC ordering
+- `useDefaultPolicy=true` runs both configured stages when automatic GC is
+  enabled
+
+When automatic GC is disabled, `useDefaultPolicy` does not enable the disabled
+structural policy. Explicit structural options still run because they are a
+direct operator action rather than automatic scheduling.
+
+Manual structural options are optional absolute byte integers. Each omitted
+member of the pair inherits the server's already-resolved configured/default
+value. An explicitly supplied value must be positive, and the resulting target
+must be lower than the resulting maximum. The server validates the complete
+request before either stage mutates cache state.
 
 ## High-Level Disk Prune Algorithm
 
@@ -333,7 +358,7 @@ At a high level, the prune implementation in `dagql/cache_prune.go` does this:
 
 This is absolutely a best-effort pruning pass, not an optimal solver.
 
-## Structural Estimate And Automatic Memory Pruning
+## Structural Estimate And Memory Pruning
 
 The cache exposes an O(1) estimate from cardinalities already protected by
 `egraphMu`:
@@ -387,10 +412,10 @@ When the estimate exceeds the maximum, `PruneMetadataEstimate`:
 
 Structural snapshot mode skips physical size measurement, usage-identity
 details, call labels, cloned call frames, digest derivation, and per-root report
-entries. Automatic output is one aggregate INFO record, emitted only after the
+entries. Structural output is one aggregate INFO record, emitted only after the
 maximum is actually exceeded, plus aggregate trace events when e-graph tracing
-is enabled. Explicit user prune retains the existing detailed disk-oriented
-response.
+is enabled. A manual request retains the existing detailed response for its disk
+stage; its structural stage remains aggregate-only.
 
 ## Stop-The-World Avoidance
 
@@ -604,7 +629,7 @@ The current logic is still policy-shaped rather than deeply semantic:
 If thresholds are not triggered but the policy is effectively "prune matching
 things anyway" (`All` or filters), the target becomes effectively unlimited.
 
-That is how explicit user prune requests can still remove matching entries even
+That is how explicit disk-prune requests can still remove matching entries even
 without disk pressure.
 
 ## Applying The Plan To Live State
@@ -704,10 +729,10 @@ Structural pruning has one separate Prometheus gauge:
 used by the trigger. There are no per-type, per-field, or per-root structural
 metrics.
 
-An automatic structural pass returns and logs only aggregate counts, estimates,
-compaction slot counts, outcome, and duration. A below-threshold call emits no
-INFO start/finish record. Explicit user prune remains compatible with its
-existing detailed response.
+A structural pass returns and logs only aggregate counts, estimates, compaction
+slot counts, outcome, and duration. A below-threshold call emits no INFO
+start/finish record. Manual pruning remains compatible with its existing
+detailed response for disk-stage removals.
 
 ## Persistence And Restart
 
@@ -822,8 +847,8 @@ ownership model.
 
 The current dagql prune model treats persisted edges as prunable retention roots
 and protects live session closure and unpruneable roots. Disk mode uses measured
-physical size and worker policies. Structural mode independently triggers from
-an O(1) `R/T/C` estimate, force-compacts class slots, and uses equal coarse
-credit without physical details. Both modes reuse the same graph snapshot,
-greedy ownership simulation, live unpruneable recheck, persisted-edge cuts,
-normal ownership cascade, and containerd lease cleanup.
+physical size and worker policies. Structural mode triggers automatically or
+manually from an O(1) `R/T/C` estimate, force-compacts class slots, and uses
+equal coarse credit without physical details. Both modes reuse the same graph
+snapshot, greedy ownership simulation, live unpruneable recheck, persisted-edge
+cuts, normal ownership cascade, and containerd lease cleanup.

--- a/internal-docs/cache_pruning.md
+++ b/internal-docs/cache_pruning.md
@@ -332,7 +332,14 @@ holding the existing server `gcmu` for the complete request:
 
 When automatic GC is disabled, `useDefaultPolicy` does not enable the disabled
 structural policy. Explicit structural options still run because they are a
-direct operator action rather than automatic scheduling.
+direct operator action rather than automatic scheduling. No default disk
+policies are active in this state, so the existing manual disk path falls back
+to its all-releasable policy when `useDefaultPolicy=true`.
+
+Structural-only means that the disk-policy stage is skipped, not that the
+request cannot reclaim disk. Cutting persisted roots can release owned cache
+entries, and a successful structural removal invokes snapshot GC. Disk-policy
+retention rules and filters do not apply to the structural pass.
 
 Manual structural options are optional absolute byte integers. Each omitted
 member of the pair inherits the server's already-resolved configured/default
@@ -435,6 +442,11 @@ The cache briefly takes a snapshot of the information it needs:
 - active session roots
 
 Then it releases the lock and does the expensive reasoning outside the lock.
+Structural planning carries the request context through active-root snapshotting,
+graph snapshotting, active-closure traversal, candidate ordering, and ownership
+simulation. It checks cancellation between phases and at bounded intervals
+inside those O(N) loops, and discards partial planning state without cutting
+persisted roots when canceled.
 
 ### 2. Apply actual cuts later
 

--- a/sdk/elixir/lib/dagger/gen/engine_cache.ex
+++ b/sdk/elixir/lib/dagger/gen/engine_cache.ex
@@ -72,7 +72,9 @@ defmodule Dagger.EngineCache do
           {:max_used_space, String.t() | nil},
           {:reserved_space, String.t() | nil},
           {:min_free_space, String.t() | nil},
-          {:target_space, String.t() | nil}
+          {:target_space, String.t() | nil},
+          {:max_estimated_bytes, integer() | nil},
+          {:target_estimated_bytes, integer() | nil}
         ]) :: :ok | {:error, term()}
   def prune(%__MODULE__{} = engine_cache, optional_args \\ []) do
     query_builder =
@@ -83,6 +85,8 @@ defmodule Dagger.EngineCache do
       |> QB.maybe_put_arg("reservedSpace", optional_args[:reserved_space])
       |> QB.maybe_put_arg("minFreeSpace", optional_args[:min_free_space])
       |> QB.maybe_put_arg("targetSpace", optional_args[:target_space])
+      |> QB.maybe_put_arg("maxEstimatedBytes", optional_args[:max_estimated_bytes])
+      |> QB.maybe_put_arg("targetEstimatedBytes", optional_args[:target_estimated_bytes])
 
     case Client.execute(engine_cache.client, query_builder) do
       {:ok, _} -> :ok

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5426,7 +5426,7 @@ func (r *EngineCache) MinFreeSpace(ctx context.Context) (int, error) {
 
 // EngineCachePruneOpts contains options for EngineCache.Prune
 type EngineCachePruneOpts struct {
-	// Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
+	// Use enabled engine-wide default disk and structural policies. If no default disk policy is enabled, the disk stage falls back to pruning all releasable disk-cache entries. If false, explicit options select stages; with no options, all releasable disk-cache entries are pruned.
 	UseDefaultPolicy bool
 	// Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
 	MaxUsedSpace string
@@ -5436,9 +5436,9 @@ type EngineCachePruneOpts struct {
 	MinFreeSpace string
 	// Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
 	TargetSpace string
-	// Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+	// Override the maximum structural metadata estimate in absolute bytes. Explicit values must be positive; the configured/default value is used when omitted.
 	MaxEstimatedBytes int
-	// Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+	// Override the structural metadata estimate to target in absolute bytes. Explicit values must be positive and lower than the resolved maximum; the configured/default value is used when omitted.
 	TargetEstimatedBytes int
 }
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5436,6 +5436,10 @@ type EngineCachePruneOpts struct {
 	MinFreeSpace string
 	// Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
 	TargetSpace string
+	// Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+	MaxEstimatedBytes int
+	// Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+	TargetEstimatedBytes int
 }
 
 // Prune the cache of releaseable entries
@@ -5464,6 +5468,14 @@ func (r *EngineCache) Prune(ctx context.Context, opts ...EngineCachePruneOpts) e
 		// `targetSpace` optional argument
 		if !querybuilder.IsZeroValue(opts[i].TargetSpace) {
 			q = q.Arg("targetSpace", opts[i].TargetSpace)
+		}
+		// `maxEstimatedBytes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MaxEstimatedBytes) {
+			q = q.Arg("maxEstimatedBytes", opts[i].MaxEstimatedBytes)
+		}
+		// `targetEstimatedBytes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].TargetEstimatedBytes) {
+			q = q.Arg("targetEstimatedBytes", opts[i].TargetEstimatedBytes)
 		}
 	}
 

--- a/sdk/php/generated/EngineCache.php
+++ b/sdk/php/generated/EngineCache.php
@@ -61,6 +61,8 @@ class EngineCache extends Client\AbstractObject implements Client\IdAble, Node
         ?string $reservedSpace = '',
         ?string $minFreeSpace = '',
         ?string $targetSpace = '',
+        ?int $maxEstimatedBytes = null,
+        ?int $targetEstimatedBytes = null,
     ): void {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('prune');
         if (null !== $useDefaultPolicy) {
@@ -77,6 +79,12 @@ class EngineCache extends Client\AbstractObject implements Client\IdAble, Node
         }
         if (null !== $targetSpace) {
         $leafQueryBuilder->setArgument('targetSpace', $targetSpace);
+        }
+        if (null !== $maxEstimatedBytes) {
+        $leafQueryBuilder->setArgument('maxEstimatedBytes', $maxEstimatedBytes);
+        }
+        if (null !== $targetEstimatedBytes) {
+        $leafQueryBuilder->setArgument('targetEstimatedBytes', $targetEstimatedBytes);
         }
         $this->queryLeaf($leafQueryBuilder, 'prune');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5466,6 +5466,8 @@ class EngineCache(Type):
         reserved_space: str | None = "",
         min_free_space: str | None = "",
         target_space: str | None = "",
+        max_estimated_bytes: int | None = None,
+        target_estimated_bytes: int | None = None,
     ) -> Void | None:
         """Prune the cache of releaseable entries
 
@@ -5486,6 +5488,12 @@ class EngineCache(Type):
         target_space:
             Override the target disk space to keep after pruning (e.g. "200GB"
             or "50%").
+        max_estimated_bytes:
+            Override the maximum structural metadata estimate in absolute
+            bytes. The configured/default value is used when omitted.
+        target_estimated_bytes:
+            Override the structural metadata estimate to target in absolute
+            bytes. The configured/default value is used when omitted.
 
         Returns
         -------
@@ -5506,6 +5514,8 @@ class EngineCache(Type):
             Arg("reservedSpace", reserved_space, ""),
             Arg("minFreeSpace", min_free_space, ""),
             Arg("targetSpace", target_space, ""),
+            Arg("maxEstimatedBytes", max_estimated_bytes, None),
+            Arg("targetEstimatedBytes", target_estimated_bytes, None),
         ]
         _ctx = self._select("prune", _args)
         await _ctx.execute()

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5474,8 +5474,11 @@ class EngineCache(Type):
         Parameters
         ----------
         use_default_policy:
-            Use the engine-wide default pruning policy if true, otherwise
-            prune the whole cache of any releasable entries.
+            Use enabled engine-wide default disk and structural policies. If
+            no default disk policy is enabled, the disk stage falls back to
+            pruning all releasable disk-cache entries. If false, explicit
+            options select stages; with no options, all releasable disk-cache
+            entries are pruned.
         max_used_space:
             Override the maximum disk space to keep before pruning (e.g.
             "200GB" or "80%").
@@ -5490,10 +5493,13 @@ class EngineCache(Type):
             or "50%").
         max_estimated_bytes:
             Override the maximum structural metadata estimate in absolute
-            bytes. The configured/default value is used when omitted.
+            bytes. Explicit values must be positive; the configured/default
+            value is used when omitted.
         target_estimated_bytes:
             Override the structural metadata estimate to target in absolute
-            bytes. The configured/default value is used when omitted.
+            bytes. Explicit values must be positive and lower than the
+            resolved maximum; the configured/default value is used when
+            omitted.
 
         Returns
         -------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6150,7 +6150,7 @@ pub struct EngineCacheEntrySetOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct EngineCachePruneOpts<'a> {
-    /// Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+    /// Override the maximum structural metadata estimate in absolute bytes. Explicit values must be positive; the configured/default value is used when omitted.
     #[builder(setter(into, strip_option), default)]
     pub max_estimated_bytes: Option<isize>,
     /// Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
@@ -6162,13 +6162,13 @@ pub struct EngineCachePruneOpts<'a> {
     /// Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
     #[builder(setter(into, strip_option), default)]
     pub reserved_space: Option<&'a str>,
-    /// Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+    /// Override the structural metadata estimate to target in absolute bytes. Explicit values must be positive and lower than the resolved maximum; the configured/default value is used when omitted.
     #[builder(setter(into, strip_option), default)]
     pub target_estimated_bytes: Option<isize>,
     /// Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
     #[builder(setter(into, strip_option), default)]
     pub target_space: Option<&'a str>,
-    /// Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
+    /// Use enabled engine-wide default disk and structural policies. If no default disk policy is enabled, the disk stage falls back to pruning all releasable disk-cache entries. If false, explicit options select stages; with no options, all releasable disk-cache entries are pruned.
     #[builder(setter(into, strip_option), default)]
     pub use_default_policy: Option<bool>,
 }

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -6150,6 +6150,9 @@ pub struct EngineCacheEntrySetOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct EngineCachePruneOpts<'a> {
+    /// Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+    #[builder(setter(into, strip_option), default)]
+    pub max_estimated_bytes: Option<isize>,
     /// Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
     #[builder(setter(into, strip_option), default)]
     pub max_used_space: Option<&'a str>,
@@ -6159,6 +6162,9 @@ pub struct EngineCachePruneOpts<'a> {
     /// Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
     #[builder(setter(into, strip_option), default)]
     pub reserved_space: Option<&'a str>,
+    /// Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+    #[builder(setter(into, strip_option), default)]
+    pub target_estimated_bytes: Option<isize>,
     /// Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
     #[builder(setter(into, strip_option), default)]
     pub target_space: Option<&'a str>,
@@ -6267,6 +6273,12 @@ impl EngineCache {
         }
         if let Some(target_space) = opts.target_space {
             query = query.arg("targetSpace", target_space);
+        }
+        if let Some(max_estimated_bytes) = opts.max_estimated_bytes {
+            query = query.arg("maxEstimatedBytes", max_estimated_bytes);
+        }
+        if let Some(target_estimated_bytes) = opts.target_estimated_bytes {
+            query = query.arg("targetEstimatedBytes", target_estimated_bytes);
         }
         query.execute(self.graphql_client.clone()).await
     }

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1392,7 +1392,7 @@ export type EngineCacheEntrySetOpts = {
 
 export type EngineCachePruneOpts = {
   /**
-   * Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
+   * Use enabled engine-wide default disk and structural policies. If no default disk policy is enabled, the disk stage falls back to pruning all releasable disk-cache entries. If false, explicit options select stages; with no options, all releasable disk-cache entries are pruned.
    */
   useDefaultPolicy?: boolean
 
@@ -1417,12 +1417,12 @@ export type EngineCachePruneOpts = {
   targetSpace?: string
 
   /**
-   * Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+   * Override the maximum structural metadata estimate in absolute bytes. Explicit values must be positive; the configured/default value is used when omitted.
    */
   maxEstimatedBytes?: number
 
   /**
-   * Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+   * Override the structural metadata estimate to target in absolute bytes. Explicit values must be positive and lower than the resolved maximum; the configured/default value is used when omitted.
    */
   targetEstimatedBytes?: number
 }
@@ -6866,13 +6866,13 @@ export class EngineCache extends BaseClient {
 
   /**
    * Prune the cache of releaseable entries
-   * @param opts.useDefaultPolicy Use the engine-wide default pruning policy if true, otherwise prune the whole cache of any releasable entries.
+   * @param opts.useDefaultPolicy Use enabled engine-wide default disk and structural policies. If no default disk policy is enabled, the disk stage falls back to pruning all releasable disk-cache entries. If false, explicit options select stages; with no options, all releasable disk-cache entries are pruned.
    * @param opts.maxUsedSpace Override the maximum disk space to keep before pruning (e.g. "200GB" or "80%").
    * @param opts.reservedSpace Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
    * @param opts.minFreeSpace Override the minimum free disk space target during pruning (e.g. "20GB" or "20%").
    * @param opts.targetSpace Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
-   * @param opts.maxEstimatedBytes Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
-   * @param opts.targetEstimatedBytes Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+   * @param opts.maxEstimatedBytes Override the maximum structural metadata estimate in absolute bytes. Explicit values must be positive; the configured/default value is used when omitted.
+   * @param opts.targetEstimatedBytes Override the structural metadata estimate to target in absolute bytes. Explicit values must be positive and lower than the resolved maximum; the configured/default value is used when omitted.
    */
   prune = async (opts?: EngineCachePruneOpts): Promise<void> => {
     if (this._prune) {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -1415,6 +1415,16 @@ export type EngineCachePruneOpts = {
    * Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
    */
   targetSpace?: string
+
+  /**
+   * Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+   */
+  maxEstimatedBytes?: number
+
+  /**
+   * Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
+   */
+  targetEstimatedBytes?: number
 }
 
 export type EnvFileGetOpts = {
@@ -6861,6 +6871,8 @@ export class EngineCache extends BaseClient {
    * @param opts.reservedSpace Override the minimum disk space to retain during pruning (e.g. "500GB" or "10%").
    * @param opts.minFreeSpace Override the minimum free disk space target during pruning (e.g. "20GB" or "20%").
    * @param opts.targetSpace Override the target disk space to keep after pruning (e.g. "200GB" or "50%").
+   * @param opts.maxEstimatedBytes Override the maximum structural metadata estimate in absolute bytes. The configured/default value is used when omitted.
+   * @param opts.targetEstimatedBytes Override the structural metadata estimate to target in absolute bytes. The configured/default value is used when omitted.
    */
   prune = async (opts?: EngineCachePruneOpts): Promise<void> => {
     if (this._prune) {


### PR DESCRIPTION
## Summary

- add absolute `maxEstimatedBytes` and `targetEstimatedBytes` controls to `Engine.localCache.prune`, including generated CLI and SDK surfaces
- run configured structural-memory pruning inline with manual `useDefaultPolicy` requests when automatic GC is enabled, and allow explicit structural pruning when automatic GC is disabled
- preserve legacy no-option and disk-only behavior while ensuring metadata-only requests do not run the implicit all-eligible disk-policy stage
- add bounded cancellation checks throughout structural snapshotting and planning, including high-fanout dependency and candidate ordering
- document the destructive disk fallback, structural disk-reclamation effects, partial-pair validation, and GC-disabled behavior accurately

## Motivation

DagQL structural-memory limits previously applied only through automatic or lifecycle GC. A manual local-cache prune applied disk policy immediately but left structural pruning to a later, unrelated background event. Operators also had no explicit structural-memory action when automatic GC was disabled.

This change makes a manual request cohesive: combined requests run disk pruning first and structural pruning second under the existing GC serialization lock. Explicit structural controls remain operator actions independent of automatic scheduling.

## Compatibility and user impact

- no-option manual prune retains the existing all-releasable disk behavior
- disk-only options continue to run only disk pruning
- metadata-only options skip the disk-policy stage, though released roots and snapshot GC may still reclaim disk
- `useDefaultPolicy` applies configured disk and structural policies only when automatic GC is enabled; with GC disabled it does not resurrect structural policy and retains the existing disk fallback
- omitted structural values inherit resolved configured/default limits; explicit values must be positive and the target must be lower than the resolved maximum
- structural options are absolute byte integers only
- new API arguments and corrected argument documentation are version-gated so the historical base schema remains unchanged

A release note, user documentation, GraphQL schema, SDK bindings, and reference artifacts are included.

## Validation

- `go test -count=1 ./dagql ./engine/server ./core/schema`
- `go test -race -count=1 ./dagql ./engine/server`
- `dagger api call engine-dev test --pkg ./core/integration --run='^TestLocalCache/TestLocalCacheManualMetadataPruneCLI$'`
- deterministic cancellation, mode-selection, validation-before-mutation, and manual-prune tests repeated up to 100 times
- `dagger check golang:lint-all markdown-lint:lint docs:check python-client:lint typescript-client:lint-typescript java-client:lint helm:lint`
- `dagger check --generate`: all 24 checks passed on this exact candidate during review; the post-rebase no-op recheck passed 23 checks and the Elixir check aborted in `mix local.hex` with the known VM error `OS monotonic time stepped backwards`

