### PR TITLE
dagql: retry canceled lazy evaluations

### DIFF
--- a/.changes/unreleased/Fixed-20260820-053238.yaml
+++ b/.changes/unreleased/Fixed-20260820-053238.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Lazy cache evaluation no longer returns cancellation caused by earlier
+  callers abandoning shared work. Healthy callers now wait for the canceled
+  callback to finish and retry without running callbacks concurrently.
+time: 2026-08-20T05:32:38Z
+custom:
+  Author: sipsma
+  PR: 13938

--- a/.dagger/modules/tla-check/dagger.gen.go
+++ b/.dagger/modules/tla-check/dagger.gen.go
@@ -226,19 +226,19 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		return dag.Module().
 			WithDescription("TLA+ model checking for the dagql cache spec (dagql/tla).\n\nRuns every TLC configuration of CacheLifecycle.tla. Green configurations\nare regression gates: any violation fails the check. Red configurations\nreproduce known deficiencies in the current code: each must violate\nexactly its designated invariant — coming up clean, or violating a\ndifferent invariant, fails the check, because either means the model or\na configuration drifted from the deficiency it reproduces.\n").
 			WithObject(
-				dag.TypeDef().WithObject("TlaCheck", dagger.TypeDefWithObjectOpts{SourceMap: dag.SourceMap("main.go", 61, 6)}).
+				dag.TypeDef().WithObject("TlaCheck", dagger.TypeDefWithObjectOpts{SourceMap: dag.SourceMap("main.go", 62, 6)}).
 					WithFunction(
 						dag.Function("CacheLifecycle",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("CacheLifecycle model-checks every configuration of the dagql cache spec\nand verifies each outcome against its expectation.").
-							WithSourceMap(dag.SourceMap("main.go", 86, 1)).
+							WithSourceMap(dag.SourceMap("main.go", 87, 1)).
 							WithCheck()).
-					WithField("Source", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{Description: "The dagql/tla spec directory.", SourceMap: dag.SourceMap("main.go", 63, 2)}).
+					WithField("Source", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{Description: "The dagql/tla spec directory.", SourceMap: dag.SourceMap("main.go", 64, 2)}).
 					WithConstructor(
 						dag.Function("New",
 							dag.TypeDef().WithObject("TlaCheck")).
-							WithSourceMap(dag.SourceMap("main.go", 66, 1)).
-							WithArg("ws", dag.TypeDef().WithObject("Workspace"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 66, 10)}))), nil
+							WithSourceMap(dag.SourceMap("main.go", 67, 1)).
+							WithArg("ws", dag.TypeDef().WithObject("Workspace"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 67, 10)}))), nil
 	default:
 		return nil, fmt.Errorf("unknown object %s", parentName)
 	}

--- a/.dagger/modules/tla-check/main.go
+++ b/.dagger/modules/tla-check/main.go
@@ -36,6 +36,7 @@ var expectedOutcome = map[string]string{
 	"liveness":          "",
 	"lazy":              "",
 	"lazy_liveness":     "",
+	"lazy_stale_cancel": "",
 	"persist":           "",
 	"persist_liveness":  "",
 	"flush_roundtrip":   "",
@@ -51,11 +52,10 @@ var expectedOutcome = map[string]string{
 	"flush_closure":     "",
 	// red: reproductions of known deficiencies in the current code; each
 	// config's comment describes the scenario and the mechanism
-	"release_inflight":  "ReturnedLive",
-	"drain_escape":      "ReturnedLive",
-	"lazy_stale_cancel": "NoStaleCancelError",
-	"flush_inflight":    "FlushCleanCapture",
-	"flush_drained":     "FlushCleanCapture",
+	"release_inflight": "ReturnedLive",
+	"drain_escape":     "ReturnedLive",
+	"flush_inflight":   "FlushCleanCapture",
+	"flush_drained":    "FlushCleanCapture",
 }
 
 type TlaCheck struct {

--- a/.dagger/modules/tla-check/main.go
+++ b/.dagger/modules/tla-check/main.go
@@ -37,6 +37,7 @@ var expectedOutcome = map[string]string{
 	"lazy":              "",
 	"lazy_liveness":     "",
 	"lazy_stale_cancel": "",
+	"lazy_import":       "",
 	"persist":           "",
 	"persist_liveness":  "",
 	"flush_roundtrip":   "",

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -739,6 +739,13 @@ func HasPendingLazyEvaluation(res AnyResult) bool {
 	if shared.lazyEvalComplete {
 		return false
 	}
+	// Attempt and pending-bookkeeping checks come before object-side state:
+	// a callback body clears its object-side pointer while its attempt is
+	// still running cache-side bookkeeping, so object-side state is only
+	// trustworthy when no attempt is in flight.
+	if shared.lazyEvalAttempt != nil || shared.lazySyncPending {
+		return true
+	}
 	if shared.lazyEval != nil {
 		return true
 	}
@@ -1651,6 +1658,12 @@ type sharedResult struct {
 	lazyEval         LazyEvalFunc
 	lazyEvalComplete bool
 	lazyEvalAttempt  *lazyEvalAttempt
+	// lazySyncPending records that a callback body already consumed its
+	// object-side lazy state but the attempt's cache-side bookkeeping
+	// (snapshot-lease sync, lease release) has not yet succeeded. The next
+	// attempt then retries only that bookkeeping instead of treating the nil
+	// object-side callback as completed evaluation.
+	lazySyncPending bool
 }
 
 type resultAttachmentState uint8
@@ -3135,33 +3148,17 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 	})
 
 	for {
-		// Fast path: if evaluation is already complete or there is nothing to do,
-		// skip preflight entirely. A retry returns here after another attempt
-		// completed successfully despite cancellation.
 		shared.lazyMu.Lock()
-		if shared.lazyEvalComplete || lazyEvalFuncOfResult(res) == nil {
-			shared.lazyMu.Unlock()
-			return nil
-		}
-		shared.lazyMu.Unlock()
-
-		shared.lazyMu.Lock()
-		currentLazyEval := lazyEvalFuncOfResult(res)
-		if currentLazyEval == nil {
-			shared.lazyEval = nil
-			shared.lazyEvalComplete = true
-			shared.lazyMu.Unlock()
-			return nil
-		}
 		if shared.lazyEvalComplete {
 			shared.lazyMu.Unlock()
 			return nil
 		}
-		shared.lazyEval = currentLazyEval
-		if shared.lazyEval == nil {
-			shared.lazyMu.Unlock()
-			return nil
-		}
+		// Consult the published attempt before any object-side lazy state.
+		// Callback bodies clear their object-side callback pointer while the
+		// attempt is still running its cache-side bookkeeping, so object-side
+		// state is only trustworthy once no attempt is in flight: retirement
+		// happens under lazyMu after the callback returns, ordering the body's
+		// writes before a reader that observes no attempt.
 		if attempt := shared.lazyEvalAttempt; attempt != nil {
 			lazyOpID := attempt.profOpID
 			// The leader initializes this attempt's OTel wait target under
@@ -3204,6 +3201,19 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 			}
 			return waitErr
 		}
+
+		// No attempt is in flight, so object-side lazy state is settled and
+		// safe to read. A nil object-side callback with no pending bookkeeping
+		// means nothing deferred remains anywhere; a nil callback with pending
+		// bookkeeping leads an attempt that retries only the bookkeeping.
+		currentLazyEval := lazyEvalFuncOfResult(res)
+		if currentLazyEval == nil && !shared.lazySyncPending {
+			shared.lazyEval = nil
+			shared.lazyEvalComplete = true
+			shared.lazyMu.Unlock()
+			return nil
+		}
+		shared.lazyEval = currentLazyEval
 
 		attemptCtx, cancel := context.WithCancelCause(context.WithoutCancel(stackCtx))
 		evalCtx := attemptCtx
@@ -3258,6 +3268,10 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 			callbackCtx := lazyCallbackCtx
 
 			var err error
+			// bodyDone means the callback body (if this attempt had one) has
+			// succeeded and consumed its object-side state; any later error in
+			// this attempt is cache-side bookkeeping, which stays retryable.
+			bodyDone := false
 			// End lazySpan before closing attempt.done so callers observe the span
 			// as ended and exported, and every joiner's target span is closed.
 			runEval := func() {
@@ -3274,8 +3288,11 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 				}
 				callbackCtx = leaseCtx
 
-				err = lazyEval(callbackCtx)
+				if lazyEval != nil {
+					err = lazyEval(callbackCtx)
+				}
 				if err == nil {
+					bodyDone = true
 					err = c.syncResultSnapshotLeases(callbackCtx, shared)
 				}
 				if releaseErr := release(context.WithoutCancel(callbackCtx)); releaseErr != nil && err == nil {
@@ -3292,6 +3309,9 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 			if err == nil {
 				shared.lazyEvalComplete = true
 				shared.lazyEval = nil
+				shared.lazySyncPending = false
+			} else if bodyDone {
+				shared.lazySyncPending = true
 			}
 			// Retire the shared pointer only after the callback has finished. Old
 			// waiters retain attempt, so they cannot read or decrement a retry's

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -1460,6 +1460,7 @@ type Cache struct {
 	testAfterSessionArbitraryRecord func()
 	testAfterSessionReleaseRecord   func()
 	testAfterHandoffHoldAcquired    func(*ongoingCall)
+	testAfterLazyEvalFinish         func(*lazyEvalAttempt)
 
 	closeOnce sync.Once
 	closeErr  error
@@ -1473,6 +1474,27 @@ type callConcurrencyKeys struct {
 type OnReleaseFunc = func(context.Context) error
 
 type sharedResultID uint64
+
+// lazyEvalAttempt is one execution of a shared result's lazy callback. The
+// shared result publishes the current attempt under lazyMu while its callback
+// is running. Waiters keep this record after callback completion so they can
+// consume that attempt's outcome without reading or decrementing a later
+// attempt's state. All fields except the immutable done channel are read or
+// written under the shared result's lazyMu.
+type lazyEvalAttempt struct {
+	done    chan struct{}
+	cancel  context.CancelCauseFunc
+	waiters int
+	err     error
+	retry   bool // err came from cancellation of this attempt's callback context
+
+	// profOpID and spanCtx are the native and OTel wait targets for this
+	// attempt. They are minted under lazyMu before the attempt is published.
+	// Their zero values mean that the corresponding telemetry source did not
+	// record this attempt.
+	profOpID uint64
+	spanCtx  trace.SpanContext
+}
 
 type sessionResourceBindings struct {
 	latestClientID string
@@ -1628,20 +1650,7 @@ type sharedResult struct {
 	lazyMu           sync.Mutex
 	lazyEval         LazyEvalFunc
 	lazyEvalComplete bool
-	lazyEvalWaitCh   chan struct{}
-	lazyEvalCancel   context.CancelCauseFunc
-	lazyEvalWaiters  int
-	lazyEvalErr      error
-	// lazyEvalProfOpID is the wcprof op for the in-flight lazy evaluation
-	// (guarded by lazyMu alongside lazyEvalWaitCh). Waiters record wait
-	// events against it.
-	lazyEvalProfOpID uint64
-	// lazyEvalSpanCtx is the OTel `lazy` op span for the in-flight lazy
-	// evaluation, the analog of lazyEvalProfOpID for the OTel
-	// profiling source. Minted and stashed under lazyMu before lazyEvalWaitCh is
-	// published so every joiner has a valid wait target (target-before-primitive).
-	// Invalid when telemetry is off.
-	lazyEvalSpanCtx trace.SpanContext
+	lazyEvalAttempt  *lazyEvalAttempt
 }
 
 type resultAttachmentState uint8
@@ -3013,41 +3022,51 @@ func (s resumedCallbackSpan) TracerProvider() trace.TracerProvider {
 	return s.tp
 }
 
-func (c *Cache) waitForLazyEvaluation(ctx context.Context, shared *sharedResult, waitCh chan struct{}) error {
-	var waitErr error
+func lazyEvalErrorCausedByContext(ctx context.Context, err error) bool {
+	if err == nil || ctx == nil || ctx.Err() == nil {
+		return false
+	}
+	cause := context.Cause(ctx)
+	return (cause != nil && errors.Is(err, cause)) || errors.Is(err, ctx.Err())
+}
+
+// waitForLazyEvaluation waits for one attempt and reports whether its outcome
+// should be retried. A retry is only requested when the callback returned the
+// cancellation of its own shared callback context while this caller remains
+// healthy. The caller's own cancellation always returns its own cause.
+func (c *Cache) waitForLazyEvaluation(ctx context.Context, shared *sharedResult, attempt *lazyEvalAttempt) (error, bool) {
 	select {
-	case <-waitCh:
+	case <-attempt.done:
 		shared.lazyMu.Lock()
-		waitErr = shared.lazyEvalErr
-		shared.lazyEvalWaiters--
-		if shared.lazyEvalWaiters == 0 && shared.lazyEvalWaitCh == waitCh {
-			shared.lazyEvalWaitCh = nil
-			shared.lazyEvalCancel = nil
-			shared.lazyEvalErr = nil
-			// Clear the joiner wait targets alongside lazyEvalWaitCh so they share
-			// its lifecycle (valid only while an attempt is in flight).
-			shared.lazyEvalProfOpID = 0
-			shared.lazyEvalSpanCtx = trace.SpanContext{}
-		}
+		waitErr := attempt.err
+		retry := attempt.retry
+		attempt.waiters--
 		shared.lazyMu.Unlock()
+		if retry {
+			if ownCause := context.Cause(ctx); ownCause != nil {
+				return ownCause, false
+			}
+			return nil, true
+		}
 		// Tag the failure with the result it belongs to so that an enclosing
 		// lazy callback's resume span can tell "a prerequisite failed" apart
 		// from "my own deferred work failed". See blockedOnPrerequisite.
 		if waitErr != nil {
 			waitErr = &prerequisiteEvalError{err: waitErr, resultID: shared.id}
 		}
+		return waitErr, false
 	case <-ctx.Done():
-		waitErr = context.Cause(ctx)
+		waitErr := context.Cause(ctx)
 		shared.lazyMu.Lock()
-		shared.lazyEvalWaiters--
-		lastWaiter := shared.lazyEvalWaiters == 0
-		cancel := shared.lazyEvalCancel
+		attempt.waiters--
+		lastWaiter := attempt.waiters == 0
+		cancel := attempt.cancel
 		shared.lazyMu.Unlock()
 		if lastWaiter && cancel != nil {
 			cancel(waitErr)
 		}
+		return waitErr, false
 	}
-	return waitErr
 }
 
 // prerequisiteEvalError wraps a lazy-evaluation failure with the identity of
@@ -3115,205 +3134,196 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		parent: stack,
 	})
 
-	// Fast path: if evaluation is already complete or there is nothing to do,
-	// skip preflight entirely.
-	shared.lazyMu.Lock()
-	if shared.lazyEvalComplete || lazyEvalFuncOfResult(res) == nil {
+	for {
+		// Fast path: if evaluation is already complete or there is nothing to do,
+		// skip preflight entirely. A retry returns here after another attempt
+		// completed successfully despite cancellation.
+		shared.lazyMu.Lock()
+		if shared.lazyEvalComplete || lazyEvalFuncOfResult(res) == nil {
+			shared.lazyMu.Unlock()
+			return nil
+		}
 		shared.lazyMu.Unlock()
-		return nil
-	}
-	shared.lazyMu.Unlock()
 
-	shared.lazyMu.Lock()
-	currentLazyEval := lazyEvalFuncOfResult(res)
-	if currentLazyEval == nil {
-		shared.lazyEval = nil
-		shared.lazyEvalComplete = true
-		shared.lazyMu.Unlock()
-		return nil
-	}
-	if shared.lazyEvalComplete {
-		shared.lazyMu.Unlock()
-		return nil
-	}
-	shared.lazyEval = currentLazyEval
-	if shared.lazyEval == nil {
-		shared.lazyMu.Unlock()
-		return nil
-	}
-	if shared.lazyEvalWaitCh != nil {
-		waitCh := shared.lazyEvalWaitCh
-		lazyOpID := shared.lazyEvalProfOpID
-		// OTel wait target for this joiner. The leader stashes it under lazyMu
-		// before publishing lazyEvalWaitCh (target-before-primitive) — valid when the
-		// current leader was recording. In a mixed-recording trace (an untraced
-		// leader on the in-flight attempt) it is the reset-to-invalid zero value
-		// (reset per attempt before publish), and EmitOTelWait below emits a
-		// gate-observable targetless wait rather than a stale link to a prior
-		// attempt's op.
-		lazyOpSpanCtx := shared.lazyEvalSpanCtx
-		shared.lazyEvalWaiters++
-		shared.lazyMu.Unlock()
-		// producerSkip drives ONLY the OTel joiner wait below; native is full detail
-		// and emits its wait unconditionally.
-		producerSkip := shared.profileSkip()
-		profWait := wcprof.BeginWait(stackCtx, lazyOpID, wcprof.WaitReasonLazy)
-		otelWaitStartNS := time.Now().UnixNano()
-		waitErr := c.waitForLazyEvaluation(stackCtx, shared, waitCh)
-		profWait.End()
-		// OTel joiner wait edge: the load-bearing edge — the
-		// lazy op is in the leader's subtree, not this joiner's, so this wait is the
-		// joiner's only causal link to the eval. EmitOTelWait is a no-op when the
-		// waiter is non-recording, and gate-observable (targetless) when the target is
-		// genuinely invalid (a non-uniform cross-session trace).
+		shared.lazyMu.Lock()
+		currentLazyEval := lazyEvalFuncOfResult(res)
+		if currentLazyEval == nil {
+			shared.lazyEval = nil
+			shared.lazyEvalComplete = true
+			shared.lazyMu.Unlock()
+			return nil
+		}
+		if shared.lazyEvalComplete {
+			shared.lazyMu.Unlock()
+			return nil
+		}
+		shared.lazyEval = currentLazyEval
+		if shared.lazyEval == nil {
+			shared.lazyMu.Unlock()
+			return nil
+		}
+		if attempt := shared.lazyEvalAttempt; attempt != nil {
+			lazyOpID := attempt.profOpID
+			// The leader initializes this attempt's OTel wait target under
+			// lazyMu before publishing shared.lazyEvalAttempt
+			// (target-before-primitive). A recording leader stores a valid target;
+			// an unrecorded leader leaves this fresh attempt record's zero value
+			// invalid. A joiner therefore cannot inherit a target from an earlier
+			// attempt, and mixed-recording waits remain gate-observable rather than
+			// silently linking to the wrong lazy operation.
+			lazyOpSpanCtx := attempt.spanCtx
+			attempt.waiters++
+			shared.lazyMu.Unlock()
+			// producerSkip drives ONLY the OTel joiner wait below; native is full
+			// detail and emits its wait unconditionally.
+			producerSkip := shared.profileSkip()
+			profWait := wcprof.BeginWait(stackCtx, lazyOpID, wcprof.WaitReasonLazy)
+			otelWaitStartNS := time.Now().UnixNano()
+			waitErr, retry := c.waitForLazyEvaluation(stackCtx, shared, attempt)
+			profWait.End()
+			// OTel joiner wait edge: the load-bearing edge — the lazy op is in the
+			// leader's subtree, not this joiner's, so this wait is the joiner's only
+			// causal link to the eval. EmitOTelWait is a no-op when the waiter is
+			// non-recording, and gate-observable (targetless) when the target is
+			// genuinely invalid (a non-uniform cross-session trace).
+			//
+			// LOAD-BEARING: gate this on the PRODUCER's stored skip flag, never the
+			// joiner's own bit. Elsewhere the profile-skip decision is safe to read
+			// off the waiter because a call and its singleflight joiners share one
+			// recipe and agree on it; a lazy forcer is a DIFFERENT recipe than the
+			// producer, so that agreement does NOT hold here. Gating on the
+			// producer's flag keeps a non-skipped forcer of a skipped-producer value
+			// from emitting an OTel wait into the deliberately absent producer span.
+			// Do NOT "simplify" this to the waiter's bit; that creates a dangling
+			// cross-recipe wait. Native keeps the full edge.
+			if !producerSkip {
+				EmitOTelWait(stackCtx, lazyOpSpanCtx, wcprof.WaitReasonLazy, otelWaitStartNS, time.Now().UnixNano())
+			}
+			if retry {
+				continue
+			}
+			return waitErr
+		}
+
+		attemptCtx, cancel := context.WithCancelCause(context.WithoutCancel(stackCtx))
+		evalCtx := attemptCtx
+		lazyEval := shared.lazyEval
+		resultCall := shared.loadResultCall()
+		if resultCall != nil {
+			evalCtx = ContextWithCall(evalCtx, resultCall)
+		}
+		attempt := &lazyEvalAttempt{
+			done:    make(chan struct{}),
+			cancel:  cancel,
+			waiters: 1,
+		}
+		// profOpID and spanCtx start invalid on every fresh attempt record. Mint
+		// either target below, while lazyMu is still held, before publishing the
+		// attempt pointer. A retry whose telemetry source is disabled therefore
+		// cannot expose a stale target from a recording attempt.
 		//
-		// LOAD-BEARING: gate this on the PRODUCER's stored skip flag, never the
-		// joiner's own bit. Elsewhere the profile-skip decision is safe to read off the
-		// waiter because a call and its singleflight joiners share one recipe and so
-		// agree on it; a lazy forcer is a DIFFERENT recipe than the producer, so that
-		// agreement does NOT hold here. Gating on the producer's flag keeps a
-		// non-skipped forcer of a skipped-producer value from emitting an OTel wait
-		// into the (deliberately) absent producer span — which the structural gate
-		// would otherwise count as unresolved. Do NOT "simplify" this to the waiter's
-		// bit; that reopens a cross-recipe dangle. (Accepted coarsening, OTel
-		// side only: such a forcer loses its OTel wait edge, folding the blocked time
-		// into its own self-time. Rare — metadata is computed eagerly. Native keeps
-		// the full edge.)
-		if !producerSkip {
-			EmitOTelWait(stackCtx, lazyOpSpanCtx, wcprof.WaitReasonLazy, otelWaitStartNS, time.Now().UnixNano())
+		// producerSkip drives ONLY the OTel lazy span and OTel lazy waits. When
+		// the producer is a reflection/introspection recipe, the OTel source mints
+		// no lazy span and all waiters use the same producer-derived gate. Native
+		// profiling remains full detail and mints its operation unconditionally.
+		producerSkip := frameProfileSkip(resultCall)
+		var lazyOp *wcprof.Op
+		if wcprof.Enabled(evalCtx) {
+			// The run of this result's lazy callback; the class ties the cost back
+			// to the call that created the lazy value.
+			evalCtx, lazyOp = wcprof.BeginOp(evalCtx, wcprof.OpKindLazy, profCallClass(resultCall), wcprof.OpOpts{
+				ClientID: profClientID(stackCtx),
+			})
+			attempt.profOpID = lazyOp.ID()
+		}
+		// Mint the OTel lazy span under lazyMu before publishing the attempt, so
+		// every joiner sees this attempt's valid target or its deliberate invalid
+		// zero value. The callback goroutine adopts and ends the span.
+		var (
+			lazySpan        trace.Span
+			lazyCallbackCtx = evalCtx
+			lazyIsResume    bool
+		)
+		if OTelProfActive(evalCtx) && !producerSkip {
+			lazyCallbackCtx, lazySpan, lazyIsResume = c.beginOTelLazyOp(evalCtx, shared.id, resultCall)
+			attempt.spanCtx = lazySpan.SpanContext()
+		}
+		shared.lazyEvalAttempt = attempt
+		shared.lazyMu.Unlock()
+
+		go func() {
+			// The lazy op span and re-pointed callback context were minted under
+			// lazyMu before this attempt was published. A span created on one
+			// goroutine and ended on another is safe.
+			callbackCtx := lazyCallbackCtx
+
+			var err error
+			// End lazySpan before closing attempt.done so callers observe the span
+			// as ended and exported, and every joiner's target span is closed.
+			runEval := func() {
+				if lazySpan != nil {
+					defer func() {
+						endOTelLazyOp(lazySpan, lazyIsResume, shared.id, &err)
+					}()
+				}
+
+				leaseCtx, release, leaseErr := withOperationLease(withoutOperationLease(callbackCtx))
+				if leaseErr != nil {
+					err = fmt.Errorf("acquire operation lease: %w", leaseErr)
+					return
+				}
+				callbackCtx = leaseCtx
+
+				err = lazyEval(callbackCtx)
+				if err == nil {
+					err = c.syncResultSnapshotLeases(callbackCtx, shared)
+				}
+				if releaseErr := release(context.WithoutCancel(callbackCtx)); releaseErr != nil && err == nil {
+					err = releaseErr
+				}
+			}
+			runEval()
+			lazyOp.EndWithResult(profErrOutcome(err), uint64(shared.id))
+
+			shared.lazyMu.Lock()
+			attempt.err = err
+			attempt.retry = lazyEvalErrorCausedByContext(attemptCtx, err)
+			attempt.cancel = nil
+			if err == nil {
+				shared.lazyEvalComplete = true
+				shared.lazyEval = nil
+			}
+			// Retire the shared pointer only after the callback has finished. Old
+			// waiters retain attempt, so they cannot read or decrement a retry's
+			// state; new callers may now safely lead a fresh callback.
+			if shared.lazyEvalAttempt == attempt {
+				shared.lazyEvalAttempt = nil
+			}
+			shared.lazyMu.Unlock()
+
+			if c.testAfterLazyEvalFinish != nil {
+				c.testAfterLazyEvalFinish(attempt)
+			}
+			close(attempt.done)
+		}()
+
+		// Native profiling is full detail and emits the leader wait
+		// unconditionally. The OTel leader wait follows lazySpan != nil, which the
+		// producer's profile-skip gate above already controls.
+		profWait := wcprof.BeginWait(stackCtx, lazyOp.ID(), wcprof.WaitReasonLazy)
+		otelWaitStartNS := time.Now().UnixNano()
+		waitErr, retry := c.waitForLazyEvaluation(stackCtx, shared, attempt)
+		profWait.End()
+		if lazySpan != nil {
+			// The leader's wait on its own lazy op is redundant with nesting but is
+			// emitted for parity with native profiling and executor waits.
+			EmitOTelWait(stackCtx, lazySpan.SpanContext(), wcprof.WaitReasonLazy, otelWaitStartNS, time.Now().UnixNano())
+		}
+		if retry {
+			continue
 		}
 		return waitErr
 	}
-
-	waitCh := make(chan struct{})
-	evalCtx, cancel := context.WithCancelCause(context.WithoutCancel(stackCtx))
-	lazyEval := shared.lazyEval
-	resultCall := shared.loadResultCall()
-	if resultCall != nil {
-		evalCtx = ContextWithCall(evalCtx, resultCall)
-	}
-	// Reset both per-attempt joiner wait targets before this attempt mints (or
-	// doesn't) and publishes lazyEvalWaitCh below. A failed lazy eval is retryable
-	// (lazyEvalComplete is set only on success), and these fields are read by
-	// joiners whenever lazyEvalWaitCh is set. If a later retry leader does not
-	// re-mint — its wcprof/telemetry is off — a stale target left by a prior
-	// recording attempt must NOT leak to a joiner: it would silently mis-link the
-	// wait to the old op instead of being gate-observable as an unresolved target
-	// (the mixed-recording rule). Each is overwritten just below
-	// only when this attempt actually mints it. (lazyEvalProfOpID is native's
-	// analog and had the same not-reset hazard; reset together to keep the two
-	// sources aligned and both honest under non-uniform recording.)
-	shared.lazyEvalProfOpID = 0
-	shared.lazyEvalSpanCtx = trace.SpanContext{}
-	// producerSkip drives ONLY the OTel lazy span (and the OTel lazy waits) below:
-	// when the producer is a reflection/introspection recipe the OTel source mints no
-	// lazy span, so its eval span context stays the reset-invalid zero and every OTel
-	// lazy waiter (gated on the same flag) emits no wait — keeping the OTel mint and
-	// OTel waits consistent across a cross-recipe forcer. Native is full detail and
-	// mints its lazy op unconditionally.
-	producerSkip := frameProfileSkip(resultCall)
-	var lazyOp *wcprof.Op
-	if wcprof.Enabled(evalCtx) {
-		// the run of this result's lazy evaluation callback; the class ties
-		// the cost back to the call that created the lazy value
-		evalCtx, lazyOp = wcprof.BeginOp(evalCtx, wcprof.OpKindLazy, profCallClass(resultCall), wcprof.OpOpts{
-			ClientID: profClientID(stackCtx),
-		})
-		shared.lazyEvalProfOpID = lazyOp.ID()
-	}
-	// OTel `lazy` op: mint its span here — under lazyMu, before
-	// lazyEvalWaitCh is published below — so every joiner has a valid wait target
-	// (target-before-primitive). The goroutine adopts it to run + end the callback,
-	// and the stamping processor re-homes the re-pointed work spans to it causally
-	// without moving any span (UI unchanged). Gated on telemetry being active (not
-	// wcprof.Enabled) so the OTel source reconstructs from a Cloud trace alone.
-	var (
-		lazySpan        trace.Span
-		lazyCallbackCtx = evalCtx
-		lazyIsResume    bool
-	)
-	if OTelProfActive(evalCtx) && !producerSkip {
-		lazyCallbackCtx, lazySpan, lazyIsResume = c.beginOTelLazyOp(evalCtx, shared.id, resultCall)
-		shared.lazyEvalSpanCtx = lazySpan.SpanContext()
-	}
-	shared.lazyEvalWaitCh = waitCh
-	shared.lazyEvalCancel = cancel
-	shared.lazyEvalWaiters = 1
-	shared.lazyEvalErr = nil
-	shared.lazyMu.Unlock()
-
-	go func() {
-		// The lazy op span and the re-pointed callback context were minted under
-		// lazyMu above (beginOTelLazyOp, before lazyEvalWaitCh is published); adopt
-		// them here. A span created on one goroutine and ended on another is fine.
-		callbackCtx := lazyCallbackCtx
-
-		var err error
-		// End lazySpan before close(waitCh) so that callers awaiting evaluation
-		// observe the span as ended (and exported, via sync processors), and so a
-		// joiner's wait target span is closed. Deferring would fire only after
-		// close(waitCh) and race with the caller's flush/read of exported spans.
-		runEval := func() {
-			if lazySpan != nil {
-				defer func() {
-					endOTelLazyOp(lazySpan, lazyIsResume, shared.id, &err)
-				}()
-			}
-
-			leaseCtx, release, leaseErr := withOperationLease(withoutOperationLease(callbackCtx))
-			if leaseErr != nil {
-				err = fmt.Errorf("acquire operation lease: %w", leaseErr)
-				return
-			}
-			callbackCtx = leaseCtx
-
-			err = lazyEval(callbackCtx)
-			if err == nil {
-				err = c.syncResultSnapshotLeases(callbackCtx, shared)
-			}
-			if releaseErr := release(context.WithoutCancel(callbackCtx)); releaseErr != nil && err == nil {
-				err = releaseErr
-			}
-		}
-		runEval()
-		lazyOp.EndWithResult(profErrOutcome(err), uint64(shared.id))
-
-		shared.lazyMu.Lock()
-		shared.lazyEvalErr = err
-		if err == nil {
-			shared.lazyEvalComplete = true
-			shared.lazyEval = nil
-		}
-		clearState := shared.lazyEvalWaiters == 0 && shared.lazyEvalWaitCh == waitCh
-		if clearState {
-			shared.lazyEvalWaitCh = nil
-			shared.lazyEvalCancel = nil
-			shared.lazyEvalErr = nil
-			// Clear the joiner wait targets alongside lazyEvalWaitCh (they are valid
-			// only while an attempt is in flight).
-			shared.lazyEvalProfOpID = 0
-			shared.lazyEvalSpanCtx = trace.SpanContext{}
-		}
-		shared.lazyMu.Unlock()
-
-		close(waitCh)
-	}()
-
-	// native: full detail, emits its leader wait unconditionally (lazyOp is minted
-	// whenever wcprof is enabled). The OTel leader wait below follows lazySpan != nil,
-	// which the OTel lazy span gate above already keyed on producerSkip.
-	profWait := wcprof.BeginWait(stackCtx, lazyOp.ID(), wcprof.WaitReasonLazy)
-	otelWaitStartNS := time.Now().UnixNano()
-	waitErr := c.waitForLazyEvaluation(stackCtx, shared, waitCh)
-	profWait.End()
-	if lazySpan != nil {
-		// The leader's OTel wait on its own lazy op: the lazy
-		// op nests under the leader, so the implicit join already serializes it and
-		// this edge is redundant-but-harmless — emitted for oracle parity with
-		// native's leader wait (just above) and matching the executor's own wait.
-		EmitOTelWait(stackCtx, lazySpan.SpanContext(), wcprof.WaitReasonLazy, otelWaitStartNS, time.Now().UnixNano())
-	}
-	return waitErr
 }
 
 func (c *Cache) Close(ctx context.Context) error {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -2995,16 +2995,22 @@ func (c *Cache) registerLazyEvaluation(shared *sharedResult, val AnyResult) {
 	if shared == nil || val == nil {
 		return
 	}
-	lazyEval := lazyEvalFuncOfResult(val)
-	if lazyEval == nil {
-		return
-	}
 
 	shared.lazyMu.Lock()
-	if shared.lazyEval == nil && !shared.lazyEvalComplete {
+	defer shared.lazyMu.Unlock()
+	// Read object-side lazy state only when no attempt is in flight, for the
+	// same reason evaluateOne does: callback bodies clear their object-side
+	// pointer without holding lazyMu, and attempt retirement under lazyMu
+	// orders those writes before a reader that observes no attempt. With an
+	// attempt published, a stored callback, pending bookkeeping, or completed
+	// evaluation, there is nothing to register.
+	if shared.lazyEval != nil || shared.lazyEvalComplete ||
+		shared.lazyEvalAttempt != nil || shared.lazySyncPending {
+		return
+	}
+	if lazyEval := lazyEvalFuncOfResult(val); lazyEval != nil {
 		shared.lazyEval = lazyEval
 	}
-	shared.lazyMu.Unlock()
 }
 
 func lazyEvalStackFromContext(ctx context.Context) *lazyEvalStackNode {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -3209,15 +3209,21 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		}
 
 		// No attempt is in flight, so object-side lazy state is settled and
-		// safe to read. A nil object-side callback with no pending bookkeeping
-		// means nothing deferred remains anywhere; a nil callback with pending
-		// bookkeeping leads an attempt that retries only the bookkeeping.
-		currentLazyEval := lazyEvalFuncOfResult(res)
-		if currentLazyEval == nil && !shared.lazySyncPending {
-			shared.lazyEval = nil
-			shared.lazyEvalComplete = true
-			shared.lazyMu.Unlock()
-			return nil
+		// safe to read. Pending bookkeeping takes precedence over the
+		// object-side callback: it means a previous attempt's body already
+		// succeeded and consumed the value's deferred work, so the next
+		// attempt retries only the bookkeeping even if the value still
+		// exposes a non-nil callback. Otherwise a nil object-side callback
+		// means nothing deferred remains anywhere.
+		var currentLazyEval LazyEvalFunc
+		if !shared.lazySyncPending {
+			currentLazyEval = lazyEvalFuncOfResult(res)
+			if currentLazyEval == nil {
+				shared.lazyEval = nil
+				shared.lazyEvalComplete = true
+				shared.lazyMu.Unlock()
+				return nil
+			}
 		}
 		shared.lazyEval = currentLazyEval
 

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -3295,10 +3295,10 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 			}
 			// Retire the shared pointer only after the callback has finished. Old
 			// waiters retain attempt, so they cannot read or decrement a retry's
-			// state; new callers may now safely lead a fresh callback.
-			if shared.lazyEvalAttempt == attempt {
-				shared.lazyEvalAttempt = nil
-			}
+			// state; new callers may now safely lead a fresh callback. The pointer
+			// still names this attempt: publishing a successor requires it to be
+			// nil, and only this path clears it.
+			shared.lazyEvalAttempt = nil
 			shared.lazyMu.Unlock()
 
 			if c.testAfterLazyEvalFinish != nil {

--- a/dagql/cache_lazy_retry_test.go
+++ b/dagql/cache_lazy_retry_test.go
@@ -489,3 +489,71 @@ func TestCacheEvaluateSettlesBookkeepingBeforeReportingComplete(t *testing.T) {
 		}
 	})
 }
+
+// An ordinary cache hit re-registers lazy evaluation through
+// ensurePersistedHitValueLoaded while another caller's callback body may be
+// clearing the same object-side lazy pointer. Registration must therefore
+// consult the published attempt under lazyMu before reading any object-side
+// state. This test drives hits concurrently with a running callback and is
+// meaningful under the race detector: with the object-side read unordered,
+// -race reports the write in the callback against the read in registration.
+func TestCacheHitRegistrationDoesNotRaceLazyCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx = ContextWithCache(ctx, c)
+	srv := cacheTestServer(t)
+	sessionID := cacheTestSessionID(t, ctx)
+
+	blockCallback := make(chan struct{})
+	var obj *cacheTestObject
+	frame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&cacheTestObject{}).Type()),
+		Field: "lazy-hit-registration-race",
+	}
+	resAny, err := c.GetOrInitCall(ctx, sessionID, srv, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		obj = &cacheTestObject{Value: 1}
+		obj.lazyEval = func(context.Context) error {
+			obj.lazyEval = nil
+			<-blockCallback
+			return nil
+		}
+		return cacheTestObjectResultWithValue(t, srv, frame, obj), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := resAny.(ObjectResult[*cacheTestObject])
+
+	evalDone := make(chan error, 1)
+	go func() { evalDone <- c.Evaluate(ctx, res) }()
+
+	hit := func() {
+		hitRes, hitErr := c.GetOrInitCall(ctx, sessionID, srv, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+			t.Error("hit-path call unexpectedly re-executed")
+			return nil, errors.New("unexpected re-execution")
+		})
+		if hitErr != nil {
+			t.Error(hitErr)
+		}
+		_ = hitRes
+	}
+	// Hits race the callback body's object-side clear while it runs, then
+	// keep going through completion so registration is exercised against
+	// every attempt state.
+	for range 50 {
+		hit()
+	}
+	close(blockCallback)
+	if err := waitLazyRetryError(t, evalDone, "evaluate outcome"); err != nil {
+		t.Fatal(err)
+	}
+	for range 10 {
+		hit()
+	}
+}

--- a/dagql/cache_lazy_retry_test.go
+++ b/dagql/cache_lazy_retry_test.go
@@ -358,3 +358,134 @@ func TestCacheEvaluatePropagatesCallbackFailure(t *testing.T) {
 		}
 	})
 }
+
+// lazyBookkeepingSnapshotManager blocks AttachLease until the test supplies
+// an outcome, so the window between a callback body finishing and the
+// attempt's bookkeeping settling can be held open deterministically.
+type lazyBookkeepingSnapshotManager struct {
+	fakeSnapshotManager
+	attachEntered chan struct{}
+	attachResult  chan error
+}
+
+func (m *lazyBookkeepingSnapshotManager) AttachLease(ctx context.Context, leaseID, snapshotID string) error {
+	_ = m.fakeSnapshotManager.AttachLease(ctx, leaseID, snapshotID)
+	m.attachEntered <- struct{}{}
+	return <-m.attachResult
+}
+
+func lazySyncState(shared *sharedResult) (pending, complete bool) {
+	shared.lazyMu.Lock()
+	defer shared.lazyMu.Unlock()
+	return shared.lazySyncPending, shared.lazyEvalComplete
+}
+
+// A callback body consumes its object-side lazy state (mirroring how core
+// types clear their Lazy pointer) before the attempt's snapshot-lease
+// bookkeeping settles. During that window a second Evaluate must join the
+// running attempt rather than observe the nil object-side callback and
+// report success. A failed bookkeeping step must stay retryable instead of
+// being swallowed as completed evaluation, and the retry must not re-run
+// the already-consumed body.
+func TestCacheEvaluateSettlesBookkeepingBeforeReportingComplete(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &lazyBookkeepingSnapshotManager{
+			attachEntered: make(chan struct{}),
+			attachResult:  make(chan error),
+		}
+
+		ctx := cacheTestContext(t.Context())
+		c, err := NewCache(ctx, "", mgr, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx = ContextWithCache(ctx, c)
+		srv := cacheTestServer(t)
+		sessionID := cacheTestSessionID(t, ctx)
+
+		var bodyRuns atomic.Int32
+		var obj *cacheTestObject
+		frame := &ResultCall{
+			Kind:  ResultCallKindField,
+			Type:  NewResultCallType((&cacheTestObject{}).Type()),
+			Field: "lazy-bookkeeping-settle",
+		}
+		resAny, err := c.GetOrInitCall(ctx, sessionID, srv, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+			obj = &cacheTestObject{Value: 1}
+			obj.lazyEval = func(context.Context) error {
+				bodyRuns.Add(1)
+				obj.snapshotLinks = []PersistedSnapshotRefLink{{
+					RefKey: "lazy-produced-snapshot",
+					Role:   "snapshot",
+				}}
+				obj.lazyEval = nil
+				return nil
+			}
+			return cacheTestObjectResultWithValue(t, srv, frame, obj), nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := resAny.(ObjectResult[*cacheTestObject])
+		shared := res.cacheSharedResult()
+
+		eval1 := make(chan error, 1)
+		go func() { eval1 <- c.Evaluate(ctx, res) }()
+
+		// The body has finished and cleared the object-side callback; the
+		// attempt is now blocked inside its snapshot-lease bookkeeping.
+		waitLazyRetrySignal(t, mgr.attachEntered, "first bookkeeping attach")
+
+		eval2 := make(chan error, 1)
+		go func() { eval2 <- c.Evaluate(ctx, res) }()
+		synctest.Wait()
+		select {
+		case err := <-eval2:
+			t.Fatalf("second Evaluate returned (%v) while the attempt's bookkeeping was still in flight", err)
+		case err := <-eval1:
+			t.Fatalf("first Evaluate returned (%v) while its bookkeeping was still in flight", err)
+		default:
+		}
+
+		injected := errors.New("attach owner lease failed")
+		mgr.attachResult <- injected
+		if err := waitLazyRetryError(t, eval1, "first Evaluate outcome"); !errors.Is(err, injected) {
+			t.Fatalf("first Evaluate error = %v, want the injected bookkeeping failure", err)
+		}
+		if err := waitLazyRetryError(t, eval2, "second Evaluate outcome"); !errors.Is(err, injected) {
+			t.Fatalf("second Evaluate error = %v, want the injected bookkeeping failure", err)
+		}
+
+		pending, complete := lazySyncState(shared)
+		if !pending || complete {
+			t.Fatalf("after failed bookkeeping: pending=%v complete=%v, want pending and not complete", pending, complete)
+		}
+		if !HasPendingLazyEvaluation(res) {
+			t.Fatal("pending bookkeeping must still report as pending lazy evaluation")
+		}
+
+		// The retry leads a bookkeeping-only attempt: no body re-run, one
+		// more attach, then completion.
+		eval3 := make(chan error, 1)
+		go func() { eval3 <- c.Evaluate(ctx, res) }()
+		waitLazyRetrySignal(t, mgr.attachEntered, "retried bookkeeping attach")
+		mgr.attachResult <- nil
+		if err := waitLazyRetryError(t, eval3, "third Evaluate outcome"); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := bodyRuns.Load(); got != 1 {
+			t.Fatalf("callback body ran %d times, want exactly 1", got)
+		}
+		if got := len(mgr.fakeSnapshotManager.attachCalls); got != 2 {
+			t.Fatalf("AttachLease called %d times, want 2 (failed then retried)", got)
+		}
+		pending, complete = lazySyncState(shared)
+		if pending || !complete {
+			t.Fatalf("after settled bookkeeping: pending=%v complete=%v, want complete and not pending", pending, complete)
+		}
+		if HasPendingLazyEvaluation(res) {
+			t.Fatal("settled evaluation must not report as pending")
+		}
+	})
+}

--- a/dagql/cache_lazy_retry_test.go
+++ b/dagql/cache_lazy_retry_test.go
@@ -490,6 +490,96 @@ func TestCacheEvaluateSettlesBookkeepingBeforeReportingComplete(t *testing.T) {
 	})
 }
 
+// A previous attempt's body succeeded but its bookkeeping failed, and the
+// value keeps exposing a non-nil callback: nothing forces HasLazyEvaluation
+// implementations to clear their callback on success. Pending bookkeeping
+// must take precedence over the re-read object-side callback, so the retry
+// runs bookkeeping only and the body executes exactly once.
+func TestCacheEvaluatePendingBookkeepingSkipsUnclearedCallback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &lazyBookkeepingSnapshotManager{
+			attachEntered: make(chan struct{}),
+			attachResult:  make(chan error),
+		}
+
+		ctx := cacheTestContext(t.Context())
+		c, err := NewCache(ctx, "", mgr, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx = ContextWithCache(ctx, c)
+		srv := cacheTestServer(t)
+		sessionID := cacheTestSessionID(t, ctx)
+
+		var bodyRuns atomic.Int32
+		var obj *cacheTestObject
+		frame := &ResultCall{
+			Kind:  ResultCallKindField,
+			Type:  NewResultCallType((&cacheTestObject{}).Type()),
+			Field: "lazy-uncleared-callback",
+		}
+		resAny, err := c.GetOrInitCall(ctx, sessionID, srv, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+			obj = &cacheTestObject{Value: 1}
+			// The body deliberately leaves obj.lazyEval armed after success.
+			obj.lazyEval = func(context.Context) error {
+				bodyRuns.Add(1)
+				obj.snapshotLinks = []PersistedSnapshotRefLink{{
+					RefKey: "lazy-produced-snapshot",
+					Role:   "snapshot",
+				}}
+				return nil
+			}
+			return cacheTestObjectResultWithValue(t, srv, frame, obj), nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := resAny.(ObjectResult[*cacheTestObject])
+		shared := res.cacheSharedResult()
+
+		eval1 := make(chan error, 1)
+		go func() { eval1 <- c.Evaluate(ctx, res) }()
+		waitLazyRetrySignal(t, mgr.attachEntered, "first bookkeeping attach")
+		injected := errors.New("attach owner lease failed")
+		mgr.attachResult <- injected
+		if err := waitLazyRetryError(t, eval1, "first Evaluate outcome"); !errors.Is(err, injected) {
+			t.Fatalf("first Evaluate error = %v, want the injected bookkeeping failure", err)
+		}
+		if pending, complete := lazySyncState(shared); !pending || complete {
+			t.Fatalf("after failed bookkeeping: pending=%v complete=%v, want pending and not complete", pending, complete)
+		}
+
+		// The retry must lead a bookkeeping-only attempt even though the
+		// value still exposes its callback.
+		eval2 := make(chan error, 1)
+		go func() { eval2 <- c.Evaluate(ctx, res) }()
+		waitLazyRetrySignal(t, mgr.attachEntered, "retried bookkeeping attach")
+		mgr.attachResult <- nil
+		if err := waitLazyRetryError(t, eval2, "second Evaluate outcome"); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := bodyRuns.Load(); got != 1 {
+			t.Fatalf("callback body ran %d times, want exactly 1", got)
+		}
+		if got := len(mgr.fakeSnapshotManager.attachCalls); got != 2 {
+			t.Fatalf("AttachLease called %d times, want 2 (failed then retried)", got)
+		}
+		if pending, complete := lazySyncState(shared); pending || !complete {
+			t.Fatalf("after settled bookkeeping: pending=%v complete=%v, want complete and not pending", pending, complete)
+		}
+
+		// Completed evaluation short-circuits before the still-armed
+		// callback can be observed again.
+		if err := c.Evaluate(ctx, res); err != nil {
+			t.Fatal(err)
+		}
+		if got := bodyRuns.Load(); got != 1 {
+			t.Fatalf("callback body ran %d times after completion, want exactly 1", got)
+		}
+	})
+}
+
 // An ordinary cache hit re-registers lazy evaluation through
 // ensurePersistedHitValueLoaded while another caller's callback body may be
 // clearing the same object-side lazy pointer. Registration must therefore

--- a/dagql/cache_lazy_retry_test.go
+++ b/dagql/cache_lazy_retry_test.go
@@ -1,0 +1,360 @@
+package dagql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func newLazyRetryTestResult(
+	t *testing.T,
+	lazyEval LazyEvalFunc,
+) (context.Context, *Cache, string, ObjectResult[*cacheTestObject]) {
+	t.Helper()
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx = ContextWithCache(ctx, c)
+	srv := cacheTestServer(t)
+	sessionID := cacheTestSessionID(t, ctx)
+	frame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&cacheTestObject{}).Type()),
+		Field: "lazy-attempt-retry",
+	}
+	resAny, err := c.GetOrInitCall(ctx, sessionID, srv, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResultWithValue(t, srv, frame, &cacheTestObject{
+			Value:    1,
+			lazyEval: lazyEval,
+		}), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx, c, sessionID, resAny.(ObjectResult[*cacheTestObject])
+}
+
+func waitLazyRetrySignal(t *testing.T, ch <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitLazyRetryError(t *testing.T, ch <-chan error, description string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		return nil
+	}
+}
+
+func updateLazyRetryMax(maxRunning *atomic.Int32, running int32) {
+	for {
+		previous := maxRunning.Load()
+		if running <= previous || maxRunning.CompareAndSwap(previous, running) {
+			return
+		}
+	}
+}
+
+func currentLazyAttempt(shared *sharedResult) (*lazyEvalAttempt, int) {
+	shared.lazyMu.Lock()
+	defer shared.lazyMu.Unlock()
+	if shared.lazyEvalAttempt == nil {
+		return nil, 0
+	}
+	return shared.lazyEvalAttempt, shared.lazyEvalAttempt.waiters
+}
+
+func TestCacheEvaluateRetriesForeignCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		var running atomic.Int32
+		var maxRunning atomic.Int32
+		firstStarted := make(chan struct{})
+		firstCanceled := make(chan struct{})
+		allowFirstFinish := make(chan struct{})
+
+		ctx, c, sessionID, result := newLazyRetryTestResult(t, func(ctx context.Context) error {
+			call := calls.Add(1)
+			nowRunning := running.Add(1)
+			updateLazyRetryMax(&maxRunning, nowRunning)
+			defer running.Add(-1)
+			if call == 1 {
+				close(firstStarted)
+				<-ctx.Done()
+				close(firstCanceled)
+				<-allowFirstFinish
+				return context.Cause(ctx)
+			}
+			return nil
+		})
+		shared := result.cacheSharedResult()
+
+		leaderCtx, cancelLeader := context.WithCancelCause(ctx)
+		leaderDone := make(chan error, 1)
+		go func() {
+			leaderDone <- c.Evaluate(leaderCtx, result)
+		}()
+		waitLazyRetrySignal(t, firstStarted, "the first lazy callback to start")
+
+		abandonErr := errors.New("first waiter abandoned")
+		cancelLeader(abandonErr)
+		if err := waitLazyRetryError(t, leaderDone, "the abandoning leader"); !errors.Is(err, abandonErr) {
+			t.Fatalf("leader error = %v, want its own cancellation %v", err, abandonErr)
+		}
+		waitLazyRetrySignal(t, firstCanceled, "the first callback to observe cancellation")
+		oldAttempt, waiters := currentLazyAttempt(shared)
+		if oldAttempt == nil || waiters != 0 {
+			t.Fatalf("canceled attempt = %p with %d waiters, want published with zero waiters", oldAttempt, waiters)
+		}
+
+		healthyDone := make(chan error, 1)
+		go func() {
+			healthyDone <- c.Evaluate(ctx, result)
+		}()
+		synctest.Wait()
+		joinedAttempt, waiters := currentLazyAttempt(shared)
+		if joinedAttempt != oldAttempt || waiters != 1 {
+			t.Fatalf("healthy caller joined attempt %p with %d waiters, want canceled attempt %p with one waiter", joinedAttempt, waiters, oldAttempt)
+		}
+
+		close(allowFirstFinish)
+		if err := waitLazyRetryError(t, healthyDone, "the healthy retrying caller"); err != nil {
+			t.Fatalf("healthy caller inherited another waiter's cancellation: %v", err)
+		}
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("lazy callback calls = %d, want two attempts", got)
+		}
+		if got := maxRunning.Load(); got != 1 {
+			t.Fatalf("maximum concurrent lazy callbacks = %d, want one", got)
+		}
+		if err := c.ReleaseSession(ctx, sessionID); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestCacheEvaluateRetiresFinishedAttemptBeforeWaitersDrain(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		var running atomic.Int32
+		var maxRunning atomic.Int32
+		firstStarted := make(chan struct{})
+		firstCanceled := make(chan struct{})
+		allowFirstFinish := make(chan struct{})
+
+		ctx, c, sessionID, result := newLazyRetryTestResult(t, func(ctx context.Context) error {
+			call := calls.Add(1)
+			nowRunning := running.Add(1)
+			updateLazyRetryMax(&maxRunning, nowRunning)
+			defer running.Add(-1)
+			if call == 1 {
+				close(firstStarted)
+				<-ctx.Done()
+				close(firstCanceled)
+				<-allowFirstFinish
+				return context.Cause(ctx)
+			}
+			return nil
+		})
+		shared := result.cacheSharedResult()
+
+		leaderCtx, cancelLeader := context.WithCancelCause(ctx)
+		leaderDone := make(chan error, 1)
+		go func() {
+			leaderDone <- c.Evaluate(leaderCtx, result)
+		}()
+		waitLazyRetrySignal(t, firstStarted, "the first lazy callback to start")
+		leaderCause := errors.New("leader canceled the first attempt")
+		cancelLeader(leaderCause)
+		if err := waitLazyRetryError(t, leaderDone, "the first leader"); !errors.Is(err, leaderCause) {
+			t.Fatalf("leader error = %v, want %v", err, leaderCause)
+		}
+		waitLazyRetrySignal(t, firstCanceled, "the callback to observe leader cancellation")
+		oldAttempt, _ := currentLazyAttempt(shared)
+		if oldAttempt == nil {
+			t.Fatal("canceled attempt was unpublished before its callback finished")
+		}
+
+		lateCtx, cancelLate := context.WithCancelCause(ctx)
+		lateDone := make(chan error, 1)
+		go func() {
+			lateDone <- c.Evaluate(lateCtx, result)
+		}()
+		synctest.Wait()
+		joinedAttempt, waiters := currentLazyAttempt(shared)
+		if joinedAttempt != oldAttempt || waiters != 1 {
+			t.Fatalf("late caller joined attempt %p with %d waiters, want canceled attempt %p with one waiter", joinedAttempt, waiters, oldAttempt)
+		}
+
+		finished := make(chan struct{})
+		allowDoneClose := make(chan struct{})
+		c.testAfterLazyEvalFinish = func(attempt *lazyEvalAttempt) {
+			if attempt != oldAttempt {
+				return
+			}
+			close(finished)
+			<-allowDoneClose
+		}
+		close(allowFirstFinish)
+		waitLazyRetrySignal(t, finished, "the canceled callback to retire its attempt")
+		if current, _ := currentLazyAttempt(shared); current != nil {
+			t.Fatalf("finished attempt remains published as %p", current)
+		}
+
+		lateCause := errors.New("late waiter canceled after callback completion")
+		cancelLate(lateCause)
+		if err := waitLazyRetryError(t, lateDone, "the late canceled waiter"); !errors.Is(err, lateCause) {
+			t.Fatalf("late waiter error = %v, want its own cancellation %v", err, lateCause)
+		}
+
+		healthyDone := make(chan error, 1)
+		go func() {
+			healthyDone <- c.Evaluate(ctx, result)
+		}()
+		if err := waitLazyRetryError(t, healthyDone, "the caller after completed-attempt retirement"); err != nil {
+			t.Fatalf("caller after retirement inherited a stale error: %v", err)
+		}
+		close(allowDoneClose)
+		waitLazyRetrySignal(t, oldAttempt.done, "the retired attempt's completion channel to close")
+
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("lazy callback calls = %d, want two attempts", got)
+		}
+		if got := maxRunning.Load(); got != 1 {
+			t.Fatalf("maximum concurrent lazy callbacks = %d, want one", got)
+		}
+		if err := c.ReleaseSession(ctx, sessionID); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestCacheEvaluateOwnCancellationOnlyCancelsOwnWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var calls atomic.Int32
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		ctx, c, sessionID, result := newLazyRetryTestResult(t, func(ctx context.Context) error {
+			calls.Add(1)
+			close(started)
+			<-release
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("callback canceled while a healthy waiter remained: %w", context.Cause(ctx))
+			}
+			return nil
+		})
+		shared := result.cacheSharedResult()
+
+		leaderDone := make(chan error, 1)
+		go func() {
+			leaderDone <- c.Evaluate(ctx, result)
+		}()
+		waitLazyRetrySignal(t, started, "the shared callback to start")
+
+		joinerCtx, cancelJoiner := context.WithCancelCause(ctx)
+		joinerDone := make(chan error, 1)
+		go func() {
+			joinerDone <- c.Evaluate(joinerCtx, result)
+		}()
+		synctest.Wait()
+		_, waiters := currentLazyAttempt(shared)
+		if waiters != 2 {
+			t.Fatalf("lazy waiters = %d, want two", waiters)
+		}
+
+		joinerCause := errors.New("joiner canceled only its own wait")
+		cancelJoiner(joinerCause)
+		if err := waitLazyRetryError(t, joinerDone, "the canceled joiner"); !errors.Is(err, joinerCause) {
+			t.Fatalf("joiner error = %v, want %v", err, joinerCause)
+		}
+		close(release)
+		if err := waitLazyRetryError(t, leaderDone, "the healthy leader"); err != nil {
+			t.Fatalf("healthy leader failed: %v", err)
+		}
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("lazy callback calls = %d, want one", got)
+		}
+		if err := c.ReleaseSession(ctx, sessionID); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestCacheEvaluatePropagatesCallbackFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// A cancellation-shaped error from a healthy callback context is still a
+		// genuine callback failure. Retry attribution must use the attempt context,
+		// not error type alone.
+		callbackErr := fmt.Errorf("genuine lazy callback failure: %w", context.Canceled)
+		var calls atomic.Int32
+		var running atomic.Int32
+		var maxRunning atomic.Int32
+		started := make(chan struct{})
+		releaseFailure := make(chan struct{})
+
+		ctx, c, sessionID, result := newLazyRetryTestResult(t, func(context.Context) error {
+			call := calls.Add(1)
+			nowRunning := running.Add(1)
+			updateLazyRetryMax(&maxRunning, nowRunning)
+			defer running.Add(-1)
+			if call == 1 {
+				close(started)
+				<-releaseFailure
+				return callbackErr
+			}
+			return nil
+		})
+		shared := result.cacheSharedResult()
+
+		leaderDone := make(chan error, 1)
+		go func() {
+			leaderDone <- c.Evaluate(ctx, result)
+		}()
+		waitLazyRetrySignal(t, started, "the failing callback to start")
+		joinerDone := make(chan error, 1)
+		go func() {
+			joinerDone <- c.Evaluate(ctx, result)
+		}()
+		synctest.Wait()
+		_, waiters := currentLazyAttempt(shared)
+		if waiters != 2 {
+			t.Fatalf("lazy waiters = %d, want two", waiters)
+		}
+
+		close(releaseFailure)
+		if err := waitLazyRetryError(t, leaderDone, "the failing leader"); !errors.Is(err, callbackErr) {
+			t.Fatalf("leader error = %v, want callback error %v", err, callbackErr)
+		}
+		if err := waitLazyRetryError(t, joinerDone, "the failing joiner"); !errors.Is(err, callbackErr) {
+			t.Fatalf("joiner error = %v, want callback error %v", err, callbackErr)
+		}
+		if err := c.Evaluate(ctx, result); err != nil {
+			t.Fatalf("retry after genuine callback failure: %v", err)
+		}
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("lazy callback calls = %d, want failed attempt and successful retry", got)
+		}
+		if got := maxRunning.Load(); got != 1 {
+			t.Fatalf("maximum concurrent lazy callbacks = %d, want one", got)
+		}
+		if err := c.ReleaseSession(ctx, sessionID); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/dagql/cache_profileskip_emit_test.go
+++ b/dagql/cache_profileskip_emit_test.go
@@ -306,7 +306,7 @@ func TestProfileSkipLazyCrossRecipeForcerStaysClean(t *testing.T) {
 	select {
 	case <-leaderReady:
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the lazy leader to publish lazyEvalWaitCh")
+		t.Fatal("timed out waiting for the lazy leader to publish its attempt")
 	}
 
 	// Joiner (traced) — the non-skipped forcer of the skipped producer.
@@ -317,7 +317,7 @@ func TestProfileSkipLazyCrossRecipeForcerStaysClean(t *testing.T) {
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		shared.lazyMu.Lock()
-		joined := shared.lazyEvalWaiters >= 2
+		joined := shared.lazyEvalAttempt != nil && shared.lazyEvalAttempt.waiters >= 2
 		shared.lazyMu.Unlock()
 		if joined {
 			break
@@ -381,7 +381,7 @@ func TestProfileSkipDoesNotBlindInvalidTargetDetector(t *testing.T) {
 	require.False(t, shared.loadResultCall().ProfileSkip, "producer is intentionally NOT skipped")
 
 	// UNTRACED leader (baseCtx): runs the eval but OTelProfActive(evalCtx) is false,
-	// so it mints no OTel lazy span → lazyEvalSpanCtx stays invalid (a genuine
+	// so it mints no OTel lazy span → the attempt span target stays invalid (a genuine
 	// mixed/untraced recording). Parks so the traced joiner can join.
 	leaderDone := make(chan error, 1)
 	go func() { leaderDone <- c.Evaluate(baseCtx, result) }()
@@ -391,9 +391,9 @@ func TestProfileSkipDoesNotBlindInvalidTargetDetector(t *testing.T) {
 		t.Fatal("timed out waiting for the untraced lazy leader")
 	}
 
-	// TRACED joiner: reads the invalid lazyEvalSpanCtx and, because the producer is
+	// TRACED joiner: reads the invalid attempt span target and, because the producer is
 	// NOT profile-skipped, STILL emits its OTel wait (targetless) — exactly what the
-	// gate must catch. (If the gate keyed on lazyEvalSpanCtx validity instead of the
+	// gate must catch. (If the gate keyed on span-target validity instead of the
 	// producer flag, this loss would be silently hidden.)
 	jCtx, jSpan := tr.Start(baseCtx, "traced-joiner")
 	jDone := make(chan error, 1)
@@ -402,7 +402,7 @@ func TestProfileSkipDoesNotBlindInvalidTargetDetector(t *testing.T) {
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		shared.lazyMu.Lock()
-		joined := shared.lazyEvalWaiters >= 2
+		joined := shared.lazyEvalAttempt != nil && shared.lazyEvalAttempt.waiters >= 2
 		shared.lazyMu.Unlock()
 		if joined {
 			break

--- a/dagql/cache_test.go
+++ b/dagql/cache_test.go
@@ -250,6 +250,14 @@ type cacheTestObject struct {
 	onRelease         func(context.Context) error
 	lazyEval          LazyEvalFunc
 	dependencyResults []AnyResult
+	snapshotLinks     []PersistedSnapshotRefLink
+}
+
+func (obj *cacheTestObject) PersistedSnapshotRefLinks() []PersistedSnapshotRefLink {
+	if obj == nil {
+		return nil
+	}
+	return obj.snapshotLinks
 }
 
 type noopTypeResolver struct{}

--- a/dagql/otelprof_hooks.go
+++ b/dagql/otelprof_hooks.go
@@ -211,7 +211,7 @@ func EmitOTelWait(ctx context.Context, target trace.SpanContext, reason wcprof.W
 	}
 	// Attach the wait edge even when target is invalid. In the always-on model
 	// the work owner and every waiter record uniformly, so a recording waiter's
-	// target (oc.execSpanCtx for call_exec, shared.lazyEvalSpanCtx for lazy) is
+	// target (oc.execSpanCtx for call_exec, the attempt span target for lazy) is
 	// always valid (the target was minted before the shared primitive). The only way it is invalid here is a non-uniform
 	// / mixed-recording trace — e.g. a recording waiter joining shared work started
 	// by an *untraced* session (ongoingCalls / lazy state are shared across

--- a/dagql/otelprof_lazy.go
+++ b/dagql/otelprof_lazy.go
@@ -105,9 +105,10 @@ func (wcprofLazyParentProcessor) Shutdown(context.Context) error   { return nil 
 func (wcprofLazyParentProcessor) ForceFlush(context.Context) error { return nil }
 
 // beginOTelLazyOp mints the OTel `lazy` op span for a deferred evaluation. It
-// MUST be called under lazyMu, before lazyEvalWaitCh is published, so a joiner
-// that observes the in-flight eval always has a valid wait target (the target is
-// minted before the waiter-observable primitive). It returns the context the callback runs under,
+// MUST be called under lazyMu, before the attempt pointer is published, so a
+// joiner that observes the in-flight eval always has that attempt's valid wait
+// target (the target is minted before the waiter-observable primitive). It
+// returns the context the callback runs under,
 // the lazy op span (whose SpanContext the caller stashes as the joiner wait
 // target and which the caller ends when the callback finishes), and isResume —
 // whether this is a producer-context re-point (so the caller applies the

--- a/dagql/otelprof_lazy_retry_test.go
+++ b/dagql/otelprof_lazy_retry_test.go
@@ -1,7 +1,7 @@
 package dagql
 
 // Regression tests for two lazy-emit hazards:
-//   - the stale lazyEvalSpanCtx bug: a failed traced lazy eval must not leave a
+//   - a stale lazy attempt span target: a failed traced lazy eval must not leave a
 //     wait target that a later untraced retry leader fails to overwrite, which a
 //     traced joiner would then mis-link to the wrong (old) lazy op instead of
 //     emitting a gate-observable targetless wait.
@@ -28,8 +28,8 @@ import (
 	"github.com/dagger/dagger/engine/wcprof"
 )
 
-// TestLazyEmitRetryDoesNotLeakStaleWaitTarget is the regression for the stale
-// lazyEvalSpanCtx bug. It drives the real evaluateOne path with three actors on
+// TestLazyEmitRetryDoesNotLeakStaleWaitTarget is the regression for a stale
+// lazy attempt span target. It drives the real evaluateOne path with three actors on
 // one shared pending result: a TRACED leader whose eval fails (minting a lazy op),
 // an UNTRACED retry leader (which must NOT re-mint), and a TRACED joiner of the
 // retry. Without the per-attempt reset, the joiner would read the failed
@@ -71,7 +71,7 @@ func TestLazyEmitRetryDoesNotLeakStaleWaitTarget(t *testing.T) {
 				if calls.Add(1) == 1 {
 					return errors.New("first lazy attempt fails (retryable)")
 				}
-				// The retry leader's callback: lazyEvalWaitCh is published now,
+				// The retry leader's callback: its attempt is published now,
 				// so signal and block long enough for the joiner to join.
 				close(leaderReady)
 				<-release
@@ -102,7 +102,7 @@ func TestLazyEmitRetryDoesNotLeakStaleWaitTarget(t *testing.T) {
 	select {
 	case <-leaderReady:
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the untraced retry leader to publish lazyEvalWaitCh")
+		t.Fatal("timed out waiting for the untraced retry leader to publish its attempt")
 	}
 
 	// J: a TRACED joiner of the retry. It reads the wait target under lazyMu and
@@ -118,7 +118,7 @@ func TestLazyEmitRetryDoesNotLeakStaleWaitTarget(t *testing.T) {
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		shared.lazyMu.Lock()
-		joined := shared.lazyEvalWaiters >= 2
+		joined := shared.lazyEvalAttempt != nil && shared.lazyEvalAttempt.waiters >= 2
 		shared.lazyMu.Unlock()
 		if joined {
 			break

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -1552,9 +1552,13 @@ EvalNoWork(e) ==
 \* Start an attempt: no attempt is published, so this caller becomes the
 \* leader. One lazyMu critical section publishes a fresh attempt record whose
 \* wait targets, done channel, cancel function, and waiter count are already
-\* initialized. An armed callback leads a full attempt ("running"); a nil
-\* object-side callback with pending bookkeeping leads a bookkeeping-only
-\* attempt that starts directly in "syncing".
+\* initialized. An armed callback leads a full attempt ("running"); pending
+\* bookkeeping leads a bookkeeping-only attempt that starts directly in
+\* "syncing". Here an armed callback and pending bookkeeping cannot coexist
+\* (body success consumes lazyCb before bookkeeping can fail); Go's
+\* evaluateOne enforces the same precedence directly by not re-reading the
+\* value's callback while lazySyncPending is set, so the correspondence does
+\* not depend on implementations clearing their callback.
 EvalStartAttempt(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -1477,10 +1477,12 @@ LatchEvalOutcomes(r, outcome) ==
 \* A new Evaluate caller appears, demanding some registered result it
 \* holds. A caller can only hold a result whose attachment barrier is not
 \* open and not errored: every result-returning API waits at the barrier
-\* and returns errors instead of values, and lazy callbacks are registered
-\* only at attachment completion (registerLazyEvaluation, immediately
-\* before the barrier closes). "none" covers results that never armed a
-\* fresh barrier, such as imported rows and adopted cache-backed values.
+\* and returns errors instead of values. Lazy callbacks are registered at
+\* attachment completion (registerLazyEvaluation, immediately before the
+\* barrier closes) and again when a persisted hit's value is loaded; both
+\* sites run after the barrier settles. "none" covers results that never
+\* armed a fresh barrier, such as imported rows and adopted cache-backed
+\* values.
 EvalSpawn ==
     /\ ModelLazy
     /\ Len(evals) < MaxEvals

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -213,6 +213,16 @@ EvalIds   == 1..Len(evals)
 InvocationIds    == 1..Len(invocations)
 OngoingCallIds     == 1..Len(ongoingCalls)
 
+\* Callback completion first latches an outcome and retires the published
+\* attempt under lazyMu. Closing that attempt's done channel is the following
+\* lock-free region. Existing waiters retain the attempt-local outcome while a
+\* new attempt may already be current on the result.
+EvalLatchedPhases == {"latchedDone", "latchedFail", "latchedCancel"}
+EvalWakePhases == {"wakeDone", "wakeFail", "wakeCancel"}
+EvalPendingPhases == {"demand", "waiting"} \cup EvalLatchedPhases \cup EvalWakePhases
+EvalTerminalPhases == {"done", "failedCallback", "abandoned"}
+EvalPhaseDomain == EvalPendingPhases \cup EvalTerminalPhases
+
 \* phase values in which an invocation has finished, one way or another.
 TerminalPhases == {"done", "failed", "canceled", "refused"}
 
@@ -312,7 +322,7 @@ ImportedResult(c, persistedFlag, depsSet, ownVal, payloadVal, launderedFlag) ==
      payload |-> payloadVal, decodePhase |-> "idle", decodeErr |-> "none",
      laundered |-> launderedFlag,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
-     lazyWaiters |-> 0, lazyRunning |-> 0, lazyErr |-> "none"]
+     lazyWaiters |-> 0, lazyRunning |-> 0]
 
 \* A collected result's ID is never reused, so after a restart the slots of
 \* results that were not in the snapshot stay as dead husks - present in
@@ -325,7 +335,7 @@ DeadHusk ==
      payload |-> "decoded", decodePhase |-> "idle", decodeErr |-> "none",
      laundered |-> FALSE,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
-     lazyWaiters |-> 0, lazyRunning |-> 0, lazyErr |-> "none"]
+     lazyWaiters |-> 0, lazyRunning |-> 0]
 
 \* The candidate import rows for position pos: any call, persisted or not,
 \* at most one dependency and only on an earlier row, payload decoded or
@@ -761,10 +771,9 @@ PubIndexFresh(o) ==
                        \* on sharedResult (cache.go:1584-1597):
                        lazyCb |-> lazyCb,        \* lazyEval callback stored?
                        lazyComplete |-> FALSE,   \* lazyEvalComplete
-                       lazyPhase |-> "idle",     \* lazyEvalWaitCh lifecycle
-                       lazyWaiters |-> 0,        \* lazyEvalWaiters
-                       lazyRunning |-> 0,        \* callbacks actually running
-                       lazyErr |-> "none"]       \* lazyEvalErr, latched
+                       lazyPhase |-> "idle",     \* published attempt lifecycle
+                       lazyWaiters |-> 0,        \* current attempt's waiters
+                       lazyRunning |-> 0]        \* callbacks actually running
         IN /\ res' = Append(withDeps, newRes)
            /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "attaching",
                                  ![o].hold = TRUE,
@@ -1385,8 +1394,9 @@ Restart ==
                                  !.waiters = 0]]
     /\ ongoingCallIndex' = [k \in Calls \X Sessions |-> 0]
     /\ evals' = [e \in EvalIds |->
-         IF evals[e].phase \in {"demand", "waiting"}
-         THEN [evals[e] EXCEPT !.phase = "abandoned"]
+         IF evals[e].phase \in EvalPendingPhases
+         THEN [evals[e] EXCEPT !.phase = "abandoned",
+                                  !.foreignCancel = FALSE]
          ELSE evals[e]]
     /\ sessionEdges' = {}
     /\ countedEdges' = {}
@@ -1397,26 +1407,30 @@ Restart ==
 (***************************************************************************)
 (* LAZY EVALUATION. A resolver can return a result whose                   *)
 (* expensive materialization is deferred: the value carries a callback,    *)
-(* stored on the sharedResult (registerLazyEvaluation, cache.go:2878).     *)
+(* stored on the sharedResult by registerLazyEvaluation.                   *)
 (* Anyone later needing the materialized value calls Cache.Evaluate,       *)
-(* which coordinates all callers per result (evaluateOne,                  *)
-(* cache.go:3000):                                                         *)
+(* which coordinates all callers per result in evaluateOne:                *)
 (*   - if evaluation already completed, return immediately                 *)
 (*   - if an attempt is in flight, join it as a waiter                     *)
 (*   - otherwise start the callback in a goroutine and wait               *)
-(* Success is permanent (lazyEvalComplete set, callback cleared,           *)
-(* cache.go:3187-3191). Failure leaves the callback in place so a later    *)
-(* Evaluate retries. Each waiter can abandon its wait independently        *)
-(* (waitForLazyEvaluation's ctx.Done arm, cache.go:2945-2954); the LAST    *)
-(* waiter to abandon cancels the running callback.                         *)
+(* Success is permanent: lazyEvalComplete is set and the callback is       *)
+(* cleared. Failure leaves the callback in place so a later Evaluate can   *)
+(* retry. Each waiter can abandon independently; the LAST waiter to leave  *)
+(* a running attempt cancels that attempt's callback context.              *)
 (*                                                                         *)
-(* One window deserves attention, and gets a property below: after the     *)
-(* last waiter abandons and cancels, the attempt's wait channel stays      *)
-(* published until the dying callback actually finishes. A brand-new       *)
-(* Evaluate arriving in that window JOINS the dying attempt               *)
-(* (evaluateOne's join arm checks only lazyEvalWaitCh != nil) and is       *)
-(* handed the earlier caller's cancellation error - it fails though        *)
-(* nothing is wrong with the result and it never asked to cancel.          *)
+(* Attempt state is separate from permanent result state. The result       *)
+(* publishes one current attempt while its callback runs. Callback finish  *)
+(* latches the outcome on that attempt and unpublishes it under lazyMu;     *)
+(* closing the attempt's done channel is the following lock-free region.   *)
+(* Existing waiters retain the retired attempt record, so they cannot read *)
+(* or decrement a retry's state. A new attempt can start after callback    *)
+(* finish even before old waiters consume their outcome.                   *)
+(*                                                                         *)
+(* A healthy waiter may have joined an attempt after every earlier waiter  *)
+(* abandoned and requested cancellation. If that callback returns its     *)
+(* shared context's cancellation, the healthy waiter treats it as an       *)
+(* intermediate retry outcome, not a returned error. Its own cancellation  *)
+(* remains terminal, and a genuine callback failure still propagates.      *)
 (*                                                                         *)
 (* Evaluators here are modeled independently of the GetOrInitCall          *)
 (* invocations: in the engine, Evaluate is called by code already          *)
@@ -1426,16 +1440,25 @@ Restart ==
 (* release-during-in-flight investigations, not here.                      *)
 (*                                                                         *)
 (* Model phases of one attempt (res[r].lazyPhase):                         *)
-(*   "idle"            no attempt in flight (lazyEvalWaitCh == nil)        *)
+(*   "idle"            no attempt is published                            *)
 (*   "running"         callback running, waiters waiting                   *)
 (*   "cancelRequested" every waiter abandoned; the last one invoked the    *)
-(*                     cancel; the callback has not finished yet. The      *)
-(*                     wait channel is still published - the stale-error   *)
-(*                     join window                                         *)
-(*   "done"            callback finished and the error is latched, but    *)
-(*                     waiters have not all drained; the last waiter to    *)
-(*                     drain resets the state to "idle"                    *)
+(*                     cancel; the callback has not finished yet. A new    *)
+(*                     waiter may still join this published attempt.       *)
+(*                                                                         *)
+(* Evaluator latched phases mean callback finish stored an attempt-local   *)
+(* outcome and retired the attempt, but that attempt's done-channel close  *)
+(* has not yet become observable to this waiter. Wake phases mean the      *)
+(* close is observable and the select can consume either completion or the *)
+(* waiter's own cancellation.                                              *)
 (***************************************************************************)
+
+LatchEvalOutcomes(r, outcome) ==
+    [e \in DOMAIN evals |->
+        IF evals[e].phase = "waiting" /\ evals[e].target = r
+        THEN [evals[e] EXCEPT !.phase = outcome,
+                                  !.foreignCancel = (outcome = "latchedCancel")]
+        ELSE evals[e]]
 
 \* A new Evaluate caller appears, demanding some registered result.
 EvalSpawn ==
@@ -1443,26 +1466,27 @@ EvalSpawn ==
     /\ Len(evals) < MaxEvals
     /\ \E r \in ResultIds :
         /\ res[r].registered
-        /\ evals' = Append(evals, [target |-> r, phase |-> "demand"])
+        /\ evals' = Append(evals,
+             [target |-> r, phase |-> "demand", foreignCancel |-> FALSE])
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* Fast path: nothing to do - evaluation already completed, or the value
-\* carries no callback (evaluateOne, cache.go:3023-3039).
+\* Fast path: evaluation already completed, or the value carries no callback.
 EvalNoWork(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN
        res[r].lazyComplete \/ res[r].lazyCb = "none"
-    /\ evals' = [evals EXCEPT ![e].phase = "done"]
+    /\ evals' = [evals EXCEPT ![e].phase = "done",
+                              ![e].foreignCancel = FALSE]
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* Start the callback: no attempt is in flight, so this caller becomes the
-\* leader - one lazyMu critical section publishes the wait channel and the
-\* cancel, then the callback goroutine starts (evaluateOne,
-\* cache.go:3145-3184).
+\* Start the callback: no attempt is published, so this caller becomes the
+\* leader. One lazyMu critical section publishes a fresh attempt record whose
+\* wait targets, done channel, cancel function, and waiter count are already
+\* initialized.
 EvalStartAttempt(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN
@@ -1472,122 +1496,119 @@ EvalStartAttempt(e) ==
        /\ res' = [res EXCEPT
             ![r].lazyPhase = "running",
             ![r].lazyWaiters = @ + 1,
-            ![r].lazyRunning = @ + 1,
-            ![r].lazyErr = "none"]
-       /\ evals' = [evals EXCEPT ![e].phase = "waiting"]
+            ![r].lazyRunning = @ + 1]
+       /\ evals' = [evals EXCEPT ![e].phase = "waiting",
+                                 ![e].foreignCancel = FALSE]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* Join an attempt already in flight (evaluateOne's join arm,
-\* cache.go:3040-3063). The guard is only "a wait channel is published" -
-\* which includes an attempt that every previous waiter has already
-\* abandoned ("cancelRequested") and one that has finished but not
-\* drained ("done"). Joining the first of those is the stale-error window.
+\* Join a published attempt. cancelRequested remains joinable because
+\* callback cancellation is cooperative; the joiner retains this attempt
+\* record and retries if its outcome is foreign cancellation.
 EvalJoin(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN
        /\ res[r].lazyCb = "armed"
        /\ ~res[r].lazyComplete
-       /\ res[r].lazyPhase \in {"running", "cancelRequested", "done"}
+       /\ res[r].lazyPhase \in {"running", "cancelRequested"}
        /\ res' = [res EXCEPT ![r].lazyWaiters = @ + 1]
-       /\ evals' = [evals EXCEPT ![e].phase = "waiting"]
+       /\ evals' = [evals EXCEPT ![e].phase = "waiting",
+                                 ![e].foreignCancel = FALSE]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* The callback finishes on its own (the goroutine tail, cache.go:3184-
-\* 3202): latch the outcome; success also marks completion and clears the
-\* callback. If no waiters remain, the goroutine itself resets the state
-\* to idle; otherwise the state stays "done" until the last waiter drains.
-\* The Go goroutine latches lazyEvalErr unconditionally. That is safe -
-\* and this model needs no cross-attempt-overwrite action - only because
-\* no second attempt can start while an old goroutine is alive: the state
-\* resets exclusively here or in the last waiter's wake, both of which
-\* happen after this latch.
+\* The callback finishes under lazyMu: latch the outcome on the attempt,
+\* retire the result's current-attempt pointer, and make the result idle.
+\* Success also marks permanent completion and clears the callback. Waiters
+\* move to an attempt-local latched phase; they no longer contribute to the
+\* result's current-attempt waiter count.
 EvalCallbackFinish(r) ==
     /\ r \in ResultIds
     /\ res[r].lazyPhase = "running"
     /\ res[r].lazyRunning > 0
     /\ \E ok \in IF LazyCanFail THEN {TRUE, FALSE} ELSE {TRUE} :
-        LET drained == res[r].lazyWaiters = 0
-        IN res' = [res EXCEPT
+        /\ res' = [res EXCEPT
              ![r].lazyRunning = @ - 1,
              ![r].lazyComplete = @ \/ ok,
              ![r].lazyCb = IF ok THEN "none" ELSE @,
-             ![r].lazyPhase = IF drained THEN "idle" ELSE "done",
-             ![r].lazyErr = IF drained THEN "none"
-                            ELSE IF ok THEN "none" ELSE "fail"]
-    /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, evals,
+             ![r].lazyPhase = "idle",
+             ![r].lazyWaiters = 0]
+        /\ evals' = LatchEvalOutcomes(r,
+             IF ok THEN "latchedDone" ELSE "latchedFail")
+    /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* The canceled callback winds down. It may still succeed (the callback
-\* returns nil despite its context being canceled) or finish with the
-\* cancellation error - which is then what any joiner who arrived during
-\* the wind-down is handed.
+\* A canceled callback may still succeed after ignoring cancellation. A
+\* cancellation-shaped failure attributable to its shared callback context
+\* is latched as foreign cancellation, which healthy waiters retry.
 EvalCallbackFinishCanceled(r) ==
     /\ r \in ResultIds
     /\ res[r].lazyPhase = "cancelRequested"
     /\ res[r].lazyRunning > 0
     /\ \E ok \in {TRUE, FALSE} :
-        LET drained == res[r].lazyWaiters = 0
-        IN res' = [res EXCEPT
+        /\ res' = [res EXCEPT
              ![r].lazyRunning = @ - 1,
              ![r].lazyComplete = @ \/ ok,
              ![r].lazyCb = IF ok THEN "none" ELSE @,
-             ![r].lazyPhase = IF drained THEN "idle" ELSE "done",
-             ![r].lazyErr = IF drained THEN "none"
-                            ELSE IF ok THEN "none" ELSE "cancel"]
-    /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, evals,
-                   sessionEdges, countedEdges, sessionRelease,
-                   epoch, flushed>>
-
-\* A waiter wakes after the callback finished (waitForLazyEvaluation's
-\* wait-channel arm, cache.go:2925-2943): it reads the latched error,
-\* drops its waiter count, and the last waiter out resets the state to
-\* idle. A "cancel" error here means this caller is failing with an
-\* abandonment error some OTHER caller caused - the stale-cancel case.
-EvalWake(e) ==
-    /\ evals[e].phase = "waiting"
-    /\ LET r == evals[e].target
-           last == res[r].lazyWaiters = 1
-       IN /\ res[r].lazyPhase = "done"
-          /\ res' = [res EXCEPT
-               ![r].lazyWaiters = @ - 1,
-               ![r].lazyPhase = IF last THEN "idle" ELSE "done",
-               ![r].lazyErr = IF last THEN "none" ELSE @]
-          /\ evals' = [evals EXCEPT ![e].phase =
-               CASE res[r].lazyErr = "none" -> "done"
-                 [] res[r].lazyErr = "fail" -> "failedCallback"
-                 [] OTHER -> "failedStale"]
+             ![r].lazyPhase = "idle",
+             ![r].lazyWaiters = 0]
+        /\ evals' = LatchEvalOutcomes(r,
+             IF ok THEN "latchedDone" ELSE "latchedCancel")
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* A waiter gives up (its own context canceled - waitForLazyEvaluation's
-\* ctx.Done arm, cache.go:2945-2954). Only the LAST waiter to leave
-\* invokes the attempt's cancel; earlier leavers just walk away. Note
-\* what is NOT cleared: the wait channel stays published until the dying
-\* callback finishes.
+\* Closing the retired attempt's done channel is the lock-free region after
+\* callback finish. Each transition below represents that broadcast becoming
+\* observable to one retained waiter; the waiter still has not selected
+\* between completion and its own context cancellation.
+EvalCallbackClose(e) ==
+    /\ evals[e].phase \in EvalLatchedPhases
+    /\ evals' = [evals EXCEPT ![e].phase =
+         CASE @ = "latchedDone" -> "wakeDone"
+           [] @ = "latchedFail" -> "wakeFail"
+           [] OTHER -> "wakeCancel"]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, sessionRelease,
+                   epoch, flushed>>
+
+\* The completion arm consumes one retired attempt's outcome. Success and
+\* genuine callback failure terminate. Foreign cancellation returns the
+\* healthy evaluator to demand so it can re-check completion, join a current
+\* attempt, or lead a fresh one.
+EvalWake(e) ==
+    /\ evals[e].phase \in EvalWakePhases
+    /\ evals' = [evals EXCEPT
+         ![e].phase = CASE @ = "wakeDone" -> "done"
+                           [] @ = "wakeFail" -> "failedCallback"
+                           [] OTHER -> "demand",
+         ![e].foreignCancel = (evals[e].phase = "wakeCancel")]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, sessionRelease,
+                   epoch, flushed>>
+
+\* A waiter gives up because its own context was canceled. While the attempt
+\* is current, it decrements that attempt's waiter count and the last waiter
+\* requests callback cancellation. Once callback finish retired the attempt,
+\* abandonment touches no result-level state, even if a new attempt is current.
 EvalAbandon(e) ==
-    /\ evals[e].phase = "waiting"
+    /\ evals[e].phase \in {"waiting"} \cup EvalLatchedPhases \cup EvalWakePhases
     /\ LET r == evals[e].target
-           last == res[r].lazyWaiters = 1
-       IN \* Abandoning is possible in "done" too: when the callback has
-          \* finished AND the waiter's own context is canceled, both arms
-          \* of the Go select are ready and the runtime picks either. A
-          \* last waiter leaving through ctx.Done does NOT clear the
-          \* attempt state (that arm clears nothing), so the latched error
-          \* stays published with zero waiters - the next Evaluate joins
-          \* it and drains the stale error. Invoking the cancel on an
-          \* already-finished attempt is a harmless no-op.
-          /\ res[r].lazyPhase \in {"running", "cancelRequested", "done"}
-          /\ res' = [res EXCEPT
-               ![r].lazyWaiters = @ - 1,
-               ![r].lazyPhase = IF last /\ res[r].lazyPhase = "running"
-                                THEN "cancelRequested" ELSE @]
-          /\ evals' = [evals EXCEPT ![e].phase = "abandoned"]
+           current == evals[e].phase = "waiting"
+           last == current /\ res[r].lazyWaiters = 1
+       IN /\ ~current \/ res[r].lazyPhase \in {"running", "cancelRequested"}
+          /\ res' = IF current
+                    THEN [res EXCEPT
+                         ![r].lazyWaiters = @ - 1,
+                         ![r].lazyPhase =
+                              IF last /\ @ = "running"
+                              THEN "cancelRequested" ELSE @]
+                    ELSE res
+          /\ evals' = [evals EXCEPT ![e].phase = "abandoned",
+                                     ![e].foreignCancel = FALSE]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
@@ -1622,7 +1643,7 @@ Next ==
     \/ EvalSpawn
     \/ \E e \in EvalIds :
          \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalJoin(e)
-         \/ EvalWake(e) \/ EvalAbandon(e)
+         \/ EvalCallbackClose(e) \/ EvalWake(e) \/ EvalAbandon(e)
     \/ \E r \in 1..Len(res) :
          EvalCallbackFinish(r) \/ EvalCallbackFinishCanceled(r)
     \/ Flush
@@ -1681,6 +1702,11 @@ WaiterProgress(i) ==
 EvalProgress(e) ==
     \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalJoin(e) \/ EvalWake(e)
 
+\* Callback completion always proceeds to close the retired attempt's done
+\* channel. This fairness covers the lock-free close becoming observable to
+\* each waiter that retained that attempt.
+LazyCallbackCloseProgress(e) == EvalCallbackClose(e)
+
 \* The lazy callback goroutine always eventually finishes, canceled or
 \* not. Fairness sits on the disjunction of both finish shapes for the
 \* same reason it does for attachment: weak fairness on the success arm
@@ -1698,6 +1724,8 @@ LiveSpec ==
     \* evaluation are untouched by the lazy machinery.
     /\ \A e \in 1..MaxEvals :
          WF_vars(e \in EvalIds /\ EvalProgress(e))
+    /\ \A e \in 1..MaxEvals :
+         WF_vars(e \in EvalIds /\ LazyCallbackCloseProgress(e))
     /\ \A r \in 1..MaxResults :
          WF_vars(r \in ResultIds /\ LazyCallbackProgress(r))
 
@@ -1727,7 +1755,14 @@ TypeOK ==
                  /\ e[2] \in sessionRelease[e[1]].snap)
     /\ epoch \in {1, 2}
     /\ \A o \in OngoingCallIds : ongoingCalls[o].waiters >= 0
-    /\ \A r \in ResultIds : res[r].lazyWaiters >= 0 /\ res[r].lazyRunning >= 0
+    /\ \A r \in ResultIds :
+         /\ res[r].lazyWaiters >= 0 /\ res[r].lazyRunning >= 0
+         /\ res[r].lazyWaiters = Cardinality(
+              {e \in EvalIds :
+                  evals[e].target = r /\ evals[e].phase = "waiting"})
+    /\ \A e \in EvalIds :
+         /\ evals[e].phase \in EvalPhaseDomain
+         /\ evals[e].foreignCancel \in BOOLEAN
     /\ \A i \in InvocationIds :
          /\ invocations[i].origin \in {"handler", "nested"}
          /\ invocations[i].refusedEpoch \in 0..epoch
@@ -1849,15 +1884,16 @@ LazyMutualExclusion ==
 LazySuccessPermanent ==
     \A r \in ResultIds : res[r].lazyComplete => res[r].lazyRunning = 0
 
-\* An Evaluate caller never fails with a cancellation error it did not
-\* cause. The code violates this: a caller arriving while a fully-
-\* abandoned attempt is still winding down joins that attempt
-\* (evaluateOne's join arm checks only that a wait channel is published)
-\* and is handed the abandoners' cancellation error - a spurious failure
-\* on a healthy, retryable result. "failedStale" records exactly that
-\* outcome at wake time.
+\* An Evaluate caller never returns a cancellation error caused by another
+\* waiter. foreignCancel becomes true when the canceled callback's outcome is
+\* latched on its retained waiters and remains true as a healthy waiter returns
+\* to demand, so the stale-cancellation configuration reaches states that
+\* exercise this predicate. Starting or joining the retry clears it. Reaching
+\* any terminal phase while it is true would mean the foreign cancellation
+\* escaped Evaluate instead of being retried.
 NoStaleCancelError ==
-    \A e \in EvalIds : evals[e].phase # "failedStale"
+    \A e \in EvalIds :
+        evals[e].foreignCancel => evals[e].phase \notin EvalTerminalPhases
 
 (***************************************************************************)
 (* IMPORT/FLUSH PROPERTIES.                                                *)
@@ -1913,8 +1949,7 @@ NoLaunderedServe ==
 EvalEventuallyTerminal ==
     \A e \in 1..MaxEvals :
         (e \in EvalIds) ~>
-            (e \in EvalIds /\ evals[e].phase \in
-                {"done", "failedCallback", "failedStale", "abandoned"})
+            (e \in EvalIds /\ evals[e].phase \in EvalTerminalPhases)
 
 \* Liveness (against LiveSpec): every issued call eventually terminates -
 \* served, failed, or canceled, never wedged forever.

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -1541,22 +1541,27 @@ EvalCallbackFinish(r) ==
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* A canceled callback may still succeed after ignoring cancellation. A
-\* cancellation-shaped failure attributable to its shared callback context
-\* is latched as foreign cancellation, which healthy waiters retry.
+\* A canceled callback may still succeed after ignoring cancellation. The
+\* retry decision in Go is per-error (lazyEvalErrorCausedByContext), not
+\* per-phase: a failure attributable to the attempt's canceled callback
+\* context is latched as foreign cancellation, which healthy waiters
+\* retry, while a genuine failure of the callback's own work (LazyCanFail)
+\* still propagates to every waiter even though cancellation was
+\* requested.
 EvalCallbackFinishCanceled(r) ==
     /\ r \in ResultIds
     /\ res[r].lazyPhase = "cancelRequested"
     /\ res[r].lazyRunning > 0
-    /\ \E ok \in {TRUE, FALSE} :
+    /\ \E outcome \in ({"latchedDone", "latchedCancel"} \cup
+                       (IF LazyCanFail THEN {"latchedFail"} ELSE {})) :
+        LET ok == outcome = "latchedDone" IN
         /\ res' = [res EXCEPT
              ![r].lazyRunning = @ - 1,
              ![r].lazyComplete = @ \/ ok,
              ![r].lazyCb = IF ok THEN "none" ELSE @,
              ![r].lazyPhase = "idle",
              ![r].lazyWaiters = 0]
-        /\ evals' = LatchEvalOutcomes(r,
-             IF ok THEN "latchedDone" ELSE "latchedCancel")
+        /\ evals' = LatchEvalOutcomes(r, outcome)
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -1474,12 +1474,19 @@ LatchEvalOutcomes(r, outcome) ==
                                   !.foreignCancel = (outcome = "latchedCancel")]
         ELSE evals[e]]
 
-\* A new Evaluate caller appears, demanding some registered result.
+\* A new Evaluate caller appears, demanding some registered result it
+\* holds. A caller can only hold a result whose attachment barrier is not
+\* open and not errored: every result-returning API waits at the barrier
+\* and returns errors instead of values, and lazy callbacks are registered
+\* only at attachment completion (registerLazyEvaluation, immediately
+\* before the barrier closes). "none" covers results that never armed a
+\* fresh barrier, such as imported rows and adopted cache-backed values.
 EvalSpawn ==
     /\ ModelLazy
     /\ Len(evals) < MaxEvals
     /\ \E r \in ResultIds :
         /\ res[r].registered
+        /\ res[r].barrier \notin {"open", "closedErr"}
         /\ evals' = Append(evals,
              [target |-> r, phase |-> "demand", foreignCancel |-> FALSE])
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -322,6 +322,7 @@ ImportedResult(c, persistedFlag, depsSet, ownVal, payloadVal, launderedFlag) ==
      payload |-> payloadVal, decodePhase |-> "idle", decodeErr |-> "none",
      laundered |-> launderedFlag,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
+     lazyCancel |-> FALSE, lazySyncPending |-> FALSE,
      lazyWaiters |-> 0, lazyRunning |-> 0]
 
 \* A collected result's ID is never reused, so after a restart the slots of
@@ -335,6 +336,7 @@ DeadHusk ==
      payload |-> "decoded", decodePhase |-> "idle", decodeErr |-> "none",
      laundered |-> FALSE,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
+     lazyCancel |-> FALSE, lazySyncPending |-> FALSE,
      lazyWaiters |-> 0, lazyRunning |-> 0]
 
 \* The candidate import rows for position pos: any call, persisted or not,
@@ -772,6 +774,8 @@ PubIndexFresh(o) ==
                        lazyCb |-> lazyCb,        \* lazyEval callback stored?
                        lazyComplete |-> FALSE,   \* lazyEvalComplete
                        lazyPhase |-> "idle",     \* published attempt lifecycle
+                       lazyCancel |-> FALSE,     \* attempt cancel requested
+                       lazySyncPending |-> FALSE, \* lazySyncPending
                        lazyWaiters |-> 0,        \* current attempt's waiters
                        lazyRunning |-> 0]        \* callbacks actually running
         IN /\ res' = Append(withDeps, newRes)
@@ -1439,12 +1443,22 @@ Restart ==
 (* when a result is collected while its callback runs belongs with the     *)
 (* release-during-in-flight investigations, not here.                      *)
 (*                                                                         *)
-(* Model phases of one attempt (res[r].lazyPhase):                         *)
-(*   "idle"            no attempt is published                            *)
-(*   "running"         callback running, waiters waiting                   *)
-(*   "cancelRequested" every waiter abandoned; the last one invoked the    *)
-(*                     cancel; the callback has not finished yet. A new    *)
-(*                     waiter may still join this published attempt.       *)
+(* One attempt has two stages, and evaluateOne consults them before any    *)
+(* object-side lazy state: callback bodies (Directory/File/Container)      *)
+(* clear their object-side callback pointer while the attempt is still     *)
+(* running its cache-side bookkeeping (snapshot-lease sync, lease          *)
+(* release), so object-side state is only trustworthy when no attempt is   *)
+(* published. Model phases of one attempt (res[r].lazyPhase):              *)
+(*   "idle"     no attempt is published                                    *)
+(*   "running"  the callback body is running (lazyCb still armed)          *)
+(*   "syncing"  the body succeeded and consumed the object-side callback   *)
+(*              (lazyCb now "none"); the same goroutine is running the     *)
+(*              cache-side bookkeeping                                     *)
+(* res[r].lazyCancel means every waiter abandoned and the last one         *)
+(* invoked the attempt's cancel; the attempt keeps running and remains     *)
+(* joinable. res[r].lazySyncPending means a previous attempt's body        *)
+(* succeeded but its bookkeeping did not: the next attempt starts in       *)
+(* "syncing" with no body, retrying only the bookkeeping.                  *)
 (*                                                                         *)
 (* Evaluator latched phases mean callback finish stored an attempt-local   *)
 (* outcome and retired the attempt, but that attempt's done-channel close  *)
@@ -1472,29 +1486,42 @@ EvalSpawn ==
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* Fast path: evaluation already completed, or the value carries no callback.
+\* Fast path under lazyMu: evaluation already completed, or nothing
+\* deferred remains anywhere - no published attempt, no object-side
+\* callback, no pending bookkeeping. Go latches lazyEvalComplete on that
+\* second shape. Requiring the attempt and bookkeeping checks is the fix
+\* for the bypass bug: trusting the consumed object-side callback while
+\* its attempt was still running bookkeeping reported success early.
 EvalNoWork(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN
-       res[r].lazyComplete \/ res[r].lazyCb = "none"
+       /\ \/ res[r].lazyComplete
+          \/ /\ res[r].lazyPhase = "idle"
+             /\ res[r].lazyCb = "none"
+             /\ ~res[r].lazySyncPending
+       /\ res' = [res EXCEPT ![r].lazyComplete = TRUE]
     /\ evals' = [evals EXCEPT ![e].phase = "done",
                               ![e].foreignCancel = FALSE]
-    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+    /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* Start the callback: no attempt is published, so this caller becomes the
+\* Start an attempt: no attempt is published, so this caller becomes the
 \* leader. One lazyMu critical section publishes a fresh attempt record whose
 \* wait targets, done channel, cancel function, and waiter count are already
-\* initialized.
+\* initialized. An armed callback leads a full attempt ("running"); a nil
+\* object-side callback with pending bookkeeping leads a bookkeeping-only
+\* attempt that starts directly in "syncing".
 EvalStartAttempt(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN
-       /\ res[r].lazyCb = "armed"
        /\ ~res[r].lazyComplete
        /\ res[r].lazyPhase = "idle"
+       /\ res[r].lazyCb = "armed" \/ res[r].lazySyncPending
        /\ res' = [res EXCEPT
-            ![r].lazyPhase = "running",
+            ![r].lazyPhase = IF res[r].lazyCb = "armed"
+                             THEN "running" ELSE "syncing",
+            ![r].lazyCancel = FALSE,
             ![r].lazyWaiters = @ + 1,
             ![r].lazyRunning = @ + 1]
        /\ evals' = [evals EXCEPT ![e].phase = "waiting",
@@ -1503,15 +1530,15 @@ EvalStartAttempt(e) ==
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* Join a published attempt. cancelRequested remains joinable because
-\* callback cancellation is cooperative; the joiner retains this attempt
-\* record and retries if its outcome is foreign cancellation.
+\* Join a published attempt in either stage, canceled or not: Go's join
+\* checks only that an attempt is published, and cancellation is
+\* cooperative. The joiner retains this attempt record and retries if its
+\* outcome is foreign cancellation.
 EvalJoin(e) ==
     /\ evals[e].phase = "demand"
     /\ LET r == evals[e].target IN
-       /\ res[r].lazyCb = "armed"
        /\ ~res[r].lazyComplete
-       /\ res[r].lazyPhase \in {"running", "cancelRequested"}
+       /\ res[r].lazyPhase \in {"running", "syncing"}
        /\ res' = [res EXCEPT ![r].lazyWaiters = @ + 1]
        /\ evals' = [evals EXCEPT ![e].phase = "waiting",
                                  ![e].foreignCancel = FALSE]
@@ -1519,49 +1546,66 @@ EvalJoin(e) ==
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* The callback finishes under lazyMu: latch the outcome on the attempt,
-\* retire the result's current-attempt pointer, and make the result idle.
-\* Success also marks permanent completion and clears the callback. Waiters
-\* move to an attempt-local latched phase; they no longer contribute to the
-\* result's current-attempt waiter count.
-EvalCallbackFinish(r) ==
+\* The callback body finishes while the attempt keeps running. Success
+\* consumes the object-side callback (Directory, File, and Container clear
+\* their Lazy pointer inside the body) and the same goroutine proceeds to
+\* the cache-side bookkeeping stage. Failure ends the whole attempt: the
+\* outcome is latched on the retained waiters and the attempt is retired,
+\* with the body left armed for a later attempt. The retry decision is
+\* per-error (lazyEvalErrorCausedByContext), not per-stage: a failure
+\* attributable to the attempt's canceled callback context latches as
+\* foreign cancellation, which healthy waiters retry, while a genuine body
+\* failure (LazyCanFail) propagates even when cancellation was requested.
+EvalBodyFinish(r) ==
     /\ r \in ResultIds
     /\ res[r].lazyPhase = "running"
     /\ res[r].lazyRunning > 0
-    /\ \E ok \in IF LazyCanFail THEN {TRUE, FALSE} ELSE {TRUE} :
-        /\ res' = [res EXCEPT
-             ![r].lazyRunning = @ - 1,
-             ![r].lazyComplete = @ \/ ok,
-             ![r].lazyCb = IF ok THEN "none" ELSE @,
-             ![r].lazyPhase = "idle",
-             ![r].lazyWaiters = 0]
-        /\ evals' = LatchEvalOutcomes(r,
-             IF ok THEN "latchedDone" ELSE "latchedFail")
+    /\ \E outcome \in ({"bodyOk"}
+            \cup (IF LazyCanFail THEN {"bodyFail"} ELSE {})
+            \cup (IF res[r].lazyCancel THEN {"bodyCancel"} ELSE {})) :
+        IF outcome = "bodyOk"
+        THEN /\ res' = [res EXCEPT ![r].lazyCb = "none",
+                                   ![r].lazyPhase = "syncing"]
+             /\ UNCHANGED evals
+        ELSE /\ res' = [res EXCEPT
+                  ![r].lazyRunning = @ - 1,
+                  ![r].lazyPhase = "idle",
+                  ![r].lazyCancel = FALSE,
+                  ![r].lazyWaiters = 0]
+             /\ evals' = LatchEvalOutcomes(r,
+                  IF outcome = "bodyFail"
+                  THEN "latchedFail" ELSE "latchedCancel")
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
-\* A canceled callback may still succeed after ignoring cancellation. The
-\* retry decision in Go is per-error (lazyEvalErrorCausedByContext), not
-\* per-phase: a failure attributable to the attempt's canceled callback
-\* context is latched as foreign cancellation, which healthy waiters
-\* retry, while a genuine failure of the callback's own work (LazyCanFail)
-\* still propagates to every waiter even though cancellation was
-\* requested.
-EvalCallbackFinishCanceled(r) ==
+\* The cache-side bookkeeping finishes and the attempt is retired under
+\* lazyMu. Success marks evaluation complete. Any failure here records
+\* lazySyncPending: the body's object-side state is already consumed, so
+\* only the bookkeeping remains retryable and the next attempt starts in
+\* "syncing" with no body. LazyCanFail doubles as the fault switch for
+\* bookkeeping failure (in Go it is environment failure, such as the
+\* snapshot manager, rather than the callback's own work); a
+\* cancellation-shaped bookkeeping failure latches as foreign cancellation
+\* exactly like a canceled body.
+EvalSyncFinish(r) ==
     /\ r \in ResultIds
-    /\ res[r].lazyPhase = "cancelRequested"
+    /\ res[r].lazyPhase = "syncing"
     /\ res[r].lazyRunning > 0
-    /\ \E outcome \in ({"latchedDone", "latchedCancel"} \cup
-                       (IF LazyCanFail THEN {"latchedFail"} ELSE {})) :
-        LET ok == outcome = "latchedDone" IN
+    /\ \E outcome \in ({"syncOk"}
+            \cup (IF LazyCanFail THEN {"syncFail"} ELSE {})
+            \cup (IF res[r].lazyCancel THEN {"syncCancel"} ELSE {})) :
         /\ res' = [res EXCEPT
              ![r].lazyRunning = @ - 1,
-             ![r].lazyComplete = @ \/ ok,
-             ![r].lazyCb = IF ok THEN "none" ELSE @,
              ![r].lazyPhase = "idle",
-             ![r].lazyWaiters = 0]
-        /\ evals' = LatchEvalOutcomes(r, outcome)
+             ![r].lazyCancel = FALSE,
+             ![r].lazyWaiters = 0,
+             ![r].lazyComplete = @ \/ outcome = "syncOk",
+             ![r].lazySyncPending = outcome # "syncOk"]
+        /\ evals' = LatchEvalOutcomes(r,
+             CASE outcome = "syncOk" -> "latchedDone"
+               [] outcome = "syncFail" -> "latchedFail"
+               [] OTHER -> "latchedCancel")
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
@@ -1604,13 +1648,11 @@ EvalAbandon(e) ==
     /\ LET r == evals[e].target
            current == evals[e].phase = "waiting"
            last == current /\ res[r].lazyWaiters = 1
-       IN /\ ~current \/ res[r].lazyPhase \in {"running", "cancelRequested"}
+       IN /\ ~current \/ res[r].lazyPhase \in {"running", "syncing"}
           /\ res' = IF current
                     THEN [res EXCEPT
                          ![r].lazyWaiters = @ - 1,
-                         ![r].lazyPhase =
-                              IF last /\ @ = "running"
-                              THEN "cancelRequested" ELSE @]
+                         ![r].lazyCancel = @ \/ last]
                     ELSE res
           /\ evals' = [evals EXCEPT ![e].phase = "abandoned",
                                      ![e].foreignCancel = FALSE]
@@ -1650,7 +1692,7 @@ Next ==
          \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalJoin(e)
          \/ EvalCallbackClose(e) \/ EvalWake(e) \/ EvalAbandon(e)
     \/ \E r \in 1..Len(res) :
-         EvalCallbackFinish(r) \/ EvalCallbackFinishCanceled(r)
+         EvalBodyFinish(r) \/ EvalSyncFinish(r)
     \/ Flush
     \/ Restart
 
@@ -1717,7 +1759,7 @@ LazyCallbackCloseProgress(e) == EvalCallbackClose(e)
 \* same reason it does for attachment: weak fairness on the success arm
 \* alone would wrongly forbid persistent failure.
 LazyCallbackProgress(r) ==
-    EvalCallbackFinish(r) \/ EvalCallbackFinishCanceled(r)
+    EvalBodyFinish(r) \/ EvalSyncFinish(r)
 
 LiveSpec ==
     /\ Spec
@@ -1762,6 +1804,10 @@ TypeOK ==
     /\ \A o \in OngoingCallIds : ongoingCalls[o].waiters >= 0
     /\ \A r \in ResultIds :
          /\ res[r].lazyWaiters >= 0 /\ res[r].lazyRunning >= 0
+         /\ res[r].lazyPhase \in {"idle", "running", "syncing"}
+         /\ res[r].lazyCb \in {"none", "armed"}
+         /\ res[r].lazyCancel \in BOOLEAN
+         /\ res[r].lazySyncPending \in BOOLEAN
          /\ res[r].lazyWaiters = Cardinality(
               {e \in EvalIds :
                   evals[e].target = r /\ evals[e].phase = "waiting"})
@@ -1882,6 +1928,26 @@ NoErroredLookupSelection ==
 \* point of the per-result singleflight in evaluateOne.
 LazyMutualExclusion ==
     \A r \in ResultIds : res[r].lazyRunning <= 1
+
+\* A successful Evaluate return implies the result's evaluation is
+\* complete. The pre-fix fast path violated this: it trusted the consumed
+\* object-side callback while that callback's attempt was still running
+\* its cache-side bookkeeping, and reported success early.
+EvalDoneComplete ==
+    \A e \in EvalIds :
+        evals[e].phase = "done" => res[evals[e].target].lazyComplete
+
+\* Completion is only ever recorded with every stage settled: the
+\* object-side callback consumed, no bookkeeping pending, no attempt in
+\* flight. The pre-fix preflight violated this by converting a consumed
+\* object-side callback into lazyEvalComplete while bookkeeping had
+\* failed or was still running.
+LazyCompleteSettled ==
+    \A r \in ResultIds :
+        res[r].lazyComplete =>
+            /\ res[r].lazyCb = "none"
+            /\ ~res[r].lazySyncPending
+            /\ res[r].lazyPhase = "idle"
 
 \* Success is permanent: once a result's evaluation completed, no callback
 \* for it is running or can start again (the callback is cleared and every

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -321,6 +321,7 @@ ImportedResult(c, persistedFlag, depsSet, ownVal, payloadVal, launderedFlag) ==
      persisted |-> persistedFlag, barrier |-> "none",
      payload |-> payloadVal, decodePhase |-> "idle", decodeErr |-> "none",
      laundered |-> launderedFlag,
+     imported |-> TRUE,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
      lazyCancel |-> FALSE, lazySyncPending |-> FALSE,
      lazyWaiters |-> 0, lazyRunning |-> 0]
@@ -335,6 +336,7 @@ DeadHusk ==
      persisted |-> FALSE, barrier |-> "none",
      payload |-> "decoded", decodePhase |-> "idle", decodeErr |-> "none",
      laundered |-> FALSE,
+     imported |-> TRUE,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
      lazyCancel |-> FALSE, lazySyncPending |-> FALSE,
      lazyWaiters |-> 0, lazyRunning |-> 0]
@@ -771,6 +773,7 @@ PubIndexFresh(o) ==
                        laundered |-> FALSE,
                        \* lazy-evaluation state, mirroring the lazyMu block
                        \* on sharedResult (cache.go:1584-1597):
+                       imported |-> FALSE,       \* fresh, not from the store
                        lazyCb |-> lazyCb,        \* lazyEval callback stored?
                        lazyComplete |-> FALSE,   \* lazyEvalComplete
                        lazyPhase |-> "idle",     \* published attempt lifecycle
@@ -1397,11 +1400,15 @@ Restart ==
                                  !.needsPersistedEdge = FALSE,
                                  !.waiters = 0]]
     /\ ongoingCallIndex' = [k \in Calls \X Sessions |-> 0]
-    /\ evals' = [e \in EvalIds |->
-         IF evals[e].phase \in EvalPendingPhases
-         THEN [evals[e] EXCEPT !.phase = "abandoned",
-                                  !.foreignCancel = FALSE]
-         ELSE evals[e]]
+    \* A restart kills the process: evaluator goroutines die with it, so no
+    \* evaluator record survives, terminal or not. (Invocations differ:
+    \* they are retained across restart with epoch bookkeeping because the
+    \* refusal properties must still judge pre-restart refusals; no
+    \* evaluator property needs that, and a retained "done" evaluator would
+    \* pair with a rebuilt incomplete result and falsely trip
+    \* EvalDoneComplete.) Clearing also resets the MaxEvals budget: a new
+    \* process gets new callers.
+    /\ evals' = <<>>
     /\ sessionEdges' = {}
     /\ countedEdges' = {}
     /\ sessionRelease' = [s \in Sessions |-> [phase |-> "live", snap |-> {}]]
@@ -1494,6 +1501,33 @@ EvalSpawn ==
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
+
+\* A hit loads an imported result's value and registers its lazy work:
+\* ensurePersistedHitValueLoaded calls registerLazyEvaluation after the
+\* value (possibly just decoded) is in memory, and persisted payloads can
+\* carry deferred work - a lazy container persists its recipe
+\* (core/container.go, persistedContainerFormLazy). Whether a given row
+\* carries lazy work is payload data the model does not track, so arming
+\* is optional: rows without lazy work are the paths where this never
+\* fires. Registration reads object-side state under lazyMu only with no
+\* attempt published, and is a no-op once a callback is stored, evaluation
+\* completed, or bookkeeping is pending, hence the guards. Fresh results
+\* arm at publication (PubIndexFresh), never here. After a restart every
+\* kept row is imported again and may re-arm, matching a store row whose
+\* payload still carries its recipe.
+ImportedLazyArm(r) ==
+    /\ ModelLazy
+    /\ r \in ResultIds
+    /\ res[r].registered
+    /\ res[r].imported
+    /\ res[r].payload = "decoded"
+    /\ res[r].lazyCb = "none"
+    /\ ~res[r].lazyComplete
+    /\ ~res[r].lazySyncPending
+    /\ res[r].lazyPhase = "idle"
+    /\ res' = [res EXCEPT ![r].lazyCb = "armed"]
+    /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex, sessionEdges,
+                   countedEdges, sessionRelease, evals, epoch, flushed>>
 
 \* Fast path under lazyMu: evaluation already completed, or nothing
 \* deferred remains anywhere - no published attempt, no object-side
@@ -1701,7 +1735,7 @@ Next ==
          \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalJoin(e)
          \/ EvalCallbackClose(e) \/ EvalWake(e) \/ EvalAbandon(e)
     \/ \E r \in 1..Len(res) :
-         EvalBodyFinish(r) \/ EvalSyncFinish(r)
+         EvalBodyFinish(r) \/ EvalSyncFinish(r) \/ ImportedLazyArm(r)
     \/ Flush
     \/ Restart
 
@@ -1813,6 +1847,7 @@ TypeOK ==
     /\ \A o \in OngoingCallIds : ongoingCalls[o].waiters >= 0
     /\ \A r \in ResultIds :
          /\ res[r].lazyWaiters >= 0 /\ res[r].lazyRunning >= 0
+         /\ res[r].imported \in BOOLEAN
          /\ res[r].lazyPhase \in {"idle", "running", "syncing"}
          /\ res[r].lazyCb \in {"none", "armed"}
          /\ res[r].lazyCancel \in BOOLEAN

--- a/dagql/tla/CacheLifecycle_lazy.cfg
+++ b/dagql/tla/CacheLifecycle_lazy.cfg
@@ -25,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = TRUE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact NoStaleCancelError
+INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact NoStaleCancelError EvalDoneComplete LazyCompleteSettled

--- a/dagql/tla/CacheLifecycle_lazy.cfg
+++ b/dagql/tla/CacheLifecycle_lazy.cfg
@@ -1,5 +1,6 @@
 \* Lazy evaluation with callback failures injected: at most one callback per
-\* result, success permanent, failure retryable, accounting exact.
+\* result, success permanent, failure and foreign cancellation retryable,
+\* accounting exact.
 \* Expected: pass.
 SPECIFICATION Spec
 CONSTANTS

--- a/dagql/tla/CacheLifecycle_lazy.cfg
+++ b/dagql/tla/CacheLifecycle_lazy.cfg
@@ -25,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = TRUE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact
+INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact NoStaleCancelError

--- a/dagql/tla/CacheLifecycle_lazy_import.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_import.cfg
@@ -1,0 +1,33 @@
+\* Lazy work on imported results: persisted payloads can carry deferred
+\* work (a lazy container persists its recipe), which arms on first value
+\* load after import or restart, possibly after a decode. Evaluators then
+\* run the full lazy protocol - joins, abandonment, foreign-cancellation
+\* retry, bookkeeping - against results the store produced rather than a
+\* fresh publication. AllowRelease is on solely so flush and restart are
+\* reachable (flush requires released sessions) and the post-restart
+\* re-arm lifecycle is exercised; the other lazy configurations keep
+\* release off. Expected: pass.
+SPECIFICATION Spec
+CONSTANTS
+    Sessions = {s1}
+    s1 = s1
+    Calls = {cA}
+    cA = cA
+    ClassOf <- OneClass
+    MaxInvocations = 1
+    MaxResults = 2
+    AllowRelease = TRUE
+    DrainOnRelease = FALSE
+    AllowPruneCut = FALSE
+    ModelLazy = TRUE
+    MaxEvals = 2
+    ModelPersistence = TRUE
+    ImportInit = TRUE
+    ModelNestedCalls = FALSE
+    FnCanFail = FALSE
+    AttachCanFail = FALSE
+    LeaseCanFail = FALSE
+    ReaderCanCancel = FALSE
+    LazyCanFail = TRUE
+    DecodeCanFail = FALSE
+INVARIANTS TypeOK OwnershipExact LazyMutualExclusion LazySuccessPermanent NoStaleCancelError EvalDoneComplete LazyCompleteSettled

--- a/dagql/tla/CacheLifecycle_lazy_liveness.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_liveness.cfg
@@ -1,5 +1,6 @@
 \* Lazy evaluation under fair scheduling: every Evaluate caller eventually
-\* terminates. Expected: pass.
+\* terminates, including callers that must retry a foreign cancellation.
+\* Expected: pass.
 SPECIFICATION LiveSpec
 CONSTANTS
     Sessions = {s1}

--- a/dagql/tla/CacheLifecycle_lazy_stale_cancel.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_stale_cancel.cfg
@@ -1,8 +1,6 @@
-\* A fresh Evaluate joining a lazy attempt that every previous waiter has
-\* already abandoned (the join check is only "a wait channel exists",
-\* cache.go:3048) is handed the abandoners' cancellation error - a spurious
-\* failure on a healthy, retryable result. Expected: NoStaleCancelError
-\* violated.
+\* A healthy Evaluate caller joins an attempt whose previous waiters caused
+\* callback cancellation, observes that foreign cancellation, and retries
+\* without returning it. Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}

--- a/dagql/tla/CacheLifecycle_lazy_stale_cancel.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_stale_cancel.cfg
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact NoStaleCancelError
+INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact NoStaleCancelError EvalDoneComplete LazyCompleteSettled

--- a/dagql/tla/CacheLifecycle_lazy_stale_cancel.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_stale_cancel.cfg
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS NoStaleCancelError
+INVARIANTS TypeOK LazyMutualExclusion LazySuccessPermanent OwnershipExact NoStaleCancelError

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -164,6 +164,14 @@ type OnReleaser interface {
 
 type LazyEvalFunc func(context.Context) error
 
+// HasLazyEvaluation is implemented by values carrying deferred work that
+// Cache.Evaluate forces. A successful callback run consumes the value's
+// deferred work; implementations should return nil from LazyEvalFunc
+// afterwards (core types clear their object-side Lazy pointer on success).
+// The cache enforces the consumption independently: once a callback body has
+// succeeded, later attempts retry only cache-side bookkeeping and never
+// re-read the value's callback, so an implementation that keeps returning a
+// non-nil function cannot cause the body to run twice.
 type HasLazyEvaluation interface {
 	LazyEvalFunc() LazyEvalFunc
 }

--- a/internal-docs/lazy_evaluation.md
+++ b/internal-docs/lazy_evaluation.md
@@ -76,6 +76,7 @@ Attached results carry cache-owned lazy state in `dagql.sharedResult`:
 - `lazyEval`
 - `lazyEvalComplete`
 - `lazyEvalAttempt`
+- `lazySyncPending`
 
 This state is guarded by `lazyMu`.
 
@@ -84,6 +85,7 @@ Conceptually:
 - `lazyEval` is the callback the cache should run
 - `lazyEvalComplete` means the attached result is fully materialized
 - `lazyEvalAttempt` is the currently running callback attempt, including its completion channel, cancel function, waiter count, outcome, and telemetry wait targets
+- `lazySyncPending` means a previous attempt's callback body succeeded but the attempt's cache-side bookkeeping (snapshot-lease sync, lease release) did not; the next attempt retries only that bookkeeping
 
 Waiters retain the particular attempt record they joined. When its callback
 finishes, the cache stores the outcome on that record and removes it as the
@@ -110,10 +112,10 @@ For a single result, `Cache.evaluateOne` works roughly like this:
 1. Validate that the cache and result are non-nil.
 2. Require that the result is attached to a real `sharedResult`.
 3. Detect recursive lazy evaluation using a stack of `sharedResultID`s stored in context.
-4. Re-read the current `LazyEvalFunc` from the wrapped value.
-5. If the result is already fully materialized, return.
-6. If another goroutine is already evaluating this result, retain its attempt record and wait on its channel.
-7. Otherwise start the lazy callback in a background goroutine and wait for it.
+4. If the result is already fully materialized, return.
+5. If another goroutine is already evaluating this result, retain its attempt record and wait on its channel. This check comes before reading any object-side lazy state: callback bodies (Directory, File, Container) clear their object-side `Lazy` pointer while their attempt is still running cache-side bookkeeping, so object-side state is only trustworthy once no attempt is published.
+6. With no attempt in flight, re-read the current `LazyEvalFunc` from the wrapped value. If it is nil and no bookkeeping is pending, mark the result complete and return.
+7. Otherwise start an attempt in a background goroutine and wait for it: the callback body if one is armed, then the cache-side bookkeeping; or only the bookkeeping when `lazySyncPending` is set.
 
 Two details are especially important.
 

--- a/internal-docs/lazy_evaluation.md
+++ b/internal-docs/lazy_evaluation.md
@@ -75,10 +75,7 @@ Attached results carry cache-owned lazy state in `dagql.sharedResult`:
 
 - `lazyEval`
 - `lazyEvalComplete`
-- `lazyEvalWaitCh`
-- `lazyEvalCancel`
-- `lazyEvalWaiters`
-- `lazyEvalErr`
+- `lazyEvalAttempt`
 
 This state is guarded by `lazyMu`.
 
@@ -86,9 +83,12 @@ Conceptually:
 
 - `lazyEval` is the callback the cache should run
 - `lazyEvalComplete` means the attached result is fully materialized
-- `lazyEvalWaitCh` means evaluation is currently in flight
-- `lazyEvalWaiters` tracks how many callers are waiting on that in-flight evaluation
-- `lazyEvalCancel` lets the cache cancel the in-flight evaluation if the last waiter goes away
+- `lazyEvalAttempt` is the currently running callback attempt, including its completion channel, cancel function, waiter count, outcome, and telemetry wait targets
+
+Waiters retain the particular attempt record they joined. When its callback
+finishes, the cache stores the outcome on that record and removes it as the
+current attempt. Existing waiters can then consume the old outcome without
+reading or changing a newer attempt's state.
 
 ## How Lazy Callbacks Get Registered
 
@@ -112,7 +112,7 @@ For a single result, `Cache.evaluateOne` works roughly like this:
 3. Detect recursive lazy evaluation using a stack of `sharedResultID`s stored in context.
 4. Re-read the current `LazyEvalFunc` from the wrapped value.
 5. If the result is already fully materialized, return.
-6. If another goroutine is already evaluating this result, wait on its channel.
+6. If another goroutine is already evaluating this result, retain its attempt record and wait on its channel.
 7. Otherwise start the lazy callback in a background goroutine and wait for it.
 
 Two details are especially important.
@@ -132,7 +132,9 @@ The actual callback runs under a context built from `context.WithoutCancel(stack
 That means one impatient caller does not immediately tear down the shared lazy callback for everyone else. Instead:
 
 - each waiter can independently cancel its own wait
-- if the last waiter goes away, the cache invokes the stored cancel func with that cause
+- if the last waiter goes away, the cache invokes that attempt's cancel func with the waiter's cause
+- the callback attempt remains current until the callback actually finishes, so a replacement callback never overlaps it
+- if a healthy waiter receives a cancellation caused by the shared callback context, it transparently retries instead of returning another waiter's cancellation
 
 This is a shared-work model, not a per-caller callback model.
 
@@ -184,12 +186,18 @@ After the lazy callback returns successfully, the cache:
 2. marks `lazyEvalComplete = true`
 3. clears the stored `lazyEval`
 
-If the callback fails, the cache does not mark the result complete. Future `Evaluate` calls can try again.
+If the callback genuinely fails, the cache does not mark the result complete.
+Every caller waiting on that attempt receives the failure, and a future
+`Evaluate` call can try again. If the callback instead returns cancellation
+caused by its shared callback context, a still-healthy waiter retries
+immediately. A waiter's own context cancellation still ends only that
+waiter's call with its own cancellation cause.
 
 So the rule is simple:
 
 - success permanently materializes the attached result
-- failure leaves it pending
+- genuine failure is returned and leaves the result pending
+- cancellation caused by abandoned shared work is retried for healthy callers
 
 ## The Second Layer: `core.Lazy[T]`
 

--- a/internal-docs/lazy_evaluation.md
+++ b/internal-docs/lazy_evaluation.md
@@ -114,7 +114,7 @@ For a single result, `Cache.evaluateOne` works roughly like this:
 3. Detect recursive lazy evaluation using a stack of `sharedResultID`s stored in context.
 4. If the result is already fully materialized, return.
 5. If another goroutine is already evaluating this result, retain its attempt record and wait on its channel. This check comes before reading any object-side lazy state: callback bodies (Directory, File, Container) clear their object-side `Lazy` pointer while their attempt is still running cache-side bookkeeping, so object-side state is only trustworthy once no attempt is published.
-6. With no attempt in flight, re-read the current `LazyEvalFunc` from the wrapped value. If it is nil and no bookkeeping is pending, mark the result complete and return.
+6. With no attempt in flight, check pending bookkeeping first: `lazySyncPending` means a previous attempt's body already succeeded and consumed the value's deferred work, so the value's callback is not re-read and the next attempt retries only the bookkeeping. Otherwise re-read the current `LazyEvalFunc` from the wrapped value; if it is nil, mark the result complete and return.
 7. Otherwise start an attempt in a background goroutine and wait for it: the callback body if one is armed, then the cache-side bookkeeping; or only the bookkeeping when `lazySyncPending` is set.
 
 Two details are especially important.


### PR DESCRIPTION
## Summary

A new healthy `Cache.Evaluate` caller could join a lazy callback attempt after every earlier waiter had abandoned and canceled it. When that callback finished with the shared cancellation, the new caller inherited an error it did not cause. A second form occurred when a completed canceled attempt remained published after its last waiter selected its own cancellation arm, allowing a later caller to drain the stale error.

This change makes cancellation caused by abandoned shared work transparent to healthy callers while preserving lazy-evaluation mutual exclusion. Reworking the coordination also exposed two adjacent defects in the same code, both fixed here: evaluation could be reported complete before an attempt's cache-side bookkeeping settled, and cache-hit lazy registration raced the callback body's object-side state.

## Runtime design

Each lazy callback execution has an attempt-scoped record containing its completion channel, cancel function, waiter count, outcome, cancellation provenance, and telemetry wait targets.

The shared result publishes one current attempt while its callback runs. Callback completion stores the outcome and retires that attempt under the lazy mutex before closing its completion channel. Existing waiters retain the retired record, so they cannot read or decrement a newer attempt's state.

A healthy waiter retries when the callback error is attributable to cancellation of that attempt's shared callback context. A waiter's own cancellation still returns its own cause, and genuine callback failures still propagate to every waiter. A new callback can begin only after the preceding callback has returned, so retries never overlap.

Evaluation preflight consults the published attempt before any object-side lazy state. Callback bodies (Directory, File, Container) clear their object-side `Lazy` pointer while the attempt is still running its cache-side bookkeeping (snapshot-lease sync, lease release), so object-side state is only trustworthy once no attempt is published; attempt retirement under the lazy mutex orders the body's writes before such a reader. A second caller arriving during the bookkeeping window therefore joins the attempt instead of observing the cleared pointer and reporting success early.

A failed attempt whose body already succeeded records pending bookkeeping. The next `Evaluate` leads a bookkeeping-only attempt that retries just the snapshot-lease sync instead of treating the consumed object-side callback as completed evaluation, so a bookkeeping failure is no longer reported once and then silently swallowed. Cache-hit lazy registration applies the same attempt-first order under the lazy mutex, closing a data race between the hit path's read and the callback body's write.

## Telemetry

Native-profiler and OpenTelemetry wait targets are fresh per attempt. They are minted, or deliberately left invalid, under the lazy mutex before the attempt pointer is published. OpenTelemetry waits remain gated by the result producer's profile-skip state, never the forcing waiter's state.

## Behavior and cost

Retry happens only after a real callback attempt completes. A genuinely canceled attempt can therefore cause one additional callback execution for a healthy caller. The object-side lazy state remains idempotent, no two callbacks for one result run concurrently, and a bookkeeping-only retry never re-runs the callback body.

## Tests and model

The deterministic standard-library `testing/synctest` coverage exercises:

- a healthy caller joining canceled work and succeeding through retry;
- own cancellation affecting only the canceling waiter;
- mutual exclusion across retries;
- cancellation-shaped genuine callback failures;
- retirement after callback finish but before the completion-channel close;
- a second caller joining an attempt whose body finished but whose bookkeeping is still in flight, a failed bookkeeping step staying retryable without re-running the body, and the retry settling completion.

A separate regression drives cache hits concurrently with a running callback and is meaningful under the race detector: with the old registration ordering, `-race` reports the object-side write against the hit path's read.

The five-second timeout guards use the synctest bubble's fake clock and remain active when all goroutines are durably blocked.

The TLA+ model separates callback retirement, completion-channel observation, and waiter wake-up, and now also separates the callback body from the attempt's cache-side bookkeeping: body success moves the attempt into a syncing stage, a bookkeeping failure records a retryable pending obligation, and a bookkeeping-only attempt starts directly in that stage. Cancellation is a flag that composes with both stages, and the canceled-finish action can latch a genuine failure, matching the per-error retry decision in the Go. Evaluators can only demand results whose attachment barrier is neither open nor errored, matching what callers can actually hold. Two new invariants gate the fixed behavior in the lazy configurations: `EvalDoneComplete` (a successful Evaluate return implies completed evaluation) and `LazyCompleteSettled` (completion is only recorded with every stage settled); weakening the preflight back to its old shape violates them within seconds. The model also covers lazy work on imported results: persisted payloads can carry deferred work (a lazy container persists its recipe), which arms on first value load after import or restart, and a new `lazy_import` configuration exercises the full lazy protocol against store-produced results interleaved with flush and restart. The `lazy_stale_cancel` configuration is a green regression gate, `lazy`, `lazy_liveness`, and `lazy_import` are green, and reachability probes confirmed that foreign-cancellation, retry-cycle, pending-bookkeeping, imported-arming, and post-restart re-arming states are explored within the configured bounds.

## Validation

- `go test ./dagql -count=1`
- `go test ./engine/server -count=1`
- `go test -race ./dagql -run '^(TestCacheHitRegistrationDoesNotRaceLazyCallback|TestCacheEvaluateSettlesBookkeepingBeforeReportingComplete|TestCacheEvaluateRetriesForeignCancellation|TestCacheEvaluateRetiresFinishedAttemptBeforeWaitersDrain|TestCacheEvaluateOwnCancellationOnlyCancelsOwnWait|TestCacheEvaluatePropagatesCallbackFailure)$' -count=1`
- `go vet ./dagql`
- `dagger check tla-check:cache-lifecycle` — all 24 configurations, every expected outcome matched
- Fresh direct TLC runs of `lazy`, `lazy_liveness`, and `lazy_stale_cancel`, plus re-break runs proving the new invariants catch the old preflight and probe runs proving the gated states are reachable
- Focused packaging generator check: `dagger check dagger-go-sdk:generate`

## Stack

This is layer three of the cache-remediation stack. It depends on #13936, which depends on #13934, and relies on the engine-lifetime-unique numeric result IDs introduced at the base of the stack.
