### PR TITLE
fix(container): preserve cache identity through registry auth

### DIFF
--- a/.changes/unreleased/Fixed-20260814-203258.yaml
+++ b/.changes/unreleased/Fixed-20260814-203258.yaml
@@ -3,4 +3,4 @@ body: Registry authentication no longer invalidates downstream container cache r
 time: 2026-08-14T20:32:58.591640281Z
 custom:
     Author: sipsma
-    PR: "0"
+    PR: "13901"

--- a/.changes/unreleased/Fixed-20260814-203258.yaml
+++ b/.changes/unreleased/Fixed-20260814-203258.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Registry authentication no longer invalidates downstream container cache reuse across sessions when applied before or after `Container.from`.
+time: 2026-08-14T20:32:58.591640281Z
+custom:
+    Author: sipsma
+    PR: "0"

--- a/core/container.go
+++ b/core/container.go
@@ -63,6 +63,13 @@ type DefaultTerminalCmdOpts struct {
 
 // Container is a content-addressed container.
 type Container struct {
+	// fromContentDigestSafe tracks whether Container.From can give its result a
+	// content digest based only on the resolved image and platform. It is false
+	// by default so derived containers conservatively retain their call identity.
+	// Only a newly constructed scratch container starts out safe; operations that
+	// do not change container state can preserve it by returning the same value.
+	fromContentDigestSafe bool
+
 	// The container's root filesystem.
 	FS *LazyAccessor[*Directory, *Container]
 
@@ -852,10 +859,17 @@ func (*Container) TypeDescription() string {
 
 func NewContainer(platform Platform) *Container {
 	return &Container{
-		FS:           new(LazyAccessor[*Directory, *Container]),
-		MetaSnapshot: new(LazyAccessor[bkcache.ImmutableRef, *Container]),
-		Platform:     platform,
+		fromContentDigestSafe: true,
+		FS:                    new(LazyAccessor[*Directory, *Container]),
+		MetaSnapshot:          new(LazyAccessor[bkcache.ImmutableRef, *Container]),
+		Platform:              platform,
 	}
+}
+
+// CanUseFromContentDigest reports whether Container.From can safely identify
+// its result using only the resolved image digest and platform.
+func (container *Container) CanUseFromContentDigest() bool {
+	return container != nil && container.fromContentDigestSafe
 }
 
 //nolint:dupl // symmetric with cloneDetachedFileForContainerResult; sharing obscures type specifics

--- a/core/container_from_test.go
+++ b/core/container_from_test.go
@@ -1,0 +1,15 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerCanUseFromContentDigest(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, NewContainer(Platform{}).CanUseFromContentDigest())
+	require.False(t, (&Container{}).CanUseFromContentDigest())
+	require.False(t, (*Container)(nil).CanUseFromContentDigest())
+}

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2901,6 +2901,11 @@ func (ContainerSuite) TestRelativePaths(ctx context.Context, t *testctx.T) {
 func (ContainerSuite) TestMultiFrom(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
+	// Ensure the bare second image is already cached. The later From must not
+	// merge with it because the mounted directory is preserved across From.
+	_, err := c.Container().From("golang:1.18.2-alpine").Sync(ctx)
+	require.NoError(t, err)
+
 	dirRes, err := testutil.QueryWithClient[struct {
 		Directory struct {
 			ID core.DirectoryID
@@ -3853,6 +3858,49 @@ func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, testRef, pushedRef)
 		require.Contains(t, pushedRef, "@sha256:")
+	}
+}
+
+func (ContainerSuite) TestWithRegistryAuthDoesNotInvalidateCache(ctx context.Context, t *testctx.T) {
+	for _, tc := range []struct {
+		name           string
+		authBeforeFrom bool
+	}{
+		{name: "before from", authBeforeFrom: true},
+		{name: "after from"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			cacheKey := identity.NewID()
+			run := func() string {
+				c := connect(ctx, t)
+				ctr := c.Container()
+				withAuth := func() {
+					ctr = ctr.WithRegistryAuth(
+						"registry.example.com",
+						"anyuser",
+						c.SetSecret("registry-auth-cache-"+cacheKey, "dummy"),
+					)
+				}
+				if tc.authBeforeFrom {
+					withAuth()
+				}
+				ctr = ctr.From(alpineImage)
+				if !tc.authBeforeFrom {
+					withAuth()
+				}
+
+				out, err := ctr.
+					WithEnvVariable("REGISTRY_AUTH_CACHE_KEY", cacheKey).
+					WithExec([]string{"cat", "/proc/sys/kernel/random/uuid"}).
+					Stdout(ctx)
+				require.NoError(t, err)
+				return strings.TrimSpace(out)
+			}
+
+			out1 := run()
+			out2 := run()
+			require.Equal(t, out1, out2, "registry auth invalidated the execution cache")
+		})
 	}
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -838,7 +838,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("tag").Doc(`Identifies the tag to import from the archive, if the archive bundles multiple tags.`),
 			),
 
-		dagql.Func("withRegistryAuth", s.withRegistryAuth).
+		dagql.NodeFunc("withRegistryAuth", s.withRegistryAuth).
 			WithInput(dagql.PerSessionInput).
 			Doc(`Attach credentials for future publishing to a registry. Use in combination with publish`).
 			Args(
@@ -847,7 +847,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("secret").Doc(`The API key, password or token to authenticate to this registry`),
 			),
 
-		dagql.Func("withoutRegistryAuth", s.withoutRegistryAuth).
+		dagql.NodeFunc("withoutRegistryAuth", s.withoutRegistryAuth).
 			WithInput(dagql.PerSessionInput).
 			Doc(`Retrieves this container without the registry authentication of a given address.`).
 			Args(
@@ -1197,13 +1197,11 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 			return inst, err
 		}
 
-		// detach identity from the :tag, make the result purely content-addressed based on the digest, but
-		// only when we are starting from scratch (as opposed to the weird case of calling from later in a chain)
-		parentCall, err := parent.ResultCall()
-		if err != nil {
-			return inst, fmt.Errorf("failed to get parent call: %w", err)
-		}
-		if parentCall.Field == "container" {
+		// Detach identity from the :tag and make the result purely
+		// content-addressed when From is operating on an otherwise untouched
+		// scratch container. Derived containers may carry state that From
+		// preserves, so they must retain their call identity.
+		if parent.Self().CanUseFromContentDigest() {
 			var err error
 			inst, err = inst.WithContentDigest(ctx, hashutil.HashStrings(
 				"container.from",
@@ -3317,6 +3315,8 @@ func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult
 		return nil, false, err
 	}
 	ctr := &core.Container{
+		// CanUseFromContentDigest intentionally defaults to false for schema
+		// children: any container transformation may carry state through From.
 		FS:                 clonedFS,
 		MetaSnapshot:       clonedMeta,
 		Config:             core.CloneContainerImageConfig(parent.Self().Config),
@@ -4234,34 +4234,35 @@ type containerWithRegistryAuthArgs struct {
 	Secret   core.SecretID
 }
 
-func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Container, args containerWithRegistryAuthArgs) (*core.Container, error) {
+func (s *containerSchema) withRegistryAuth(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithRegistryAuthArgs) (dagql.ObjectResult[*core.Container], error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	srv, err := query.Server.Server(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get server: %w", err)
+		return parent, fmt.Errorf("failed to get server: %w", err)
 	}
 
 	secret, err := args.Secret.Load(ctx, srv)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 
 	secretBytes, err := secret.Self().Plaintext(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 
 	auth, err := query.Auth(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	if err := auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
-		return nil, err
+		return parent, err
 	}
 
+	// Registry credentials belong to the session, not the container.
 	return parent, nil
 }
 
@@ -4269,19 +4270,20 @@ type containerWithoutRegistryAuthArgs struct {
 	Address string
 }
 
-func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
+func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutRegistryAuthArgs) (dagql.ObjectResult[*core.Container], error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	auth, err := query.Auth(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	if err := auth.RemoveCredential(args.Address); err != nil {
-		return nil, err
+		return parent, err
 	}
 
+	// Registry credentials belong to the session, not the container.
 	return parent, nil
 }
 

--- a/core/schema/container_internal_test.go
+++ b/core/schema/container_internal_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCloneContainerForSchemaChildDisablesFromContentDigest(t *testing.T) {
+	t.Parallel()
+
+	dag, err := dagql.NewServer(t.Context(), &core.Query{})
+	require.NoError(t, err)
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*core.Container]{Typed: &core.Container{}}))
+
+	parent, err := dagql.NewObjectResultForCall(core.NewContainer(core.Platform{}), dag, &dagql.ResultCall{
+		Kind:        dagql.ResultCallKindSynthetic,
+		SyntheticOp: "scratch-container",
+		Type:        dagql.NewResultCallType((&core.Container{}).Type()),
+	})
+	require.NoError(t, err)
+	require.True(t, parent.Self().CanUseFromContentDigest())
+
+	child, _, err := cloneContainerForSchemaChild(t.Context(), parent)
+	require.NoError(t, err)
+	require.False(t, child.CanUseFromContentDigest())
+}
+
 func TestWithImageConfigMetadataMutatesContainerConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep registry authentication as session-local state without making it part of semantic container result identity
- return the attached parent `ObjectResult` from `withRegistryAuth` and `withoutRegistryAuth`, since they mutate ambient session auth rather than the container
- conservatively allow `Container.from` to publish stable image content identity only for an untouched scratch container
- cover cross-session cache reuse with auth both before and after `From`, plus constructor/clone defaults and modified-container `MultiFrom` preservation

## Problem

Adding registry credentials to an otherwise unchanged container caused image pulls and downstream executions to miss cache across Dagger sessions. This was especially visible for the common sequence `container -> withRegistryAuth -> from(image) -> downstream operations`, even when the configured credentials were unrelated to the pulled image.

The root cause was that the auth mutation was scoped correctly with `dagql.PerSessionInput`, but `dagql.Func` wrapped the unchanged Go container pointer in a new result whose identity included that session-local input. Session-local auth side effects were therefore coupled to semantic container result identity.

## Approach

`withRegistryAuth` and `withoutRegistryAuth` are now `NodeFunc`s that still execute against the current session's auth provider, but return the already-attached parent result. The e-graph can therefore treat the returned container as exactly the unchanged semantic value it is, allowing downstream cache reuse across sessions.

`Container.from` no longer identifies the safe path by inspecting the parent field name. A newly constructed scratch container carries a private safety bit, while schema child cloning defaults it to false. This keeps stable image content identity available for untouched containers while conservatively preserving call identity for genuinely modified containers whose state survives `From`.

This takes a different approach from the now-closed #13899: it retains normal per-session caching and restores result equivalence instead of marking registry-auth operations `DoNotCache`.

## Validation

- `go test ./core ./core/schema -count=1`
- `dagger api call engine-dev test --pkg ./core/integration --run='^TestContainer/(TestMultiFrom|TestWithRegistryAuth.*)$'` — 8 passed
- `git diff --check`
- `dagger generate -y` — `dagger-go-sdk:generate` passed; the overall run was blocked in the unrelated Elixir generator because the BEAM runtime aborted with `OS monotonic time stepped backwards` (exit 134); no generated changes were produced
- `dagger check '*:lint'` — Helm, Java, Markdown, and Python passed; `elixir-client:lint` hit the same BEAM host-clock abort

Closes #13898.
