### PR TITLE
feat(engine): configurable build-step parallelism 

### DIFF
--- a/.changes/unreleased/Added-20260817-094048.yaml
+++ b/.changes/unreleased/Added-20260817-094048.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: |
+  Add configurable build-step parallelism. Set `maxParallelism` in
+  `engine.json` for an engine-global limit shared by every session, and/or in a
+  workspace's `dagger.toml` for a per-session limit. Each accepts one strategy:
+  `num` (an absolute number) or `cpu` (a percentage of the engine's CPU cores).
+time: 2026-08-17T09:40:48.000000000+00:00
+custom:
+    Author: DanielHabenicht
+    PR: "0"

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -272,10 +271,6 @@ func addFlags(app *cli.App) {
 		cli.BoolFlag{
 			Name:  "oci-worker-selinux",
 			Usage: "apply SELinux labels",
-		},
-		cli.StringFlag{
-			Name:  "oci-max-parallelism",
-			Usage: "maximum number of parallel build steps that can be run at the same time (or \"num-cpu\" to automatically set to the number of CPUs). 0 means unlimited parallelism.",
 		},
 		cli.StringFlag{
 			Name:  "oci-worker-gc-keepstorage",
@@ -786,19 +781,6 @@ func applyMainFlags(c *cli.Context, cfg *bkconfig.Config) error {
 	}
 	if c.GlobalIsSet("oci-worker-selinux") {
 		cfg.Workers.OCI.SELinux = c.GlobalBool("oci-worker-selinux")
-	}
-	if c.GlobalIsSet("oci-max-parallelism") {
-		maxParallelismStr := c.GlobalString("oci-max-parallelism")
-		var maxParallelism int
-		if maxParallelismStr == "num-cpu" {
-			maxParallelism = runtime.NumCPU()
-		} else {
-			maxParallelism, err = strconv.Atoi(maxParallelismStr)
-			if err != nil {
-				return fmt.Errorf("failed to parse oci-max-parallelism, should be positive integer, 0 for unlimited, or 'num-cpu' for setting to the number of CPUs: %w", err)
-			}
-		}
-		cfg.Workers.OCI.MaxParallelism = maxParallelism
 	}
 
 	return nil

--- a/cmd/engine/main_test.go
+++ b/cmd/engine/main_test.go
@@ -2,48 +2,12 @@ package main
 
 import (
 	"os"
-	"runtime"
 	"testing"
 
 	bkconfig "github.com/dagger/dagger/internal/buildkit/cmd/buildkitd/config"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 )
-
-func TestParallelismFlag(t *testing.T) {
-	t.Parallel()
-	app := cli.NewApp()
-	addFlags(app)
-
-	cfg := &bkconfig.Config{}
-	app.Action = func(c *cli.Context) error {
-		err := applyMainFlags(c, cfg)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	t.Run("default", func(t *testing.T) {
-		err := app.Run([]string{"buildkitd"})
-		require.NoError(t, err)
-		require.Equal(t, 0, cfg.Workers.OCI.MaxParallelism)
-	})
-	t.Run("int", func(t *testing.T) {
-		err := app.Run([]string{"buildkitd", "--oci-max-parallelism", "5"})
-		require.NoError(t, err)
-		require.Equal(t, 5, cfg.Workers.OCI.MaxParallelism)
-	})
-	t.Run("num-cpu", func(t *testing.T) {
-		err := app.Run([]string{"buildkitd", "--oci-max-parallelism", "num-cpu"})
-		require.NoError(t, err)
-		require.Equal(t, runtime.NumCPU(), cfg.Workers.OCI.MaxParallelism)
-	})
-	t.Run("invalid", func(t *testing.T) {
-		err := app.Run([]string{"buildkitd", "--oci-max-parallelism", "foo"})
-		require.Error(t, err)
-	})
-}
 
 func TestEngineNameLabel(t *testing.T) {
 	app := cli.NewApp()

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -2147,6 +2147,25 @@ func (state *ContainerExecState) Evaluate(ctx context.Context, container *Contai
 			procInfo.Stdin = io.NopCloser(strings.NewReader(opts.Stdin))
 		}
 
+		// Bound concurrency: the engine-global cap (engine.json) then this
+		// session's cap (dagger.toml). Acquired last, after all deps are
+		// satisfied, and always global-before-session so they can't deadlock;
+		// skip nested execs, which must not hold a slot while waiting on nested
+		// work.
+		if nestedClientMetadata == nil && (execMD == nil || !execMD.Internal) {
+			releaseEngineSlot, err := engineClient.AcquireEngineSlot(execCtx)
+			if err != nil {
+				return err
+			}
+			defer releaseEngineSlot()
+
+			releaseSessionSlot, err := engineClient.AcquireSessionSlot(execCtx, clientMetadata.SessionID)
+			if err != nil {
+				return err
+			}
+			defer releaseSessionSlot()
+		}
+
 		execErrCh := make(chan error, 1)
 		go func() {
 			execErrCh <- engineClient.Run(

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -23,6 +23,50 @@ type Config struct {
 	CheckGenerated *bool                  `json:"check-generated,omitempty" toml:"check-generated,omitempty"`
 	Env            map[string]EnvOverlay  `json:"env,omitempty" toml:"env"`
 	Ports          map[string]PortMapping `json:"ports,omitempty" toml:"ports,omitempty"`
+	// MaxParallelism bounds concurrent build steps for this workspace's sessions.
+	// Composes with the engine-global engine.json bound (an exec must fit both).
+	MaxParallelism *MaxParallelism `json:"maxParallelism,omitempty" toml:"maxParallelism,omitempty"`
+}
+
+// MaxParallelism bounds concurrent build steps via one strategy. At most one may
+// be set; unset means unbounded.
+type MaxParallelism struct {
+	// Num is an absolute number of parallel build steps.
+	Num int `json:"num,omitempty" toml:"num,omitempty"`
+	// CPU is a percentage (1-100) of the engine's CPU cores; resolves to at least 1.
+	CPU int `json:"cpu,omitempty" toml:"cpu,omitempty"`
+}
+
+func (p *MaxParallelism) validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.Num < 0 {
+		return fmt.Errorf("maxParallelism num %d: must not be negative", p.Num)
+	}
+	if p.CPU < 0 || p.CPU > 100 {
+		return fmt.Errorf("maxParallelism cpu %d: must be a percentage between 1 and 100", p.CPU)
+	}
+	if p.Num > 0 && p.CPU > 0 {
+		return fmt.Errorf("maxParallelism: set only one of num or cpu")
+	}
+	return nil
+}
+
+// Resolve returns the concrete limit for numCPU; 0 means unbounded.
+func (p *MaxParallelism) Resolve(numCPU int) int {
+	if p == nil {
+		return 0
+	}
+	if p.CPU > 0 {
+		// round down to not exceed the requested share
+		n := numCPU * p.CPU / 100
+		if n < 1 {
+			n = 1
+		}
+		return n
+	}
+	return p.Num
 }
 
 // PortMapping declares a host port that forwards to a workspace service.
@@ -141,6 +185,9 @@ func ResolveModuleEntrySource(configDir, source string) string {
 func ParseConfig(data []byte) (*Config, error) {
 	var cfg Config
 	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse dagger.toml: %w", err)
+	}
+	if err := cfg.MaxParallelism.validate(); err != nil {
 		return nil, fmt.Errorf("parse dagger.toml: %w", err)
 	}
 	if err := populateClientOptions(data, &cfg); err != nil {
@@ -378,6 +425,14 @@ func SerializeConfig(cfg *Config) []byte {
 		fmt.Fprintf(&b, "check-generated = %t\n\n", *cfg.CheckGenerated)
 	}
 
+	if cfg.MaxParallelism != nil {
+		if cfg.MaxParallelism.CPU > 0 {
+			fmt.Fprintf(&b, "maxParallelism = { cpu = %d }\n\n", cfg.MaxParallelism.CPU)
+		} else if cfg.MaxParallelism.Num > 0 {
+			fmt.Fprintf(&b, "maxParallelism = { num = %d }\n\n", cfg.MaxParallelism.Num)
+		}
+	}
+
 	wroteModules := writeModuleEntries(&b, cfg.Modules)
 	if wroteModules && (len(cfg.Env) > 0 || len(cfg.Ports) > 0) {
 		b.WriteString("\n")
@@ -402,6 +457,10 @@ func cloneConfig(cfg *Config) *Config {
 	if cfg.CheckGenerated != nil {
 		checkGenerated := *cfg.CheckGenerated
 		cloned.CheckGenerated = &checkGenerated
+	}
+	if cfg.MaxParallelism != nil {
+		maxParallelism := *cfg.MaxParallelism
+		cloned.MaxParallelism = &maxParallelism
 	}
 	if len(cfg.Modules) > 0 {
 		cloned.Modules = make(map[string]ModuleEntry, len(cfg.Modules))

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -1161,3 +1161,45 @@ func TestUndefinedEnvErrorExtensions(t *testing.T) {
 	require.Equal(t, UndefinedEnvErrorType, ext.Extensions()["_type"])
 	require.Equal(t, "prdo", ext.Extensions()["env"])
 }
+
+func TestMaxParallelismConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parse num", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte("maxParallelism = { num = 8 }\n"))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.MaxParallelism)
+		require.Equal(t, 8, cfg.MaxParallelism.Num)
+		require.Equal(t, 8, cfg.MaxParallelism.Resolve(16))
+	})
+
+	t.Run("parse cpu percentage", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte("maxParallelism = { cpu = 50 }\n"))
+		require.NoError(t, err)
+		require.Equal(t, 50, cfg.MaxParallelism.CPU)
+		require.Equal(t, 8, cfg.MaxParallelism.Resolve(16))
+		require.Equal(t, 1, cfg.MaxParallelism.Resolve(1)) // rounds down, min 1
+	})
+
+	t.Run("rejects both strategies", func(t *testing.T) {
+		_, err := ParseConfig([]byte("maxParallelism = { num = 8, cpu = 50 }\n"))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects out-of-range cpu", func(t *testing.T) {
+		_, err := ParseConfig([]byte("maxParallelism = { cpu = 150 }\n"))
+		require.Error(t, err)
+	})
+
+	t.Run("round-trips through serialize", func(t *testing.T) {
+		for _, in := range []string{"maxParallelism = { num = 8 }\n", "maxParallelism = { cpu = 50 }\n"} {
+			cfg, err := ParseConfig([]byte(in))
+			require.NoError(t, err)
+			out := SerializeConfig(cfg)
+			require.Contains(t, string(out), "maxParallelism = {")
+			reparsed, err := ParseConfig(out)
+			require.NoError(t, err)
+			require.Equal(t, cfg.MaxParallelism, reparsed.MaxParallelism)
+		}
+	})
+}

--- a/docs/current_docs/reference/configuration/engine.mdx
+++ b/docs/current_docs/reference/configuration/engine.mdx
@@ -372,6 +372,64 @@ than `maxEstimatedBytes`.
 Setting `gc.enabled` to `false` also stops automatic metadata pruning. Metadata
 can still be pruned [on demand](./cache.mdx#manual-pruning).
 
+## Parallelism
+
+By default, the Dagger Engine runs build steps (container execs) with unbounded
+parallelism. On busy or resource-constrained machines it can be useful to cap
+how many execs run concurrently, so that a large build graph does not saturate
+all available CPUs.
+
+There are two independent limits, and an exec must fit under **both**:
+
+- an **engine-global** limit, configured in `engine.json` — a machine-wide
+  ceiling shared by every session/client connected to the engine.
+- a **per-session** limit, configured in a workspace's `dagger.toml` — bounds
+  the execs of that one `dagger` invocation (including nested module calls).
+
+Both use the same `maxParallelism` shape, selecting one strategy:
+
+- `num`: an absolute number of concurrent execs
+- `cpu`: a percentage (1-100) of the CPU cores available to the engine
+
+The bound applies to user container execs. Services and the internal execs that
+run module code are not counted against it, so configuring a limit cannot
+deadlock a build.
+
+### Engine-global (`engine.json`)
+
+```json
+{
+  "maxParallelism": { "num": 8 }
+}
+```
+
+```json
+{
+  "maxParallelism": { "cpu": 50 }
+}
+```
+
+### Per-session (`dagger.toml`)
+
+Set it in a workspace's `dagger.toml` to bound just that project's build
+concurrency, independent of other sessions on the same engine:
+
+```toml
+maxParallelism = { num = 8 }
+```
+
+```toml
+maxParallelism = { cpu = 50 }
+```
+
+When unset, that scope is unbounded.
+
+:::note
+The `cpu` strategy resolves against the CPU cores the engine process sees.
+Inside a container that is not pinned to a CPU set, that is typically the number
+of host cores, not the container's `--cpus` quota.
+:::
+
 ## Custom registries
 
 Dagger can be configured to use container registry mirrors for any registry

--- a/docs/static/reference/dagger-workspace.schema.json
+++ b/docs/static/reference/dagger-workspace.schema.json
@@ -35,6 +35,10 @@
             "$ref": "#/$defs/PortMapping"
           },
           "type": "object"
+        },
+        "maxParallelism": {
+          "$ref": "#/$defs/MaxParallelism",
+          "description": "MaxParallelism bounds concurrent build steps for this workspace's sessions. Composes with the engine-global engine.json bound (an exec must fit both)."
         }
       },
       "additionalProperties": false,
@@ -71,6 +75,21 @@
       "additionalProperties": false,
       "type": "object",
       "description": "EnvOverlay is a named workspace environment overlay."
+    },
+    "MaxParallelism": {
+      "properties": {
+        "num": {
+          "type": "integer",
+          "description": "Num is an absolute number of parallel build steps."
+        },
+        "cpu": {
+          "type": "integer",
+          "description": "CPU is a percentage (1-100) of the engine's CPU cores; resolves to at least 1."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "MaxParallelism bounds concurrent build steps via one strategy."
     },
     "ModuleAsSDK": {
       "properties": {

--- a/docs/static/reference/engine.schema.json
+++ b/docs/static/reference/engine.schema.json
@@ -31,6 +31,10 @@
           },
           "type": "object",
           "description": "Registries configures custom registry mirrors, root CAs, and insecure/HTTP access."
+        },
+        "maxParallelism": {
+          "$ref": "#/$defs/MaxParallelism",
+          "description": "MaxParallelism bounds concurrent build steps. When unset, parallelism is unbounded."
         }
       },
       "additionalProperties": false,
@@ -155,6 +159,21 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "MaxParallelism": {
+      "properties": {
+        "num": {
+          "type": "integer",
+          "description": "Num is an absolute number of parallel build steps."
+        },
+        "cpu": {
+          "type": "integer",
+          "description": "CPU is a percentage (1-100) of the engine's CPU cores; resolves to at least 1."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "MaxParallelism bounds concurrent build steps via one strategy."
     },
     "RegistryConfig": {
       "properties": {

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -33,6 +34,10 @@ type Config struct {
 	// Registries configures custom registry mirrors, root CAs, and
 	// insecure/HTTP access.
 	Registries map[string]RegistryConfig `json:"registries,omitempty"`
+
+	// MaxParallelism bounds concurrent build steps. When unset, parallelism is
+	// unbounded.
+	MaxParallelism *MaxParallelism `json:"maxParallelism,omitempty"`
 }
 
 type LogLevel string
@@ -242,4 +247,55 @@ type Security struct {
 	// Disabling this option ensures that dagger build containers do not run as
 	// privileged, and is a basic form of security hardening.
 	InsecureRootCapabilities *bool `json:"insecureRootCapabilities,omitempty"`
+}
+
+// MaxParallelism bounds concurrent build steps via one strategy. At most one
+// may be set; unset means unbounded.
+type MaxParallelism struct {
+	// Num is an absolute number of parallel build steps.
+	Num int `json:"num,omitempty"`
+
+	// CPU is a percentage (1-100) of the engine's CPU cores; resolves to at least 1.
+	CPU int `json:"cpu,omitempty"`
+}
+
+func (p *MaxParallelism) UnmarshalJSON(data []byte) error {
+	type raw MaxParallelism
+	var r raw
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&r); err != nil {
+		return fmt.Errorf("invalid maxParallelism: %w", err)
+	}
+	*p = MaxParallelism(r)
+	return p.validate()
+}
+
+func (p MaxParallelism) validate() error {
+	if p.Num < 0 {
+		return fmt.Errorf("invalid maxParallelism num %d: must not be negative", p.Num)
+	}
+	if p.CPU < 0 || p.CPU > 100 {
+		return fmt.Errorf("invalid maxParallelism cpu %d: must be a percentage between 1 and 100", p.CPU)
+	}
+	if p.Num > 0 && p.CPU > 0 {
+		return fmt.Errorf("invalid maxParallelism: set only one of num or cpu")
+	}
+	return nil
+}
+
+// Resolve returns the concrete limit for numCPU; 0 means unbounded.
+func (p *MaxParallelism) Resolve(numCPU int) int {
+	if p == nil {
+		return 0
+	}
+	if p.CPU > 0 {
+		// round down to not exceed the requested share
+		n := numCPU * p.CPU / 100
+		if n < 1 {
+			n = 1
+		}
+		return n
+	}
+	return p.Num
 }

--- a/engine/config/config_test.go
+++ b/engine/config/config_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxParallelismUnmarshal(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		input   string
+		want    MaxParallelism
+		wantErr bool
+	}{
+		{name: "num", input: `{"num": 8}`, want: MaxParallelism{Num: 8}},
+		{name: "cpu percentage", input: `{"cpu": 50}`, want: MaxParallelism{CPU: 50}},
+		{name: "cpu full", input: `{"cpu": 100}`, want: MaxParallelism{CPU: 100}},
+		{name: "empty", input: `{}`, want: MaxParallelism{}},
+		{name: "num negative", input: `{"num": -1}`, wantErr: true},
+		{name: "cpu too high", input: `{"cpu": 150}`, wantErr: true},
+		{name: "cpu negative", input: `{"cpu": -1}`, wantErr: true},
+		{name: "both strategies", input: `{"num": 8, "cpu": 50}`, wantErr: true},
+		{name: "unknown strategy", input: `{"ram": 4}`, wantErr: true},
+		{name: "not an object", input: `8`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got MaxParallelism
+			err := got.UnmarshalJSON([]byte(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMaxParallelismResolve(t *testing.T) {
+	t.Parallel()
+	var nilP *MaxParallelism
+	require.Equal(t, 0, nilP.Resolve(8))
+
+	for _, tc := range []struct {
+		name   string
+		p      MaxParallelism
+		numCPU int
+		want   int
+	}{
+		{name: "unbounded", p: MaxParallelism{}, numCPU: 16, want: 0},
+		{name: "num", p: MaxParallelism{Num: 4}, numCPU: 16, want: 4},
+		{name: "cpu full", p: MaxParallelism{CPU: 100}, numCPU: 16, want: 16},
+		{name: "cpu half", p: MaxParallelism{CPU: 50}, numCPU: 16, want: 8},
+		{name: "cpu rounds down", p: MaxParallelism{CPU: 50}, numCPU: 3, want: 1},
+		{name: "cpu never below one", p: MaxParallelism{CPU: 10}, numCPU: 2, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.p.Resolve(tc.numCPU))
+		})
+	}
+}
+
+func TestMaxParallelismRoundTrip(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load(strings.NewReader(`{"maxParallelism": {"cpu": 50}}`))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.MaxParallelism)
+	require.Equal(t, 50, cfg.MaxParallelism.CPU)
+	require.Equal(t, 4, cfg.MaxParallelism.Resolve(8))
+
+	var sb strings.Builder
+	require.NoError(t, cfg.Save(&sb))
+	require.Contains(t, sb.String(), `"maxParallelism":{"cpu":50}`)
+
+	cfg, err = Load(strings.NewReader(`{"maxParallelism": {"num": 6}}`))
+	require.NoError(t, err)
+	require.Equal(t, 6, cfg.MaxParallelism.Num)
+	require.Equal(t, 6, cfg.MaxParallelism.Resolve(8))
+	sb.Reset()
+	require.NoError(t, cfg.Save(&sb))
+	require.Contains(t, sb.String(), `"maxParallelism":{"num":6}`)
+
+	// unknown strategy keys are rejected by the top-level loader too
+	_, err = Load(strings.NewReader(`{"maxParallelism": {"ram": 4}}`))
+	require.Error(t, err)
+}

--- a/engine/engineutil/client.go
+++ b/engine/engineutil/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -90,9 +91,20 @@ type Opts struct {
 	Interactive        bool
 	InteractiveCommand []string
 
+	// MaxParallelism bounds concurrent user execs engine-wide. 0 means unbounded.
+	MaxParallelism int
+
 	imageExportWriter *imageexport.Writer
 	running           map[string]*execState
 	runningMu         *sync.RWMutex
+	execSem           *semaphore.Weighted
+	// per-session bounds from each session's dagger.toml, keyed by session ID
+	sessionSems *sessionSemaphores
+}
+
+type sessionSemaphores struct {
+	mu   sync.Mutex
+	sems map[string]*semaphore.Weighted
 }
 
 // Client is dagger's internal engine utility client
@@ -122,6 +134,10 @@ func NewOpts(opts Opts) (*Opts, error) {
 	opts.imageExportWriter = imageWriter
 	opts.running = make(map[string]*execState)
 	opts.runningMu = &sync.RWMutex{}
+	if opts.MaxParallelism > 0 {
+		opts.execSem = semaphore.NewWeighted(int64(opts.MaxParallelism))
+	}
+	opts.sessionSems = &sessionSemaphores{sems: map[string]*semaphore.Weighted{}}
 	return &opts, nil
 }
 
@@ -143,6 +159,12 @@ func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 	}
 	if opts.runningMu == nil {
 		opts.runningMu = &sync.RWMutex{}
+	}
+	if opts.execSem == nil && opts.MaxParallelism > 0 {
+		opts.execSem = semaphore.NewWeighted(int64(opts.MaxParallelism))
+	}
+	if opts.sessionSems == nil {
+		opts.sessionSems = &sessionSemaphores{sems: map[string]*semaphore.Weighted{}}
 	}
 	if opts.GetHostServiceCaller == nil {
 		opts.GetHostServiceCaller = opts.GetClientCaller
@@ -170,6 +192,55 @@ func (opts *Opts) Close() error {
 		}
 	}
 	return rerr
+}
+
+// AcquireEngineSlot blocks until an engine-global slot is free and returns a
+// release func (no-op when unbounded). Only gate leaf execs; gating nested
+// execs can deadlock.
+func (c *Client) AcquireEngineSlot(ctx context.Context) (func(), error) {
+	return acquire(ctx, c.execSem)
+}
+
+// SetSessionParallelism registers a per-session bound from the session's
+// dagger.toml (idempotent; limit <= 0 clears it).
+func (opts *Opts) SetSessionParallelism(sessionID string, limit int) {
+	opts.sessionSems.mu.Lock()
+	defer opts.sessionSems.mu.Unlock()
+	if limit <= 0 {
+		delete(opts.sessionSems.sems, sessionID)
+		return
+	}
+	if _, ok := opts.sessionSems.sems[sessionID]; !ok {
+		opts.sessionSems.sems[sessionID] = semaphore.NewWeighted(int64(limit))
+	}
+}
+
+// ClearSessionParallelism drops a session's bound when the session ends.
+func (opts *Opts) ClearSessionParallelism(sessionID string) {
+	opts.sessionSems.mu.Lock()
+	delete(opts.sessionSems.sems, sessionID)
+	opts.sessionSems.mu.Unlock()
+}
+
+// AcquireSessionSlot is AcquireEngineSlot for the session's dagger.toml bound.
+func (opts *Opts) AcquireSessionSlot(ctx context.Context, sessionID string) (func(), error) {
+	opts.sessionSems.mu.Lock()
+	sem := opts.sessionSems.sems[sessionID]
+	opts.sessionSems.mu.Unlock()
+	return acquire(ctx, sem)
+}
+
+func acquire(ctx context.Context, sem *semaphore.Weighted) (func(), error) {
+	if sem == nil {
+		return func() {}, nil
+	}
+	if err := sem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() { sem.Release(1) })
+	}, nil
 }
 
 func (c *Client) withClientCloseCancel(ctx context.Context) (context.Context, context.CancelCauseFunc, error) {

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -409,6 +409,9 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		return nil, fmt.Errorf("failed to create clean mount namespace: %w", err)
 	}
 
+	// engine-global build-step bound, from engine.json (0 = unbounded)
+	maxParallelism := cfg.MaxParallelism.Resolve(runtime.NumCPU())
+
 	srv.engineUtilOpts, err = engineutil.NewOpts(engineutil.Opts{
 		ID:               rand.Text(),
 		Labels:           baseLabels,
@@ -430,6 +433,7 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 		ApparmorProfile:     srv.apparmorProfile,
 		SELinux:             srv.selinux,
 		Entitlements:        srv.entitlements,
+		MaxParallelism:      maxParallelism,
 
 		HostMntNS:  hostMntNS,
 		CleanMntNS: srv.cleanMntNS,

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -701,6 +701,7 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 // teardown can't delete a freshly created same-id session. Call only after the
 // session's teardown is complete and lifecycleMu has been released.
 func (srv *Server) deleteSession(sess *daggerSession) {
+	srv.engineUtilOpts.ClearSessionParallelism(sess.sessionID)
 	srv.daggerSessionsMu.Lock()
 	if srv.daggerSessions[sess.sessionID] == sess {
 		delete(srv.daggerSessions, sess.sessionID)

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -693,6 +694,13 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 		if err != nil {
 			return err
 		}
+	}
+	if clientMD != nil {
+		limit := 0
+		if wsConfig != nil {
+			limit = wsConfig.MaxParallelism.Resolve(runtime.NumCPU())
+		}
+		srv.engineUtilOpts.SetSessionParallelism(clientMD.SessionID, limit)
 	}
 
 	// --- Compat mode: build the ambient compat workspace from legacy dagger.json ---

--- a/internal/buildkit/cmd/buildkitd/config/config.go
+++ b/internal/buildkit/cmd/buildkitd/config/config.go
@@ -119,9 +119,6 @@ type OCIConfig struct {
 
 	// SELinux enables applying SELinux labels.
 	SELinux bool `toml:"selinux"`
-
-	// MaxParallelism is the maximum number of parallel build steps that can be run at the same time.
-	MaxParallelism int `toml:"max-parallelism"`
 }
 
 type ContainerdConfig struct {
@@ -141,8 +138,6 @@ type ContainerdConfig struct {
 
 	// SELinux enables applying SELinux labels.
 	SELinux bool `toml:"selinux"`
-
-	MaxParallelism int `toml:"max-parallelism"`
 
 	DefaultCgroupParent string `toml:"defaultCgroupParent"`
 


### PR DESCRIPTION
By default user container execs run with unbounded concurrency. Having many checks (with e.g. build steps) may quickly overwhelm devices with lower RAM/CPU combinations. As there is no throttle currently available these users are left with executing checks one by one. 

With this PR there are now two mechanisms to limit the number of parallel `exec` statements that layer on top of each other: 

  - engine-global, from engine.json "maxParallelism", shared by every session on the engine (hard max limit) -> Handles hosted scenarios (e.g. CI) where engines handle multiple sessions and need a global limit to not crash. 
  - per-session, from a workspace's dagger.toml "maxParallelism" (session limit) -> Handles the use case for CLI one off commands (where engine configuration options are not set because the engine is spawned by the CLI) 

Both use one strategy object: `num` (absolute) or `cpu` (percentage of the engine's cores, rounded down, min 1). 

Slots are acquired last (after the parent exec, cache locks, services and mounts are satisfied) and always engine-before-session.
Execs that spawn nested engine work (privileged nesting, internal module-runtime execs) and services are not gated.


From: https://discord.com/channels/707636530424053791/1536399707163598969