### PR TITLE
docs: clarify engine memory pruning configuration

### DIFF
--- a/docs/current_docs/reference/configuration/cache.mdx
+++ b/docs/current_docs/reference/configuration/cache.mdx
@@ -49,21 +49,19 @@ dagger -m core api call engine local-cache prune
 
 That will remove *all* cache entries not currently being used by connected clients from the disk.
 
-To instead trigger a prune that follows the enabled disk and structural
-metadata rules in the engine's [configured cache garbage collection
-policy](./engine.mdx), use the following command:
+To instead trigger a prune that follows the engine's [configured cache garbage
+collection policy](./engine.mdx), use the following command:
 
 ```shell
 dagger -m core api call engine local-cache prune --use-default-policy
 ```
 
-If automatic garbage collection is disabled, no default disk policies are
-active. For compatibility, `--use-default-policy` then falls back to the same
-all-releasable disk prune as a request with no options; it does not enable the
-structural stage. Use explicit structural options to run that stage while
-automatic garbage collection is disabled.
+This applies both the configured disk policies and the configured in-memory
+metadata limits. If garbage collection is disabled, there is no configured
+policy to follow. The command then prunes all releasable disk entries, exactly
+like a request with no options, and does not prune metadata.
 
-Structural metadata can also be pruned explicitly with absolute byte limits:
+To prune metadata on its own, pass the limits as absolute byte counts:
 
 ```shell
 dagger -m core api call engine local-cache prune \
@@ -71,20 +69,12 @@ dagger -m core api call engine local-cache prune \
   --target-estimated-bytes=3221225472
 ```
 
-These example values match the built-in 4 GiB maximum and 3 GiB target. A
-structural pass removes roots only when the current estimate exceeds the
-maximum.
+The example values are the built-in defaults. Metadata is pruned only when the
+estimate is above `--max-estimated-bytes`. Passing either flag prunes metadata,
+even when garbage collection is disabled. An omitted flag uses the engine's
+configured value. Values must be positive integers, and the target must be
+lower than the maximum. Percentages and size strings are not accepted.
 
-Supplying either structural option enables structural pruning for that request,
-even when automatic garbage collection is disabled. An omitted option inherits
-the engine's resolved configured/default value. Explicit values must be
-positive, and the resolved target must be lower than the resolved maximum.
-Percentages and size strings are not accepted.
-
-A request containing only structural options does not run the disk-policy
-stage. Structural pruning can still release cache entries and trigger snapshot
-garbage collection, which may reclaim disk; disk-policy retention rules and
-filters do not constrain that structural pass. Disk options and structural
-options can be combined; the disk stage runs first, followed by the structural
-stage in the same serialized request. Active session closures and
-engine-lifetime unpruneable roots remain protected in both stages.
+A request with only these two flags does not prune the disk cache, though
+removing metadata can still free disk space. If a request also overrides the
+disk space limits, the disk prune runs first and the metadata prune second.

--- a/docs/current_docs/reference/configuration/engine.mdx
+++ b/docs/current_docs/reference/configuration/engine.mdx
@@ -222,44 +222,6 @@ gc = false
 </TabItem>
 </Tabs>
 
-The garbage collector also limits the in-memory metadata retained by Dagger's
-operation cache. This limit is separate from the disk-space policy: pruning can
-run when cached operations use little or no disk, and it does not depend on a
-worker disk policy being configured.
-
-The current provisional metadata estimate limit is 4 GiB. When the estimate
-exceeds that limit, the engine removes cold persisted cache roots toward a 3
-GiB target. These implementation defaults remain subject to final tuning and
-canary evidence. Active results and engine-lifetime unpruneable results remain
-protected. Removed results can be recomputed by later calls.
-
-The limits can be changed in `engine.json` using absolute integer bytes:
-
-```json
-{
-  "gc": {
-    "dagqlCache": {
-      "maxEstimatedBytes": 4294967296,
-      "targetEstimatedBytes": 3221225472
-    }
-  }
-}
-```
-
-`targetEstimatedBytes` must be positive and lower than
-`maxEstimatedBytes`. Omitting either field, or setting it to `0`, uses its
-built-in default. These fields do not accept percentages or size strings.
-Setting `gc.enabled` to `false` disables automatic disk and operation-metadata
-garbage collection. Explicit manual structural pruning remains available.
-Manual `useDefaultPolicy` does not enable the structural stage in this case;
-because no default disk policies are active, its existing disk path falls back
-to pruning all releasable disk-cache entries.
-
-The metadata value is a coarse structural estimate based on the number of live
-cached results, symbolic operation terms, and allocated equivalence-class
-slots. It is inexpensive to read, but it is not a measurement or hard limit of
-the engine process's resident memory.
-
 The default cache policy attempts to keep the long-term cache storage under 75%
 of the total disk, while also ensuring that at least 20% of the disk remains
 free for other applications and tools. The cache policy can be further tweaked
@@ -373,6 +335,42 @@ To adjust the garbage collector's fine-grained policies:
 
 </TabItem>
 </Tabs>
+
+The garbage collector also limits the metadata that Dagger keeps in memory for
+the operation cache. This limit is separate from the disk policies above. It
+applies even when cached operations use little or no disk, and it does not
+need a disk policy to be configured.
+
+The metadata estimate is a coarse count of the cached results and internal
+terms the engine holds in memory. It is not a measurement of the engine
+process's memory usage.
+
+When the estimate goes above `maxEstimatedBytes`, the engine removes cached
+results, least recently used first, aiming for `targetEstimatedBytes`. Results
+in use and results kept for the engine's lifetime are never removed. Removed
+results are recomputed if a later call needs them. The engine checks the
+estimate after each session ends and on a background timer.
+
+`maxEstimatedBytes` defaults to 4 GiB and `targetEstimatedBytes` to 3 GiB. Both
+are set in `engine.json` as absolute integer bytes:
+
+```json
+{
+  "gc": {
+    "dagqlCache": {
+      "maxEstimatedBytes": 4294967296,
+      "targetEstimatedBytes": 3221225472
+    }
+  }
+}
+```
+
+Percentages and size strings are not accepted. Omitting a field, or setting it
+to `0`, uses its default. `targetEstimatedBytes` must be positive and lower
+than `maxEstimatedBytes`.
+
+Setting `gc.enabled` to `false` also stops automatic metadata pruning. Metadata
+can still be pruned [on demand](./cache.mdx#manual-pruning).
 
 ## Custom registries
 


### PR DESCRIPTION
## Summary

Clarifies and reorganizes the memory pruning documentation that already landed with the feature in #13887. No behavior changes.

On the engine configuration page, the metadata limit now follows the disk policies instead of splitting them apart. It states the `gc.dagqlCache` field names, the 4 GiB and 3 GiB defaults, the absolute byte units, the validation rules, and when pruning runs.

On the cache page, the manual pruning section states what each prune flag does, when metadata is pruned, and how the metadata prune relates to the disk prune.

Only `docs/current_docs` is updated. The released version snapshots under `docs/versioned_docs` do not support these controls, so they are left alone.

## Test plan

`dagger check docs:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)