### PR TITLE
fix(workspace): record as-sdk paths relative to the dagger.toml holding them

### DIFF
--- a/.changes/unreleased/Changed-20260819-100500.yaml
+++ b/.changes/unreleased/Changed-20260819-100500.yaml
@@ -2,15 +2,16 @@ kind: Changed
 body: |
   `dagger.toml` now records every path the same way: the `path` of an
   `[[modules.<sdk>.as-sdk.modules]]` or `[[modules.<sdk>.as-sdk.clients]]`
-  entry — and a local client `module` ref — resolves like `[modules.<name>].source`
-  and like an `[[include]]`: a leading `/` anchors at the workspace root,
-  anything else is relative to the directory holding that `dagger.toml`, and
-  escaping the root is refused. They used to be workspace-root-relative
-  whatever they looked like, so a config in a subdirectory spelled the same
-  module two different ways in the same file. Configs at the workspace root,
-  where the two anchors coincide, are unaffected; a `dagger.toml` in a
-  subdirectory written by an earlier version needs its as-sdk paths rewritten
-  relative to itself (or given a leading `/`).
+  entry — and a local client `module` ref — is relative to the directory
+  holding that `dagger.toml`, exactly like `[modules.<name>].source`. A leading
+  `/` anchors at the workspace root, as it does for an `[[include]]` (unlike a
+  `source`, where it still names an absolute filesystem path), and escaping the
+  root is refused. These entries used to be workspace-root-relative whatever
+  they looked like, so a config in a subdirectory spelled the same module two
+  different ways in the same file. Configs at the workspace root, where the two
+  anchors coincide, are unaffected; a `dagger.toml` in a subdirectory written by
+  an earlier version needs its as-sdk paths rewritten relative to itself (or
+  given a leading `/`).
 time: 2026-08-19T10:05:00Z
 custom:
   Author: eunomie

--- a/.changes/unreleased/Changed-20260819-100500.yaml
+++ b/.changes/unreleased/Changed-20260819-100500.yaml
@@ -1,0 +1,17 @@
+kind: Changed
+body: |
+  `dagger.toml` now records every path the same way: the `path` of an
+  `[[modules.<sdk>.as-sdk.modules]]` or `[[modules.<sdk>.as-sdk.clients]]`
+  entry — and a local client `module` ref — resolves like `[modules.<name>].source`
+  and like an `[[include]]`: a leading `/` anchors at the workspace root,
+  anything else is relative to the directory holding that `dagger.toml`, and
+  escaping the root is refused. They used to be workspace-root-relative
+  whatever they looked like, so a config in a subdirectory spelled the same
+  module two different ways in the same file. Configs at the workspace root,
+  where the two anchors coincide, are unaffected; a `dagger.toml` in a
+  subdirectory written by an earlier version needs its as-sdk paths rewritten
+  relative to itself (or given a leading `/`).
+time: 2026-08-19T10:05:00Z
+custom:
+  Author: eunomie
+  PR: "13892"

--- a/.changes/unreleased/Fixed-20260819-124500.yaml
+++ b/.changes/unreleased/Fixed-20260819-124500.yaml
@@ -1,0 +1,20 @@
+kind: Fixed
+body: |
+  A local module ref carrying a dot outside its first path segment — the shape a
+  workspace-relative ref takes from a monorepo subdirectory, like
+  `common/.dagger/mymod` — is no longer mistaken for a git ref. `dagger api
+  client init go clients/api common/.dagger/mymod` failed with `local path
+  "common/.dagger/mymod" does not exist`; only the segment ahead of the first
+  separator is read as a host now, the way Go import paths are.
+
+  Paths typed on Windows are read as paths too. The engine always runs on Linux,
+  where a backslash is an ordinary character, so `dagger module init --path
+  common\clients\one` used to create a single directory named
+  `common\clients\one`, `dagger install ..\dep` never collapsed the `..`, and
+  a `..\..\` spelling slipped past the check that refuses to escape the
+  workspace root. Separators are normalized where a workspace path, a local
+  module ref or an as-sdk entry is read.
+time: 2026-08-19T12:45:00Z
+custom:
+  Author: eunomie
+  PR: "13892"

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -962,6 +962,8 @@ func (GeneratorsSuite) TestAPIClientInitDottedModulePath(ctx context.Context, t 
 	}{
 		{name: "workspace-relative", ref: "common/.dagger/target"},
 		{name: "explicitly relative", ref: "./common/.dagger/target"},
+		// A ref typed on Windows reaches the Linux engine verbatim.
+		{name: "windows separators", ref: `common\.dagger\target`},
 	} {
 		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			initialized := base.

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -936,6 +936,54 @@ func (GeneratorsSuite) TestInitFromSubdirectoryCwd(ctx context.Context, t *testc
 	})
 }
 
+// TestAPIClientInitDottedModulePath covers a module ref whose dot segment is
+// not the first one ("common/.dagger/target"), the shape a root-relative ref
+// takes from a monorepo subdirectory. The ref classifier used to read any dot
+// as a hostname and route such a ref to git.
+func (GeneratorsSuite) TestAPIClientInitDottedModulePath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixture(t, c).
+		WithNewFile("common/.dagger/target/dagger.json", `{
+  "name": "target",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`)
+
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{name: "workspace-relative", ref: "common/.dagger/target"},
+		{name: "explicitly relative", ref: "./common/.dagger/target"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			initialized := base.
+				WithWorkdir("/work/common").
+				With(daggerExec(
+					"api", "client", "init", "fixture", "clients/dotted", tc.ref, "--auto-apply"))
+			out, err := initialized.CombinedOutput(ctx)
+			require.NoError(t, err, out)
+
+			// The client path resolves against the caller, so it lands under
+			// common/; the module ref stays workspace-root-relative.
+			scaffold, err := initialized.File("/work/common/clients/dotted/scaffold.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "common/.dagger/target\n", scaffold)
+
+			// The generators ran for the new client too, which reads the
+			// recorded ref back through the SDK's client list.
+			generated, err := initialized.File("/work/common/clients/dotted/generated-client.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "common/.dagger/target\n", generated)
+
+			config, err := initialized.File("/work/dagger.toml").Contents(ctx)
+			require.NoError(t, err)
+			require.Contains(t, config, `module = "common/.dagger/target"`)
+		})
+	}
+}
+
 func (GeneratorsSuite) TestGeneratorGroupChangesSyncWithNestedSDKCodegen(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -484,13 +484,9 @@ func initGeneratorFixture(t testing.TB, c *dagger.Client) *dagger.Container {
 
 // initGeneratorFixtureAt builds the fixture with its dagger.toml under
 // configDir, so tests can exercise a workspace config that is not at the
-// workspace (git) root. [modules.X].source is config-directory-relative while
-// as-sdk paths are workspace-root-relative, hence the two path shapes below.
-//
-// The SDK module deliberately sits at a dot-free path: a client's module ref is
-// classified as local by looking for a leading "." or "/" and otherwise for the
-// absence of a dot, so "common/.dagger/init-fixture" would be mistaken for a
-// remote ref.
+// workspace (git) root. Every path in dagger.toml — [modules.X].source and the
+// as-sdk entries alike — is recorded relative to that config directory, so the
+// fixture below reads the same wherever configDir sits.
 func initGeneratorFixtureAt(t testing.TB, c *dagger.Client, configDir string) *dagger.Container {
 	inConfigDir := func(p string) string { return path.Join(configDir, p) }
 	return goGitBase(t, c).
@@ -503,11 +499,11 @@ source = "sdk/init-fixture"
 name = "fixture"
 
 [[modules.init-fixture.as-sdk.modules]]
-path = "`+inConfigDir("existing/mod")+`"
+path = "existing/mod"
 
 [[modules.init-fixture.as-sdk.clients]]
-path = "`+inConfigDir("existing/client")+`"
-module = "`+inConfigDir("sdk/init-fixture")+`"
+path = "existing/client"
+module = "sdk/init-fixture"
 `).
 		WithNewFile(inConfigDir("sdk/init-fixture/dagger.json"), `{
   "name": "init-fixture",
@@ -794,12 +790,13 @@ func (GeneratorsSuite) TestInitFromSubdirectoryWorkspace(ctx context.Context, t 
 		require.NoError(t, err)
 		require.False(t, exists, "module init must not scaffold outside the config directory")
 
-		// [modules.X].source is config-directory-relative; as-sdk paths are
-		// workspace-root-relative.
+		// Both paths dagger.toml records for the new module — its install
+		// source and the as-sdk entry — are relative to the config directory,
+		// so they read the same.
 		config, err := initialized.File("/work/common/dagger.toml").Contents(ctx)
 		require.NoError(t, err)
 		require.Contains(t, config, `source = ".dagger/modules/newmod"`)
-		require.Contains(t, config, `path = "common/.dagger/modules/newmod"`)
+		require.Contains(t, config, `path = ".dagger/modules/newmod"`)
 	})
 
 	t.Run("module init resolves an explicit --path against the caller", func(ctx context.Context, t *testctx.T) {
@@ -871,6 +868,15 @@ func (GeneratorsSuite) TestInitFromSubdirectoryWorkspace(ctx context.Context, t 
 		exists, err := initialized.Exists(ctx, "/work/clients")
 		require.NoError(t, err)
 		require.False(t, exists, "client init must not scaffold outside the requested path")
+
+		// The recorded client is anchored at the dagger.toml holding it, its
+		// local module ref included, while the SDK is handed the
+		// workspace-root-relative form above. The fixture already records one
+		// client against the same module, so the new entry is the second.
+		config, err := initialized.File("/work/common/dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, config, `path = "clients/one"`)
+		require.Equal(t, 2, strings.Count(config, `module = "sdk/init-fixture"`), config)
 	})
 }
 

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -61,15 +61,35 @@ func (s *moduleSchema) currentModuleAsSDK(
 		sdkName = name
 	}
 
+	// as-sdk entries are recorded against the config directory; SDKs are
+	// handed workspace-root-relative paths, the same currency as ws.Cwd and
+	// the changesets they return.
+	configDir, err := workspaceConfigDirectory(ws)
+	if err != nil {
+		return nil, err
+	}
+
 	result := &core.CurrentModuleAsSDK{Name: sdkName}
 	for _, mod := range entry.AsSDK.Modules {
-		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{Path: mod.Path})
+		modPath, err := workspace.ResolveSDKManagedPath(configDir, mod.Path)
+		if err != nil {
+			return nil, fmt.Errorf("module managed by %q: %w", name, err)
+		}
+		result.Modules = append(result.Modules, &core.CurrentModuleAsSDKModule{Path: modPath})
 	}
 	result.Modules = currentModuleAsSDKModulesForCwd(result.Modules, ws.Cwd)
 	for _, client := range entry.AsSDK.Clients {
+		clientPath, err := workspace.ResolveSDKManagedPath(configDir, client.Path)
+		if err != nil {
+			return nil, fmt.Errorf("client managed by %q: %w", name, err)
+		}
+		clientModule, err := resolveSDKManagedClientModule(configDir, client.Module)
+		if err != nil {
+			return nil, fmt.Errorf("client managed by %q: %w", name, err)
+		}
 		result.Clients = append(result.Clients, &core.CurrentModuleAsSDKClient{
-			Path:           client.Path,
-			Module:         client.Module,
+			Path:           clientPath,
+			Module:         clientModule,
 			Pin:            client.Pin,
 			BoundWorkspace: wsResult,
 		})
@@ -179,7 +199,9 @@ func (s *moduleSchema) currentModuleAsSDKClientModuleSource(
 		return res, fmt.Errorf("current module is not installed as an SDK in this workspace")
 	}
 
-	_, moduleLoadRef, err := resolveWorkspaceClientModuleRef(ws, client.Module)
+	// client.Module was already resolved to workspace-root coordinates by
+	// currentModuleAsSDK, so it needs no further anchoring here.
+	moduleLoadRef, _, err := resolveWorkspaceClientModuleRef(ws, client.Module, ".")
 	if err != nil {
 		return res, err
 	}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2115,16 +2115,6 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 	return depCfg, nil
 }
 
-func isLocalLegacyModuleRef(source, pin string) bool {
-	if pin != "" {
-		return false
-	}
-	if len(source) > 0 && (source[0] == '/' || source[0] == '.') {
-		return true
-	}
-	return !strings.Contains(source, ".")
-}
-
 func replaceModuleRefVersion(refString, version string) string {
 	before, _, found := strings.Cut(refString, "@")
 	if found {
@@ -2236,7 +2226,7 @@ func (s *moduleSourceSchema) moduleSourceWithUpdateToolchains(
 			}
 			matched = true
 			delete(updateReqs, req)
-			if !isLocalLegacyModuleRef(cfg.Source, cfg.Pin) {
+			if !workspace.IsLocalRef(cfg.Source, cfg.Pin) {
 				refString := cfg.Source
 				if req.version != "" {
 					refString = replaceModuleRefVersion(refString, req.version)
@@ -2365,7 +2355,7 @@ func (s *moduleSourceSchema) moduleSourceWithUpdateBlueprint(
 	}
 
 	cfg := parentSrc.Self().ConfigBlueprint
-	if isLocalLegacyModuleRef(cfg.Source, cfg.Pin) {
+	if workspace.IsLocalRef(cfg.Source, cfg.Pin) {
 		return parentSrc.Result, nil
 	}
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3643,17 +3643,24 @@ func sdkOwnersByModulePath(ctx context.Context, ws *core.Workspace) (map[string]
 	if err != nil {
 		return nil, err
 	}
-	return sdkOwnersByModulePathFromConfig(cfg)
+	configDir, err := workspaceConfigDirectory(ws)
+	if err != nil {
+		return nil, err
+	}
+	return sdkOwnersByModulePathFromConfig(configDir, cfg)
 }
 
-func sdkOwnersByModulePathFromConfig(cfg *workspace.Config) (map[string]string, error) {
+func sdkOwnersByModulePathFromConfig(configDir string, cfg *workspace.Config) (map[string]string, error) {
 	owners := map[string]string{}
 	for name, entry := range cfg.Modules {
 		if entry.AsSDK == nil {
 			continue
 		}
 		for _, managed := range entry.AsSDK.Modules {
-			path := cleanWorkspaceRelPath(managed.Path)
+			path, err := workspace.ResolveSDKManagedPath(configDir, managed.Path)
+			if err != nil {
+				return nil, fmt.Errorf("module managed by %q: %w", name, err)
+			}
 			if existing, ok := owners[path]; ok && existing != name {
 				sdkNames := []string{existing, name}
 				slices.Sort(sdkNames)

--- a/core/schema/modulesource_test.go
+++ b/core/schema/modulesource_test.go
@@ -265,7 +265,7 @@ func TestSDKOwnersByModulePathFromConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("maps normalized module paths", func(t *testing.T) {
-		owners, err := sdkOwnersByModulePathFromConfig(&workspace.Config{
+		owners, err := sdkOwnersByModulePathFromConfig(".", &workspace.Config{
 			Modules: map[string]workspace.ModuleEntry{
 				"go-sdk": {
 					AsSDK: &workspace.ModuleAsSDK{
@@ -290,8 +290,28 @@ func TestSDKOwnersByModulePathFromConfig(t *testing.T) {
 		}, owners)
 	})
 
+	t.Run("resolves paths against a config directory below the root", func(t *testing.T) {
+		owners, err := sdkOwnersByModulePathFromConfig("apps/demo", &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"go-sdk": {
+					AsSDK: &workspace.ModuleAsSDK{
+						Modules: []workspace.SDKManagedModule{
+							{Path: ".dagger/modules/go"},
+							{Path: "../shared"},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"apps/demo/.dagger/modules/go": "go-sdk",
+			"apps/shared":                  "go-sdk",
+		}, owners)
+	})
+
 	t.Run("rejects paths managed by multiple SDKs", func(t *testing.T) {
-		_, err := sdkOwnersByModulePathFromConfig(&workspace.Config{
+		_, err := sdkOwnersByModulePathFromConfig(".", &workspace.Config{
 			Modules: map[string]workspace.ModuleEntry{
 				"go-sdk": {
 					AsSDK: &workspace.ModuleAsSDK{

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -2634,11 +2634,17 @@ func (s *workspaceSchema) selectWorkspaceGitRepository(
 //   - Absolute paths resolve from the workspace boundary (/).
 //
 // Returns a path relative to the workspace boundary.
+//
+// A path typed on Windows arrives spelled with backslashes, which mean nothing
+// to the Linux engine resolving it — filepath would keep "a\b" as a single
+// element named "a\b" — so separators are normalized first, as they are for
+// host paths (see engine/client/pathutil). The cost is that a file whose name
+// really does contain a backslash cannot be addressed through these APIs.
 func resolveWorkspacePath(pathArg, basePath string) (string, error) {
 	if basePath == "" {
 		basePath = "."
 	}
-	clean := filepath.Clean(pathArg)
+	clean := filepath.Clean(strings.ReplaceAll(pathArg, `\`, "/"))
 	var resolved string
 	if filepath.IsAbs(clean) {
 		// Absolute path: relative to workspace boundary (strip leading /).

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -345,7 +345,10 @@ func (s *workspaceSchema) withoutModule(
 		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("module %q is not installed in the workspace", args.Name)
 	}
 
-	managedModulePath, removeManagedModuleDir := removeSDKManagedModuleReference(staged.Config, staged.ConfigDir, entry)
+	managedModulePath, removeManagedModuleDir, err := removeSDKManagedModuleReference(staged.Config, staged.ConfigDir, entry)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
 	delete(staged.Config.Modules, args.Name)
 	updatedConfig, err := workspace.UpdateConfigBytes(staged.Data, staged.Config)
 	if err != nil {

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/dagger/dagger/core"
@@ -46,12 +45,11 @@ func (s *workspaceSchema) initClientChanges(
 	if err != nil {
 		return res, scope, err
 	}
-	moduleRef, moduleLoadRef, err := resolveWorkspaceClientModuleRef(ws, args.Module)
+	staged, err := s.loadWorkspaceConfigForOverlay(ctx, ws, workspaceConfigMustExist, args.Here)
 	if err != nil {
 		return res, scope, err
 	}
-
-	staged, err := s.loadWorkspaceConfigForOverlay(ctx, ws, workspaceConfigMustExist, args.Here)
+	moduleLoadRef, configModuleRef, err := resolveWorkspaceClientModuleRef(ws, args.Module, staged.ConfigDir)
 	if err != nil {
 		return res, scope, err
 	}
@@ -74,11 +72,20 @@ func (s *workspaceSchema) initClientChanges(
 	}
 	modulePin := targetModule.Self().Pin()
 
-	removeClientEntryAtPath(cfg, clientPath)
+	// dagger.toml records paths relative to the directory holding it, while
+	// everything downstream of here is workspace-root-relative.
+	configClientPath, err := workspace.SDKManagedPathFor(staged.ConfigDir, clientPath)
+	if err != nil {
+		return res, scope, err
+	}
+
+	if err := removeClientEntryAtPath(cfg, staged.ConfigDir, clientPath); err != nil {
+		return res, scope, err
+	}
 	sdkEntry = cfg.Modules[sdkName]
 	sdkEntry.AsSDK.Clients = append(sdkEntry.AsSDK.Clients, workspace.SDKManagedClient{
-		Path:   clientPath,
-		Module: moduleRef,
+		Path:   configClientPath,
+		Module: configModuleRef,
 		Pin:    modulePin,
 	})
 	cfg.Modules[sdkName] = sdkEntry
@@ -126,7 +133,7 @@ func (s *workspaceSchema) initClientChanges(
 	if err != nil {
 		return res, scope, err
 	}
-	sdkChanges, err := clientInitializer.InitClient(ctx, sdkWorkspace, clientPath, moduleRef, sdkArgs)
+	sdkChanges, err := clientInitializer.InitClient(ctx, sdkWorkspace, clientPath, moduleLoadRef, sdkArgs)
 	if err != nil {
 		return res, scope, fmt.Errorf("sdk client init: %w", err)
 	}
@@ -201,7 +208,11 @@ func resolveWorkspaceClientPath(pathArg, cwd string) (string, error) {
 	return resolved, nil
 }
 
-func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref string) (configRef string, loadRef string, _ error) {
+// resolveWorkspaceClientModuleRef normalizes a client's module ref into the two
+// forms it is needed in: loadRef, workspace-root-relative, is what module
+// loading reads from, while configRef is how the entry is spelled in the
+// dagger.toml at configDir. A canonical ref has no anchor, so it is both.
+func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref, configDir string) (loadRef string, configRef string, _ error) {
 	if !workspace.IsLocalRef(ref, "") {
 		return ref, ref, nil
 	}
@@ -223,7 +234,27 @@ func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref string) (configRef 
 	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
 		return "", "", fmt.Errorf("module ref %q must not escape the workspace root", ref)
 	}
-	return filepath.ToSlash(cleaned), filepath.ToSlash(cleaned), nil
+	loadRef = filepath.ToSlash(cleaned)
+	configRef, err := workspace.SDKManagedPathFor(configDir, loadRef)
+	if err != nil {
+		return "", "", err
+	}
+	// A spelling that would read back as a git ref — a dot in its first segment,
+	// like "sdk.v1/foo" — keeps an explicit local marker.
+	if !workspace.IsLocalRef(configRef, "") {
+		configRef = "./" + configRef
+	}
+	return loadRef, configRef, nil
+}
+
+// resolveSDKManagedClientModule reads back what resolveWorkspaceClientModuleRef
+// stored: a local ref anchors like every other as-sdk path, a canonical ref has
+// no anchor and stays verbatim.
+func resolveSDKManagedClientModule(configDir, ref string) (string, error) {
+	if !workspace.IsLocalRef(ref, "") {
+		return ref, nil
+	}
+	return workspace.ResolveSDKManagedPath(configDir, ref)
 }
 
 func workspaceClientModuleSourceSelector(ref string, pin string) dagql.Selector {
@@ -240,18 +271,32 @@ func workspaceClientModuleSourceSelector(ref string, pin string) dagql.Selector 
 	}
 }
 
-func removeClientEntryAtPath(cfg *workspace.Config, clientPath string) {
+// removeClientEntryAtPath drops any client recorded at clientPath, which is
+// workspace-root-relative while the entries themselves are recorded against
+// configDir. An entry that cannot be resolved is a corruption every other
+// reader fails on, so it fails here too rather than being mistaken for a miss.
+func removeClientEntryAtPath(cfg *workspace.Config, configDir, clientPath string) error {
 	if cfg == nil {
-		return
+		return nil
 	}
-	cleanPath := filepath.Clean(clientPath)
+	cleanPath := filepath.ToSlash(cleanWorkspaceRelPath(clientPath))
 	for moduleName, entry := range cfg.Modules {
 		if entry.AsSDK == nil || len(entry.AsSDK.Clients) == 0 {
 			continue
 		}
-		entry.AsSDK.Clients = slices.DeleteFunc(entry.AsSDK.Clients, func(client workspace.SDKManagedClient) bool {
-			return filepath.Clean(client.Path) == cleanPath
-		})
+		kept := make([]workspace.SDKManagedClient, 0, len(entry.AsSDK.Clients))
+		for _, client := range entry.AsSDK.Clients {
+			resolved, err := workspace.ResolveSDKManagedPath(configDir, client.Path)
+			if err != nil {
+				return fmt.Errorf("client managed by %q: %w", moduleName, err)
+			}
+			if resolved == cleanPath {
+				continue
+			}
+			kept = append(kept, client)
+		}
+		entry.AsSDK.Clients = kept
 		cfg.Modules[moduleName] = entry
 	}
+	return nil
 }

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -216,7 +216,10 @@ func resolveWorkspaceClientModuleRef(ws *core.Workspace, ref, configDir string) 
 	if !workspace.IsLocalRef(ref, "") {
 		return ref, ref, nil
 	}
-	cleaned := filepath.Clean(ref)
+	// A local ref may be spelled with Windows separators; every path below this
+	// point is addressed on the engine, where filepath treats a backslash as an
+	// ordinary character.
+	cleaned := filepath.Clean(strings.ReplaceAll(ref, `\`, "/"))
 	if filepath.IsAbs(cleaned) {
 		hostRoot, ok := ws.LocalSourceHostPath()
 		if !ok {

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -99,6 +99,13 @@ func (s *workspaceSchema) initModuleChanges(
 		return res, scope, err
 	}
 
+	// Everything in dagger.toml is written relative to the directory holding
+	// it, while relPath is workspace-root-relative like the rest of the engine.
+	configPath, err := workspace.SDKManagedPathFor(staged.ConfigDir, relPath)
+	if err != nil {
+		return res, scope, err
+	}
+
 	// Reject name conflicts in installed modules and reject path conflicts
 	// across any SDK's authored modules. Two SDKs claiming the same path is
 	// a corruption we shouldn't silently extend.
@@ -110,13 +117,17 @@ func (s *workspaceSchema) initModuleChanges(
 			continue
 		}
 		for _, m := range installed.AsSDK.Modules {
-			if filepath.Clean(m.Path) == relPath {
+			authored, err := workspace.ResolveSDKManagedPath(staged.ConfigDir, m.Path)
+			if err != nil {
+				return res, scope, fmt.Errorf("module managed by %q: %w", installedName, err)
+			}
+			if authored == relPath {
 				return res, scope, fmt.Errorf("a module is already authored at %q under modules.%s.as-sdk", relPath, installedName)
 			}
 		}
 	}
 
-	sdkEntry.AsSDK.Modules = append(sdkEntry.AsSDK.Modules, workspace.SDKManagedModule{Path: relPath})
+	sdkEntry.AsSDK.Modules = append(sdkEntry.AsSDK.Modules, workspace.SDKManagedModule{Path: configPath})
 	cfg.Modules[sdkName] = sdkEntry
 
 	loadedSDK, err := s.loadWorkspaceSDK(ctx, ws, staged.ConfigDir, sdkRef)
@@ -142,14 +153,7 @@ func (s *workspaceSchema) initModuleChanges(
 	}
 
 	if usingDefaultPath {
-		// [modules.<name>].source is resolved against the config directory,
-		// while relPath is workspace-root-relative — same convention split
-		// `dagger install` handles when it records a local ref.
-		configSource, err := filepath.Rel(staged.ConfigDir, relPath)
-		if err != nil {
-			return res, scope, fmt.Errorf("resolve module source %q from %q: %w", relPath, staged.ConfigDir, err)
-		}
-		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: filepath.ToSlash(configSource)}
+		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: configPath}
 	}
 
 	// Render new dagger.toml bytes through the format-preserving editor.

--- a/core/schema/workspace_sdk.go
+++ b/core/schema/workspace_sdk.go
@@ -36,7 +36,11 @@ func (s *workspaceSchema) sdks(
 		if entry.AsSDK == nil {
 			continue
 		}
-		sdks = append(sdks, workspaceSDKFromEntry(configDir, name, entry))
+		sdk, err := workspaceSDKFromEntry(configDir, name, entry)
+		if err != nil {
+			return nil, err
+		}
+		sdks = append(sdks, sdk)
 	}
 	sdks.Sort()
 
@@ -73,9 +77,11 @@ func (s *workspaceSchema) sdk(
 	if err != nil {
 		return dagql.ObjectResult[*core.WorkspaceSDK]{}, err
 	}
-	result, err := workspaceSDKResults(ctx, parent, core.WorkspaceSDKs{
-		workspaceSDKFromEntry(configDir, moduleName, entry),
-	})
+	sdk, err := workspaceSDKFromEntry(configDir, moduleName, entry)
+	if err != nil {
+		return dagql.ObjectResult[*core.WorkspaceSDK]{}, err
+	}
+	result, err := workspaceSDKResults(ctx, parent, core.WorkspaceSDKs{sdk})
 	if err != nil {
 		return dagql.ObjectResult[*core.WorkspaceSDK]{}, err
 	}
@@ -163,7 +169,7 @@ func (s *workspaceSchema) workspaceSDK(
 	return sdk, nil
 }
 
-func workspaceSDKFromEntry(configDir, moduleName string, entry workspace.ModuleEntry) *core.WorkspaceSDK {
+func workspaceSDKFromEntry(configDir, moduleName string, entry workspace.ModuleEntry) (*core.WorkspaceSDK, error) {
 	name := entry.AsSDK.Name
 	if name == "" {
 		name = moduleName
@@ -173,25 +179,35 @@ func workspaceSDKFromEntry(configDir, moduleName string, entry workspace.ModuleE
 		Ref:  resolvedModuleEntrySourceWithPin(configDir, entry),
 	}
 	for _, mod := range entry.AsSDK.Modules {
-		source := filepath.ToSlash(cleanWorkspaceRelPath(mod.Path))
+		source, err := workspace.ResolveSDKManagedPath(configDir, mod.Path)
+		if err != nil {
+			return nil, fmt.Errorf("module managed by %q: %w", moduleName, err)
+		}
 		sdk.Modules = append(sdk.Modules, &core.WorkspaceModule{
 			Name:   filepath.ToSlash(filepath.Base(source)),
 			Source: source,
 		})
 	}
 	for _, client := range entry.AsSDK.Clients {
-		ref := client.Module
+		ref, err := resolveSDKManagedClientModule(configDir, client.Module)
+		if err != nil {
+			return nil, fmt.Errorf("client managed by %q: %w", moduleName, err)
+		}
 		if client.Pin != "" && !strings.Contains(ref, "@") {
 			ref += "@" + client.Pin
 		}
+		clientPath, err := workspace.ResolveSDKManagedPath(configDir, client.Path)
+		if err != nil {
+			return nil, fmt.Errorf("client managed by %q: %w", moduleName, err)
+		}
 		sdk.Clients = append(sdk.Clients, &core.WorkspaceModule{
-			Name:   filepath.ToSlash(cleanWorkspaceRelPath(client.Path)),
+			Name:   clientPath,
 			Source: ref,
 		})
 	}
 	core.WorkspaceModules(sdk.Modules).Sort()
 	core.WorkspaceModules(sdk.Clients).Sort()
-	return sdk
+	return sdk, nil
 }
 
 func installedSDKSource(cfg *workspace.Config, name string) (string, workspace.ModuleEntry, string, error) {

--- a/core/schema/workspace_sdk_test.go
+++ b/core/schema/workspace_sdk_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"testing"
 
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/stretchr/testify/require"
 )
@@ -93,12 +94,15 @@ func TestWorkspaceSDKEntryPaths(t *testing.T) {
 	require.Equal(t, "apps/sdk@sha256:abc", resolvedModuleEntrySourceWithPin("apps/demo", entry))
 	require.Equal(t, "../../../apps/sdk@sha256:abc", mustModuleEntrySourceWithPinRelativeTo(t, "apps/demo", ".dagger/modules/new", entry))
 
-	sdk := workspaceSDKFromEntry("apps/demo", "custom-sdk", entry)
+	// The as-sdk path is recorded against the config directory, like the
+	// entry's own source, and surfaces workspace-root-relative.
+	sdk, err := workspaceSDKFromEntry("apps/demo", "custom-sdk", entry)
+	require.NoError(t, err)
 	require.Equal(t, "custom", sdk.Name)
 	require.Equal(t, "apps/sdk@sha256:abc", sdk.Ref)
 	require.Len(t, sdk.Modules, 1)
 	require.Equal(t, "demo", sdk.Modules[0].Name)
-	require.Equal(t, ".dagger/modules/demo", sdk.Modules[0].Source)
+	require.Equal(t, "apps/demo/.dagger/modules/demo", sdk.Modules[0].Source)
 }
 
 func TestModuleEntrySourceWithPinRelativeToLeavesGitRefsCanonical(t *testing.T) {
@@ -134,9 +138,107 @@ func TestRemoveClientEntryAtPathPreservesSDKMarker(t *testing.T) {
 		},
 	}
 
-	removeClientEntryAtPath(cfg, "./lib/client")
+	require.NoError(t, removeClientEntryAtPath(cfg, ".", "./lib/client"))
 
 	entry := cfg.Modules["go"]
 	require.NotNil(t, entry.AsSDK)
 	require.Empty(t, entry.AsSDK.Clients)
+}
+
+func TestRemoveClientEntryAtPathRejectsEscapingEntry(t *testing.T) {
+	t.Parallel()
+
+	cfg := &workspace.Config{
+		Modules: map[string]workspace.ModuleEntry{
+			"go": {
+				Source: "github.com/dagger/go-sdk",
+				AsSDK: &workspace.ModuleAsSDK{
+					Clients: []workspace.SDKManagedClient{
+						{Path: "../outside", Module: ".dagger/modules/api"},
+					},
+				},
+			},
+		},
+	}
+
+	require.ErrorContains(t, removeClientEntryAtPath(cfg, ".", "./lib/client"), "escapes the workspace root")
+}
+
+// A client module ref is stored relative to the dagger.toml holding it, and has
+// to read back as a local path. Only a spelling the classifier would call a git
+// ref — a dot in its first segment, "sdk.v1/api" — needs the explicit marker.
+func TestResolveWorkspaceClientModuleRefStoresClassifiableLocalRef(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		ref           string
+		configDir     string
+		wantLoadRef   string
+		wantConfigRef string
+	}{
+		{name: "dotted path stays local", ref: "./sdk.v1/api", configDir: ".", wantLoadRef: "sdk.v1/api", wantConfigRef: "./sdk.v1/api"},
+		{name: "dotted path from nested config", ref: "./sdk.v1/api", configDir: "apps", wantLoadRef: "sdk.v1/api", wantConfigRef: "../sdk.v1/api"},
+		{name: "plain path keeps the bare spelling", ref: "./modules/api", configDir: ".", wantLoadRef: "modules/api", wantConfigRef: "modules/api"},
+		{name: "dot in a later segment needs no marker", ref: ".dagger/modules/api", configDir: ".", wantLoadRef: ".dagger/modules/api", wantConfigRef: ".dagger/modules/api"},
+		{name: "nested config", ref: "modules/api", configDir: "apps/demo", wantLoadRef: "modules/api", wantConfigRef: "../../modules/api"},
+		{name: "remote ref verbatim", ref: "github.com/acme/sdk", configDir: "apps/demo", wantLoadRef: "github.com/acme/sdk", wantConfigRef: "github.com/acme/sdk"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			loadRef, configRef, err := resolveWorkspaceClientModuleRef(&core.Workspace{}, tc.ref, tc.configDir)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantLoadRef, loadRef)
+			require.Equal(t, tc.wantConfigRef, configRef)
+			require.True(t, workspace.IsLocalRef(configRef, "") == workspace.IsLocalRef(tc.ref, ""),
+				"stored ref must classify the same way as the ref it came from")
+		})
+	}
+}
+
+// A hand-written root-anchored as-sdk entry, matched by consumers that see the
+// module through its config-relative install source.
+func TestRootAnchoredAsSDKEntryIsMatched(t *testing.T) {
+	cfg := func() *workspace.Config {
+		return &workspace.Config{
+			Modules: map[string]workspace.ModuleEntry{
+				"mymod": {Source: ".dagger/modules/mymod"},
+				"go-sdk": {
+					Source: "github.com/dagger/go-sdk",
+					AsSDK: &workspace.ModuleAsSDK{
+						Modules: []workspace.SDKManagedModule{{Path: "/common/.dagger/modules/mymod"}},
+						Clients: []workspace.SDKManagedClient{{Path: "/common/clients/one", Module: "/common/sdk/api"}},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("uninstall removes the as-sdk entry", func(t *testing.T) {
+		c := cfg()
+		path, del, err := removeSDKManagedModuleReference(c, "common", c.Modules["mymod"])
+		require.NoError(t, err)
+		require.True(t, del)
+		require.Equal(t, "common/.dagger/modules/mymod", path)
+		require.Empty(t, c.Modules["go-sdk"].AsSDK.Modules)
+	})
+
+	t.Run("client init replaces the entry at the same path", func(t *testing.T) {
+		c := cfg()
+		require.NoError(t, removeClientEntryAtPath(c, "common", "common/clients/one"))
+		require.Empty(t, c.Modules["go-sdk"].AsSDK.Clients)
+	})
+
+	t.Run("ownership map and sdk listing resolve it", func(t *testing.T) {
+		owners, err := sdkOwnersByModulePathFromConfig("common", cfg())
+		require.NoError(t, err)
+		require.Equal(t, "go-sdk", owners["common/.dagger/modules/mymod"])
+
+		sdk, err := workspaceSDKFromEntry("common", "go-sdk", cfg().Modules["go-sdk"])
+		require.NoError(t, err)
+		require.Equal(t, "common/.dagger/modules/mymod", sdk.Modules[0].Source)
+		require.Equal(t, "common/clients/one", sdk.Clients[0].Name)
+		require.Equal(t, "common/sdk/api", sdk.Clients[0].Source)
+	})
 }

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -365,6 +365,25 @@ func TestResolveWorkspacePath(t *testing.T) {
 		got, err := resolveWorkspacePath("../../..", "services/payment")
 		require.ErrorContains(t, err, "escapes workspace root", fmt.Sprintf("got %q instead of an error", got))
 	})
+
+	// A path typed on Windows reaches the Linux engine spelled with
+	// backslashes, where filepath reads the whole thing as one element: the
+	// segments never separate, "\.." never collapses, and the escape guard
+	// above never sees a "..".
+	t.Run("windows separators", func(t *testing.T) {
+		for _, tc := range []struct{ arg, base, want string }{
+			{`src\gen`, "services/payment", "services/payment/src/gen"},
+			{`..\shared`, "services/payment", "services/shared"},
+			{`\shared\config`, "services/payment", "shared/config"},
+		} {
+			got, err := resolveWorkspacePath(tc.arg, tc.base)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got, tc.arg)
+		}
+
+		got, err := resolveWorkspacePath(`..\..\..`, "services/payment")
+		require.ErrorContains(t, err, "escapes workspace root", fmt.Sprintf("got %q instead of an error", got))
+	})
 }
 
 func TestWorkspacePathInOrLeadingToCwd(t *testing.T) {

--- a/core/schema/workspace_uninstall.go
+++ b/core/schema/workspace_uninstall.go
@@ -1,8 +1,8 @@
 package schema
 
 import (
+	"fmt"
 	"path/filepath"
-	"slices"
 
 	"github.com/dagger/dagger/core/workspace"
 )
@@ -14,10 +14,12 @@ type workspaceUninstallArgs struct {
 
 // removeSDKManagedModuleReference removes the installed module's source path
 // from any [[modules.<sdk>.as-sdk.modules]] list. It returns a workspace-relative
-// path only when the matched source is safe to delete from the overlay.
-func removeSDKManagedModuleReference(cfg *workspace.Config, configDir string, entry workspace.ModuleEntry) (string, bool) {
+// path only when the matched source is safe to delete from the overlay. An
+// as-sdk entry that cannot be resolved is a corruption every other reader fails
+// on, so it fails here too rather than being mistaken for a miss.
+func removeSDKManagedModuleReference(cfg *workspace.Config, configDir string, entry workspace.ModuleEntry) (string, bool, error) {
 	if cfg == nil || entry.AsSDK != nil || !workspace.IsLocalRef(entry.Source, entry.Pin) {
-		return "", false
+		return "", false, nil
 	}
 
 	resolvedSource := workspace.ResolveModuleEntrySource(configDir, entry.Source)
@@ -28,28 +30,34 @@ func removeSDKManagedModuleReference(cfg *workspace.Config, configDir string, en
 			continue
 		}
 
-		sdkEntry.AsSDK.Modules = slices.DeleteFunc(sdkEntry.AsSDK.Modules, func(mod workspace.SDKManagedModule) bool {
-			if filepath.ToSlash(filepath.Clean(mod.Path)) == sourcePath {
-				removed = true
-				return true
+		kept := make([]workspace.SDKManagedModule, 0, len(sdkEntry.AsSDK.Modules))
+		for _, mod := range sdkEntry.AsSDK.Modules {
+			managed, err := workspace.ResolveSDKManagedPath(configDir, mod.Path)
+			if err != nil {
+				return "", false, fmt.Errorf("module managed by %q: %w", moduleName, err)
 			}
-			return false
-		})
+			if managed == sourcePath {
+				removed = true
+				continue
+			}
+			kept = append(kept, mod)
+		}
+		sdkEntry.AsSDK.Modules = kept
 		cfg.Modules[moduleName] = sdkEntry
 	}
 	if !removed {
-		return "", false
+		return "", false, nil
 	}
 
 	// Local installed modules can point outside the workspace (for example,
 	// "../dep"). Clean up the TOML reference above, but only delete authored
 	// SDK module directories that resolve inside the workspace.
 	if filepath.IsAbs(resolvedSource) {
-		return "", false
+		return "", false, nil
 	}
-	deletePath, err := resolveWorkspacePath(sourcePath, ".")
-	if err != nil || deletePath == "." {
-		return "", false
+	deletePath := filepath.Clean(filepath.FromSlash(sourcePath))
+	if deletePath == "." || !filepath.IsLocal(deletePath) {
+		return "", false, nil
 	}
-	return deletePath, true
+	return filepath.ToSlash(deletePath), true, nil
 }

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -147,7 +147,9 @@ func ResolveModuleEntrySource(configDir, source string) string {
 // escaping the root is refused. Unlike ResolveModuleEntrySource these entries
 // are always paths, never refs, so no ref classification happens here.
 func ResolveSDKManagedPath(configDir, p string) (string, error) {
-	clean := path.Clean(filepath.ToSlash(p))
+	// filepath.ToSlash is a no-op on the engine reading this, so a path spelled
+	// with Windows separators is normalized explicitly.
+	clean := path.Clean(strings.ReplaceAll(p, `\`, "/"))
 	var resolved string
 	if path.IsAbs(clean) {
 		resolved = strings.TrimPrefix(clean, "/")

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -135,6 +136,47 @@ func ResolveModuleEntrySource(configDir, source string) string {
 		return filepath.Clean(source)
 	}
 	return filepath.Clean(filepath.Join(configDir, source))
+}
+
+// ResolveSDKManagedPath turns an as-sdk path into the workspace-relative path
+// the engine addresses modules and clients by, following the same rule as every
+// other path a workspace resolves: a leading "/" means the workspace root,
+// anything else is relative to the directory of the config that records it, and
+// escaping the root is refused. Unlike ResolveModuleEntrySource these entries
+// are always paths, never refs, so no ref classification happens here.
+func ResolveSDKManagedPath(configDir, p string) (string, error) {
+	clean := path.Clean(filepath.ToSlash(p))
+	var resolved string
+	if path.IsAbs(clean) {
+		resolved = strings.TrimPrefix(clean, "/")
+	} else {
+		resolved = path.Join(filepath.ToSlash(configDir), clean)
+	}
+	resolved = path.Clean(resolved)
+	if resolved == "" {
+		resolved = "."
+	}
+	if resolved != "." && !filepath.IsLocal(filepath.FromSlash(resolved)) {
+		return "", fmt.Errorf("%q escapes the workspace root", p)
+	}
+	return resolved, nil
+}
+
+// SDKManagedPathFor is the inverse of ResolveSDKManagedPath: it expresses a
+// workspace-relative path the way an as-sdk entry records it. A target outside
+// the config directory keeps a "../" prefix, as its install source would.
+func SDKManagedPathFor(configDir, workspacePath string) (string, error) {
+	if configDir == "" {
+		configDir = "."
+	}
+	if workspacePath == "" {
+		workspacePath = "."
+	}
+	rel, err := filepath.Rel(configDir, filepath.Clean(workspacePath))
+	if err != nil {
+		return "", fmt.Errorf("resolve %q from %q: %w", workspacePath, configDir, err)
+	}
+	return filepath.ToSlash(rel), nil
 }
 
 // ParseConfig parses dagger.toml bytes into a workspace config.

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -75,17 +75,19 @@ type ModuleAsSDK struct {
 	Clients []SDKManagedClient `json:"clients,omitempty" toml:"clients,omitempty"`
 }
 
-// SDKManagedModule is a workspace-relative path to a module that an SDK
-// authors and manages here. The path is the only required field; the
-// module's own engine state lives in <path>/dagger-module.toml.
+// SDKManagedModule is a path to a module that an SDK authors and manages here,
+// resolved against the directory holding this dagger.toml, with a leading "/"
+// anchoring it at the workspace root instead. The path is the only required
+// field; the module's own engine state lives in <path>/dagger-module.toml.
 type SDKManagedModule struct {
 	Path string `json:"path" toml:"path"`
 }
 
-// SDKManagedClient is a workspace-relative path to a generated client
-// produced by an SDK, bound to one module. Module accepts a
-// workspace-relative path or canonical ref, same resolution as
-// [modules.X].source. Shape will evolve as concrete client SDKs implement.
+// SDKManagedClient is a generated client produced by an SDK and bound to one
+// module, with its path — and a Module given as a local path — resolved against
+// the directory holding this dagger.toml, a leading "/" anchoring at the
+// workspace root instead. Module also accepts a canonical ref, same resolution
+// as [modules.X].source. Shape will evolve as concrete client SDKs implement.
 type SDKManagedClient struct {
 	Path    string            `json:"path" toml:"path"`
 	Module  string            `json:"module" toml:"module"`

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -965,6 +965,11 @@ func TestSDKManagedPaths(t *testing.T) {
 		require.ErrorContains(t, err, "escapes the workspace root")
 	})
 
+	t.Run("reads Windows separators", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "apps/demo/.dagger/modules/greeter", mustResolve(t, "apps/demo", `.dagger\modules\greeter`))
+	})
+
 	t.Run("treats every entry as a path, never a ref", func(t *testing.T) {
 		t.Parallel()
 		// ResolveModuleEntrySource would hand this back untouched, reading the

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -935,6 +935,61 @@ func TestResolveModuleEntrySource(t *testing.T) {
 	})
 }
 
+func TestSDKManagedPaths(t *testing.T) {
+	t.Parallel()
+
+	mustResolve := func(t *testing.T, configDir, p string) string {
+		t.Helper()
+		resolved, err := ResolveSDKManagedPath(configDir, p)
+		require.NoError(t, err)
+		return resolved
+	}
+
+	t.Run("resolves against the config directory", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "apps/demo/.dagger/modules/greeter", mustResolve(t, "apps/demo", ".dagger/modules/greeter"))
+		require.Equal(t, "apps/demo", mustResolve(t, "apps/demo", "."))
+		require.Equal(t, "apps/shared", mustResolve(t, "apps/demo", "../shared"))
+		require.Equal(t, ".dagger/modules/greeter", mustResolve(t, ".", ".dagger/modules/greeter"))
+	})
+
+	t.Run("a leading slash anchors at the workspace root", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "tools/greeter", mustResolve(t, "apps/demo", "/tools/greeter"))
+		require.Equal(t, ".", mustResolve(t, "apps/demo", "/"))
+	})
+
+	t.Run("refuses to escape the workspace root", func(t *testing.T) {
+		t.Parallel()
+		_, err := ResolveSDKManagedPath("apps/demo", "../../../outside")
+		require.ErrorContains(t, err, "escapes the workspace root")
+	})
+
+	t.Run("treats every entry as a path, never a ref", func(t *testing.T) {
+		t.Parallel()
+		// ResolveModuleEntrySource would hand this back untouched, reading the
+		// dot as a domain; as-sdk entries are always paths.
+		require.Equal(t, "apps/demo/modules/v1.2", mustResolve(t, "apps/demo", "modules/v1.2"))
+	})
+
+	t.Run("records workspace paths relative to the config directory", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct{ configDir, workspacePath, want string }{
+			{"apps/demo", "apps/demo/.dagger/modules/greeter", ".dagger/modules/greeter"},
+			{"apps/demo", "apps/demo", "."},
+			{"apps/demo", "apps/shared", "../shared"},
+			{".", "modules/greeter", "modules/greeter"},
+			{"", "modules/greeter", "modules/greeter"},
+		} {
+			got, err := SDKManagedPathFor(tc.configDir, tc.workspacePath)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, cleanRelPath(tc.workspacePath), mustResolve(t, tc.configDir, got),
+				"round trip through %q", tc.configDir)
+		}
+	})
+}
+
 func TestDeleteConfigValue(t *testing.T) {
 	t.Parallel()
 

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -990,6 +990,51 @@ func TestSDKManagedPaths(t *testing.T) {
 	})
 }
 
+// A hand-written root-anchored as-sdk entry is legal config; editing the file
+// around it must not restate it in the engine's own spelling.
+func TestRootAnchoredAsSDKPathRoundTrip(t *testing.T) {
+	data := []byte(`[modules.init-fixture]
+source = "sdk/init-fixture"
+
+[modules.init-fixture.as-sdk]
+name = "fixture"
+
+[[modules.init-fixture.as-sdk.modules]]
+path = "/tools/mod"
+
+[[modules.init-fixture.as-sdk.clients]]
+path = "/clients/one"
+module = "/sdk/init-fixture"
+`)
+	cfg, err := ParseConfig(data)
+	require.NoError(t, err)
+
+	entry := cfg.Modules["init-fixture"]
+	require.Equal(t, "/tools/mod", entry.AsSDK.Modules[0].Path)
+
+	// resolution, from a config in a subdirectory
+	got, err := ResolveSDKManagedPath("common", entry.AsSDK.Modules[0].Path)
+	require.NoError(t, err)
+	require.Equal(t, "tools/mod", got)
+	got, err = ResolveSDKManagedPath("common", entry.AsSDK.Clients[0].Path)
+	require.NoError(t, err)
+	require.Equal(t, "clients/one", got)
+
+	// now let the engine add an entry and rewrite the file
+	entry.AsSDK.Modules = append(entry.AsSDK.Modules, SDKManagedModule{Path: ".dagger/modules/new"})
+	cfg.Modules["init-fixture"] = entry
+	out, err := UpdateConfigBytes(data, cfg)
+	require.NoError(t, err)
+	t.Logf("rewritten config:\n%s", out)
+
+	reparsed, err := ParseConfig(out)
+	require.NoError(t, err)
+	re := reparsed.Modules["init-fixture"]
+	require.Equal(t, "/tools/mod", re.AsSDK.Modules[0].Path, "hand-written spelling must survive")
+	require.Equal(t, "/clients/one", re.AsSDK.Clients[0].Path)
+	require.Equal(t, "/sdk/init-fixture", re.AsSDK.Clients[0].Module)
+}
+
 func TestDeleteConfigValue(t *testing.T) {
 	t.Parallel()
 

--- a/core/workspace/localref.go
+++ b/core/workspace/localref.go
@@ -1,0 +1,32 @@
+package workspace
+
+import (
+	"strings"
+
+	"github.com/dagger/dagger/core/gitref"
+)
+
+// IsLocalRef performs a fast heuristic check to determine whether a module
+// reference string refers to a local path instead of a git source.
+func IsLocalRef(source, pin string) bool {
+	switch gitref.FastKindCheck(source, pin) {
+	case gitref.KindLocal:
+		return true
+	case gitref.KindGit:
+		return false
+	}
+	// The ref has a dot but no scheme and no leading path marker. Only the part
+	// ahead of the first slash can be a host, so a dot further down the path
+	// ("common/.dagger/mymod") still reads as local.
+	host, _, _ := strings.Cut(source, "/")
+	if _, afterUser, scpLike := strings.Cut(host, "@"); scpLike {
+		host = afterUser
+	}
+	if strings.Contains(host, ".") || strings.Contains(host, ":") {
+		return false
+	}
+	// A dot-free host otherwise has to be spelled with a scheme, except for
+	// Azure DevOps Server, whose on-prem refs name themselves with a "_git"
+	// path segment (see the matcher in engine/vcs).
+	return !strings.Contains(source, "/_git/")
+}

--- a/core/workspace/localref.go
+++ b/core/workspace/localref.go
@@ -16,9 +16,11 @@ func IsLocalRef(source, pin string) bool {
 		return false
 	}
 	// The ref has a dot but no scheme and no leading path marker. Only the part
-	// ahead of the first slash can be a host, so a dot further down the path
-	// ("common/.dagger/mymod") still reads as local.
-	host, _, _ := strings.Cut(source, "/")
+	// ahead of the first separator can be a host, so a dot further down the path
+	// ("common/.dagger/mymod") still reads as local. A path typed on Windows
+	// separates with backslashes, which no git ref ever does; filepath.ToSlash
+	// would be a no-op here, since the engine reading this runs on Linux.
+	host, _, _ := strings.Cut(strings.ReplaceAll(source, `\`, "/"), "/")
 	if _, afterUser, scpLike := strings.Cut(host, "@"); scpLike {
 		host = afterUser
 	}

--- a/core/workspace/localref_test.go
+++ b/core/workspace/localref_test.go
@@ -27,6 +27,9 @@ func TestIsLocalRef(t *testing.T) {
 		{name: "dot segment below a subdirectory", source: "common/.dagger/mymod", isLocal: true},
 		{name: "dot segment deeply nested", source: "a/b/c/.dagger/mymod", isLocal: true},
 		{name: "dotted leaf below a subdirectory", source: "common/mymod.v2", isLocal: true},
+		// A path typed on Windows: no git ref separates with backslashes.
+		{name: "windows dot segment below a subdirectory", source: `common\.dagger\mymod`, isLocal: true},
+		{name: "windows dotted leaf", source: `common\mymod.v2`, isLocal: true},
 
 		{name: "github", source: "github.com/acme/mymod", isLocal: false},
 		{name: "github subdir", source: "github.com/acme/repo/sub/mymod", isLocal: false},

--- a/core/workspace/localref_test.go
+++ b/core/workspace/localref_test.go
@@ -1,0 +1,63 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLocalRef(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		source  string
+		pin     string
+		isLocal bool
+	}{
+		{name: "empty", source: "", isLocal: true},
+		{name: "cwd", source: ".", isLocal: true},
+		{name: "explicit relative", source: "./mymod", isLocal: true},
+		{name: "parent", source: "..", isLocal: true},
+		{name: "explicit parent", source: "../libs/mymod", isLocal: true},
+		{name: "absolute", source: "/srv/workspace/mymod", isLocal: true},
+		{name: "bare name", source: "mymod", isLocal: true},
+		{name: "nested path", source: "path/to/mymod", isLocal: true},
+		{name: "leading dot segment", source: ".dagger/mymod", isLocal: true},
+		{name: "dot segment below a subdirectory", source: "common/.dagger/mymod", isLocal: true},
+		{name: "dot segment deeply nested", source: "a/b/c/.dagger/mymod", isLocal: true},
+		{name: "dotted leaf below a subdirectory", source: "common/mymod.v2", isLocal: true},
+
+		{name: "github", source: "github.com/acme/mymod", isLocal: false},
+		{name: "github subdir", source: "github.com/acme/repo/sub/mymod", isLocal: false},
+		{name: "github with version", source: "github.com/acme/mymod@v1.2.3", isLocal: false},
+		{name: "gitlab with branch", source: "gitlab.com/acme/mymod@main", isLocal: false},
+		{name: "scp-style", source: "git@github.com:acme/mymod", isLocal: false},
+		{name: "scp-style dot-free host", source: "git@internal:acme/mymod.git", isLocal: false},
+		{name: "userless scp-style dot-free host", source: "internal:2222/acme/mymod.git", isLocal: false},
+		{name: "https scheme", source: "https://github.com/acme/mymod", isLocal: false},
+		{name: "http scheme", source: "http://github.com/acme/mymod", isLocal: false},
+		{name: "ssh scheme", source: "ssh://git@github.com/acme/mymod", isLocal: false},
+		{name: "bare host", source: "github.com", isLocal: false},
+		{name: "dotted first segment", source: "mymod.v2", isLocal: false},
+		{name: "azure devops services", source: "dev.azure.com/acme/public/_git/mymod", isLocal: false},
+		{name: "azure devops server on-prem", source: "azdo/tfs/acme/public/_git/mymod.git", isLocal: false},
+		// "_git" belongs to Azure's on-prem shorthand, so a dotted path under a
+		// directory of that name reads remote — as it did before this rule.
+		{name: "dotted path below a _git segment", source: "src/_git/mymod.git", isLocal: false},
+
+		{name: "pin wins over a bare name", source: "mymod", pin: "abcdef0", isLocal: false},
+		{name: "pin wins over a relative path", source: "./mymod", pin: "abcdef0", isLocal: false},
+		{name: "pin wins over a dot segment", source: "common/.dagger/mymod", pin: "abcdef0", isLocal: false},
+
+		// A dot-free host is indistinguishable from a bare local path without
+		// a scheme; callers disambiguate with `ssh://` or `https://`.
+		{name: "dot-free host reads as local", source: "localhost/acme/mymod", isLocal: true},
+		{name: "dot-free host reads as local, dotted leaf", source: "localhost/acme/mymod.git", isLocal: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.isLocal, IsLocalRef(tc.source, tc.pin))
+		})
+	}
+}

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -122,18 +122,6 @@ func uniqueModuleName(modules map[string]ModuleEntry, base string) string {
 	}
 }
 
-// IsLocalRef performs a fast heuristic check to determine whether a module
-// reference string refers to a local path instead of a git source.
-func IsLocalRef(source, pin string) bool {
-	if pin != "" {
-		return false
-	}
-	if len(source) > 0 && (source[0] == '/' || source[0] == '.') {
-		return true
-	}
-	return !strings.Contains(source, ".")
-}
-
 // MigrationPlan is the pure filesystem plan for migrating a legacy
 // dagger.json project to workspace format.
 type MigrationPlan struct {

--- a/docs/static/reference/dagger-workspace.schema.json
+++ b/docs/static/reference/dagger-workspace.schema.json
@@ -189,7 +189,7 @@
         "path",
         "module"
       ],
-      "description": "SDKManagedClient is a workspace-relative path to a generated client produced by an SDK, bound to one module."
+      "description": "SDKManagedClient is a generated client produced by an SDK and bound to one module, with its path — and a Module given as a local path — resolved against the directory holding this dagger.toml, a leading \"/\" anchoring at the workspace root instead."
     },
     "SDKManagedModule": {
       "properties": {
@@ -202,7 +202,7 @@
       "required": [
         "path"
       ],
-      "description": "SDKManagedModule is a workspace-relative path to a module that an SDK authors and manages here."
+      "description": "SDKManagedModule is a path to a module that an SDK authors and manages here, resolved against the directory holding this dagger.toml, with a leading \"/\" anchoring it at the workspace root instead."
     }
   }
 }

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -40,6 +40,7 @@ import (
 
 	"dagger.io/dagger/engineconn"
 	"github.com/dagger/dagger/analytics"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
@@ -723,8 +724,10 @@ func isObviouslyRemoteWorkspaceRef(ref string) bool {
 		}
 	}
 
-	head, _, hasSlash := strings.Cut(ref, "/")
-	return hasSlash && strings.Contains(head, ".")
+	// A single dotted token ("my.dir") is far more likely a directory that does
+	// not exist yet than a host, so stay conservative and require a path.
+	_, _, hasSlash := strings.Cut(ref, "/")
+	return hasSlash && !workspace.IsLocalRef(ref, "")
 }
 
 func Tracer() trace.Tracer {

--- a/internal/cmd/dagger/main_test.go
+++ b/internal/cmd/dagger/main_test.go
@@ -19,3 +19,20 @@ func TestCommandProgressDefault(t *testing.T) {
 	require.Empty(t, commandProgressDefault([]string{"call"}))
 	require.Empty(t, commandProgressDefault(nil))
 }
+
+func TestIsObviouslyRemoteWorkspaceRef(t *testing.T) {
+	require.True(t, isObviouslyRemoteWorkspaceRef("github.com/acme/mono"))
+	require.True(t, isObviouslyRemoteWorkspaceRef("git@github.com:acme/mono"))
+	require.True(t, isObviouslyRemoteWorkspaceRef("https://github.com/acme/mono"))
+
+	require.False(t, isObviouslyRemoteWorkspaceRef(""))
+	require.False(t, isObviouslyRemoteWorkspaceRef("./services/api"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("../services/api"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("/srv/services/api"))
+
+	// A dot below the first path segment names a directory, not a host, and a
+	// lone dotted token stays local however it reads.
+	require.False(t, isObviouslyRemoteWorkspaceRef("services/api.v2"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("common/.dagger/mymod"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("my.dir"))
+}

--- a/internal/cmd/dagger/module_sdk.go
+++ b/internal/cmd/dagger/module_sdk.go
@@ -123,7 +123,8 @@ func runModuleSdk(cmd *cobra.Command, args []string) error {
 //     dagger.json). The first match defines the module directory.
 //  2. Continue walking up to the workspace root (the nearest dagger.toml).
 //  3. Read the workspace config and scan [[modules.*.as-sdk.modules]] for
-//     a path entry matching the module's workspace-relative directory.
+//     a path entry matching the module's directory, both relative to the
+//     dagger.toml found in step 2.
 //  4. Return the parent module's short name (which is also the SDK name).
 //
 // Per the runtime/SDK split, dagger-module.toml no longer records the SDK.
@@ -132,18 +133,30 @@ func runModuleSdk(cmd *cobra.Command, args []string) error {
 // which SDK to dispatch to; that's an error the user resolves by
 // installing/registering the module via `dagger module init`.
 func currentModuleSDKName() (string, error) {
-	moduleDir, workspaceRoot, err := locateModuleAndWorkspaceRoot()
+	moduleDir, configDir, err := locateModuleAndWorkspaceRoot()
 	if err != nil {
 		return "", err
 	}
 
-	modulePath, err := filepath.Rel(workspaceRoot, moduleDir)
+	// as-sdk paths are anchored two ways — relative to the config, or at the
+	// workspace root behind a leading "/" — so the comparison happens in
+	// workspace-root coordinates. Without a git root the config directory is
+	// the only boundary there is.
+	boundary := gitRootAbove(configDir)
+	if boundary == "" {
+		boundary = configDir
+	}
+	modulePath, err := filepath.Rel(boundary, moduleDir)
 	if err != nil {
 		return "", fmt.Errorf("compute workspace-relative module path: %w", err)
 	}
 	modulePath = filepath.ToSlash(filepath.Clean(modulePath))
+	configDirRel, err := filepath.Rel(boundary, configDir)
+	if err != nil {
+		return "", fmt.Errorf("compute workspace-relative config path: %w", err)
+	}
 
-	wsConfigPath := filepath.Join(workspaceRoot, workspace.ConfigFileName)
+	wsConfigPath := filepath.Join(configDir, workspace.ConfigFileName)
 	wsData, err := os.ReadFile(wsConfigPath)
 	if err != nil {
 		return "", fmt.Errorf("read workspace config %q: %w", wsConfigPath, err)
@@ -158,12 +171,32 @@ func currentModuleSDKName() (string, error) {
 			continue
 		}
 		for _, m := range installed.AsSDK.Modules {
-			if filepath.ToSlash(filepath.Clean(m.Path)) == modulePath {
+			managed, err := workspace.ResolveSDKManagedPath(configDirRel, m.Path)
+			if err != nil {
+				return "", fmt.Errorf("module managed by %q in %s: %w", installedName, wsConfigPath, err)
+			}
+			if managed == modulePath {
 				return installedName, nil
 			}
 		}
 	}
 	return "", fmt.Errorf("module at %q is not registered under any [[modules.*.as-sdk.modules]] in %s; register it via `dagger module init` or add an entry by hand", modulePath, wsConfigPath)
+}
+
+// gitRootAbove returns the nearest directory at or above dir holding a .git,
+// which is the workspace boundary paths in dagger.toml measure against, or ""
+// when the config is not in a repository.
+func gitRootAbove(dir string) string {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // locateModuleAndWorkspaceRoot walks upward from cwd, returning the first

--- a/internal/cmd/dagger/module_sdk_test.go
+++ b/internal/cmd/dagger/module_sdk_test.go
@@ -1,8 +1,13 @@
 package daggercmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,6 +48,66 @@ func TestModuleSdkHelpHeuristic(t *testing.T) {
 				}
 			}
 			require.Equal(t, tt.wantDispatch, hasSubcommand)
+		})
+	}
+}
+
+// TestCurrentModuleSDKName covers the lookup against both spellings an
+// as-sdk entry can use: relative to the dagger.toml, or root-anchored.
+func TestCurrentModuleSDKName(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		managedPath string
+		wantErr     string
+	}{
+		{name: "config-relative", managedPath: ".dagger/modules/foo"},
+		{name: "root-anchored", managedPath: "/.dagger/modules/foo"},
+		{name: "escaping", managedPath: "../foo", wantErr: "escapes the workspace root"},
+		{name: "unrelated", managedPath: ".dagger/modules/bar", wantErr: "is not registered"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(root, workspace.ConfigFileName), fmt.Appendf(nil,
+				"[modules.my-sdk]\nsource = \"github.com/dagger/my-sdk\"\n\n[modules.my-sdk.as-sdk]\n\n[[modules.my-sdk.as-sdk.modules]]\npath = %q\n", tt.managedPath), 0o644))
+			moduleDir := filepath.Join(root, ".dagger", "modules", "foo")
+			require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(moduleDir, modules.Filename), []byte("name = \"foo\"\n"), 0o644))
+
+			t.Chdir(moduleDir)
+			name, err := currentModuleSDKName()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, "my-sdk", name)
+		})
+	}
+}
+
+// A dagger.toml in a subdirectory of the repo is where the two spellings stop
+// coinciding: a config-relative entry is measured from the config, a
+// root-anchored one from the repository root above it.
+func TestCurrentModuleSDKNameFromSubdirectoryConfig(t *testing.T) {
+	for _, tt := range []struct{ name, managedPath string }{
+		{"config-relative", ".dagger/modules/foo"},
+		{"root-anchored", "/common/.dagger/modules/foo"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+			configDir := filepath.Join(root, "common")
+			require.NoError(t, os.MkdirAll(configDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(configDir, workspace.ConfigFileName), fmt.Appendf(nil,
+				"[modules.my-sdk]\nsource = \"github.com/dagger/my-sdk\"\n\n[modules.my-sdk.as-sdk]\n\n[[modules.my-sdk.as-sdk.modules]]\npath = %q\n", tt.managedPath), 0o644))
+			moduleDir := filepath.Join(configDir, ".dagger", "modules", "foo")
+			require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(moduleDir, modules.Filename), []byte("name = \"foo\"\n"), 0o644))
+
+			t.Chdir(moduleDir)
+			name, err := currentModuleSDKName()
+			require.NoError(t, err)
+			require.Equal(t, "my-sdk", name)
 		})
 	}
 }

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -1077,14 +1077,7 @@ func workspaceAddressLooksRemote(address string) bool {
 	if address == "" || strings.HasPrefix(address, "file://") {
 		return false
 	}
-	switch gitref.FastKindCheck(address, "") {
-	case gitref.KindLocal:
-		return false
-	case gitref.KindGit:
-		return true
-	default:
-		return strings.Contains(address, ".") && !strings.HasPrefix(address, "/")
-	}
+	return !workspacepkg.IsLocalRef(address, "")
 }
 
 func parseWorkspaceRemoteAddress(ctx context.Context, address string) (workspaceRemoteAddress, bool, error) {

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -542,6 +542,10 @@ func TestWorkspaceAddressLooksRemote(t *testing.T) {
 	require.False(t, workspaceAddressLooksRemote("."))
 	require.False(t, workspaceAddressLooksRemote("./services/api"))
 	require.False(t, workspaceAddressLooksRemote("file:///repo/services/api"))
+
+	// A dot below the first path segment names a directory, not a host.
+	require.False(t, workspaceAddressLooksRemote("services/api.v2"))
+	require.False(t, workspaceAddressLooksRemote("common/.dagger/mymod"))
 }
 
 func TestWorkspaceRemoteVersionKind(t *testing.T) {


### PR DESCRIPTION
## What

`dagger.toml` carried two path conventions:

- `[modules.<name>].source` resolves against the **config directory**.
- `[[modules.<sdk>.as-sdk.modules]].path` (and the clients equivalent) resolved against the **workspace root**.

For instance (using #13890)

```toml
[modules.my-module]
source = ".dagger/modules/my-module"

[[modules.dagger-go-sdk.as-sdk.modules]]
path = "common/.dagger/modules/my-module"
```

While both are true, it feels a bad UX to have two paths not representing the same thing. By reading the toml file it's impossible to understand that `*.as-sdk.modules.path` is a workspace-root-relative one.

Now the same module reads the same way twice:

```toml
[modules.my-module]
source = ".dagger/modules/my-module"

[[modules.dagger-go-sdk.as-sdk.modules]]
path = ".dagger/modules/my-module"
```

`as-sdk.modules[].path`, `as-sdk.clients[].path` and a local `as-sdk.clients[].module` now resolve like every other path a workspace resolves — `[modules.<name>].source`, an `[[include]]`, a path typed at the CLI: a leading `/` anchors at the workspace root, anything else is relative to the directory holding that `dagger.toml`, and escaping the root is refused.

## Is anything broken today?

Not really, all that is working because the paths doesn't have the same meaning. It's more a question of being consistent.

At the workspace root — where every config sits today — the two anchors coincide and nothing moves. A `dagger.toml` in a subdirectory written before this needs its as-sdk paths rewritten relative to itself, or given a leading `/`.

## Where it lands

`dagger module init` and `dagger api client init` record the config-relative spelling. Every reader — SDK ownership for generation, `dagger uninstall`, `workspace.sdks`, `currentModule.asSDK` — resolves it back to workspace-root coordinates before use, so SDKs keep receiving workspace-root-relative paths and no SDK changes with this, including the out-of-repo `dagger/go-sdk`.

## Includes #13893

The first three commits are #13893, folded in: `IsLocalRef` read any dot as a hostname, so a local ref like `common/.dagger/mymod` — the shape a workspace-relative ref takes from a monorepo subdirectory — was routed to the git loader. Only the segment ahead of the first slash is read as a host now, the way Go import paths are.

That fix is what keeps the client read path here honest: a client module recorded as `.dagger/modules/api` under a subdirectory config resolves to `common/.dagger/modules/api`, and without #13893 that value classifies as a git ref on the way back in. A ref whose *first* segment carries a dot (`mymod.v2`) still needs the explicit `./`, which init records.

One follow-up on top of it, in its own commit: paths typed on Windows were not read as paths at all. The engine always runs on Linux, where a backslash is an ordinary character — `filepath` keeps `a\b` as one element and `filepath.ToSlash` is a no-op — and the CLI forwards a typed path verbatim. So `dagger module init --path common\clients\one` created a single directory named `common\clients\one`, `dagger install ..\dep` never collapsed the `..`, and a `..\..\` spelling walked past the guard that refuses to escape the workspace root. Separators are normalized where a workspace path, a local module ref and an as-sdk entry are read, as `engine/client/pathutil` already does for host paths.

## Tests

- `core/workspace`: the resolver in both directions — config-relative, root-anchored, `..` inside the workspace, escape refused — plus a round trip proving a hand-written `/`-anchored entry survives the engine rewriting the file around it.
- `core/schema`: ownership mapping from a config below the root; a root-anchored entry matched by uninstall, client replacement, ownership and the SDK listing; the stored client ref classifies the same way as the ref it came from.
- `internal/cmd/dagger`: the `dagger sdk <subcommand>` lookup, for both spellings, with the config at the root and in a subdirectory.
- `core/integration`: the subdirectory-workspace init tests assert both paths read the same, and #13893's dotted-module-path client init runs against the current caller-relative `--path` semantics. `^TestGenerators$` → 131 passed, 0 failed; `^TestWorkspaceAPI$|^TestWorkspaceModules$|^TestWorkspaceMigration$` green in the same shape.

## Follow-up

The resolution rule is implemented twice now: here, and in `IncludeSource.resolveIncludePath` for `[[include]]` entries, which is not on `main` yet. Once it lands the two should collapse into a single helper in `core/workspace`.
