### PR TITLE
fix: make `dagger module init` work from a subdirectory workspace

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -12,6 +12,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"path"
 	"strings"
 	"testing"
 
@@ -478,32 +479,47 @@ func (m *ClientGeneratorFixture) GenerateClients(ctx context.Context, ws *dagger
 // pre-existing client, so anything generated outside the initialized path shows
 // up as a stray marker.
 func initGeneratorFixture(t testing.TB, c *dagger.Client) *dagger.Container {
+	return initGeneratorFixtureAt(t, c, ".")
+}
+
+// initGeneratorFixtureAt builds the fixture with its dagger.toml under
+// configDir, so tests can exercise a workspace config that is not at the
+// workspace (git) root. [modules.X].source is config-directory-relative while
+// as-sdk paths are workspace-root-relative, hence the two path shapes below.
+//
+// The SDK module deliberately sits at a dot-free path: a client's module ref is
+// classified as local by looking for a leading "." or "/" and otherwise for the
+// absence of a dot, so "common/.dagger/init-fixture" would be mistaken for a
+// remote ref.
+func initGeneratorFixtureAt(t testing.TB, c *dagger.Client, configDir string) *dagger.Container {
+	inConfigDir := func(p string) string { return path.Join(configDir, p) }
 	return goGitBase(t, c).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", testCLIBinPath).
 		With(nonNestedDevEngine(c)).
-		WithNewFile("dagger.toml", `[modules.init-fixture]
-source = ".dagger/init-fixture"
+		WithNewFile(inConfigDir("dagger.toml"), `[modules.init-fixture]
+source = "sdk/init-fixture"
 
 [modules.init-fixture.as-sdk]
 name = "fixture"
 
 [[modules.init-fixture.as-sdk.modules]]
-path = "existing/mod"
+path = "`+inConfigDir("existing/mod")+`"
 
 [[modules.init-fixture.as-sdk.clients]]
-path = "existing/client"
-module = ".dagger/init-fixture"
+path = "`+inConfigDir("existing/client")+`"
+module = "`+inConfigDir("sdk/init-fixture")+`"
 `).
-		WithNewFile(".dagger/init-fixture/dagger.json", `{
+		WithNewFile(inConfigDir("sdk/init-fixture/dagger.json"), `{
   "name": "init-fixture",
   "engineVersion": "latest",
   "sdk": { "source": "go" },
   "source": "."
 }`).
-		WithNewFile(".dagger/init-fixture/main.go", `package main
+		WithNewFile(inConfigDir("sdk/init-fixture/main.go"), `package main
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 
@@ -514,12 +530,36 @@ type InitFixture struct{}
 
 // InitModule scaffolds the SDK-owned files for a new module.
 func (m *InitFixture) InitModule(ctx context.Context, ws *dagger.Workspace, name string, path string) (*dagger.Changeset, error) {
-	return dag.Directory().WithNewFile(path+"/scaffold.txt", name+"\n").Changes(dag.Directory()), nil
+	local, err := cwdLocalPath(ctx, ws, path)
+	if err != nil {
+		return nil, err
+	}
+	return dag.Directory().WithNewFile(local+"/scaffold.txt", name+"\n").Changes(dag.Directory()), nil
 }
 
 // InitClient scaffolds the SDK-owned files for a new client.
 func (m *InitFixture) InitClient(ctx context.Context, ws *dagger.Workspace, path string, module string) (*dagger.Changeset, error) {
-	return dag.Directory().WithNewFile(path+"/scaffold.txt", module+"\n").Changes(dag.Directory()), nil
+	local, err := cwdLocalPath(ctx, ws, path)
+	if err != nil {
+		return nil, err
+	}
+	return dag.Directory().WithNewFile(local+"/scaffold.txt", module+"\n").Changes(dag.Directory()), nil
+}
+
+// cwdLocalPath mirrors the polyfill's workspace fork: the engine hands an SDK
+// workspace-root-relative paths, but a returned changeset is applied wherever
+// the caller stands, so the path has to be rebased onto the workspace cwd — and
+// cannot be staged at all when it lies outside it.
+func cwdLocalPath(ctx context.Context, ws *dagger.Workspace, workspacePath string) (string, error) {
+	cwd, err := workspaceCwd(ctx, ws)
+	if err != nil {
+		return "", err
+	}
+	rel, ok := relativeToCwd(cwd, workspacePath)
+	if !ok {
+		return "", fmt.Errorf("workspace path %s is outside changeset root %s", workspacePath, cwd)
+	}
+	return rel, nil
 }
 
 // +generate
@@ -668,17 +708,17 @@ func (GeneratorsSuite) TestAPIClientInitGeneratesForNewClientOnly(ctx context.Co
 
 	t.Run("generates the new client", func(ctx context.Context, t *testctx.T) {
 		initialized := base.With(daggerExec(
-			"api", "client", "init", "fixture", "clients/one", ".dagger/init-fixture", "--auto-apply"))
+			"api", "client", "init", "fixture", "clients/one", "sdk/init-fixture", "--auto-apply"))
 		out, err := initialized.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 
 		scaffold, err := initialized.File("clients/one/scaffold.txt").Contents(ctx)
 		require.NoError(t, err)
-		require.Equal(t, ".dagger/init-fixture\n", scaffold)
+		require.Equal(t, "sdk/init-fixture\n", scaffold)
 
 		generated, err := initialized.File("clients/one/generated-client.txt").Contents(ctx)
 		require.NoError(t, err)
-		require.Equal(t, ".dagger/init-fixture\n", generated)
+		require.Equal(t, "sdk/init-fixture\n", generated)
 
 		for _, stray := range []string{"existing/mod/generated-module.txt", "existing/client/generated-client.txt"} {
 			exists, err := initialized.Exists(ctx, stray)
@@ -689,15 +729,176 @@ func (GeneratorsSuite) TestAPIClientInitGeneratesForNewClientOnly(ctx context.Co
 
 	t.Run("--no-generate scaffolds without generating", func(ctx context.Context, t *testctx.T) {
 		initialized := base.With(daggerExec(
-			"api", "client", "init", "fixture", "clients/one", ".dagger/init-fixture", "--no-generate", "--auto-apply"))
+			"api", "client", "init", "fixture", "clients/one", "sdk/init-fixture", "--no-generate", "--auto-apply"))
 
 		scaffold, err := initialized.File("clients/one/scaffold.txt").Contents(ctx)
 		require.NoError(t, err)
-		require.Equal(t, ".dagger/init-fixture\n", scaffold)
+		require.Equal(t, "sdk/init-fixture\n", scaffold)
 
 		exists, err := initialized.Exists(ctx, "clients/one/generated-client.txt")
 		require.NoError(t, err)
 		require.False(t, exists)
+	})
+}
+
+// TestInitFromSubdirectoryWorkspace covers dagger/dagger#13889: a dagger.toml
+// in a subdirectory of the git repo (the monorepo layout, several projects
+// under one root) leaves the caller's workspace cwd below the workspace root.
+// Init changesets are applied at the workspace root, so the SDK has to be shown
+// a cwd that matches — otherwise it either refuses the path outright or strips
+// the cwd prefix and splits the new module across two directories.
+func (GeneratorsSuite) TestInitFromSubdirectoryWorkspace(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixtureAt(t, c, "common").WithWorkdir("/work/common")
+
+	// withInitModule changes the workspace cwd internally, to measure and
+	// export its root-owned edits. That must not leak: as a value, the
+	// workspace it returns is the caller's, moved only by the changeset.
+	t.Run("the returned workspace keeps the caller cwd", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerQuery(`{
+			currentWorkspace {
+				cwd
+				withInitModule(name: "cwdcheck", sdk: "fixture", noGenerate: true) {
+					cwd
+				}
+			}
+		}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, out, `"cwd": "/"`,
+			"init must not move the caller's cwd to the workspace root")
+		require.Equal(t, 2, strings.Count(out, `"cwd": "/common"`),
+			"the workspace before and after init should share a cwd: %s", out)
+	})
+
+	t.Run("module init scaffolds beside its dagger.toml", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec("module", "init", "fixture", "newmod", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		// The engine's module config and the SDK's scaffold land together,
+		// under the project the dagger.toml belongs to.
+		scaffold, err := initialized.File("/work/common/.dagger/modules/newmod/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "newmod\n", scaffold)
+		_, err = initialized.File("/work/common/.dagger/modules/newmod/dagger-module.toml").Contents(ctx)
+		require.NoError(t, err)
+
+		// ...and so does the generator output, in the same apply.
+		generated, err := initialized.File("/work/common/.dagger/modules/newmod/generated-module.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "common/.dagger/modules/newmod\n", generated)
+
+		// Nothing was written at the git root, where the cwd-stripped path
+		// would have put it.
+		exists, err := initialized.Exists(ctx, "/work/.dagger")
+		require.NoError(t, err)
+		require.False(t, exists, "module init must not scaffold outside the config directory")
+
+		// [modules.X].source is config-directory-relative; as-sdk paths are
+		// workspace-root-relative.
+		config, err := initialized.File("/work/common/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `source = ".dagger/modules/newmod"`)
+		require.Contains(t, config, `path = "common/.dagger/modules/newmod"`)
+	})
+
+	t.Run("module init honors an explicit workspace-root-relative path", func(ctx context.Context, t *testctx.T) {
+		t.Run("inside caller cwd", func(ctx context.Context, t *testctx.T) {
+			initialized := base.With(daggerExec(
+				"module", "init", "fixture", "hello", "--path", "common/hello", "--auto-apply"))
+			out, err := initialized.CombinedOutput(ctx)
+			require.NoError(t, err, out)
+
+			scaffold, err := initialized.File("/work/common/hello/scaffold.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "hello\n", scaffold)
+			_, err = initialized.File("/work/common/hello/dagger-module.toml").Contents(ctx)
+			require.NoError(t, err)
+
+			// The pre-fix failure mode: no error, but the SDK's file lands at the
+			// cwd-stripped path while the engine's config stays put.
+			exists, err := initialized.Exists(ctx, "/work/hello")
+			require.NoError(t, err)
+			require.False(t, exists, "module init must not split the module across directories")
+		})
+
+		t.Run("outside caller cwd", func(ctx context.Context, t *testctx.T) {
+			initialized := base.With(daggerExec(
+				"module", "init", "fixture", "hello", "--path", "tools/hello", "--auto-apply"))
+			out, err := initialized.CombinedOutput(ctx)
+			require.NoError(t, err, out)
+
+			// This distinguishes root-anchoring from rerooting under /work/common.
+			scaffold, err := initialized.File("/work/tools/hello/scaffold.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "hello\n", scaffold)
+			_, err = initialized.File("/work/tools/hello/dagger-module.toml").Contents(ctx)
+			require.NoError(t, err)
+
+			exists, err := initialized.Exists(ctx, "/work/common/tools")
+			require.NoError(t, err)
+			require.False(t, exists, "module init must not reroot explicit paths under the caller cwd")
+		})
+	})
+
+	t.Run("client init scaffolds at the requested path", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"api", "client", "init", "fixture", "common/clients/one", "common/sdk/init-fixture", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		scaffold, err := initialized.File("/work/common/clients/one/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "common/sdk/init-fixture\n", scaffold)
+
+		exists, err := initialized.Exists(ctx, "/work/clients")
+		require.NoError(t, err)
+		require.False(t, exists, "client init must not scaffold outside the requested path")
+	})
+}
+
+// TestInitFromSubdirectoryCwd covers the plainest form of the same mismatch:
+// the workspace config is at the root, where it always has been, and only the
+// caller has moved. Init writes the workspace dagger.toml and the module under
+// the config directory — both above the caller — so it is only expressible
+// against the workspace root, which is also where init exports.
+func (GeneratorsSuite) TestInitFromSubdirectoryCwd(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixture(t, c).
+		WithExec([]string{"mkdir", "-p", "/work/sub"}).
+		WithWorkdir("/work/sub")
+
+	t.Run("module init from below the config directory", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec("module", "init", "fixture", "newmod", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		scaffold, err := initialized.File("/work/.dagger/modules/newmod/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "newmod\n", scaffold)
+		_, err = initialized.File("/work/.dagger/modules/newmod/dagger-module.toml").Contents(ctx)
+		require.NoError(t, err)
+
+		config, err := initialized.File("/work/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `source = ".dagger/modules/newmod"`)
+
+		// Nothing lands under the caller: the cwd-measured reading of these
+		// paths is what used to strip the leading directories.
+		exists, err := initialized.Exists(ctx, "/work/sub/.dagger")
+		require.NoError(t, err)
+		require.False(t, exists, "init must not scaffold under the caller cwd")
+	})
+
+	t.Run("client init from below the config directory", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"api", "client", "init", "fixture", "clients/one", "sdk/init-fixture", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		scaffold, err := initialized.File("/work/clients/one/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "sdk/init-fixture\n", scaffold)
 	})
 }
 

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -802,10 +802,10 @@ func (GeneratorsSuite) TestInitFromSubdirectoryWorkspace(ctx context.Context, t 
 		require.Contains(t, config, `path = "common/.dagger/modules/newmod"`)
 	})
 
-	t.Run("module init honors an explicit workspace-root-relative path", func(ctx context.Context, t *testctx.T) {
-		t.Run("inside caller cwd", func(ctx context.Context, t *testctx.T) {
+	t.Run("module init resolves an explicit --path against the caller", func(ctx context.Context, t *testctx.T) {
+		t.Run("relative to the current directory", func(ctx context.Context, t *testctx.T) {
 			initialized := base.With(daggerExec(
-				"module", "init", "fixture", "hello", "--path", "common/hello", "--auto-apply"))
+				"module", "init", "fixture", "hello", "--path", "hello", "--auto-apply"))
 			out, err := initialized.CombinedOutput(ctx)
 			require.NoError(t, err, out)
 
@@ -815,20 +815,19 @@ func (GeneratorsSuite) TestInitFromSubdirectoryWorkspace(ctx context.Context, t 
 			_, err = initialized.File("/work/common/hello/dagger-module.toml").Contents(ctx)
 			require.NoError(t, err)
 
-			// The pre-fix failure mode: no error, but the SDK's file lands at the
-			// cwd-stripped path while the engine's config stays put.
+			// The engine config and the SDK scaffold land together. Splitting
+			// them across directories is the failure this whole suite is about.
 			exists, err := initialized.Exists(ctx, "/work/hello")
 			require.NoError(t, err)
 			require.False(t, exists, "module init must not split the module across directories")
 		})
 
-		t.Run("outside caller cwd", func(ctx context.Context, t *testctx.T) {
+		t.Run("leading slash means the workspace root", func(ctx context.Context, t *testctx.T) {
 			initialized := base.With(daggerExec(
-				"module", "init", "fixture", "hello", "--path", "tools/hello", "--auto-apply"))
+				"module", "init", "fixture", "hello", "--path", "/tools/hello", "--auto-apply"))
 			out, err := initialized.CombinedOutput(ctx)
 			require.NoError(t, err, out)
 
-			// This distinguishes root-anchoring from rerooting under /work/common.
 			scaffold, err := initialized.File("/work/tools/hello/scaffold.txt").Contents(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "hello\n", scaffold)
@@ -837,13 +836,31 @@ func (GeneratorsSuite) TestInitFromSubdirectoryWorkspace(ctx context.Context, t 
 
 			exists, err := initialized.Exists(ctx, "/work/common/tools")
 			require.NoError(t, err)
-			require.False(t, exists, "module init must not reroot explicit paths under the caller cwd")
+			require.False(t, exists, "a rooted --path must not resolve under the caller")
+		})
+
+		t.Run("climbing out of the current directory", func(ctx context.Context, t *testctx.T) {
+			initialized := base.With(daggerExec(
+				"module", "init", "fixture", "hello", "--path", "../tools/hello", "--auto-apply"))
+			out, err := initialized.CombinedOutput(ctx)
+			require.NoError(t, err, out)
+
+			_, err = initialized.File("/work/tools/hello/dagger-module.toml").Contents(ctx)
+			require.NoError(t, err)
+		})
+
+		t.Run("escaping the workspace root is rejected", func(ctx context.Context, t *testctx.T) {
+			out, err := base.With(daggerExecFail(
+				"module", "init", "fixture", "hello", "--path", "../../escape", "--auto-apply")).
+				CombinedOutput(ctx)
+			require.NoError(t, err)
+			require.Contains(t, out, "must not escape the workspace root")
 		})
 	})
 
-	t.Run("client init scaffolds at the requested path", func(ctx context.Context, t *testctx.T) {
+	t.Run("client init resolves its path against the caller", func(ctx context.Context, t *testctx.T) {
 		initialized := base.With(daggerExec(
-			"api", "client", "init", "fixture", "common/clients/one", "common/sdk/init-fixture", "--auto-apply"))
+			"api", "client", "init", "fixture", "clients/one", "common/sdk/init-fixture", "--auto-apply"))
 		out, err := initialized.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 
@@ -896,9 +913,26 @@ func (GeneratorsSuite) TestInitFromSubdirectoryCwd(ctx context.Context, t *testc
 		out, err := initialized.CombinedOutput(ctx)
 		require.NoError(t, err, out)
 
+		// Relative to the caller, so it lands under sub/ even though the
+		// dagger.toml it edits is a directory above.
+		scaffold, err := initialized.File("/work/sub/clients/one/scaffold.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "sdk/init-fixture\n", scaffold)
+	})
+
+	t.Run("client init with a rooted path", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"api", "client", "init", "fixture", "/clients/one", "sdk/init-fixture", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
 		scaffold, err := initialized.File("/work/clients/one/scaffold.txt").Contents(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "sdk/init-fixture\n", scaffold)
+
+		exists, err := initialized.Exists(ctx, "/work/sub/clients")
+		require.NoError(t, err)
+		require.False(t, exists, "a rooted client path must not resolve under the caller")
 	})
 }
 

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -248,7 +248,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("name").Doc("Name of the new module."),
 				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name to use."),
-				dagql.Arg("path").Doc(`Workspace-relative path for the new module.`),
+				dagql.Arg("path").Doc(`Path for the new module, relative to the workspace cwd; a leading "/" is relative to the workspace root. Defaults to .dagger/modules/<name> beside the workspace config.`),
 				dagql.Arg("source").Doc("Source subpath within the new module."),
 				dagql.Arg("include").Doc("Additional include patterns for the module."),
 				dagql.Arg("args").Doc("SDK-specific init arguments."),
@@ -260,7 +260,7 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			Doc("Return this workspace with a generated API client initialized.",
 				"The SDK's generators run for the new client, so the returned workspace carries its generated bindings.").
 			Args(
-				dagql.Arg("path").Doc("Workspace-relative output directory for the generated client."),
+				dagql.Arg("path").Doc(`Output directory for the generated client, relative to the workspace cwd; a leading "/" is relative to the workspace root.`),
 				dagql.Arg("sdk").Doc("Workspace SDK name or module entry name to use."),
 				dagql.Arg("module").Doc("Workspace-relative path or canonical ref for the module the client binds to."),
 				dagql.Arg("args").Doc("SDK-specific init arguments."),

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -132,7 +132,11 @@ func (s *workspaceSchema) initClientChanges(
 	if !ok {
 		return res, scope, fmt.Errorf("%q does not support client init", args.SDK)
 	}
-	sdkChanges, err := clientInitializer.InitClient(ctx, parent, clientPath, moduleRef, sdkArgs)
+	sdkWorkspace, err := rootAnchoredWorkspace(ctx, parent)
+	if err != nil {
+		return res, scope, err
+	}
+	sdkChanges, err := clientInitializer.InitClient(ctx, sdkWorkspace, clientPath, moduleRef, sdkArgs)
 	if err != nil {
 		return res, scope, fmt.Errorf("sdk client init: %w", err)
 	}

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -47,7 +47,7 @@ func (s *workspaceSchema) initClientChanges(
 		return res, scope, fmt.Errorf("module ref is required")
 	}
 
-	clientPath, err := cleanWorkspaceClientPath(args.Path)
+	clientPath, err := resolveWorkspaceClientPath(args.Path, ws.Cwd)
 	if err != nil {
 		return res, scope, err
 	}
@@ -195,18 +195,20 @@ func (s *workspaceSchema) resolveClientTargetModule(
 	return src, nil
 }
 
-func cleanWorkspaceClientPath(path string) (string, error) {
-	cleaned := filepath.Clean(path)
-	if cleaned == "." || cleaned == string(filepath.Separator) {
+// resolveWorkspaceClientPath resolves the client's output directory the way
+// module init resolves --path, and every other workspace path a user types:
+// relative to where they are standing, with a leading "/" meaning the
+// workspace root. The result is workspace-root-relative, which is what the
+// as-sdk client entry records and what generation is scoped to.
+func resolveWorkspaceClientPath(pathArg, cwd string) (string, error) {
+	resolved, err := resolveWorkspacePath(pathArg, cwd)
+	if err != nil {
+		return "", fmt.Errorf("client path %q must not escape the workspace root", pathArg)
+	}
+	if resolved == "." {
 		return "", fmt.Errorf("client path must point to a directory below the workspace root")
 	}
-	if filepath.IsAbs(cleaned) {
-		return "", fmt.Errorf("client path %q must be workspace-relative, not absolute", path)
-	}
-	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("client path %q must not escape the workspace root", path)
-	}
-	return cleaned, nil
+	return resolved, nil
 }
 
 func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref string) (configRef string, loadRef string, _ error) {

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -186,7 +186,11 @@ func (s *workspaceSchema) initModuleChanges(
 	if !ok {
 		return res, scope, fmt.Errorf("%q does not support module init", args.SDK)
 	}
-	sdkChanges, err := moduleInitializer.InitModule(ctx, parent, args.Name, relPath, sdkArgs)
+	sdkWorkspace, err := rootAnchoredWorkspace(ctx, parent)
+	if err != nil {
+		return res, scope, err
+	}
+	sdkChanges, err := moduleInitializer.InitModule(ctx, sdkWorkspace, args.Name, relPath, sdkArgs)
 	if err != nil {
 		return res, scope, fmt.Errorf("sdk module init: %w", err)
 	}

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -60,16 +60,19 @@ func (s *workspaceSchema) initModuleChanges(
 		return res, scope, fmt.Errorf("SDK name is required")
 	}
 
-	// --path is workspace-root-relative. Validate it before reading the config
-	// so a bad path is reported as a bad path, not as whatever else the
-	// workspace's dagger.toml turns out to be missing or malformed about.
-	relPath := filepath.Clean(args.Path)
+	// --path reads like every other workspace path a user types: relative to
+	// where they are standing, with a leading "/" meaning the workspace root
+	// (resolveWorkspacePath, the same resolver `dagger install` uses for a
+	// local ref). Everything downstream of here is workspace-root-relative.
+	// Resolved before the config is read so a bad path is reported as a bad
+	// path, not as whatever else the workspace's dagger.toml turns out to be
+	// missing or malformed about.
+	var relPath string
 	usingDefaultPath := args.Path == ""
 	if !usingDefaultPath {
-		if filepath.IsAbs(relPath) {
-			return res, scope, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
-		}
-		if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		var err error
+		relPath, err = resolveWorkspacePath(args.Path, ws.Cwd)
+		if err != nil {
 			return res, scope, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
 		}
 	}

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -60,25 +60,36 @@ func (s *workspaceSchema) initModuleChanges(
 		return res, scope, fmt.Errorf("SDK name is required")
 	}
 
-	// Resolve the workspace-relative path for the new module. Empty = default
-	// layout; we treat that as the signal to auto-install in [modules.*].
-	relPath := args.Path
-	usingDefaultPath := relPath == ""
-	if usingDefaultPath {
-		relPath = filepath.Join(".dagger", "modules", args.Name)
-	}
-	relPath = filepath.Clean(relPath)
-	if filepath.IsAbs(relPath) {
-		return res, scope, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
-	}
-	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
-		return res, scope, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
+	// --path is workspace-root-relative. Validate it before reading the config
+	// so a bad path is reported as a bad path, not as whatever else the
+	// workspace's dagger.toml turns out to be missing or malformed about.
+	relPath := filepath.Clean(args.Path)
+	usingDefaultPath := args.Path == ""
+	if !usingDefaultPath {
+		if filepath.IsAbs(relPath) {
+			return res, scope, fmt.Errorf("--path %q must be workspace-relative, not absolute", args.Path)
+		}
+		if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+			return res, scope, fmt.Errorf("--path %q must not escape the workspace root", args.Path)
+		}
 	}
 
 	staged, err := s.loadWorkspaceConfigForOverlay(ctx, ws, workspaceConfigMustExist, args.Here)
 	if err != nil {
 		return res, scope, err
 	}
+
+	// An empty --path means the default layout, which is also the signal to
+	// auto-install in [modules.*]. The default is anchored at the directory
+	// holding the dagger.toml being edited, not at the workspace root: a config
+	// in a subdirectory records module sources relative to itself, so
+	// scaffolding anywhere else would write an entry pointing outside its own
+	// project. ConfigDir is already a clean path inside the root, so the join
+	// cannot escape.
+	if usingDefaultPath {
+		relPath = filepath.Join(staged.ConfigDir, ".dagger", "modules", args.Name)
+	}
+
 	cfg := staged.Config
 	sdkName, sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
@@ -128,7 +139,14 @@ func (s *workspaceSchema) initModuleChanges(
 	}
 
 	if usingDefaultPath {
-		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: relPath}
+		// [modules.<name>].source is resolved against the config directory,
+		// while relPath is workspace-root-relative — same convention split
+		// `dagger install` handles when it records a local ref.
+		configSource, err := filepath.Rel(staged.ConfigDir, relPath)
+		if err != nil {
+			return res, scope, fmt.Errorf("resolve module source %q from %q: %w", relPath, staged.ConfigDir, err)
+		}
+		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: filepath.ToSlash(configSource)}
 	}
 
 	// Render new dagger.toml bytes through the format-preserving editor.

--- a/core/schema/workspace_sdk_init.go
+++ b/core/schema/workspace_sdk_init.go
@@ -57,6 +57,42 @@ func (s *workspaceSchema) loadWorkspaceSDK(
 	return loaded, nil
 }
 
+// rootAnchoredWorkspace returns ws with its cwd at the workspace root.
+//
+// An SDK's initModule/initClient stages its files relative to Workspace.cwd,
+// because a changeset returned from a plain function call is applied wherever
+// the client is standing. Init changesets are not: they are merged into the
+// workspace overlay and exported at the workspace root (Workspace.export writes
+// to ExportHostPath), against paths the engine resolved root-relative. Handing
+// the SDK the caller's cwd makes those two conventions disagree the moment the
+// caller is not at the root — the SDK either strips the cwd prefix and scatters
+// its files (engine config in one place, sources in another) or refuses a path
+// that lies outside the cwd altogether. Anchoring at the root is what makes the
+// cwd the SDK sees match where the changeset actually lands.
+func rootAnchoredWorkspace(
+	ctx context.Context,
+	ws dagql.ObjectResult[*core.Workspace],
+) (dagql.ObjectResult[*core.Workspace], error) {
+	if ws.Self() == nil || cleanWorkspaceRelPath(ws.Self().Cwd) == "." {
+		return ws, nil
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return ws, fmt.Errorf("dagql server: %w", err)
+	}
+	// Built through withWorkdir rather than a bare clone so the result stays an
+	// attached dagql result whose ID resolves when the SDK passes it back
+	// (see scopedStagedWorkspace).
+	var rooted dagql.ObjectResult[*core.Workspace]
+	if err := srv.Select(ctx, ws, &rooted, dagql.Selector{
+		Field: "withWorkdir",
+		Args:  []dagql.NamedInput{{Name: "path", Value: dagql.String(".")}},
+	}); err != nil {
+		return ws, fmt.Errorf("anchor workspace at root: %w", err)
+	}
+	return rooted, nil
+}
+
 func mergeWorkspaceInitChangeset(ctx context.Context, base dagql.ObjectResult[*core.Changeset], sdkChanges dagql.ObjectResult[*core.Changeset]) (dagql.ObjectResult[*core.Changeset], error) {
 	if sdkChanges.Self() == nil {
 		return base, nil

--- a/docs/current_docs/extending/sdks/go.mdx
+++ b/docs/current_docs/extending/sdks/go.mdx
@@ -47,19 +47,23 @@ If the repository does not have a `dagger.toml` yet, use `dagger sdk install --h
 
 ### Where the module is created
 
-By default, `dagger module init` places the new module under the workspace root:
+By default, `dagger module init` places the new module beside the `dagger.toml`
+it is editing:
 
 ```
-<workspace>/.dagger/modules/<name>
+<dagger.toml directory>/.dagger/modules/<name>
 ```
 
-Pass `--path` to choose a different location (the target must not already contain a Dagger module):
+That is the workspace root unless the config lives in a subdirectory, as it does
+when several projects share one repository.
+
+Pass `--path` to choose a different workspace-root-relative location (the target must not already contain a Dagger module). The workspace root is the git root, not the shell's current directory; from any subdirectory, `--path ci` means `<workspace>/ci`.
 
 ```shell
-dagger module init go my-module --path ./ci
+dagger module init go my-module --path ci
 ```
 
-A custom path is registered as a module authored by the SDK, but is not automatically installed as a callable workspace module. Use `dagger install ./ci` to install it too.
+A custom path is registered as a module authored by the SDK, but is not automatically installed as a callable workspace module. Use `dagger install ./ci` from the workspace root to install it too.
 
 Pass `--legacy-template` to use the Go SDK's legacy starter instead of its default minimal `main.go`:
 

--- a/docs/current_docs/extending/sdks/go.mdx
+++ b/docs/current_docs/extending/sdks/go.mdx
@@ -57,13 +57,14 @@ it is editing:
 That is the workspace root unless the config lives in a subdirectory, as it does
 when several projects share one repository.
 
-Pass `--path` to choose a different workspace-root-relative location (the target must not already contain a Dagger module). The workspace root is the git root, not the shell's current directory; from any subdirectory, `--path ci` means `<workspace>/ci`.
+Pass `--path` to choose a different location (the target must not already contain a Dagger module). It is relative to your current directory, like any other path you type; a leading `/` means the workspace root.
 
 ```shell
-dagger module init go my-module --path ci
+dagger module init go my-module --path ci     # ./ci
+dagger module init go my-module --path /ci    # <workspace root>/ci
 ```
 
-A custom path is registered as a module authored by the SDK, but is not automatically installed as a callable workspace module. Use `dagger install ./ci` from the workspace root to install it too.
+A custom path is registered as a module authored by the SDK, but is not automatically installed as a callable workspace module. Use `dagger install ./ci` to install it too.
 
 Pass `--legacy-template` to use the Go SDK's legacy starter instead of its default minimal `main.go`:
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -285,6 +285,9 @@ Initialize a generated API client
 
 Initialize a generated API client at &lt;path&gt;.
 
+&lt;path&gt; is relative to the current directory; a leading "/" means the workspace
+root.
+
 &lt;sdk&gt; is an SDK installed in this workspace. Run `dagger sdk install <sdk>`
 to add more choices.
 
@@ -2248,10 +2251,10 @@ What the engine does (atomically, in one Changeset):
      skip this.
 
 When --path is omitted, the module is created under .dagger/modules/&lt;name&gt;
-beside the dagger.toml being edited (workspace-root-relative as
-&lt;dagger.toml dir&gt;/.dagger/modules/&lt;name&gt;). Custom paths are
-workspace-root-relative and skip the [modules.&lt;name&gt;] install (the user is
-managing workspace layout explicitly).
+beside the dagger.toml being edited. Pass --path to choose a location: it is
+relative to the current directory, and a leading "/" means the workspace
+root. A custom path skips the [modules.&lt;name&gt;] install (the user is managing
+workspace layout explicitly).
 
 ```
 dagger module init <sdk> <name> [flags]
@@ -2267,7 +2270,7 @@ dagger sdk install go && dagger module init go my-module
 
 ```
       --no-generate   Skip running the SDK's generators for the new module
-      --path string   Workspace-root-relative module path (default: <dagger.toml dir>/.dagger/modules/<name>)
+      --path string   Module path, relative to the current directory ("/" = workspace root; default: .dagger/modules/<name> beside dagger.toml)
 ```
 
 ### Options inherited from parent commands

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2241,15 +2241,17 @@ What the engine does (atomically, in one Changeset):
      scaffold at &lt;path&gt;.
   3. Records [[modules.&lt;sdk-module&gt;.as-sdk.modules]] authoring entry for
      &lt;path&gt;.
-  4. When --path is the default (.dagger/modules/&lt;name&gt;), also installs
-     the new module as [modules.&lt;name&gt;] so it's callable here.
+  4. When --path is omitted, also installs the new module as
+     [modules.&lt;name&gt;] so it's callable here.
   5. Runs the SDK's generators scoped to &lt;path&gt;, so the new module is
      loadable without a separate 'dagger generate'. Pass --no-generate to
      skip this.
 
---path defaults to .dagger/modules/&lt;name&gt;. Custom paths skip the
-[modules.&lt;name&gt;] install (the user is managing workspace layout
-explicitly).
+When --path is omitted, the module is created under .dagger/modules/&lt;name&gt;
+beside the dagger.toml being edited (workspace-root-relative as
+&lt;dagger.toml dir&gt;/.dagger/modules/&lt;name&gt;). Custom paths are
+workspace-root-relative and skip the [modules.&lt;name&gt;] install (the user is
+managing workspace layout explicitly).
 
 ```
 dagger module init <sdk> <name> [flags]
@@ -2265,7 +2267,7 @@ dagger sdk install go && dagger module init go my-module
 
 ```
       --no-generate   Skip running the SDK's generators for the new module
-      --path string   Module path relative to the workspace root (default: .dagger/modules/<name>)
+      --path string   Workspace-root-relative module path (default: <dagger.toml dir>/.dagger/modules/<name>)
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5917,7 +5917,10 @@ type Workspace implements Node {
   The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
   """
   withInitClient(
-    """Workspace-relative output directory for the generated client."""
+    """
+    Output directory for the generated client, relative to the workspace cwd; a
+    leading "/" is relative to the workspace root.
+    """
     path: String!
 
     """Workspace SDK name or module entry name to use."""
@@ -5950,7 +5953,11 @@ type Workspace implements Node {
     """Workspace SDK name or module entry name to use."""
     sdk: String!
 
-    """Workspace-relative path for the new module."""
+    """
+    Path for the new module, relative to the workspace cwd; a leading "/" is
+    relative to the workspace root. Defaults to .dagger/modules/<name> beside
+    the workspace config.
+    """
     path: String = ""
 
     """Source subpath within the new module."""

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -84,7 +84,10 @@ func runAPIClientInitWithSDK(cmd *cobra.Command, sdkName, clientPath, moduleRef 
 			opts.Args = dagger.JSON(sdkArgs)
 		}
 		current := dag.CurrentWorkspace()
-		updated := current.WithInitClient(clientPath, sdkName, moduleRef, opts)
+		// Root-measured for the same reason as module init: the workspace
+		// config this edits can sit above the caller, and the apply happens
+		// at the workspace root.
+		updated := current.WithInitClient(clientPath, sdkName, moduleRef, opts).WithWorkdir(".")
 		_, err = handleWorkspaceResponse(ctx, dag, current, updated, autoApply)
 		return err
 	})

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -33,6 +33,9 @@ var apiClientInitCmd = &cobra.Command{
 	Short: "Initialize a generated API client",
 	Long: `Initialize a generated API client at <path>.
 
+<path> is relative to the current directory; a leading "/" means the workspace
+root.
+
 <sdk> is an SDK installed in this workspace. Run ` + "`dagger sdk install <sdk>`" + `
 to add more choices.
 

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -187,7 +187,11 @@ func runModuleInitWithSDK(cmd *cobra.Command, sdkName, name string) error {
 			opts.Args = dagger.JSON(sdkArgs)
 		}
 		current := dag.CurrentWorkspace()
-		updated := current.WithInitModule(name, sdkName, opts)
+		// Init edits the workspace config and scaffolds beside it, both of
+		// which can sit above the caller, and it exports at the workspace
+		// root. Read the diff from the root so changes() takes them in --
+		// same reason `dagger setup` does this for migration.
+		updated := current.WithInitModule(name, sdkName, opts).WithWorkdir(".")
 		_, err = handleWorkspaceResponse(ctx, dag, current, updated, autoApply)
 		return err
 	})

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -151,10 +151,10 @@ What the engine does (atomically, in one Changeset):
      skip this.
 
 When --path is omitted, the module is created under .dagger/modules/<name>
-beside the dagger.toml being edited (workspace-root-relative as
-<dagger.toml dir>/.dagger/modules/<name>). Custom paths are
-workspace-root-relative and skip the [modules.<name>] install (the user is
-managing workspace layout explicitly).`,
+beside the dagger.toml being edited. Pass --path to choose a location: it is
+relative to the current directory, and a leading "/" means the workspace
+root. A custom path skips the [modules.<name>] install (the user is managing
+workspace layout explicitly).`,
 	Example: "dagger sdk install go && dagger module init go my-module",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -163,7 +163,7 @@ managing workspace layout explicitly).`,
 }
 
 func init() {
-	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Workspace-root-relative module path (default: <dagger.toml dir>/.dagger/modules/<name>)")
+	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Module path, relative to the current directory (\"/\" = workspace root; default: .dagger/modules/<name> beside dagger.toml)")
 	moduleInitCmd.PersistentFlags().BoolVar(&moduleInitNoGenerate, "no-generate", false, "Skip running the SDK's generators for the new module")
 	moduleCmd.AddCommand(moduleInitCmd)
 }

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -144,15 +144,17 @@ What the engine does (atomically, in one Changeset):
      scaffold at <path>.
   3. Records [[modules.<sdk-module>.as-sdk.modules]] authoring entry for
      <path>.
-  4. When --path is the default (.dagger/modules/<name>), also installs
-     the new module as [modules.<name>] so it's callable here.
+  4. When --path is omitted, also installs the new module as
+     [modules.<name>] so it's callable here.
   5. Runs the SDK's generators scoped to <path>, so the new module is
      loadable without a separate 'dagger generate'. Pass --no-generate to
      skip this.
 
---path defaults to .dagger/modules/<name>. Custom paths skip the
-[modules.<name>] install (the user is managing workspace layout
-explicitly).`,
+When --path is omitted, the module is created under .dagger/modules/<name>
+beside the dagger.toml being edited (workspace-root-relative as
+<dagger.toml dir>/.dagger/modules/<name>). Custom paths are
+workspace-root-relative and skip the [modules.<name>] install (the user is
+managing workspace layout explicitly).`,
 	Example: "dagger sdk install go && dagger module init go my-module",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -161,7 +163,7 @@ explicitly).`,
 }
 
 func init() {
-	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Module path relative to the workspace root (default: .dagger/modules/<name>)")
+	moduleInitCmd.PersistentFlags().StringVar(&moduleInitPath, "path", "", "Workspace-root-relative module path (default: <dagger.toml dir>/.dagger/modules/<name>)")
 	moduleInitCmd.PersistentFlags().BoolVar(&moduleInitNoGenerate, "no-generate", false, "Skip running the SDK's generators for the new module")
 	moduleCmd.AddCommand(moduleInitCmd)
 }

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16788,7 +16788,7 @@ func (r *Workspace) WithInitClient(path string, sdk string, module string, opts 
 
 // WorkspaceWithInitModuleOpts contains options for Workspace.WithInitModule
 type WorkspaceWithInitModuleOpts struct {
-	// Workspace-relative path for the new module.
+	// Path for the new module, relative to the workspace cwd; a leading "/" is relative to the workspace root. Defaults to .dagger/modules/<name> beside the workspace config.
 	Path string
 	// Source subpath within the new module.
 	Source string

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15683,7 +15683,8 @@ class Workspace(Type):
         Parameters
         ----------
         path:
-            Workspace-relative output directory for the generated client.
+            Output directory for the generated client, relative to the
+            workspace cwd; a leading "/" is relative to the workspace root.
         sdk:
             Workspace SDK name or module entry name to use.
         module:
@@ -15731,7 +15732,9 @@ class Workspace(Type):
         sdk:
             Workspace SDK name or module entry name to use.
         path:
-            Workspace-relative path for the new module.
+            Path for the new module, relative to the workspace cwd; a leading
+            "/" is relative to the workspace root. Defaults to
+            .dagger/modules/<name> beside the workspace config.
         source:
             Source subpath within the new module.
         include:

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -15213,7 +15213,7 @@ pub struct WorkspaceWithInitModuleOpts<'a> {
     /// Skip running the SDK's generators for the new module.
     #[builder(setter(into, strip_option), default)]
     pub no_generate: Option<bool>,
-    /// Workspace-relative path for the new module.
+    /// Path for the new module, relative to the workspace cwd; a leading "/" is relative to the workspace root. Defaults to .dagger/modules/<name> beside the workspace config.
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
     /// Source subpath within the new module.
@@ -15974,7 +15974,7 @@ impl Workspace {
     ///
     /// # Arguments
     ///
-    /// * `path` - Workspace-relative output directory for the generated client.
+    /// * `path` - Output directory for the generated client, relative to the workspace cwd; a leading "/" is relative to the workspace root.
     /// * `sdk` - Workspace SDK name or module entry name to use.
     /// * `module` - Workspace-relative path or canonical ref for the module the client binds to.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -15999,7 +15999,7 @@ impl Workspace {
     ///
     /// # Arguments
     ///
-    /// * `path` - Workspace-relative output directory for the generated client.
+    /// * `path` - Output directory for the generated client, relative to the workspace cwd; a leading "/" is relative to the workspace root.
     /// * `sdk` - Workspace SDK name or module entry name to use.
     /// * `module` - Workspace-relative path or canonical ref for the module the client binds to.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3291,7 +3291,7 @@ export type WorkspaceWithInitClientOpts = {
 
 export type WorkspaceWithInitModuleOpts = {
   /**
-   * Workspace-relative path for the new module.
+   * Path for the new module, relative to the workspace cwd; a leading "/" is relative to the workspace root. Defaults to .dagger/modules/<name> beside the workspace config.
    */
   path?: string
 
@@ -15456,7 +15456,7 @@ export class Workspace extends BaseClient {
    * Return this workspace with a generated API client initialized.
    *
    * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
-   * @param path Workspace-relative output directory for the generated client.
+   * @param path Output directory for the generated client, relative to the workspace cwd; a leading "/" is relative to the workspace root.
    * @param sdk Workspace SDK name or module entry name to use.
    * @param module Workspace-relative path or canonical ref for the module the client binds to.
    * @param opts.args SDK-specific init arguments.
@@ -15484,7 +15484,7 @@ export class Workspace extends BaseClient {
    * The SDK's generators run for the new module, so the returned workspace carries the generated code it needs to be loadable.
    * @param name Name of the new module.
    * @param sdk Workspace SDK name or module entry name to use.
-   * @param opts.path Workspace-relative path for the new module.
+   * @param opts.path Path for the new module, relative to the workspace cwd; a leading "/" is relative to the workspace root. Defaults to .dagger/modules/<name> beside the workspace config.
    * @param opts.source Source subpath within the new module.
    * @param opts.include Additional include patterns for the module.
    * @param opts.args SDK-specific init arguments.


### PR DESCRIPTION
Fixes #13889.

`dagger module init` misplaces or rejects files whenever you run it from
anywhere other than the workspace root. Three fixes here, all in the same
corner of init; they're separate commits and can be read independently.

## 1. Init is anchored at the workspace root

Init writes files the caller doesn't own — the workspace `dagger.toml`, the new
module's `dagger-module.toml`, and whatever the SDK scaffolds — then exports
them itself at the workspace root (`Workspace.export` writes to
`ExportHostPath`). Two things were measured from the caller's cwd instead.

**The SDK** stages its files relative to `Workspace.cwd`, because a changeset
returned from an ordinary function call is applied wherever the client stands.
Handed the caller's workspace, it strips the cwd prefix, so the module comes out
split — engine config in one directory, sources in another:

```console
$ cd subdir && dagger module init go my-module --path subdir/plop
dagger.toml                    +2
plop/main.go                   +34     ← SDK, cwd-stripped
subdir/plop/dagger-module.toml +5      ← engine, root-relative
```

**`Workspace.changes`** re-roots to the caller's cwd for the same reason, so the
workspace init hands back can't describe its own edits from a subdirectory — the
workspace `dagger.toml` sits above the caller and has no cwd-relative spelling:

```console
$ cd subdir && dagger module init go my-module
Error: changes fall outside the current directory "subdir": ..., dagger.toml
```

Both are now anchored at the root: the SDK gets a workspace whose cwd matches
where its changeset lands, and the workspace init returns measures its changes
from the same place it exports them. Nothing changes for changesets that really
are applied at the caller's cwd — `dagger generate` included — and neither the
polyfill nor any SDK is touched.

Note this is not specific to a `dagger.toml` in a subdirectory. A config at the
repo root with the caller one directory down hits it identically; a subdirectory
config just guarantees it, since the workspace root is the git root.

## 2. The default module path follows its `dagger.toml`

`.dagger/modules/<name>` was joined against the workspace root, but
`[modules.<name>].source` is resolved against the config directory. With a
config in a subdirectory those disagree, and init would record an entry pointing
outside its own project. The default is now `<config dir>/.dagger/modules/<name>`,
with the recorded source made config-dir-relative — the same conversion
`dagger install` already does for a local ref. Nothing changes for a workspace
whose config is at the root.

## 3. Init paths are resolved against the caller

`module init --path` and `api client init <path>` were workspace-root-relative,
while every other path you type at the workspace — `Workspace.directory`,
`Workspace.file`, a local ref given to `dagger install` — is relative to where
you are standing, with a leading `/` meaning the workspace root. From a
subdirectory that made `--path ci` mean `<root>/ci` rather than `./ci`,
silently, and left no spelling for the root at all.

Both now go through `resolveWorkspacePath`, the resolver `dagger install`
already uses:

```console
dagger module init go my-module --path ci      # ./ci
dagger module init go my-module --path /ci     # <workspace root>/ci
dagger module init go my-module --path ../ci   # climbs, still inside the root
```

Everything downstream still sees a workspace-root-relative path. Escaping the
root is still rejected, as is a client path resolving to the root itself.

This is a behaviour change for anyone passing these paths from a subdirectory.
At the workspace root, where cwd and root coincide, nothing moves.

## Tests

`TestInitFromSubdirectoryWorkspace` and `TestInitFromSubdirectoryCwd` cover the
two ways a caller ends up below the workspace root — a subdirectory config, and
a root config with the caller in a subdirectory — for module init, client init,
and `--path` resolved relatively, rooted with a leading `/`, climbing with
`..`, and rejected when it escapes the workspace.

The fixture SDK now mirrors the polyfill's cwd rebasing, so it reproduces the
real failure rather than a synthetic one.
