### PR TITLE
fix(core): honor dependency pins over source refs

### DIFF
--- a/core/integration/module_path_inputs_test.go
+++ b/core/integration/module_path_inputs_test.go
@@ -1540,9 +1540,10 @@ func (ModuleSuite) TestContextGitRemoteDep(ctx context.Context, t *testctx.T) {
 	}
 }
 
-// Regression test for #11996. An unversioned dependency with a named pin must
-// resolve that tag or branch rather than silently falling back to the default branch.
-func (ModuleSuite) TestContextGitRemoteDepNamedPin(ctx context.Context, t *testctx.T) {
+// Regression test for #11996. A dependency's named pin must resolve that tag
+// or branch even when source also contains a different symbolic ref such as
+// @main, rather than silently following the source ref.
+func (ModuleSuite) TestContextGitRemoteDepNamedPinOverridesSourceRef(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	remoteRepo := "github.com/dagger/dagger-test-modules"

--- a/core/integration/testdata/modules/go/path-context-git-remote-dep-named-pin/dagger.json
+++ b/core/integration/testdata/modules/go/path-context-git-remote-dep-named-pin/dagger.json
@@ -7,7 +7,7 @@
   "dependencies": [
     {
       "name": "context-git",
-      "source": "github.com/dagger/dagger-test-modules/context-git",
+      "source": "github.com/dagger/dagger-test-modules/context-git@main",
       "pin": "v1.2.3"
     }
   ]

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -177,30 +177,10 @@ func (p *ParsedGitRefString) GitRef(
 	}
 	repoSelector = withCommitArg(repoSelector)
 
-	refSelector := dagql.Selector{Field: "head"}
-	switch {
-	case modTag != "":
-		refSelector = withCommitArg(dagql.Selector{
-			Field: "tag",
-			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String(modTag)},
-			},
-		})
-	case pinCommitRef != "" && !pinIsSHA:
-		// A config pin is authoritative, even when the source ref also
-		// contains a floating or symbolic version such as "@main".
-		refSelector = dagql.Selector{
-			Field: "ref",
-			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String(pinCommitRef)},
-			},
-		}
-	case p.HasVersion:
-		refSelector = withCommitArg(dagql.Selector{
-			Field: "ref",
-			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String(p.ModVersion)},
-			},
+	refSelector := gitRefSelector(p, modTag, pinCommitRef)
+	if pinIsSHA && (modTag != "" || p.HasVersion) {
+		refSelector.Args = append(refSelector.Args, dagql.NamedInput{
+			Name: "commit", Value: dagql.String(pinCommitRef),
 		})
 	}
 	var gitRef dagql.ObjectResult[*GitRef]
@@ -210,6 +190,36 @@ func (p *ParsedGitRefString) GitRef(
 	}
 
 	return gitRef, nil
+}
+
+func gitRefSelector(p *ParsedGitRefString, modTag, pinCommitRef string) dagql.Selector {
+	switch {
+	case modTag != "":
+		return dagql.Selector{
+			Field: "tag",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(modTag)},
+			},
+		}
+	case pinCommitRef != "" && !gitutil.IsCommitSHA(pinCommitRef):
+		// A config pin is authoritative, even when the source ref also
+		// contains a floating or symbolic version such as "@main".
+		return dagql.Selector{
+			Field: "ref",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(pinCommitRef)},
+			},
+		}
+	case p.HasVersion:
+		return dagql.Selector{
+			Field: "ref",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(p.ModVersion)},
+			},
+		}
+	default:
+		return dagql.Selector{Field: "head"}
+	}
 }
 
 // Match a version string in a list of versions with optional subPath

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -140,7 +140,7 @@ func (p *ParsedGitRefString) GitRef(
 	}
 
 	var modTag string
-	if p.HasVersion && semver.IsValid(p.ModVersion) {
+	if pinCommitRef == "" && p.HasVersion && semver.IsValid(p.ModVersion) {
 		var tags dagql.Array[dagql.String]
 		err := dag.Select(ctx, dag.Root(), &tags,
 			dagql.Selector{
@@ -186,6 +186,15 @@ func (p *ParsedGitRefString) GitRef(
 				{Name: "name", Value: dagql.String(modTag)},
 			},
 		})
+	case pinCommitRef != "" && !pinIsSHA:
+		// A config pin is authoritative, even when the source ref also
+		// contains a floating or symbolic version such as "@main".
+		refSelector = dagql.Selector{
+			Field: "ref",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.String(pinCommitRef)},
+			},
+		}
 	case p.HasVersion:
 		refSelector = withCommitArg(dagql.Selector{
 			Field: "ref",
@@ -193,13 +202,6 @@ func (p *ParsedGitRefString) GitRef(
 				{Name: "name", Value: dagql.String(p.ModVersion)},
 			},
 		})
-	case pinCommitRef != "" && !pinIsSHA:
-		refSelector = dagql.Selector{
-			Field: "ref",
-			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String(pinCommitRef)},
-			},
-		}
 	}
 	var gitRef dagql.ObjectResult[*GitRef]
 	err := dag.Select(ctx, dag.Root(), &gitRef, repoSelector, refSelector)

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -5,8 +5,28 @@ import (
 	"os"
 	"testing"
 
+	"github.com/dagger/dagger/core/gitref"
+	"github.com/dagger/dagger/dagql"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGitRefSelectorUsesPinOverSourceVersion(t *testing.T) {
+	t.Parallel()
+
+	parsed := &ParsedGitRefString{
+		Parsed: gitref.Parsed{
+			HasVersion: true,
+			ModVersion: "main",
+		},
+	}
+
+	selector := gitRefSelector(parsed, "", "v1.2.3")
+
+	require.Equal(t, "ref", selector.Field)
+	require.Len(t, selector.Args, 1)
+	require.Equal(t, "name", selector.Args[0].Name)
+	require.Equal(t, dagql.String("v1.2.3"), selector.Args[0].Value)
+}
 
 func TestMatchVersion(t *testing.T) {
 	vers := []string{"v1.0.0", "v1.0.1", "v2.0.0", "path/v1.0.1", "path/v2.0.1"}


### PR DESCRIPTION
## Summary

- Honor a dependency `pin` when `source` also contains a symbolic or versioned Git ref.
- Skip source semver tag matching when a config pin is present.
- Add a focused unit regression asserting that `source @main` plus `pin v1.2.3` selects `ref(name: "v1.2.3")`.
- Keep integration coverage for the pinned remote dependency path.

## Testing

Added additional unit tests.

## AI Usage Disclaimer

I used AI for most of this change, aside from the PR description. It wrote code that is roughly on par with what I would have written myself and helped track down the precise issue far faster than I would have on my own.