### PR TITLE
fix: classify dotted workspace-relative module refs as local

### DIFF
--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -701,6 +701,52 @@ func (GeneratorsSuite) TestAPIClientInitGeneratesForNewClientOnly(ctx context.Co
 	})
 }
 
+// TestAPIClientInitDottedModulePath covers a module ref whose dot segment is
+// not the first one ("common/.dagger/target"), the shape a root-relative ref
+// takes from a monorepo subdirectory. The ref classifier used to read any dot
+// as a hostname and route such a ref to git.
+func (GeneratorsSuite) TestAPIClientInitDottedModulePath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixture(t, c).
+		WithNewFile("common/.dagger/target/dagger.json", `{
+  "name": "target",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`)
+
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{name: "workspace-relative", ref: "common/.dagger/target"},
+		{name: "explicitly relative", ref: "./common/.dagger/target"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			initialized := base.
+				WithWorkdir("/work/common").
+				With(daggerExec(
+					"api", "client", "init", "fixture", "clients/dotted", tc.ref, "--auto-apply"))
+			out, err := initialized.CombinedOutput(ctx)
+			require.NoError(t, err, out)
+
+			scaffold, err := initialized.File("/work/clients/dotted/scaffold.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "common/.dagger/target\n", scaffold)
+
+			// The generators ran for the new client too, which reads the
+			// recorded ref back through the SDK's client list.
+			generated, err := initialized.File("/work/clients/dotted/generated-client.txt").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "common/.dagger/target\n", generated)
+
+			config, err := initialized.File("/work/dagger.toml").Contents(ctx)
+			require.NoError(t, err)
+			require.Contains(t, config, `module = "common/.dagger/target"`)
+		})
+	}
+}
+
 func (GeneratorsSuite) TestGeneratorGroupChangesSyncWithNestedSDKCodegen(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2115,16 +2115,6 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 	return depCfg, nil
 }
 
-func isLocalLegacyModuleRef(source, pin string) bool {
-	if pin != "" {
-		return false
-	}
-	if len(source) > 0 && (source[0] == '/' || source[0] == '.') {
-		return true
-	}
-	return !strings.Contains(source, ".")
-}
-
 func replaceModuleRefVersion(refString, version string) string {
 	before, _, found := strings.Cut(refString, "@")
 	if found {
@@ -2236,7 +2226,7 @@ func (s *moduleSourceSchema) moduleSourceWithUpdateToolchains(
 			}
 			matched = true
 			delete(updateReqs, req)
-			if !isLocalLegacyModuleRef(cfg.Source, cfg.Pin) {
+			if !workspace.IsLocalRef(cfg.Source, cfg.Pin) {
 				refString := cfg.Source
 				if req.version != "" {
 					refString = replaceModuleRefVersion(refString, req.version)
@@ -2365,7 +2355,7 @@ func (s *moduleSourceSchema) moduleSourceWithUpdateBlueprint(
 	}
 
 	cfg := parentSrc.Self().ConfigBlueprint
-	if isLocalLegacyModuleRef(cfg.Source, cfg.Pin) {
+	if workspace.IsLocalRef(cfg.Source, cfg.Pin) {
 		return parentSrc.Result, nil
 	}
 

--- a/core/workspace/localref.go
+++ b/core/workspace/localref.go
@@ -1,0 +1,32 @@
+package workspace
+
+import (
+	"strings"
+
+	"github.com/dagger/dagger/core/gitref"
+)
+
+// IsLocalRef performs a fast heuristic check to determine whether a module
+// reference string refers to a local path instead of a git source.
+func IsLocalRef(source, pin string) bool {
+	switch gitref.FastKindCheck(source, pin) {
+	case gitref.KindLocal:
+		return true
+	case gitref.KindGit:
+		return false
+	}
+	// The ref has a dot but no scheme and no leading path marker. Only the part
+	// ahead of the first slash can be a host, so a dot further down the path
+	// ("common/.dagger/mymod") still reads as local.
+	host, _, _ := strings.Cut(source, "/")
+	if _, afterUser, scpLike := strings.Cut(host, "@"); scpLike {
+		host = afterUser
+	}
+	if strings.Contains(host, ".") || strings.Contains(host, ":") {
+		return false
+	}
+	// A dot-free host otherwise has to be spelled with a scheme, except for
+	// Azure DevOps Server, whose on-prem refs name themselves with a "_git"
+	// path segment (see the matcher in engine/vcs).
+	return !strings.Contains(source, "/_git/")
+}

--- a/core/workspace/localref_test.go
+++ b/core/workspace/localref_test.go
@@ -1,0 +1,63 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLocalRef(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		source  string
+		pin     string
+		isLocal bool
+	}{
+		{name: "empty", source: "", isLocal: true},
+		{name: "cwd", source: ".", isLocal: true},
+		{name: "explicit relative", source: "./mymod", isLocal: true},
+		{name: "parent", source: "..", isLocal: true},
+		{name: "explicit parent", source: "../libs/mymod", isLocal: true},
+		{name: "absolute", source: "/srv/workspace/mymod", isLocal: true},
+		{name: "bare name", source: "mymod", isLocal: true},
+		{name: "nested path", source: "path/to/mymod", isLocal: true},
+		{name: "leading dot segment", source: ".dagger/mymod", isLocal: true},
+		{name: "dot segment below a subdirectory", source: "common/.dagger/mymod", isLocal: true},
+		{name: "dot segment deeply nested", source: "a/b/c/.dagger/mymod", isLocal: true},
+		{name: "dotted leaf below a subdirectory", source: "common/mymod.v2", isLocal: true},
+
+		{name: "github", source: "github.com/acme/mymod", isLocal: false},
+		{name: "github subdir", source: "github.com/acme/repo/sub/mymod", isLocal: false},
+		{name: "github with version", source: "github.com/acme/mymod@v1.2.3", isLocal: false},
+		{name: "gitlab with branch", source: "gitlab.com/acme/mymod@main", isLocal: false},
+		{name: "scp-style", source: "git@github.com:acme/mymod", isLocal: false},
+		{name: "scp-style dot-free host", source: "git@internal:acme/mymod.git", isLocal: false},
+		{name: "userless scp-style dot-free host", source: "internal:2222/acme/mymod.git", isLocal: false},
+		{name: "https scheme", source: "https://github.com/acme/mymod", isLocal: false},
+		{name: "http scheme", source: "http://github.com/acme/mymod", isLocal: false},
+		{name: "ssh scheme", source: "ssh://git@github.com/acme/mymod", isLocal: false},
+		{name: "bare host", source: "github.com", isLocal: false},
+		{name: "dotted first segment", source: "mymod.v2", isLocal: false},
+		{name: "azure devops services", source: "dev.azure.com/acme/public/_git/mymod", isLocal: false},
+		{name: "azure devops server on-prem", source: "azdo/tfs/acme/public/_git/mymod.git", isLocal: false},
+		// "_git" belongs to Azure's on-prem shorthand, so a dotted path under a
+		// directory of that name reads remote — as it did before this rule.
+		{name: "dotted path below a _git segment", source: "src/_git/mymod.git", isLocal: false},
+
+		{name: "pin wins over a bare name", source: "mymod", pin: "abcdef0", isLocal: false},
+		{name: "pin wins over a relative path", source: "./mymod", pin: "abcdef0", isLocal: false},
+		{name: "pin wins over a dot segment", source: "common/.dagger/mymod", pin: "abcdef0", isLocal: false},
+
+		// A dot-free host is indistinguishable from a bare local path without
+		// a scheme; callers disambiguate with `ssh://` or `https://`.
+		{name: "dot-free host reads as local", source: "localhost/acme/mymod", isLocal: true},
+		{name: "dot-free host reads as local, dotted leaf", source: "localhost/acme/mymod.git", isLocal: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.isLocal, IsLocalRef(tc.source, tc.pin))
+		})
+	}
+}

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -122,18 +122,6 @@ func uniqueModuleName(modules map[string]ModuleEntry, base string) string {
 	}
 }
 
-// IsLocalRef performs a fast heuristic check to determine whether a module
-// reference string refers to a local path instead of a git source.
-func IsLocalRef(source, pin string) bool {
-	if pin != "" {
-		return false
-	}
-	if len(source) > 0 && (source[0] == '/' || source[0] == '.') {
-		return true
-	}
-	return !strings.Contains(source, ".")
-}
-
 // MigrationPlan is the pure filesystem plan for migrating a legacy
 // dagger.json project to workspace format.
 type MigrationPlan struct {

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -40,6 +40,7 @@ import (
 
 	"dagger.io/dagger/engineconn"
 	"github.com/dagger/dagger/analytics"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
@@ -726,8 +727,10 @@ func isObviouslyRemoteWorkspaceRef(ref string) bool {
 		}
 	}
 
-	head, _, hasSlash := strings.Cut(ref, "/")
-	return hasSlash && strings.Contains(head, ".")
+	// A single dotted token ("my.dir") is far more likely a directory that does
+	// not exist yet than a host, so stay conservative and require a path.
+	_, _, hasSlash := strings.Cut(ref, "/")
+	return hasSlash && !workspace.IsLocalRef(ref, "")
 }
 
 func Tracer() trace.Tracer {

--- a/internal/cmd/dagger/main_test.go
+++ b/internal/cmd/dagger/main_test.go
@@ -19,3 +19,20 @@ func TestCommandProgressDefault(t *testing.T) {
 	require.Empty(t, commandProgressDefault([]string{"call"}))
 	require.Empty(t, commandProgressDefault(nil))
 }
+
+func TestIsObviouslyRemoteWorkspaceRef(t *testing.T) {
+	require.True(t, isObviouslyRemoteWorkspaceRef("github.com/acme/mono"))
+	require.True(t, isObviouslyRemoteWorkspaceRef("git@github.com:acme/mono"))
+	require.True(t, isObviouslyRemoteWorkspaceRef("https://github.com/acme/mono"))
+
+	require.False(t, isObviouslyRemoteWorkspaceRef(""))
+	require.False(t, isObviouslyRemoteWorkspaceRef("./services/api"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("../services/api"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("/srv/services/api"))
+
+	// A dot below the first path segment names a directory, not a host, and a
+	// lone dotted token stays local however it reads.
+	require.False(t, isObviouslyRemoteWorkspaceRef("services/api.v2"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("common/.dagger/mymod"))
+	require.False(t, isObviouslyRemoteWorkspaceRef("my.dir"))
+}

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -1077,14 +1077,7 @@ func workspaceAddressLooksRemote(address string) bool {
 	if address == "" || strings.HasPrefix(address, "file://") {
 		return false
 	}
-	switch gitref.FastKindCheck(address, "") {
-	case gitref.KindLocal:
-		return false
-	case gitref.KindGit:
-		return true
-	default:
-		return strings.Contains(address, ".") && !strings.HasPrefix(address, "/")
-	}
+	return !workspacepkg.IsLocalRef(address, "")
 }
 
 func parseWorkspaceRemoteAddress(ctx context.Context, address string) (workspaceRemoteAddress, bool, error) {

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -541,6 +541,10 @@ func TestWorkspaceAddressLooksRemote(t *testing.T) {
 	require.False(t, workspaceAddressLooksRemote("."))
 	require.False(t, workspaceAddressLooksRemote("./services/api"))
 	require.False(t, workspaceAddressLooksRemote("file:///repo/services/api"))
+
+	// A dot below the first path segment names a directory, not a host.
+	require.False(t, workspaceAddressLooksRemote("services/api.v2"))
+	require.False(t, workspaceAddressLooksRemote("common/.dagger/mymod"))
 }
 
 func TestWorkspaceRemoteVersionKind(t *testing.T) {


### PR DESCRIPTION
`dagger api client init` fails on a module path with a dot in it:

```console
$ dagger api client init go clients/api common/.dagger/mymod
load module source: local path "common/.dagger/mymod" does not exist
```

You hit this from a subdirectory of a monorepo, where a module that is
`.dagger/mymod` at the workspace root is `common/.dagger/mymod` relative to it.
Adding `./` doesn't help: the ref is cleaned before it gets classified.

## Why

`IsLocalRef` treated a ref as local if it started with `.` or `/`, or if it had
no dot anywhere. The no-dot check was standing in for "is this a hostname".
`common/.dagger/mymod` fails both, so it went to the git loader.

Now it calls `gitref.FastKindCheck` (which already knows about pins, `./`, and
the http/https/ssh schemes) and only looks for the host ahead of the first
slash, like Go import paths do. Dot-free hosts still need a scheme, except
scp-style (`git@internal:org/repo.git`) and Azure DevOps Server (`/_git/`).

## Also

The same heuristic was copy-pasted in three other places, and they'd drifted:

- `isLocalLegacyModuleRef` in `core/schema/modulesource.go`, used by `dagger
  update`: identical copy, deleted.
- `workspaceAddressLooksRemote`: same bug, so `-W services/api.v2` was read as a
  git ref.
- `isObviouslyRemoteWorkspaceRef`: already used the first-segment rule, just
  spelled out again.

All three go through `IsLocalRef` now. `auth/registry.go` and `engine/vcs` also
poke at dots but they answer different questions, so I left them alone.

## Known limitation

`./mymod.v2` at the workspace root still reads as a git ref. The `./` is cleaned
away and the cleaned form is what lands in `as-sdk.clients.module`, so the next
load has nothing to go on. Fixing it means writing the `./` into the config,
which is a format change, so not here.

## Tests

`localref_test.go` covers the classifier. `TestAPIClientInitDottedModulePath`
runs `client init` from a subdirectory against `common/.dagger/target`; both
subtests fail without the fix, with the error above. CLI side has
`TestIsObviouslyRemoteWorkspaceRef` plus a couple of new cases in
`TestWorkspaceAddressLooksRemote`.
