### PR TITLE
docs: correct cache identity references

### DIFF
--- a/internal-docs/cachebasics.md
+++ b/internal-docs/cachebasics.md
@@ -323,9 +323,12 @@ Two calls can be deduped while they are actively running only if they share:
 - the same call identity
 - the same `ConcurrencyKey`
 
-In normal dagql field execution, the default concurrency key is the client ID.
+In normal dagql field execution, the default concurrency key is the session ID
+from the current client metadata.
 
-That is a deliberate tradeoff. Dedupe across clients is possible in principle, but it complicates cancellation/disconnect handling a lot. So today, in-flight singleflight mostly stays within a client.
+That lets equivalent in-flight calls from different clients in the same session
+be deduped together. Calls from different sessions have different default
+concurrency keys.
 
 ## The short mental model
 

--- a/internal-docs/egraph.md
+++ b/internal-docs/egraph.md
@@ -236,13 +236,12 @@ That behavior lives mainly in:
 
 ## How Call Identity Feeds The E-Graph
 
-The e-graph consumes structural identity produced upstream by `ResultCall` /
-`call.ID`.
+The e-graph consumes structural identity produced upstream by `ResultCall`.
 
-The key functions are in `dagql/call/id.go`:
+The relevant derivations are in `dagql/result_call_frame.go`:
 
-- `SelfDigestAndInputRefs`
-- `SelfDigestAndInputs`
+- `ResultCall.SelfDigestAndInputRefs` derives structural identity.
+- `ResultCall.ContentPreferredDigest` derives content-preferred identity.
 
 The shape is:
 
@@ -255,9 +254,10 @@ That distinction is why structural equivalence works: the cache can say
 "same operation over equivalent inputs" without flattening the whole call into
 one undifferentiated digest.
 
-Content-preferred digest is related but separate. In `dagql/call/id_content.go`,
-it expresses "if outputs are interchangeable by content, what digest should we
-prefer?" It is used as equivalence evidence, not as the authoritative recipe.
+Content-preferred identity is related but separate. If a `ResultCall` has an
+explicit content digest, `ContentPreferredDigest` returns it; otherwise, it
+hashes the call shape while recursively preferring content identity for
+referenced results. It does not replace the authoritative recipe digest.
 
 ## Main Entry Points Into The E-Graph
 
@@ -748,7 +748,7 @@ well:
    - `importPersistedState`
    - `ensurePersistedHitValueLoaded`
 
-4. `dagql/call/id.go` and `dagql/call/id_content.go`
+4. `dagql/result_call_frame.go`
    - structural identity
    - content-preferred digest
 


### PR DESCRIPTION
## Summary

- document that normal DagQL field execution uses the session ID from current client metadata as its default concurrency key
- point e-graph structural and content-preferred identity documentation to the current `ResultCall` implementation in `dagql/result_call_frame.go`

## Why

The cache basics guide still described the old client-ID concurrency boundary, even though current code deduplicates equivalent in-flight calls across clients in the same session. The e-graph guide also referenced the removed `dagql/call/id_content.go` implementation and stale `call.ID` derivation symbols.

## Impact

Documentation now matches the current cache identity implementation. There are no production-code or runtime behavior changes.

## Validation

- `markdownlint-cli@0.48.0` with the repository `.markdownlint.yaml` configuration on both changed files
- `git diff --check`
- verified the referenced current source paths and `ResultCall` symbols
