### PR TITLE
LLM: fail turns cut short by refusal or output limit

### DIFF
--- a/core/llm_anthropic.go
+++ b/core/llm_anthropic.go
@@ -372,6 +372,15 @@ func (c *AnthropicClient) SendQuery(ctx context.Context, history []*LLMMessage, 
 		return nil, err
 	}
 
+	// A turn cut short — a refusal, a token or context limit — can still have
+	// streamed content before it stopped, so the stop reason has to be checked
+	// on its own rather than only when nothing accumulated. Otherwise a refusal
+	// landing a few thinking tokens in reads as a clean finish, and the caller
+	// idles on a reply carrying no text and no tool calls.
+	if !anthropicStoppedCleanly(acc.StopReason) {
+		return nil, &ModelFinishedError{Reason: string(acc.StopReason)}
+	}
+
 	// Check that we have some accumulated content.
 	if len(acc.Content) == 0 {
 		return nil, &ModelFinishedError{
@@ -425,6 +434,22 @@ func (c *AnthropicClient) SendQuery(ctx context.Context, history []*LLMMessage, 
 		DisplaySpans:     displaySpans,
 		ToolCallDisplays: toolCallDisplays,
 	}, nil
+}
+
+// anthropicStoppedCleanly reports whether a stop reason means the model
+// finished its turn normally. It rejects only the reasons known to leave the
+// turn unusable, so a reason added to the API later keeps working instead of
+// failing every request.
+func anthropicStoppedCleanly(reason anthropic.StopReason) bool {
+	switch reason {
+	case anthropic.StopReasonRefusal,
+		anthropic.StopReasonMaxTokens,
+		// Absent from the non-beta enum, but the API still sends it.
+		"model_context_window_exceeded":
+		return false
+	default:
+		return true
+	}
 }
 
 // appendOrMerge appends content blocks to the messages slice. If the last

--- a/core/llm_google.go
+++ b/core/llm_google.go
@@ -287,6 +287,11 @@ func (c *GenaiClient) processStreamResponse(
 		if candidate.Content == nil {
 			return contentBlocks, tokenUsage, &ModelFinishedError{Reason: string(candidate.FinishReason)}
 		}
+		// A blocked or truncated candidate can arrive with content attached, so
+		// the finish reason is checked even when Content is set.
+		if !genaiFinishedCleanly(candidate.FinishReason) {
+			return contentBlocks, tokenUsage, &ModelFinishedError{Reason: string(candidate.FinishReason)}
+		}
 
 		for _, part := range candidate.Content.Parts {
 			sig := ""
@@ -347,6 +352,21 @@ func (c *GenaiClient) processStreamResponse(
 	flushThinking()
 	flushText()
 	return contentBlocks, tokenUsage, nil
+}
+
+// genaiFinishedCleanly reports whether a candidate's finish reason means the
+// model finished normally. Gemini's enum is almost entirely failure modes
+// (SAFETY, RECITATION, BLOCKLIST, PROHIBITED_CONTENT, MALFORMED_FUNCTION_CALL,
+// ...), so this allows the good reasons rather than listing the bad ones. A
+// finish reason is reported only on the last streamed chunk, so an empty one
+// means the turn is still in progress.
+func genaiFinishedCleanly(reason genai.FinishReason) bool {
+	switch reason {
+	case "", genai.FinishReasonStop, genai.FinishReasonUnspecified:
+		return true
+	default:
+		return false
+	}
 }
 
 // decodeThoughtSignature turns a base64-encoded thought signature (as stored on

--- a/core/llm_openai.go
+++ b/core/llm_openai.go
@@ -200,6 +200,13 @@ func (c *OpenAIClient) SendQuery(ctx context.Context, history []*LLMMessage, too
 
 	choice := chatCompletion.Choices[0]
 
+	// A filtered or truncated choice can still carry partial content, so the
+	// finish reason is checked on its own rather than only when no blocks come
+	// out of it below. See anthropicStoppedCleanly.
+	if !openAIFinishedCleanly(choice.FinishReason) {
+		return nil, &ModelFinishedError{Reason: choice.FinishReason}
+	}
+
 	// Convert the OpenAI response into content blocks.
 	var contentBlocks []*LLMContentBlock
 	if choice.Message.Content != "" {
@@ -240,6 +247,18 @@ func (c *OpenAIClient) SendQuery(ctx context.Context, history []*LLMMessage, too
 		DisplaySpans:     displaySpans,
 		ToolCallDisplays: toolCallDisplays,
 	}, nil
+}
+
+// openAIFinishedCleanly reports whether a chat completion finish reason means
+// the model finished its turn normally. Like the Anthropic check, it rejects
+// only the reasons known to leave the turn unusable.
+func openAIFinishedCleanly(reason string) bool {
+	switch reason {
+	case "length", "content_filter":
+		return false
+	default:
+		return true
+	}
 }
 
 func openAICompletionUsage(usage openai.CompletionUsage) LLMTokenUsage {

--- a/core/llm_openai_codex.go
+++ b/core/llm_openai_codex.go
@@ -58,6 +58,7 @@ func (c *OpenAICodexClient) IsRetryable(err error) bool {
 	return false
 }
 
+//nolint:gocyclo // streaming response handling is clearest as one protocol state machine
 func (c *OpenAICodexClient) SendQuery(ctx context.Context, history []*LLMMessage, tools []LLMTool, opts *LLMCallOpts) (_ *LLMResponse, rerr error) {
 	// Stream this turn's content into per-block display spans.
 	dp := newDisplayPhases(ctx, opts.CallDigest)
@@ -196,6 +197,26 @@ func (c *OpenAICodexClient) SendQuery(ctx context.Context, history []*LLMMessage
 					dp.Close(reasonIdx)
 				}
 			}
+
+		case "response.incomplete", "response.failed":
+			// A turn cut short ends with one of these instead of
+			// response.completed. Anything streamed so far is partial — a
+			// truncated tool call, half a message — so report the stop rather
+			// than letting the partial turn read as a clean finish.
+			var resp responses.Response
+			if event.Type == "response.incomplete" {
+				resp = event.AsResponseIncomplete().Response
+			} else {
+				resp = event.AsResponseFailed().Response
+			}
+			reason := resp.IncompleteDetails.Reason
+			if reason == "" {
+				reason = resp.Error.Message
+			}
+			if reason == "" {
+				reason = string(resp.Status)
+			}
+			return nil, &ModelFinishedError{Reason: reason}
 
 		case "response.completed":
 			e := event.AsResponseCompleted()

--- a/core/llm_stop_reason_test.go
+++ b/core/llm_stop_reason_test.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/genai"
+)
+
+// A turn cut short has to surface as a ModelFinishedError even when partial
+// content streamed before it stopped, so each provider's reason check is
+// exercised on its own rather than through a live client.
+
+func TestAnthropicStoppedCleanly(t *testing.T) {
+	for _, reason := range []anthropic.StopReason{
+		anthropic.StopReasonEndTurn,
+		anthropic.StopReasonToolUse,
+		anthropic.StopReasonStopSequence,
+		anthropic.StopReasonPauseTurn,
+		"",                        // not reported
+		"some_reason_added_later", // unknown reasons stay usable
+	} {
+		assert.True(t, anthropicStoppedCleanly(reason), "reason %q should be clean", reason)
+	}
+
+	for _, reason := range []anthropic.StopReason{
+		anthropic.StopReasonRefusal,
+		anthropic.StopReasonMaxTokens,
+		"model_context_window_exceeded",
+	} {
+		assert.False(t, anthropicStoppedCleanly(reason), "reason %q should end the turn", reason)
+	}
+}
+
+func TestOpenAIFinishedCleanly(t *testing.T) {
+	for _, reason := range []string{"stop", "tool_calls", "function_call", ""} {
+		assert.True(t, openAIFinishedCleanly(reason), "reason %q should be clean", reason)
+	}
+
+	for _, reason := range []string{"length", "content_filter"} {
+		assert.False(t, openAIFinishedCleanly(reason), "reason %q should end the turn", reason)
+	}
+}
+
+func TestGenaiFinishedCleanly(t *testing.T) {
+	// Empty is the common case: Gemini reports a finish reason only on the last
+	// streamed chunk.
+	for _, reason := range []genai.FinishReason{
+		"",
+		genai.FinishReasonStop,
+		genai.FinishReasonUnspecified,
+	} {
+		assert.True(t, genaiFinishedCleanly(reason), "reason %q should be clean", reason)
+	}
+
+	for _, reason := range []genai.FinishReason{
+		genai.FinishReasonSafety,
+		genai.FinishReasonMaxTokens,
+		genai.FinishReasonRecitation,
+		genai.FinishReasonBlocklist,
+		genai.FinishReasonProhibitedContent,
+		genai.FinishReasonMalformedFunctionCall,
+		genai.FinishReasonOther,
+	} {
+		assert.False(t, genaiFinishedCleanly(reason), "reason %q should end the turn", reason)
+	}
+}


### PR DESCRIPTION
A provider can end a turn early — a safety refusal, an output-token ceiling, a
truncated stream — and until now that mostly looked like success.

Every provider client consulted the stop reason only when *no* content came
back at all. A turn that streamed something and then stopped short fell through
the empty-content guard and was handed to the agent loop as a normal response.
An Anthropic refusal that fired a few thinking tokens first left exactly one
truncated block: content was non-empty, the stop reason was discarded, and the
loop saw a valid turn with no tool calls. It closed the turn and parked idle.
No error anywhere — the agent just stopped, and the reason it stopped was
thrown away one layer down.

**The fix is ordering:** each client now checks the stop reason *before* it
looks at content.

The check is deliberately asymmetric, because the enums are:

- **Anthropic** and **OpenAI** reject a known-bad list, so a stop reason the
  client has never heard of keeps working instead of failing a good turn.
- **Gemini** allows a known-good list, since its enum is almost entirely
  failure modes and an empty reason just means the stream is still open.
- The **Codex** client handled only `response.completed`; it now handles
  `response.incomplete` and `response.failed` too.

A cut-short turn surfaces as a `ModelFinishedError` the user can actually see,
rather than a silent idle. Recovery behavior is untouched — this only changes
whether the failure is reported, not what happens next.

`core/llm_stop_reason_test.go` covers each client's classification, including
the unrecognized-reason path that must stay permissive.

---

Independent bug fix, based on `main`. Extracted from the LLM workspace stack
(#13832–#13838); it has no dependency on those PRs and can land on its own.
