### PR TITLE
fix: accept @ and # in git refs

### DIFF
--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -129,6 +129,9 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 	_, span := tracer.Start(ctx, fmt.Sprintf("parseGitRefString: %s", refString), telemetry.Internal())
 	defer telemetry.EndWithCause(span, &rerr)
 
+	// Module refs historically use "@" for versions, while other Git-backed
+	// resource addresses use "#". Accept both spellings at this boundary.
+	refString = strings.Replace(refString, "#", "@", 1)
 	scheme, schemelessRef := parseScheme(refString)
 
 	if scheme == NoScheme && isSCPLike(schemelessRef) {

--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -178,6 +178,28 @@ func newWorkspaceModuleSettingsCtr(t *testctx.T, c *dagger.Client, configTOML st
 func (WorkspaceSuite) TestWorkspaceModuleSettingsRuntime(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
+	t.Run("git refs accept the same separators in sources and settings", func(ctx context.Context, t *testctx.T) {
+		ctr := newWorkspaceModuleSettingsCtr(t, c, `[modules.wolfi]
+source = "https://github.com/dagger/dagger/modules/wolfi#v0.20.2"
+
+[modules.superconstructor]
+source = "defaults/superconstructor"
+entrypoint = true
+
+[modules.superconstructor.settings]
+count = 7
+greeting = "hello"
+dir = "https://github.com/dagger/dagger@v0.18.3"
+file = "/foo/hello.txt"
+password = "env://PASSWORD"
+service = "tcp://www:80"
+`)
+
+		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "dir", "entries"}, nestedExec).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "README.md")
+	})
+
 	t.Run("workspace module settings drive constructor help and runtime", func(ctx context.Context, t *testctx.T) {
 		ctr := newWorkspaceModuleSettingsCtr(t, c, `[modules.superconstructor]
 source = "defaults/superconstructor"

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -58,6 +58,13 @@ func TestParseRefString(t *testing.T) {
 			wantVersion:  "version",
 		},
 		{
+			urlStr:       "https://github.com/shykes/daggerverse/ci#version",
+			wantKind:     ModuleSourceKindGit,
+			wantCloneRef: "https://github.com/shykes/daggerverse",
+			wantSubdir:   "ci",
+			wantVersion:  "version",
+		},
+		{
 			// no dot in the ref string: treated as a local path
 			urlStr:     "./some/local/path",
 			wantKind:   ModuleSourceKindLocal,

--- a/util/gitutil/url.go
+++ b/util/gitutil/url.go
@@ -176,22 +176,35 @@ func IsGitTransport(remote string) bool {
 }
 
 func fromURL(url *url.URL) *GitURL {
+	path, fragment := splitGitVersion(url.Path, url.Fragment)
 	return &GitURL{
 		Scheme:   url.Scheme,
 		User:     url.User,
 		Host:     url.Host,
-		Path:     url.Path,
-		Fragment: splitGitFragment(url.Fragment),
+		Path:     path,
+		Fragment: fragment,
 	}
 }
 
 func fromSCPStyleURL(url *sshutil.SCPStyleURL) *GitURL {
+	path, fragment := splitGitVersion(url.Path, url.Fragment)
 	return &GitURL{
 		Scheme:   SSHProtocol,
 		User:     url.User,
 		Host:     url.Host,
-		Path:     url.Path,
-		Fragment: splitGitFragment(url.Fragment),
+		Path:     path,
+		Fragment: fragment,
 		scpStyle: true,
 	}
+}
+
+// splitGitVersion accepts the module-source "@ref" spelling in addition to
+// the BuildKit-style "#ref" fragment. An explicit fragment takes precedence.
+func splitGitVersion(path, fragment string) (string, *GitURLFragment) {
+	if fragment == "" {
+		if repoPath, ref, ok := strings.Cut(path, "@"); ok {
+			return repoPath, splitGitFragment(ref)
+		}
+	}
+	return path, splitGitFragment(fragment)
 }

--- a/util/gitutil/url_test.go
+++ b/util/gitutil/url_test.go
@@ -39,6 +39,15 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			url: "https://github.com/moby/buildkit@v1.0.0",
+			result: GitURL{
+				Scheme:   HTTPSProtocol,
+				Host:     "github.com",
+				Path:     "/moby/buildkit",
+				Fragment: &GitURLFragment{Ref: "v1.0.0"},
+			},
+		},
+		{
 			url: "http://github.com/moby/buildkit#v1.0.0:subdir",
 			result: GitURL{
 				Scheme:   HTTPProtocol,
@@ -87,6 +96,17 @@ func TestParseURL(t *testing.T) {
 		},
 		{
 			url: "git@github.com:moby/buildkit.git#v1.0.0",
+			result: GitURL{
+				Scheme:   SSHProtocol,
+				Host:     "github.com",
+				Path:     "moby/buildkit.git",
+				Fragment: &GitURLFragment{Ref: "v1.0.0"},
+				User:     url.User("git"),
+				scpStyle: true,
+			},
+		},
+		{
+			url: "git@github.com:moby/buildkit.git@v1.0.0",
 			result: GitURL{
 				Scheme:   SSHProtocol,
 				Host:     "github.com",


### PR DESCRIPTION
Git refs used different separators depending on where they appeared:

- Module sources accepted `@ref`, but not `#ref`.
- Git-backed directory and file arguments accepted `#ref`, but not `@ref`.

This PR makes both forms work everywhere. Users can now write either separator in `dagger.toml` module sources and in directory or file settings, and copy a Git URL between them without changing it.

Includes a workspace regression test that loads a module source using `#ref` and reads a directory setting using `@ref`.

Tests:
- `go test ./util/gitutil -run '^TestParseURL$'`
- `go test ./core -run '^TestParseRefString$' -count=1`
- `dagger --x-release=v1.0.0-beta.9 api call engine-dev test --pkg ./core/integration --run='TestWorkspace/TestWorkspaceModuleSettingsRuntime/git_refs_accept_the_same_separators_in_sources_and_settings'`

Fixes #13856