### PR TITLE
engine: support secret salt environment override

### DIFF
--- a/engine/server/secret_salt_test.go
+++ b/engine/server/secret_salt_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSecretSalt(t *testing.T) {
+	t.Run("environment override", func(t *testing.T) {
+		rootDir := t.TempDir()
+		secretSaltPath := filepath.Join(rootDir, "secret-salt")
+		fileSalt := bytes.Repeat([]byte{0x11}, secretSaltSize)
+		require.NoError(t, os.WriteFile(secretSaltPath, fileSalt, 0600))
+
+		envSalt := bytes.Repeat([]byte{0x22}, secretSaltSize)
+		t.Setenv(secretSaltEnvName, base64.StdEncoding.EncodeToString(envSalt))
+
+		secretSalt, err := loadSecretSalt(rootDir)
+		require.NoError(t, err)
+		require.Equal(t, envSalt, secretSalt)
+
+		persistedSalt, err := os.ReadFile(secretSaltPath)
+		require.NoError(t, err)
+		require.Equal(t, fileSalt, persistedSalt)
+	})
+
+	for _, tc := range []struct {
+		name   string
+		values []string
+	}{
+		{
+			name: "invalid base64",
+			values: []string{
+				"not-base64",
+				base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x22}, secretSaltSize)) + "\n",
+			},
+		},
+		{name: "wrong decoded length", values: []string{base64.StdEncoding.EncodeToString([]byte("too short"))}},
+		{name: "empty", values: []string{""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+			fileSalt := bytes.Repeat([]byte{0x11}, secretSaltSize)
+			secretSaltPath := filepath.Join(rootDir, "secret-salt")
+			require.NoError(t, os.WriteFile(secretSaltPath, fileSalt, 0600))
+
+			for _, value := range tc.values {
+				t.Setenv(secretSaltEnvName, value)
+				_, err := loadSecretSalt(rootDir)
+				require.ErrorContains(t, err, secretSaltEnvName)
+			}
+
+			persistedSalt, readErr := os.ReadFile(secretSaltPath)
+			require.NoError(t, readErr)
+			require.Equal(t, fileSalt, persistedSalt)
+		})
+	}
+
+	t.Run("file fallback", func(t *testing.T) {
+		unsetSecretSaltEnv(t)
+		rootDir := t.TempDir()
+		fileSalt := bytes.Repeat([]byte{0x33}, secretSaltSize)
+		require.NoError(t, os.WriteFile(filepath.Join(rootDir, "secret-salt"), fileSalt, 0600))
+
+		secretSalt, err := loadSecretSalt(rootDir)
+		require.NoError(t, err)
+		require.Equal(t, fileSalt, secretSalt)
+	})
+
+	t.Run("generated file fallback", func(t *testing.T) {
+		unsetSecretSaltEnv(t)
+		rootDir := t.TempDir()
+
+		secretSalt, err := loadSecretSalt(rootDir)
+		require.NoError(t, err)
+		require.Len(t, secretSalt, secretSaltSize)
+
+		persistedSalt, err := os.ReadFile(filepath.Join(rootDir, "secret-salt"))
+		require.NoError(t, err)
+		require.Equal(t, secretSalt, persistedSalt)
+	})
+}
+
+func unsetSecretSaltEnv(t *testing.T) {
+	t.Helper()
+	value, ok := os.LookupEnv(secretSaltEnvName)
+	require.NoError(t, os.Unsetenv(secretSaltEnvName))
+	t.Cleanup(func() {
+		if ok {
+			require.NoError(t, os.Setenv(secretSaltEnvName, value))
+		} else {
+			require.NoError(t, os.Unsetenv(secretSaltEnvName))
+		}
+	})
+}

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -185,7 +186,11 @@ type NewServerOpts struct {
 	BuildkitConfig *bkconfig.Config
 }
 
-//nolint:gocyclo // NewServer performs the engine's existing linear initialization sequence.
+const (
+	secretSaltEnvName = "DAGGER_SECRET_SALT"
+	secretSaltSize    = 32
+)
+
 func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 	cfg := opts.Config
 	bkcfg := opts.BuildkitConfig
@@ -453,24 +458,47 @@ func NewServer(ctx context.Context, opts *NewServerOpts) (*Server, error) {
 	go srv.gcClientDBs()
 
 	// initialize the secret salt
-	secretSaltPath := filepath.Join(srv.rootDir, "secret-salt")
-	srv.secretSalt, err = os.ReadFile(secretSaltPath)
-	if err != nil || len(srv.secretSalt) != 32 {
-		if err != nil && !os.IsNotExist(err) {
-			slog.Warn("failed to read secret salt", "error", err)
-		}
-		srv.secretSalt = make([]byte, 32)
-		_, err = rand.Read(srv.secretSalt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read secret salt rand bytes: %w", err)
-		}
-		err = os.WriteFile(secretSaltPath, srv.secretSalt, 0600)
-		if err != nil {
-			slog.Warn("failed to write secret salt", "error", err, "path", secretSaltPath)
-		}
+	srv.secretSalt, err = loadSecretSalt(srv.rootDir)
+	if err != nil {
+		return nil, err
 	}
 
 	return srv, nil
+}
+
+func loadSecretSalt(rootDir string) ([]byte, error) {
+	if encodedSalt, ok := os.LookupEnv(secretSaltEnvName); ok {
+		encoding := base64.StdEncoding.Strict()
+		secretSalt, err := encoding.DecodeString(encodedSalt)
+		if err != nil {
+			return nil, fmt.Errorf("decode %s: %w", secretSaltEnvName, err)
+		}
+		if len(secretSalt) != secretSaltSize {
+			return nil, fmt.Errorf("%s must decode to exactly %d bytes, got %d", secretSaltEnvName, secretSaltSize, len(secretSalt))
+		}
+		if encoding.EncodeToString(secretSalt) != encodedSalt {
+			return nil, fmt.Errorf("%s must use canonical base64 encoding", secretSaltEnvName)
+		}
+		return secretSalt, nil
+	}
+
+	secretSaltPath := filepath.Join(rootDir, "secret-salt")
+	secretSalt, err := os.ReadFile(secretSaltPath)
+	if err == nil && len(secretSalt) == secretSaltSize {
+		return secretSalt, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to read secret salt", "error", err)
+	}
+
+	secretSalt = make([]byte, secretSaltSize)
+	if _, err := rand.Read(secretSalt); err != nil {
+		return nil, fmt.Errorf("failed to read secret salt rand bytes: %w", err)
+	}
+	if err := os.WriteFile(secretSaltPath, secretSalt, 0600); err != nil {
+		slog.Warn("failed to write secret salt", "error", err, "path", secretSaltPath)
+	}
+	return secretSalt, nil
 }
 
 func (srv *Server) configureLocalCacheGC(gcConfig config.GCConfig, workerGCConfig bkconfig.GCConfig) error {


### PR DESCRIPTION
Remote-cache engines need to use the same secret salt for cache keys involving secrets to match across engines. This change lets operators supply that shared salt through `DAGGER_SECRET_SALT`, which unblocks multi-engine remote-cache testing and may also be a reasonable long-term configuration mechanism.

`DAGGER_SECRET_SALT` must contain canonical, standard padded Base64 that decodes to exactly 32 bytes. When present and valid, it takes precedence and the existing salt file is neither read nor written. A present empty, invalid, non-canonical, or wrong-length value fails engine startup. When the variable is absent, the existing salt-file read and generation behavior is unchanged.

Coverage and validation:

- focused secret-salt test: 7 passed
- full `./engine/server` package: 186 passed
- `dagger check golang:lint-all`
- `dagger check engine-dev:generate`
- `gofmt` and `git diff --check`
