### PR TITLE
[backport-0.21] fix(container): preserve cache identity through registry auth

### DIFF
--- a/.changes/unreleased/Fixed-20260814-203258.yaml
+++ b/.changes/unreleased/Fixed-20260814-203258.yaml
@@ -3,4 +3,4 @@ body: Registry authentication no longer invalidates downstream container cache r
 time: 2026-08-14T20:32:58.591640281Z
 custom:
     Author: sipsma
-    PR: "0"
+    PR: "13901"

--- a/.changes/unreleased/Fixed-20260814-203258.yaml
+++ b/.changes/unreleased/Fixed-20260814-203258.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Registry authentication no longer invalidates downstream container cache reuse across sessions when applied before or after `Container.from`.
+time: 2026-08-14T20:32:58.591640281Z
+custom:
+    Author: sipsma
+    PR: "0"

--- a/core/container.go
+++ b/core/container.go
@@ -60,6 +60,13 @@ type DefaultTerminalCmdOpts struct {
 
 // Container is a content-addressed container.
 type Container struct {
+	// fromContentDigestSafe tracks whether Container.From can give its result a
+	// content digest based only on the resolved image and platform. It is false
+	// by default so derived containers conservatively retain their call identity.
+	// Only a newly constructed scratch container starts out safe; operations that
+	// do not change container state can preserve it by returning the same value.
+	fromContentDigestSafe bool
+
 	// The container's root filesystem.
 	FS *LazyAccessor[*Directory, *Container]
 
@@ -824,10 +831,17 @@ func (*Container) TypeDescription() string {
 
 func NewContainer(platform Platform) *Container {
 	return &Container{
-		FS:           new(LazyAccessor[*Directory, *Container]),
-		MetaSnapshot: new(LazyAccessor[bkcache.ImmutableRef, *Container]),
-		Platform:     platform,
+		fromContentDigestSafe: true,
+		FS:                    new(LazyAccessor[*Directory, *Container]),
+		MetaSnapshot:          new(LazyAccessor[bkcache.ImmutableRef, *Container]),
+		Platform:              platform,
 	}
+}
+
+// CanUseFromContentDigest reports whether Container.From can safely identify
+// its result using only the resolved image digest and platform.
+func (container *Container) CanUseFromContentDigest() bool {
+	return container != nil && container.fromContentDigestSafe
 }
 
 //nolint:dupl // symmetric with cloneDetachedFileForContainerResult; sharing obscures type specifics

--- a/core/container_from_test.go
+++ b/core/container_from_test.go
@@ -1,0 +1,15 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerCanUseFromContentDigest(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, NewContainer(Platform{}).CanUseFromContentDigest())
+	require.False(t, (&Container{}).CanUseFromContentDigest())
+	require.False(t, (*Container)(nil).CanUseFromContentDigest())
+}

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2876,6 +2876,11 @@ func (ContainerSuite) TestRelativePaths(ctx context.Context, t *testctx.T) {
 func (ContainerSuite) TestMultiFrom(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
+	// Ensure the bare second image is already cached. The later From must not
+	// merge with it because the mounted directory is preserved across From.
+	_, err := c.Container().From("golang:1.18.2-alpine").Sync(ctx)
+	require.NoError(t, err)
+
 	dirRes, err := testutil.QueryWithClient[struct {
 		Directory struct {
 			ID core.DirectoryID
@@ -3828,6 +3833,49 @@ func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, testRef, pushedRef)
 		require.Contains(t, pushedRef, "@sha256:")
+	}
+}
+
+func (ContainerSuite) TestWithRegistryAuthDoesNotInvalidateCache(ctx context.Context, t *testctx.T) {
+	for _, tc := range []struct {
+		name           string
+		authBeforeFrom bool
+	}{
+		{name: "before from", authBeforeFrom: true},
+		{name: "after from"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			cacheKey := identity.NewID()
+			run := func() string {
+				c := connect(ctx, t)
+				ctr := c.Container()
+				withAuth := func() {
+					ctr = ctr.WithRegistryAuth(
+						"registry.example.com",
+						"anyuser",
+						c.SetSecret("registry-auth-cache-"+cacheKey, "dummy"),
+					)
+				}
+				if tc.authBeforeFrom {
+					withAuth()
+				}
+				ctr = ctr.From(alpineImage)
+				if !tc.authBeforeFrom {
+					withAuth()
+				}
+
+				out, err := ctr.
+					WithEnvVariable("REGISTRY_AUTH_CACHE_KEY", cacheKey).
+					WithExec([]string{"cat", "/proc/sys/kernel/random/uuid"}).
+					Stdout(ctx)
+				require.NoError(t, err)
+				return strings.TrimSpace(out)
+			}
+
+			out1 := run()
+			out2 := run()
+			require.Equal(t, out1, out2, "registry auth invalidated the execution cache")
+		})
 	}
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -799,7 +799,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("tag").Doc(`Identifies the tag to import from the archive, if the archive bundles multiple tags.`),
 			),
 
-		dagql.Func("withRegistryAuth", s.withRegistryAuth).
+		dagql.NodeFunc("withRegistryAuth", s.withRegistryAuth).
 			WithInput(dagql.PerSessionInput).
 			Doc(`Attach credentials for future publishing to a registry. Use in combination with publish`).
 			Args(
@@ -808,7 +808,7 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("secret").Doc(`The API key, password or token to authenticate to this registry`),
 			),
 
-		dagql.Func("withoutRegistryAuth", s.withoutRegistryAuth).
+		dagql.NodeFunc("withoutRegistryAuth", s.withoutRegistryAuth).
 			WithInput(dagql.PerSessionInput).
 			Doc(`Retrieves this container without the registry authentication of a given address.`).
 			Args(
@@ -1091,13 +1091,11 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 			return inst, err
 		}
 
-		// detach identity from the :tag, make the result purely content-addressed based on the digest, but
-		// only when we are starting from scratch (as opposed to the weird case of calling from later in a chain)
-		parentCall, err := parent.ResultCall()
-		if err != nil {
-			return inst, fmt.Errorf("failed to get parent call: %w", err)
-		}
-		if parentCall.Field == "container" {
+		// Detach identity from the :tag and make the result purely
+		// content-addressed when From is operating on an otherwise untouched
+		// scratch container. Derived containers may carry state that From
+		// preserves, so they must retain their call identity.
+		if parent.Self().CanUseFromContentDigest() {
 			var err error
 			inst, err = inst.WithContentDigest(ctx, hashutil.HashStrings(
 				"container.from",
@@ -3109,6 +3107,8 @@ func cloneContainerForSchemaChild(ctx context.Context, parent dagql.ObjectResult
 		return nil, false, err
 	}
 	ctr := &core.Container{
+		// CanUseFromContentDigest intentionally defaults to false for schema
+		// children: any container transformation may carry state through From.
 		FS:                 clonedFS,
 		MetaSnapshot:       clonedMeta,
 		Config:             core.CloneContainerImageConfig(parent.Self().Config),
@@ -3996,34 +3996,35 @@ type containerWithRegistryAuthArgs struct {
 	Secret   core.SecretID
 }
 
-func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Container, args containerWithRegistryAuthArgs) (*core.Container, error) {
+func (s *containerSchema) withRegistryAuth(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithRegistryAuthArgs) (dagql.ObjectResult[*core.Container], error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	srv, err := query.Server.Server(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get server: %w", err)
+		return parent, fmt.Errorf("failed to get server: %w", err)
 	}
 
 	secret, err := args.Secret.Load(ctx, srv)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 
 	secretBytes, err := secret.Self().Plaintext(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 
 	auth, err := query.Auth(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	if err := auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
-		return nil, err
+		return parent, err
 	}
 
+	// Registry credentials belong to the session, not the container.
 	return parent, nil
 }
 
@@ -4031,19 +4032,20 @@ type containerWithoutRegistryAuthArgs struct {
 	Address string
 }
 
-func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
+func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent dagql.ObjectResult[*core.Container], args containerWithoutRegistryAuthArgs) (dagql.ObjectResult[*core.Container], error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	auth, err := query.Auth(ctx)
 	if err != nil {
-		return nil, err
+		return parent, err
 	}
 	if err := auth.RemoveCredential(args.Address); err != nil {
-		return nil, err
+		return parent, err
 	}
 
+	// Registry credentials belong to the session, not the container.
 	return parent, nil
 }
 

--- a/core/schema/container_internal_test.go
+++ b/core/schema/container_internal_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCloneContainerForSchemaChildDisablesFromContentDigest(t *testing.T) {
+	t.Parallel()
+
+	dag, err := dagql.NewServer(t.Context(), &core.Query{})
+	require.NoError(t, err)
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*core.Container]{Typed: &core.Container{}}))
+
+	parent, err := dagql.NewObjectResultForCall(core.NewContainer(core.Platform{}), dag, &dagql.ResultCall{
+		Kind:        dagql.ResultCallKindSynthetic,
+		SyntheticOp: "scratch-container",
+		Type:        dagql.NewResultCallType((&core.Container{}).Type()),
+	})
+	require.NoError(t, err)
+	require.True(t, parent.Self().CanUseFromContentDigest())
+
+	child, _, err := cloneContainerForSchemaChild(t.Context(), parent)
+	require.NoError(t, err)
+	require.False(t, child.CanUseFromContentDigest())
+}
+
 func TestWithImageConfigMetadataMutatesContainerConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Backports #13901 to the v0.21 maintenance line for v0.21.9.

Registry authentication remains session-local, but `withRegistryAuth` and `withoutRegistryAuth` now return the attached parent result instead of coupling ambient auth side effects to semantic container identity. This restores downstream cache reuse across sessions when auth is applied before or after `Container.from`.

`Container.from` also retains the source fix's conservative safety state: untouched scratch containers can publish stable image content identity, while genuinely modified containers preserve their call identity.

This addresses the v0.21.x behavior reported in #13898.

## Source provenance

- Source PR: https://github.com/dagger/dagger/pull/13901
- Main merge commit: https://github.com/dagger/dagger/commit/06aee1f521bd84d84f6ba76d237ab5e2f3e7a73e
- Source implementation commit: https://github.com/dagger/dagger/commit/f07d62dbd0c723c23d7b5fee594e381df032cab7
- Source release-note commit: https://github.com/dagger/dagger/commit/738a73717d4b24404f89e7b42359169deb334351
- Applied with `cherry-pick -x -s` as `243a3631e77ee27bc29dd74f2d9f514f18030a82` and `91f653ce333bfb2cd046a272f8470a4fbc6561ce`

## v0.21 adaptation

No adaptation was required. Both source commits cherry-picked cleanly onto `upstream/backport-0.21` at `67425bb6379a6588564d2194a766b31fde5e865c`.

The maintenance branch already contains the required `NodeFunc`, `PerSessionInput`, attached `ObjectResult`, schema-child clone, and `From` content-digest machinery. The two backport commits have the same stable patch IDs as their source commits, and the final delta remains the exact six-file source change: 128 insertions and 23 deletions.

## Validation

Passed:

- `go test ./core ./core/schema -count=1`
- `dagger call engine-dev test --pkg='./core/integration' --run='^TestContainer/(TestMultiFrom|TestWithRegistryAuth|TestWithRegistryAuthDoesNotInvalidateCache)$'` — 6 passed, trace `a8e85bdb40ef9653a3d02bc7d2f57fc5`
- `dagger -m ./toolchains/go call --source=. lint-module --module=core` — trace `f8d55258f1fb0cacac6ad7f624154d4c`
- `gofmt -d` on all changed Go files
- `git diff --check upstream/backport-0.21...HEAD`
- Stable patch-ID comparison against both source commits

Local environment limitations preserved for remote CI verification:

- `dagger generate -y` produced no generated changes, but the broad workspace run was blocked by v1-CLI/v0.21 module API incompatibilities (`LLM.History*` and `CurrentWorkspace`) and the host BEAM `OS monotonic time stepped backwards` abort; trace `f91fb9fffcc3b497bdde175364e1e19b`.
- The broad `dagger check '*:lint'` entrypoint stopped while loading the same incompatible release module before any lint ran; the scoped core lint above passed.
- The pre-existing `TestWithRegistryAuthAfterAnonymousBearerPull` was attempted twice but failed while starting its nested dev-engine tunnel with `unexpected EOF`, before any registry-auth operation ran; traces `0fc8022d0db0a0778a813aab5d7532d4` and `2967ee131baafc7493880c628a64ab2d`.

## Release note

Carries the exact source `Fixed` entry at `.changes/unreleased/Fixed-20260814-203258.yaml`, attributed to source PR #13901.
