### PR TITLE
workspace: allow volume settings

### DIFF
--- a/core/schema/workspace_settings_hints.go
+++ b/core/schema/workspace_settings_hints.go
@@ -115,6 +115,7 @@ func constructorHintsFromModule(mod *core.Module) []constructorArgHint {
 
 var addressSupportedObjectSettingExamples = map[string]string{ //nolint:gosec
 	"Container":     `"alpine:latest"`,
+	"Volume":        `"engine-volume://data"`,
 	"Directory":     `"./path"`,
 	"File":          `"./file"`,
 	"Secret":        `"env://MY_SECRET"`,

--- a/core/schema/workspace_settings_hints_test.go
+++ b/core/schema/workspace_settings_hints_test.go
@@ -19,6 +19,7 @@ func TestWorkspaceSettingHintTypeInfo(t *testing.T) {
 		name         string
 		typeDef      *core.TypeDef
 		configurable bool
+		exampleValue string
 	}{
 		{
 			name:         "primitive",
@@ -29,6 +30,12 @@ func TestWorkspaceSettingHintTypeInfo(t *testing.T) {
 			name:         "address backed object",
 			typeDef:      objectTypeDef(t, dag, "Secret"),
 			configurable: true,
+		},
+		{
+			name:         "volume",
+			typeDef:      objectTypeDef(t, dag, "Volume"),
+			configurable: true,
+			exampleValue: `"engine-volume://data"`,
 		},
 		{
 			name:         "workspace object",
@@ -56,8 +63,11 @@ func TestWorkspaceSettingHintTypeInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, _, configurable := typeInfoFromTypeDef(tt.typeDef)
+			_, exampleValue, configurable := typeInfoFromTypeDef(tt.typeDef)
 			require.Equal(t, tt.configurable, configurable)
+			if tt.exampleValue != "" {
+				require.Equal(t, tt.exampleValue, exampleValue)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Treat Volume constructor arguments as address-backed workspace settings and show an engine-volume address as their configuration example. Cover the allowlist entry so future changes keep Volume discoverable.