### PR TITLE
fix: drop ReadHeaderTimeout on HTTP/2 servers

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -533,7 +533,15 @@ func main() { //nolint:gocyclo
 		protocols.SetHTTP1(true)
 		protocols.SetUnencryptedHTTP2(true)
 		httpServer = &http.Server{
-			ReadHeaderTimeout: 30 * time.Second,
+			// NOTE: do NOT set ReadHeaderTimeout here (gosec G112). As of Go
+			// 1.26.6, net/http arms a connection-level read deadline from
+			// ReadHeaderTimeout *before* handing an unencrypted HTTP/2
+			// connection off to the HTTP/2 server, and the HTTP/2 server only
+			// disarms that deadline when ReadTimeout > 0. The result is a hard
+			// cap on connection lifetime: every client connection dies after
+			// ReadHeaderTimeout no matter how active it is, and since all of a
+			// client's streams share one h2 connection, any query outliving it
+			// fails with `Post "http://dagger/query": unexpected EOF`.
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("content-type"), "application/grpc") {
 					// The docs on grpcServer.ServeHTTP warn that some features are missing vs. serving fully "native" gRPC,

--- a/engine/engineutil/executor_spec.go
+++ b/engine/engineutil/executor_spec.go
@@ -1114,7 +1114,10 @@ func (c *Client) setupNestedClient(ctx context.Context, state *execState) (rerr 
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
 	httpSrv := &http.Server{
-		ReadHeaderTimeout: 10 * time.Second,
+		// NOTE: no ReadHeaderTimeout (gosec G112) — see cmd/engine/main.go. On
+		// Go >= 1.26.6 it becomes a hard lifetime cap on unencrypted HTTP/2
+		// connections, which would kill every module function call that runs
+		// longer than it.
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			c.SessionHandler.ServeHTTPToNestedClient(resp, req, state.nestedClientMetadata, state.callerClientID, false, state.nestedClientModule, state.nestedClientFunctionCall)
 		}),

--- a/internal/cmd/dagger/listen.go
+++ b/internal/cmd/dagger/listen.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
@@ -71,8 +70,9 @@ func Listen(ctx context.Context, engineClient *client.Client, _ *dagger.Module, 
 
 	srv := &http.Server{
 		Handler: handler,
-		// Gosec G112: prevent slowloris attacks
-		ReadHeaderTimeout: 10 * time.Second,
+		// NOTE: no ReadHeaderTimeout (gosec G112) — see cmd/engine/main.go. On
+		// Go >= 1.26.6 it becomes a hard lifetime cap on unencrypted HTTP/2
+		// connections, which would kill every session outliving it.
 		BaseContext: func(_ net.Listener) context.Context {
 			return ctx
 		},


### PR DESCRIPTION
Any dagger session that outlives 30 seconds currently dies with:

```
Error: Post "http://dagger/query": unexpected EOF
```

Reproduces on anything slow enough — no module or agent involved:

```console
$ dagger core container from --address=alpine with-exec --args=sh,-c,'sleep 45; echo ok' stdout
Error: Post "http://dagger/query": unexpected EOF     # at 31.2s, deterministically
```

The engine logs nothing useful. From its side the client simply vanishes: three `client went away` lines for the telemetry streams, then session teardown. No panic, no crash, no restart.

## Cause

`net/http` in **Go 1.26.6** now arms a connection-level read deadline from `ReadHeaderTimeout` *before* handing an unencrypted HTTP/2 connection off to the HTTP/2 server:

```go
+	if d := c.server.readHeaderTimeout(); d > 0 {
+		c.rwc.SetReadDeadline(time.Now().Add(d))
+	}
 	protos := c.server.protocols()
 	if c.tlsState == nil && protos.UnencryptedHTTP2() {
 		if c.maybeServeUnencryptedHTTP2(ctx) {
```

The HTTP/2 server only disarms that deadline when `ReadTimeout > 0` (`h2_bundle.go`, `processHeaders`). None of our servers set `ReadTimeout`, so `ReadHeaderTimeout` silently became a hard cap on **connection lifetime**, independent of how active the connection is.

A client multiplexes its GraphQL queries *and* its `/v1/traces|logs|metrics` streams over a single HTTP/2 connection, so when the deadline fires every stream dies at once — which is why one slow query takes down the whole session, and why the failure looks like an unexplained disconnect rather than a timeout.

Reduced to a standalone program (h2c server + `http2.Transport`, handler sleeps 6s):

| Go | `ReadHeaderTimeout` | result |
| --- | --- | --- |
| 1.26.6 | 3s | `unexpected EOF` at 3.0s |
| 1.26.6 | 0 | ok at 6.0s |
| 1.26.5 | 3s | ok at 6.0s |

Confirmed by bisecting engines with one unchanged CLI binary: `dagger-engine-v1.0.0-beta.9` (built with go1.26.5) passes a 46s query; an engine built today (go1.26.6) fails at 30s.

## Why now

Nothing in the repo changed. `engine/distconsts/consts.go` pins `GolangVersion = "1.26"` → `golang:1.26-alpine`, a floating minor tag, and `go.mod` has no `toolchain` directive. go1.26.6 was released 2026-08-11, so the first engine rebuild whose image cache missed after that date picked it up. That const used to carry a full patch pin (`1.25.5` → `1.25.6` → `1.25.7`, each an explicit CVE bump); #11843 dropped the patch component.

Because the trigger is a cache miss on a floating tag, this lands at a different moment for each developer and CI runner, with no commit to blame.

## Fix

Drop `ReadHeaderTimeout` from the three servers that enable unencrypted HTTP/2:

- `cmd/engine/main.go` (30s) — the engine's client API
- `engine/engineutil/executor_spec.go` (10s) — the nested-client API that module functions dial, so **any module function call outliving 10s** lost its engine connection
- `internal/cmd/dagger/listen.go` (10s) — `dagger listen` sessions

The latter two are latent versions of the same bug rather than what I was chasing, but they fail identically.

## Notes for review

This forfeits the gosec **G112** slowloris guard on these three servers; the comments say so, and all three listen on local or otherwise trusted endpoints. Restoring the guard properly would mean implementing it as a listener wrapper that arms a timer on accept and cancels it on the first read, rather than as a connection deadline the HTTP/2 server never clears — happy to do that here instead if preferred.

Re-pinning `GolangVersion` to a patch version is worth doing separately for reproducibility, but note it would neither have prevented this nor fix it; the change here is what fixes it, on any toolchain.

## Verification

Rebuilt the dev engine with this patch:

- a 60s query returns `ok` at 63.2s (was: `unexpected EOF` at 31.2s)
- `dagger --env dev agent` reaches the prompt and stays healthy well past 30s, driven under a real pty
