### PR TITLE
TUI: keep notification and flowing output stable

### DIFF
--- a/dagql/idtui/conversation_report_test.go
+++ b/dagql/idtui/conversation_report_test.go
@@ -73,6 +73,43 @@ func TestConversationReportFlagsToolResultTokens(t *testing.T) {
 	}
 }
 
+func TestRunningConversationRenderIsStable(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	db := dagui.NewDB()
+	rootID, runningID := prettyTestSpanID(1), prettyTestSpanID(2)
+	effectID, failedID := prettyTestSpanID(3), prettyTestSpanID(4)
+	start := time.Unix(100, 0)
+	db.ImportSnapshots([]dagui.SpanSnapshot{
+		{ID: rootID, TraceID: prettyTestTraceID(), Name: "shell", StartTime: start},
+		{ID: runningID, TraceID: prettyTestTraceID(), Name: "running_tool", LLMRole: "assistant", LLMTool: "running_tool", ParentID: rootID, StartTime: start.Add(time.Second)},
+		{ID: effectID, TraceID: prettyTestTraceID(), Name: "linked work", ParentID: rootID, StartTime: start.Add(2 * time.Second), Links: []dagui.SpanLink{causeLink(runningID)}},
+		{ID: failedID, TraceID: prettyTestTraceID(), Name: "failed_tool", LLMRole: "assistant", LLMTool: "failed_tool", ParentID: rootID, StartTime: start.Add(3 * time.Second), EndTime: start.Add(5 * time.Second), Status: sdktrace.Status{Code: codes.Error}, Final: true},
+	})
+	db.SetPrimarySpan(rootID)
+	fe := NewWithDB(io.Discard, db)
+	fe.shell = stubShellHandler{}
+	fe.recalculateViewLocked()
+	if !fe.flowingMode() {
+		t.Fatal("conversation frontend should render in flowing mode")
+	}
+	render := func(now time.Time) string {
+		fe.claims = newRenderClaims()
+		r := newRenderer(fe.db, 0, fe.FrontendOpts, false)
+		r.now = now
+		return strings.Join(fe.renderConversationSection(tuist.Context{Width: 120}, r), "\n")
+	}
+	first, second := render(start.Add(5*time.Second)), render(start.Add(time.Hour))
+	if first != second {
+		t.Fatalf("running conversation changed across live ticks:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if !strings.Contains(first, "RUNNING") || !strings.Contains(first, "2.0s ERROR") {
+		t.Fatalf("running conversation presentation changed:\n%s", first)
+	}
+	if len(fe.durationViews) != 0 || len(fe.statusSpinners) != 0 {
+		t.Fatalf("conversation mounted animated children: durations=%d spinners=%d", len(fe.durationViews), len(fe.statusSpinners))
+	}
+}
+
 // TestConversationReportNestsSubAgent verifies the final report surfaces the LLM
 // conversation under a CONVERSATION heading, in start-time order, with a
 // sub-agent's turns nested one level under the tool call that spawned them.

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -327,9 +327,8 @@ type SpanTreeView struct {
 
 	// durationViews are inline, self-updating duration components owned by this
 	// rendered occurrence of a span tree, keyed by span ID (a row can summarize
-	// running effect spans in its title). Like statusSpinners they are only
-	// mounted while a span is running, so their ticker keeps the elapsed
-	// duration fresh even on rows without a status spinner (e.g. LLM messages).
+	// running effect spans in its title). They are only mounted for running rows
+	// in viewport-clipped views; flowing output must remain inert in scrollback.
 	durationViews map[dagui.SpanID]*DurationView
 
 	// childrenGapPrefix is the prefix for gap lines between this node's
@@ -604,15 +603,10 @@ const durationTickInterval = 100 * time.Millisecond
 
 // DurationView is a self-updating component that renders a span's elapsed
 // activity duration. It mirrors the status spinner's lifecycle: it is only
-// mounted while the span is running, so its OnMount ticker re-renders on an
-// interval and marks itself dirty. Because Compo.Update propagates upward, each
-// tick re-runs the owning SpanTreeView's Render -- rebuilding the title line
-// with a fresh clock -- so the duration stays live.
-//
-// This is what keeps durations fresh on rows that have no status spinner to
-// drive re-renders, notably LLM message spans (renderStepTitle skips the status
-// icon for LLMRole spans), whose duration would otherwise freeze at whatever
-// time the title was last rendered.
+// mounted while a span is running in a viewport-clipped view, so its OnMount
+// ticker re-renders on an interval and marks itself dirty. Because Compo.Update
+// propagates upward, each tick re-runs the owning SpanTreeView's Render --
+// rebuilding the title line with a fresh clock -- so the duration stays live.
 type DurationView struct {
 	tuist.Compo
 
@@ -6211,7 +6205,7 @@ func progressTrack(out TermOutput, width, eighths int, fill, track termenv.Color
 // indicating whether it's interesting enough to reveal at a summary level.
 func (fe *frontendPretty) statusIcon(ctx tuist.Context, host statusIconHost, span *dagui.Span) (string, bool) {
 	if span.IsRunningOrEffectsRunning() {
-		if host == nil {
+		if host == nil || fe.flowingMode() {
 			return DotHalf, true
 		}
 		return host.RenderChildInline(ctx, host.spinnerForStatus(span.ID)), true
@@ -6255,13 +6249,16 @@ func (fe *frontendPretty) renderStatusIcon(ctx tuist.Context, out TermOutput, ro
 	fmt.Fprint(out, statusIcon.String())
 }
 
-// renderDurationDynamic renders a span's duration. While the span is running
-// (and outside the final, non-interactive render) it goes through a
-// self-updating DurationView child, so the duration keeps ticking even on rows
-// with no status spinner to drive re-renders -- notably LLM message spans. Once
-// the span stops running the child is no longer rendered (and so dismounts,
-// stopping its ticker) and the final duration is written as static text.
+// renderDurationDynamic renders a span's duration. Running rows in flowing mode
+// are deliberately inert: the whole over-tall frame flows into native terminal
+// scrollback, where a ticking duration would force Tuist to redraw even when the
+// row is off-screen. Viewport-clipped views keep using a self-updating
+// DurationView; once a span stops, every view falls back to its static final
+// duration.
 func (fe *frontendPretty) renderDurationDynamic(ctx tuist.Context, out TermOutput, r *renderer, span *dagui.Span, host statusIconHost, space bool) {
+	if fe.flowingMode() && span.IsRunningOrEffectsRunning() {
+		return
+	}
 	if !fe.finalRender && host != nil && span.IsRunningOrEffectsRunning() {
 		if space {
 			fmt.Fprint(out, out.String(" "))
@@ -6275,7 +6272,10 @@ func (fe *frontendPretty) renderDurationDynamic(ctx tuist.Context, out TermOutpu
 }
 
 func (fe *frontendPretty) renderStatus(out TermOutput, span *dagui.Span) {
-	if span.CheckPassed {
+	if fe.flowingMode() && span.IsRunningOrEffectsRunning() {
+		fmt.Fprint(out, out.String(" "))
+		fmt.Fprint(out, out.String("RUNNING").Foreground(termenv.ANSIYellow))
+	} else if span.CheckPassed {
 		fmt.Fprint(out, out.String(" "))
 		fmt.Fprint(out, out.String("OK").Foreground(termenv.ANSIGreen))
 	} else if span.IsFailedOrCausedFailure() && !span.IsCanceled() {

--- a/dagql/idtui/notification.go
+++ b/dagql/idtui/notification.go
@@ -61,6 +61,19 @@ func (n *NotificationBubble) Render(ctx tuist.Context) {
 	bgStyle := lipgloss.NewStyle().
 		Width(innerWidth)
 	for _, line := range contentLines {
+		// Clamp the line to the space between the borders before padding.
+		// lipgloss's Width WRAPS rather than truncates, so an over-long line
+		// comes back as a multi-row string — and tuist treats every ctx.Line
+		// entry as exactly one terminal row, so that desynchronizes the frame's
+		// line accounting: the diff renderer's relative cursor moves drift by
+		// the number of extra rows, duplicating and clobbering lines all over
+		// the screen, not just in this box. Tabs and carriage returns advance
+		// the cursor without contributing visible width, so they are neutralized
+		// too. Sidebar content comes from producers that may ignore the width
+		// they are handed (long host paths, unbounded error text), so the box
+		// clamps rather than trusting them. See TestNotificationBubbleOverlongContent.
+		line = strings.ReplaceAll(tuist.ExpandTabs(line, 8), "\r", "")
+		line = tuist.Truncate(line, innerWidth-1, "…")
 		// Apply background to the full inner width
 		padded := bgStyle.Render(" " + line)
 		ctx.Line(leftBorder + padded + rightBorder)

--- a/dagql/idtui/notification.go
+++ b/dagql/idtui/notification.go
@@ -67,12 +67,11 @@ func (n *NotificationBubble) Render(ctx tuist.Context) {
 		// entry as exactly one terminal row, so that desynchronizes the frame's
 		// line accounting: the diff renderer's relative cursor moves drift by
 		// the number of extra rows, duplicating and clobbering lines all over
-		// the screen, not just in this box. Tabs and carriage returns advance
-		// the cursor without contributing visible width, so they are neutralized
-		// too. Sidebar content comes from producers that may ignore the width
-		// they are handed (long host paths, unbounded error text), so the box
-		// clamps rather than trusting them. See TestNotificationBubbleOverlongContent.
-		line = strings.ReplaceAll(tuist.ExpandTabs(line, 8), "\r", "")
+		// the screen, not just in this box. Sidebar content comes from producers
+		// that may ignore the width they are handed (long host paths, unbounded
+		// error text), so the box clamps rather than trusting them.
+		// See TestNotificationBubbleOverlongContent.
+		line = strings.Map(dropRowBreaks, tuist.ExpandTabs(line, 8))
 		line = tuist.Truncate(line, innerWidth-1, "…")
 		// Apply background to the full inner width
 		padded := bgStyle.Render(" " + line)
@@ -163,6 +162,20 @@ func (n *NotificationBubble) buildTopBorder(profile termenv.Profile, borderFg te
 	}
 
 	return corner1 + innerStr + corner2
+}
+
+// dropRowBreaks removes the control characters that move the terminal cursor
+// off the row being painted: vertical tab and form feed move down a row, and a
+// bare carriage return jumps back to column 0 so the rest of the line overwrites
+// what it already painted. All of them measure as zero columns, so truncating by
+// visible width does not remove them. (Line feeds are handled by splitting the
+// content into rows before this runs.)
+func dropRowBreaks(r rune) rune {
+	switch r {
+	case '\r', '\v', '\f':
+		return -1
+	}
+	return r
 }
 
 // notificationWidth returns the width for notification bubbles.

--- a/dagql/idtui/notification_test.go
+++ b/dagql/idtui/notification_test.go
@@ -2,8 +2,10 @@ package idtui
 
 import (
 	"io"
+	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/muesli/termenv"
@@ -46,6 +48,119 @@ func TestNotificationTopBorderWidth(t *testing.T) {
 		}
 		if len(plain) == 0 || plain[len(plain)-1] != []rune(CornerTopRight)[0] {
 			t.Errorf("innerWidth=%d: top border missing right corner: %q", innerWidth, string(plain))
+		}
+	}
+}
+
+// fixedWidthHost renders a single child at an exact width, standing in for the
+// overlay that hosts notification bubbles in the real frontend (which sizes
+// them with tuist.SizeAbs(notificationWidth(...))).
+type fixedWidthHost struct {
+	tuist.Compo
+
+	width int
+	child tuist.Component
+}
+
+func (h *fixedWidthHost) Render(ctx tuist.Context) {
+	h.RenderChild(ctx.Resize(h.width, ctx.Height), h.child)
+}
+
+// renderComponentLines renders c at an exact width and returns the raw lines it
+// emitted via ctx.Line — i.e. exactly the slice entries the framework treats as
+// one terminal row each.
+func renderComponentLines(t *testing.T, c tuist.Component, width int) []string {
+	t.Helper()
+	tui := tuist.New(tuist.NewHeadlessTerminal(width, 40))
+	tui.AddChild(&fixedWidthHost{width: width, child: c})
+	return tui.RenderLines()
+}
+
+// TestNotificationBubbleOverlongContent guards the invariant tuist relies on:
+// every string handed to ctx.Line is exactly ONE terminal row — no embedded
+// newlines, and no more visible columns than the box is wide.
+//
+// The bubble pads content with lipgloss.NewStyle().Width(innerWidth).Render(),
+// and lipgloss Width does not truncate: it calls Wrap (see charm.land/
+// lipgloss/v2 style.go "Word wrap" -> lipgloss.Wrap -> ansi.Wrap), which
+// word-wraps and hard-breaks words longer than the width. So an over-long
+// content line — e.g. a filesystem path with no whitespace, which sidebar
+// producers such as updateReferencesPreview emit without honouring the width
+// they are given — turns one ctx.Line entry into a multi-row string, and the
+// framework's line accounting (and the overlay compositor) corrupt the screen.
+func TestNotificationBubbleOverlongContent(t *testing.T) {
+	const bubbleWidth = 40
+
+	// A realistic "References" entry: long, and with no whitespace to wrap on.
+	longPath := "sdk/typescript/runtime/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts"
+
+	term := tuist.NewHeadlessTerminal(120, 40)
+	fe := newWithTerminalProfile(io.Discard, dagui.NewDB(), term, termenv.Ascii)
+
+	var gotWidth int
+	bubble := newNotificationBubble(fe, SidebarSection{
+		Title: "References",
+		ContentFunc: func(width int) string {
+			// Deliberately ignore width, exactly like updateReferencesPreview.
+			gotWidth = width
+			return longPath
+		},
+	})
+
+	lines := renderComponentLines(t, bubble, bubbleWidth)
+	if gotWidth <= 0 {
+		t.Fatalf("ContentFunc was not called with a usable width (got %d)", gotWidth)
+	}
+
+	for i, line := range lines {
+		if strings.Contains(line, "\n") {
+			t.Errorf("line %d contains embedded newline(s): tuist treats each "+
+				"ctx.Line entry as exactly one row, so this desynchronizes line "+
+				"accounting.\nrows within the entry: %q",
+				i, strings.Split(stripANSICodes(line), "\n"))
+		}
+		if w := tuist.VisibleWidth(line); w > bubbleWidth {
+			t.Errorf("line %d visible width = %d, want <= %d: %q",
+				i, w, bubbleWidth, stripANSICodes(line))
+		}
+	}
+
+	// The box must be exactly what it looks like: top border, one row per
+	// content line, bottom border — and the number of slice entries must match
+	// the number of physical rows the terminal will actually show.
+	physicalRows := 0
+	for _, line := range lines {
+		physicalRows += strings.Count(line, "\n") + 1
+	}
+	if physicalRows != len(lines) {
+		t.Errorf("emitted %d ctx.Line entries but they occupy %d terminal rows",
+			len(lines), physicalRows)
+	}
+	if want := 3; len(lines) != want {
+		t.Errorf("emitted %d lines, want %d (top border, 1 content row, bottom border)",
+			len(lines), want)
+	}
+}
+
+// TestNotificationLipglossWidthWraps documents the upstream behavior the bubble
+// depends on: charm.land/lipgloss/v2 Style.Width(n) pads short input but WRAPS
+// long input (hard-breaking unbreakable words), it never truncates.
+func TestNotificationLipglossWidthWraps(t *testing.T) {
+	style := lipgloss.NewStyle().Width(10)
+
+	if got := style.Render("hi"); got != "hi        " {
+		t.Errorf("short input: Render(%q) = %q, want padding to width 10", "hi", got)
+	}
+
+	for _, input := range []string{
+		"one two three four five",       // wraps on spaces
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // no spaces: hard-wrapped
+		"a/very/long/path/with/no/spaces/at/all.txt",
+	} {
+		got := style.Render(input)
+		if !strings.Contains(got, "\n") {
+			t.Errorf("Render(%q) = %q; expected wrapping (newlines), which is "+
+				"the behavior notification.go must defend against", input, got)
 		}
 	}
 }

--- a/dagql/idtui/notification_test.go
+++ b/dagql/idtui/notification_test.go
@@ -89,13 +89,14 @@ func renderComponentLines(t *testing.T, c tuist.Component, width int) []string {
 // they are given — turns one ctx.Line entry into a multi-row string, and the
 // framework's line accounting (and the overlay compositor) corrupt the screen.
 func TestNotificationBubbleOverlongContent(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
 	const bubbleWidth = 40
 
 	// A realistic "References" entry: long, and with no whitespace to wrap on.
 	longPath := "sdk/typescript/runtime/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts"
 
 	term := tuist.NewHeadlessTerminal(120, 40)
-	fe := newWithTerminalProfile(io.Discard, dagui.NewDB(), term, termenv.Ascii)
+	fe := newWithTerminal(io.Discard, dagui.NewDB(), term)
 
 	var gotWidth int
 	bubble := newNotificationBubble(fe, SidebarSection{

--- a/go.mod
+++ b/go.mod
@@ -159,8 +159,8 @@ require (
 	github.com/vito/dang/v2 v2.1.3
 	github.com/vito/go-interact v1.0.2
 	github.com/vito/go-sse v1.1.3
-	github.com/vito/midterm v0.2.5-0.20260728152709-9f5888c96c1f
-	github.com/vito/tuist v0.0.10
+	github.com/vito/midterm v0.2.5
+	github.com/vito/tuist v0.0.11-0.20260811005514-1d38ff923562
 	github.com/vito/tuist/teav1 v0.0.0-20260728151937-82e472c0ece3
 	github.com/zeebo/xxh3 v1.1.0
 	go.etcd.io/bbolt v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -780,10 +780,10 @@ github.com/vito/go-interact v1.0.2 h1:viJuANio3WH9utUG4rKbJC9V3JR5JgYNS+i0efeA+G
 github.com/vito/go-interact v1.0.2/go.mod h1:s+y0jK9Z2etBYt5ZM6+DhpOsE5C7NNGC3jrJvW0BBpc=
 github.com/vito/go-sse v1.1.3 h1:tZOiC+xKmuRPoySTupO6liK7ciSX0B2NKXha5hEtUAE=
 github.com/vito/go-sse v1.1.3/go.mod h1:kMjgO+XCwBS0se2X/aS5T4aLBvHWAKOUqZOqXKdyrAg=
-github.com/vito/midterm v0.2.5-0.20260728152709-9f5888c96c1f h1:cPYDnZ3qjrMfup7p6mSkdScRzohRvla5nd0alNsHUjM=
-github.com/vito/midterm v0.2.5-0.20260728152709-9f5888c96c1f/go.mod h1:tY1HnZGargiJIhQC0DyMrUOa2Tlo1d4uz0UIDAKOaSE=
-github.com/vito/tuist v0.0.10 h1:Es0KRYYUFf82MZqHPLRkrnvC1MEcF3kpl0OG5rP8qjk=
-github.com/vito/tuist v0.0.10/go.mod h1:43TBITDgv8Rs2jqb1+zqVP9se44asloKoBW5S2lvxXw=
+github.com/vito/midterm v0.2.5 h1:cBx/lw5dKTYoUQB0q2B+MkfM3FOUQ7IYgUh3BNw2A2I=
+github.com/vito/midterm v0.2.5/go.mod h1:tY1HnZGargiJIhQC0DyMrUOa2Tlo1d4uz0UIDAKOaSE=
+github.com/vito/tuist v0.0.11-0.20260811005514-1d38ff923562 h1:R/HJ/xSWzGpV787Y1M9qo8f9shIsNGFfnzmE2GL/Spc=
+github.com/vito/tuist v0.0.11-0.20260811005514-1d38ff923562/go.mod h1:mkzO6GwRKQN/7AmTtL8QXJzHNAf4b3YjeeXSj9bPbnc=
 github.com/vito/tuist/teav1 v0.0.0-20260728151937-82e472c0ece3 h1:zQbfsYBz58qFI+fEfXxUJzLjcfhc0/E4WBykq/m9604=
 github.com/vito/tuist/teav1 v0.0.0-20260728151937-82e472c0ece3/go.mod h1:eD5acyvnjmQfdhnW7R0XWnr47zqX4JIjUm714uR2TIk=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=


### PR DESCRIPTION
Four related fixes for one class of bug: content that occupies more terminal
rows than the renderer thinks it does, which corrupts everything painted after
it.

**The invariant.** tuist treats every `ctx.Line` entry as exactly one terminal
row — overlay height, viewport clipping and the diff renderer's relative cursor
moves are all counted in slice elements. An entry that occupies two rows makes
`hardwareCursorRow` a lie from that frame on, so subsequent updates land one row
off and duplicate or clobber unrelated lines across the screen.

**Notification bubbles broke it.** `NotificationBubble` padded each content line
with `lipgloss.NewStyle().Width(innerWidth).Render()`, and lipgloss v2's `Width`
does not truncate — `Style.Render` calls `Wrap` → `ansi.Wrap`, which word-wraps
and hard-breaks long words. A long host path from the References section, or an
unbounded error string, came back as a multi-row string handed to a single
`ctx.Line`. tuist's own width clamp doesn't catch it either, because
`ansi.Truncate` measures `"\n"` as zero width and preserves it — which is why
the corrupted rows ended in a stray character from the wrapped remainder
instead of the closing border.

Each line is now clamped to the inner width with an ANSI-aware truncate before
padding.

**Zero-width cursor movers broke it too.** Vertical tab and form feed move the
cursor down a row just like a line feed; a bare carriage return jumps to column
0 so the rest of the line overwrites what it already painted. All three measure
as zero columns, so neither the bubble's clamp nor tuist's caught them. They're
now dropped alongside the existing tab expansion, so the box's one-row-per-line
guarantee holds for any content a producer hands it — not just over-long
content.

**Guarded at the framework level.** `go.mod` picks up the tuist row-count guard:
`Context.Line`/`Context.Lines` split embedded newlines into separate rows at the
source, and `renderFrame` expands tabs before measuring width and neutralizes
surviving cursor-moving controls. A component emitting a multi-row string can no
longer desynchronize the diff renderer at all. (Also pulls midterm to v0.2.5,
which tuist bumped in the same merge to restore the `go-ansicode` Handler
interface its `vt` package builds against.)

**Flowing mode stops repainting history.** Flowing shell output enters native
terminal scrollback, where mutating any old line forces a full synchronized
frame repaint. Running rows now render with a stable marker and no elapsed
duration in that mode, while viewport-clipped views keep their animated
indicators.

Tests cover the overlong-bubble case, pin the upstream lipgloss wrapping
behavior the bubble must defend against, and assert that neither running
conversation tools nor linked effects mount a ticker-backed child in flowing
mode while completed error output stays unchanged.

---

Independent fix, based on `main`. Extracted from the LLM workspace stack
(#13832–#13838); it has no dependency on those PRs and can land on its own.
