### PR TITLE
feat(llm): support OrcaRouter as an LLM provider

### DIFF
--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1606,6 +1606,7 @@ Add or update API key for a provider
 Add or update API key for a provider.
 
 Supported providers:
+  - orcarouter: Unified access to 150+ models (https://www.orcarouter.ai/console)
   - openrouter: Unified access to 100+ models (https://openrouter.ai/keys)
   - anthropic: Claude models (https://console.anthropic.com/settings/keys)
   - openai: GPT models (https://platform.openai.com/api-keys)

--- a/internal/cmd/dagger/llm_config.go
+++ b/internal/cmd/dagger/llm_config.go
@@ -108,7 +108,7 @@ func applyLLMConfigEnv() {
 		switch cfg.LLM.DefaultProvider {
 		case "anthropic":
 			setIfEmpty("ANTHROPIC_MODEL", cfg.LLM.DefaultModel)
-		case "openai", "openrouter":
+		case "openai", "openrouter", "orcarouter":
 			setIfEmpty("OPENAI_MODEL", cfg.LLM.DefaultModel)
 		case "openai-codex":
 			setIfEmpty("OPENAI_CODEX_MODEL", cfg.LLM.DefaultModel)
@@ -123,7 +123,7 @@ func applyLLMConfigEnv() {
 	// otherwise openai — so map iteration order can't pair one provider's key
 	// with the other's base URL.
 	openAISlotOwner := ""
-	for _, name := range []string{"openai", "openrouter"} {
+	for _, name := range []string{"openai", "openrouter", "orcarouter"} {
 		if p, ok := cfg.LLM.Providers[name]; ok && p.Enabled {
 			if openAISlotOwner == "" || name == cfg.LLM.DefaultProvider {
 				openAISlotOwner = name
@@ -177,6 +177,18 @@ func applyLLMConfigEnv() {
 			base := p.BaseURL
 			if base == "" {
 				base = "https://openrouter.ai/api/v1"
+			}
+			setIfEmpty("OPENAI_BASE_URL", base)
+		case "orcarouter":
+			// OrcaRouter is OpenAI-compatible; route it through the OpenAI vars.
+			if name != openAISlotOwner {
+				continue
+			}
+			setIfEmpty("OPENAI_API_KEY", p.APIKey)
+			setIfEmpty("OPENAI_MODEL", p.Model)
+			base := p.BaseURL
+			if base == "" {
+				base = "https://api.orcarouter.ai/v1"
 			}
 			setIfEmpty("OPENAI_BASE_URL", base)
 		case "local":
@@ -291,6 +303,7 @@ var llmAddKeyCmd = &cobra.Command{
 	Long: `Add or update API key for a provider.
 
 Supported providers:
+  - orcarouter: Unified access to 150+ models (https://www.orcarouter.ai/console)
   - openrouter: Unified access to 100+ models (https://openrouter.ai/keys)
   - anthropic: Claude models (https://console.anthropic.com/settings/keys)
   - openai: GPT models (https://platform.openai.com/api-keys)
@@ -301,7 +314,7 @@ Supported providers:
 		provider := args[0]
 
 		// Validate provider name
-		validProviders := []string{"openrouter", "anthropic", "openai", "google"}
+		validProviders := []string{"orcarouter", "openrouter", "anthropic", "openai", "google"}
 		if !slices.Contains(validProviders, provider) {
 			return fmt.Errorf("unsupported provider %q, must be one of: %s",
 				provider, strings.Join(validProviders, ", "))
@@ -336,9 +349,12 @@ Supported providers:
 			Enabled: true,
 		}
 
-		// Set BaseURL for OpenRouter
+		// Set BaseURL for OpenRouter and OrcaRouter
 		if provider == "openrouter" {
 			providerCfg.BaseURL = "https://openrouter.ai/api/v1"
+		}
+		if provider == "orcarouter" {
+			providerCfg.BaseURL = "https://api.orcarouter.ai/v1"
 		}
 
 		cfg.LLM.Providers[provider] = providerCfg
@@ -353,6 +369,8 @@ Supported providers:
 			switch provider {
 			case "openrouter":
 				cfg.LLM.DefaultModel = "anthropic/claude-sonnet-4.5"
+			case "orcarouter":
+				cfg.LLM.DefaultModel = "openai/gpt-5.5"
 			case "anthropic":
 				cfg.LLM.DefaultModel = "claude-sonnet-4.5"
 			case "openai":

--- a/internal/cmd/dagger/llm_config_test.go
+++ b/internal/cmd/dagger/llm_config_test.go
@@ -54,8 +54,8 @@ func TestRemoveKeyClearsDefaultModel(t *testing.T) {
 	}
 }
 
-// TestApplyLLMConfigEnvOpenAISlot verifies that when both openai and
-// openrouter are enabled, the shared OPENAI_* variables are owned by exactly
+// TestApplyLLMConfigEnvOpenAISlot verifies that when openai, openrouter and
+// orcarouter are enabled, the shared OPENAI_* variables are owned by exactly
 // one provider, chosen deterministically rather than by map iteration order.
 func TestApplyLLMConfigEnvOpenAISlot(t *testing.T) {
 	for _, tc := range []struct {
@@ -69,6 +69,12 @@ func TestApplyLLMConfigEnvOpenAISlot(t *testing.T) {
 			defaultProvider: "openrouter",
 			wantKey:         "sk-openrouter",
 			wantBaseURL:     "https://openrouter.ai/api/v1",
+		},
+		{
+			name:            "default orcarouter wins the slot",
+			defaultProvider: "orcarouter",
+			wantKey:         "sk-orcarouter",
+			wantBaseURL:     "https://api.orcarouter.ai/v1",
 		},
 		{
 			name:            "openai wins when default is neither",
@@ -103,6 +109,7 @@ func TestApplyLLMConfigEnvOpenAISlot(t *testing.T) {
 					Providers: map[string]llmconfig.Provider{
 						"openai":     {APIKey: "sk-openai", Enabled: true},
 						"openrouter": {APIKey: "sk-openrouter", Enabled: true},
+						"orcarouter": {APIKey: "sk-orcarouter", Enabled: true},
 						"anthropic":  {APIKey: "sk-anthropic", Enabled: true},
 					},
 				},

--- a/internal/cmd/dagger/llmconfig/models.go
+++ b/internal/cmd/dagger/llmconfig/models.go
@@ -48,6 +48,7 @@ var providerEntries = []ProviderEntry{
 	{"OpenAI (API key)", "openai", "openai", false},
 	{"OpenAI Codex (ChatGPT subscription)", "openai-codex", "openai-codex", true},
 	{"OpenRouter", "openrouter", "openrouter", false},
+	{"OrcaRouter", "orcarouter", "orcarouter", false},
 }
 
 // ProviderEntries returns the ordered list of provider options for setup UIs.
@@ -62,6 +63,7 @@ var catwalkProviderID = map[string]catwalk.InferenceProvider{
 	"openai-codex": catwalk.InferenceProviderOpenAI,
 	"google":       catwalk.InferenceProviderGemini,
 	"openrouter":   catwalk.InferenceProviderOpenRouter,
+	"orcarouter":   catwalk.InferenceProviderOpenRouter,
 }
 
 var (

--- a/internal/cmd/dagger/llmconfig/setup.go
+++ b/internal/cmd/dagger/llmconfig/setup.go
@@ -220,6 +220,9 @@ func setupAPIKeyProvider(ctx context.Context, ph PromptHandler, provider string)
 	if provider == "openrouter" {
 		providerCfg.BaseURL = "https://openrouter.ai/api/v1"
 	}
+	if provider == "orcarouter" {
+		providerCfg.BaseURL = "https://api.orcarouter.ai/v1"
+	}
 
 	defaultModel := DefaultModelForProvider(provider)
 
@@ -459,6 +462,8 @@ func promptLiteralKey(ctx context.Context, ph PromptHandler, provider string) (s
 	switch provider {
 	case "openrouter":
 		signupURL = "https://openrouter.ai/keys"
+	case "orcarouter":
+		signupURL = "https://www.orcarouter.ai/console"
 	case "anthropic":
 		signupURL = "https://console.anthropic.com/settings/keys"
 	case "openai":


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is
an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI,
Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single
endpoint and API key. It also provides gateway-level security controls for AI
agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `internal/cmd/dagger/llm_config.go`: register `orcarouter` in the shared
  OpenAI env slot (`OPENAI_API_KEY` / `OPENAI_MODEL` / `OPENAI_BASE_URL`), in
  `llm add-key` provider validation, base-URL defaulting
  (`https://api.orcarouter.ai/v1`) and the default model
- `internal/cmd/dagger/llmconfig/models.go`: add OrcaRouter to the interactive
  setup provider list and the catwalk model catalog
- `internal/cmd/dagger/llmconfig/setup.go`: base URL and signup URL for the
  interactive API-key flow
- `internal/cmd/dagger/llm_config_test.go`: extend the OPENAI_* slot tests to
  cover orcarouter
- `docs/current_docs/reference/cli/index.mdx`: document the new provider
  alongside the existing ones

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo: OrcaRouter joins the named
providers in the model picker, setup flow and docs, so the config reference
stays consistent for users.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. `dagger llm add-key orcarouter` (or pick OrcaRouter in `dagger llm setup`).
3. Pick a model id such as `openai/gpt-5.5`, `anthropic/claude-opus-4.8` or
   `z-ai/glm-5.2`. The full catalog is at https://www.orcarouter.ai/models.

## Verification

- Unit tests: `TestApplyLLMConfigEnvOpenAISlot` (including the new
  `default orcarouter wins the slot` case) and `TestRemoveKeyClearsDefaultModel`
  pass; the `internal/cmd/dagger/llmconfig` package tests pass.
- Live API: `dagger llm add-key orcarouter` persists
  `base_url = "https://api.orcarouter.ai/v1"` with default model
  `openai/gpt-5.5`; a live chat completion through OrcaRouter using
  `openai/gpt-5.5` succeeds.
- Build: `go build ./cmd/dagger` and `GOOS=linux go build ./internal/cmd/dagger/...`
  pass.
