### PR TITLE
core: make SchemaBuilder.Lookup nil-safe

### DIFF
--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -113,6 +113,9 @@ func (b *SchemaBuilder) With(mod Mod, opts InstallOpts) *SchemaBuilder {
 }
 
 func (b *SchemaBuilder) Lookup(name string) (Mod, bool) {
+	if b == nil {
+		return nil, false
+	}
 	for _, e := range b.entries {
 		if e.mod.Name() == name {
 			return e.mod, true


### PR DESCRIPTION
`SchemaBuilder.Lookup` dereferenced its receiver unconditionally, but the
builder that reaches it can legitimately be nil.

`CurrentServedDeps` returns `(nil, err)` once the calling client's session is
gone, and `parseCallerCalleeRefs` discards that error before calling `Lookup`.
So a module call issued from an agent's tool loop — where sessions come and go
underneath long-running work — could crash the whole engine from telemetry
span enrichment alone. Nothing about the call itself was wrong; the panic came
from decorating it.

Guard the nil receiver the way `Mods()` already does, so a nil builder simply
resolves nothing and the enrichment degrades to "no refs".

Three lines in `core/moddeps.go`.

---

This is one half of a pair. #13914 fixes the other nil dereference
reachable from the same discarded-error path (`cm.Labels` off nil client
metadata) and carries the regression tests that exercise both crashes.

Independent bug fix, based on `main`. Extracted from the LLM workspace stack
(#13832–#13838); it has no dependency on those PRs and can land on its own.
