### PR TITLE
ci: unpin helm from the retired wolfi helm 3.x package

### DIFF
--- a/.dagger/modules/release/helm.go
+++ b/.dagger/modules/release/helm.go
@@ -23,7 +23,7 @@ func (r *Release) helmChart() *dagger.Container {
 	return dag.Wolfi().
 		Container(dagger.WolfiContainerOpts{
 			Packages: []string{
-				"helm~3.18.4",
+				"helm-3~3.19.2",
 			},
 		}).
 		WithDirectory("/dagger-helm", r.helmChartSource()).

--- a/dagger.toml
+++ b/dagger.toml
@@ -50,6 +50,13 @@ test = "e2e/**"
 source = "github.com/dagger/helm@d0a7e172e8212b31c6061bb699495b1e8ba0958f"
 legacy-default-path = true
 
+[modules.helm.settings]
+# The module installs the wolfi `helm` package as `helm~<version>`, and that
+# package moved to the 4.x line, so 3.x versions no longer resolve. Charts are
+# still packaged with helm 3 (see .dagger/modules/release/helm.go); revisit once
+# the module can select the `helm-3` package.
+version = "4.0.1"
+
 [modules.java-client]
 source = ".dagger/modules/java-client-dev"
 legacy-default-path = true

--- a/docs/current_docs/modules/helm.mdx
+++ b/docs/current_docs/modules/helm.mdx
@@ -32,11 +32,11 @@ The module discovers charts by finding every `Chart.yaml` in the workspace and t
 
 List the current settings and their values with `dagger settings helm`, then set one with `dagger settings helm <key> <value>`. Settings are stored in `dagger.toml` under `[modules.helm.settings]`:
 
-- **`version`** (default `3.18.4`): the Helm version used for `lint` and `template`. Pin it so local runs and CI use the same Helm release.
+- **`version`** (default `3.18.4`): the Helm version used for `lint` and `template`. Pin it so local runs and CI use the same Helm release. The module resolves it as the Wolfi `helm~<version>` package, which now tracks the 4.x line, so 3.x versions no longer resolve.
 - **`valuesGlob`** (default `ci/*-values.yaml`): a glob, relative to each chart root, that selects the values files to check. Every matching file becomes a separate scenario in both `lint` and `assert-template`. The default follows Helm chart-testing's CI convention, so files like `ci/prod-values.yaml` are picked up automatically.
 
 ```bash
-dagger settings helm version 3.18.4
+dagger settings helm version 4.0.1
 dagger settings helm valuesGlob "ci/*-values.yaml"
 ```
 

--- a/e2e/helm/helm_test.go
+++ b/e2e/helm/helm_test.go
@@ -220,7 +220,7 @@ func helmContainer(dag *dagger.Client) *dagger.Container {
 
 	return dag.Container().
 		From(helmImage).
-		WithExec([]string{"apk", "add", "--no-cache", "helm~3.18.4", "kubectl"}).
+		WithExec([]string{"apk", "add", "--no-cache", "helm-3~3.19.2", "kubectl"}).
 		WithDirectory("/dagger-helm", chart).
 		WithWorkdir("/dagger-helm")
 }


### PR DESCRIPTION
> [!NOTE]
> This unblocks CI repo-wide. `main` and every open PR are currently red. Chainguard moved the wolfi `helm` apk package to the 4.x line, so every `helm~3.18.4` constraint fails to resolve:

```
ERROR: unable to select packages:
  helm-4-4.2.3-r1:
    breaks: world[helm~3.18.4]
```

That breaks `ci:bootstrap`, `golang:test-all` (via `e2e/helm`), `helm:lint` and `helm:assert-template`. No repo code is at fault — reproduced with a bare `apk add`. Available wolfi packages are now `helm-4.0.1-r0` (bare `helm`), `helm-3-3.19.2-r2`, `helm-4-4.2.3-r1`.

## Fix

- The paths that **package/ship** our chart move to the versioned package so they stay on Helm 3: `helm~3.18.4` → `helm-3~3.19.2` in `.dagger/modules/release/helm.go` and `e2e/helm/helm_test.go`.
- `helm:lint` / `helm:assert-template` don't come from those pins — they come from the external `github.com/dagger/helm` module, which hardcodes `apk add "helm~" + version`, so 3.x is unselectable there without an upstream change. Its `[modules.helm.settings] version` is set to `4.0.1` (verified it lints/templates our chart fine).

Follow-up (not this PR): teach `github.com/dagger/helm` to select the `helm-3` package so the checker can go back to 3.x.

## Verified locally (dev engine)

- `helm lint` and `helm assert-template` → PASS (were ERROR).
- `e2e/helm`: `TestCustomProbes`, `TestPackageDryRun`, `TestInstallK3S` (all 4 subtests: default/port daemonset, default/port statefulset) → PASS.
- `helm-3~3.19.2` install → `helm version` v3.19.2; `helm package .` → `dagger-helm-1.0.0-beta.10.tgz` OK.

`docs/versioned_docs/version-0.21.7/modules/helm.mdx` still references `3.18.4` and is left untouched — versioned docs are frozen snapshots.
