### PR TITLE
Add missing view gates

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -239,6 +239,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.NodeFunc("withVolatileVariable", s.withVolatileVariable).
+			View(AfterVersion("v0.21.4")).
 			WithInput(dagql.PerSessionInput).
 			Doc(`Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.`,
 				`This is an expert-only escape hatch. If a volatile value affects observable exec results, stale cached results may be reused.`).
@@ -260,6 +261,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			),
 
 		dagql.NodeFunc("withoutVolatileVariable", s.withoutVolatileVariable).
+			View(AfterVersion("v0.21.4")).
 			Doc(`Retrieves this container minus the given volatile environment variable.`).
 			Args(
 				dagql.Arg("name").Doc(`The name of the volatile environment variable (e.g., "CI_RUN_ID").`),
@@ -379,7 +381,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user:group to set for the mounted directory and its contents.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("readOnly").Doc(`Mount the directory read-only.`).
 					View(AfterVersion("v0.21.0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
@@ -394,7 +396,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user or user:group to set for the mounted file.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 			),
@@ -430,7 +432,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					any effect if/when the cache has already been created.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 			),
@@ -454,7 +456,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user:group to set for the mounted secret.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("mode").Doc(`Permission given to the mounted secret (e.g., 0600).`,
 					`This option requires an owner to be set to be active.`),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
@@ -469,7 +471,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user:group to set for the mounted socket.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 			),
@@ -500,7 +502,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user:group to set for the file.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 			),
@@ -533,7 +535,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user:group to set for the files.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 					`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
 			),
@@ -550,7 +552,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					`A user:group to set for the file.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(
 					`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 						`environment variables defined in the container (e.g. "/$VAR/foo.txt").`),
@@ -581,7 +583,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("owner").Doc(`A user:group to set for the directory and its contents.`,
 					`The user and group can either be an ID (1000:1000) or a name (foo:bar).`,
 					`If the group is omitted, it defaults to the same as the user.`),
-				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v0.21.8")),
+				dagql.Arg("inheritOwner").Doc(`Set the owner to the container's current user.`).View(AfterVersion("v1.0.0-0")),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
 					`environment variables defined in the container (e.g. "/$VAR/foo").`),
 				dagql.Arg("permissions").View(AfterVersion("v0.21.0")),
@@ -603,7 +605,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("expectedType").Doc(`If specified, also validate the type of file (e.g. "REGULAR_TYPE", "DIRECTORY_TYPE", or "SYMLINK_TYPE").`),
 				dagql.Arg("doNotFollowSymlinks").Doc(`If specified, do not follow symlinks.`),
 				dagql.Arg("expand").Doc(`Replace "${VAR}" or "$VAR" in the value of path according to the current `+
-					`environment variables defined in the container (e.g. "/$VAR/foo").`),
+					`environment variables defined in the container (e.g. "/$VAR/foo").`).
+					View(AfterVersion("v0.21.5")),
 			),
 
 		dagql.NodeFunc("stat", s.stat).

--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -202,6 +202,7 @@ func (s llmSchema) Install(srv *dagql.Server) {
 					View(AfterVersion("v1.0.0-0")),
 			),
 		dagql.Func("hasPending", s.hasPending).
+			View(AfterVersion("v1.0.0-0")).
 			Doc("Report whether anything is queued to send to the model: an unsent prompt or unevaluated tool results. When true, another step will do work; when false, the turn is complete."),
 		dagql.Func("fork", s.fork).
 			View(AfterVersion("v1.0.0-0")).

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -242,7 +242,8 @@ func (s *moduleSchema) Install(dag *dagql.Server) {
 		dagql.Func("currentTypeDefs", s.currentTypeDefs).
 			WithInput(dagql.CurrentSchemaInput).
 			Args(
-				dagql.Arg("returnAllTypes").Doc(`Return the full referenced typedef closure instead of only top-level served typedefs.`),
+				dagql.Arg("returnAllTypes").Doc(`Return the full referenced typedef closure instead of only top-level served typedefs.`).
+					View(AfterVersion("v0.21.0")),
 				dagql.Arg("hideCore").Doc(
 					`Strip core API functions from the Query type, leaving only module-sourced functions (constructors, entrypoint proxies, etc.).`,
 					`Core types (Container, Directory, etc.) are kept so return types and method chaining still work.`,

--- a/core/schema/testdata/base_schema.graphqls
+++ b/core/schema/testdata/base_schema.graphqls
@@ -423,12 +423,6 @@ type Container implements Exportable & Node & Syncer {
 
     """If specified, do not follow symlinks."""
     doNotFollowSymlinks: Boolean = false
-
-    """
-    Replace "${VAR}" or "$VAR" in the value of path according to the current
-    environment variables defined in the container (e.g. "/$VAR/foo").
-    """
-    expand: Boolean = false
   ): Boolean!
 
   """
@@ -1326,20 +1320,6 @@ type Container implements Exportable & Node & Syncer {
     name: String!
   ): Container!
 
-  """
-  Set a new non-secret environment variable for future execs without invalidating exec cache when only its value changes.
-
-  This is an expert-only escape hatch. If a volatile value affects observable
-  exec results, stale cached results may be reused.
-  """
-  withVolatileVariable(
-    """Name of the volatile variable (e.g., "CI_RUN_ID")."""
-    name: String!
-
-    """Value of the volatile variable."""
-    value: String!
-  ): Container!
-
   """Change the container's working directory. Like WORKDIR in Dockerfile."""
   withWorkdir(
     """The path to set as the working directory (e.g., "/app")."""
@@ -1494,14 +1474,6 @@ type Container implements Exportable & Node & Syncer {
   Should default to root.
   """
   withoutUser: Container!
-
-  """
-  Retrieves this container minus the given volatile environment variable.
-  """
-  withoutVolatileVariable(
-    """The name of the volatile environment variable (e.g., "CI_RUN_ID")."""
-    name: String!
-  ): Container!
 
   """
   Unset the container's working directory.
@@ -3278,13 +3250,6 @@ type LLM implements Node & Syncer {
   """create a branch in the LLM's history"""
   attempt(number: Int!): LLM!
 
-  """
-  Report whether anything is queued to send to the model: an unsent prompt or
-  unevaluated tool results. When true, another step will do work; when false,
-  the turn is complete.
-  """
-  hasPending: Boolean!
-
   """A unique identifier for this LLM."""
   id: ID!
 
@@ -4000,11 +3965,6 @@ type Query implements Node {
   The TypeDef representations of the objects currently being served in the session.
   """
   currentTypeDefs(
-    """
-    Return the full referenced typedef closure instead of only top-level served typedefs.
-    """
-    returnAllTypes: Boolean = false
-
     """
     Strip core API functions from the Query type, leaving only module-sourced
     functions (constructors, entrypoint proxies, etc.).


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/13883

  1. Ground truth: ran real released engines (v0.19.11, v0.20.8, and every v0.21.x patch, via DAGGER_X_RELEASE) and captured their schemas with a raw introspection query — importantly with includeDeprecated: true on args,
  since deprecated compat args like keepGitDir are hidden by default and initially looked like false leaks.
  2. Branch side: rendered this branch's schema at each of those versions' views using the existing test plumbing (NewCoreSchemaBase + Fork(view) + getSchemaJSON), run in a linux container via a throwaway test.
  3. Diffed the two per version at the type/field/arg/enum level. Anything visible in the branch's "vX view" that the real vX engine never served is a leak. The earliest real release that does contain the item gives the
  correct gate version — e.g. withVolatileVariable first appears in real v0.21.4 → AfterVersion("v0.21.4"); inheritOwner and hasPending appear in no v0.2x release at all → AfterVersion("v1.0.0-0").
  4. Validated by re-rendering after the edits: every view from v0.21.1–v0.21.8 now diffs clean against its real engine. (v0.19/v0.20 views still have pre-existing leaks I left alone — pinning those needs per-patch
  captures of the older series, and some need dagql changes.)