### PR TITLE
dagql: preserve late singleflight persistence intent

### DIFF
--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	telemetry "github.com/dagger/otel-go"
@@ -1839,12 +1840,21 @@ func wrapSharedResultWithResolver(ctx context.Context, res *sharedResult, hitCac
 // ongoingCall tracks one in-flight GetOrInitCall execution and points at the
 // shared result payload that will be returned to waiters.
 type ongoingCall struct {
-	callConcurrencyKeys     callConcurrencyKeys
-	isPersistable           bool
-	ttlSeconds              int64
-	initCompletedResultOnce sync.Once
-	handoffHoldActive       bool
-	initCompletedResultErr  error
+	callConcurrencyKeys callConcurrencyKeys
+	// isPersistable is monotonic persistence intent aggregated from every
+	// request admitted to this call. Late joiners update it under callsMu while
+	// publication reads it under egraphMu, so all accesses must be atomic.
+	isPersistable atomic.Bool
+	// persistedDuringPublication records whether the publication-time intent
+	// snapshot installed the persisted edge. If a late joiner arrives after
+	// that snapshot, needsPersistRepair is set when callsMu closes admission.
+	persistedDuringPublication bool
+	needsPersistRepair         bool
+	persistedEdgeExpiresAtUnix int64
+	ttlSeconds                 int64
+	initCompletedResultOnce    sync.Once
+	handoffHoldActive          bool
+	initCompletedResultErr     error
 
 	waitCh                     chan struct{}
 	cancel                     context.CancelCauseFunc
@@ -3859,7 +3869,7 @@ func (c *Cache) getOrInitCallInner(
 	if req.ConcurrencyKey != "" {
 		if oc := c.ongoingCalls[callConcKeys]; oc != nil {
 			if req.IsPersistable {
-				oc.isPersistable = true
+				oc.isPersistable.Store(true)
 			}
 			// already an ongoing call
 			oc.waiters++
@@ -3915,7 +3925,6 @@ func (c *Cache) getOrInitCallInner(
 	}
 	oc := &ongoingCall{
 		callConcurrencyKeys:      callConcKeys,
-		isPersistable:            req.IsPersistable,
 		ttlSeconds:               req.TTL,
 		waitCh:                   make(chan struct{}),
 		cancel:                   cancel,
@@ -3928,6 +3937,9 @@ func (c *Cache) getOrInitCallInner(
 		// source dangle-proof: a skipped target never minted its call_exec span, so a
 		// joiner must not emit a wait into it. Native is unaffected (full detail).
 		profSkip: req.ResultCall.ProfileSkip,
+	}
+	if req.IsPersistable {
+		oc.isPersistable.Store(true)
 	}
 	if execSpan != nil {
 		// stash the call_exec span context as the joiner wait target, under
@@ -4161,13 +4173,8 @@ func (c *Cache) wait(
 			oc.cancel(canceledErr)
 		}
 		c.callsMu.Unlock()
-		if releaseHandoff && oc.res != nil {
-			c.egraphMu.Lock()
-			queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
-			collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
-			c.egraphMu.Unlock()
-			oc.handoffHoldActive = false
-			if relErr := errors.Join(decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases)); relErr != nil {
+		if releaseHandoff {
+			if relErr := c.releaseOngoingCallHandoff(ctx, oc); relErr != nil {
 				return nil, errors.Join(canceledErr, relErr)
 			}
 		}
@@ -4216,23 +4223,20 @@ func (c *Cache) wait(
 		}
 		EndProfSpan(pubSpan, &oc.initCompletedResultErr)
 		c.callsMu.Lock()
+		oc.needsPersistRepair = oc.initCompletedResultErr == nil &&
+			oc.res != nil &&
+			!oc.persistedDuringPublication &&
+			oc.isPersistable.Load()
 		delete(c.ongoingCalls, oc.callConcurrencyKeys)
 		c.callsMu.Unlock()
 	})
-	// TODO there's a race condition here: thread one enters the .Do() above but hasn't finished calling initCompletedResult(....), the second thread will skip over the Do(),
-	// then check the err below before it's actually written to
 	if oc.initCompletedResultErr != nil {
 		c.callsMu.Lock()
 		oc.waiters--
 		lastWaiter := oc.waiters == 0
 		c.callsMu.Unlock()
 		if lastWaiter && oc.handoffHoldActive {
-			c.egraphMu.Lock()
-			queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
-			collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
-			c.egraphMu.Unlock()
-			oc.handoffHoldActive = false
-			if relErr := errors.Join(decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases)); relErr != nil {
+			if relErr := c.releaseOngoingCallHandoff(ctx, oc); relErr != nil {
 				return nil, relErr
 			}
 		}
@@ -4244,12 +4248,7 @@ func (c *Cache) wait(
 		lastWaiter := oc.waiters == 0
 		c.callsMu.Unlock()
 		if lastWaiter && oc.handoffHoldActive {
-			c.egraphMu.Lock()
-			queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
-			collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
-			c.egraphMu.Unlock()
-			oc.handoffHoldActive = false
-			if relErr := errors.Join(decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases)); relErr != nil {
+			if relErr := c.releaseOngoingCallHandoff(ctx, oc); relErr != nil {
 				return nil, relErr
 			}
 		}
@@ -4270,12 +4269,7 @@ func (c *Cache) wait(
 	lastWaiter := oc.waiters == 0
 	c.callsMu.Unlock()
 	if lastWaiter && oc.handoffHoldActive {
-		c.egraphMu.Lock()
-		queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
-		collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
-		c.egraphMu.Unlock()
-		oc.handoffHoldActive = false
-		if relErr := errors.Join(decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases)); relErr != nil {
+		if relErr := c.releaseOngoingCallHandoff(ctx, oc); relErr != nil {
 			return nil, relErr
 		}
 	}
@@ -4287,10 +4281,33 @@ func (c *Cache) wait(
 	return retResAny, nil
 }
 
+// releaseOngoingCallHandoff releases the temporary ownership that protects a
+// published result until every admitted waiter has finished. If persistence
+// intent arrived after publication's initial snapshot, repair the missed edge
+// inside this already-required egraph critical section before dropping the
+// handoff ownership.
+func (c *Cache) releaseOngoingCallHandoff(ctx context.Context, oc *ongoingCall) error {
+	if c == nil || oc == nil || oc.res == nil || !oc.handoffHoldActive {
+		return nil
+	}
+
+	c.egraphMu.Lock()
+	if oc.needsPersistRepair {
+		c.upsertPersistedEdgeLocked(ctx, oc.res, oc.persistedEdgeExpiresAtUnix, false)
+	}
+	queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
+	collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
+	c.egraphMu.Unlock()
+	oc.handoffHoldActive = false
+
+	return errors.Join(decErr, collectErr, runOnReleaseFuncs(context.WithoutCancel(ctx), collectReleases))
+}
+
 //nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity
 func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, oc *ongoingCall, req *CallRequest, sessionID string) error {
 	resWasCacheBacked := false
 	now := time.Now()
+	oc.persistedEdgeExpiresAtUnix = candidateSharedResultExpiryUnix(now.Unix(), oc.ttlSeconds)
 	var (
 		resultTermSelf   digest.Digest
 		resultTermInputs []digest.Digest
@@ -4597,8 +4614,9 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		c.egraphMu.Unlock()
 		return err
 	}
-	if oc.isPersistable {
-		c.upsertPersistedEdgeLocked(ctx, oc.res, candidateSharedResultExpiryUnix(now.Unix(), oc.ttlSeconds), false)
+	if oc.isPersistable.Load() {
+		c.upsertPersistedEdgeLocked(ctx, oc.res, oc.persistedEdgeExpiresAtUnix, false)
+		oc.persistedDuringPublication = true
 	}
 	// The cache-backed path already took the handoff hold when it adopted the
 	// canonical result above; only fresh results take it here.

--- a/dagql/cache_debug.go
+++ b/dagql/cache_debug.go
@@ -1524,7 +1524,7 @@ func (c *Cache) WriteDebugCacheSnapshot(w io.Writer) error {
 					CallKey:        key.callKey,
 					ConcurrencyKey: key.concurrencyKey,
 					Waiters:        call.waiters,
-					IsPersistable:  call.isPersistable,
+					IsPersistable:  call.isPersistable.Load(),
 					TTLSeconds:     call.ttlSeconds,
 					Completed:      completed,
 				}

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -5525,6 +5525,182 @@ func TestCachePersistableRetainedAcrossSessionClose(t *testing.T) {
 	assert.Equal(t, 1, base.Size())
 }
 
+func TestCacheLatePersistableJoinRepairsBeforeHandoffRelease(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		lateWaiters         int
+		canceledFinalWaiter bool
+	}{
+		{
+			name:        "successful final waiter",
+			lateWaiters: 2,
+		},
+		{
+			name:                "canceled final waiter",
+			lateWaiters:         1,
+			canceledFinalWaiter: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unwrapValue := func(res AnyResult) int {
+				t.Helper()
+				value, ok := UnwrapAs[cacheTestLeaseCheckedInt](res)
+				assert.Assert(t, ok, "expected cacheTestLeaseCheckedInt result, got %T", res)
+				return int(value.Int)
+			}
+
+			ctx := cacheTestContext(t.Context())
+			cacheIface, err := NewCache(ctx, "", nil, nil)
+			assert.NilError(t, err)
+			c := cacheIface
+
+			const (
+				sessionID      = "late-persistable-session"
+				concurrencyKey = "late-persistable-concurrency"
+			)
+			key := cacheTestIntCall("late-persistable-repair")
+			callConcKeys := callConcurrencyKeys{
+				callKey:        cacheTestCallDigest(key).String(),
+				concurrencyKey: concurrencyKey,
+			}
+
+			publicationPassedPersistCheck := make(chan struct{})
+			allowPublicationToFinish := make(chan struct{})
+			leaderResCh := make(chan AnyResult, 1)
+			leaderErrCh := make(chan error, 1)
+			go func() {
+				res, err := c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{
+					ResultCall:     key,
+					ConcurrencyKey: concurrencyKey,
+					TTL:            60,
+				}, func(context.Context) (AnyResult, error) {
+					return cacheTestDetachedResult(key, cacheTestLeaseCheckedInt{
+						Int: NewInt(42),
+						onAttach: func(context.Context) error {
+							close(publicationPassedPersistCheck)
+							<-allowPublicationToFinish
+							return nil
+						},
+					}), nil
+				})
+				leaderResCh <- res
+				leaderErrCh <- err
+			}()
+
+			select {
+			case <-publicationPassedPersistCheck:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for publication to pass persistence check")
+			}
+
+			// Simulate requests whose e-graph lookup missed before indexing but
+			// whose callsMu admission happens after publication read false. Keep
+			// their waiter slots outstanding so the leader cannot release the
+			// publication handoff before the test selects the final waiter.
+			c.callsMu.Lock()
+			oc := c.ongoingCalls[callConcKeys]
+			assert.Assert(t, oc != nil)
+			assert.Assert(t, !oc.persistedDuringPublication)
+			oc.isPersistable.Store(true)
+			oc.waiters += tc.lateWaiters
+			expectedExpiry := time.Now().Unix() + 3600
+			oc.persistedEdgeExpiresAtUnix = expectedExpiry
+			c.callsMu.Unlock()
+
+			close(allowPublicationToFinish)
+			var leaderRes AnyResult
+			select {
+			case leaderRes = <-leaderResCh:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for leader result")
+			}
+			select {
+			case err := <-leaderErrCh:
+				assert.NilError(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for leader error")
+			}
+			assert.Equal(t, 42, unwrapValue(leaderRes))
+
+			c.callsMu.Lock()
+			assert.Assert(t, oc.needsPersistRepair)
+			assert.Equal(t, tc.lateWaiters, oc.waiters)
+			_, ongoing := c.ongoingCalls[callConcKeys]
+			c.callsMu.Unlock()
+			assert.Assert(t, !ongoing)
+
+			if tc.canceledFinalWaiter {
+				// Leave only the handoff owner. If repair happened after the
+				// decrement, this final cancellation would collect the result.
+				assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+
+				// Publication is complete and no goroutine reads waitCh anymore.
+				// Replace the closed channel so wait deterministically selects the
+				// canceled path for the synthetic final waiter.
+				oc.waitCh = make(chan struct{})
+				canceledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				_, err := c.wait(canceledCtx, sessionID, noopTypeResolver{}, oc, &CallRequest{
+					ResultCall:     key,
+					ConcurrencyKey: concurrencyKey,
+					IsPersistable:  true,
+				}, true)
+				assert.ErrorIs(t, err, context.Canceled)
+			} else {
+				for range tc.lateWaiters {
+					res, err := c.wait(ctx, sessionID, noopTypeResolver{}, oc, &CallRequest{
+						ResultCall:     key,
+						ConcurrencyKey: concurrencyKey,
+						IsPersistable:  true,
+					}, true)
+					assert.NilError(t, err)
+					assert.Equal(t, 42, unwrapValue(res))
+				}
+				assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+			}
+
+			shared := leaderRes.cacheSharedResult()
+			c.egraphMu.RLock()
+			edge, found := c.persistedEdgesByResult[shared.id]
+			live := c.resultsByID[shared.id] == shared
+			ownershipCount := shared.incomingOwnershipCount
+			c.egraphMu.RUnlock()
+			assert.Assert(t, found)
+			assert.Equal(t, expectedExpiry, edge.expiresAtUnix)
+			assert.Assert(t, live)
+			assert.Equal(t, int64(1), ownershipCount)
+			assert.Equal(t, 1, c.EntryStats().RetainedCalls)
+			assert.Equal(t, 1, c.Size())
+		})
+	}
+}
+
+func TestOngoingCallPersistableIntentConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	oc := &ongoingCall{}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 10_000 {
+			oc.isPersistable.Store(true)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 10_000 {
+			_ = oc.isPersistable.Load()
+		}
+	}()
+	close(start)
+	wg.Wait()
+	assert.Assert(t, oc.isPersistable.Load())
+}
+
 func TestCacheNonPersistableDropsWhenRefsDrain(t *testing.T) {
 	t.Parallel()
 	ctx := cacheTestContext(t.Context())


### PR DESCRIPTION
## Summary

- make ongoing-call persistence intent atomic
- snapshot late persistence intent when singleflight admission closes
- repair a missed persisted edge during the existing final-handoff release

## Problem

`ongoingCall.isPersistable` was a plain boolean written by joining callers and read by the publishing initializer without common synchronization. That is a Go data race.

Changing the field to an atomic alone is insufficient. A late joiner can still publish persistence intent after the initializer's publication-time load but before the completed ongoing call is removed. The load and store are individually safe, but the late intent is lost semantically and the successful result can remain session-owned instead of retained.

## Fix

The ongoing call now stores persistence intent atomically and records whether publication installed a persisted edge, along with the original edge expiry. When initialization completes, deletion from the ongoing-call map takes a final intent snapshot while already holding `callsMu`.

If that snapshot finds successful late persistence intent that publication missed, the final waiter repairs the persisted edge inside its already-required handoff-release `egraphMu` critical section, before decrementing the handoff ownership. All successful final-handoff paths use the same release helper, including a canceled final waiter.

This adds no `callsMu` or `egraphMu` acquisitions and no common-path e-graph mutation. The common path adds only atomic/scalar bookkeeping; the conditional upsert is limited to the missed-late-intent case and preserves the original expiry.

## Testing

Deterministic tests cover multiple successful late waiters, a canceled final waiter, original-expiry preservation, and repair before the final ownership decrement. Concurrent intent access is also exercised under the race detector.

- `go test ./dagql -run '^Test(CacheLatePersistableJoinRepairsBeforeHandoffRelease|OngoingCallPersistableIntentConcurrentAccess)$' -count=1`
- `go test -race ./dagql -run '^Test(CacheLatePersistableJoinRepairsBeforeHandoffRelease|OngoingCallPersistableIntentConcurrentAccess)$' -count=1`
- `go test ./dagql -run '^Test(CacheConcurrent|CachePersistableRetainedAcrossSessionClose|CacheNonPersistableDropsWhenRefsDrain|CachePersistableHitUpgradesExistingResultToRetained|CacheLatePersistableJoinRepairsBeforeHandoffRelease|OngoingCallPersistableIntentConcurrentAccess|CacheCanonicalEquivalentSwapRacesSessionRelease)$' -count=1`
- `go test -race ./dagql -run '^Test(CacheConcurrent|CachePersistableRetainedAcrossSessionClose|CacheNonPersistableDropsWhenRefsDrain|CachePersistableHitUpgradesExistingResultToRetained|CacheLatePersistableJoinRepairsBeforeHandoffRelease|OngoingCallPersistableIntentConcurrentAccess|CacheCanonicalEquivalentSwapRacesSessionRelease)$' -count=1`
- `go test ./dagql -count=1`
- `go test -race ./dagql -count=1`
- `dagger check --generate`
- `dagger check 'dagger-dang-sdk:generate'`
- `dagger check '*:lint'`
- `dagger check golang:lint-all`
- `git diff --check`

The generated-artifact matrix passed 22 of 24 checks. The transient `dagger-dang-sdk:generate` engine EOF passed on isolated rerun. The Elixir generator and Elixir lint could not execute because the Erlang VM repeatedly reported that the host monotonic clock stepped backward; the other selected lint checks passed.
