### PR TITLE
fix: stop the recurring test-base CI flake at its git layer

### DIFF
--- a/.dagger/modules/test-split/main.dang
+++ b/.dagger/modules/test-split/main.dang
@@ -38,8 +38,9 @@ type TestSplit {
     ebpfProgs: [String!],
     pkg: String! = "./core/integration",
     race: Boolean,
+    timeout: String,
   ): Void {
-    engineDev(ws: self.ws).test(race: race, skip: skip.join("|"), ebpfProgs: ebpfProgs, pkg: pkg)
+    engineDev(ws: self.ws).test(race: race, skip: skip.join("|"), ebpfProgs: ebpfProgs, pkg: pkg, timeout: timeout)
   }
 
   """
@@ -83,6 +84,11 @@ type TestSplit {
       ],
       pkg: "./...",
       race: true,
+      # Successful runs of this shard sit at a 12m median and a 19m maximum, and
+      # CI kills the check at 30m. Keeping go test's own timeout under that cap
+      # is what turns a hang into a goroutine dump instead of an opaque
+      # 'max execution time exceeded'.
+      timeout: "25m",
     )
   }
 

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -168,6 +168,50 @@ func (repo *RemoteGitRepository) remoteCacheScope() []string {
 	return scope
 }
 
+const (
+	transientRetryAttempts = 3
+	// Every attempt runs under the engine-wide per-remote lock, so retrying
+	// stalls every other caller of that remote. Bound the retries rather than the
+	// whole loop: the first attempt keeps the caller's deadline, since a cold
+	// mirror fetch of a large repository is legitimately slow, while the retries
+	// that follow a fast-failing transient error stay cheap.
+	transientRetryBudget = 3 * time.Minute
+)
+
+// retryTransient re-runs a remote git operation that failed for a reason git
+// itself reports as transient: the remote dropping the connection, or a
+// concurrent writer changing the mirror underneath the command. Both are
+// idempotent to retry and both were regularly turning CI runs red.
+func retryTransient(ctx context.Context, what string, fn func(context.Context) error) error {
+	logger := slog.SpanLogger(ctx, InstrumentationLibrary)
+
+	attemptCtx := ctx
+	var err error
+	for attempt := 1; ; attempt++ {
+		err = fn(attemptCtx)
+		if err == nil {
+			return nil
+		}
+		if attempt == transientRetryAttempts || !errors.Is(err, gitutil.ErrTransient) {
+			if attempt > 1 {
+				return fmt.Errorf("%s failed after %d attempts: %w", what, attempt, err)
+			}
+			return err
+		}
+		logger.Warn("retrying transient git failure", "operation", what, "attempt", attempt, "error", err)
+		if attempt == 1 {
+			var cancel context.CancelFunc
+			attemptCtx, cancel = context.WithTimeout(ctx, transientRetryBudget)
+			defer cancel()
+		}
+		select {
+		case <-time.After(time.Duration(attempt) * time.Second):
+		case <-attemptCtx.Done():
+			return errors.Join(fmt.Errorf("%s failed after %d attempts: %w", what, attempt, err), context.Cause(attemptCtx))
+		}
+	}
+}
+
 func (repo *RemoteGitRepository) runLsRemote(ctx context.Context) (*gitutil.Remote, error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
@@ -189,8 +233,12 @@ func (repo *RemoteGitRepository) runLsRemote(ctx context.Context) (*gitutil.Remo
 	}
 	defer cleanup()
 
-	remote, err := git.LsRemote(ctx, repo.URL.Remote())
-	if err != nil {
+	var remote *gitutil.Remote
+	if err := retryTransient(ctx, "ls-remote "+repo.URL.Remote(), func(ctx context.Context) error {
+		var err error
+		remote, err = git.LsRemote(ctx, repo.URL.Remote())
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	return remote, nil
@@ -400,13 +448,17 @@ func (repo *RemoteGitRepository) fetch(ctx context.Context, git *gitutil.GitCLI,
 		args = append(args, "origin")
 		args = append(args, refSpecs...)
 
-		if _, err := git.Run(ctx, args...); err != nil {
+		run := func(ctx context.Context) error {
+			_, err := git.Run(ctx, args...)
+			return err
+		}
+		if err := retryTransient(ctx, "fetch "+repo.URL.Remote(), run); err != nil {
 			if errors.Is(err, gitutil.ErrShallowNotSupported) {
 				// fallback to full fetch
 				args = slices.DeleteFunc(args, func(s string) bool {
 					return strings.HasPrefix(s, "--depth")
 				})
-				_, err = git.Run(ctx, args...)
+				err = retryTransient(ctx, "fetch "+repo.URL.Remote(), run)
 			}
 			if err != nil {
 				return err

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -259,7 +259,10 @@ func (repo *RemoteGitRepository) setup(ctx context.Context) (_ *gitutil.GitCLI, 
 	if err != nil {
 		return nil, nil, err
 	}
-	var opts []gitutil.Option
+	// Every command built here talks to the remote while holding the engine-wide
+	// per-remote lock, so a stalled connection blocks every other caller of that
+	// remote until the whole build is cancelled.
+	opts := []gitutil.Option{gitutil.WithStallTimeouts()}
 
 	cleanups := cleanups.Cleanups{}
 	defer func() {

--- a/core/git_remote.go
+++ b/core/git_remote.go
@@ -335,7 +335,7 @@ func (repo *RemoteGitRepository) mount(ctx context.Context, depth int, includeTa
 			return err
 		}
 		defer cleanup()
-		git = git.New(gitutil.WithGitDir(remote))
+		git = git.New(gitutil.WithGitDir(remote), gitutil.WithSnapshotBackedRepo())
 		gitDir, err := git.GitDir(ctx)
 		if err != nil {
 			return fmt.Errorf("could not find git dir: %w", err)
@@ -595,7 +595,7 @@ func (repo *RemoteGitRepository) initRemote(ctx context.Context, fn func(string)
 		}
 	}()
 
-	git := gitutil.NewGitCLI(gitutil.WithGitDir(dir))
+	git := gitutil.NewGitCLI(gitutil.WithGitDir(dir), gitutil.WithSnapshotBackedRepo())
 	initializeRepo := false
 	if _, err := os.Lstat(filepath.Join(dir, "HEAD")); errors.Is(err, os.ErrNotExist) {
 		initializeRepo = true
@@ -651,7 +651,11 @@ func (ref *RemoteGitRef) Tree(ctx context.Context, srv *dagql.Server, discardGit
 			if err := os.MkdirAll(checkoutDir, 0711); err != nil {
 				return err
 			}
-			checkoutGit := git.New(gitutil.WithWorkTree(checkoutDir), gitutil.WithGitDir(checkoutDirGit))
+			checkoutGit := git.New(
+				gitutil.WithWorkTree(checkoutDir),
+				gitutil.WithGitDir(checkoutDirGit),
+				gitutil.WithSnapshotBackedRepo(),
+			)
 
 			return doGitCheckout(ctx, checkoutGit, ref.repo.URL.Remote(), gitURL, ref.Ref, depth, discardGitDir)
 		})

--- a/core/git_remote_test.go
+++ b/core/git_remote_test.go
@@ -3,8 +3,10 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/util/gitutil"
@@ -122,4 +124,73 @@ func TestNamedFetchRefSpecsChangesWithPinnedSHA(t *testing.T) {
 	require.Len(t, baseSpecs, 1)
 	require.Len(t, updatedSpecs, 1)
 	require.NotEqual(t, baseSpecs[0], updatedSpecs[0], "fallback destination should track pinned ref+sha pair")
+}
+
+func TestRetryTransient(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("retries until success", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(ctx, "fetch", func(context.Context) error {
+			calls++
+			if calls < 2 {
+				return errors.Join(gitutil.ErrTransient, errors.New("exit status 128"))
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("gives up and returns the last error", func(t *testing.T) {
+		calls := 0
+		boom := errors.Join(gitutil.ErrTransient, errors.New("exit status 128"))
+		err := retryTransient(ctx, "fetch", func(context.Context) error {
+			calls++
+			return boom
+		})
+		require.ErrorIs(t, err, gitutil.ErrTransient)
+		require.Equal(t, 3, calls)
+		require.ErrorContains(t, err, "after 3 attempts")
+	})
+
+	t.Run("does not retry other failures", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(ctx, "fetch", func(context.Context) error {
+			calls++
+			return gitutil.ErrGitAuthFailed
+		})
+		require.ErrorIs(t, err, gitutil.ErrGitAuthFailed)
+		require.Equal(t, 1, calls)
+		require.NotContains(t, err.Error(), "attempts", "a first-try failure is reported as-is")
+	})
+
+	t.Run("stops when the context is done", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		calls := 0
+		err := retryTransient(ctx, "fetch", func(context.Context) error {
+			calls++
+			cancel()
+			return errors.Join(gitutil.ErrTransient, errors.New("exit status 128"))
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("bounds the retries but not the first attempt", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(ctx, "fetch", func(ctx context.Context) error {
+			calls++
+			deadline, ok := ctx.Deadline()
+			if calls == 1 {
+				require.False(t, ok, "a cold fetch of a large repository keeps the caller's deadline")
+			} else {
+				require.True(t, ok, "retries share one budget")
+				require.LessOrEqual(t, time.Until(deadline), transientRetryBudget)
+			}
+			return errors.Join(gitutil.ErrTransient, errors.New("exit status 128"))
+		})
+		require.ErrorIs(t, err, gitutil.ErrTransient)
+		require.Equal(t, 3, calls)
+	})
 }

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -426,29 +426,73 @@ func (sess *daggerSession) StoreTelemetrySeenKey(key string) {
 	sess.seenKeys.Store(key, struct{}{})
 }
 
-// inflightSessionTelemetryFlushes counts engine-wide concurrent session-level
-// telemetry flushes. Every flush fans out to every client in its session, so
-// concurrent flushes multiply pressure on the same client stores; the gauge makes
-// that amplification visible next to each flush's duration.
-var inflightSessionTelemetryFlushes atomic.Int64
+// inflightTelemetryFlushes counts engine-wide concurrent telemetry flushes,
+// whole-session and subtree-scoped alike. Overlapping flushes contend on the
+// same client stores whatever their scope, so the gauge makes that amplification
+// visible next to each flush's duration; the "scope" field logged beside it says
+// which clients a given flush actually covered.
+var inflightTelemetryFlushes atomic.Int64
 
 func (sess *daggerSession) FlushTelemetry(ctx context.Context, reason string) error {
-	inflight := inflightSessionTelemetryFlushes.Add(1)
-	defer inflightSessionTelemetryFlushes.Add(-1)
+	return sess.flushTelemetry(ctx, reason, nil)
+}
 
+// telemetryFlushTargets returns the clients a flush must cover: every client in
+// the session, or -- when root is non-nil -- root plus the clients that export
+// into root's telemetry store (its descendants).
+func (sess *daggerSession) telemetryFlushTargets(root *daggerClient) []*daggerClient {
 	sess.clientMu.Lock()
+	defer sess.clientMu.Unlock()
 	clients := make([]*daggerClient, 0, len(sess.clients))
 	for _, client := range sess.clients {
+		if root != nil && client != root && !slices.Contains(client.parents, root) {
+			continue
+		}
 		clients = append(clients, client)
 	}
-	sess.clientMu.Unlock()
+	return clients
+}
+
+// flushTelemetry flushes every client in the session, or -- when root is
+// non-nil -- root and its descendants.
+//
+// A client's providers write to its own DB *and every ancestor DB*, so records
+// an ancestor's store is waiting on can sit in a still-live descendant's batch
+// processor. Hence the subtree form: a nested client drains its own store on
+// shutdown, and without sweeping its descendants it drains that tail away.
+//
+// The sweep is best-effort, not a completeness guarantee: it covers what each
+// descendant has queued at the moment its ForceFlush runs. A client published
+// after the target snapshot, or emitting after its own barrier returns, is
+// missed by design -- the main client's session-wide flush at the end of the
+// session is what catches those stragglers.
+//
+// With a chain of n nested clients each sweeping its own subtree the session
+// performs n(n+1)/2 client flushes rather than n. That is acceptable because
+// children shut down before their parents, so by the time an ancestor sweeps its
+// subtree the descendants' processors are already drained and the extra
+// ForceFlush calls are no-ops on empty queues: the amplification is in cheap
+// no-ops, not exporter work. Coalescing overlapping provider flushes through a
+// coordinator would remove even those, at the cost of new machinery on a
+// shutdown path.
+func (sess *daggerSession) flushTelemetry(ctx context.Context, reason string, root *daggerClient) error {
+	inflight := inflightTelemetryFlushes.Add(1)
+	defer inflightTelemetryFlushes.Add(-1)
+
+	clients := sess.telemetryFlushTargets(root)
+
+	scope := "session"
+	if root != nil {
+		scope = "subtree:" + root.clientID
+	}
 
 	lg := slog.With(
 		"sessionID", sess.sessionID,
 		"reason", reason,
+		"scope", scope,
 		"clients", len(clients),
-		"inflightSessionFlushes", inflight)
-	lg.Debug("flushing session telemetry")
+		"inflightFlushes", inflight)
+	lg.Debug("flushing telemetry")
 
 	start := time.Now()
 	eg := new(errgroup.Group)
@@ -461,9 +505,9 @@ func (sess *daggerSession) FlushTelemetry(ctx context.Context, reason string) er
 
 	lg = lg.With("duration", time.Since(start), "error", err)
 	if time.Since(start) > slowDrainOp {
-		lg.Warn("slow session telemetry flush")
+		lg.Warn("slow telemetry flush")
 	} else {
-		lg.Debug("session telemetry flush done")
+		lg.Debug("telemetry flush done")
 	}
 	return err
 }
@@ -2035,15 +2079,20 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		}
 	}
 
-	// Flush telemetry so nested spans land in the DBs the CLI drains. A client's
-	// own providers already export its spans to its own DB *and every ancestor
-	// DB*, so a nested client only needs to flush itself; re-flushing every
-	// sibling on each nested shutdown is redundant and, under a parallel
-	// teardown storm, self-inflicts an O(n^2) burst of concurrent whole-session
-	// flushes, multiplying exporter work and spill pressure enough to blow the
-	// client's shutdown budget. The main client (which shuts down last and whose
-	// DB the CLI ultimately drains) still does a session-wide flush to sweep up any
-	// stragglers from clients that hadn't shut down yet.
+	// Flush telemetry so nested spans land in the DBs the CLI drains. A nested
+	// client drains its own store right after this and renders its final report
+	// from it, so it sweeps the descendants whose records that store is still
+	// waiting on -- e.g. the module runtime that ran a failing exec, whose error
+	// status and stdout/stderr are otherwise still sitting in a batch processor
+	// (see core/integration TestUpPartialStartupFailure). The sweep is
+	// best-effort: it takes the tail queued by the time each descendant's
+	// ForceFlush runs, and nothing emitted after that. It also stops at this
+	// client's own subtree: re-flushing every sibling is redundant and, under a
+	// parallel teardown storm, self-inflicts an O(n^2) burst of concurrent
+	// whole-session flushes, multiplying exporter work and spill pressure enough
+	// to blow the client's shutdown budget. The main client (which shuts down
+	// last and whose DB the CLI ultimately drains) still does a session-wide
+	// flush, and that is what catches stragglers a subtree sweep missed.
 	var flushErr error
 	if client.clientID == sess.mainClientCallerID {
 		flushErr = drainPhase("flush session telemetry", func() error {
@@ -2051,7 +2100,7 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 		})
 	} else {
 		flushErr = drainPhase("flush client telemetry", func() error {
-			return client.FlushTelemetry(ctx)
+			return sess.flushTelemetry(ctx, "nested client shutdown", client)
 		})
 	}
 	if flushErr != nil {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/dagger/dagger/engine/engineutil"
 	"github.com/dagger/dagger/internal/buildkit/util/flightcontrol"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/grpc"
 )
 
@@ -2229,4 +2231,123 @@ func sessionTestModuleResult(t *testing.T, name string) dagql.ObjectResult[*core
 	)
 	require.NoError(t, err)
 	return res
+}
+
+func TestTelemetryFlushTargets(t *testing.T) {
+	// main -> up (a nested CLI) -> runtime (the module runtime it loaded) ->
+	// exec, plus an unrelated sibling of up with a child of its own. parents
+	// holds the whole ancestor chain, root-first, as newDaggerClient builds it.
+	main := &daggerClient{clientID: "main"}
+	up := &daggerClient{clientID: "up", parents: []*daggerClient{main}}
+	runtime := &daggerClient{clientID: "runtime", parents: []*daggerClient{main, up}}
+	exec := &daggerClient{clientID: "exec", parents: []*daggerClient{main, up, runtime}}
+	sibling := &daggerClient{clientID: "sibling", parents: []*daggerClient{main}}
+	siblingChild := &daggerClient{clientID: "siblingChild", parents: []*daggerClient{main, sibling}}
+
+	sess := &daggerSession{
+		sessionID:          "sess",
+		mainClientCallerID: "main",
+		clients: map[string]*daggerClient{
+			"main": main, "up": up, "runtime": runtime, "exec": exec,
+			"sibling": sibling, "siblingChild": siblingChild,
+		},
+	}
+
+	ids := func(clients []*daggerClient) []string {
+		out := make([]string, 0, len(clients))
+		for _, c := range clients {
+			out = append(out, c.clientID)
+		}
+		slices.Sort(out)
+		return out
+	}
+
+	whole := []string{"exec", "main", "runtime", "sibling", "siblingChild", "up"}
+	require.Equal(t, whole, ids(sess.telemetryFlushTargets(nil)))
+
+	// Rooting at the main client covers the same set: every other client
+	// descends from it.
+	require.Equal(t, whole, ids(sess.telemetryFlushTargets(main)))
+
+	// A nested client must sweep every descendant whose records its own
+	// telemetry store is still waiting on, however deep -- but not a sibling's
+	// subtree, which exports into the sibling's store and main's, not into up's.
+	require.Equal(t, []string{"exec", "runtime", "up"}, ids(sess.telemetryFlushTargets(up)))
+	require.Equal(t, []string{"exec", "runtime"}, ids(sess.telemetryFlushTargets(runtime)))
+	require.Equal(t, []string{"sibling", "siblingChild"}, ids(sess.telemetryFlushTargets(sibling)))
+
+	// A leaf only has itself.
+	require.Equal(t, []string{"exec"}, ids(sess.telemetryFlushTargets(exec)))
+}
+
+// recordingSpanExporter stands in for a client's telemetry store.
+type recordingSpanExporter struct {
+	mu    sync.Mutex
+	names []string
+}
+
+func (e *recordingSpanExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, span := range spans {
+		e.names = append(e.names, span.Name())
+	}
+	return nil
+}
+
+func (e *recordingSpanExporter) Shutdown(context.Context) error { return nil }
+
+func (e *recordingSpanExporter) exported() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := slices.Clone(e.names)
+	slices.Sort(out)
+	return out
+}
+
+func TestFlushTelemetrySubtreeDeliversDescendantRecords(t *testing.T) {
+	ctx := t.Context()
+
+	// A descendant's records reach an ancestor's store through the descendant's
+	// own provider, so only flushing that provider delivers them. Batch timeout
+	// long enough that nothing is exported unless a ForceFlush drives it.
+	batchTo := sdktrace.WithBatchTimeout(time.Hour)
+	upStore := &recordingSpanExporter{}
+	siblingStore := &recordingSpanExporter{}
+
+	main := &daggerClient{clientID: "main"}
+	up := &daggerClient{clientID: "up", parents: []*daggerClient{main}}
+	runtime := &daggerClient{clientID: "runtime", parents: []*daggerClient{main, up}}
+	sibling := &daggerClient{clientID: "sibling", parents: []*daggerClient{main}}
+
+	runtime.tracerProvider = sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(upStore, batchTo)),
+	)
+	sibling.tracerProvider = sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(siblingStore, batchTo)),
+	)
+	t.Cleanup(func() {
+		require.NoError(t, runtime.tracerProvider.Shutdown(context.WithoutCancel(ctx)))
+		require.NoError(t, sibling.tracerProvider.Shutdown(context.WithoutCancel(ctx)))
+	})
+
+	sess := &daggerSession{
+		sessionID:          "sess",
+		mainClientCallerID: "main",
+		clients: map[string]*daggerClient{
+			"main": main, "up": up, "runtime": runtime, "sibling": sibling,
+		},
+	}
+
+	_, span := runtime.tracerProvider.Tracer("test").Start(ctx, "runtime-work")
+	span.End()
+	_, siblingSpan := sibling.tracerProvider.Tracer("test").Start(ctx, "sibling-work")
+	siblingSpan.End()
+
+	require.Empty(t, upStore.exported(), "queued, not yet exported")
+
+	require.NoError(t, sess.flushTelemetry(ctx, "test", up))
+
+	require.Equal(t, []string{"runtime-work"}, upStore.exported())
+	require.Empty(t, siblingStore.exported(), "a sibling's provider must not be flushed")
 }

--- a/util/gitutil/cli.go
+++ b/util/gitutil/cli.go
@@ -36,6 +36,8 @@ type GitCLI struct {
 	ignoreError bool
 	config      map[string]string
 
+	snapshotBackedRepo bool
+
 	indexFile string
 }
 
@@ -172,6 +174,19 @@ func WithStreams(streams StreamFunc) Option {
 	}
 }
 
+// WithSnapshotBackedRepo marks the repository as living on a snapshot-backed
+// mount, where a file's ctime, inode and device can all change without its
+// content changing because snapshots share content via hardlinks. Left alone,
+// git treats those files as changed underneath it -- that is what
+// "fatal: shallow file has changed since we read it" reports about .git/shallow.
+// mtime + size is all that can be trusted there. See gitEphemeralConfig in
+// core/changeset.go, which disables the same stat fields for the same reason.
+func WithSnapshotBackedRepo() Option {
+	return func(b *GitCLI) {
+		b.snapshotBackedRepo = true
+	}
+}
+
 // WithIndexFile sets the GIT_INDEX_FILE environment variable for the git commands.
 func WithIndexFile(indexFile string) Option {
 	return func(b *GitCLI) {
@@ -243,6 +258,12 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, rerr erro
 		"-c", "gc.autoDetach=false",
 		"-c", "maintenance.autoDetach=false",
 	)
+	if cli.snapshotBackedRepo {
+		cmd.Args = append(cmd.Args,
+			"-c", "core.checkStat=minimal",
+			"-c", "core.trustctime=false",
+		)
+	}
 	if cli.workTree != "" {
 		cmd.Args = append(cmd.Args, "--work-tree", cli.workTree)
 	}

--- a/util/gitutil/cli.go
+++ b/util/gitutil/cli.go
@@ -37,6 +37,7 @@ type GitCLI struct {
 	config      map[string]string
 
 	snapshotBackedRepo bool
+	stallTimeouts      bool
 
 	indexFile string
 }
@@ -187,6 +188,18 @@ func WithSnapshotBackedRepo() Option {
 	}
 }
 
+// WithStallTimeouts makes a connection that stops making progress fail instead
+// of hanging forever. Git has no network deadline of its own: an HTTP transfer
+// that stalls, or an SSH connection to a host that stops answering, blocks until
+// the caller's context is cancelled -- and callers that hold a lock for the
+// duration block everyone else behind them too. Failing gives the caller
+// something it can classify and retry.
+func WithStallTimeouts() Option {
+	return func(b *GitCLI) {
+		b.stallTimeouts = true
+	}
+}
+
 // WithIndexFile sets the GIT_INDEX_FILE environment variable for the git commands.
 func WithIndexFile(indexFile string) Option {
 	return func(b *GitCLI) {
@@ -264,6 +277,13 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, rerr erro
 			"-c", "core.trustctime=false",
 		)
 	}
+	if cli.stallTimeouts {
+		// Give up on a transfer that has moved less than 1KB/s for a minute.
+		cmd.Args = append(cmd.Args,
+			"-c", "http.lowSpeedLimit=1000",
+			"-c", "http.lowSpeedTime=60",
+		)
+	}
 	if cli.workTree != "" {
 		cmd.Args = append(cmd.Args, "--work-tree", cli.workTree)
 	}
@@ -298,7 +318,7 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, rerr erro
 	cmd.Env = []string{
 		"PATH=" + os.Getenv("PATH"),
 		"GIT_TERMINAL_PROMPT=0",
-		"GIT_SSH_COMMAND=" + getGitSSHCommand(cli.sshKnownHosts),
+		"GIT_SSH_COMMAND=" + getGitSSHCommand(cli.sshKnownHosts, cli.stallTimeouts),
 		//	"GIT_TRACE=1",
 		"GIT_ASKPASS=echo",      // Ensure git does not ask for a password (avoids cryptic error message)
 		"GIT_CONFIG_NOSYSTEM=1", // Disable reading from system gitconfig.
@@ -348,12 +368,17 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, rerr erro
 	return buf.Bytes(), nil
 }
 
-func getGitSSHCommand(knownHosts string) string {
+func getGitSSHCommand(knownHosts string, stallTimeouts bool) string {
 	gitSSHCommand := "ssh -F /dev/null"
 	if knownHosts != "" {
 		gitSSHCommand += " -o UserKnownHostsFile=" + knownHosts
 	} else {
 		gitSSHCommand += " -o StrictHostKeyChecking=no"
+	}
+	if stallTimeouts {
+		// ssh waits on the TCP stack by default, which never gives up on a host
+		// that accepted the connection and then went silent.
+		gitSSHCommand += " -o ConnectTimeout=30 -o ServerAliveInterval=30 -o ServerAliveCountMax=3"
 	}
 	return gitSSHCommand
 }

--- a/util/gitutil/cli.go
+++ b/util/gitutil/cli.go
@@ -233,6 +233,16 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, rerr erro
 
 	// Block sneaky repositories from using repos from the filesystem as submodules.
 	cmd.Args = append(cmd.Args, "-c", "protocol.file.allow=user")
+	// Auto-maintenance detaches by default, so it outlives the command that
+	// spawned it: it escapes whatever lock the caller held, and for engine-managed
+	// repos it can still be rewriting refs (including .git/shallow, which the next
+	// fetch stat-checks) after the snapshot it lives in has been unmounted. Running
+	// it synchronously is enough to close that; disabling it outright would leave
+	// the long-lived shared mirrors accumulating a pack per fetch forever.
+	cmd.Args = append(cmd.Args,
+		"-c", "gc.autoDetach=false",
+		"-c", "maintenance.autoDetach=false",
+	)
 	if cli.workTree != "" {
 		cmd.Args = append(cmd.Args, "--work-tree", cli.workTree)
 	}
@@ -312,7 +322,7 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, rerr erro
 			}
 		default:
 		}
-		return buf.Bytes(), fmt.Errorf("git error: %w", translateError(err, errbuf.String()))
+		return buf.Bytes(), fmt.Errorf("git error: %w", annotateWithStderr(translateError(err, errbuf.String()), errbuf.String()))
 	}
 	return buf.Bytes(), nil
 }

--- a/util/gitutil/cli_test.go
+++ b/util/gitutil/cli_test.go
@@ -1,0 +1,35 @@
+package gitutil
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotBackedRepoConfig(t *testing.T) {
+	capture := func(args *[]string) Option {
+		return WithExec(func(_ context.Context, cmd *exec.Cmd) error {
+			*args = cmd.Args
+			return nil
+		})
+	}
+
+	t.Run("off by default", func(t *testing.T) {
+		var args []string
+		_, err := NewGitCLI(capture(&args)).Run(context.Background(), "status")
+		require.NoError(t, err)
+		require.NotContains(t, strings.Join(args, " "), "core.checkStat")
+	})
+
+	t.Run("relaxes the stat fields snapshots invalidate", func(t *testing.T) {
+		var args []string
+		_, err := NewGitCLI(capture(&args), WithSnapshotBackedRepo()).Run(context.Background(), "status")
+		require.NoError(t, err)
+		joined := strings.Join(args, " ")
+		require.Contains(t, joined, "core.checkStat=minimal")
+		require.Contains(t, joined, "core.trustctime=false")
+	})
+}

--- a/util/gitutil/cli_test.go
+++ b/util/gitutil/cli_test.go
@@ -33,3 +33,39 @@ func TestSnapshotBackedRepoConfig(t *testing.T) {
 		require.Contains(t, joined, "core.trustctime=false")
 	})
 }
+
+func TestStallTimeouts(t *testing.T) {
+	capture := func(cmd **exec.Cmd) Option {
+		return WithExec(func(_ context.Context, c *exec.Cmd) error {
+			*cmd = c
+			return nil
+		})
+	}
+	sshCommand := func(cmd *exec.Cmd) string {
+		for _, env := range cmd.Env {
+			if after, ok := strings.CutPrefix(env, "GIT_SSH_COMMAND="); ok {
+				return after
+			}
+		}
+		return ""
+	}
+
+	t.Run("off by default", func(t *testing.T) {
+		var cmd *exec.Cmd
+		_, err := NewGitCLI(capture(&cmd)).Run(context.Background(), "fetch")
+		require.NoError(t, err)
+		require.NotContains(t, strings.Join(cmd.Args, " "), "http.lowSpeed")
+		require.NotContains(t, sshCommand(cmd), "ServerAliveInterval")
+	})
+
+	t.Run("bounds http and ssh stalls", func(t *testing.T) {
+		var cmd *exec.Cmd
+		_, err := NewGitCLI(capture(&cmd), WithStallTimeouts()).Run(context.Background(), "fetch")
+		require.NoError(t, err)
+		joined := strings.Join(cmd.Args, " ")
+		require.Contains(t, joined, "http.lowSpeedLimit=1000")
+		require.Contains(t, joined, "http.lowSpeedTime=60")
+		require.Contains(t, sshCommand(cmd), "-o ConnectTimeout=30")
+		require.Contains(t, sshCommand(cmd), "-o ServerAliveInterval=30 -o ServerAliveCountMax=3")
+	})
+}

--- a/util/gitutil/error.go
+++ b/util/gitutil/error.go
@@ -14,7 +14,41 @@ var (
 	ErrShallowNotSupported = errors.New("shallow clone not supported")
 	// ErrSHAFetchUnsupported is a normalized signal that retry-by-named-ref may succeed.
 	ErrSHAFetchUnsupported = errors.New("sha fetch unsupported by remote")
+	// ErrTransient marks a failure that is worth retrying as-is: a network
+	// hiccup talking to the remote, or a local repository that another process
+	// mutated underneath the command.
+	ErrTransient = errors.New("transient git failure")
 )
+
+// transientStderr are stderr fragments that mean "this git command may well
+// succeed if it is simply run again". They cover two families:
+//
+//   - the remote end dropping or refusing the connection mid-transfer
+//   - a concurrent writer changing the repository underneath us, which git
+//     detects via the stat data it recorded when it read the file
+var transientStderr = []string{
+	// concurrent local writer (e.g. detached `gc --auto` from an earlier fetch)
+	"shallow file has changed since we read it",
+	"shallow file was changed during fetch",
+	// another process holds the ref lock; the deterministic failures that share
+	// the "cannot lock ref" prefix (ref/directory conflicts) are not matched
+	".lock': file exists",
+	// remote/network
+	"the remote end hung up unexpectedly",
+	"early eof",
+	"rpc failed",
+	"connection reset by peer",
+	"connection closed by",
+	"connection timed out",
+	"operation timed out",
+	"could not resolve host",
+	"failed to connect to",
+	"unexpected disconnect",
+	"remote error: internal server error",
+	// git reports HTTP status as "The requested URL returned error: 502"
+	"returned error: 5",
+	"returned error: 429",
+}
 
 func translateError(err error, stderr string) error {
 	if err == nil {
@@ -51,6 +85,12 @@ func translateError(err error, stderr string) error {
 		strings.Contains(stderr, "not our ref") ||
 		strings.Contains(stderr, "couldn't find remote ref") {
 		return ErrSHAFetchUnsupported
+	}
+
+	for _, fragment := range transientStderr {
+		if strings.Contains(stderr, fragment) {
+			return fmt.Errorf("%w: %w", ErrTransient, err)
+		}
 	}
 
 	return err

--- a/util/gitutil/error.go
+++ b/util/gitutil/error.go
@@ -3,6 +3,8 @@ package gitutil
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -52,4 +54,50 @@ func translateError(err error, stderr string) error {
 	}
 
 	return err
+}
+
+// credentialedURL matches the userinfo of a URL appearing anywhere in a line,
+// e.g. "fatal: Authentication failed for 'https://user:token@host/repo'".
+var credentialedURL = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]*@`)
+
+// redactCredentials masks credentials embedded in URLs. Anything git prints on
+// stderr is remote-controlled and routinely echoes back the URL it was given,
+// so it must never be attached to an error verbatim.
+func redactCredentials(s string) string {
+	return credentialedURL.ReplaceAllString(s, "${1}xxxxx@")
+}
+
+// annotateWithStderr keeps git's own explanation attached to the error. Without
+// it an unclassified failure surfaces only as "exit status 128", which is what
+// made recurring CI failures unattributable.
+func annotateWithStderr(err error, stderr string) error {
+	if err == nil {
+		return nil
+	}
+	// `git fetch --progress` writes sideband progress to stderr too, so the very
+	// last line is often a progress update rather than the reason: prefer git's
+	// own diagnostic prefixes when they are there.
+	var lastLine, lastDiagnostic string
+	for line := range strings.SplitSeq(strings.TrimSpace(stderr), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lastLine = line
+		if strings.HasPrefix(line, "fatal:") || strings.HasPrefix(line, "error:") {
+			lastDiagnostic = line
+		}
+	}
+	if lastDiagnostic != "" {
+		lastLine = lastDiagnostic
+	}
+	lastLine = redactCredentials(lastLine)
+	if lastLine == "" || strings.Contains(err.Error(), lastLine) {
+		return err
+	}
+	const maxLen = 300
+	if len(lastLine) > maxLen {
+		lastLine = lastLine[:maxLen] + "…"
+	}
+	return fmt.Errorf("%w: %s", err, lastLine)
 }

--- a/util/gitutil/error_test.go
+++ b/util/gitutil/error_test.go
@@ -34,6 +34,44 @@ func TestTranslateErrorContextPassthrough(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestTranslateErrorTransient(t *testing.T) {
+	cases := []string{
+		"fatal: shallow file has changed since we read it",
+		"Connection closed by 172.65.251.78 port 22\nfatal: Could not read from remote repository.",
+		"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly",
+		"fatal: the remote end hung up unexpectedly",
+		"fatal: Unable to create '/mirror/.git/refs/remotes/origin/main.lock': File exists.",
+		"error: RPC failed; HTTP 502 curl 22 The requested URL returned error: 502",
+		"error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429",
+	}
+
+	for _, stderr := range cases {
+		t.Run(stderr, func(t *testing.T) {
+			err := translateError(errors.New("exit status 128"), stderr)
+			require.ErrorIs(t, err, ErrTransient)
+			require.ErrorContains(t, err, "exit status 128")
+		})
+	}
+}
+
+func TestTranslateErrorNotTransient(t *testing.T) {
+	cases := []string{
+		"fatal: couldn't find remote ref refs/heads/nope",
+		// git's generic SSH footer follows permanent failures too
+		"git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+		"error: unable to create file vendor/mod.go: Permission denied",
+		"error: cannot lock ref 'refs/heads/foo': 'refs/heads/foo/bar' exists; cannot create 'refs/heads/foo'",
+		"fatal: update_ref failed for ref 'refs/tags/v1.0.0': reference already exists",
+	}
+
+	for _, stderr := range cases {
+		t.Run(stderr, func(t *testing.T) {
+			err := translateError(errors.New("exit status 128"), stderr)
+			require.NotErrorIs(t, err, ErrTransient)
+		})
+	}
+}
+
 func TestAnnotateWithStderr(t *testing.T) {
 	err := annotateWithStderr(errors.New("exit status 128"), "remote: Counting objects\nfatal: shallow file has changed since we read it\n")
 	require.ErrorContains(t, err, "exit status 128")

--- a/util/gitutil/error_test.go
+++ b/util/gitutil/error_test.go
@@ -33,3 +33,29 @@ func TestTranslateErrorContextPassthrough(t *testing.T) {
 	err := translateError(context.Canceled, "")
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestAnnotateWithStderr(t *testing.T) {
+	err := annotateWithStderr(errors.New("exit status 128"), "remote: Counting objects\nfatal: shallow file has changed since we read it\n")
+	require.ErrorContains(t, err, "exit status 128")
+	require.ErrorContains(t, err, "shallow file has changed since we read it")
+
+	// already-classified errors don't get their own text repeated
+	sentinel := annotateWithStderr(ErrGitAuthFailed, "fatal: Authentication failed")
+	require.ErrorIs(t, sentinel, ErrGitAuthFailed)
+}
+
+func TestAnnotateWithStderrRedactsCredentials(t *testing.T) {
+	cases := []string{
+		"fatal: Authentication failed for 'https://user:hunter2@github.com/org/repo.git/'",
+		"remote: fatal: unable to access 'https://x-access-token:ghp_hunter2@github.com/org/repo/': 403",
+		"fatal: could not read Password for 'https://hunter2@gitlab.com'",
+	}
+
+	for _, stderr := range cases {
+		t.Run(stderr, func(t *testing.T) {
+			err := annotateWithStderr(errors.New("exit status 128"), stderr)
+			require.NotContains(t, err.Error(), "hunter2")
+			require.Contains(t, err.Error(), "xxxxx@")
+		})
+	}
+}


### PR DESCRIPTION
The `test-split:test-base` shard has been failing across unrelated PRs for weeks, always cleared by a re-trigger and always written off as infrastructure. This is what is actually happening.

## Evidence

Mined every commit status on the last 150 PRs and replayed 45 Dagger Cloud traces. 32 `test-base` runs errored (or were cancelled) and then passed unchanged on a re-run of the same SHA — i.e. genuine flakes, not PR-specific breakage. They fall into four buckets:

| count | signature |
|---|---|
| 6 | `failed to fetch remote https://github.com/dagger/dagger: git error: exit status 128`, stderr `fatal: shallow file has changed since we read it` — always `TestAddress/TestGit` |
| 8 | shard hangs; CI kills the check at its 30m cap with `Cancelled - max execution time exceeded` and no test output |
| ~3 | a remote drops the connection mid-operation (`Connection closed by … port 22`) |
| 2 | Dagger Cloud engine provisioning (not addressable here) |

Successful runs of the shard sit at a 12m median and a 19m maximum, so the hung runs are hangs, not a shard that outgrew its budget.

Three previously suspected causes — the `TestChecks/TestChecksFailFast` `context canceled` rendering race, `exit status 137` container kills, and the `AttachDependencyResultsKinds` index panic — appear in **zero** of the 45 replayed traces and are not what is failing today.

## What the diff does

Everything red here is git, so the fix is at the git layer.

1. **Keep git's own error text.** An unclassified failure surfaced as `git error: exit status 128` with the reason dropped, which is precisely why four prior sightings were unattributable. The last diagnostic line is now attached, with URL credentials redacted first. Auto-maintenance also gets `gc.autoDetach=false` / `maintenance.autoDetach=false`: detached maintenance outlives the command that spawned it, escaping the engine's per-remote lock and potentially writing into a snapshot that has already been unmounted. (It is left *enabled*, just synchronous — the shared mirrors still need compacting.)

2. **Retry transient remote git failures.** `fetch` and `ls-remote` are idempotent; a stderr classifier marks the connection drops and concurrent-writer failures as `ErrTransient` and retries up to 3 times. The first attempt keeps the caller's deadline (a cold mirror fetch is legitimately slow); the retries share a 3-minute budget, because they run under the engine-wide per-remote lock. Retries are logged to the span and the attempt count is carried on the final error.

3. **Don't trust ctime on snapshot-backed repositories.** Engine git repos live on snapshot mounts that share content via hardlinks, so a file's ctime/inode/device can change without its content changing — and git stat-checks `.git/shallow`, which is what `shallow file has changed since we read it` reports. `core.checkStat=minimal` + `core.trustctime=false` for those repos only; `core/changeset.go` already documents and applies the identical workaround for the same storage.

4. **Bound stalled git network operations.** No git invocation in the engine had a network deadline: a stalled HTTP transfer or a silent SSH host blocks forever *while holding the engine-wide per-remote lock*, taking every other caller of that remote down with it. `http.lowSpeed{Limit,Time}` plus ssh `ConnectTimeout`/`ServerAlive*` turn that into a fast, classified, retryable failure — which is the best explanation on the table for the 8 hung runs.

5. **Give the base shard a go test timeout under the CI cap.** It was 30m, the same as the cap, so go test never got to fire and a hang was reported as an opaque cancellation instead of a goroutine dump. 25m for that shard only.

## Second flake bucket: the swallowed `startup failed` (`TestUpPartialStartupFailure`)

The census above missed a second bucket of roughly the same weight as the git one (~6 of the 32): the trace renderer truncates the embedded go-test output, so it read as noise. Root-caused now.

A nested client — the CLI running `dagger up` inside an exec — drains its own telemetry store at shutdown and renders its final report from it, but `serveShutdown` flushed only that client's *own* OTel providers, while those providers export to the client's own DB **and every ancestor DB**. A still-live descendant (the module runtime that ran the failing exec) still held the tail of the ancestor's store in its batch processors, so `dagger up` printed `! exit code: 1` with the service's `startup failed` stderr swallowed entirely.

**Fix (patch 6, `engine/server: flush a nested client's descendants on shutdown`).** A non-main client now sweeps its own subtree's providers on shutdown, not just its own. Measured against a dev engine with the nested exec cache-busted per iteration: **9/10 failures before, 0/20 after**.

## Honest limits

The `shallow file has changed since we read it` race was diagnosed from traces and code, not reproduced locally — a local harness could not force git into the stat check. Two mechanisms remain possible (detached maintenance, or snapshot stat churn); (1), (3) and (4) close all of them, and (2) is the safety net if something else is still writing. Both reviewers independently confirmed there is no in-process lock gap: the mirror key and the lock key cannot diverge, and the locker is engine-wide.

Follow-ups deliberately left out: moving the retry into `gitutil` so submodule fetches in `doGitCheckout` are covered too, and capturing the *engine's* goroutine dump when a shard times out (the go test dump only shows the client blocked in a GraphQL call, not the stuck fetch).
