### PR TITLE
fix: preserve container identity for registry auth

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3829,11 +3829,56 @@ func (ContainerSuite) TestExecError(ctx context.Context, t *testctx.T) {
 	})
 }
 
+func (ContainerSuite) TestWithRegistryAuthDoesNotInvalidateCache(ctx context.Context, t *testctx.T) {
+	for _, tc := range []struct {
+		name           string
+		authBeforeFrom bool
+	}{
+		{name: "before from", authBeforeFrom: true},
+		{name: "after from"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			cacheKey := identity.NewID()
+			run := func() string {
+				c := connect(ctx, t)
+				ctr := c.Container()
+				withAuth := func() {
+					ctr = ctr.WithRegistryAuth(
+						"registry.example.com",
+						"anyuser",
+						c.SetSecret("registry-auth-cache-"+cacheKey, "dummy"),
+					)
+				}
+				if tc.authBeforeFrom {
+					withAuth()
+				}
+				ctr = ctr.From(alpineImage)
+				if !tc.authBeforeFrom {
+					withAuth()
+				}
+
+				out, err := ctr.
+					WithEnvVariable("REGISTRY_AUTH_CACHE_KEY", cacheKey).
+					WithExec([]string{"cat", "/proc/sys/kernel/random/uuid"}).
+					Stdout(ctx)
+				require.NoError(t, err)
+				return strings.TrimSpace(out)
+			}
+
+			out1 := run()
+			out2 := run()
+			require.Equal(t, out1, out2, "registry auth invalidated the execution cache")
+		})
+	}
+}
+
 func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	testRef := privateRegistryRef("container-with-registry-auth")
-	container := c.Container().From(alpineImage)
+	container := c.Container().
+		From(alpineImage).
+		WithNewFile("/registry-auth-marker", "registry auth works")
 
 	// Push without credentials should fail
 	_, err := container.Publish(ctx, testRef)
@@ -3841,7 +3886,9 @@ func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 
 	for range 2 {
 		c := connect(ctx, t)
-		container := c.Container().From(alpineImage)
+		container := c.Container().
+			From(alpineImage).
+			WithNewFile("/registry-auth-marker", "registry auth works")
 		pushedRef, err := container.
 			WithRegistryAuth(
 				privateRegistryHost,
@@ -3854,6 +3901,26 @@ func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 		require.NotEqual(t, testRef, pushedRef)
 		require.Contains(t, pushedRef, "@sha256:")
 	}
+
+	c = connect(ctx, t)
+	base := c.Container()
+	secret := c.SetSecret("pull-secret", "xFlejaPdjrt25Dvr")
+	_, err = base.
+		WithRegistryAuth(privateRegistryHost, "john", secret).
+		Sync(ctx)
+	require.NoError(t, err)
+	_, err = base.
+		WithoutRegistryAuth(privateRegistryHost).
+		Sync(ctx)
+	require.NoError(t, err)
+
+	contents, err := base.
+		WithRegistryAuth(privateRegistryHost, "john", secret).
+		From(testRef).
+		File("/registry-auth-marker").
+		Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "registry auth works", contents)
 }
 
 func (ContainerSuite) TestWithRegistryAuthAfterAnonymousBearerPull(ctx context.Context, t *testctx.T) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -838,8 +838,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("tag").Doc(`Identifies the tag to import from the archive, if the archive bundles multiple tags.`),
 			),
 
-		dagql.Func("withRegistryAuth", s.withRegistryAuth).
-			WithInput(dagql.PerSessionInput).
+		dagql.NodeFunc("withRegistryAuth", s.withRegistryAuth).
+			DoNotCache("Mutates the session's registry credentials.").
 			Doc(`Attach credentials for future publishing to a registry. Use in combination with publish`).
 			Args(
 				dagql.Arg("address").Doc(`The image address that needs authentication. Same format as "docker push". Example: "registry.dagger.io/dagger:latest"`),
@@ -847,8 +847,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("secret").Doc(`The API key, password or token to authenticate to this registry`),
 			),
 
-		dagql.Func("withoutRegistryAuth", s.withoutRegistryAuth).
-			WithInput(dagql.PerSessionInput).
+		dagql.NodeFunc("withoutRegistryAuth", s.withoutRegistryAuth).
+			DoNotCache("Mutates the session's registry credentials.").
 			Doc(`Retrieves this container without the registry authentication of a given address.`).
 			Args(
 				dagql.Arg("address").Doc(`Registry's address to remove the authentication from.`,
@@ -4234,34 +4234,35 @@ type containerWithRegistryAuthArgs struct {
 	Secret   core.SecretID
 }
 
-func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Container, args containerWithRegistryAuthArgs) (*core.Container, error) {
+func (s *containerSchema) withRegistryAuth(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithRegistryAuthArgs) (dagql.ObjectResult[*core.Container], error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	srv, err := query.Server.Server(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get server: %w", err)
+		return parent, fmt.Errorf("failed to get server: %w", err)
 	}
 
 	secret, err := args.Secret.Load(ctx, srv)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 
 	secretBytes, err := secret.Self().Plaintext(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 
 	auth, err := query.Auth(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	if err := auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
-		return nil, err
+		return parent, err
 	}
 
+	// Registry credentials belong to the session, not the container.
 	return parent, nil
 }
 
@@ -4269,19 +4270,20 @@ type containerWithoutRegistryAuthArgs struct {
 	Address string
 }
 
-func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
+func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutRegistryAuthArgs) (dagql.ObjectResult[*core.Container], error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	auth, err := query.Auth(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	if err := auth.RemoveCredential(args.Address); err != nil {
-		return nil, err
+		return parent, err
 	}
 
+	// Registry credentials belong to the session, not the container.
 	return parent, nil
 }
 


### PR DESCRIPTION
## Summary

- keep registry authentication session state out of container cache identity
- execute each add/remove mutation without result caching so operation order is preserved
- add cross-session cache coverage and private registry pull coverage

## Testing

- original Go reproduction against the patched development engine
- focused container registry tests: 8 passed
- `dagger check golang:lint-all`
- `dagger check test-split:test-container`: 657 passed; one unrelated proxy test failed when GitHub returned HTTP 503

Closes #13898.
