### PR TITLE
dagql: persist only complete cache results

### DIFF
--- a/.changes/unreleased/Fixed-20260820-041856.yaml
+++ b/.changes/unreleased/Fixed-20260820-041856.yaml
@@ -1,0 +1,10 @@
+kind: Fixed
+body: |
+  Persistable cache results that fail dependency attachment no longer remain
+  retained as permanent lookup errors or get restored as healthy after an
+  engine restart. Persisted cache snapshots now contain only complete result
+  dependency closures.
+time: 2026-08-20T04:18:56Z
+custom:
+  Author: sipsma
+  PR: 13935

--- a/.dagger/modules/tla-check/main.go
+++ b/.dagger/modules/tla-check/main.go
@@ -44,13 +44,14 @@ var expectedOutcome = map[string]string{
 	"drain_orphan":     "",
 	"rollback":         "",
 	"rollback_decode":  "",
+	"lost_cancel":      "",
+	"poisoned":         "",
+	"poisoned_restart": "",
+	"flush_closure":    "",
 	// red: reproductions of known deficiencies in the current code; each
 	// config's comment describes the scenario and the mechanism
-	"lost_cancel":       "NoLostCancels",
 	"release_inflight":  "ReturnedLive",
 	"drain_escape":      "ReturnedLive",
-	"poisoned":          "NoRetainedPoisonedEntry",
-	"poisoned_restart":  "NoLaunderedServe",
 	"lazy_stale_cancel": "NoStaleCancelError",
 	"flush_inflight":    "FlushCleanCapture",
 	"flush_drained":     "FlushCleanCapture",

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -894,8 +894,14 @@ func (c *Cache) snapshotSessionResultIDsCancelable(checker *pruneCancellationChe
 	return roots, nil
 }
 
+// upsertPersistedEdgeLocked requires egraphMu for writing.
 func (c *Cache) upsertPersistedEdgeLocked(ctx context.Context, res *sharedResult, expiresAtUnix int64, unpruneable bool) {
 	if c == nil || res == nil || res.id == 0 {
+		return
+	}
+	// Collection can legitimately win a race with deferred callers, so a stale
+	// upsert is a no-op rather than an error.
+	if c.resultsByID[res.id] != res {
 		return
 	}
 	if c.persistedEdgesByResult == nil {
@@ -936,6 +942,10 @@ func (c *Cache) MakeResultUnpruneable(ctx context.Context, res AnyResult) error 
 	}
 
 	c.egraphMu.Lock()
+	if c.resultsByID[shared.id] != shared {
+		c.egraphMu.Unlock()
+		return fmt.Errorf("make result unpruneable: result %d was already collected", shared.id)
+	}
 	c.upsertPersistedEdgeLocked(ctx, shared, 0, true)
 	c.egraphMu.Unlock()
 	return nil
@@ -1631,6 +1641,35 @@ type sharedResult struct {
 	lazyEvalSpanCtx trace.SpanContext
 }
 
+type resultAttachmentState uint8
+
+const (
+	resultAttachmentClean resultAttachmentState = iota
+	resultAttachmentOpen
+	resultAttachmentFailed
+)
+
+func (res *sharedResult) attachmentState() resultAttachmentState {
+	if res == nil {
+		return resultAttachmentFailed
+	}
+
+	res.attachDepsMu.Lock()
+	defer res.attachDepsMu.Unlock()
+	if res.attachDepsWaitCh == nil {
+		return resultAttachmentClean
+	}
+	select {
+	case <-res.attachDepsWaitCh:
+		if res.attachDepsErr != nil {
+			return resultAttachmentFailed
+		}
+		return resultAttachmentClean
+	default:
+		return resultAttachmentOpen
+	}
+}
+
 type sharedResultPayloadState struct {
 	self               Typed
 	isObject           bool
@@ -1881,14 +1920,12 @@ func wrapSharedResultWithResolver(ctx context.Context, res *sharedResult, hitCac
 type ongoingCall struct {
 	callConcurrencyKeys callConcurrencyKeys
 	// isPersistable is monotonic persistence intent aggregated from every
-	// request admitted to this call. Late joiners update it under callsMu while
-	// publication reads it under egraphMu, so all accesses must be atomic.
+	// request admitted to this call. The call-state path uses callsMu, while
+	// debug snapshots can read independently, so all accesses remain atomic.
 	isPersistable atomic.Bool
-	// persistedDuringPublication records whether the publication-time intent
-	// snapshot installed the persisted edge. If a late joiner arrives after
-	// that snapshot, needsPersistRepair is set when callsMu closes admission.
-	persistedDuringPublication bool
-	needsPersistRepair         bool
+	// needsPersistedEdge records that successful publication must commit the
+	// aggregate persistence intent before dropping its handoff ownership.
+	needsPersistedEdge         bool
 	persistedEdgeExpiresAtUnix int64
 	ttlSeconds                 int64
 	initCompletedResultOnce    sync.Once
@@ -1970,10 +2007,16 @@ func (c *Cache) canonicalEquivalentSharedResultLocked(sessionID string, res *sha
 	}
 
 	if candidates.Empty() {
+		if res.attachmentState() == resultAttachmentFailed {
+			return nil
+		}
 		return res
 	}
 	if canonical := c.selectLookupCandidateForSessionLocked(sessionID, candidates); canonical != nil {
 		return canonical
+	}
+	if res.attachmentState() == resultAttachmentFailed {
+		return nil
 	}
 	return res
 }
@@ -3960,6 +4003,7 @@ func (c *Cache) getOrInitCallInner(
 	sharedWorkCtx, releaseSharedWorkLease, err := withOperationLease(withoutOperationLease(callCtx))
 	if err != nil {
 		c.callsMu.Unlock()
+		cancel(err)
 		execOp.End(wcprof.OutcomeError)
 		if execSpan != nil {
 			execSpan.End()
@@ -4237,9 +4281,8 @@ func (c *Cache) wait(
 		}
 		EndProfSpan(pubSpan, &oc.initCompletedResultErr)
 		c.callsMu.Lock()
-		oc.needsPersistRepair = oc.initCompletedResultErr == nil &&
+		oc.needsPersistedEdge = oc.initCompletedResultErr == nil &&
 			oc.res != nil &&
-			!oc.persistedDuringPublication &&
 			oc.isPersistable.Load()
 		delete(c.ongoingCalls, oc.callConcurrencyKeys)
 		c.callsMu.Unlock()
@@ -4287,7 +4330,7 @@ func (c *Cache) wait(
 	var handoffErr error
 	if lastWaiter && oc.handoffHoldActive {
 		// The final waiter always completes the centralized handoff so late
-		// persistence intent is repaired before its temporary ownership drops.
+		// persistence intent is committed before its temporary ownership drops.
 		handoffErr = c.releaseOngoingCallHandoff(ctx, oc)
 	}
 	if claimErr != nil {
@@ -4305,17 +4348,16 @@ func (c *Cache) wait(
 }
 
 // releaseOngoingCallHandoff releases the temporary ownership that protects a
-// published result until every admitted waiter has finished. If persistence
-// intent arrived after publication's initial snapshot, repair the missed edge
-// inside this already-required egraph critical section before dropping the
-// handoff ownership.
+// published result until every admitted waiter has finished. Successful
+// publication commits aggregate persistence intent inside the same egraph
+// critical section before dropping the handoff ownership.
 func (c *Cache) releaseOngoingCallHandoff(ctx context.Context, oc *ongoingCall) error {
 	if c == nil || oc == nil || oc.res == nil || !oc.handoffHoldActive {
 		return nil
 	}
 
 	c.egraphMu.Lock()
-	if oc.needsPersistRepair {
+	if oc.needsPersistedEdge {
 		c.upsertPersistedEdgeLocked(ctx, oc.res, oc.persistedEdgeExpiresAtUnix, false)
 	}
 	queue, decErr := c.decrementIncomingOwnershipLocked(ctx, oc.res, nil)
@@ -4358,6 +4400,10 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 		if existingRes := oc.val.cacheSharedResult(); existingRes != nil && existingRes.id != 0 {
 			c.egraphMu.Lock()
 			oc.res = c.canonicalEquivalentSharedResultLocked(sessionID, existingRes, time.Now().Unix())
+			if oc.res == nil {
+				c.egraphMu.Unlock()
+				return fmt.Errorf("adopt cache-backed result %d: no clean canonical result", existingRes.id)
+			}
 			// Take the publication handoff hold inside the same critical
 			// section as the canonical pick: the adopted result may be owned
 			// only by another session, and a concurrent session release must
@@ -4639,10 +4685,6 @@ func (c *Cache) initCompletedResult(ctx context.Context, resolver TypeResolver, 
 	if err := c.recomputeRequiredSessionResourcesLocked(oc.res); err != nil {
 		c.egraphMu.Unlock()
 		return err
-	}
-	if oc.isPersistable.Load() {
-		c.upsertPersistedEdgeLocked(ctx, oc.res, oc.persistedEdgeExpiresAtUnix, false)
-		oc.persistedDuringPublication = true
 	}
 	// The cache-backed path already took the handoff hold when it adopted the
 	// canonical result above; only fresh results take it here.

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -608,6 +608,9 @@ func (c *Cache) appendDigestResultsLocked(candidates *set.TreeSet[*sharedResult]
 		if res == nil {
 			continue
 		}
+		if res.attachmentState() == resultAttachmentFailed {
+			continue
+		}
 		if c.resultExpiredAtLocked(res, nowUnix) {
 			if sawExpired != nil {
 				*sawExpired = true
@@ -627,6 +630,9 @@ func (c *Cache) appendTermSetResultsLocked(candidates *set.TreeSet[*sharedResult
 		for resID := range c.termResults[termID] {
 			res := c.resultsByID[resID]
 			if res == nil {
+				continue
+			}
+			if res.attachmentState() == resultAttachmentFailed {
 				continue
 			}
 			if c.resultExpiredAtLocked(res, nowUnix) {
@@ -879,12 +885,13 @@ func (c *Cache) lookupCacheForRequestLocked(
 	requestSelf digest.Digest,
 	requestInputs []digest.Digest,
 	requestInputRefs []ResultCallStructuralInputRef,
-) (AnyResult, bool, error) {
+) (AnyResult, bool, int64, error) {
 	if req == nil || req.ResultCall == nil {
-		return nil, false, nil
+		return nil, false, 0, nil
 	}
 	now := time.Now()
 	nowUnix := now.Unix()
+	persistedEdgeExpiresAtUnix := candidateSharedResultExpiryUnix(nowUnix, req.TTL)
 	match := c.lookupMatchForCallLocked(req.ResultCall, requestDigest, requestSelf, requestInputs, nowUnix)
 	c.traceLookupAttempt(ctx, requestDigest.String(), match.selfDigest.String(), match.inputDigests, req.IsPersistable)
 	hitRes := c.selectLookupCandidateForSessionLocked(sessionID, match.candidates)
@@ -909,7 +916,7 @@ func (c *Cache) lookupCacheForRequestLocked(
 
 	if hitRes == nil {
 		c.traceLookupMissNoMatch(ctx, requestDigest.String(), match.primaryLookupPossible, match.missingInputIndex, match.termDigest, match.termSetSize)
-		return nil, false, nil
+		return nil, false, 0, nil
 	}
 
 	// fast-path: if we got a very simple recipe-digest hit we can skip trying to teach the egraph anything new
@@ -920,7 +927,7 @@ func (c *Cache) lookupCacheForRequestLocked(
 			hitCache: true,
 		}
 		c.traceLookupHit(ctx, requestDigest.String(), hitRes, match.termDigest)
-		return retRes, true, nil
+		return retRes, true, 0, nil
 	}
 
 	// We have a cache hit. Teach this request identity onto the existing shared
@@ -930,21 +937,18 @@ func (c *Cache) lookupCacheForRequestLocked(
 	// conservative expiry merge policy here so TTL remains effective on hits.
 	res.expiresAtUnix = mergeSharedResultExpiryUnix(
 		res.expiresAtUnix,
-		candidateSharedResultExpiryUnix(nowUnix, req.TTL),
+		persistedEdgeExpiresAtUnix,
 	)
 	touchSharedResultLastUsed(res, now.UnixNano())
-	if req.IsPersistable {
-		c.upsertPersistedEdgeLocked(ctx, res, candidateSharedResultExpiryUnix(nowUnix, req.TTL), false)
-	}
 	if err := c.teachResultIdentityLocked(ctx, res, req.ResultCall, requestDigest, requestSelf, requestInputs, requestInputRefs); err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
 	retRes := Result[Typed]{
 		shared:   res,
 		hitCache: true,
 	}
 	c.traceLookupHit(ctx, requestDigest.String(), res, match.termDigest)
-	return retRes, true, nil
+	return retRes, true, persistedEdgeExpiresAtUnix, nil
 }
 
 func (c *Cache) lookupCacheForRequest(
@@ -968,7 +972,7 @@ func (c *Cache) lookupCacheForRequest(
 	}
 
 	c.egraphMu.Lock()
-	retRes, hit, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs)
+	retRes, hit, persistedEdgeExpiresAtUnix, err := c.lookupCacheForRequestLocked(ctx, sessionID, req, requestDigest, requestSelf, requestInputs, requestInputRefs)
 	if err != nil || !hit {
 		c.egraphMu.Unlock()
 		return retRes, hit, err
@@ -989,6 +993,14 @@ func (c *Cache) lookupCacheForRequest(
 	loadedHit, err := c.ensurePersistedHitValueLoaded(ctx, resolver, retRes)
 	if err != nil {
 		return nil, false, err
+	}
+	if req.IsPersistable {
+		// Only persistable hits pay this second graph-lock acquisition. Keep
+		// the expiry captured at hit selection even if the barrier wait took
+		// long enough to cross a wall-clock second.
+		c.egraphMu.Lock()
+		c.upsertPersistedEdgeLocked(ctx, hitShared, persistedEdgeExpiresAtUnix, false)
+		c.egraphMu.Unlock()
 	}
 
 	if c.traceEnabled() {

--- a/dagql/cache_persistence_worker.go
+++ b/dagql/cache_persistence_worker.go
@@ -28,6 +28,7 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 	var snapshot persistStateSnapshot
 
 	c.egraphMu.RLock()
+	selectedResultIDs, persistedRootIDs := c.snapshotPersistedRootClosureLocked()
 
 	addEqClassID := func(eqClassIDs map[eqClassID]struct{}, eqID eqClassID) {
 		eqID = c.findEqClassLocked(eqID)
@@ -38,54 +39,10 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 	}
 
 	eqClassIDs := make(map[eqClassID]struct{})
+	retainedOutputEqClassIDs := make(map[eqClassID]struct{})
 
-	for eqID := range c.eqClassToDigests {
-		addEqClassID(eqClassIDs, eqID)
-	}
-	for eqID := range c.eqClassExtraDigests {
-		addEqClassID(eqClassIDs, eqID)
-	}
-
-	termIDs := make([]egraphTermID, 0, len(c.egraphTerms))
-	for termID := range c.egraphTerms {
-		termIDs = append(termIDs, termID)
-	}
-	slices.Sort(termIDs)
-	for _, termID := range termIDs {
-		term := c.egraphTerms[termID]
-		if term == nil {
-			continue
-		}
-		outputEqID := c.findEqClassLocked(term.outputEqID)
-		addEqClassID(eqClassIDs, outputEqID)
-		inputProvenance := c.termInputProvenance[termID]
-		if len(inputProvenance) != len(term.inputEqIDs) {
-			c.egraphMu.RUnlock()
-			return persistStateSnapshot{}, fmt.Errorf("persist term %d: input provenance len %d does not match input eq IDs len %d", termID, len(inputProvenance), len(term.inputEqIDs))
-		}
-		inputEqIDs := make([]eqClassID, len(term.inputEqIDs))
-		copy(inputEqIDs, term.inputEqIDs)
-		for i, inputEqID := range inputEqIDs {
-			inputEqID = c.findEqClassLocked(inputEqID)
-			inputEqIDs[i] = inputEqID
-			addEqClassID(eqClassIDs, inputEqID)
-			snapshot.termInputs = append(snapshot.termInputs, persistdb.MirrorTermInput{
-				TermID:         int64(termID),
-				Position:       int64(i),
-				InputEqClassID: int64(inputEqID),
-				ProvenanceKind: string(inputProvenance[i]),
-			})
-		}
-		snapshot.terms = append(snapshot.terms, persistdb.MirrorTerm{
-			ID:              int64(termID),
-			SelfDigest:      term.selfDigest.String(),
-			TermDigest:      calcEgraphTermDigest(term.selfDigest, inputEqIDs),
-			OutputEqClassID: int64(outputEqID),
-		})
-	}
-
-	resultIDs := make([]sharedResultID, 0, len(c.resultsByID))
-	for resultID := range c.resultsByID {
+	resultIDs := make([]sharedResultID, 0, len(selectedResultIDs))
+	for resultID := range selectedResultIDs {
 		resultIDs = append(resultIDs, resultID)
 	}
 	slices.Sort(resultIDs)
@@ -102,6 +59,10 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 		slices.Sort(depIDs)
 		resultDeps := make([]persistdb.MirrorResultDep, 0, len(depIDs))
 		for _, depID := range depIDs {
+			if _, selected := selectedResultIDs[depID]; !selected {
+				c.egraphMu.RUnlock()
+				return persistStateSnapshot{}, fmt.Errorf("persist result %d: dependency %d is outside persisted root closure", resultID, depID)
+			}
 			resultDeps = append(resultDeps, persistdb.MirrorResultDep{
 				ParentResultID: int64(resultID),
 				DepResultID:    int64(depID),
@@ -111,6 +72,11 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 		outputEqClasses := c.outputEqClassesForResultLocked(resultID)
 		outputEqIDs := make([]eqClassID, 0, len(outputEqClasses))
 		for outputEqID := range outputEqClasses {
+			outputEqID = c.findEqClassLocked(outputEqID)
+			if outputEqID == 0 {
+				continue
+			}
+			retainedOutputEqClassIDs[outputEqID] = struct{}{}
 			addEqClassID(eqClassIDs, outputEqID)
 			outputEqIDs = append(outputEqIDs, outputEqID)
 		}
@@ -144,8 +110,49 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 		})
 	}
 
-	persistedResultIDs := make([]sharedResultID, 0, len(c.persistedEdgesByResult))
-	for resultID := range c.persistedEdgesByResult {
+	termIDs := make([]egraphTermID, 0, len(c.egraphTerms))
+	for termID := range c.egraphTerms {
+		termIDs = append(termIDs, termID)
+	}
+	slices.Sort(termIDs)
+	for _, termID := range termIDs {
+		term := c.egraphTerms[termID]
+		if term == nil {
+			continue
+		}
+		outputEqID := c.findEqClassLocked(term.outputEqID)
+		if _, retained := retainedOutputEqClassIDs[outputEqID]; !retained {
+			continue
+		}
+		addEqClassID(eqClassIDs, outputEqID)
+		inputProvenance := c.termInputProvenance[termID]
+		if len(inputProvenance) != len(term.inputEqIDs) {
+			c.egraphMu.RUnlock()
+			return persistStateSnapshot{}, fmt.Errorf("persist term %d: input provenance len %d does not match input eq IDs len %d", termID, len(inputProvenance), len(term.inputEqIDs))
+		}
+		inputEqIDs := make([]eqClassID, len(term.inputEqIDs))
+		copy(inputEqIDs, term.inputEqIDs)
+		for i, inputEqID := range inputEqIDs {
+			inputEqID = c.findEqClassLocked(inputEqID)
+			inputEqIDs[i] = inputEqID
+			addEqClassID(eqClassIDs, inputEqID)
+			snapshot.termInputs = append(snapshot.termInputs, persistdb.MirrorTermInput{
+				TermID:         int64(termID),
+				Position:       int64(i),
+				InputEqClassID: int64(inputEqID),
+				ProvenanceKind: string(inputProvenance[i]),
+			})
+		}
+		snapshot.terms = append(snapshot.terms, persistdb.MirrorTerm{
+			ID:              int64(termID),
+			SelfDigest:      term.selfDigest.String(),
+			TermDigest:      calcEgraphTermDigest(term.selfDigest, inputEqIDs),
+			OutputEqClassID: int64(outputEqID),
+		})
+	}
+
+	persistedResultIDs := make([]sharedResultID, 0, len(persistedRootIDs))
+	for resultID := range persistedRootIDs {
 		persistedResultIDs = append(persistedResultIDs, resultID)
 	}
 	slices.Sort(persistedResultIDs)
@@ -245,6 +252,12 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 		case err != nil:
 			return persistStateSnapshot{}, fmt.Errorf("persist result %d envelope: %w", resultSnapshot.resultID, err)
 		}
+		if err := validatePersistedResultCallReferences(resultSnapshot.frame, selectedResultIDs); err != nil {
+			return persistStateSnapshot{}, fmt.Errorf("persist result %d call frame: %w", resultSnapshot.resultID, err)
+		}
+		if err := validatePersistedEnvelopeReferences(encoding.Envelope, selectedResultIDs); err != nil {
+			return persistStateSnapshot{}, fmt.Errorf("persist result %d payload: %w", resultSnapshot.resultID, err)
+		}
 
 		payload, err := json.Marshal(encoding.Envelope)
 		if err != nil {
@@ -261,6 +274,165 @@ func (c *Cache) snapshotPersistState(ctx context.Context) (persistStateSnapshot,
 		resultSnapshot.resultSnapshotLinks = resultSnapshotLinkRows(resultSnapshot.resultID, encoding.SnapshotLinks)
 	}
 	return snapshot, nil
+}
+
+// snapshotPersistedRootClosureLocked returns every clean result reachable from
+// a persisted root whose full dependency closure is clean and registered. It
+// requires egraphMu for reading.
+func (c *Cache) snapshotPersistedRootClosureLocked() (map[sharedResultID]struct{}, map[sharedResultID]struct{}) {
+	invalid := make(map[sharedResultID]struct{})
+	parentsByDependency := make(map[sharedResultID][]sharedResultID)
+	invalidQueue := make([]sharedResultID, 0)
+	markInvalid := func(resultID sharedResultID) {
+		if _, found := invalid[resultID]; found {
+			return
+		}
+		invalid[resultID] = struct{}{}
+		invalidQueue = append(invalidQueue, resultID)
+	}
+
+	for resultID, res := range c.resultsByID {
+		if res == nil {
+			continue
+		}
+		if res.attachmentState() != resultAttachmentClean {
+			markInvalid(resultID)
+		}
+		for depID := range res.deps {
+			parentsByDependency[depID] = append(parentsByDependency[depID], resultID)
+			if c.resultsByID[depID] == nil {
+				markInvalid(resultID)
+			}
+		}
+	}
+	for len(invalidQueue) > 0 {
+		resultID := invalidQueue[len(invalidQueue)-1]
+		invalidQueue = invalidQueue[:len(invalidQueue)-1]
+		for _, parentID := range parentsByDependency[resultID] {
+			markInvalid(parentID)
+		}
+	}
+
+	persistedRoots := make(map[sharedResultID]struct{}, len(c.persistedEdgesByResult))
+	stack := make([]sharedResultID, 0, len(c.persistedEdgesByResult))
+	for resultID := range c.persistedEdgesByResult {
+		if c.resultsByID[resultID] == nil {
+			continue
+		}
+		if _, rejected := invalid[resultID]; rejected {
+			continue
+		}
+		persistedRoots[resultID] = struct{}{}
+		stack = append(stack, resultID)
+	}
+
+	selected := make(map[sharedResultID]struct{})
+	for len(stack) > 0 {
+		resultID := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, found := selected[resultID]; found {
+			continue
+		}
+		res := c.resultsByID[resultID]
+		if res == nil {
+			continue
+		}
+		if _, rejected := invalid[resultID]; rejected {
+			continue
+		}
+		selected[resultID] = struct{}{}
+		for depID := range res.deps {
+			stack = append(stack, depID)
+		}
+	}
+	return selected, persistedRoots
+}
+
+func validatePersistedResultCallReferences(frame *ResultCall, selected map[sharedResultID]struct{}) error {
+	seen := make(map[*ResultCall]struct{})
+	var walkFrame func(*ResultCall) error
+	var walkRef func(*ResultCallRef) error
+	var walkLiteral func(*ResultCallLiteral) error
+
+	walkRef = func(ref *ResultCallRef) error {
+		if ref == nil {
+			return nil
+		}
+		if ref.ResultID != 0 {
+			if _, found := selected[sharedResultID(ref.ResultID)]; !found {
+				return fmt.Errorf("references result %d outside persisted root closure", ref.ResultID)
+			}
+		}
+		return walkFrame(ref.Call)
+	}
+	walkLiteral = func(lit *ResultCallLiteral) error {
+		if lit == nil {
+			return nil
+		}
+		if err := walkRef(lit.ResultRef); err != nil {
+			return err
+		}
+		for _, item := range lit.ListItems {
+			if err := walkLiteral(item); err != nil {
+				return err
+			}
+		}
+		for _, field := range lit.ObjectFields {
+			if field != nil {
+				if err := walkLiteral(field.Value); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	walkFrame = func(current *ResultCall) error {
+		if current == nil {
+			return nil
+		}
+		if _, found := seen[current]; found {
+			return nil
+		}
+		seen[current] = struct{}{}
+		if err := walkRef(current.Receiver); err != nil {
+			return err
+		}
+		if current.Module != nil {
+			if err := walkRef(current.Module.ResultRef); err != nil {
+				return err
+			}
+		}
+		for _, arg := range current.Args {
+			if arg != nil {
+				if err := walkLiteral(arg.Value); err != nil {
+					return err
+				}
+			}
+		}
+		for _, arg := range current.ImplicitInputs {
+			if arg != nil {
+				if err := walkLiteral(arg.Value); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return walkFrame(frame)
+}
+
+func validatePersistedEnvelopeReferences(env PersistedResultEnvelope, selected map[sharedResultID]struct{}) error {
+	if env.ResultID != 0 {
+		if _, found := selected[sharedResultID(env.ResultID)]; !found {
+			return fmt.Errorf("references result %d outside persisted root closure", env.ResultID)
+		}
+	}
+	for _, item := range env.Items {
+		if err := validatePersistedEnvelopeReferences(item, selected); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 //nolint:gocyclo // intrinsically long state machine; refactoring would hurt clarity

--- a/dagql/cache_persistence_worker_test.go
+++ b/dagql/cache_persistence_worker_test.go
@@ -193,7 +193,7 @@ func TestCachePersistenceWorkerMirrorsAuthoritativeEgraphState(t *testing.T) {
 	assert.Check(t, cmp.Equal(resultInputCount, 1))
 }
 
-func TestCachePersistenceSnapshotRemainsValidAfterLiveResultRemoval(t *testing.T) {
+func TestCachePersistenceSnapshotOmitsSessionOnlyResult(t *testing.T) {
 	t.Parallel()
 
 	ctx := cacheTestContext(t.Context())
@@ -215,9 +215,7 @@ func TestCachePersistenceSnapshotRemainsValidAfterLiveResultRemoval(t *testing.T
 
 	snapshot, err := c.snapshotPersistState(ctx)
 	assert.NilError(t, err)
-	assert.Equal(t, 1, len(snapshot.results))
-	assert.Assert(t, snapshot.results[0].row.ID != 0)
-	snapshotResultID := snapshot.results[0].row.ID
+	assert.Equal(t, 0, len(snapshot.results))
 
 	cacheTestReleaseSession(t, cacheIface, ctx)
 	assert.Equal(t, 0, c.Size())
@@ -226,10 +224,128 @@ func TestCachePersistenceSnapshotRemainsValidAfterLiveResultRemoval(t *testing.T
 
 	rows, err := c.pdb.ListMirrorResults(ctx)
 	assert.NilError(t, err)
-	assert.Equal(t, 1, len(rows))
-	assert.Equal(t, snapshotResultID, rows[0].ID)
+	assert.Equal(t, 0, len(rows))
+}
 
-	assert.Check(t, cmp.Contains(rows[0].CallFrameJSON, `"field":"persist-snapshot-self-contained"`))
+func TestCachePersistenceSnapshotKeepsOnlyCompletePersistedRootClosures(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+	cacheIface, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	c := cacheIface
+
+	create := func(field string, receiver *sharedResult, persistable bool, value int) AnyResult {
+		t.Helper()
+		frame := cacheTestIntCall(field)
+		if receiver != nil {
+			frame.Receiver = &ResultCallRef{ResultID: uint64(receiver.id)}
+		}
+		res, err := c.GetOrInitCall(ctx, "root-closure", noopTypeResolver{}, &CallRequest{
+			ResultCall:     frame,
+			ConcurrencyKey: field,
+			IsPersistable:  persistable,
+		}, func(context.Context) (AnyResult, error) {
+			return cacheTestIntResult(frame, value), nil
+		})
+		assert.NilError(t, err)
+		return res
+	}
+
+	keptDep := create("root-closure-kept-dep", nil, false, 1)
+	dirtyDep := create("root-closure-dirty-dep", nil, false, 2)
+	keptRoot := create("root-closure-kept-root", keptDep.cacheSharedResult(), true, 3)
+	droppedRoot := create("root-closure-dropped-root", dirtyDep.cacheSharedResult(), true, 4)
+	sessionOnly := create("root-closure-session-only", nil, false, 5)
+	assert.NilError(t, c.AddExplicitDependency(ctx, droppedRoot, keptDep, "shared-clean-dependency"))
+
+	dirtyShared := dirtyDep.cacheSharedResult()
+	dirtyShared.attachDepsMu.Lock()
+	dirtyShared.attachDepsWaitCh = make(chan struct{})
+	dirtyShared.attachDepsErr = context.Canceled
+	close(dirtyShared.attachDepsWaitCh)
+	dirtyShared.attachDepsMu.Unlock()
+
+	snapshot, err := c.snapshotPersistState(ctx)
+	assert.NilError(t, err)
+	selected := make(map[sharedResultID]struct{}, len(snapshot.results))
+	for _, result := range snapshot.results {
+		selected[result.resultID] = struct{}{}
+	}
+	_, keptDepSelected := selected[keptDep.cacheSharedResult().id]
+	_, keptRootSelected := selected[keptRoot.cacheSharedResult().id]
+	_, dirtyDepSelected := selected[dirtyDep.cacheSharedResult().id]
+	_, droppedRootSelected := selected[droppedRoot.cacheSharedResult().id]
+	_, sessionOnlySelected := selected[sessionOnly.cacheSharedResult().id]
+	assert.Assert(t, keptDepSelected)
+	assert.Assert(t, keptRootSelected)
+	assert.Assert(t, !dirtyDepSelected)
+	assert.Assert(t, !droppedRootSelected)
+	assert.Assert(t, !sessionOnlySelected)
+	assert.Equal(t, 1, len(snapshot.persistedEdges))
+	assert.Equal(t, int64(keptRoot.cacheSharedResult().id), snapshot.persistedEdges[0].ResultID)
+
+	assert.NilError(t, c.applyPersistStateSnapshot(ctx, snapshot))
+	rows, err := c.sqlDB.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	assert.NilError(t, err)
+	assert.Assert(t, !rows.Next(), "persisted mirror has a dangling foreign key")
+	assert.NilError(t, rows.Err())
+	assert.NilError(t, rows.Close())
+
+	for _, droppedID := range []sharedResultID{
+		dirtyDep.cacheSharedResult().id,
+		droppedRoot.cacheSharedResult().id,
+		sessionOnly.cacheSharedResult().id,
+	} {
+		for _, table := range []struct {
+			name   string
+			column string
+		}{
+			{name: "results", column: "id"},
+			{name: "persisted_edges", column: "result_id"},
+			{name: "result_output_eq_classes", column: "result_id"},
+			{name: "result_snapshot_links", column: "result_id"},
+			{name: "result_deps", column: "parent_result_id"},
+			{name: "result_deps", column: "dep_result_id"},
+		} {
+			var count int
+			err := c.sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table.name+` WHERE `+table.column+` = ?`, droppedID).Scan(&count)
+			assert.NilError(t, err)
+			assert.Equal(t, 0, count, table.name+"."+table.column)
+		}
+	}
+
+	for table, want := range map[string]int{
+		"eq_classes":               2,
+		"eq_class_digests":         2,
+		"terms":                    2,
+		"term_inputs":              1,
+		"results":                  2,
+		"persisted_edges":          1,
+		"result_output_eq_classes": 2,
+		"result_deps":              1,
+		"result_snapshot_links":    0,
+	} {
+		var count int
+		err := c.sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&count)
+		assert.NilError(t, err)
+		assert.Equal(t, want, count, table)
+	}
+
+	assert.NilError(t, c.Close(context.Background()))
+	restarted, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, restarted.Close(context.Background()))
+	}()
+	restarted.egraphMu.RLock()
+	assert.Equal(t, 2, len(restarted.resultsByID))
+	assert.Assert(t, restarted.resultsByID[keptRoot.cacheSharedResult().id] != nil)
+	assert.Assert(t, restarted.resultsByID[keptDep.cacheSharedResult().id] != nil)
+	assert.Assert(t, restarted.resultsByID[droppedRoot.cacheSharedResult().id] == nil)
+	assert.Assert(t, restarted.resultsByID[dirtyDep.cacheSharedResult().id] == nil)
+	assert.Assert(t, restarted.resultsByID[sessionOnly.cacheSharedResult().id] == nil)
+	restarted.egraphMu.RUnlock()
+	assertCacheOwnershipExact(t, restarted)
 }
 
 func TestCachePersistenceCleanShutdownToggleOnClose(t *testing.T) {

--- a/dagql/cache_publication_boundary_test.go
+++ b/dagql/cache_publication_boundary_test.go
@@ -1,0 +1,292 @@
+package dagql
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func waitForSessionResult(t *testing.T, c *Cache, sessionID string) *sharedResult {
+	t.Helper()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		c.egraphMu.RLock()
+		c.sessionMu.Lock()
+		var resultID sharedResultID
+		for id := range c.sessionResultIDsBySession[sessionID] {
+			resultID = id
+			break
+		}
+		c.sessionMu.Unlock()
+		res := c.resultsByID[resultID]
+		c.egraphMu.RUnlock()
+		if res != nil {
+			return res
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for session %q to claim a result", sessionID)
+		}
+	}
+}
+
+func TestCachePersistableAttachmentFailureDoesNotRetain(t *testing.T) {
+	c, err := NewCache(t.Context(), "", nil, nil)
+	assert.NilError(t, err)
+
+	call := cacheTestIntCall("persistable-attachment-failure")
+	attachErr := errors.New("attachment failed")
+	var initCalls atomic.Int32
+	_, err = c.GetOrInitCall(t.Context(), "failing-publication", noopTypeResolver{}, &CallRequest{
+		ResultCall:     call,
+		ConcurrencyKey: "failing-publication",
+		IsPersistable:  true,
+	}, func(context.Context) (AnyResult, error) {
+		initCalls.Add(1)
+		return cacheTestDetachedResult(call, cacheTestLeaseCheckedInt{
+			Int: NewInt(1),
+			onAttach: func(context.Context) error {
+				return attachErr
+			},
+		}), nil
+	})
+	assert.ErrorIs(t, err, attachErr)
+
+	c.egraphMu.RLock()
+	assert.Equal(t, 0, len(c.resultsByID))
+	assert.Equal(t, 0, len(c.persistedEdgesByResult))
+	c.egraphMu.RUnlock()
+
+	res, err := c.GetOrInitCall(t.Context(), "replacement", noopTypeResolver{}, &CallRequest{
+		ResultCall:     call,
+		ConcurrencyKey: "replacement",
+		IsPersistable:  true,
+	}, func(context.Context) (AnyResult, error) {
+		initCalls.Add(1)
+		return cacheTestIntResult(call, 2), nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !res.HitCache())
+	assert.Equal(t, int32(2), initCalls.Load())
+	c.egraphMu.RLock()
+	_, persisted := c.persistedEdgesByResult[res.cacheSharedResult().id]
+	c.egraphMu.RUnlock()
+	assert.Assert(t, persisted)
+}
+
+func TestCachePersistableHitWaitsForCleanAttachmentBeforePersisting(t *testing.T) {
+	c, err := NewCache(t.Context(), "", nil, nil)
+	assert.NilError(t, err)
+
+	call := cacheTestIntCall("persistable-hit-waits-for-attachment")
+	attachmentStarted := make(chan struct{})
+	allowAttachment := make(chan struct{})
+	leaderResCh := make(chan AnyResult, 1)
+	leaderErrCh := make(chan error, 1)
+	go func() {
+		res, err := c.GetOrInitCall(t.Context(), "leader", noopTypeResolver{}, &CallRequest{
+			ResultCall:     call,
+			ConcurrencyKey: "leader",
+		}, func(context.Context) (AnyResult, error) {
+			return cacheTestDetachedResult(call, cacheTestLeaseCheckedInt{
+				Int: NewInt(1),
+				onAttach: func(context.Context) error {
+					close(attachmentStarted)
+					<-allowAttachment
+					return nil
+				},
+			}), nil
+		})
+		leaderResCh <- res
+		leaderErrCh <- err
+	}()
+	<-attachmentStarted
+
+	hitResCh := make(chan AnyResult, 1)
+	hitErrCh := make(chan error, 1)
+	go func() {
+		res, err := c.GetOrInitCall(t.Context(), "persistable-hit", noopTypeResolver{}, &CallRequest{
+			ResultCall:     call,
+			ConcurrencyKey: "persistable-hit",
+			IsPersistable:  true,
+			TTL:            73,
+		}, func(context.Context) (AnyResult, error) {
+			return nil, errors.New("persistable hit unexpectedly executed")
+		})
+		hitResCh <- res
+		hitErrCh <- err
+	}()
+
+	shared := waitForSessionResult(t, c, "persistable-hit")
+	c.egraphMu.RLock()
+	hitTimeExpiry := shared.expiresAtUnix
+	_, persistedBeforeAttachment := c.persistedEdgesByResult[shared.id]
+	c.egraphMu.RUnlock()
+	assert.Assert(t, hitTimeExpiry != 0)
+	assert.Assert(t, !persistedBeforeAttachment)
+
+	close(allowAttachment)
+	leaderRes := <-leaderResCh
+	assert.NilError(t, <-leaderErrCh)
+	hitRes := <-hitResCh
+	assert.NilError(t, <-hitErrCh)
+	assert.Assert(t, !leaderRes.HitCache())
+	assert.Assert(t, hitRes.HitCache())
+
+	c.egraphMu.RLock()
+	edge, persistedAfterAttachment := c.persistedEdgesByResult[shared.id]
+	c.egraphMu.RUnlock()
+	assert.Assert(t, persistedAfterAttachment)
+	assert.Equal(t, hitTimeExpiry, edge.expiresAtUnix)
+}
+
+func TestCacheErroredAttachmentIsSkippedAndReexecuted(t *testing.T) {
+	c, err := NewCache(t.Context(), "", nil, nil)
+	assert.NilError(t, err)
+	srv := cacheTestServer(t)
+	call := cacheTestIntCall("errored-attachment-reexecute")
+	attachErr := errors.New("concurrent attachment failed")
+	attachmentStarted := make(chan struct{})
+	allowFailure := make(chan struct{})
+	var initCalls atomic.Int32
+
+	leaderErrCh := make(chan error, 1)
+	go func() {
+		_, err := c.GetOrInitCall(t.Context(), "leader", srv, &CallRequest{
+			ResultCall:     call,
+			ConcurrencyKey: "leader",
+		}, func(context.Context) (AnyResult, error) {
+			initCalls.Add(1)
+			return cacheTestDetachedResult(call, cacheTestLeaseCheckedInt{
+				Int: NewInt(1),
+				onAttach: func(context.Context) error {
+					close(attachmentStarted)
+					<-allowFailure
+					return attachErr
+				},
+			}), nil
+		})
+		leaderErrCh <- err
+	}()
+	<-attachmentStarted
+
+	hitErrCh := make(chan error, 1)
+	go func() {
+		_, err := c.GetOrInitCall(t.Context(), "persistable-hit", srv, &CallRequest{
+			ResultCall:     call,
+			ConcurrencyKey: "persistable-hit",
+			IsPersistable:  true,
+		}, func(context.Context) (AnyResult, error) {
+			return nil, errors.New("persistable hit unexpectedly executed")
+		})
+		hitErrCh <- err
+	}()
+
+	poisoned := waitForSessionResult(t, c, "persistable-hit")
+	c.egraphMu.RLock()
+	_, persistedBeforeFailure := c.persistedEdgesByResult[poisoned.id]
+	c.egraphMu.RUnlock()
+	assert.Assert(t, !persistedBeforeFailure)
+
+	close(allowFailure)
+	assert.ErrorIs(t, <-leaderErrCh, attachErr)
+	assert.ErrorContains(t, <-hitErrCh, attachErr.Error())
+	assert.Equal(t, resultAttachmentFailed, poisoned.attachmentState())
+
+	c.egraphMu.Lock()
+	assert.Assert(t, c.resultsByID[poisoned.id] == poisoned)
+	_, persistedAfterFailure := c.persistedEdgesByResult[poisoned.id]
+	canonical := c.canonicalEquivalentSharedResultLocked("canonical", poisoned, time.Now().Unix())
+	c.egraphMu.Unlock()
+	assert.Assert(t, !persistedAfterFailure)
+	assert.Assert(t, canonical == nil)
+
+	adopt := &ongoingCall{val: Result[Typed]{shared: poisoned}}
+	err = c.initCompletedResult(t.Context(), srv, adopt, &CallRequest{ResultCall: call}, "adopt")
+	assert.ErrorContains(t, err, "no clean canonical result")
+
+	replacement, err := c.GetOrInitCall(t.Context(), "replacement", srv, &CallRequest{
+		ResultCall:     call,
+		ConcurrencyKey: "replacement",
+	}, func(context.Context) (AnyResult, error) {
+		initCalls.Add(1)
+		return cacheTestIntResult(call, 2), nil
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !replacement.HitCache())
+	assert.Equal(t, int32(2), initCalls.Load())
+	assert.Assert(t, replacement.cacheSharedResult().id != poisoned.id)
+
+	resolvedID, err := c.resultIDForCall(call)
+	assert.NilError(t, err)
+	assert.Equal(t, replacement.cacheSharedResult().id, resolvedID)
+
+	digestHit, hit, err := c.lookupCacheForDigests(t.Context(), "digest", srv, cacheTestCallDigest(call), nil)
+	assert.NilError(t, err)
+	assert.Assert(t, hit)
+	assert.Equal(t, replacement.cacheSharedResult().id, digestHit.cacheSharedResult().id)
+
+	idHit, err := c.LoadResultByResultID(t.Context(), "id-load", srv, uint64(poisoned.id))
+	assert.NilError(t, err)
+	assert.Equal(t, replacement.cacheSharedResult().id, idHit.cacheSharedResult().id)
+
+	assert.NilError(t, c.ReleaseSession(t.Context(), "persistable-hit"))
+	c.egraphMu.RLock()
+	assert.Assert(t, c.resultsByID[poisoned.id] == nil)
+	c.egraphMu.RUnlock()
+	assert.NilError(t, c.ReleaseSession(t.Context(), "replacement"))
+	assert.NilError(t, c.ReleaseSession(t.Context(), "digest"))
+	assert.NilError(t, c.ReleaseSession(t.Context(), "id-load"))
+}
+
+func TestCachePersistedEdgeInstallRejectsCollectedResult(t *testing.T) {
+	c, err := NewCache(t.Context(), "", nil, nil)
+	assert.NilError(t, err)
+	call := cacheTestIntCall("collected-persisted-edge")
+	res, err := c.GetOrInitCall(t.Context(), "owner", noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(call, 1), nil
+	})
+	assert.NilError(t, err)
+	shared := res.cacheSharedResult()
+	assert.NilError(t, c.ReleaseSession(t.Context(), "owner"))
+
+	err = c.MakeResultUnpruneable(t.Context(), res)
+	assert.ErrorContains(t, err, "already collected")
+	c.egraphMu.RLock()
+	_, persisted := c.persistedEdgesByResult[shared.id]
+	c.egraphMu.RUnlock()
+	assert.Assert(t, !persisted)
+	assert.Equal(t, int64(0), shared.incomingOwnershipCount)
+}
+
+func TestCacheOperationLeaseFailureCancelsSharedContext(t *testing.T) {
+	c, err := NewCache(t.Context(), "", nil, nil)
+	assert.NilError(t, err)
+	leaseErr := errors.New("operation lease unavailable")
+	capturedCtx := make(chan context.Context, 1)
+	ctx := ContextWithOperationLeaseProvider(t.Context(), OperationLeaseProviderFunc(func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+		capturedCtx <- ctx
+		return nil, nil, leaseErr
+	}))
+	call := cacheTestIntCall("lease-failure-cancel")
+	_, err = c.GetOrInitCall(ctx, "lease-failure", noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(call, 1), nil
+	})
+	assert.ErrorIs(t, err, leaseErr)
+
+	sharedCtx := <-capturedCtx
+	select {
+	case <-sharedCtx.Done():
+		assert.ErrorIs(t, context.Cause(sharedCtx), leaseErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("shared call context was not canceled after operation-lease failure")
+	}
+}

--- a/dagql/cache_session_ownership_test.go
+++ b/dagql/cache_session_ownership_test.go
@@ -159,7 +159,7 @@ func TestCacheSessionResultClaimAndReleaseAreAtomic(t *testing.T) {
 	})
 }
 
-func TestCacheRefusedFinalWaiterRepairsPersistenceBeforeHandoffRelease(t *testing.T) {
+func TestCacheRefusedFinalWaiterCommitsPersistenceBeforeHandoffRelease(t *testing.T) {
 	c, err := NewCache(t.Context(), "", nil, nil)
 	assert.NilError(t, err)
 

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -5540,7 +5540,7 @@ func TestCachePersistableRetainedAcrossSessionClose(t *testing.T) {
 	assert.Equal(t, 1, base.Size())
 }
 
-func TestCacheLatePersistableJoinRepairsBeforeHandoffRelease(t *testing.T) {
+func TestCacheLatePersistableJoinCommitsBeforeHandoffRelease(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
 		lateWaiters         int
@@ -5573,13 +5573,13 @@ func TestCacheLatePersistableJoinRepairsBeforeHandoffRelease(t *testing.T) {
 				sessionID      = "late-persistable-session"
 				concurrencyKey = "late-persistable-concurrency"
 			)
-			key := cacheTestIntCall("late-persistable-repair")
+			key := cacheTestIntCall("late-persistable-commit")
 			callConcKeys := callConcurrencyKeys{
 				callKey:        cacheTestCallDigest(key).String(),
 				concurrencyKey: concurrencyKey,
 			}
 
-			publicationPassedPersistCheck := make(chan struct{})
+			publicationReachedAttachment := make(chan struct{})
 			allowPublicationToFinish := make(chan struct{})
 			leaderResCh := make(chan AnyResult, 1)
 			leaderErrCh := make(chan error, 1)
@@ -5592,7 +5592,7 @@ func TestCacheLatePersistableJoinRepairsBeforeHandoffRelease(t *testing.T) {
 					return cacheTestDetachedResult(key, cacheTestLeaseCheckedInt{
 						Int: NewInt(42),
 						onAttach: func(context.Context) error {
-							close(publicationPassedPersistCheck)
+							close(publicationReachedAttachment)
 							<-allowPublicationToFinish
 							return nil
 						},
@@ -5603,19 +5603,18 @@ func TestCacheLatePersistableJoinRepairsBeforeHandoffRelease(t *testing.T) {
 			}()
 
 			select {
-			case <-publicationPassedPersistCheck:
+			case <-publicationReachedAttachment:
 			case <-time.After(5 * time.Second):
-				t.Fatal("timed out waiting for publication to pass persistence check")
+				t.Fatal("timed out waiting for publication to reach dependency attachment")
 			}
 
 			// Simulate requests whose e-graph lookup missed before indexing but
-			// whose callsMu admission happens after publication read false. Keep
+			// whose callsMu admission happens while publication is attaching. Keep
 			// their waiter slots outstanding so the leader cannot release the
 			// publication handoff before the test selects the final waiter.
 			c.callsMu.Lock()
 			oc := c.ongoingCalls[callConcKeys]
 			assert.Assert(t, oc != nil)
-			assert.Assert(t, !oc.persistedDuringPublication)
 			oc.isPersistable.Store(true)
 			oc.waiters += tc.lateWaiters
 			expectedExpiry := time.Now().Unix() + 3600
@@ -5638,14 +5637,14 @@ func TestCacheLatePersistableJoinRepairsBeforeHandoffRelease(t *testing.T) {
 			assert.Equal(t, 42, unwrapValue(leaderRes))
 
 			c.callsMu.Lock()
-			assert.Assert(t, oc.needsPersistRepair)
+			assert.Assert(t, oc.needsPersistedEdge)
 			assert.Equal(t, tc.lateWaiters, oc.waiters)
 			_, ongoing := c.ongoingCalls[callConcKeys]
 			c.callsMu.Unlock()
 			assert.Assert(t, !ongoing)
 
 			if tc.canceledFinalWaiter {
-				// Leave only the handoff owner. If repair happened after the
+				// Leave only the handoff owner. If persistence happened after the
 				// decrement, this final cancellation would collect the result.
 				assert.NilError(t, c.ReleaseSession(ctx, sessionID))
 

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -128,10 +128,8 @@ CONSTANTS
     FnCanFail,          \* the executed fn may return an error
     AttachCanFail,      \* attachDependencyResults may fail
     LeaseCanFail,       \* withOperationLease may fail. Its error branch
-                        \* (cache.go:3917-3925) returns without calling the
-                        \* WithCancelCause cancel created at cache.go:3897 -
-                        \* a known leak in the current code, counted by
-                        \* NoLostCancels.
+                        \* discharges the local cancel and returns without
+                        \* publishing shared state.
     ReaderCanCancel,    \* a caller's context may cancel while it waits at
                         \* the read barrier (ensurePersistedHitValueLoaded's
                         \* ctx.Done arms, cache_persistence_import.go:562,
@@ -193,7 +191,6 @@ VARIABLES
                         \*   phase "released":   both sections ran
                         \* snap holds the record snapshot the decrement
                         \* section will consume.
-    lostCancels,        \* count of WithCancelCause cancels never discharged
     evals,              \* one record per issued Cache.Evaluate caller
                         \* (empty unless ModelLazy)
     epoch,              \* 1 before the modeled restart, 2 after. One
@@ -205,7 +202,7 @@ VARIABLES
                         \* e-graph detail this model abstracts away.
 
 vars == <<invocations, res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-          sessionRelease, lostCancels, evals, epoch, flushed>>
+          sessionRelease, evals, epoch, flushed>>
 
 
 \* The currently-allocated ID ranges (sequences are 1-indexed).
@@ -250,10 +247,15 @@ DerivedOwn(r) ==
     SessEdgeCount(r) + DepParentCount(r)
       + HoldCount(r) + PersistedCount(r)
 
-\* All registered results whose call is in equivalence class k - the
-\* candidates a lookup for class k could return.
+\* All registered results whose call is in equivalence class k.
 LiveInClass(k) ==
     {r \in ResultIds : res[r].registered /\ ClassOf[res[r].call] = k}
+
+\* Lookup and canonical selection exclude an entry after dependency
+\* attachment closes with an error. An open barrier remains eligible because
+\* a reader may wait for its eventual outcome.
+LookupEligibleInClass(k) ==
+    {r \in LiveInClass(k) : res[r].barrier # "closedErr"}
 
 \* "The caller got a result it can actually keep": the session's atomic edge
 \* claim is still counted when the result returns.
@@ -364,7 +366,6 @@ Init ==
     /\ sessionEdges = {}
     /\ countedEdges = {}
     /\ sessionRelease = [s \in Sessions |-> [phase |-> "live", snap |-> {}]]
-    /\ lostCancels = 0
     /\ evals = <<>>
     /\ epoch = 1
     /\ flushed = [done |-> FALSE, rows |-> <<>>]
@@ -393,6 +394,7 @@ NewInvocation(s, c, p, o) ==
      \* their real goroutines and the cache's in-memory tombstones do not, so this
      \* field ties a refusal to the epoch whose lifecycle state produced it.
      refusedEpoch |-> 0,
+     lookupBarrierAtSelection |-> "none",
      retLive |-> TRUE, retOwned |-> TRUE,
      retBarrierOK |-> TRUE, retClean |-> TRUE]
 
@@ -402,7 +404,7 @@ Spawn ==
         /\ DrainOnRelease => sessionRelease[s].phase = "live"
         /\ invocations' = Append(invocations, NewInvocation(s, c, p, "handler"))
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 SpawnNested ==
     /\ ModelNestedCalls
@@ -413,47 +415,43 @@ SpawnNested ==
              /\ ongoingCalls[o].fnState \in {"running", "canceled"}
         /\ invocations' = Append(invocations, NewInvocation(s, c, p, "nested"))
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
-(* LookupHit: the lookup finds a live equivalent result. The egraphMu      *)
-(* section selects the result and applies persistence intent, then nests   *)
+(* LookupHit: the lookup finds a live equivalent result whose attachment   *)
+(* has not failed. The egraphMu section selects the result, then nests      *)
 (* sessionMu to claim the session edge. A released-session tombstone       *)
-(* refuses the claim without adding an edge.                               *)
+(* refuses the claim without adding an edge. Persistable hits commit their *)
+(* edge only after the read barrier and payload load succeed.               *)
 (*                                                                         *)
 (* Go: lookupCacheForRequest, cache_egraph.go:950-1001. Inside the one     *)
 (* lock hold:                                                              *)
 (*   - a candidate in the request's equivalence class is selected          *)
 (*   - the session record and ownership unit are added together             *)
-(*   - a persistable request also upserts the persisted edge               *)
-(*     (lookupCacheForRequestLocked's IsPersistable arm)                   *)
 (* After the lock, an accepted hit passes the read barrier before return.  *)
 (***************************************************************************)
 LookupHit(i) ==
     /\ invocations[i].phase = "lookup"
-    /\ \E r \in LiveInClass(ClassOf[invocations[i].call]) :
+    /\ \E r \in LookupEligibleInClass(ClassOf[invocations[i].call]) :
         LET s == invocations[i].sess
             haveEdge == <<s, r>> \in sessionEdges
-            withPersist ==
-                IF invocations[i].persistable /\ ~res[r].persisted
-                THEN [res EXCEPT ![r].persisted = TRUE,
-                                      ![r].own = @ + 1]
-                ELSE res
         IN IF sessionRelease[s].phase = "live"
-           THEN /\ res' = IF haveEdge THEN withPersist
-                           ELSE [withPersist EXCEPT ![r].own = @ + 1]
+           THEN /\ res' = IF haveEdge THEN res
+                           ELSE [res EXCEPT ![r].own = @ + 1]
                 /\ sessionEdges' = sessionEdges \cup {<<s, r>>}
                 /\ countedEdges' = countedEdges \cup {<<s, r>>}
                 /\ invocations' = [invocations EXCEPT ![i].phase = "readBarrier",
                                         ![i].resId = r,
-                                        ![i].path = "hit"]
-           ELSE /\ res' = withPersist
+                                        ![i].path = "hit",
+                                        ![i].lookupBarrierAtSelection = res[r].barrier]
+           ELSE /\ UNCHANGED res
                 /\ invocations' = [invocations EXCEPT ![i].phase = "refused",
                                         ![i].resId = r,
                                         ![i].path = "hit",
+                                        ![i].lookupBarrierAtSelection = res[r].barrier,
                                         ![i].refusedEpoch = epoch]
                 /\ UNCHANGED <<sessionEdges, countedEdges>>
-    /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionRelease, lostCancels, evals, epoch, flushed>>
+    /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionRelease, evals, epoch, flushed>>
 
 \* LookupMiss: the lookup finds nothing usable; fall through to the
 \* singleflight. A miss is allowed even when a candidate exists - that
@@ -463,7 +461,7 @@ LookupMiss(i) ==
     /\ invocations[i].phase = "lookup"
     /\ invocations' = [invocations EXCEPT ![i].phase = "join"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* Join: an ongoing call for this (call, session) already exists - become  *)
@@ -473,12 +471,9 @@ LookupMiss(i) ==
 (* section: bump oc.waiters, and stamp the persistence intent (the         *)
 (* atomic.Bool oc.isPersistable) onto the shared ongoingCall.              *)
 (*                                                                         *)
-(* Publication reads the intent in its own egraphMu section               *)
-(* (cache.go:4617) while the entry is still in the index, so a joiner's    *)
-(* intent can land after that read. The code preserves such late intent:   *)
-(* the Once tail snapshots it when it closes admission (see               *)
-(* PubUnregister) and the final handoff release repairs the missed edge    *)
-(* (see RepairThenDropHold). The guarantee is that the edge exists by the  *)
+(* The Once tail snapshots aggregate intent when it closes admission (see  *)
+(* PubUnregister), and the final handoff release commits the edge (see      *)
+(* PersistThenDropHold). The guarantee is that the edge exists by the       *)
 (* FINAL handoff release - not by each persistable waiter's own return; a  *)
 (* non-final late joiner can return before the edge lands. That is what    *)
 (* PersistableIntentDurable checks.                                        *)
@@ -494,7 +489,7 @@ Join(i) ==
           /\ invocations' = [invocations EXCEPT ![i].phase = "waiting", ![i].oc = o,
                                   ![i].path = "wait"]
     /\ UNCHANGED <<res, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* CreateOc: no ongoing call exists - create one and start executing.      *)
@@ -516,31 +511,25 @@ CreateOc(i) ==
              waiters |-> 1, fnState |-> "running", fnErr |-> FALSE,
              outcome |-> "none", reuseFrom |-> 0,
              isPersistable |-> invocations[i].persistable,
-             \* late persistence-intent bookkeeping; see PubUnregister:
-             persistedDuringPub |-> FALSE, needsRepair |-> FALSE,
+             \* final-handoff persistence bookkeeping; see PubUnregister:
+             needsPersistedEdge |-> FALSE,
              pubState |-> "none", pubBy |-> 0, hold |-> FALSE, resId |-> 0,
              inIndex |-> TRUE])
        /\ ongoingCallIndex' = [ongoingCallIndex EXCEPT ![k] = Len(ongoingCalls) + 1]
        /\ invocations' = [invocations EXCEPT ![i].phase = "waiting", ![i].oc = Len(ongoingCalls) + 1,
                                ![i].path = "wait"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
-\* CreateOcLeaseFail: the operation lease cannot be acquired and the call
-\* fails before anything starts.
-\*
-\* Go: the withOperationLease error branch, cache.go:3917-3925. This
-\* branch returns without calling the WithCancelCause cancel created at
-\* cache.go:3897. The parent context is WithoutCancel, so nothing wedges -
-\* it is an undischarged cancel, not corruption. The NoLostCancels
-\* property counts it; the lost_cancel configuration reproduces it as an
-\* expected violation.
+\* CreateOcLeaseFail: the operation lease cannot be acquired. The call
+\* discharges its newly-created cancel and fails before publishing any
+\* ongoing call, result, or ownership edge.
 CreateOcLeaseFail(i) ==
     /\ LeaseCanFail
     /\ invocations[i].phase = "join"
     /\ ongoingCallIndex[<<invocations[i].call, invocations[i].sess>>] = 0
-    /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
-    /\ lostCancels' = lostCancels + 1
+    /\ invocations' = [invocations EXCEPT ![i].phase = "failed",
+                                           ![i].path = "leaseFailure"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
@@ -557,13 +546,13 @@ CreateOcLeaseFail(i) ==
 FnComplete(o) ==
     /\ ongoingCalls[o].fnState = "running"
     /\ \/ ongoingCalls' = [ongoingCalls EXCEPT ![o].fnState = "done", ![o].outcome = "fresh"]
-       \/ \E r \in LiveInClass(ClassOf[ongoingCalls[o].call]) :
+       \/ \E r \in LookupEligibleInClass(ClassOf[ongoingCalls[o].call]) :
             ongoingCalls' = [ongoingCalls EXCEPT ![o].fnState = "done",
                                ![o].outcome = "reuse", ![o].reuseFrom = r]
        \/ /\ FnCanFail
           /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].fnState = "done", ![o].fnErr = TRUE]
     /\ UNCHANGED <<invocations, res, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* WaiterCancel: a waiter's own context is canceled while the fn is still  *)
@@ -598,7 +587,7 @@ WaiterCancel(i) ==
                         ELSE ongoingCallIndex
           /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* FnWindDown: the cancel-requested executor finally exits. Until it does,
 \* its resolver can still issue nested cache calls (SpawnNested) - that
@@ -609,22 +598,19 @@ FnWindDown(o) ==
     /\ ongoingCalls[o].fnState = "canceled"
     /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].fnState = "exited"]
     /\ UNCHANGED <<invocations, res, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
-\* Release the publication handoff hold, first repairing a missed persisted
-\* edge if the admission-close snapshot flagged one. Mirrors
-\* releaseOngoingCallHandoff (cache.go:4289-4306): the repair runs inside
-\* the same egraphMu section that drops the hold. Like the Go upsert
-\* (upsertPersistedEdgeLocked, cache.go:866), the repair does NOT re-check
-\* registration - composed with a release during in-flight work it would
-\* put a persisted edge on an already-collected result, exactly as the
-\* code would.
-RepairThenDropHold(o) ==
+\* Commit aggregate persistence intent and release the publication handoff
+\* hold in one egraphMu critical section. The registration check prevents a
+\* stale result pointer from recreating an edge after collection.
+PersistThenDropHold(o) ==
     LET r == ongoingCalls[o].resId
-        repaired == IF ongoingCalls[o].needsRepair /\ ~res[r].persisted
+        persisted == IF ongoingCalls[o].needsPersistedEdge
+                           /\ res[r].registered
+                           /\ ~res[r].persisted
                     THEN [res EXCEPT ![r].persisted = TRUE, ![r].own = @ + 1]
                     ELSE res
-    IN DecAndCascade(repaired, r)
+    IN DecAndCascade(persisted, r)
 
 (***************************************************************************)
 (* WaiterCancelLate: the select takes ctx.Done even though waitCh is       *)
@@ -633,7 +619,7 @@ RepairThenDropHold(o) ==
 (* through the same !completed branch (cache.go:4164-4182): waiters--,     *)
 (* and the LAST departing waiter removes a still-indexed entry,            *)
 (* discharges the fn cancel, and then releases the handoff hold - with     *)
-(* the late-persist repair - in a separate egraphMu section (see           *)
+(* the final persistence commit - in a separate egraphMu section (see      *)
 (* WaiterDropHoldCanceled).                                                *)
 (*                                                                         *)
 (* Guard notes:                                                            *)
@@ -670,21 +656,20 @@ WaiterCancelLate(i) ==
                 IF last /\ postOnce /\ ongoingCalls[o].hold
                 THEN "cancelDropHold" ELSE "canceled"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* WaiterDropHoldCanceled: the canceled final waiter drops the handoff
-\* hold in its own egraphMu section (releaseOngoingCallHandoff,
-\* cache.go:4289-4306), repairing a missed persisted edge first when the
-\* admission-close snapshot flagged one - late persistence intent survives
-\* even when the final waiter departs through cancellation.
+\* hold in its own egraphMu section. Aggregate persistence intent is
+\* committed first, so late intent survives even when the final waiter
+\* departs through cancellation.
 WaiterDropHoldCanceled(i) ==
     /\ invocations[i].phase = "cancelDropHold"
     /\ LET o == invocations[i].oc IN
        /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].hold = FALSE]
-       /\ res' = RepairThenDropHold(o)
+       /\ res' = PersistThenDropHold(o)
        /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
     /\ UNCHANGED <<ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* WaiterObserveFnErr: the fn failed; each waiter observes the error and
 \* returns it. The last waiter removes the Cache.ongoingCalls index entry.
@@ -702,7 +687,7 @@ WaiterObserveFnErr(i) ==
                         ELSE ongoingCallIndex
           /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 (***************************************************************************)
 (* PUBLICATION - initCompletedResult, entered through the sync.Once in     *)
@@ -728,7 +713,7 @@ PubBegin(o) ==
         /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "begun",
                                                 ![o].pubBy = w]
     /\ UNCHANGED <<invocations, res, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* PubIndexFresh: publish a freshly computed value. One egraphMu critical  *)
@@ -737,10 +722,8 @@ PubBegin(o) ==
 (*      from this instant, before attachment completes                     *)
 (*   2. add exact dependency edges from the result-call refs, each         *)
 (*      incrementing its dependency                                        *)
-(*   3. upsert the persisted edge on persistence intent                    *)
-(*      (cache.go:4617-4620; late intent is described at Join)             *)
-(*   4. take the publication handoff hold                                  *)
-(*   5. arm the dependency-attachment barrier (cache.go:4627-4631)         *)
+(*   3. take the publication handoff hold                                  *)
+(*   4. arm the dependency-attachment barrier                              *)
 (***************************************************************************)
 PubIndexFresh(o) ==
     /\ ongoingCalls[o].pubState = "begun"
@@ -757,9 +740,9 @@ PubIndexFresh(o) ==
                 ELSE res[r]]
             newRes == [call |-> ongoingCalls[o].call, registered |-> TRUE,
                        released |-> FALSE,
-                       own |-> 1 + (IF ongoingCalls[o].isPersistable THEN 1 ELSE 0),
+                       own |-> 1,
                        deps |-> deps,
-                       persisted |-> ongoingCalls[o].isPersistable,
+                       persisted |-> FALSE,
                        barrier |-> "open",
                        \* fresh results have their typed payload in memory;
                        \* only imported entries carry encoded envelopes
@@ -777,15 +760,9 @@ PubIndexFresh(o) ==
         IN /\ res' = Append(withDeps, newRes)
            /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "attaching",
                                  ![o].hold = TRUE,
-                                 ![o].resId = Len(res) + 1,
-                                 \* the publication-time intent snapshot
-                                 \* (cache.go:4617-4620): remembers that this
-                                 \* read already installed the edge, so the
-                                 \* admission-close snapshot at PubUnregister
-                                 \* will not flag a repair for it
-                                 ![o].persistedDuringPub = ongoingCalls[o].isPersistable]
+                                 ![o].resId = Len(res) + 1]
     /\ UNCHANGED <<invocations, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* ADOPTION BRANCH: the fn returned an already-attached result, so         *)
@@ -793,13 +770,13 @@ PubIndexFresh(o) ==
 (* sharedResult.                                                           *)
 (***************************************************************************)
 
-\* The canonical equivalent: the lowest-ID live result in the class of the
-\* result the fn returned - or that result itself if nothing in the class
-\* is live. Mirrors canonicalEquivalentSharedResultLocked.
+\* The canonical equivalent: the lowest-ID attachment-eligible result in the
+\* class of the result the fn returned. Zero means no clean result can be
+\* adopted; the Go publication returns a normal error in that defensive case.
 CanonicalPick(o) ==
     LET k == ClassOf[res[ongoingCalls[o].reuseFrom].call]
-        live == LiveInClass(k)
-    IN IF live = {} THEN ongoingCalls[o].reuseFrom
+        live == LookupEligibleInClass(k)
+    IN IF live = {} THEN 0
        ELSE CHOOSE r \in live : \A q \in live : r <= q
 
 \* PubAdopt: one egraphMu critical section both picks the canonical
@@ -812,11 +789,22 @@ PubAdopt(o) ==
     /\ ongoingCalls[o].pubState = "begun"
     /\ ongoingCalls[o].outcome = "reuse"
     /\ LET r == CanonicalPick(o) IN
+        /\ r # 0
         /\ res' = [res EXCEPT ![r].own = @ + 1]
         /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "adopted",
                               ![o].hold = TRUE, ![o].resId = r]
     /\ UNCHANGED <<invocations, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
+
+\* If every canonical equivalent failed attachment before the adoption lock,
+\* publication returns an ordinary error without taking a handoff hold.
+PubAdoptReject(o) ==
+    /\ ongoingCalls[o].pubState = "begun"
+    /\ ongoingCalls[o].outcome = "reuse"
+    /\ CanonicalPick(o) = 0
+    /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "failed"]
+    /\ UNCHANGED <<invocations, res, ongoingCallIndex, sessionEdges, countedEdges,
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* PubIndexReuse: finish publication for an adopted result - the egraphMu  *)
@@ -825,8 +813,6 @@ PubAdopt(o) ==
 (*     indexWaitResultInEgraphLocked refuses to re-register it             *)
 (*     (cache_egraph.go:1548) and publication fails rather than serve a    *)
 (*     collected result                                                    *)
-(*   - oc.isPersistable is consumed here for adopted results               *)
-(*     (cache.go:4617-4620)                                                *)
 (*   - no attach barrier: adopted results were already attached            *)
 (*     (resWasCacheBacked, cache.go:4627)                                  *)
 (***************************************************************************)
@@ -836,19 +822,10 @@ PubIndexReuse(o) ==
        IF ~res[r].registered
        THEN /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "failed"]
             /\ UNCHANGED res
-       ELSE LET withPersist ==
-                    IF ongoingCalls[o].isPersistable /\ ~res[r].persisted
-                    THEN [res EXCEPT ![r].persisted = TRUE,
-                                     ![r].own = @ + 1]
-                    ELSE res
-            IN /\ res' = withPersist
-               /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "done",
-                                     \* same intent snapshot as PubIndexFresh
-                                     \* (the upsert at cache.go:4617-4620 is
-                                     \* common to both publication branches)
-                                     ![o].persistedDuringPub = ongoingCalls[o].isPersistable]
+       ELSE /\ UNCHANGED res
+            /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "done"]
     /\ UNCHANGED <<invocations, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* ATTACHMENT PHASE for fresh results. attachDependencyResults runs        *)
@@ -858,8 +835,10 @@ PubIndexReuse(o) ==
 (*     records the dependency edge; each such AddExplicitDependency is     *)
 (*     its own egraphMu critical section (cache.go:2137)              *)
 (*   - PubFinishOk: attachment succeeded; close the barrier clean          *)
-(*   - PubAttachFail: attachment failed; release the hold, cascade, close  *)
-(*     the barrier with the error (cache.go:4635-4656)                     *)
+(*   - PubAttachFailDropHold: attachment failed; release the hold and      *)
+(*     cascade in one egraphMu critical section                            *)
+(*   - PubAttachFailCloseBarrier: close the barrier with the error in the  *)
+(*     following attachDepsMu critical section                             *)
 (*                                                                         *)
 (* STATED ASSUMPTION: dependency edges never form a cycle. The Go cache    *)
 (* does not enforce this - addExplicitDependencyLocked (cache.go:2168)     *)
@@ -902,44 +881,48 @@ PubAttachAddDep(o) ==
              ![ongoingCalls[o].resId].deps = @ \cup {d},
              ![d].own = @ + 1]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 PubFinishOk(o) ==
     /\ ongoingCalls[o].pubState = "attaching"
     /\ res' = [res EXCEPT ![ongoingCalls[o].resId].barrier = "closedOk"]
     /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "done"]
     /\ UNCHANGED <<invocations, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
-PubAttachFail(o) ==
+PubAttachFailDropHold(o) ==
     /\ AttachCanFail
     /\ ongoingCalls[o].pubState = "attaching"
-    /\ res' = DecAndCascade(
-         [res EXCEPT ![ongoingCalls[o].resId].barrier = "closedErr"], ongoingCalls[o].resId)
-    /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "failed", ![o].hold = FALSE]
+    /\ res' = DecAndCascade(res, ongoingCalls[o].resId)
+    /\ ongoingCalls' = [ongoingCalls EXCEPT
+         ![o].pubState = "attachFailClosing", ![o].hold = FALSE]
     /\ UNCHANGED <<invocations, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
+
+PubAttachFailCloseBarrier(o) ==
+    /\ ongoingCalls[o].pubState = "attachFailClosing"
+    /\ res' = [res EXCEPT ![ongoingCalls[o].resId].barrier = "closedErr"]
+    /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "failed"]
+    /\ UNCHANGED <<invocations, ongoingCallIndex, sessionEdges, countedEdges,
+                   sessionRelease, evals, epoch, flushed>>
 
 \* PubUnregister: the entry leaves the Cache.ongoingCalls index - the tail of the Once
 \* (wait, cache.go:4225-4231), in its own callsMu critical section AFTER
 \* publication finished. Joining stays possible until this fires. This is
-\* also where admission closes, so the late-persist repair decision is
-\* snapshotted here (cache.go:4226-4229): repair is needed when
-\* publication succeeded, a result exists, the publication-time snapshot
-\* did not install the persisted edge, and some admitted request asked
-\* for persistence.
+\* also where admission closes, so final persistence intent is snapshotted:
+\* publication must have succeeded, a result must exist, and some admitted
+\* request must have asked for persistence.
 PubUnregister(o) ==
     /\ ongoingCalls[o].pubState \in {"done", "failed"}
     /\ ongoingCalls[o].inIndex
     /\ ongoingCallIndex' = [ongoingCallIndex EXCEPT ![<<ongoingCalls[o].call, ongoingCalls[o].sess>>] = 0]
     /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].inIndex = FALSE,
-          ![o].needsRepair =
+          ![o].needsPersistedEdge =
               /\ ongoingCalls[o].pubState = "done"
               /\ ongoingCalls[o].resId # 0
-              /\ ~ongoingCalls[o].persistedDuringPub
               /\ ongoingCalls[o].isPersistable]
     /\ UNCHANGED <<invocations, res, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* WaiterObservePubErr: publication failed; each waiter observes the error
 \* and returns it, decrementing the waiter count under callsMu. If the
@@ -959,20 +942,20 @@ WaiterObservePubErr(i) ==
           /\ invocations' = [invocations EXCEPT
                ![i].phase = IF dropHold THEN "pubErrDropHold" ELSE "failed"]
     /\ UNCHANGED <<res, ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* WaiterDropHoldPubErr: the last waiter of a failed publication drops the
 \* handoff hold in its own egraphMu section (releaseOngoingCallHandoff,
-\* cache.go:4289-4306). The repair arm is vacuous here: needsRepair
-\* requires a successful publication.
+\* cache.go:4289-4306). The persistence arm is vacuous here because
+\* needsPersistedEdge requires a successful publication.
 WaiterDropHoldPubErr(i) ==
     /\ invocations[i].phase = "pubErrDropHold"
     /\ LET o == invocations[i].oc IN
        /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].hold = FALSE]
-       /\ res' = RepairThenDropHold(o)
+       /\ res' = PersistThenDropHold(o)
        /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
     /\ UNCHANGED <<ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 (***************************************************************************)
 (* WAITER SUCCESS PATH. In code order (wait, cache.go:4259-4281):          *)
@@ -984,7 +967,7 @@ WaiterDropHoldPubErr(i) ==
 (*                                                                         *)
 (* The claim is one egraphMu critical section with sessionMu nested inside *)
 (* it. A released tombstone refuses the claim. The waiter still departs,   *)
-(* and the final waiter still repairs persistence before dropping the hold. *)
+(* and the final waiter still commits persistence before dropping the hold. *)
 (***************************************************************************)
 
 WaiterClaim(i) ==
@@ -1008,7 +991,7 @@ WaiterClaim(i) ==
                                         ![i].refusedEpoch = epoch]
                /\ UNCHANGED <<res, sessionEdges, countedEdges>>
     /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* WaiterDepart: waiters--, under callsMu. The last waiter goes on to
 \* release the handoff hold. Go: wait, cache.go:4267-4270.
@@ -1023,12 +1006,11 @@ WaiterDepart(i) ==
                          THEN IF refused THEN "refusedReleaseHold" ELSE "releaseHold"
                          ELSE IF refused THEN "refused" ELSE "readBarrier"]
     /\ UNCHANGED <<res, ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* WaiterReleaseHold: the last waiter drops the publication handoff hold,
-\* in its own egraphMu section - releaseOngoingCallHandoff
-\* (cache.go:4289-4306), which first repairs a missed persisted edge when
-\* the admission-close snapshot flagged one. From here on, only real
+\* in its own egraphMu section - releaseOngoingCallHandoff, which first
+\* commits the admission-close persistence intent. From here on, only real
 \* edges (session, dependency, persisted) keep the result alive.
 \* Go: wait, cache.go:4271-4275 -> releaseOngoingCallHandoff.
 WaiterReleaseHold(i) ==
@@ -1037,10 +1019,10 @@ WaiterReleaseHold(i) ==
            refused == invocations[i].phase = "refusedReleaseHold"
        IN
        /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].hold = FALSE]
-       /\ res' = RepairThenDropHold(o)
+       /\ res' = PersistThenDropHold(o)
        /\ invocations' = [invocations EXCEPT ![i].phase = IF refused THEN "refused" ELSE "readBarrier"]
     /\ UNCHANGED <<ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 (***************************************************************************)
 (* THE READ BARRIER: every return path waits for the result's dependency   *)
@@ -1062,20 +1044,39 @@ ReadBarrierOk(i) ==
           \* returned; the decode actions below handle that arm and loop
           \* back here once the payload is in memory.
           /\ res[r].payload = "decoded"
-          \* There is no per-return persist repair: the missed persisted
-          \* edge is repaired at the FINAL handoff release, so a non-final
-          \* persistable joiner can return before the edge exists. That is
-          \* why PersistableIntentDurable is stated over quiesced calls,
-          \* not over each waiter's return.
           /\ invocations' = [invocations EXCEPT
-               ![i].phase = "done",
+               ![i].phase = IF invocations[i].path = "hit"
+                                  /\ invocations[i].persistable
+                             THEN "persistHit" ELSE "done",
                ![i].retLive = res[r].registered /\ ~res[r].released,
                ![i].retOwned = ProtectedReturn(invocations[i].sess, r),
                ![i].retBarrierOK = res[r].barrier \in {"none", "closedOk"},
                ![i].retClean = ~res[r].laundered]
           /\ UNCHANGED res
     /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
+
+\* A persistable cache hit takes one additional egraphMu critical section
+\* after attachment and payload loading succeed. The upsert keeps the expiry
+\* computed during lookup; TTL values are abstracted from this model. The
+\* registration guard prevents resurrection if the result was collected in
+\* the interval before this lock acquisition.
+PersistHit(i) ==
+    /\ invocations[i].phase = "persistHit"
+    /\ LET r == invocations[i].resId
+           persisted == IF res[r].registered /\ ~res[r].persisted
+                        THEN [res EXCEPT ![r].persisted = TRUE,
+                                         ![r].own = @ + 1]
+                        ELSE res
+       IN /\ res' = persisted
+          /\ invocations' = [invocations EXCEPT
+               ![i].phase = "done",
+               ![i].retLive = res[r].registered /\ ~res[r].released,
+               ![i].retOwned = ProtectedReturn(invocations[i].sess, r),
+               ![i].retBarrierOK = res[r].barrier \in {"none", "closedOk"},
+               ![i].retClean = ~res[r].laundered]
+    /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
+                   sessionRelease, evals, epoch, flushed>>
 
 ReadBarrierErrHit(i) ==
     /\ invocations[i].phase = "readBarrier"
@@ -1083,7 +1084,7 @@ ReadBarrierErrHit(i) ==
     /\ res[invocations[i].resId].barrier = "closedErr"
     /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 ReadBarrierErrWait(i) ==
     /\ invocations[i].phase = "readBarrier"
@@ -1091,7 +1092,7 @@ ReadBarrierErrWait(i) ==
     /\ res[invocations[i].resId].barrier = "closedErr"
     /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* READER CANCELLATION (ReaderCanCancel). ensurePersistedHitValueLoaded    *)
@@ -1108,7 +1109,7 @@ ReadBarrierCancelHit(i) ==
     /\ invocations[i].path = "hit"
     /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 \* The WAIT-path twin: the error propagates and the claimed session edge
 \* simply remains (wait, cache.go:4277-4281) - same as ReadBarrierErrWait.
@@ -1118,7 +1119,7 @@ ReadBarrierCancelWait(i) ==
     /\ invocations[i].path = "wait"
     /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* PERSISTED-PAYLOAD DECODE. An imported result can exist                  *)
@@ -1152,7 +1153,7 @@ DecodeLead(i) ==
                              ![r].decodeErr = "none"]
        /\ invocations' = [invocations EXCEPT ![i].phase = "decoding"]
     /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 DecodeLeadFinish(i) ==
     /\ invocations[i].phase = "decoding"
@@ -1169,7 +1170,7 @@ DecodeLeadFinish(i) ==
                                      ![r].decodeErr = "fail"]
                /\ invocations' = [invocations EXCEPT ![i].phase = "decodeErr"]
     /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 DecodeJoin(i) ==
     /\ invocations[i].phase = "readBarrier"
@@ -1179,7 +1180,7 @@ DecodeJoin(i) ==
        /\ res[r].decodePhase = "running"
        /\ invocations' = [invocations EXCEPT ![i].phase = "decodeJoined"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 DecodeWake(i) ==
     /\ invocations[i].phase = "decodeJoined"
@@ -1188,7 +1189,7 @@ DecodeWake(i) ==
        /\ invocations' = [invocations EXCEPT ![i].phase =
             IF res[r].decodeErr = "fail" THEN "decodeErr" ELSE "readBarrier"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 \* Decode failed for a HIT-path caller.
 DecodeFailHit(i) ==
@@ -1196,7 +1197,7 @@ DecodeFailHit(i) ==
     /\ invocations[i].path = "hit"
     /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
-                   lostCancels, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 \* Decode failed for a WAIT-path caller: the error just propagates; the
 \* session edge claimed after publication remains (wait, cache.go:4271-4275).
@@ -1205,7 +1206,7 @@ DecodeFailWait(i) ==
     /\ invocations[i].path = "wait"
     /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* ReleaseSession, in its two real critical sections.                      *)
@@ -1238,7 +1239,7 @@ ReleaseSessionRecord(s) ==
                  snap |-> snap]]
           /\ sessionEdges' = {e \in sessionEdges : e[1] # s}
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
-                   countedEdges, lostCancels, evals, epoch, flushed>>
+                   countedEdges, evals, epoch, flushed>>
 
 \* The egraphMu section: remove one unit per snapshotted, still-registered
 \* result, then collect.
@@ -1255,7 +1256,7 @@ ReleaseSessionCollect(s) ==
           /\ sessionRelease' = [sessionRelease EXCEPT ![s] =
                 [phase |-> "released", snap |-> {}]]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, lostCancels, evals, epoch, flushed>>
+                   sessionEdges, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* PruneCut: cut one persisted root edge and let the normal cascade        *)
@@ -1272,7 +1273,7 @@ PruneCut(r) ==
     /\ res[r].persisted
     /\ res' = DecAndCascade([res EXCEPT ![r].persisted = FALSE], r)
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, lostCancels, evals, epoch, flushed>>
+                   sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* FLUSH AND RESTART. Graceful shutdown removes every                      *)
@@ -1286,18 +1287,34 @@ PruneCut(r) ==
 (* that, so a snapshot racing an unfinished publication is a reachable    *)
 (* capture and the FlushCleanCapture property judges it.                   *)
 (*                                                                         *)
-(* Each snapshot row records, besides the result's durable state, two      *)
-(* verdicts used only by properties:                                       *)
+(* Snapshot selection starts at persisted roots. A root is kept only when  *)
+(* its entire transitive dependency closure is registered and cleanly      *)
+(* attached; every kept row is reachable from such a root. If any node is  *)
+(* open, errored, or missing, that node and every root depending on it are  *)
+(* rejected.                                                               *)
+(*                                                                         *)
+(* Each candidate row also records two verdicts used only by properties:   *)
 (*   dirty    - the attach barrier was not cleanly closed at capture       *)
 (*              (still open, or closed with an error). The Go writes no    *)
 (*              such marker: attachDeps state lives only in memory, which  *)
-(*              is exactly why a restart serves these entries as if they   *)
-(*              were fine. (Encoding a half-attached payload may also      *)
-(*              simply fail and abort the flush - the safe outcome; the    *)
-(*              model explores the successful-encode worst case.)          *)
+(*              is why the snapshot must reject them rather than rely on   *)
+(*              restart to remember the failure.                           *)
 (*   ownClean - ownership at capture was fully explained by persisted +    *)
 (*              dependency edges, nothing transient.                       *)
 (***************************************************************************)
+
+CleanAttachedResult(r) ==
+    res[r].registered /\ res[r].barrier \in {"none", "closedOk"}
+
+CleanPersistedRoot(r) ==
+    /\ CleanAttachedResult(r)
+    /\ res[r].persisted
+    /\ \A d \in ResultIds :
+         DepReachable(res, r, d) => CleanAttachedResult(d)
+
+KeptByPersistedRoot(r) ==
+    \E root \in ResultIds :
+        CleanPersistedRoot(root) /\ DepReachable(res, root, r)
 
 Flush ==
     /\ ModelPersistence
@@ -1307,7 +1324,7 @@ Flush ==
     \* critical sections) before Cache.Close snapshots.
     /\ \A s \in Sessions : sessionRelease[s].phase = "released"
     /\ flushed' = [done |-> TRUE, rows |-> [r \in 1..Len(res) |->
-         [keep      |-> res[r].registered,
+         [keep      |-> KeptByPersistedRoot(r),
           call      |-> res[r].call,
           persisted |-> res[r].persisted,
           deps      |-> res[r].deps,
@@ -1315,7 +1332,7 @@ Flush ==
           ownClean  |-> res[r].own =
               PersistedCount(r) + DepParentCount(r)]]]
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    evals, epoch>>
 
 (***************************************************************************)
@@ -1356,7 +1373,7 @@ Restart ==
          [ongoingCalls[o] EXCEPT !.fnState = "exited", !.pubState = "none",
                                  !.pubBy = 0,
                                  !.hold = FALSE, !.inIndex = FALSE,
-                                 !.needsRepair = FALSE,
+                                 !.needsPersistedEdge = FALSE,
                                  !.waiters = 0]]
     /\ ongoingCallIndex' = [k \in Calls \X Sessions |-> 0]
     /\ evals' = [e \in EvalIds |->
@@ -1366,7 +1383,6 @@ Restart ==
     /\ sessionEdges' = {}
     /\ countedEdges' = {}
     /\ sessionRelease' = [s \in Sessions |-> [phase |-> "live", snap |-> {}]]
-    /\ lostCancels' = 0
     /\ UNCHANGED flushed
 
 ---------------------------------------------------------------------------
@@ -1421,7 +1437,7 @@ EvalSpawn ==
         /\ res[r].registered
         /\ evals' = Append(evals, [target |-> r, phase |-> "demand"])
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* Fast path: nothing to do - evaluation already completed, or the value
@@ -1432,7 +1448,7 @@ EvalNoWork(e) ==
        res[r].lazyComplete \/ res[r].lazyCb = "none"
     /\ evals' = [evals EXCEPT ![e].phase = "done"]
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* Start the callback: no attempt is in flight, so this caller becomes the
@@ -1452,7 +1468,7 @@ EvalStartAttempt(e) ==
             ![r].lazyErr = "none"]
        /\ evals' = [evals EXCEPT ![e].phase = "waiting"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* Join an attempt already in flight (evaluateOne's join arm,
@@ -1469,7 +1485,7 @@ EvalJoin(e) ==
        /\ res' = [res EXCEPT ![r].lazyWaiters = @ + 1]
        /\ evals' = [evals EXCEPT ![e].phase = "waiting"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* The callback finishes on its own (the goroutine tail, cache.go:3184-
@@ -1495,7 +1511,7 @@ EvalCallbackFinish(r) ==
              ![r].lazyErr = IF drained THEN "none"
                             ELSE IF ok THEN "none" ELSE "fail"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, evals,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* The canceled callback winds down. It may still succeed (the callback
@@ -1516,7 +1532,7 @@ EvalCallbackFinishCanceled(r) ==
              ![r].lazyErr = IF drained THEN "none"
                             ELSE IF ok THEN "none" ELSE "cancel"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, evals,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* A waiter wakes after the callback finished (waitForLazyEvaluation's
@@ -1538,7 +1554,7 @@ EvalWake(e) ==
                  [] res[r].lazyErr = "fail" -> "failedCallback"
                  [] OTHER -> "failedStale"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 \* A waiter gives up (its own context canceled - waitForLazyEvaluation's
@@ -1565,7 +1581,7 @@ EvalAbandon(e) ==
                                 THEN "cancelRequested" ELSE @]
           /\ evals' = [evals EXCEPT ![e].phase = "abandoned"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease, lostCancels,
+                   sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
 ---------------------------------------------------------------------------
@@ -1582,14 +1598,16 @@ Next ==
          \/ WaiterDropHoldCanceled(i)
          \/ WaiterClaim(i)
          \/ WaiterDepart(i) \/ WaiterReleaseHold(i)
-         \/ ReadBarrierOk(i) \/ ReadBarrierErrHit(i) \/ ReadBarrierErrWait(i)
+         \/ ReadBarrierOk(i) \/ PersistHit(i)
+         \/ ReadBarrierErrHit(i) \/ ReadBarrierErrWait(i)
          \/ ReadBarrierCancelHit(i) \/ ReadBarrierCancelWait(i)
          \/ DecodeLead(i) \/ DecodeLeadFinish(i) \/ DecodeJoin(i)
          \/ DecodeWake(i) \/ DecodeFailHit(i) \/ DecodeFailWait(i)
     \/ \E o \in OngoingCallIds :
          \/ FnComplete(o) \/ PubBegin(o)
-         \/ PubIndexFresh(o) \/ PubAdopt(o) \/ PubIndexReuse(o)
-         \/ PubAttachAddDep(o) \/ PubFinishOk(o) \/ PubAttachFail(o)
+         \/ PubIndexFresh(o) \/ PubAdopt(o) \/ PubAdoptReject(o) \/ PubIndexReuse(o)
+         \/ PubAttachAddDep(o) \/ PubFinishOk(o)
+         \/ PubAttachFailDropHold(o) \/ PubAttachFailCloseBarrier(o)
          \/ PubUnregister(o) \/ FnWindDown(o)
     \/ \E s \in Sessions : ReleaseSessionRecord(s) \/ ReleaseSessionCollect(s)
     \/ \E r \in 1..Len(res) : PruneCut(r)
@@ -1628,14 +1646,15 @@ Spec == Init /\ [][Next]_vars
 (*   - FnComplete's fairness guarantees SOME outcome, not a successful     *)
 (*     one (the outcome choice inside stays nondeterministic)              *)
 (*   - fairness sits on the disjunction of the attach outcomes             *)
-(*     (PubFinishOk or PubAttachFail), never on the success arm alone -    *)
+(*     (PubFinishOk or PubAttachFailDropHold), never on the success arm -  *)
 (*     fairness on the success arm would wrongly forbid persistent         *)
 (*     failure                                                             *)
 (***************************************************************************)
 SystemProgress(o) ==
     \/ FnComplete(o) \/ PubBegin(o)
-    \/ PubIndexFresh(o) \/ PubAdopt(o) \/ PubIndexReuse(o)
-    \/ PubFinishOk(o) \/ PubAttachFail(o)
+    \/ PubIndexFresh(o) \/ PubAdopt(o) \/ PubAdoptReject(o) \/ PubIndexReuse(o)
+    \/ PubFinishOk(o) \/ PubAttachFailDropHold(o)
+    \/ PubAttachFailCloseBarrier(o)
     \/ PubUnregister(o)
 
 WaiterProgress(i) ==
@@ -1644,7 +1663,8 @@ WaiterProgress(i) ==
     \/ WaiterDropHoldPubErr(i) \/ WaiterDropHoldCanceled(i)
     \/ WaiterClaim(i)
     \/ WaiterDepart(i) \/ WaiterReleaseHold(i)
-    \/ ReadBarrierOk(i) \/ ReadBarrierErrHit(i) \/ ReadBarrierErrWait(i)
+    \/ ReadBarrierOk(i) \/ PersistHit(i)
+    \/ ReadBarrierErrHit(i) \/ ReadBarrierErrWait(i)
     \/ DecodeLead(i) \/ DecodeLeadFinish(i) \/ DecodeJoin(i)
     \/ DecodeWake(i) \/ DecodeFailHit(i) \/ DecodeFailWait(i)
 
@@ -1703,6 +1723,8 @@ TypeOK ==
     /\ \A i \in InvocationIds :
          /\ invocations[i].origin \in {"handler", "nested"}
          /\ invocations[i].refusedEpoch \in 0..epoch
+         /\ invocations[i].lookupBarrierAtSelection
+              \in {"none", "open", "closedOk", "closedErr"}
 
 \* Ownership accounting is exact: for every registered result, the
 \* incrementally-maintained counter equals the recount of its edges
@@ -1735,12 +1757,10 @@ ReturnedOwned ==
 NoHalfAttachedRead ==
     \A i \in InvocationIds : invocations[i].phase = "done" => invocations[i].retBarrierOK
 
-\* Persistence intent is never lost: once a call's admission has closed
-\* and its handoff hold has been released (waiters drained), an admitted
-\* persistable request implies the persisted edge exists - even when the
-\* final waiter departed through cancellation. Note the guarantee is
-\* stated over quiesced calls, not per return: a non-final late joiner
-\* can return before the repair lands at the final handoff release.
+\* Persistence intent is never lost: once a successful call's admission has
+\* closed and its handoff hold has been released, an admitted persistable
+\* request implies the persisted edge exists. This includes a refused or
+\* canceled final waiter because final handoff commits the edge first.
 PersistableIntentDurable ==
     \A o \in OngoingCallIds :
         (/\ ongoingCalls[o].pubState = "done"
@@ -1752,9 +1772,15 @@ PersistableIntentDurable ==
          /\ res[ongoingCalls[o].resId].registered)
             => res[ongoingCalls[o].resId].persisted
 
-\* Every created WithCancelCause cancel is eventually discharged.
-\* (Violated on main by the lease-error branch; see CreateOcLeaseFail.)
-NoLostCancels == lostCancels = 0
+\* Operation-lease failure terminates before an ongoing call, result, or
+\* ownership edge is published. The Go branch also discharges its local
+\* cancel, which has no persistent model state after the action completes.
+LeaseFailureClean ==
+    \A i \in InvocationIds :
+        invocations[i].path = "leaseFailure" =>
+            /\ invocations[i].phase = "failed"
+            /\ invocations[i].oc = 0
+            /\ invocations[i].resId = 0
 
 \* Racing alone never manufactures an execution failure: if no failure
 \* injection is enabled, no invocation ends in "failed". Cancellation and a
@@ -1784,23 +1810,20 @@ RefusedOnlyAfterRelease ==
             \/ /\ invocations[i].refusedEpoch = epoch
                /\ sessionRelease[invocations[i].sess].phase # "live"
 
-\* A result whose dependency attachment failed must not be retained beyond
-\* the failed call that produced it. The code violates this for persistable
-\* calls: the persisted edge is added inside the publication critical
-\* section (cache.go:4617-4620), BEFORE attachment runs (cache.go:4635), and the
-\* attach-error path releases only the handoff hold - the persisted edge
-\* survives. The result stays registered and lookup-visible with its
-\* barrier closed on an error, so every future equivalent call finds it,
-\* waits on the barrier, and fails - it never falls back to executing.
-\* Nothing in the code ever clears this state: the error lives only in
-\* memory, so a graceful shutdown flushes the entry like any retained
-\* result and a restart re-imports it without the error, serving a payload
-\* whose attachment never completed. Until then, only pruning the
-\* persisted edge (or wiping the store) recovers.
+\* Attachment failure never gains a persisted edge. A concurrent hit may
+\* have claimed a session edge while the barrier was open, so the errored
+\* result can remain registered until that session releases it.
 NoRetainedPoisonedEntry ==
     \A r \in ResultIds :
         (res[r].registered /\ res[r].barrier = "closedErr") =>
             ~res[r].persisted
+
+\* The selection-time marker distinguishes a forbidden lookup made after an
+\* attachment error from a legitimate lookup that selected an open barrier
+\* before the attachment later failed.
+NoErroredLookupSelection ==
+    \A i \in InvocationIds :
+        invocations[i].lookupBarrierAtSelection # "closedErr"
 
 (***************************************************************************)
 (* LAZY-EVALUATION PROPERTIES. Each names what the code's lazyMu           *)
@@ -1854,10 +1877,23 @@ FlushCleanCapture ==
             flushed.rows[r].keep =>
                 (~flushed.rows[r].dirty /\ flushed.rows[r].ownClean)
 
-\* A result imported from a snapshot row that was captured dirty
-\* (mid-attachment, or attach-failed) is never served to a caller. The
-\* code violates this: the dirtiness lives only in memory, so the
-\* restarted engine serves the entry as if it were fine.
+\* Every written result belongs to a complete clean dependency closure rooted
+\* at a written persisted edge. This is the result-level abstraction of the
+\* concrete database foreign-key and payload-reference checks in Go.
+FlushReferentialIntegrity ==
+    flushed.done =>
+        \A r \in DOMAIN flushed.rows :
+            flushed.rows[r].keep =>
+                /\ ~flushed.rows[r].dirty
+                /\ \A d \in flushed.rows[r].deps : flushed.rows[d].keep
+                /\ \E root \in DOMAIN flushed.rows :
+                     /\ flushed.rows[root].keep
+                     /\ flushed.rows[root].persisted
+                     /\ DepReachable(flushed.rows, root, r)
+
+\* A result that was open or attachment-errored at snapshot time is never
+\* imported and served. Flush rejects every persisted root whose dependency
+\* closure contains such a result.
 NoLaunderedServe ==
     \A i \in InvocationIds :
         invocations[i].phase = "done" => invocations[i].retClean

--- a/dagql/tla/CacheLifecycle_core.cfg
+++ b/dagql/tla/CacheLifecycle_core.cfg
@@ -28,4 +28,4 @@ CONSTANTS
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
 SYMMETRY Symm
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection ReturnedLive ReturnedOwned NoHalfAttachedRead PersistableIntentDurable NoLostCancels NoSpuriousErrors NoOrphanEdgesAtQuiescence
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection ReturnedLive ReturnedOwned NoHalfAttachedRead PersistableIntentDurable NoSpuriousErrors NoOrphanEdgesAtQuiescence

--- a/dagql/tla/CacheLifecycle_flush_closure.cfg
+++ b/dagql/tla/CacheLifecycle_flush_closure.cfg
@@ -1,13 +1,13 @@
-\* Attachment failure across flush and restart: shutdown rejects persisted
-\* roots whose dependency closure contains an open or errored attachment, so
-\* restart cannot serve an entry whose attachment never completed.
-\* Expected: pass.
+\* A persisted root can depend on a result whose attachment later fails.
+\* Flush rejects that root and its incomplete closure while preserving every
+\* result reachable from another fully clean persisted root. Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}
     s1 = s1
-    Calls = {cA}
+    Calls = {cA, cB}
     cA = cA
+    cB = cB
     ClassOf <- OneClass
     MaxInvocations = 2
     MaxResults = 2
@@ -25,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection NoLaunderedServe FlushReferentialIntegrity
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushReferentialIntegrity NoLaunderedServe

--- a/dagql/tla/CacheLifecycle_flush_drained.cfg
+++ b/dagql/tla/CacheLifecycle_flush_drained.cfg
@@ -1,6 +1,7 @@
 \* The flush_inflight outcome with every session released and the drain
-\* honored: an executor-nested call's publication is still in flight when
-\* the snapshot is captured, because the drain does not cover the executor.
+\* honored: an executor-nested call can still adopt a clean persisted result
+\* and hold transient publication ownership because the drain does not cover
+\* the executor.
 \* Expected: FlushCleanCapture violated.
 SPECIFICATION Spec
 CONSTANTS

--- a/dagql/tla/CacheLifecycle_flush_inflight.cfg
+++ b/dagql/tla/CacheLifecycle_flush_inflight.cfg
@@ -1,7 +1,6 @@
-\* Flush racing an unfinished publication: publication is split across
-\* critical sections, so the shutdown snapshot can capture a result whose
-\* attach barrier is still open, retained partly by a transient handoff
-\* hold. Expected: FlushCleanCapture violated.
+\* Flush racing an unfinished publication: a clean persisted result can be
+\* adopted by redundant execution and carry a transient handoff hold when the
+\* shutdown snapshot captures it. Expected: FlushCleanCapture violated.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}

--- a/dagql/tla/CacheLifecycle_flush_roundtrip.cfg
+++ b/dagql/tla/CacheLifecycle_flush_roundtrip.cfg
@@ -26,4 +26,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushCleanCapture NoLaunderedServe
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushCleanCapture FlushReferentialIntegrity NoLaunderedServe

--- a/dagql/tla/CacheLifecycle_lost_cancel.cfg
+++ b/dagql/tla/CacheLifecycle_lost_cancel.cfg
@@ -1,7 +1,6 @@
-\* The operation-lease error branch (cache.go:3917-3925) returns without
-\* calling the WithCancelCause cancel created at cache.go:3897.
-\* Expected: NoLostCancels violated - an undischarged cancel, a leak in the
-\* current code, not corruption.
+\* The operation-lease error branch discharges its local cancel and returns
+\* without publishing an ongoing call, result, or ownership edge.
+\* Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}
@@ -25,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS NoLostCancels
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection LeaseFailureClean

--- a/dagql/tla/CacheLifecycle_orphan_edges.cfg
+++ b/dagql/tla/CacheLifecycle_orphan_edges.cfg
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease PersistableIntentDurable

--- a/dagql/tla/CacheLifecycle_poisoned.cfg
+++ b/dagql/tla/CacheLifecycle_poisoned.cfg
@@ -1,10 +1,8 @@
-\* A persistable call whose dependency attachment fails: the persisted edge
-\* is upserted inside the publication critical section (cache.go:4617-4620)
-\* before attachment runs (cache.go:4635), and the attach-error path drops
-\* only the handoff hold - the edge survives. The entry stays registered
-\* and lookup-visible with its barrier closed on an error, so every future
-\* equivalent call finds it and fails instead of executing.
-\* Expected: NoRetainedPoisonedEntry violated.
+\* A persistable publication fails dependency attachment while another
+\* persistable invocation may select its still-open barrier. Neither path
+\* installs a persisted edge before attachment succeeds, and selection never
+\* chooses an entry whose barrier was already closed with an error.
+\* Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}
@@ -28,4 +26,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS NoRetainedPoisonedEntry
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection NoRetainedPoisonedEntry NoErroredLookupSelection

--- a/internal-docs/cache_persistence.md
+++ b/internal-docs/cache_persistence.md
@@ -232,17 +232,19 @@ imported-layer indexes on restart.
 
 On graceful shutdown, the cache snapshots and writes:
 
-- all live `sharedResult`s in `resultsByID`
-- all live terms
-- all live eq-classes and their digests
+- complete, clean result dependency closures reachable from persisted edges
+- terms whose output eq-classes contain those retained results
+- the eq-classes and digests referenced by retained results and terms
 - result-to-output-eq-class associations
 - exact result dependency edges
 - persisted root edges
 - result snapshot ownership links
 - snapshot manager persistent metadata rows
 
-That is important: the store does not just save a small set of "roots." It
-saves the live retained cache graph and the metadata needed to reconstruct it.
+That is important: the store does not save only the root rows. It validates each
+persisted root's full dependency closure and saves the complete clean closures
+plus the metadata needed to reconstruct them. A root is omitted if any result in
+its closure is still attaching, finished attachment with an error, or is missing.
 
 In other words, persistence is trying to serialize the current cache state, not
 just enough information to replay everything later.
@@ -285,7 +287,9 @@ At the dagql field-definition level, `Field.IsPersistable()` sets the field spec
 to mark results of that field as eligible for persistence.
 
 At execution time, that turns into `CallRequest.IsPersistable`, and the cache
-responds by adding a persisted edge for the completed result.
+adds a persisted edge after the completed result finishes dependency attachment
+successfully. A persistable cache hit adds or updates its edge only after the
+hit's attachment barrier and persisted-payload load both succeed.
 
 That persisted edge does two things:
 

--- a/internal-docs/cache_pruning.md
+++ b/internal-docs/cache_pruning.md
@@ -191,8 +191,12 @@ User-visible persistable behavior is driven by `Field.IsPersistable()`.
 
 At execution time this becomes `CallRequest.IsPersistable`.
 
-When a persistable result is completed, `initCompletedResult` calls
-`upsertPersistedEdgeLocked`.
+When a persistable result completes dependency attachment successfully, the
+final publication handoff calls `upsertPersistedEdgeLocked` before dropping its
+temporary ownership.
+
+For a persistable cache hit, the upsert instead happens after its attachment
+barrier and persisted-payload load both succeed.
 
 That:
 


### PR DESCRIPTION
## Summary

Persisted cache ownership could be installed before a result finished dependency attachment or persisted-payload loading. If attachment then failed, the persisted edge retained a lookup-visible result whose barrier permanently returned that error. Equivalent calls kept selecting the failed result instead of re-executing. Graceful shutdown also serialized all live results without distinguishing complete state from in-progress or failed attachment, allowing an incomplete result to look healthy after restart.

This change moves persistence to the success boundary and makes shutdown persistence select only complete cache state.

## Runtime changes

- Fresh and adopted publications commit aggregate persistence intent at the final successful handoff, immediately before dropping the temporary publication ownership.
- Persistable cache hits retain the expiry calculated at hit selection, wait for dependency attachment and payload loading to succeed, then install the persisted edge in a fresh graph-lock section.
- Request, digest, canonical-ID, and publication-adoption candidate selection exclude results whose attachment barrier closed with an error.
- Persisted-edge upserts verify that the result is still registered, preventing a deferred upsert from recreating ownership after collection. `MakeResultUnpruneable` reports an explicit error for an already-collected result.
- Shutdown walks from persisted roots and writes only roots whose complete transitive dependency closure is registered and cleanly attached. It validates result-call and persisted-payload references against that selected closure before writing all related result, dependency, output-class, term, snapshot-link, and persisted-edge rows.
- The operation-lease failure path now cancels its shared call context before returning.

## Deliberate behavior

A hit selected while attachment is still open may wait and observe that attachment failure once. Once the barrier records the error, later equivalent lookups skip the result and re-execute. The failed hit's session ownership remains until that session releases it.

A persistable call still commits its persisted edge after successful publication when its final waiter is refused because the session was released. The edge is prunable and has no session owner.

Reference-validation failure aborts the flush. This follows the existing fail-closed store policy: a failed persistence transaction is not treated as a valid clean shutdown, so the store is discarded on the next boot.

Candidate gathering now briefly takes each candidate's attachment mutex while holding the graph lock on every lookup. These are small critical sections, but this is a new lookup hot-path lock acquisition. Persistable hits, which are uncommon, also take a second graph-lock section after attachment and payload loading succeed.

## Model changes

The TLA+ model now matches the success-boundary persistence and errored-candidate filtering behavior, models publication attachment failure as its separate graph-lock and attachment-lock actions, and models flush selection as clean persisted-root closure.

- `poisoned`, `poisoned_restart`, and `lost_cancel` are green configurations.
- `flush_closure` is a new green configuration.
- `flush_roundtrip` now checks referential integrity.
- A release-enabled configuration checks that admitted persistence intent remains durable after a successful call quiesces, including final-waiter refusal.
- `flush_inflight` and `flush_drained` remain intentionally expected-red for the separate shutdown-quiescence gap: a transient publication hold can still exist at capture time. They do not represent incomplete-result laundering.

The model removes the old lost-cancel ghost counter because the corrected local cancel has no observable persistent state after the lease-failure action. The deterministic Go test and `go vet` guard that call.

## Validation

- `go test ./dagql -count=1`
- One targeted `go test -race ./dagql -run ... -count=1` covering the new publication-boundary, flush-closure, lost-cancel, and refused-final-waiter cases
- `go vet ./dagql ./engine/server` — the two former `dagql/cache.go` lost-cancel diagnostics are gone; only the pre-existing `engine/server/session_attachables.go` diagnostic remains
- `dagger check tla-check:cache-lifecycle` — every configured expected outcome matched
- Focused TLC run of `CacheLifecycle_orphan_edges.cfg` after adding the release-enabled persistence-durability invariant — no error, 74 distinct states
- `gofmt` and `git diff --check`

## Stack

This is the second layer of a same-repository stack and depends on #13934. Its base is therefore `sipsma/remote-cache-track1-session-edges`, not `main`.
