### PR TITLE
core: include resolved platform in cache identity

### DIFF
--- a/.dagger/modules/engine-dev/test.go
+++ b/.dagger/modules/engine-dev/test.go
@@ -248,6 +248,10 @@ func (dev *EngineDev) testContainer(ctx context.Context, ebpfProgs []string) (*d
 	// during our test suite
 	devEngine = devEngine.
 		WithEnvVariable("_DAGGER_ENGINE_SYSTEMENV_GODEBUG", "goindex=0")
+	devEnginePlatform, err := devEngine.Platform(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	devBinary := dag.DaggerCli(dagger.DaggerCliOpts{VcsCommit: dev.VCSCommit, VcsDirty: dev.VCSDirty, Ws: dev.Ws}).Binary()
 	// This creates an engine.tar container file that can be used by the integration tests.
@@ -300,6 +304,7 @@ func (dev *EngineDev) testContainer(ctx context.Context, ebpfProgs []string) (*d
 		WithExec([]string{"go", "install", "github.com/dagger/otel-go/cmd/otelgotest"}).
 		WithMountedDirectory(utilDirPath, testEngineUtils).
 		WithEnvVariable("_DAGGER_TESTS_ENGINE_TAR", filepath.Join(utilDirPath, "engine.tar")).
+		WithEnvVariable("_DAGGER_TESTS_ENGINE_PLATFORM", string(devEnginePlatform)).
 		WithServiceBinding("daggerengine", devEngineSvc).
 		WithMountedCache("/run", engineRunVol).
 		WithServiceBinding("registry", registrySvc)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -40,7 +40,7 @@ var _ SchemaResolvers = &containerSchema{}
 
 func (s *containerSchema) Install(srv *dagql.Server) {
 	dagql.Fields[*core.Query]{
-		dagql.Func("container", s.container).
+		dagql.FuncWithDynamicInputs("container", s.container, s.containerDynamicInputs).
 			Doc(`Creates a scratch container, with no image or metadata.`,
 				`To pull an image, follow up with the "from" function.`).
 			Args(
@@ -1002,6 +1002,18 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 
 type containerArgs struct {
 	Platform dagql.Optional[core.Platform]
+}
+
+func (s *containerSchema) containerDynamicInputs(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Query],
+	args containerArgs,
+	req *dagql.CallRequest,
+) error {
+	if args.Platform.Valid {
+		return nil
+	}
+	return req.SetArgInput(ctx, "platform", parent.Self().Platform(), false)
 }
 
 func (s *containerSchema) container(ctx context.Context, parent *core.Query, args containerArgs) (_ *core.Container, rerr error) {

--- a/core/schema/container_internal_test.go
+++ b/core/schema/container_internal_test.go
@@ -8,10 +8,71 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
+
+func TestContainerDefaultPlatformCacheIdentity(t *testing.T) {
+	ctx := context.Background()
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close(context.Background()))
+	})
+	ctx = dagql.ContextWithCache(ctx, cache)
+	ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+		ClientID:  "container-platform-client",
+		SessionID: "container-platform-session",
+	})
+
+	amd64 := core.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := core.Platform{OS: "linux", Architecture: "arm64"}
+	srv := &currentTypeDefsTestServer{platform: amd64}
+	root := core.NewRoot(srv)
+	coreSchemaBase, err := NewCoreSchemaBase(ctx, srv)
+	require.NoError(t, err)
+	dag, err := coreSchemaBase.Fork(ctx, root, "")
+	require.NoError(t, err)
+	srv.dag = dag
+
+	selectContainer := func(platform dagql.Input) dagql.ObjectResult[*core.Container] {
+		t.Helper()
+		selector := dagql.Selector{Field: "container"}
+		if platform != nil {
+			selector.Args = []dagql.NamedInput{{Name: "platform", Value: platform}}
+		}
+		var ctr dagql.ObjectResult[*core.Container]
+		require.NoError(t, dag.Select(ctx, dag.Root(), &ctr, selector))
+		return ctr
+	}
+	recipeDigest := func(ctr dagql.ObjectResult[*core.Container]) string {
+		t.Helper()
+		id, err := ctr.RecipeID(ctx)
+		require.NoError(t, err)
+		return id.Digest().String()
+	}
+
+	omittedAMD64 := selectContainer(nil)
+	require.Equal(t, amd64, omittedAMD64.Self().Platform)
+
+	explicitAMD64 := selectContainer(dagql.Opt(amd64))
+	require.Equal(t, recipeDigest(omittedAMD64), recipeDigest(explicitAMD64))
+
+	srv.platform = arm64
+	omittedARM64 := selectContainer(nil)
+	require.Equal(t, arm64, omittedARM64.Self().Platform)
+	require.NotEqual(t, recipeDigest(omittedAMD64), recipeDigest(omittedARM64))
+
+	explicitAMD64OnARM64 := selectContainer(dagql.Opt(amd64))
+	require.Equal(t, amd64, explicitAMD64OnARM64.Self().Platform)
+	require.Equal(t, recipeDigest(explicitAMD64), recipeDigest(explicitAMD64OnARM64))
+
+	nullOnARM64 := selectContainer(dagql.NoOpt[core.Platform]())
+	require.Equal(t, arm64, nullOnARM64.Self().Platform)
+	require.Equal(t, recipeDigest(omittedARM64), recipeDigest(nullOnARM64))
+}
 
 func TestCloneContainerForSchemaChildDisablesFromContentDigest(t *testing.T) {
 	t.Parallel()

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -31,6 +31,7 @@ var _ SchemaResolvers = &directorySchema{}
 func (s *directorySchema) Install(srv *dagql.Server) {
 	dagql.Fields[*core.Query]{
 		dagql.NodeFunc("directory", s.directory).
+			WithInput(engineDefaultPlatformInput).
 			Doc(`Creates an empty directory.`),
 	}.Install(srv)
 
@@ -240,7 +241,8 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 			WithInput(dagql.PerClientInput).
 			View(BeforeVersion("v0.12.0")).
 			Extend(),
-		dagql.NodeFunc("dockerBuild", s.dockerBuild).
+		dagql.NodeFuncWithDynamicInputs("dockerBuild", s.dockerBuild, s.dockerBuildDynamicInputs).
+			WithInput(engineDefaultPlatformInput).
 			Doc(`Use Dockerfile compatibility to build a container from this directory. Only use this function for Dockerfile compatibility. Otherwise use the native Container type directly, it is feature-complete and supports all Dockerfile features.`).
 			Args(
 				dagql.Arg("dockerfile").Doc(`Path to the Dockerfile to use (e.g., "frontend.Dockerfile").`),
@@ -1781,6 +1783,24 @@ func (s *directorySchema) dockerBuild(ctx context.Context, parent dagql.ObjectRe
 		args.NoInit,
 		sshSocket,
 	)
+}
+
+func (s *directorySchema) dockerBuildDynamicInputs(
+	ctx context.Context,
+	_ dagql.ObjectResult[*core.Directory],
+	args dirDockerBuildArgs,
+	req *dagql.CallRequest,
+) error {
+	if args.Platform.Valid {
+		return nil
+	}
+
+	platform, err := currentEngineDefaultPlatform(ctx)
+	if err != nil {
+		return err
+	}
+
+	return req.SetArgInput(ctx, "platform", platform, false)
 }
 
 type directoryTerminalArgs struct {

--- a/core/schema/platform.go
+++ b/core/schema/platform.go
@@ -7,6 +7,21 @@ import (
 	"github.com/dagger/dagger/dagql"
 )
 
+var engineDefaultPlatformInput = dagql.ImplicitInput{
+	Name: "engineDefaultPlatform",
+	Resolver: func(ctx context.Context, _ map[string]dagql.Input) (dagql.Input, error) {
+		return currentEngineDefaultPlatform(ctx)
+	},
+}
+
+func currentEngineDefaultPlatform(ctx context.Context) (core.Platform, error) {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return core.Platform{}, err
+	}
+	return query.Platform(), nil
+}
+
 type platformSchema struct{}
 
 var _ SchemaResolvers = &platformSchema{}
@@ -14,6 +29,7 @@ var _ SchemaResolvers = &platformSchema{}
 func (s *platformSchema) Install(srv *dagql.Server) {
 	dagql.Fields[*core.Query]{
 		dagql.Func("defaultPlatform", s.defaultPlatform).
+			WithInput(engineDefaultPlatformInput).
 			Doc(`The default platform of the engine.`),
 	}.Install(srv)
 

--- a/core/schema/platform_internal_test.go
+++ b/core/schema/platform_internal_test.go
@@ -1,0 +1,69 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineDefaultPlatformCacheIdentity(t *testing.T) {
+	ctx := context.Background()
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close(context.Background()))
+	})
+	ctx = dagql.ContextWithCache(ctx, cache)
+	ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{
+		ClientID:  "default-platform-client",
+		SessionID: "default-platform-session",
+	})
+
+	amd64 := core.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := core.Platform{OS: "linux", Architecture: "arm64"}
+	srv := &currentTypeDefsTestServer{platform: amd64}
+	root := core.NewRoot(srv)
+	ctx = core.ContextWithQuery(ctx, root)
+	coreSchemaBase, err := NewCoreSchemaBase(ctx, srv)
+	require.NoError(t, err)
+	dag, err := coreSchemaBase.Fork(ctx, root, "")
+	require.NoError(t, err)
+	srv.dag = dag
+
+	selectDefaultPlatform := func() core.Platform {
+		t.Helper()
+		var platform core.Platform
+		require.NoError(t, dag.Select(ctx, dag.Root(), &platform, dagql.Selector{Field: "defaultPlatform"}))
+		return platform
+	}
+
+	require.Equal(t, amd64, selectDefaultPlatform())
+	srv.platform = arm64
+	require.Equal(t, arm64, selectDefaultPlatform())
+
+	queryType, ok := dag.ObjectType("Query")
+	require.True(t, ok)
+	directoryField, ok := queryType.FieldSpec("directory", call.View(""))
+	require.True(t, ok)
+	require.Equal(t, []string{"engineDefaultPlatform"}, implicitInputNames(directoryField))
+
+	directoryType, ok := dag.ObjectType("Directory")
+	require.True(t, ok)
+	dockerBuildField, ok := directoryType.FieldSpec("dockerBuild", call.View(""))
+	require.True(t, ok)
+	require.NotNil(t, dockerBuildField.GetDynamicInput)
+	require.Equal(t, []string{"engineDefaultPlatform"}, implicitInputNames(dockerBuildField))
+}
+
+func implicitInputNames(spec dagql.FieldSpec) []string {
+	names := make([]string, 0, len(spec.ImplicitInputs))
+	for _, input := range spec.ImplicitInputs {
+		names = append(names, input.Name)
+	}
+	return names
+}

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -25,6 +25,7 @@ type currentTypeDefsTestServer struct {
 	deps             *core.SchemaBuilder
 	dag              *dagql.Server
 	mainClient       *engine.ClientMetadata
+	platform         core.Platform
 	workspaceLock    *workspace.Lock
 	workspaceLockOK  bool
 	workspaceLockErr error
@@ -112,7 +113,7 @@ func (s *currentTypeDefsTestServer) Services(context.Context) (*core.Services, e
 	return nil, nil
 }
 
-func (s *currentTypeDefsTestServer) Platform() core.Platform { return core.Platform{} }
+func (s *currentTypeDefsTestServer) Platform() core.Platform { return s.platform }
 
 func (s *currentTypeDefsTestServer) OCIStore() content.Store { return nil }
 

--- a/dagql/idtui/golden_test.go
+++ b/dagql/idtui/golden_test.go
@@ -72,6 +72,51 @@ func TestTelemetry(t *testing.T) {
 	})
 }
 
+func TestNormalizeTelemetryNativePlatform(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		native    string
+		nonNative string
+	}{
+		{name: "amd64", native: "linux/amd64", nonNative: "linux/arm64"},
+		{name: "arm64", native: "linux/arm64", nonNative: "linux/amd64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := fmt.Sprintf(`
+$ container(platform: %q): Container!
+$ .dockerBuild(platform: %q): Container!
+$ container(platform: %q): Container!
+$ .dockerBuild(platform: %q): Container!
+$ other(platform: %q): Other!
+`, tc.native, tc.native, tc.nonNative, tc.nonNative, tc.native)
+			expected := fmt.Sprintf(`
+$ container(platform: "linux/ARCH"): Container!
+$ .dockerBuild(platform: "linux/ARCH"): Container!
+$ container(platform: %q): Container!
+$ .dockerBuild(platform: %q): Container!
+$ other(platform: %q): Other!
+`, tc.nonNative, tc.nonNative, tc.native)
+
+			require.Equal(t, expected, normalizeTelemetryNativePlatform(input, tc.native))
+		})
+	}
+}
+
+func normalizeTelemetryNativePlatform(out, nativePlatform string) string {
+	if nativePlatform == "" {
+		return out
+	}
+
+	// Dynamic argument canonicalization makes the engine's resolved platform
+	// visible for these two calls. Normalize only their exact native value so
+	// the rendering goldens stay architecture-independent while explicit
+	// non-native platforms and other platform-bearing calls remain meaningful.
+	return strings.NewReplacer(
+		fmt.Sprintf(`container(platform: %q)`, nativePlatform), `container(platform: "linux/ARCH")`,
+		fmt.Sprintf(`dockerBuild(platform: %q)`, nativePlatform), `dockerBuild(platform: "linux/ARCH")`,
+	).Replace(out)
+}
+
 func (s TelemetrySuite) TestGolden(ctx context.Context, t *testctx.T) {
 	// setup a git repo so function call tests can pick up the right metadata
 
@@ -470,7 +515,10 @@ func (ex Example) Run(ctx context.Context, t *testctx.T, s TelemetrySuite) (stri
 		expected += "Expected stderr:\n\n" + errBuf.String()
 	}
 
-	return scrub.Stabilize(expected), db
+	return normalizeTelemetryNativePlatform(
+		scrub.Stabilize(expected),
+		os.Getenv("_DAGGER_TESTS_ENGINE_PLATFORM"),
+	), db
 }
 
 func testDB(t *testctx.T) (*dagui.DB, net.Listener) {

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .cachedExecs: Void X.Xs
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴$ withExec echo 'cached-execs cached for good' X.Xs CACHED
 ├╴$ withExec echo 'im also cached for good' X.Xs CACHED

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/cached-execs
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .cachedExecs: Void X.Xs
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴$ withExec echo 'cached-execs cached for good' X.Xs CACHED
 ├╴$ withExec echo 'im also cached for good' X.Xs CACHED

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
@@ -20,7 +20,7 @@ $ viztest: Viztest! X.Xs CACHED
 ✔ .customSpan: String! X.Xs
 ┃ hello from Go! it is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X
 ╰╴✔ custom span X.Xs
-  ├╴$ container: Container! X.Xs CACHED
+  ├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
   ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
   ├╴✔ withExec echo 'hello from Go! it is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' X.Xs
   │ ┃ hello from Go! it is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/custom-span
@@ -20,7 +20,7 @@ $ viztest: Viztest! X.Xs CACHED
 ✔ .customSpan: String! X.Xs
 ┃ hello from Go! it is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X
 ╰╴✔ custom span X.Xs
-  ├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+  ├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
   ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
   ├╴✔ withExec echo 'hello from Go! it is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' X.Xs
   │ ┃ hello from Go! it is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -19,7 +19,7 @@ Expected stderr:
 $ viztest: Viztest! X.Xs CACHED
 ✔ .dockerBuild: Container! X.Xs
 ├╴✔ withNewFile Dockerfile (contents: "FROM busybox:1.35\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo what is up?\nRUN echo im another layer\n") X.Xs
-╰╴✔ .dockerBuild: Container! X.Xs
+╰╴✔ .dockerBuild(platform: "linux/amd64"): Container! X.Xs
   ├╴✘ Directory.file(path: "Dockerfile.dockerignore"): File! X.Xs ERROR
   │ ! stat Dockerfile.dockerignore: no such file or directory
   │

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -19,7 +19,7 @@ Expected stderr:
 $ viztest: Viztest! X.Xs CACHED
 ✔ .dockerBuild: Container! X.Xs
 ├╴✔ withNewFile Dockerfile (contents: "FROM busybox:1.35\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo what is up?\nRUN echo im another layer\n") X.Xs
-╰╴✔ .dockerBuild(platform: "linux/amd64"): Container! X.Xs
+╰╴✔ .dockerBuild(platform: "linux/ARCH"): Container! X.Xs
   ├╴✘ Directory.file(path: "Dockerfile.dockerignore"): File! X.Xs ERROR
   │ ! stat Dockerfile.dockerignore: no such file or directory
   │

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -14,7 +14,7 @@ Expected stderr:
 $ viztest: Viztest! X.Xs CACHED
 ✘ .dockerBuildFail: Container! X.Xs ERROR
 ├╴✔ withNewFile Dockerfile (contents: "FROM busybox:1.34\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo im failing && false\n") X.Xs
-╰╴✘ .dockerBuild: Container! X.Xs ERROR
+╰╴✘ .dockerBuild(platform: "linux/amd64"): Container! X.Xs ERROR
   ├╴✘ Directory.file(path: "Dockerfile.dockerignore"): File! X.Xs ERROR
   │ ! stat Dockerfile.dockerignore: no such file or directory
   │

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -14,7 +14,7 @@ Expected stderr:
 $ viztest: Viztest! X.Xs CACHED
 ✘ .dockerBuildFail: Container! X.Xs ERROR
 ├╴✔ withNewFile Dockerfile (contents: "FROM busybox:1.34\nRUN echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X\nRUN echo hello, world!\nRUN echo im failing && false\n") X.Xs
-╰╴✘ .dockerBuild(platform: "linux/amd64"): Container! X.Xs ERROR
+╰╴✘ .dockerBuild(platform: "linux/ARCH"): Container! X.Xs ERROR
   ├╴✘ Directory.file(path: "Dockerfile.dockerignore"): File! X.Xs ERROR
   │ ! stat Dockerfile.dockerignore: no such file or directory
   │

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .encapsulate: Void X.Xs
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs
 ╰╴✘ withExec sh -c 'echo im doing a lot of work; echo and then failing; exit 1' X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/encapsulate
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .encapsulate: Void X.Xs
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs
 ╰╴✘ withExec sh -c 'echo im doing a lot of work; echo and then failing; exit 1' X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .failEffect: Container! X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ╰╴✘ withExec sh -c 'echo this is a failing effect; exit 1' X.Xs ERROR
   ┃ this is a failing effect

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-effect
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .failEffect: Container! X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ╰╴✘ withExec sh -c 'echo this is a failing effect; exit 1' X.Xs ERROR
   ┃ this is a failing effect

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .failLog: Void X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs
 ╰╴✘ withExec sh -c 'echo im doing a lot of work; echo and then failing; exit 1' X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/fail-log
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .failLog: Void X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs
 ╰╴✘ withExec sh -c 'echo im doing a lot of work; echo and then failing; exit 1' X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
@@ -36,7 +36,7 @@ $ viztest: Viztest! X.Xs CACHED
 │   ┆ ): Directory!
 │   ): Directory! X.Xs CACHED
 │
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .withDirectory(
 │   ┆ path: "/level-1"
 │   ┆ source: Directory.withFile(

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/nested-calls
@@ -36,7 +36,7 @@ $ viztest: Viztest! X.Xs CACHED
 │   ┆ ): Directory!
 │   ): Directory! X.Xs CACHED
 │
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .withDirectory(
 │   ┆ path: "/level-1"
 │   ┆ source: Directory.withFile(

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .pending: Void X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/pending
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .pending: Void X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X X.Xs
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/python/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/python/custom-span
@@ -20,7 +20,7 @@ Expected stderr:
 ✔ .customSpan: String! X.Xs
 ┃ hello from Python! it is currently 20XX-XX-XX XX:XX:XX.XXXX
 ╰╴✔ custom span X.Xs
-  ├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+  ├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
   ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
   ├╴✔ withExec echo 'hello from Python! it is currently 20XX-XX-XX XX:XX:XX.XXXX' X.Xs
   │ ┃ hello from Python! it is currently 20XX-XX-XX XX:XX:XX.XXXX

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/python/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/python/custom-span
@@ -20,7 +20,7 @@ Expected stderr:
 ✔ .customSpan: String! X.Xs
 ┃ hello from Python! it is currently 20XX-XX-XX XX:XX:XX.XXXX
 ╰╴✔ custom span X.Xs
-  ├╴$ container: Container! X.Xs CACHED
+  ├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
   ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
   ├╴✔ withExec echo 'hello from Python! it is currently 20XX-XX-XX XX:XX:XX.XXXX' X.Xs
   │ ┃ hello from Python! it is currently 20XX-XX-XX XX:XX:XX.XXXX

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/python/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/python/pending
@@ -28,7 +28,7 @@ Expected stderr:
 ┃   File "/src/xxh3:XXXXXXXXXXXXXXXX/viztest/python/sdk/src/dagger/client/_core.py", line XXX, in execute
 ┃     raise error from e
 ┃ dagger.ExecError: exit code: 1 [traceparent:00000000000000000000000000000000-0000000000000000]
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX X.Xs
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/python/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/python/pending
@@ -28,7 +28,7 @@ Expected stderr:
 ┃   File "/src/xxh3:XXXXXXXXXXXXXXXX/viztest/python/sdk/src/dagger/client/_core.py", line XXX, in execute
 ┃     raise error from e
 ┃ dagger.ExecError: exit code: 1 [traceparent:00000000000000000000000000000000-0000000000000000]
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=20XX-XX-XX XX:XX:XX.XXXX X.Xs
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/service-error-attribution
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/service-error-attribution
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .serviceErrorAttribution: Void X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴$ .asService(args: ["sh", "-c", "echo service is starting; sleep 1; echo service is crashing >&2; exit 42"]): Service! X.Xs ERROR
 │ ┃ service is starting

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/service-error-attribution
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/service-error-attribution
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✘ .serviceErrorAttribution: Void X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴$ .asService(args: ["sh", "-c", "echo service is starting; sleep 1; echo service is crashing >&2; exit 42"]): Service! X.Xs ERROR
 │ ┃ service is starting

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/custom-span
@@ -20,7 +20,7 @@ $ typescript: Typescript! X.Xs CACHED
 ✔ .customSpan: String! X.Xs
 ┃ hello from TypeScript! it is currently XXXX-XX-XXTXX:XX:XX.XXXZ
 ╰╴✔ custom span X.Xs
-  ├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+  ├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
   ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
   ├╴✔ withExec echo 'hello from TypeScript! it is currently XXXX-XX-XXTXX:XX:XX.XXXZ' X.Xs
   │ ┃ hello from TypeScript! it is currently XXXX-XX-XXTXX:XX:XX.XXXZ

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/custom-span
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/custom-span
@@ -20,7 +20,7 @@ $ typescript: Typescript! X.Xs CACHED
 ✔ .customSpan: String! X.Xs
 ┃ hello from TypeScript! it is currently XXXX-XX-XXTXX:XX:XX.XXXZ
 ╰╴✔ custom span X.Xs
-  ├╴$ container: Container! X.Xs CACHED
+  ├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
   ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
   ├╴✔ withExec echo 'hello from TypeScript! it is currently XXXX-XX-XXTXX:XX:XX.XXXZ' X.Xs
   │ ┃ hello from TypeScript! it is currently XXXX-XX-XXTXX:XX:XX.XXXZ

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-effect
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ typescript: Typescript! X.Xs CACHED
 ✘ .failEffect: Container! X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ╰╴✘ withExec sh -c 'echo this is a failing effect; exit 1' X.Xs ERROR
   ┃ this is a failing effect

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-effect
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-effect
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ typescript: Typescript! X.Xs CACHED
 ✘ .failEffect: Container! X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ╰╴✘ withExec sh -c 'echo this is a failing effect; exit 1' X.Xs ERROR
   ┃ this is a failing effect

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ typescript: Typescript! X.Xs CACHED
 ✘ .failLog: Void X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=XXXX-XX-XXTXX:XX:XX.XXXZ X.Xs
 ╰╴✘ withExec sh -c 'echo im doing a lot of work; echo and then failing; exit 1' X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/fail-log
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ typescript: Typescript! X.Xs CACHED
 ✘ .failLog: Void X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=XXXX-XX-XXTXX:XX:XX.XXXZ X.Xs
 ╰╴✘ withExec sh -c 'echo im doing a lot of work; echo and then failing; exit 1' X.Xs ERROR

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/pending
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ typescript: Typescript! X.Xs CACHED
 ✘ .pending: Void X.Xs ERROR
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=XXXX-XX-XXTXX:XX:XX.XXXZ X.Xs
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/pending
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/typescript/pending
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ typescript: Typescript! X.Xs CACHED
 ✘ .pending: Void X.Xs ERROR
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴$ .from(address: "alpine:latest"): Container! X.Xs CACHED
 ├╴✔ withEnvVariable NOW=XXXX-XX-XXTXX:XX:XX.XXXZ X.Xs
 ├╴✔ withExec sleep 1 X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .useCachedExecService: Void X.Xs
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴✔ .from(address: "busybox"): Container! X.Xs
 ├╴$ withExec echo 'exec-service cached for good' X.Xs CACHED
 ├╴$ withExec echo 'im also cached for good' X.Xs CACHED

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-cached-exec-service
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .useCachedExecService: Void X.Xs
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴✔ .from(address: "busybox"): Container! X.Xs
 ├╴$ withExec echo 'exec-service cached for good' X.Xs CACHED
 ├╴$ withExec echo 'im also cached for good' X.Xs CACHED

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .useExecService: Void X.Xs
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴✔ .from(address: "busybox"): Container! X.Xs
 ├╴✔ withNewFile /srv/index.html (contents: "<h1>hello, world!</h1><p>the time is 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X</p>") X.Xs
 ├╴✔ .withExposedPort(port: 80): Container! X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-exec-service
@@ -13,7 +13,7 @@ Expected stderr:
 
 $ viztest: Viztest! X.Xs CACHED
 ✔ .useExecService: Void X.Xs
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴✔ .from(address: "busybox"): Container! X.Xs
 ├╴✔ withNewFile /srv/index.html (contents: "<h1>hello, world!</h1><p>the time is 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X</p>") X.Xs
 ├╴✔ .withExposedPort(port: 80): Container! X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -19,7 +19,7 @@ Expected stderr:
 $ viztest: Viztest! X.Xs CACHED
 ✔ .useNoExecService: String! X.Xs
 ┃ PONG
-├╴$ container: Container! X.Xs CACHED
+├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
 ├╴✔ .from(address: "redis:7.4.3"): Container! X.Xs
 ├╴$ .withExposedPort(port: 6379): Container! X.Xs CACHED
 ├╴$ .asService: Service! X.Xs CACHED

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/use-no-exec-service
@@ -19,7 +19,7 @@ Expected stderr:
 $ viztest: Viztest! X.Xs CACHED
 ✔ .useNoExecService: String! X.Xs
 ┃ PONG
-├╴$ container(platform: "linux/amd64"): Container! X.Xs CACHED
+├╴$ container(platform: "linux/ARCH"): Container! X.Xs CACHED
 ├╴✔ .from(address: "redis:7.4.3"): Container! X.Xs
 ├╴$ .withExposedPort(port: 6379): Container! X.Xs CACHED
 ├╴$ .asService: Service! X.Xs CACHED


### PR DESCRIPTION
## Summary

DagQL omitted optional arguments from call identity before resolvers applied engine defaults. Platform-dependent resolvers could therefore execute with a concrete engine platform while their cache identity represented only the abstract omission. The same problem affected ambient platform values that had no public argument at all.

This change makes the resolved platform part of the identities for:

- `Query.container`
- `Query.defaultPlatform`
- `Query.directory`
- `Directory.dockerBuild`, including both its target platform and the native build platform used by Dockerfile `BUILDPLATFORM` values

## Implementation

`container` and the target-platform portion of `dockerBuild` use dynamic inputs to rewrite an omitted or null optional `platform` argument to the concrete engine platform before cache lookup. This also canonicalizes omission with an explicitly supplied native platform.

`defaultPlatform` and `directory` have no natural platform argument, so they use an implicit `engineDefaultPlatform` identity input. `dockerBuild` also carries that implicit input independently because its native build platform affects Dockerfile conversion even when the target platform is explicit.

The GraphQL schema is unchanged. Existing entries under the old incomplete identities are intentionally not reused. Explicit `container(platform:)` identities remain unchanged; default-dependent calls and `dockerBuild` calls receive corrected identities that partition by the relevant engine platform.

Telemetry goldens retain evidence that dynamic canonicalization supplied a platform argument, while normalizing only the actual test engine native value to `linux/ARCH`. Explicit non-native platform values and other platform-bearing calls remain literal, keeping the fixtures portable across amd64 and arm64 runners.

## Validation

- `go test ./core/schema -count=1`
- `go test ./dagql/idtui -run ^TestNormalizeTelemetryNativePlatform -count=1`
- Focused `engine-dev test-telemetry` run covering all 19 affected golden scenarios: 21 tests passed
- `git diff --check`

The focused schema tests verify omitted/explicit-native canonicalization, explicit-null behavior, platform partitioning, and the implicit/dynamic identity wiring. The telemetry normalization test exercises synthetic amd64 and arm64 native values and verifies non-native and unrelated platform arguments are preserved.