### PR TITLE
core/telemetry: tolerate missing caller metadata

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -257,10 +257,21 @@ func parseCallerCalleeRefs(ctx context.Context, q *Query, frame *dagql.ResultCal
 	if frame == nil || frame.Module == nil {
 		return nil, nil
 	}
+	// All of these are best-effort: telemetry enrichment must never fail — let
+	// alone crash — a call, and each returns a nil value alongside its error,
+	// e.g. when the client's session has already gone away. So treat every
+	// result as possibly nil from here on.
 	cm, _ := q.MainClientCallerMetadata(ctx)
 	fc, _ := q.CurrentFunctionCall(ctx)
 	m, _ := q.CurrentModule(ctx)
 	sd, _ := q.CurrentServedDeps(ctx)
+
+	// Read the caller's labels through a local map so nil metadata simply
+	// means "no labels" rather than a nil dereference.
+	var callerLabels map[string]string
+	if cm != nil {
+		callerLabels = cm.Labels
+	}
 
 	callerRef, calleeRef := &moduleCallRef{}, &moduleCallRef{}
 	// there's a caller
@@ -282,9 +293,9 @@ func parseCallerCalleeRefs(ctx context.Context, q *Query, frame *dagql.ResultCal
 		if ms.Git != nil {
 			idx := strings.LastIndex(ms.AsString(), "@")
 			callerRef.ref, callerRef.version = ms.AsString()[:idx], ms.AsString()[idx+1:]
-		} else if gremote, ok := cm.Labels["dagger.io/git.remote"]; ok {
+		} else if gremote, ok := callerLabels["dagger.io/git.remote"]; ok {
 			callerRef.ref = path.Join(gremote, ms.SourceRootSubpath)
-			if gref, ok := cm.Labels["dagger.io/git.ref"]; ok {
+			if gref, ok := callerLabels["dagger.io/git.ref"]; ok {
 				callerRef.version = gref
 			}
 		} else {
@@ -316,12 +327,12 @@ func parseCallerCalleeRefs(ctx context.Context, q *Query, frame *dagql.ResultCal
 		} else {
 			if ms.Local != nil {
 				calleeRef.ref = strings.ReplaceAll(calleeRef.ref, ms.Local.ContextDirectoryPath, "")
-				if gremote, ok := cm.Labels["dagger.io/git.remote"]; ok {
+				if gremote, ok := callerLabels["dagger.io/git.remote"]; ok {
 					calleeRef.ref = path.Join(gremote, calleeRef.ref)
 				} else {
 					return nil, nil
 				}
-			} else if gremote, ok := cm.Labels["dagger.io/git.remote"]; ok {
+			} else if gremote, ok := callerLabels["dagger.io/git.remote"]; ok {
 				subPath := ms.SourceRootSubpath
 				calleeRef.ref = path.Join(gremote, subPath)
 			} else {
@@ -330,7 +341,7 @@ func parseCallerCalleeRefs(ctx context.Context, q *Query, frame *dagql.ResultCal
 		}
 
 		// if not within a function and a local call, use the git ref as the version
-		if gr, ok := cm.Labels["dagger.io/git.ref"]; fc == nil && ok {
+		if gr, ok := callerLabels["dagger.io/git.ref"]; fc == nil && ok {
 			calleeRef.version = gr
 		} else {
 			calleeRef.version = callerRef.version

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"testing"
@@ -45,7 +46,11 @@ type mockServer struct {
 	moduleSource   *ModuleSource
 	functionCall   *FunctionCall
 	clientMetadata *engine.ClientMetadata
-	attachables    map[string]*grpc.ClientConn
+	// when set, the client-scoped lookups fail the way the real server does
+	// once the calling client's session is gone: a nil value alongside an
+	// error.
+	clientLookupErr error
+	attachables     map[string]*grpc.ClientConn
 }
 
 func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed) {
@@ -106,10 +111,16 @@ func (ms *mockServer) CurrentFunctionCall(context.Context) (*FunctionCall, error
 }
 
 func (ms *mockServer) CurrentServedDeps(context.Context) (*SchemaBuilder, error) {
+	if ms.clientLookupErr != nil {
+		return nil, ms.clientLookupErr
+	}
 	return NewSchemaBuilder(nil, nil), nil
 }
 
 func (ms *mockServer) MainClientCallerMetadata(context.Context) (*engine.ClientMetadata, error) {
+	if ms.clientLookupErr != nil {
+		return nil, ms.clientLookupErr
+	}
 	if ms.clientMetadata != nil {
 		return ms.clientMetadata, nil
 	}
@@ -231,6 +242,51 @@ func TestParseCallerCalleeRefs(t *testing.T) {
 	require.Equal(t, "github.com/dagger/dagger-test-modules/versioned", calleeRef.ref)
 	require.Equal(t, "0cabe03cc0a9079e738c92b2c589d81fd560011f", calleeRef.version)
 	require.Equal(t, "VersionedGitSSH.hello", calleeRef.functionName)
+}
+
+// Telemetry enrichment runs on every module call, including ones made long
+// after the calling client's session went away — e.g. from an agent's tool
+// loop. The client-scoped lookups then hand back nil values alongside their
+// error, so parsing must degrade to "no refs" instead of dereferencing them.
+func TestParseCallerCalleeRefsWithoutClient(t *testing.T) {
+	call := &dagql.ResultCall{
+		Kind:  dagql.ResultCallKindField,
+		Field: "VersionedGitSSH.hello",
+		Type:  dagql.NewResultCallType((&Void{}).Type()),
+		Module: &dagql.ResultCallModule{
+			Name: "versioned_git_ssh",
+			Ref:  "git@github.com:dagger/dagger-test-modules/versioned@main",
+			Pin:  "0cabe03cc0a9079e738c92b2c589d81fd560011f",
+		},
+	}
+
+	t.Run("no current module and no served deps", func(t *testing.T) {
+		// nil *SchemaBuilder: the callee module can't be resolved at all.
+		mockSrv := &mockServer{
+			clientLookupErr: errors.New("session not found"),
+			functionCall:    &FunctionCall{Name: "callerFunction"},
+		}
+
+		callerRef, calleeRef := parseCallerCalleeRefs(t.Context(), &Query{Server: mockSrv}, call)
+		require.Nil(t, callerRef)
+		require.Nil(t, calleeRef)
+	})
+
+	t.Run("no caller metadata", func(t *testing.T) {
+		// nil *ClientMetadata: a local caller whose git labels are unknowable.
+		mockSrv := &mockServer{
+			clientLookupErr: errors.New("session not found"),
+			moduleSource: &ModuleSource{
+				Kind:  ModuleSourceKindLocal,
+				Local: &LocalModuleSource{ContextDirectoryPath: "/src"},
+			},
+			functionCall: &FunctionCall{Name: "callerFunction"},
+		}
+
+		callerRef, calleeRef := parseCallerCalleeRefs(t.Context(), &Query{Server: mockSrv}, call)
+		require.Nil(t, callerRef)
+		require.Nil(t, calleeRef)
+	})
 }
 
 func TestAroundFuncMarksIntrospectionRootAsSkipped(t *testing.T) {


### PR DESCRIPTION
`parseCallerCalleeRefs` is best-effort span enrichment, but it read `cm.Labels`
straight off the client metadata — and that metadata is nil whenever
`MainClientCallerMetadata` fails.

That is the same discarded-error path that made a nil served-deps builder crash
`SchemaBuilder.Lookup`: the error is dropped, the nil flows on, and something
that exists purely to decorate a span takes down the engine instead.

Read the labels through a local map so absent metadata means "no labels" and
the call degrades to no refs, which is what best-effort enrichment should do.

`core/telemetry_test.go` covers both nil client-scoped lookups — each of which
panicked before this change and the `Lookup` guard.

---

This is one half of a pair. #13913 guards the nil receiver in
`SchemaBuilder.Lookup`; the tests here exercise both crashes, so reviewing them
together is easiest. They touch disjoint files and can land in either order.

Independent bug fix, based on `main`. Extracted from the LLM workspace stack
(#13832–#13838); it has no dependency on those PRs and can land on its own.
