### PR TITLE
dagql: defer session release until in-flight operations finish

### DIFF
--- a/.changes/unreleased/Fixed-20260820-090638.yaml
+++ b/.changes/unreleased/Fixed-20260820-090638.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Session shutdown no longer releases cache results while in-flight cache operations or lazy callbacks are still using them. Shutdown persistence now waits for cache quiescence.
+time: 2026-08-20T09:06:38.051510224Z
+custom:
+    Author: sipsma
+    PR: "13940"

--- a/.dagger/modules/tla-check/dagger.gen.go
+++ b/.dagger/modules/tla-check/dagger.gen.go
@@ -224,21 +224,21 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 		}
 	case "":
 		return dag.Module().
-			WithDescription("TLA+ model checking for the dagql cache spec (dagql/tla).\n\nRuns every TLC configuration of CacheLifecycle.tla. Green configurations\nare regression gates: any violation fails the check. Red configurations\nreproduce known deficiencies in the current code: each must violate\nexactly its designated invariant — coming up clean, or violating a\ndifferent invariant, fails the check, because either means the model or\na configuration drifted from the deficiency it reproduces.\n").
+			WithDescription("TLA+ model checking for the dagql cache spec (dagql/tla).\n\nRuns every TLC configuration of CacheLifecycle.tla. Green configurations\nare regression gates: any violation fails the check. A configuration may\nname an expected invariant only while it deliberately tracks an accepted\nmodel finding.\n").
 			WithObject(
-				dag.TypeDef().WithObject("TlaCheck", dagger.TypeDefWithObjectOpts{SourceMap: dag.SourceMap("main.go", 62, 6)}).
+				dag.TypeDef().WithObject("TlaCheck", dagger.TypeDefWithObjectOpts{SourceMap: dag.SourceMap("main.go", 59, 6)}).
 					WithFunction(
 						dag.Function("CacheLifecycle",
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("CacheLifecycle model-checks every configuration of the dagql cache spec\nand verifies each outcome against its expectation.").
-							WithSourceMap(dag.SourceMap("main.go", 87, 1)).
+							WithSourceMap(dag.SourceMap("main.go", 84, 1)).
 							WithCheck()).
-					WithField("Source", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{Description: "The dagql/tla spec directory.", SourceMap: dag.SourceMap("main.go", 64, 2)}).
+					WithField("Source", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{Description: "The dagql/tla spec directory.", SourceMap: dag.SourceMap("main.go", 61, 2)}).
 					WithConstructor(
 						dag.Function("New",
 							dag.TypeDef().WithObject("TlaCheck")).
-							WithSourceMap(dag.SourceMap("main.go", 67, 1)).
-							WithArg("ws", dag.TypeDef().WithObject("Workspace"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 67, 10)}))), nil
+							WithSourceMap(dag.SourceMap("main.go", 64, 1)).
+							WithArg("ws", dag.TypeDef().WithObject("Workspace"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 64, 10)}))), nil
 	default:
 		return nil, fmt.Errorf("unknown object %s", parentName)
 	}

--- a/.dagger/modules/tla-check/dagger.gen.go
+++ b/.dagger/modules/tla-check/dagger.gen.go
@@ -205,6 +205,34 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*TlaCheck).CacheLifecycle(&parent, ctx)
+		case "One":
+			var parent TlaCheck
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var config string
+			if inputArgs["config"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["config"]), &config)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg config", err))
+				}
+			}
+			var invariant string
+			if inputArgs["invariant"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["invariant"]), &invariant)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg invariant", err))
+				}
+			}
+			var define string
+			if inputArgs["define"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["define"]), &define)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg define", err))
+				}
+			}
+			return (*TlaCheck).One(&parent, ctx, config, invariant, define)
 		case "":
 			var parent TlaCheck
 			err = json.Unmarshal(parentJSON, &parent)
@@ -233,6 +261,14 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							WithDescription("CacheLifecycle model-checks every configuration of the dagql cache spec\nand verifies each outcome against its expectation.").
 							WithSourceMap(dag.SourceMap("main.go", 84, 1)).
 							WithCheck()).
+					WithFunction(
+						dag.Function("One",
+							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
+							WithDescription("One runs a single TLC configuration and returns the raw TLC output,\nusing the same pinned jar and invocation as the CacheLifecycle check.\nUnlike the check, it applies no expectation: violations come back in\nthe output for the caller to read.\n\nWith invariant set, the configuration's INVARIANTS line is replaced by\nthat single invariant, the specification is forced to the safety-only\nSpec, and PROPERTY lines are dropped, so one question runs in\nisolation. With define also set, the given TLA+ operator definition is\nappended to the spec first; that runs a scratch probe invariant (for\nexample a reachability probe expected to violate) without editing the\nrepository.").
+							WithSourceMap(dag.SourceMap("main.go", 132, 1)).
+							WithArg("config", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{Description: "configuration name without the CacheLifecycle_ prefix, e.g. \"lazy\"", SourceMap: dag.SourceMap("main.go", 135, 2)}).
+							WithArg("invariant", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{Description: "invariant to check instead of the configuration's INVARIANTS line", SourceMap: dag.SourceMap("main.go", 138, 2)}).
+							WithArg("define", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{Description: "TLA+ operator definition to append to the spec, e.g. \"ProbeX == ...\"", SourceMap: dag.SourceMap("main.go", 141, 2)})).
 					WithField("Source", dag.TypeDef().WithObject("Directory"), dagger.TypeDefWithFieldOpts{Description: "The dagql/tla spec directory.", SourceMap: dag.SourceMap("main.go", 61, 2)}).
 					WithConstructor(
 						dag.Function("New",

--- a/.dagger/modules/tla-check/internal/dagger/tla-check.gen.go
+++ b/.dagger/modules/tla-check/internal/dagger/tla-check.gen.go
@@ -24,6 +24,7 @@ type TlaCheck struct { // tla-check (../../../../../:0:0)
 
 	cacheLifecycle *Void
 	id             *ID
+	one            *string
 }
 
 func (r *TlaCheck) WithGraphQLQuery(q *querybuilder.Selection) *TlaCheck {
@@ -90,6 +91,49 @@ func (r *TlaCheck) UnmarshalJSON(bs []byte) error {
 	}
 	*r = TlaCheck{query: selectNode(dag.query, id, "TlaCheck")}
 	return nil
+}
+
+// TlaCheckOneOpts contains options for TlaCheck.One
+type TlaCheckOneOpts struct {
+	// invariant to check instead of the configuration's INVARIANTS line
+	Invariant string
+	// TLA+ operator definition to append to the spec, e.g. "ProbeX == ..."
+	Define string
+}
+
+// One runs a single TLC configuration and returns the raw TLC output,
+// using the same pinned jar and invocation as the CacheLifecycle check.
+// Unlike the check, it applies no expectation: violations come back in
+// the output for the caller to read.
+//
+// With invariant set, the configuration's INVARIANTS line is replaced by
+// that single invariant, the specification is forced to the safety-only
+// Spec, and PROPERTY lines are dropped, so one question runs in
+// isolation. With define also set, the given TLA+ operator definition is
+// appended to the spec first; that runs a scratch probe invariant (for
+// example a reachability probe expected to violate) without editing the
+// repository.
+func (r *TlaCheck) One(ctx context.Context, config string, opts ...TlaCheckOneOpts) (string, error) {
+	if r.one != nil {
+		return *r.one, nil
+	}
+	q := r.query.Select("one")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `invariant` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Invariant) {
+			q = q.Arg("invariant", opts[i].Invariant)
+		}
+		// `define` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Define) {
+			q = q.Arg("define", opts[i].Define)
+		}
+	}
+	q = q.Arg("config", config)
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The dagql/tla spec directory.

--- a/.dagger/modules/tla-check/main.go
+++ b/.dagger/modules/tla-check/main.go
@@ -1,11 +1,9 @@
 // TLA+ model checking for the dagql cache spec (dagql/tla).
 //
 // Runs every TLC configuration of CacheLifecycle.tla. Green configurations
-// are regression gates: any violation fails the check. Red configurations
-// reproduce known deficiencies in the current code: each must violate
-// exactly its designated invariant — coming up clean, or violating a
-// different invariant, fails the check, because either means the model or
-// a configuration drifted from the deficiency it reproduces.
+// are regression gates: any violation fails the check. A configuration may
+// name an expected invariant only while it deliberately tracks an accepted
+// model finding.
 package main
 
 import (
@@ -51,12 +49,11 @@ var expectedOutcome = map[string]string{
 	"poisoned_adoption": "",
 	"poisoned_restart":  "",
 	"flush_closure":     "",
-	// red: reproductions of known deficiencies in the current code; each
-	// config's comment describes the scenario and the mechanism
-	"release_inflight": "ReturnedLive",
-	"drain_escape":     "ReturnedLive",
-	"flush_inflight":   "FlushCleanCapture",
-	"flush_drained":    "FlushCleanCapture",
+	"release_inflight":  "",
+	"drain_escape":      "",
+	"flush_inflight":    "",
+	"flush_drained":     "",
+	"lazy_release":      "",
 }
 
 type TlaCheck struct {

--- a/.dagger/modules/tla-check/main.go
+++ b/.dagger/modules/tla-check/main.go
@@ -117,6 +117,78 @@ func (m *TlaCheck) CacheLifecycle(ctx context.Context) error {
 	return nil
 }
 
+// One runs a single TLC configuration and returns the raw TLC output,
+// using the same pinned jar and invocation as the CacheLifecycle check.
+// Unlike the check, it applies no expectation: violations come back in
+// the output for the caller to read.
+//
+// With invariant set, the configuration's INVARIANTS line is replaced by
+// that single invariant, the specification is forced to the safety-only
+// Spec, and PROPERTY lines are dropped, so one question runs in
+// isolation. With define also set, the given TLA+ operator definition is
+// appended to the spec first; that runs a scratch probe invariant (for
+// example a reachability probe expected to violate) without editing the
+// repository.
+func (m *TlaCheck) One(
+	ctx context.Context,
+	// configuration name without the CacheLifecycle_ prefix, e.g. "lazy"
+	config string,
+	// +optional
+	// invariant to check instead of the configuration's INVARIANTS line
+	invariant string,
+	// +optional
+	// TLA+ operator definition to append to the spec, e.g. "ProbeX == ..."
+	define string,
+) (string, error) {
+	if define != "" && invariant == "" {
+		return "", fmt.Errorf("define requires invariant: name which invariant to check")
+	}
+	ctr := m.base()
+
+	if define != "" {
+		spec, err := m.Source.File("CacheLifecycle.tla").Contents(ctx)
+		if err != nil {
+			return "", fmt.Errorf("read spec: %w", err)
+		}
+		// The module body ends at the last ==== line; definitions must sit
+		// above it.
+		term := strings.LastIndex(spec, "\n====")
+		if term < 0 {
+			return "", fmt.Errorf("spec terminator not found")
+		}
+		spec = spec[:term] + "\n" + define + "\n" + spec[term:]
+		ctr = ctr.WithNewFile("/spec/CacheLifecycle.tla", spec)
+	}
+
+	cfgPath := fmt.Sprintf("CacheLifecycle_%s.cfg", config)
+	if invariant != "" {
+		cfg, err := m.Source.File(cfgPath).Contents(ctx)
+		if err != nil {
+			return "", fmt.Errorf("read config %s: %w", cfgPath, err)
+		}
+		lines := strings.Split(cfg, "\n")
+		kept := lines[:0]
+		for _, line := range lines {
+			switch {
+			case strings.HasPrefix(line, "SPECIFICATION"):
+				kept = append(kept, "SPECIFICATION Spec")
+			case strings.HasPrefix(line, "INVARIANTS"):
+				kept = append(kept, "INVARIANTS "+invariant)
+			case strings.HasPrefix(line, "PROPERTY"):
+				// dropped: a lone invariant is a safety question
+			default:
+				kept = append(kept, line)
+			}
+		}
+		ctr = ctr.WithNewFile("/spec/"+cfgPath, strings.Join(kept, "\n"))
+	}
+
+	cmd := fmt.Sprintf(
+		"java -XX:+UseParallelGC -cp /tla2tools.jar tlc2.TLC -workers auto -deadlock -config %s CacheLifecycle.tla 2>&1; true",
+		cfgPath)
+	return ctr.WithExec([]string{"sh", "-c", cmd}).Stdout(ctx)
+}
+
 // runOne executes one TLC configuration and returns "" on the expected
 // outcome, or a human-readable failure line. TLC exits nonzero on
 // violations, so the exec swallows the exit code and the output is parsed

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -2234,7 +2234,9 @@ func (s *containerSchema) withVolatileVariable(ctx context.Context, parent dagql
 	if err != nil {
 		return inst, fmt.Errorf("resolve volatile variable %q: current dagql cache: %w", args.Name, err)
 	}
-	cache.SetVolatileVars(ctx, clientMetadata.SessionID, args.Name, args.Value)
+	if err := cache.SetVolatileVars(ctx, clientMetadata.SessionID, args.Name, args.Value); err != nil {
+		return inst, fmt.Errorf("record volatile variable %q: %w", args.Name, err)
+	}
 
 	parentDig, err := parent.ContentPreferredDigest(ctx)
 	if err != nil {

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -140,7 +140,247 @@ const cachePersistenceSchemaVersion = "17"
 
 var ErrCacheRecursiveCall = fmt.Errorf("recursive call detected")
 var ErrCacheSessionReleased = errors.New("cache session released")
+var ErrCacheClosed = errors.New("cache closed")
 var ErrPersistStateNotReady = errors.New("persist state not ready")
+
+const cacheSessionReleasedBit uint64 = 1 << 63
+
+// cacheSessionLifecycle is retained for the engine lifetime, matching the
+// released-session tombstone lifetime. lifecycle packs the release bit and the
+// active operation count into one atomic word so operation admission does not
+// contend on the cache-wide session mutex. Release and admission are linearized
+// by compare-and-swap on this word.
+type cacheSessionLifecycle struct {
+	lifecycle atomic.Uint64
+
+	releaseMu      sync.Mutex
+	releasePlan    *cacheSessionReleasePlan
+	cleanupStarted bool
+}
+
+type cacheSessionReleasePlan struct {
+	ctx               context.Context
+	sessionID         string
+	resultIDs         map[sharedResultID]struct{}
+	arbitraryCallKeys map[string]struct{}
+}
+
+type cacheOperation struct {
+	cache     *Cache
+	session   *cacheSessionLifecycle
+	sessionID string
+	active    bool
+}
+
+func (c *Cache) beginCacheOperation() (cacheOperation, error) {
+	if c == nil {
+		return cacheOperation{}, errors.New("begin cache operation: nil cache")
+	}
+	if c.closing.Load() {
+		return cacheOperation{}, ErrCacheClosed
+	}
+	c.activeGlobalOperations.Add(1)
+	if c.closing.Load() {
+		c.endCacheOperation()
+		return cacheOperation{}, ErrCacheClosed
+	}
+	return cacheOperation{cache: c, active: true}, nil
+}
+
+func (c *Cache) sessionLifecycle(sessionID string) *cacheSessionLifecycle {
+	if sessionID == "" {
+		return nil
+	}
+	if state, ok := c.sessionLifecycles.Load(sessionID); ok {
+		return state.(*cacheSessionLifecycle)
+	}
+	state := new(cacheSessionLifecycle)
+	actual, _ := c.sessionLifecycles.LoadOrStore(sessionID, state)
+	return actual.(*cacheSessionLifecycle)
+}
+
+func (c *Cache) beginSessionOperation(sessionID string) (cacheOperation, error) {
+	if sessionID == "" {
+		return c.beginCacheOperation()
+	}
+	if c == nil {
+		return cacheOperation{}, errors.New("begin cache operation: nil cache")
+	}
+	if c.closing.Load() {
+		return cacheOperation{}, ErrCacheClosed
+	}
+
+	state := c.sessionLifecycle(sessionID)
+	for {
+		old := state.lifecycle.Load()
+		if old&cacheSessionReleasedBit != 0 {
+			return cacheOperation{}, fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
+		}
+		if old == cacheSessionReleasedBit-1 {
+			return cacheOperation{}, fmt.Errorf("begin cache operation for session %q: active operation count overflow", sessionID)
+		}
+		if state.lifecycle.CompareAndSwap(old, old+1) {
+			if c.closing.Load() {
+				rejected := cacheOperation{cache: c, session: state, sessionID: sessionID, active: true}
+				rejected.finish(false)
+				return cacheOperation{}, ErrCacheClosed
+			}
+			op := cacheOperation{cache: c, session: state, sessionID: sessionID, active: true}
+			if c.testAfterSessionOperationEnter != nil {
+				c.testAfterSessionOperationEnter(sessionID)
+			}
+			return op, nil
+		}
+	}
+}
+
+func (c *Cache) beginContextOperation(ctx context.Context) (cacheOperation, error) {
+	sessionID := ""
+	if clientMetadata, err := engine.ClientMetadataFromContext(ctx); err == nil {
+		sessionID = clientMetadata.SessionID
+	}
+	return c.beginSessionOperation(sessionID)
+}
+
+// finish ends an operation. A value-bearing success is refused when release
+// won the atomic race with operation exit. The server drains handler-origin
+// calls before release, so this refusal is reserved for doomed detached work.
+func (op *cacheOperation) finish(valueBearingSuccess bool) bool {
+	if op == nil || !op.active {
+		return false
+	}
+	op.active = false
+
+	lateRefusal := false
+	if op.session != nil {
+		if op.cache.testBeforeSessionOperationExit != nil {
+			op.cache.testBeforeSessionOperationExit(op.sessionID)
+		}
+		for {
+			old := op.session.lifecycle.Load()
+			count := old &^ cacheSessionReleasedBit
+			if count == 0 {
+				panic(fmt.Sprintf("cache operation count underflow for session %q", op.sessionID))
+			}
+			lateRefusal = valueBearingSuccess && old&cacheSessionReleasedBit != 0
+			lastReleasedOperation := old == cacheSessionReleasedBit|1
+			if lastReleasedOperation {
+				// Once the session count reaches zero, this global-only token keeps
+				// Cache.Close from observing quiescence while cleanup hooks run.
+				op.cache.activeGlobalOperations.Add(1)
+			}
+			if op.session.lifecycle.CompareAndSwap(old, old-1) {
+				if lastReleasedOperation {
+					if _, err := op.cache.tryCleanupReleasedSession(op.session); err != nil {
+						op.cache.recordReleaseCleanupError(op.sessionID, true, err)
+					}
+					op.cache.endCacheOperation()
+				}
+				break
+			}
+			if lastReleasedOperation {
+				op.cache.endCacheOperation()
+			}
+		}
+		op.cache.signalQuiescenceWaiter()
+	} else {
+		op.cache.endCacheOperation()
+	}
+	return lateRefusal
+}
+
+func (c *Cache) endCacheOperation() {
+	if c.activeGlobalOperations.Add(-1) != 0 {
+		return
+	}
+	c.signalQuiescenceWaiter()
+}
+
+func (c *Cache) signalQuiescenceWaiter() {
+	if !c.closing.Load() {
+		return
+	}
+	c.operationWaitMu.Lock()
+	if c.operationWaitCh != nil {
+		close(c.operationWaitCh)
+		c.operationWaitCh = nil
+	}
+	c.operationWaitMu.Unlock()
+}
+
+func (c *Cache) operationsQuiescent() bool {
+	if c.activeGlobalOperations.Load() != 0 {
+		return false
+	}
+	quiescent := true
+	c.sessionLifecycles.Range(func(_, value any) bool {
+		state := value.(*cacheSessionLifecycle)
+		if state.lifecycle.Load()&^cacheSessionReleasedBit != 0 {
+			quiescent = false
+			return false
+		}
+		return true
+	})
+	return quiescent
+}
+
+func (c *Cache) waitForQuiescence(ctx context.Context) error {
+	c.closing.Store(true)
+	if c.testAfterCacheClosing != nil {
+		c.testAfterCacheClosing()
+	}
+	for !c.operationsQuiescent() {
+		c.operationWaitMu.Lock()
+		if c.operationsQuiescent() {
+			c.operationWaitMu.Unlock()
+			break
+		}
+		if c.operationWaitCh == nil {
+			c.operationWaitCh = make(chan struct{})
+		}
+		waitCh := c.operationWaitCh
+		c.operationWaitMu.Unlock()
+
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
+	}
+	return nil
+}
+
+func (c *Cache) markSessionReleased(state *cacheSessionLifecycle) (uint64, bool) {
+	for {
+		old := state.lifecycle.Load()
+		if old&cacheSessionReleasedBit != 0 {
+			return old, false
+		}
+		if state.lifecycle.CompareAndSwap(old, old|cacheSessionReleasedBit) {
+			return old, true
+		}
+	}
+}
+
+func (c *Cache) recordReleaseCleanupError(sessionID string, deferred bool, err error) {
+	if err == nil {
+		return
+	}
+	mode := "synchronous"
+	if deferred {
+		mode = "deferred"
+	}
+	slog.Error("dagql cache session cleanup failed", "sessionID", sessionID, "mode", mode, "err", err)
+	c.releaseCleanupErrMu.Lock()
+	c.releaseCleanupErr = errors.Join(c.releaseCleanupErr, fmt.Errorf("%s release session %q: %w", mode, sessionID, err))
+	c.releaseCleanupErrMu.Unlock()
+}
+
+func (c *Cache) releaseCleanupError() error {
+	c.releaseCleanupErrMu.Lock()
+	defer c.releaseCleanupErrMu.Unlock()
+	return c.releaseCleanupErr
+}
 
 type CachePersistenceResetReason string
 
@@ -268,7 +508,7 @@ func (c *Cache) acquireSessionResultLocked(ctx context.Context, sessionID string
 
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
-	if _, released := c.releasedSessionIDs[sessionID]; released {
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
 		return false, 0, fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
 	}
 	if _, found := c.resultsByID[shared.id]; !found {
@@ -363,6 +603,10 @@ func (c *Cache) BindSessionResource(_ context.Context, sessionID string, clientI
 	}
 
 	c.sessionMu.Lock()
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		c.sessionMu.Unlock()
+		return fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
+	}
 	if c.sessionResourcesBySession == nil {
 		c.sessionResourcesBySession = make(map[string]map[SessionResourceHandle]*sessionResourceBindings)
 	}
@@ -391,9 +635,15 @@ func (c *Cache) BindSessionResource(_ context.Context, sessionID string, clientI
 	return nil
 }
 
-func (c *Cache) SetVolatileVars(_ context.Context, sessionID, k, v string) {
+func (c *Cache) SetVolatileVars(_ context.Context, sessionID, k, v string) error {
+	if sessionID == "" {
+		return errors.New("set volatile vars: empty session ID")
+	}
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		return fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
+	}
 
 	if c.sessionVolatileVarsBySession == nil {
 		c.sessionVolatileVarsBySession = make(map[string]map[string]string)
@@ -402,11 +652,18 @@ func (c *Cache) SetVolatileVars(_ context.Context, sessionID, k, v string) {
 		c.sessionVolatileVarsBySession[sessionID] = make(map[string]string)
 	}
 	c.sessionVolatileVarsBySession[sessionID][k] = v
+	return nil
 }
 
 func (c *Cache) ResolveVolatileVars(_ context.Context, sessionID string) map[string]string {
+	if sessionID == "" {
+		return nil
+	}
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		return nil
+	}
 
 	if c.sessionVolatileVarsBySession == nil {
 		return nil
@@ -450,6 +707,10 @@ func (c *Cache) ResolveSessionResourceCandidates(
 	}
 
 	c.sessionMu.Lock()
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		c.sessionMu.Unlock()
+		return nil, fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
+	}
 	sessionBindings := c.sessionResourcesBySession[sessionID]
 	bindings := sessionBindings[handle]
 	if bindings == nil || len(bindings.byClientID) == 0 {
@@ -762,7 +1023,7 @@ func (c *Cache) acquireSessionArbitraryLocked(sessionID string, shared *sharedAr
 
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
-	if _, released := c.releasedSessionIDs[sessionID]; released {
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
 		return fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
 	}
 	if c.sessionArbitraryCallKeysBySession == nil {
@@ -782,6 +1043,11 @@ func (c *Cache) acquireSessionArbitraryLocked(sessionID string, shared *sharedAr
 	return nil
 }
 
+// ReleaseSession marks a session dead immediately. Its return means cleanup is
+// complete or irrevocably assigned to the last active cache operation; cleanup
+// hooks may therefore run later on that operation's goroutine. Every cleanup
+// error is accumulated for Cache.Close; deferred errors are also logged on the
+// goroutine that observes them because ReleaseSession has already returned.
 func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
 	if sessionID == "" {
 		return fmt.Errorf("release session: empty session ID")
@@ -789,44 +1055,89 @@ func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
 	if c == nil {
 		return nil
 	}
+	op, err := c.beginCacheOperation()
+	if err != nil {
+		return fmt.Errorf("release session %q: %w", sessionID, err)
+	}
+	defer op.finish(false)
+
+	state := c.sessionLifecycle(sessionID)
+	state.releaseMu.Lock()
+	oldLifecycle, newlyReleased := c.markSessionReleased(state)
+	if !newlyReleased {
+		state.releaseMu.Unlock()
+		return nil
+	}
 
 	c.sessionMu.Lock()
-	if c.releasedSessionIDs == nil {
-		c.releasedSessionIDs = make(map[string]struct{})
-	}
-	c.releasedSessionIDs[sessionID] = struct{}{}
-	resultIDs := c.sessionResultIDsBySession[sessionID]
-	arbitraryCallKeys := c.sessionArbitraryCallKeysBySession[sessionID]
-	delete(c.sessionResultIDsBySession, sessionID)
-	delete(c.sessionArbitraryCallKeysBySession, sessionID)
-	delete(c.sessionLazySpansBySession, sessionID)
-	delete(c.sessionResultInstallSpans, sessionID)
-	delete(c.sessionResourcesBySession, sessionID)
-	delete(c.sessionVolatileVarsBySession, sessionID)
-	delete(c.sessionHandlesBySession, sessionID)
+	resultIDs := maps.Clone(c.sessionResultIDsBySession[sessionID])
+	arbitraryCallKeys := maps.Clone(c.sessionArbitraryCallKeysBySession[sessionID])
 	c.sessionMu.Unlock()
+	state.releasePlan = &cacheSessionReleasePlan{
+		ctx:               context.WithoutCancel(ctx),
+		sessionID:         sessionID,
+		resultIDs:         resultIDs,
+		arbitraryCallKeys: arbitraryCallKeys,
+	}
+	state.releaseMu.Unlock()
 	if c.testAfterSessionReleaseRecord != nil {
 		c.testAfterSessionReleaseRecord()
 	}
 
+	if oldLifecycle&^cacheSessionReleasedBit != 0 {
+		return nil
+	}
+	_, cleanupErr := c.tryCleanupReleasedSession(state)
+	if cleanupErr != nil {
+		c.recordReleaseCleanupError(sessionID, false, cleanupErr)
+	}
+	return cleanupErr
+}
+
+func (c *Cache) tryCleanupReleasedSession(state *cacheSessionLifecycle) (bool, error) {
+	if state == nil || state.lifecycle.Load() != cacheSessionReleasedBit {
+		return false, nil
+	}
+	state.releaseMu.Lock()
+	if state.releasePlan == nil || state.cleanupStarted || state.lifecycle.Load() != cacheSessionReleasedBit {
+		state.releaseMu.Unlock()
+		return false, nil
+	}
+	state.cleanupStarted = true
+	plan := state.releasePlan
+	state.releaseMu.Unlock()
+
+	err := c.cleanupReleasedSession(plan)
+
+	state.releaseMu.Lock()
+	state.releasePlan = nil
+	state.releaseMu.Unlock()
+	return true, err
+}
+
+func (c *Cache) cleanupReleasedSession(plan *cacheSessionReleasePlan) error {
+	if plan == nil {
+		return nil
+	}
+	ctx := plan.ctx
 	var (
 		rerr       error
 		onReleases []OnReleaseFunc
 	)
 	c.egraphMu.Lock()
-	queue := make([]*sharedResult, 0, len(resultIDs))
-	for resultID := range resultIDs {
+	queue := make([]*sharedResult, 0, len(plan.resultIDs))
+	for resultID := range plan.resultIDs {
 		var err error
-		queue, err = c.removeSessionResultLocked(ctx, sessionID, resultID, len(resultIDs), queue)
+		queue, err = c.removeSessionResultLocked(ctx, plan.sessionID, resultID, len(plan.resultIDs), queue)
 		rerr = errors.Join(rerr, err)
 	}
-	collectReleases, collectErr := c.collectUnownedResultsLocked(context.WithoutCancel(ctx), queue)
+	collectReleases, collectErr := c.collectUnownedResultsLocked(ctx, queue)
 	onReleases = append(onReleases, collectReleases...)
 	rerr = errors.Join(rerr, collectErr)
 	c.egraphMu.Unlock()
 
-	rerr = errors.Join(rerr, runOnReleaseFuncs(context.WithoutCancel(ctx), onReleases))
-	for callKey := range arbitraryCallKeys {
+	rerr = errors.Join(rerr, runOnReleaseFuncs(ctx, onReleases))
+	for callKey := range plan.arbitraryCallKeys {
 		var onRelease OnReleaseFunc
 		c.callsMu.Lock()
 		res := c.completedArbitraryCalls[callKey]
@@ -850,9 +1161,19 @@ func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
 		}
 		c.callsMu.Unlock()
 		if onRelease != nil {
-			rerr = errors.Join(rerr, onRelease(context.WithoutCancel(ctx)))
+			rerr = errors.Join(rerr, onRelease(ctx))
 		}
 	}
+
+	c.sessionMu.Lock()
+	delete(c.sessionResultIDsBySession, plan.sessionID)
+	delete(c.sessionArbitraryCallKeysBySession, plan.sessionID)
+	delete(c.sessionLazySpansBySession, plan.sessionID)
+	delete(c.sessionResultInstallSpans, plan.sessionID)
+	delete(c.sessionResourcesBySession, plan.sessionID)
+	delete(c.sessionVolatileVarsBySession, plan.sessionID)
+	delete(c.sessionHandlesBySession, plan.sessionID)
+	c.sessionMu.Unlock()
 	return rerr
 }
 
@@ -1213,10 +1534,16 @@ func (c *Cache) syncResultSnapshotLeases(ctx context.Context, res *sharedResult)
 	return nil
 }
 
-func (c *Cache) SyncResultSnapshotOwnerLeases(ctx context.Context, res AnyResult) error {
+func (c *Cache) SyncResultSnapshotOwnerLeases(ctx context.Context, res AnyResult) (rerr error) {
 	if c == nil || res == nil {
 		return nil
 	}
+	op, err := c.beginContextOperation(ctx)
+	if err != nil {
+		return fmt.Errorf("sync result snapshot owner leases: %w", err)
+	}
+	defer op.finish(false)
+
 	shared := res.cacheSharedResult()
 	if shared == nil || shared.id == 0 {
 		return nil
@@ -1332,10 +1659,25 @@ func wipeSQLiteFiles(dbPath string) error {
 type Cache struct {
 	// callsMu protects in-flight call bookkeeping and arbitrary in-memory call maps.
 	callsMu sync.Mutex
-	// sessionMu protects per-session tracked cache-backed results and arbitrary values.
+	// sessionMu protects per-session tracked cache-backed results, arbitrary
+	// values, resources, and telemetry maps. Hot operation admission uses the
+	// per-session atomic lifecycle records below instead of this global mutex.
 	sessionMu sync.Mutex
 	// egraphMu protects all e-graph state and indexes.
 	egraphMu sync.RWMutex
+
+	closing                atomic.Bool
+	activeGlobalOperations atomic.Int64
+	operationWaitMu        sync.Mutex
+	operationWaitCh        chan struct{}
+
+	// sessionLifecycles retains one small atomic record per session for the
+	// engine lifetime. The packed release bit and operation count make admission
+	// linearizable without global lock traffic.
+	sessionLifecycles sync.Map
+
+	releaseCleanupErrMu sync.Mutex
+	releaseCleanupErr   error
 
 	persistenceResetReason CachePersistenceResetReason
 
@@ -1435,7 +1777,6 @@ type Cache struct {
 
 	sessionResultIDsBySession         map[string]map[sharedResultID]struct{}
 	sessionArbitraryCallKeysBySession map[string]map[string]struct{}
-	releasedSessionIDs                map[string]struct{}
 	sessionLazySpansBySession         map[string]map[sharedResultID]trace.SpanContext
 	// sessionResultInstallSpans records which API spans returned/own which
 	// results in a session. Lazy resume spans cause-link the install spans of
@@ -1468,6 +1809,9 @@ type Cache struct {
 	testAfterSessionReleaseRecord   func()
 	testAfterHandoffHoldAcquired    func(*ongoingCall)
 	testAfterLazyEvalFinish         func(*lazyEvalAttempt)
+	testAfterSessionOperationEnter  func(string)
+	testBeforeSessionOperationExit  func(string)
+	testAfterCacheClosing           func()
 
 	closeOnce sync.Once
 	closeErr  error
@@ -2145,7 +2489,15 @@ func (c *Cache) AttachResult(ctx context.Context, sessionID string, resolver Typ
 	if sessionID == "" {
 		return nil, errors.New("attach result: empty session ID")
 	}
-	return c.attachResult(ctx, sessionID, resolver, res)
+	op, err := c.beginSessionOperation(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("attach result: %w", err)
+	}
+	attached, attachErr := c.attachResult(ctx, sessionID, resolver, res)
+	if op.finish(attachErr == nil && attached != nil) {
+		return nil, fmt.Errorf("attach result: %w: %q", ErrCacheSessionReleased, sessionID)
+	}
+	return attached, attachErr
 }
 
 func (c *Cache) attachResult(ctx context.Context, sessionID string, resolver TypeResolver, res AnyResult) (AnyResult, error) {
@@ -2249,6 +2601,9 @@ func (c *Cache) attachResult(ctx context.Context, sessionID string, resolver Typ
 }
 
 func (c *Cache) AddExplicitDependency(ctx context.Context, parent AnyResult, dep AnyResult, reason string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if parent == nil || dep == nil {
 		return nil
 	}
@@ -2261,20 +2616,18 @@ func (c *Cache) AddExplicitDependency(ctx context.Context, parent AnyResult, dep
 	if depShared == nil || depShared.id == 0 {
 		return fmt.Errorf("add explicit dependency: dep %T is not an attached result in this cache", dep)
 	}
-	if parentShared.id == depShared.id {
-		return nil
-	}
-
 	c.egraphMu.Lock()
 	defer c.egraphMu.Unlock()
 
+	// A collected result's numeric ID can be reused after an empty e-graph
+	// reset. Match the exact pointers supplied by the caller before mutating.
 	parentRes := c.resultsByID[parentShared.id]
-	if parentRes == nil {
-		return fmt.Errorf("add explicit dependency: parent result %d missing from cache", parentShared.id)
+	if parentRes != parentShared {
+		return fmt.Errorf("add explicit dependency: parent result %d was already collected or replaced", parentShared.id)
 	}
 	depRes := c.resultsByID[depShared.id]
-	if depRes == nil {
-		return fmt.Errorf("add explicit dependency: dep result %d missing from cache", depShared.id)
+	if depRes != depShared {
+		return fmt.Errorf("add explicit dependency: dep result %d was already collected or replaced", depShared.id)
 	}
 	return c.addExplicitDependencyLocked(ctx, parentRes, depRes, reason)
 }
@@ -2508,7 +2861,31 @@ func (r Result[T]) DerefValue() (AnyResult, bool) {
 	return r.resultWithDerefView(), true
 }
 
-func (r Result[T]) NthValue(ctx context.Context, nth int) (AnyResult, error) {
+func (r Result[T]) NthValue(ctx context.Context, nth int) (ret AnyResult, rerr error) {
+	if r.shared != nil && r.shared.id != 0 {
+		clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("load %dth value from %T: current client metadata: %w", nth, r.Self(), err)
+		}
+		if clientMetadata.SessionID == "" {
+			return nil, fmt.Errorf("load %dth value from %T: empty session ID", nth, r.Self())
+		}
+		cache, err := EngineCache(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("load %dth value from %T: current dagql cache: %w", nth, r.Self(), err)
+		}
+		op, err := cache.beginSessionOperation(clientMetadata.SessionID)
+		if err != nil {
+			return nil, fmt.Errorf("load %dth value from %T: %w", nth, r.Self(), err)
+		}
+		defer func() {
+			if op.finish(rerr == nil && ret != nil) {
+				ret = nil
+				rerr = fmt.Errorf("load %dth value from %T: %w: %q", nth, r.Self(), ErrCacheSessionReleased, clientMetadata.SessionID)
+			}
+		}()
+	}
+
 	self := r.Self()
 	enumerableSelf, ok := any(self).(Enumerable)
 	if !ok {
@@ -2704,6 +3081,9 @@ func (r Result[T]) WithContentDigest(ctx context.Context, contentDigest digest.D
 }
 
 func (r Result[T]) WithSessionResourceHandle(ctx context.Context, handle SessionResourceHandle) (Result[T], error) {
+	if err := ctx.Err(); err != nil {
+		return r, err
+	}
 	if handle == "" {
 		return r, fmt.Errorf("set session resource handle on %T: empty handle", r.Self())
 	}
@@ -2718,9 +3098,10 @@ func (r Result[T]) WithSessionResourceHandle(ctx context.Context, handle Session
 		cache.egraphMu.Lock()
 		defer cache.egraphMu.Unlock()
 
+		// The numeric ID can name a newer result after collection and reset.
 		cached := cache.resultsByID[r.shared.id]
-		if cached == nil {
-			return r, fmt.Errorf("set session resource handle on %T: result %d missing from cache", r.Self(), r.shared.id)
+		if cached != r.shared {
+			return r, fmt.Errorf("set session resource handle on %T: result %d was already collected or replaced", r.Self(), r.shared.id)
 		}
 		cached.sessionResourceHandle = handle
 		if err := cache.recomputeRequiredSessionResourcesLocked(cached); err != nil {
@@ -3129,13 +3510,23 @@ func (c *Cache) Evaluate(ctx context.Context, results ...AnyResult) error {
 	return eg.Wait()
 }
 
-func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
+func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) (rerr error) {
 	if c == nil {
 		return errors.New("evaluate: nil cache")
 	}
 	if res == nil {
 		return nil
 	}
+	waiterOp, err := c.beginContextOperation(ctx)
+	if err != nil {
+		return fmt.Errorf("evaluate: %w", err)
+	}
+	defer func() {
+		if waiterOp.finish(rerr == nil) {
+			rerr = fmt.Errorf("evaluate: %w: %q", ErrCacheSessionReleased, waiterOp.sessionID)
+		}
+	}()
+
 	shared := res.cacheSharedResult()
 	if shared == nil || shared.id == 0 {
 		return fmt.Errorf("evaluate %T: detached result", res)
@@ -3228,6 +3619,12 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		shared.lazyEval = currentLazyEval
 
 		attemptCtx, cancel := context.WithCancelCause(context.WithoutCancel(stackCtx))
+		attemptOp, err := c.beginContextOperation(attemptCtx)
+		if err != nil {
+			shared.lazyMu.Unlock()
+			cancel(err)
+			return fmt.Errorf("start lazy evaluation: %w", err)
+		}
 		evalCtx := attemptCtx
 		lazyEval := shared.lazyEval
 		resultCall := shared.loadResultCall()
@@ -3274,6 +3671,7 @@ func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) error {
 		shared.lazyMu.Unlock()
 
 		go func() {
+			defer attemptOp.finish(false)
 			// The lazy op span and re-pointed callback context were minted under
 			// lazyMu before this attempt was published. A span created on one
 			// goroutine and ended on another is safe.
@@ -3365,9 +3763,19 @@ func (c *Cache) Close(ctx context.Context) error {
 			"hasSQLDB", c.sqlDB != nil,
 			"hasPersistDB", c.pdb != nil,
 		)
-		if err := c.persistCurrentState(ctx); err != nil {
-			slog.Error("failed to persist dagql cache during close", "err", err)
+		if err := c.waitForQuiescence(ctx); err != nil {
+			slog.Error("dagql cache close failed waiting for quiescence; persistence will remain dirty", "err", err)
+			c.closeErr = errors.Join(c.closeErr, fmt.Errorf("wait for dagql cache quiescence: %w", err))
+		}
+		if err := c.releaseCleanupError(); err != nil {
+			slog.Error("dagql cache close found session cleanup errors; persistence will remain dirty", "err", err)
 			c.closeErr = errors.Join(c.closeErr, err)
+		}
+		if c.closeErr == nil {
+			if err := c.persistCurrentState(ctx); err != nil {
+				slog.Error("failed to persist dagql cache during close", "err", err)
+				c.closeErr = errors.Join(c.closeErr, err)
+			}
 		}
 		if c.closeErr != nil {
 			if closeErr := closeCacheDBs(c.sqlDB, c.pdb); closeErr != nil {
@@ -3399,6 +3807,7 @@ func (c *Cache) Close(ctx context.Context) error {
 
 func (c *Cache) CloseDiscardingPersistence() error {
 	c.closeOnce.Do(func() {
+		c.closing.Store(true)
 		slog.Info(
 			"discarding dagql cache without persistence",
 			"hasSQLDB", c.sqlDB != nil,
@@ -3827,7 +4236,15 @@ func (c *Cache) GetOrInitCall(
 	if sessionID == "" {
 		return nil, errors.New("get or init call: empty session ID")
 	}
-	return c.getOrInitCall(ctx, sessionID, resolver, req, fn)
+	op, err := c.beginSessionOperation(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("get or init call: %w", err)
+	}
+	res, callErr := c.getOrInitCall(ctx, sessionID, resolver, req, fn)
+	if op.finish(callErr == nil && res != nil) {
+		return nil, fmt.Errorf("get or init call: %w: %q", ErrCacheSessionReleased, sessionID)
+	}
+	return res, callErr
 }
 
 func (c *Cache) getOrInitCall(

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -271,7 +271,7 @@ func (op *cacheOperation) finish(valueBearingSuccess bool) bool {
 			}
 			if op.session.lifecycle.CompareAndSwap(old, old-1) {
 				if lastReleasedOperation {
-					if _, err := op.cache.tryCleanupReleasedSession(op.session); err != nil {
+					if err := op.cache.tryCleanupReleasedSession(op.session); err != nil {
 						op.cache.recordReleaseCleanupError(op.sessionID, true, err)
 					}
 					op.cache.endCacheOperation()
@@ -1087,21 +1087,21 @@ func (c *Cache) ReleaseSession(ctx context.Context, sessionID string) error {
 	if oldLifecycle&^cacheSessionReleasedBit != 0 {
 		return nil
 	}
-	_, cleanupErr := c.tryCleanupReleasedSession(state)
+	cleanupErr := c.tryCleanupReleasedSession(state)
 	if cleanupErr != nil {
 		c.recordReleaseCleanupError(sessionID, false, cleanupErr)
 	}
 	return cleanupErr
 }
 
-func (c *Cache) tryCleanupReleasedSession(state *cacheSessionLifecycle) (bool, error) {
+func (c *Cache) tryCleanupReleasedSession(state *cacheSessionLifecycle) error {
 	if state == nil || state.lifecycle.Load() != cacheSessionReleasedBit {
-		return false, nil
+		return nil
 	}
 	state.releaseMu.Lock()
 	if state.releasePlan == nil || state.cleanupStarted || state.lifecycle.Load() != cacheSessionReleasedBit {
 		state.releaseMu.Unlock()
-		return false, nil
+		return nil
 	}
 	state.cleanupStarted = true
 	plan := state.releasePlan
@@ -1112,7 +1112,7 @@ func (c *Cache) tryCleanupReleasedSession(state *cacheSessionLifecycle) (bool, e
 	state.releaseMu.Lock()
 	state.releasePlan = nil
 	state.releaseMu.Unlock()
-	return true, err
+	return err
 }
 
 func (c *Cache) cleanupReleasedSession(plan *cacheSessionReleasePlan) error {
@@ -2861,30 +2861,39 @@ func (r Result[T]) DerefValue() (AnyResult, bool) {
 	return r.resultWithDerefView(), true
 }
 
-func (r Result[T]) NthValue(ctx context.Context, nth int) (ret AnyResult, rerr error) {
-	if r.shared != nil && r.shared.id != 0 {
-		clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("load %dth value from %T: current client metadata: %w", nth, r.Self(), err)
-		}
-		if clientMetadata.SessionID == "" {
-			return nil, fmt.Errorf("load %dth value from %T: empty session ID", nth, r.Self())
-		}
-		cache, err := EngineCache(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("load %dth value from %T: current dagql cache: %w", nth, r.Self(), err)
-		}
-		op, err := cache.beginSessionOperation(clientMetadata.SessionID)
-		if err != nil {
-			return nil, fmt.Errorf("load %dth value from %T: %w", nth, r.Self(), err)
-		}
-		defer func() {
-			if op.finish(rerr == nil && ret != nil) {
-				ret = nil
-				rerr = fmt.Errorf("load %dth value from %T: %w: %q", nth, r.Self(), ErrCacheSessionReleased, clientMetadata.SessionID)
-			}
-		}()
+func (r Result[T]) beginNthValueOperation(ctx context.Context, nth int) (cacheOperation, string, error) {
+	if r.shared == nil || r.shared.id == 0 {
+		return cacheOperation{}, "", nil
 	}
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return cacheOperation{}, "", fmt.Errorf("load %dth value from %T: current client metadata: %w", nth, r.Self(), err)
+	}
+	if clientMetadata.SessionID == "" {
+		return cacheOperation{}, "", fmt.Errorf("load %dth value from %T: empty session ID", nth, r.Self())
+	}
+	cache, err := EngineCache(ctx)
+	if err != nil {
+		return cacheOperation{}, "", fmt.Errorf("load %dth value from %T: current dagql cache: %w", nth, r.Self(), err)
+	}
+	op, err := cache.beginSessionOperation(clientMetadata.SessionID)
+	if err != nil {
+		return cacheOperation{}, "", fmt.Errorf("load %dth value from %T: %w", nth, r.Self(), err)
+	}
+	return op, clientMetadata.SessionID, nil
+}
+
+func (r Result[T]) NthValue(ctx context.Context, nth int) (ret AnyResult, rerr error) {
+	op, sessionID, err := r.beginNthValueOperation(ctx, nth)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if op.finish(rerr == nil && ret != nil) {
+			ret = nil
+			rerr = fmt.Errorf("load %dth value from %T: %w: %q", nth, r.Self(), ErrCacheSessionReleased, sessionID)
+		}
+	}()
 
 	self := r.Self()
 	enumerableSelf, ok := any(self).(Enumerable)
@@ -3510,39 +3519,50 @@ func (c *Cache) Evaluate(ctx context.Context, results ...AnyResult) error {
 	return eg.Wait()
 }
 
-func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) (rerr error) {
+func (c *Cache) beginEvaluateOne(ctx context.Context, res AnyResult) (cacheOperation, *sharedResult, context.Context, error) {
 	if c == nil {
-		return errors.New("evaluate: nil cache")
+		return cacheOperation{}, nil, nil, errors.New("evaluate: nil cache")
 	}
 	if res == nil {
-		return nil
+		return cacheOperation{}, nil, nil, nil
 	}
 	waiterOp, err := c.beginContextOperation(ctx)
 	if err != nil {
-		return fmt.Errorf("evaluate: %w", err)
+		return cacheOperation{}, nil, nil, fmt.Errorf("evaluate: %w", err)
 	}
-	defer func() {
-		if waiterOp.finish(rerr == nil) {
-			rerr = fmt.Errorf("evaluate: %w: %q", ErrCacheSessionReleased, waiterOp.sessionID)
-		}
-	}()
 
 	shared := res.cacheSharedResult()
 	if shared == nil || shared.id == 0 {
-		return fmt.Errorf("evaluate %T: detached result", res)
+		waiterOp.finish(false)
+		return cacheOperation{}, nil, nil, fmt.Errorf("evaluate %T: detached result", res)
 	}
 
 	stack := lazyEvalStackFromContext(ctx)
-	if stack != nil {
-		if lazyEvalStackContains(stack, shared.id) {
-			return fmt.Errorf("recursive lazy evaluation detected")
-		}
+	if stack != nil && lazyEvalStackContains(stack, shared.id) {
+		waiterOp.finish(false)
+		return cacheOperation{}, nil, nil, fmt.Errorf("recursive lazy evaluation detected")
 	}
 
 	stackCtx := context.WithValue(ctx, lazyEvalStackCtxKey{}, &lazyEvalStackNode{
 		id:     shared.id,
 		parent: stack,
 	})
+	return waiterOp, shared, stackCtx, nil
+}
+
+func (c *Cache) evaluateOne(ctx context.Context, res AnyResult) (rerr error) {
+	waiterOp, shared, stackCtx, err := c.beginEvaluateOne(ctx, res)
+	if err != nil {
+		return err
+	}
+	if shared == nil {
+		return nil
+	}
+	defer func() {
+		if waiterOp.finish(rerr == nil) {
+			rerr = fmt.Errorf("evaluate: %w: %q", ErrCacheSessionReleased, waiterOp.sessionID)
+		}
+	}()
 
 	for {
 		shared.lazyMu.Lock()

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -774,6 +774,13 @@ func (c *Cache) captureSessionLazySpanContext(ctx context.Context, sessionID str
 	}
 
 	c.sessionMu.Lock()
+	// A detached writer arriving after release must not recreate the session
+	// maps ReleaseSession deleted: session IDs are single-use, so nothing
+	// would ever delete the recreated entry again.
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		c.sessionMu.Unlock()
+		return
+	}
 	if c.sessionLazySpansBySession == nil {
 		c.sessionLazySpansBySession = make(map[string]map[sharedResultID]trace.SpanContext)
 	}
@@ -848,6 +855,11 @@ type sessionResultInstallSpan struct {
 func (c *Cache) recordSessionResultInstallSpanLocked(sessionID string, resultID sharedResultID, spanCtx trace.SpanContext, ownsClosure bool) {
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
+	// Same released-session refusal as the lazy-span writer: never recreate
+	// a single-use session's telemetry maps after release deleted them.
+	if c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		return
+	}
 	if c.sessionResultInstallSpans == nil {
 		c.sessionResultInstallSpans = make(map[string]map[sharedResultID]map[string]sessionResultInstallSpan)
 	}

--- a/dagql/cache.go
+++ b/dagql/cache.go
@@ -2619,17 +2619,15 @@ func (c *Cache) AddExplicitDependency(ctx context.Context, parent AnyResult, dep
 	c.egraphMu.Lock()
 	defer c.egraphMu.Unlock()
 
-	// A collected result's numeric ID can be reused after an empty e-graph
-	// reset. Match the exact pointers supplied by the caller before mutating.
-	parentRes := c.resultsByID[parentShared.id]
-	if parentRes != parentShared {
-		return fmt.Errorf("add explicit dependency: parent result %d was already collected or replaced", parentShared.id)
+	// Numeric result IDs are engine-lifetime unique, so registration under
+	// the ID means release has not collected the result in the meantime.
+	if _, found := c.resultsByID[parentShared.id]; !found {
+		return fmt.Errorf("add explicit dependency: parent result %d was already collected", parentShared.id)
 	}
-	depRes := c.resultsByID[depShared.id]
-	if depRes != depShared {
-		return fmt.Errorf("add explicit dependency: dep result %d was already collected or replaced", depShared.id)
+	if _, found := c.resultsByID[depShared.id]; !found {
+		return fmt.Errorf("add explicit dependency: dep result %d was already collected", depShared.id)
 	}
-	return c.addExplicitDependencyLocked(ctx, parentRes, depRes, reason)
+	return c.addExplicitDependencyLocked(ctx, parentShared, depShared, reason)
 }
 
 func (c *Cache) addExplicitDependencyLocked(
@@ -3107,13 +3105,13 @@ func (r Result[T]) WithSessionResourceHandle(ctx context.Context, handle Session
 		cache.egraphMu.Lock()
 		defer cache.egraphMu.Unlock()
 
-		// The numeric ID can name a newer result after collection and reset.
-		cached := cache.resultsByID[r.shared.id]
-		if cached != r.shared {
-			return r, fmt.Errorf("set session resource handle on %T: result %d was already collected or replaced", r.Self(), r.shared.id)
+		// Numeric result IDs are engine-lifetime unique, so a registered ID
+		// still names this exact result.
+		if _, found := cache.resultsByID[r.shared.id]; !found {
+			return r, fmt.Errorf("set session resource handle on %T: result %d was already collected", r.Self(), r.shared.id)
 		}
-		cached.sessionResourceHandle = handle
-		if err := cache.recomputeRequiredSessionResourcesLocked(cached); err != nil {
+		r.shared.sessionResourceHandle = handle
+		if err := cache.recomputeRequiredSessionResourcesLocked(r.shared); err != nil {
 			return r, err
 		}
 		return r, nil

--- a/dagql/cache_arbitrary.go
+++ b/dagql/cache_arbitrary.go
@@ -68,6 +68,23 @@ func (c *Cache) GetOrInitArbitrary(
 	if sessionID == "" {
 		return nil, fmt.Errorf("get or init arbitrary %q: empty session ID", callKey)
 	}
+	op, err := c.beginSessionOperation(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("get or init arbitrary %q: %w", callKey, err)
+	}
+	res, callErr := c.getOrInitArbitrary(ctx, sessionID, callKey, fn)
+	if op.finish(callErr == nil && res != nil) {
+		return nil, fmt.Errorf("get or init arbitrary %q: %w: %q", callKey, ErrCacheSessionReleased, sessionID)
+	}
+	return res, callErr
+}
+
+func (c *Cache) getOrInitArbitrary(
+	ctx context.Context,
+	sessionID string,
+	callKey string,
+	fn func(context.Context) (any, error),
+) (ArbitraryCachedResult, error) {
 	if callKey == "" {
 		return nil, fmt.Errorf("cache call key is empty")
 	}

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -1058,10 +1058,11 @@ func (c *Cache) TeachCallEquivalentToResult(ctx context.Context, sessionID strin
 
 	c.egraphMu.Lock()
 	defer c.egraphMu.Unlock()
-	// Digest derivation above is outside egraphMu. Release can collect the
-	// result and an empty e-graph reset can reuse its numeric ID in that gap.
-	if c.resultsByID[shared.id] != shared {
-		return fmt.Errorf("teach call equivalence: result %d was already collected or replaced", shared.id)
+	// Digest derivation above is outside egraphMu, so release can collect
+	// the result in that gap. Numeric result IDs are engine-lifetime unique,
+	// so registration under the ID means it is still this exact result.
+	if _, found := c.resultsByID[shared.id]; !found {
+		return fmt.Errorf("teach call equivalence: result %d was already collected", shared.id)
 	}
 	return c.teachResultIdentityLocked(ctx, shared, frame, requestDigest, requestSelf, requestInputs, requestInputRefs)
 }
@@ -1124,11 +1125,11 @@ func (c *Cache) TeachContentDigest(ctx context.Context, res AnyResult, contentDi
 		}
 
 		c.egraphMu.Lock()
-		// Keep the caller's pointer stable across retries. Rebinding by numeric
-		// ID could silently select a newer result after an empty-cache reset.
-		if c.resultsByID[shared.id] != shared {
+		// Numeric result IDs are engine-lifetime unique, so a registered ID
+		// still names the caller's result across retries.
+		if _, found := c.resultsByID[shared.id]; !found {
 			c.egraphMu.Unlock()
-			return fmt.Errorf("teach content digest: result %d was already collected or replaced", shared.id)
+			return fmt.Errorf("teach content digest: result %d was already collected", shared.id)
 		}
 		if shared.loadResultCall() == nil {
 			c.egraphMu.Unlock()

--- a/dagql/cache_egraph.go
+++ b/dagql/cache_egraph.go
@@ -1010,6 +1010,12 @@ func (c *Cache) lookupCacheForRequest(
 }
 
 func (c *Cache) TeachCallEquivalentToResult(ctx context.Context, sessionID string, frame *ResultCall, res AnyResult) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if sessionID != "" && c.sessionLifecycle(sessionID).lifecycle.Load()&cacheSessionReleasedBit != 0 {
+		return fmt.Errorf("%w: %q", ErrCacheSessionReleased, sessionID)
+	}
 	if frame == nil {
 		return fmt.Errorf("teach call equivalence: nil call")
 	}
@@ -1052,6 +1058,11 @@ func (c *Cache) TeachCallEquivalentToResult(ctx context.Context, sessionID strin
 
 	c.egraphMu.Lock()
 	defer c.egraphMu.Unlock()
+	// Digest derivation above is outside egraphMu. Release can collect the
+	// result and an empty e-graph reset can reuse its numeric ID in that gap.
+	if c.resultsByID[shared.id] != shared {
+		return fmt.Errorf("teach call equivalence: result %d was already collected or replaced", shared.id)
+	}
 	return c.teachResultIdentityLocked(ctx, shared, frame, requestDigest, requestSelf, requestInputs, requestInputRefs)
 }
 
@@ -1113,10 +1124,11 @@ func (c *Cache) TeachContentDigest(ctx context.Context, res AnyResult, contentDi
 		}
 
 		c.egraphMu.Lock()
-		shared = c.resultsByID[shared.id]
-		if shared == nil {
+		// Keep the caller's pointer stable across retries. Rebinding by numeric
+		// ID could silently select a newer result after an empty-cache reset.
+		if c.resultsByID[shared.id] != shared {
 			c.egraphMu.Unlock()
-			return fmt.Errorf("teach content digest: result %T missing from cache", res)
+			return fmt.Errorf("teach content digest: result %d was already collected or replaced", shared.id)
 		}
 		if shared.loadResultCall() == nil {
 			c.egraphMu.Unlock()

--- a/dagql/cache_lazy_retry_test.go
+++ b/dagql/cache_lazy_retry_test.go
@@ -244,6 +244,74 @@ func TestCacheEvaluateRetiresFinishedAttemptBeforeWaitersDrain(t *testing.T) {
 	})
 }
 
+func TestCacheLazyAttemptDefersSessionCleanupUntilCallbackExit(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	allowCallbackExit := make(chan struct{})
+	released := make(chan struct{})
+
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx = ContextWithCache(ctx, c)
+	srv := cacheTestServer(t)
+	sessionID := cacheTestSessionID(t, ctx)
+	frame := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&cacheTestObject{}).Type()),
+		Field: "lazy-attempt-release",
+	}
+	resAny, err := c.GetOrInitCall(ctx, sessionID, srv, &CallRequest{ResultCall: frame}, func(context.Context) (AnyResult, error) {
+		return cacheTestObjectResultWithValue(t, srv, frame, &cacheTestObject{
+			Value: 1,
+			lazyEval: func(callbackCtx context.Context) error {
+				close(started)
+				<-callbackCtx.Done()
+				close(canceled)
+				<-allowCallbackExit
+				return context.Cause(callbackCtx)
+			},
+			onRelease: func(context.Context) error {
+				close(released)
+				return nil
+			},
+		}), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resAny.(ObjectResult[*cacheTestObject])
+
+	evalCtx, cancelEval := context.WithCancelCause(ctx)
+	evalDone := make(chan error, 1)
+	go func() { evalDone <- c.Evaluate(evalCtx, result) }()
+	waitLazyRetrySignal(t, started, "the lazy callback to start")
+
+	evalCause := errors.New("lazy waiter canceled")
+	cancelEval(evalCause)
+	if err := waitLazyRetryError(t, evalDone, "the lazy waiter to return"); !errors.Is(err, evalCause) {
+		t.Fatalf("Evaluate error = %v, want %v", err, evalCause)
+	}
+	waitLazyRetrySignal(t, canceled, "the lazy callback to observe cancellation")
+
+	if err := c.ReleaseSession(ctx, sessionID); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-released:
+		t.Fatal("session cleanup ran before the lazy callback exited")
+	default:
+	}
+
+	close(allowCallbackExit)
+	waitLazyRetrySignal(t, released, "session cleanup after lazy callback exit")
+	if got := c.Size(); got != 0 {
+		t.Fatalf("cache size after lazy attempt cleanup = %d, want 0", got)
+	}
+}
+
 func TestCacheEvaluateOwnCancellationOnlyCancelsOwnWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var calls atomic.Int32

--- a/dagql/cache_persistence_resolver.go
+++ b/dagql/cache_persistence_resolver.go
@@ -107,10 +107,30 @@ func (c *Cache) loadResultByResultID(ctx context.Context, sessionID string, dag 
 }
 
 func (c *Cache) LoadResultByResultID(ctx context.Context, sessionID string, dag *Server, resultID uint64) (AnyResult, error) {
-	return c.loadResultByResultID(ctx, sessionID, dag, resultID)
+	op, err := c.beginSessionOperation(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("load result %d: %w", resultID, err)
+	}
+	res, loadErr := c.loadResultByResultID(ctx, sessionID, dag, resultID)
+	if op.finish(loadErr == nil && res != nil) {
+		return nil, fmt.Errorf("load result %d: %w: %q", resultID, ErrCacheSessionReleased, sessionID)
+	}
+	return res, loadErr
 }
 
 func (c *Cache) ResultCallByResultID(ctx context.Context, sessionID string, resultID uint64) (*ResultCall, error) {
+	op, err := c.beginSessionOperation(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve result %d call frame: %w", resultID, err)
+	}
+	frame, callErr := c.loadResultCallByResultID(ctx, sessionID, resultID)
+	if op.finish(callErr == nil && frame != nil) {
+		return nil, fmt.Errorf("resolve result %d call frame: %w: %q", resultID, ErrCacheSessionReleased, sessionID)
+	}
+	return frame, callErr
+}
+
+func (c *Cache) loadResultCallByResultID(ctx context.Context, sessionID string, resultID uint64) (*ResultCall, error) {
 	mode := sharedResultLookupExact
 	if sessionID != "" {
 		mode = sharedResultLookupCanonicalEquivalent
@@ -125,6 +145,35 @@ func (c *Cache) ResultCallByResultID(ctx context.Context, sessionID string, resu
 		return nil, fmt.Errorf("resolve result %d call frame: missing result call frame", resultID)
 	}
 	return frame.clone(), nil
+}
+
+func (c *Cache) resultCallRefByResultID(ctx context.Context, sessionID string, resultID uint64) (*ResultCallRef, error) {
+	op, err := c.beginSessionOperation(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve result %d call ref: %w", resultID, err)
+	}
+	shared, _, _, lookupErr := c.sharedResultByResultID(
+		ctx,
+		sessionID,
+		sharedResultID(resultID),
+		sharedResultLookupCanonicalEquivalent,
+	)
+	var ref *ResultCallRef
+	if lookupErr == nil {
+		frame := shared.loadResultCall()
+		if frame == nil {
+			lookupErr = fmt.Errorf("resolve result %d call ref: missing result call frame", resultID)
+		} else if frame.Type == nil || frame.Type.NamedType != "Query" {
+			ref = &ResultCallRef{ResultID: uint64(shared.id), shared: shared}
+		}
+	}
+	if op.finish(lookupErr == nil && ref != nil) {
+		return nil, fmt.Errorf("resolve result %d call ref: %w: %q", resultID, ErrCacheSessionReleased, sessionID)
+	}
+	if lookupErr != nil {
+		return nil, lookupErr
+	}
+	return ref, nil
 }
 
 func (c *Cache) WalkResultCall(rootCall *ResultCall, visit func(*ResultCallRef, *ResultCall) error) error {

--- a/dagql/cache_session_ownership_test.go
+++ b/dagql/cache_session_ownership_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"gotest.tools/v3/assert"
 )
 
@@ -542,4 +543,56 @@ func TestCacheCloseCancellationFailsDirtyWhileOperationActive(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, reopened.PersistenceResetReason(), CachePersistenceResetUncleanShutdown)
 	assert.NilError(t, reopened.CloseDiscardingPersistence())
+}
+
+// A detached writer that captures telemetry spans after its session was
+// released must not recreate the per-session span maps: session IDs are
+// single-use, so a recreated entry would be retained for the engine
+// lifetime.
+func TestCacheReleasedSessionDoesNotRecreateSpanMaps(t *testing.T) {
+	ctx := t.Context()
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	const sessionID = "span-capture-released"
+	call := cacheTestIntCall("span-capture-released")
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{7},
+		SpanID:  trace.SpanID{7},
+	})
+	spanIn := trace.ContextWithSpanContext(ctx, spanCtx)
+
+	res, err := c.GetOrInitCall(spanIn, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(call, 1), nil
+	})
+	assert.NilError(t, err)
+
+	// Positive control: before release, both writers record state, so a
+	// post-release no-op below cannot be explained by broken test inputs.
+	c.captureSessionLazySpanContext(spanIn, sessionID, res)
+	c.captureSessionResultInstallSpan(spanIn, sessionID, res)
+	c.sessionMu.Lock()
+	_, lazyBefore := c.sessionLazySpansBySession[sessionID]
+	_, installBefore := c.sessionResultInstallSpans[sessionID]
+	c.sessionMu.Unlock()
+	assert.Assert(t, lazyBefore)
+	assert.Assert(t, installBefore)
+
+	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+	c.sessionMu.Lock()
+	_, lazyAfterRelease := c.sessionLazySpansBySession[sessionID]
+	_, installAfterRelease := c.sessionResultInstallSpans[sessionID]
+	c.sessionMu.Unlock()
+	assert.Assert(t, !lazyAfterRelease)
+	assert.Assert(t, !installAfterRelease)
+
+	c.captureSessionLazySpanContext(spanIn, sessionID, res)
+	c.captureSessionResultInstallSpan(spanIn, sessionID, res)
+
+	c.sessionMu.Lock()
+	_, lazyRecreated := c.sessionLazySpansBySession[sessionID]
+	_, installRecreated := c.sessionResultInstallSpans[sessionID]
+	c.sessionMu.Unlock()
+	assert.Assert(t, !lazyRecreated)
+	assert.Assert(t, !installRecreated)
 }

--- a/dagql/cache_session_ownership_test.go
+++ b/dagql/cache_session_ownership_test.go
@@ -2,7 +2,9 @@ package dagql
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -261,7 +263,7 @@ func TestCacheArbitrarySessionClaimAndReleaseAreAtomic(t *testing.T) {
 		}()
 		<-releaseStarted
 		close(allowClaim)
-		assert.NilError(t, <-claimErr)
+		assert.ErrorIs(t, <-claimErr, ErrCacheSessionReleased)
 		assert.NilError(t, <-releaseErr)
 		c.testAfterSessionArbitraryRecord = nil
 
@@ -298,7 +300,7 @@ func TestCacheArbitrarySessionClaimAndReleaseAreAtomic(t *testing.T) {
 	})
 }
 
-func TestCacheArbitraryRefusedOwnerReleasesUnownedValue(t *testing.T) {
+func TestCacheArbitraryReleasedSessionDoesNotInitializeValue(t *testing.T) {
 	c, err := NewCache(t.Context(), "", nil, nil)
 	assert.NilError(t, err)
 	assert.NilError(t, c.ReleaseSession(t.Context(), "released"))
@@ -314,7 +316,7 @@ func TestCacheArbitraryRefusedOwnerReleasesUnownedValue(t *testing.T) {
 		}, nil
 	})
 	assert.ErrorIs(t, err, ErrCacheSessionReleased)
-	assert.Equal(t, releaseCalls.Load(), int32(1))
+	assert.Equal(t, releaseCalls.Load(), int32(0))
 	assert.Equal(t, c.Size(), 0)
 	assertArbitraryOwnershipExact(t, c)
 }
@@ -331,4 +333,213 @@ func TestCacheReleasedSessionErrorIncludesSessionID(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, ErrCacheSessionReleased)
 	assert.ErrorContains(t, err, fmt.Sprintf("%q", "released-session"))
+}
+
+func TestCacheSessionReleaseRefusesClaimedResultAtOperationExit(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	const sessionID = "release-inflight"
+	call := cacheTestIntCall("release-inflight")
+	var releaseCalls atomic.Int32
+	_, err = c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return Result[Typed]{shared: &sharedResult{
+			self: cacheTestOnReleaseInt{Int: NewInt(42), onRelease: func(context.Context) error {
+				releaseCalls.Add(1)
+				return nil
+			}},
+			resultCall: call,
+			hasValue:   true,
+		}}, nil
+	})
+	assert.NilError(t, err)
+
+	atExit := make(chan struct{})
+	allowExit := make(chan struct{})
+	c.testBeforeSessionOperationExit = func(gotSessionID string) {
+		if gotSessionID != sessionID {
+			return
+		}
+		close(atExit)
+		<-allowExit
+	}
+	type callResult struct {
+		res AnyResult
+		err error
+	}
+	resultCh := make(chan callResult, 1)
+	go func() {
+		res, err := c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+			return nil, errors.New("cache hit unexpectedly executed initializer")
+		})
+		resultCh <- callResult{res: res, err: err}
+	}()
+	<-atExit
+
+	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+	assert.Equal(t, releaseCalls.Load(), int32(0), "release ran while the cache operation was active")
+
+	close(allowExit)
+	got := <-resultCh
+	assert.Assert(t, got.res == nil)
+	assert.ErrorIs(t, got.err, ErrCacheSessionReleased)
+	assert.Equal(t, releaseCalls.Load(), int32(1))
+	assert.Equal(t, c.Size(), 0)
+}
+
+func TestCacheArbitraryReleaseRefusesValueAtOperationExit(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	const sessionID = "arbitrary-release-inflight"
+	const callKey = "arbitrary-release-inflight"
+	var releaseCalls atomic.Int32
+	_, err = c.GetOrInitArbitrary(ctx, sessionID, callKey, func(context.Context) (any, error) {
+		return cacheTestOpaqueValue{value: "value", onRelease: func(context.Context) error {
+			releaseCalls.Add(1)
+			return nil
+		}}, nil
+	})
+	assert.NilError(t, err)
+
+	atExit := make(chan struct{})
+	allowExit := make(chan struct{})
+	c.testBeforeSessionOperationExit = func(gotSessionID string) {
+		if gotSessionID != sessionID {
+			return
+		}
+		close(atExit)
+		<-allowExit
+	}
+	type arbitraryCallResult struct {
+		res ArbitraryCachedResult
+		err error
+	}
+	resultCh := make(chan arbitraryCallResult, 1)
+	go func() {
+		res, err := c.GetOrInitArbitrary(ctx, sessionID, callKey, ArbitraryValueFunc("unexpected"))
+		resultCh <- arbitraryCallResult{res: res, err: err}
+	}()
+	<-atExit
+
+	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+	assert.Equal(t, releaseCalls.Load(), int32(0))
+	close(allowExit)
+
+	got := <-resultCh
+	assert.Assert(t, got.res == nil)
+	assert.ErrorIs(t, got.err, ErrCacheSessionReleased)
+	assert.Equal(t, releaseCalls.Load(), int32(1))
+	assert.Equal(t, c.Size(), 0)
+}
+
+func TestCacheDeferredReleaseErrorSurfacesFromClose(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	const sessionID = "deferred-release-error"
+	call := cacheTestIntCall("deferred-release-error")
+	releaseErr := errors.New("deferred release failed")
+	_, err = c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return Result[Typed]{shared: &sharedResult{
+			self:       cacheTestOnReleaseInt{Int: NewInt(1), onRelease: func(context.Context) error { return releaseErr }},
+			resultCall: call,
+			hasValue:   true,
+		}}, nil
+	})
+	assert.NilError(t, err)
+
+	atExit := make(chan struct{})
+	allowExit := make(chan struct{})
+	c.testBeforeSessionOperationExit = func(gotSessionID string) {
+		if gotSessionID == sessionID {
+			close(atExit)
+			<-allowExit
+		}
+	}
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, ValueFunc(nil))
+		callDone <- err
+	}()
+	<-atExit
+	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+	close(allowExit)
+	assert.ErrorIs(t, <-callDone, ErrCacheSessionReleased)
+	assert.ErrorIs(t, c.Close(ctx), releaseErr)
+}
+
+func TestCacheSynchronousReleaseErrorFailsCloseDirty(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	c, err := NewCache(ctx, "", nil, nil)
+	assert.NilError(t, err)
+
+	const sessionID = "synchronous-release-error"
+	call := cacheTestIntCall("synchronous-release-error")
+	releaseErr := errors.New("synchronous release failed")
+	_, err = c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return Result[Typed]{shared: &sharedResult{
+			self:       cacheTestOnReleaseInt{Int: NewInt(1), onRelease: func(context.Context) error { return releaseErr }},
+			resultCall: call,
+			hasValue:   true,
+		}}, nil
+	})
+	assert.NilError(t, err)
+
+	assert.ErrorIs(t, c.ReleaseSession(ctx, sessionID), releaseErr)
+	assert.ErrorIs(t, c.Close(ctx), releaseErr)
+}
+
+func TestCacheCloseCancellationFailsDirtyWhileOperationActive(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	dbPath := filepath.Join(t.TempDir(), "cache.db")
+	c, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+
+	const sessionID = "close-active"
+	call := cacheTestIntCall("close-active")
+	_, err = c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(call, 1), nil
+	})
+	assert.NilError(t, err)
+
+	atExit := make(chan struct{})
+	allowExit := make(chan struct{})
+	c.testBeforeSessionOperationExit = func(gotSessionID string) {
+		if gotSessionID == sessionID {
+			close(atExit)
+			<-allowExit
+		}
+	}
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, ValueFunc(nil))
+		callDone <- err
+	}()
+	<-atExit
+
+	closing := make(chan struct{})
+	c.testAfterCacheClosing = func() { close(closing) }
+	closeCtx, cancelClose := context.WithCancel(ctx)
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- c.Close(closeCtx) }()
+	<-closing
+	closeRefusedCall := cacheTestIntCall("close-refused")
+	_, err = c.GetOrInitCall(ctx, "close-refused", noopTypeResolver{}, &CallRequest{ResultCall: closeRefusedCall}, func(context.Context) (AnyResult, error) {
+		return cacheTestIntResult(closeRefusedCall, 2), nil
+	})
+	assert.ErrorIs(t, err, ErrCacheClosed)
+	cancelClose()
+	assert.ErrorIs(t, <-closeDone, context.Canceled)
+
+	close(allowExit)
+	assert.NilError(t, <-callDone)
+
+	reopened, err := NewCache(ctx, dbPath, nil, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, reopened.PersistenceResetReason(), CachePersistenceResetUncleanShutdown)
+	assert.NilError(t, reopened.CloseDiscardingPersistence())
 }

--- a/dagql/cache_snapshot_persistence_test.go
+++ b/dagql/cache_snapshot_persistence_test.go
@@ -64,6 +64,8 @@ type fakeSnapshotManager struct {
 	removeCalls         []string
 	deleteStaleKeep     map[string]struct{}
 	deleteStaleCallSeen bool
+	attachStarted       chan struct{}
+	allowAttach         chan struct{}
 }
 
 func (*fakeSnapshotManager) Search(context.Context, string, bool) ([]bkcache.RefMetadata, error) {
@@ -134,11 +136,50 @@ func (*fakeSnapshotManager) IdentityMapping() *idtools.IdentityMapping {
 
 func (m *fakeSnapshotManager) AttachLease(ctx context.Context, leaseID, snapshotID string) error {
 	_ = ctx
+	if m.attachStarted != nil {
+		close(m.attachStarted)
+		<-m.allowAttach
+	}
 	m.attachCalls = append(m.attachCalls, struct{ LeaseID, SnapshotID string }{
 		LeaseID:    leaseID,
 		SnapshotID: snapshotID,
 	})
 	return nil
+}
+
+func TestCacheSnapshotOwnerLeaseSyncDefersSessionCleanup(t *testing.T) {
+	ctx := cacheTestContext(t.Context())
+	snapshotManager := &fakeSnapshotManager{}
+	c, err := NewCache(ctx, "", snapshotManager, nil)
+	assert.NilError(t, err)
+	sessionID := cacheTestSessionID(t, ctx)
+
+	call := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType((&persistSnapshotValue{}).Type()),
+		Field: "snapshot-owner-release",
+	}
+	value := &persistSnapshotValue{Name: "value", SnapshotID: "snapshot-a"}
+	_, err = c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, func(context.Context) (AnyResult, error) {
+		return cacheTestPlainResult(value), nil
+	})
+	assert.NilError(t, err)
+
+	value.SnapshotID = "snapshot-b"
+	res, err := c.GetOrInitCall(ctx, sessionID, noopTypeResolver{}, &CallRequest{ResultCall: call}, ValueFunc(nil))
+	assert.NilError(t, err)
+	snapshotManager.attachStarted = make(chan struct{})
+	snapshotManager.allowAttach = make(chan struct{})
+	syncDone := make(chan error, 1)
+	go func() { syncDone <- c.SyncResultSnapshotOwnerLeases(ctx, res) }()
+	<-snapshotManager.attachStarted
+
+	assert.NilError(t, c.ReleaseSession(ctx, sessionID))
+	assert.Assert(t, c.Size() > 0, "release collected a result during snapshot-owner lease synchronization")
+
+	close(snapshotManager.allowAttach)
+	assert.NilError(t, <-syncDone)
+	assert.Equal(t, c.Size(), 0)
 }
 
 func (m *fakeSnapshotManager) RemoveLease(ctx context.Context, leaseID string) error {

--- a/dagql/call_request_input.go
+++ b/dagql/call_request_input.go
@@ -116,23 +116,11 @@ func resultCallRefFromIDInput(ctx context.Context, id *call.ID, memo recipeCallM
 	if err != nil {
 		return nil, fmt.Errorf("resolve ID input %q: current dagql cache: %w", idInputDebugString(id), err)
 	}
-	shared, _, _, err := cache.sharedResultByResultID(
-		ctx,
-		clientMetadata.SessionID,
-		sharedResultID(id.EngineResultID()),
-		sharedResultLookupCanonicalEquivalent,
-	)
+	ref, err := cache.resultCallRefByResultID(ctx, clientMetadata.SessionID, id.EngineResultID())
 	if err != nil {
 		return nil, fmt.Errorf("resolve ID input %q: %w", idInputDebugString(id), err)
 	}
-	frame := shared.loadResultCall()
-	if frame == nil {
-		return nil, fmt.Errorf("resolve ID input %q: missing result call frame", idInputDebugString(id))
-	}
-	if frame.Type != nil && frame.Type.NamedType == "Query" {
-		return nil, nil
-	}
-	return &ResultCallRef{ResultID: uint64(shared.id), shared: shared}, nil
+	return ref, nil
 }
 
 func resultCallFromRecipeIDInput(ctx context.Context, id *call.ID, memo recipeCallMemo) (*ResultCall, error) {

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1360,7 +1360,7 @@ func (s *Server) loadNthValue(
 	return res, nil
 }
 
-func (s *Server) LoadType(ctx context.Context, id *call.ID) (_ AnyResult, rerr error) {
+func (s *Server) LoadType(ctx context.Context, id *call.ID) (ret AnyResult, rerr error) {
 	ctx = srvToContext(ctx, s)
 	if id == nil {
 		return nil, fmt.Errorf("load type: nil ID")
@@ -1394,8 +1394,18 @@ func (s *Server) LoadType(ctx context.Context, id *call.ID) (_ AnyResult, rerr e
 	if err != nil {
 		return nil, fmt.Errorf("load %s: current dagql cache: %w", id.Display(), err)
 	}
+	cacheOp, err := cache.beginSessionOperation(clientMetadata.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", id.Display(), err)
+	}
+	defer func() {
+		if cacheOp.finish(rerr == nil && ret != nil) {
+			ret = nil
+			rerr = fmt.Errorf("load %s: %w: %q", id.Display(), ErrCacheSessionReleased, clientMetadata.SessionID)
+		}
+	}()
 	if id.IsHandle() {
-		res, err := cache.LoadResultByResultID(ctx, clientMetadata.SessionID, s, id.EngineResultID())
+		res, err := cache.loadResultByResultID(ctx, clientMetadata.SessionID, s, id.EngineResultID())
 		if err != nil {
 			return nil, err
 		}

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1360,6 +1360,25 @@ func (s *Server) loadNthValue(
 	return res, nil
 }
 
+func beginLoadTypeCacheOperation(ctx context.Context, id *call.ID) (*Cache, cacheOperation, string, error) {
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return nil, cacheOperation{}, "", fmt.Errorf("load %s: current client metadata: %w", id.Display(), err)
+	}
+	if clientMetadata.SessionID == "" {
+		return nil, cacheOperation{}, "", fmt.Errorf("load %s: empty session ID", id.Display())
+	}
+	cache, err := EngineCache(ctx)
+	if err != nil {
+		return nil, cacheOperation{}, "", fmt.Errorf("load %s: current dagql cache: %w", id.Display(), err)
+	}
+	cacheOp, err := cache.beginSessionOperation(clientMetadata.SessionID)
+	if err != nil {
+		return nil, cacheOperation{}, "", fmt.Errorf("load %s: %w", id.Display(), err)
+	}
+	return cache, cacheOp, clientMetadata.SessionID, nil
+}
+
 func (s *Server) LoadType(ctx context.Context, id *call.ID) (ret AnyResult, rerr error) {
 	ctx = srvToContext(ctx, s)
 	if id == nil {
@@ -1383,29 +1402,18 @@ func (s *Server) LoadType(ctx context.Context, id *call.ID) (ret AnyResult, rerr
 		}
 	}()
 
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	cache, cacheOp, sessionID, err := beginLoadTypeCacheOperation(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("load %s: current client metadata: %w", id.Display(), err)
-	}
-	if clientMetadata.SessionID == "" {
-		return nil, fmt.Errorf("load %s: empty session ID", id.Display())
-	}
-	cache, err := EngineCache(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("load %s: current dagql cache: %w", id.Display(), err)
-	}
-	cacheOp, err := cache.beginSessionOperation(clientMetadata.SessionID)
-	if err != nil {
-		return nil, fmt.Errorf("load %s: %w", id.Display(), err)
+		return nil, err
 	}
 	defer func() {
 		if cacheOp.finish(rerr == nil && ret != nil) {
 			ret = nil
-			rerr = fmt.Errorf("load %s: %w: %q", id.Display(), ErrCacheSessionReleased, clientMetadata.SessionID)
+			rerr = fmt.Errorf("load %s: %w: %q", id.Display(), ErrCacheSessionReleased, sessionID)
 		}
 	}()
 	if id.IsHandle() {
-		res, err := cache.loadResultByResultID(ctx, clientMetadata.SessionID, s, id.EngineResultID())
+		res, err := cache.loadResultByResultID(ctx, sessionID, s, id.EngineResultID())
 		if err != nil {
 			return nil, err
 		}
@@ -1432,7 +1440,7 @@ func (s *Server) LoadType(ctx context.Context, id *call.ID) (ret AnyResult, rerr
 		ctx:       ctx,
 		srv:       s,
 		cache:     cache,
-		sessionID: clientMetadata.SessionID,
+		sessionID: sessionID,
 		loads:     make(map[string]*recipeLoadFuture),
 	}
 	return state.load(id)

--- a/dagql/tla/CacheLifecycle.tla
+++ b/dagql/tla/CacheLifecycle.tla
@@ -16,24 +16,22 @@
 (*   - persisted decode, import, flush, restart (ModelPersistence)         *)
 (*   - calls issued from inside a call executor, which the server's drain  *)
 (*     neither counts nor rejects (ModelNestedCalls)                       *)
+(*   - per-session operation accounting: admission against the release     *)
+(*     tombstone, late refusal at the return boundary, deferred release    *)
+(*     cleanup by the last exiting operation, lazy callback attempt        *)
+(*     tokens, and shutdown quiescence (Cache.Close)                       *)
 (*                                                                         *)
-(* The model reflects the code as it is. Configurations select scenarios   *)
-(* (which machinery is active, which external events and failures can      *)
-(* happen), never alternative code shapes. Where the current code has a    *)
-(* known deficiency, a configuration reproduces it as an expected          *)
-(* invariant violation, so the deficiency cannot silently change shape.    *)
+(* Configurations select scenarios: which machinery is active and which    *)
+(* external events and failures can happen. They never select alternative  *)
+(* implementations.                                                        *)
 (*                                                                         *)
 (* GRANULARITY                                                             *)
-(* One atomic model action per Go critical section: one hold of egraphMu,  *)
-(* callsMu, sessionMu, or lazyMu, or one lock-free region between holds.  *)
-(* Races live BETWEEN critical sections; the model explores exactly those  *)
-(* interleavings and no finer-grained fake ones. Every action's comment    *)
-(* names the Go function and lines it abstracts.                           *)
+(* One atomic model action represents one Go critical section or one       *)
+(* lock-free atomic transition. Races live between those actions.          *)
 (*                                                                         *)
 (* ABSTRACTIONS                                                            *)
 (*   - Equivalence is a static partition of call identities (ClassOf).     *)
-(*     The e-graph's merging machinery is not modeled. Lookup returns      *)
-(*     some live result in the request's class, or misses.                 *)
+(*     The e-graph's class-merging machinery is not modeled.               *)
 (*   - Lookup may miss even when a candidate exists. This over-            *)
 (*     approximates the candidate/session filtering that is not modeled,   *)
 (*     and it exercises the engine's accepted duplicate-execution window   *)
@@ -42,18 +40,22 @@
 (*     considers equivalent are interchangeable.                           *)
 (*   - Not modeled: session resources, TTL/expiry, DoNotCache,             *)
 (*     recipe-replay taint, and the arbitrary-value cache                  *)
-(*     (acquireSessionArbitraryLocked, cache.go:751 - the same atomic      *)
-(*     record-and-count claim as the modeled result claim, under callsMu   *)
-(*     with sessionMu nested; Go tests carry its coverage).                *)
-(*   - ReleaseSession can fire at ANY time, including while the session    *)
-(*     has calls in flight. The server's drain (dagqlInFlight,             *)
-(*     engine/server/session.go:603-608) narrows but does not close that   *)
-(*     window: it counts only serveQuery handler goroutines, and the       *)
-(*     detached call executor (cache.go:3954) keeps issuing nested cache   *)
-(*     calls with the same session ID while it unwinds from cancellation.  *)
-(*     DrainOnRelease models the drain as implemented (handler calls       *)
-(*     only); ModelNestedCalls adds the executor-nested calls that         *)
-(*     escape it.                                                          *)
+(*     (acquireSessionArbitraryLocked - the same atomic record-and-count   *)
+(*     claim as the modeled result claim, under callsMu with sessionMu     *)
+(*     nested; it follows the same operation-accounting and                *)
+(*     deferred-release contract; Go tests carry its coverage).            *)
+(*   - Not modeled: the lock-time registration guards in the e-graph       *)
+(*     mutation helpers (TeachCallEquivalentToResult, TeachContentDigest,  *)
+(*     AddExplicitDependency, WithSessionResourceHandle). Numeric result   *)
+(*     IDs are engine-lifetime unique, so those guards only refuse         *)
+(*     mutations for already-collected results; Go tests carry them.       *)
+(*   - Every modeled cache operation has session metadata. The             *)
+(*     implementation also uses a cache-wide operation count when metadata *)
+(*     is absent; shutdown treats both counts identically.                 *)
+(*   - ReleaseSession can fire while cache operations are active. The      *)
+(*     server drain controls only whether handler-origin calls are still   *)
+(*     admitted to release; executor-nested calls remain outside it. Cache *)
+(*     operation accounting covers both origins.                           *)
 (***************************************************************************)
 EXTENDS Naturals, Sequences, FiniteSets, TLC
 
@@ -65,26 +67,17 @@ CONSTANTS
                         \* is in; results of same-class calls are
                         \* interchangeable for cache hits
     MaxInvocations,     \* how many GetOrInitCalls may be issued in total
-    MaxResults,         \* bound on allocated sharedResult IDs
+    MaxResults,         \* bound on allocated sharedResult records
 
     \* --- external events -------------------------------------------------
     AllowRelease,       \* enable session release; off in configs that
                         \* isolate a question from release races
-    DrainOnRelease,     \* model the server's politeness around release, AS
-                        \* IMPLEMENTED - it covers handler-origin calls only:
-                        \*   - TRUE: ReleaseSession waits until the
-                        \*     session's HANDLER-origin calls are terminal
-                        \*     (the dagqlInFlight drain, session.go:603-608,
-                        \*     counts serveQuery handlers only) and released
-                        \*     sessions get no new handler calls (the
-                        \*     dagqlClosing reject, session.go:1719-1725).
-                        \*     Executor-NESTED calls (ModelNestedCalls) are
-                        \*     not counted and not rejected - exactly as in
-                        \*     the engine.
-                        \*   - FALSE: the cache on its own, no politeness
-                        \* TRUE asks "does the drain, as implemented,
-                        \* prevent this?"; FALSE asks what the cache
-                        \* guarantees by itself.
+    DrainOnRelease,     \* model the server's handler drain. TRUE delays
+                        \* release until handler-origin calls are terminal;
+                        \* FALSE allows release without that courtesy.
+                        \* Executor-nested calls are outside the drain in
+                        \* either case. The cache's own operation count is
+                        \* load-bearing for safety in both cases.
     AllowPruneCut,      \* enable the PruneCut action; off in configs that
                         \* isolate a question from prune races
 
@@ -102,25 +95,14 @@ CONSTANTS
     ImportInit,         \* the model may START from a small imported graph
                         \* instead of an empty cache - results retained by
                         \* persisted and dependency edges, no session edges,
-                        \* payloads possibly still encoded ("envelope"),
-                        \* exactly what importPersistedState reconstructs
-                        \* after a clean restart.
-    ModelNestedCalls,   \* calls issued from inside a call executor.
-                        \* GetOrInitCall runs fn on a detached goroutine
-                        \* (cache.go:3954) whose context survives caller
-                        \* cancellation (WithCancelCause of WithoutCancel,
-                        \* cache.go:3897), and resolvers make nested cache
-                        \* calls carrying the SAME session ID
-                        \* (dagql/objects.go:684; context values survive
-                        \* WithoutCancel). Nothing counts that goroutine:
-                        \* the drain waits only for serveQuery handlers, so
-                        \* after a cancellation, teardown can pass the drain
-                        \* and run ReleaseSession while the executor is
-                        \* still unwinding and still claiming session
-                        \* edges. Nested spawns are allowed while any of
-                        \* the session's executors is running or winding
-                        \* down, and are never blocked by DrainOnRelease.
-
+                        \* payloads possibly still encoded ("envelope") -
+                        \* the result-level shape importPersistedState
+                        \* reconstructs after a clean restart.
+    ModelNestedCalls,   \* calls issued from inside a detached call executor.
+                        \* They carry the same session ID and may reach the
+                        \* cache after the handler drain has completed. New
+                        \* operations are refused after the cache tombstone;
+                        \* operations admitted earlier keep release deferred.
     \* --- failure and cancellation injection --------------------------------
     \* Each enables one nondeterministic event the environment can inject.
     \* Configurations keep injections off unless their question needs them,
@@ -147,10 +129,13 @@ CONSTANTS
 
 \* Config sanity check, evaluated once at startup: the ClassOf table must
 \* assign a class to every call and to nothing else.
-ASSUME DOMAIN ClassOf = Calls
+ASSUME /\ DOMAIN ClassOf = Calls
+       /\ Calls # {}
 
 \* Convenience value for configs: every call in one equivalence class.
 OneClass == [c \in Calls |-> "k1"]
+DistinctClasses == [c \in Calls |-> c]
+EquivalenceClasses == {ClassOf[c] : c \in Calls}
 
 \* Sessions are interchangeable with each other, and so are calls: the spec
 \* never treats any one specially. Declaring that symmetry (SYMMETRY Symm
@@ -183,25 +168,19 @@ VARIABLES
                         \* present. Claims add both sets atomically. The sets
                         \* differ only while release has removed records and
                         \* has not yet removed their snapshotted units.
-    sessionRelease,     \* per-session release progress, mirroring
-                        \* ReleaseSession's two critical sections
-                        \* (cache.go:760-834):
-                        \*   phase "live":       not released
-                        \*   phase "collecting": the sessionMu section ran -
-                        \*     records snapshotted into snap and wiped -
-                        \*     but the egraphMu decrements have not
-                        \*   phase "released":   both sections ran
-                        \* snap holds the record snapshot the decrement
-                        \* section will consume.
+    sessionRelease,     \* per-session lifecycle. active counts admitted
+                        \* cache operations. phase is live, marking,
+                        \* deferred, collecting, deleting, or released.
+                        \* snap is the release plan's result-edge snapshot;
+                        \* exitingLazy is 1 when one or more callback tokens
+                        \* are between done close and goroutine exit.
     evals,              \* one record per issued Cache.Evaluate caller
                         \* (empty unless ModelLazy)
     epoch,              \* 1 before the modeled restart, 2 after. One
                         \* graceful-shutdown/restart cycle per run.
-    flushed             \* "none", or the snapshot the graceful shutdown
-                        \* captured: one row per then-registered result.
-                        \* Mirrors what snapshotPersistState writes
-                        \* (cache_persistence_worker.go:27) minus the
-                        \* e-graph detail this model abstracts away.
+    flushed             \* shutdown state and, once complete, the snapshot:
+                        \* closing refuses admission; rows contains one
+                        \* record per result captured by persistence.
 
 vars == <<invocations, res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
           sessionRelease, evals, epoch, flushed>>
@@ -220,11 +199,13 @@ OngoingCallIds     == 1..Len(ongoingCalls)
 EvalLatchedPhases == {"latchedDone", "latchedFail", "latchedCancel"}
 EvalWakePhases == {"wakeDone", "wakeFail", "wakeCancel"}
 EvalPendingPhases == {"demand", "waiting"} \cup EvalLatchedPhases \cup EvalWakePhases
-EvalTerminalPhases == {"done", "failedCallback", "abandoned"}
-EvalPhaseDomain == EvalPendingPhases \cup EvalTerminalPhases
+EvalExitPhases == {"returnDone", "returnFailed", "returnAbandoned", "returnRefused"}
+EvalTerminalPhases == {"done", "failedCallback", "abandoned", "refused"}
+EvalPhaseDomain == EvalPendingPhases \cup EvalExitPhases \cup EvalTerminalPhases
 
 \* phase values in which an invocation has finished, one way or another.
 TerminalPhases == {"done", "failed", "canceled", "refused"}
+InvocationExitPhases == {"returning", "failing", "canceling", "refusing"}
 
 (***************************************************************************)
 (* Recounting ownership from scratch.                                      *)
@@ -259,7 +240,7 @@ DerivedOwn(r) ==
     SessEdgeCount(r) + DepParentCount(r)
       + HoldCount(r) + PersistedCount(r)
 
-\* All registered results whose call is in equivalence class k.
+\* All registered results whose semantic call is in equivalence class k.
 LiveInClass(k) ==
     {r \in ResultIds : res[r].registered /\ ClassOf[res[r].call] = k}
 
@@ -281,8 +262,10 @@ ProtectedReturn(s, r) ==
 (*                                                                         *)
 (* Mirrors collectUnownedResultsLocked (cache.go:979-1026), which runs     *)
 (* inside the same egraphMu critical section as whatever decrement         *)
-(* triggered it. released=TRUE here stands in for "the OnRelease hooks     *)
-(* have run" (in the code they run just after the lock drops).             *)
+(* triggered it. released=TRUE conservatively means cleanup hooks are now  *)
+(* eligible to have run; Go invokes them just after dropping egraphMu.     *)
+(* Making the result dead at collection is the earlier, dangerous side of  *)
+(* that small interval for every returned-live safety check.               *)
 (***************************************************************************)
 RECURSIVE Cascade(_)
 Cascade(rf) ==
@@ -311,8 +294,8 @@ DecAndCascade(rf, r) == Cascade([rf EXCEPT ![r].own = @ - 1])
 (* read barrier to decode on first use. The model can start from any       *)
 (* such graph of up to two results: every result must be retained          *)
 (* (persisted itself, or the dependency of a retained result), deps point  *)
-(* only at earlier IDs, and ownership counts are computed from the edges   *)
-(* exactly as import's increments do.                                      *)
+(* only at earlier record slots, and ownership counts are computed from    *)
+(* the edges exactly as import's increments do.                            *)
 (***************************************************************************)
 
 ImportedResult(c, persistedFlag, depsSet, ownVal, payloadVal, launderedFlag) ==
@@ -324,7 +307,7 @@ ImportedResult(c, persistedFlag, depsSet, ownVal, payloadVal, launderedFlag) ==
      imported |-> TRUE,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
      lazyCancel |-> FALSE, lazySyncPending |-> FALSE,
-     lazyWaiters |-> 0, lazyRunning |-> 0]
+     lazyWaiters |-> 0, lazyRunning |-> 0, lazyTokenSession |-> 0]
 
 \* A collected result's ID is never reused, so after a restart the slots of
 \* results that were not in the snapshot stay as dead husks - present in
@@ -339,7 +322,7 @@ DeadHusk ==
      imported |-> TRUE,
      lazyCb |-> "none", lazyComplete |-> FALSE, lazyPhase |-> "idle",
      lazyCancel |-> FALSE, lazySyncPending |-> FALSE,
-     lazyWaiters |-> 0, lazyRunning |-> 0]
+     lazyWaiters |-> 0, lazyRunning |-> 0, lazyTokenSession |-> 0]
 
 \* The candidate import rows for position pos: any call, persisted or not,
 \* at most one dependency and only on an earlier row, payload decoded or
@@ -374,6 +357,8 @@ InitialResStates ==
                     ImportGraphRetained(h)}}
     ELSE {<<>>}
 
+RegisteredResultIds == {r \in ResultIds : res[r].registered}
+
 Init ==
     /\ invocations = <<>>
     /\ res \in InitialResStates
@@ -381,57 +366,67 @@ Init ==
     /\ ongoingCallIndex = [k \in Calls \X Sessions |-> 0]
     /\ sessionEdges = {}
     /\ countedEdges = {}
-    /\ sessionRelease = [s \in Sessions |-> [phase |-> "live", snap |-> {}]]
+    /\ sessionRelease = [s \in Sessions |->
+         [phase |-> "live", snap |-> {}, active |-> 0, exitingLazy |-> 0]]
     /\ evals = <<>>
     /\ epoch = 1
-    /\ flushed = [done |-> FALSE, rows |-> <<>>]
+    /\ flushed = [closing |-> FALSE, done |-> FALSE, rows |-> <<>>]
 
 (***************************************************************************)
-(* Spawn: a client issues GetOrInitCall(session, call, persistable)        *)
-(* through a serveQuery handler. Under DrainOnRelease, released sessions   *)
-(* get no new handler calls (the dagqlClosing reject,                      *)
-(* session.go:1719-1725); without it, nothing in the cache itself          *)
-(* prevents a released session from issuing calls.                         *)
+(* Spawn: a client issues GetOrInitCall through a serveQuery handler. The  *)
+(* cache atomically refuses a released session or increments its active    *)
+(* operation count before entering lookup. The server drain additionally   *)
+(* prevents new handler calls after teardown begins.                       *)
 (*                                                                         *)
 (* SpawnNested: a call issued from INSIDE a call executor - a resolver's   *)
-(* nested Select (dagql/objects.go:684) running on the detached fn         *)
-(* goroutine (cache.go:3954). It carries the same session ID, it is not    *)
-(* counted by the drain, and it is not rejected after release; its only    *)
-(* precondition is that some executor of the session is still running or   *)
-(* winding down from cancellation. The model does not bind the nested      *)
-(* call to a specific executor - any live executor of the session          *)
-(* suffices.                                                               *)
+(* nested Select running on the detached fn goroutine. It carries the same *)
+(* session ID and is not counted by the server drain. It still enters at   *)
+(* the cache boundary, where the tombstone refuses it after release.        *)
 (***************************************************************************)
-NewInvocation(s, c, p, o) ==
-    [sess |-> s, call |-> c, persistable |-> p, phase |-> "lookup",
+NewInvocation(s, c, p, o, admitted) ==
+    [sess |-> s, call |-> c, persistable |-> p,
+     phase |-> IF admitted THEN "lookup" ELSE "refused",
      origin |-> o,
+     opActive |-> admitted,
      oc |-> 0, resId |-> 0, path |-> "none",
      \* Invocations survive a modeled restart for property checking even though
      \* their real goroutines and the cache's in-memory tombstones do not, so this
      \* field ties a refusal to the epoch whose lifecycle state produced it.
-     refusedEpoch |-> 0,
+     refusedEpoch |-> IF admitted THEN 0 ELSE epoch,
      lookupBarrierAtSelection |-> "none",
      retLive |-> TRUE, retOwned |-> TRUE,
      retBarrierOK |-> TRUE, retClean |-> TRUE]
 
 Spawn ==
     /\ Len(invocations) < MaxInvocations
+    /\ ~flushed.closing
     /\ \E s \in Sessions, c \in Calls, p \in BOOLEAN :
         /\ DrainOnRelease => sessionRelease[s].phase = "live"
-        /\ invocations' = Append(invocations, NewInvocation(s, c, p, "handler"))
+        /\ LET admitted == sessionRelease[s].phase = "live" IN
+           /\ invocations' = Append(invocations,
+                NewInvocation(s, c, p, "handler", admitted))
+           /\ sessionRelease' = IF admitted
+                THEN [sessionRelease EXCEPT ![s].active = @ + 1]
+                ELSE sessionRelease
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 SpawnNested ==
     /\ ModelNestedCalls
     /\ Len(invocations) < MaxInvocations
+    /\ ~flushed.closing
     /\ \E s \in Sessions, c \in Calls, p \in BOOLEAN :
         /\ \E o \in OngoingCallIds :
              /\ ongoingCalls[o].sess = s
              /\ ongoingCalls[o].fnState \in {"running", "canceled"}
-        /\ invocations' = Append(invocations, NewInvocation(s, c, p, "nested"))
+        /\ LET admitted == sessionRelease[s].phase = "live" IN
+           /\ invocations' = Append(invocations,
+                NewInvocation(s, c, p, "nested", admitted))
+           /\ sessionRelease' = IF admitted
+                THEN [sessionRelease EXCEPT ![s].active = @ + 1]
+                ELSE sessionRelease
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
-                   sessionRelease, evals, epoch, flushed>>
+                   evals, epoch, flushed>>
 
 (***************************************************************************)
 (* LookupHit: the lookup finds a live equivalent result whose attachment   *)
@@ -461,7 +456,7 @@ LookupHit(i) ==
                                         ![i].path = "hit",
                                         ![i].lookupBarrierAtSelection = res[r].barrier]
            ELSE /\ UNCHANGED res
-                /\ invocations' = [invocations EXCEPT ![i].phase = "refused",
+                /\ invocations' = [invocations EXCEPT ![i].phase = "refusing",
                                         ![i].resId = r,
                                         ![i].path = "hit",
                                         ![i].lookupBarrierAtSelection = res[r].barrier,
@@ -544,7 +539,7 @@ CreateOcLeaseFail(i) ==
     /\ LeaseCanFail
     /\ invocations[i].phase = "join"
     /\ ongoingCallIndex[<<invocations[i].call, invocations[i].sess>>] = 0
-    /\ invocations' = [invocations EXCEPT ![i].phase = "failed",
+    /\ invocations' = [invocations EXCEPT ![i].phase = "failing",
                                            ![i].path = "leaseFailure"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
@@ -607,14 +602,14 @@ WaiterCancel(i) ==
                         THEN [ongoingCallIndex EXCEPT
                                 ![<<ongoingCalls[o].call, ongoingCalls[o].sess>>] = 0]
                         ELSE ongoingCallIndex
-          /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
+          /\ invocations' = [invocations EXCEPT ![i].phase = "canceling"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
 \* FnWindDown: the cancel-requested executor finally exits. Until it does,
 \* its resolver can still issue nested cache calls (SpawnNested) - that
-\* window is the drain escape. Gated by ModelNestedCalls so earlier
-\* configurations keep their exact state spaces.
+\* window is the drain escape. Gated by ModelNestedCalls so unrelated
+\* scenarios do not pay for nested-executor states.
 FnWindDown(o) ==
     /\ ModelNestedCalls
     /\ ongoingCalls[o].fnState = "canceled"
@@ -676,7 +671,7 @@ WaiterCancelLate(i) ==
                         ELSE ongoingCallIndex
           /\ invocations' = [invocations EXCEPT ![i].phase =
                 IF last /\ postOnce /\ ongoingCalls[o].hold
-                THEN "cancelDropHold" ELSE "canceled"]
+                THEN "cancelDropHold" ELSE "canceling"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -689,7 +684,7 @@ WaiterDropHoldCanceled(i) ==
     /\ LET o == invocations[i].oc IN
        /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].hold = FALSE]
        /\ res' = PersistThenDropHold(o)
-       /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
+       /\ invocations' = [invocations EXCEPT ![i].phase = "canceling"]
     /\ UNCHANGED <<ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -707,7 +702,7 @@ WaiterObserveFnErr(i) ==
                         THEN [ongoingCallIndex EXCEPT
                                 ![<<ongoingCalls[o].call, ongoingCalls[o].sess>>] = 0]
                         ELSE ongoingCallIndex
-          /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
+          /\ invocations' = [invocations EXCEPT ![i].phase = "failing"]
     /\ UNCHANGED <<res, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -780,7 +775,8 @@ PubIndexFresh(o) ==
                        lazyCancel |-> FALSE,     \* attempt cancel requested
                        lazySyncPending |-> FALSE, \* lazySyncPending
                        lazyWaiters |-> 0,        \* current attempt's waiters
-                       lazyRunning |-> 0]        \* callbacks actually running
+                       lazyRunning |-> 0,        \* callbacks actually running
+                       lazyTokenSession |-> 0]   \* active callback token owner
         IN /\ res' = Append(withDeps, newRes)
            /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].pubState = "attaching",
                                  ![o].hold = TRUE,
@@ -964,7 +960,7 @@ WaiterObservePubErr(i) ==
                                \* WaiterClaim
           /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].waiters = @ - 1]
           /\ invocations' = [invocations EXCEPT
-               ![i].phase = IF dropHold THEN "pubErrDropHold" ELSE "failed"]
+               ![i].phase = IF dropHold THEN "pubErrDropHold" ELSE "failing"]
     /\ UNCHANGED <<res, ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -977,7 +973,7 @@ WaiterDropHoldPubErr(i) ==
     /\ LET o == invocations[i].oc IN
        /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].hold = FALSE]
        /\ res' = PersistThenDropHold(o)
-       /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
+       /\ invocations' = [invocations EXCEPT ![i].phase = "failing"]
     /\ UNCHANGED <<ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -1028,7 +1024,7 @@ WaiterDepart(i) ==
           /\ invocations' = [invocations EXCEPT
                ![i].phase = IF last /\ ongoingCalls[o].hold
                          THEN IF refused THEN "refusedReleaseHold" ELSE "releaseHold"
-                         ELSE IF refused THEN "refused" ELSE "readBarrier"]
+                         ELSE IF refused THEN "refusing" ELSE "readBarrier"]
     /\ UNCHANGED <<res, ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -1044,7 +1040,7 @@ WaiterReleaseHold(i) ==
        IN
        /\ ongoingCalls' = [ongoingCalls EXCEPT ![o].hold = FALSE]
        /\ res' = PersistThenDropHold(o)
-       /\ invocations' = [invocations EXCEPT ![i].phase = IF refused THEN "refused" ELSE "readBarrier"]
+       /\ invocations' = [invocations EXCEPT ![i].phase = IF refused THEN "refusing" ELSE "readBarrier"]
     /\ UNCHANGED <<ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -1071,11 +1067,7 @@ ReadBarrierOk(i) ==
           /\ invocations' = [invocations EXCEPT
                ![i].phase = IF invocations[i].path = "hit"
                                   /\ invocations[i].persistable
-                             THEN "persistHit" ELSE "done",
-               ![i].retLive = res[r].registered /\ ~res[r].released,
-               ![i].retOwned = ProtectedReturn(invocations[i].sess, r),
-               ![i].retBarrierOK = res[r].barrier \in {"none", "closedOk"},
-               ![i].retClean = ~res[r].laundered]
+                             THEN "persistHit" ELSE "returning"]
           /\ UNCHANGED res
     /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
@@ -1094,11 +1086,7 @@ PersistHit(i) ==
                         ELSE res
        IN /\ res' = persisted
           /\ invocations' = [invocations EXCEPT
-               ![i].phase = "done",
-               ![i].retLive = res[r].registered /\ ~res[r].released,
-               ![i].retOwned = ProtectedReturn(invocations[i].sess, r),
-               ![i].retBarrierOK = res[r].barrier \in {"none", "closedOk"},
-               ![i].retClean = ~res[r].laundered]
+               ![i].phase = "returning"]
     /\ UNCHANGED <<ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
@@ -1106,7 +1094,7 @@ ReadBarrierErrHit(i) ==
     /\ invocations[i].phase = "readBarrier"
     /\ invocations[i].path = "hit"
     /\ res[invocations[i].resId].barrier = "closedErr"
-    /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
+    /\ invocations' = [invocations EXCEPT ![i].phase = "failing"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
@@ -1114,7 +1102,7 @@ ReadBarrierErrWait(i) ==
     /\ invocations[i].phase = "readBarrier"
     /\ invocations[i].path = "wait"
     /\ res[invocations[i].resId].barrier = "closedErr"
-    /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
+    /\ invocations' = [invocations EXCEPT ![i].phase = "failing"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
@@ -1131,7 +1119,7 @@ ReadBarrierCancelHit(i) ==
     /\ ReaderCanCancel
     /\ invocations[i].phase = "readBarrier"
     /\ invocations[i].path = "hit"
-    /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
+    /\ invocations' = [invocations EXCEPT ![i].phase = "canceling"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
@@ -1141,7 +1129,7 @@ ReadBarrierCancelWait(i) ==
     /\ ReaderCanCancel
     /\ invocations[i].phase = "readBarrier"
     /\ invocations[i].path = "wait"
-    /\ invocations' = [invocations EXCEPT ![i].phase = "canceled"]
+    /\ invocations' = [invocations EXCEPT ![i].phase = "canceling"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
@@ -1219,7 +1207,7 @@ DecodeWake(i) ==
 DecodeFailHit(i) ==
     /\ invocations[i].phase = "decodeErr"
     /\ invocations[i].path = "hit"
-    /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
+    /\ invocations' = [invocations EXCEPT ![i].phase = "failing"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges, sessionRelease,
                    evals, epoch, flushed>>
 
@@ -1228,47 +1216,95 @@ DecodeFailHit(i) ==
 DecodeFailWait(i) ==
     /\ invocations[i].phase = "decodeErr"
     /\ invocations[i].path = "wait"
-    /\ invocations' = [invocations EXCEPT ![i].phase = "failed"]
+    /\ invocations' = [invocations EXCEPT ![i].phase = "failing"]
     /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges, countedEdges,
                    sessionRelease, evals, epoch, flushed>>
 
+\* Decrement an admitted operation. When this is the last operation after a
+\* release plan was published, cleanup becomes irrevocably assigned to this
+\* operation before its goroutine returns.
+FinishSessionOperation(sr, s) ==
+    LET old == sr[s]
+        remaining == old.active - 1
+        nextPhase == IF remaining = 0 /\ old.phase = "deferred"
+                     THEN "collecting" ELSE old.phase
+    IN [sr EXCEPT ![s] = [old EXCEPT !.active = remaining,
+                                      !.phase = nextPhase]]
+
+\* Operation exit is the return boundary. A successful value is changed to a
+\* released-session refusal when release won before this atomic decrement.
+\* Cleanup cannot run before the decrement because the active count is still
+\* positive; if this is the last operation, the same transition assigns it.
+InvocationOperationExit(i) ==
+    /\ invocations[i].phase \in InvocationExitPhases
+    /\ invocations[i].opActive
+    /\ LET s == invocations[i].sess
+           r == invocations[i].resId
+           success == invocations[i].phase = "returning"
+           lateRefusal == success /\ sessionRelease[s].phase # "live"
+           terminal == CASE lateRefusal -> "refused"
+                         [] invocations[i].phase = "returning" -> "done"
+                         [] invocations[i].phase = "failing" -> "failed"
+                         [] invocations[i].phase = "canceling" -> "canceled"
+                         [] OTHER -> "refused"
+       IN /\ sessionRelease[s].active > 0
+          /\ sessionRelease' = FinishSessionOperation(sessionRelease, s)
+          /\ invocations' = [invocations EXCEPT
+               ![i].phase = terminal,
+               ![i].opActive = FALSE,
+               ![i].refusedEpoch = IF lateRefusal THEN epoch ELSE @,
+               ![i].retLive = IF success
+                    THEN res[r].registered /\ ~res[r].released ELSE @,
+               ![i].retOwned = IF success
+                    THEN ProtectedReturn(s, r) ELSE @,
+               ![i].retBarrierOK = IF success
+                    THEN res[r].barrier \in {"none", "closedOk"} ELSE @,
+               ![i].retClean = IF success THEN ~res[r].laundered ELSE @]
+    /\ UNCHANGED <<res, ongoingCalls, ongoingCallIndex, sessionEdges,
+                   countedEdges, evals, epoch, flushed>>
+
 (***************************************************************************)
-(* ReleaseSession, in its two real critical sections.                      *)
-(*                                                                         *)
-(* Go: Cache.ReleaseSession. First a sessionMu section marks the session   *)
-(* released, snapshots its complete atomic edges, and deletes its records. *)
-(* Then an egraphMu section removes one ownership unit per registered      *)
-(* snapshotted result and collects whatever reaches zero.                  *)
-(*                                                                         *)
-(* Release can begin at ANY time unless DrainOnRelease is on - and the     *)
-(* drain, as implemented, only waits out HANDLER-origin calls              *)
-(* (dagqlInFlight counts serveQuery handlers, session.go:603-608);         *)
-(* executor-nested calls keep running through it. Once per session.        *)
+(* Release first sets the tombstone with an atomic compare-and-swap. It    *)
+(* then snapshots session edges while holding the session mutex and        *)
+(* publishes an immutable cleanup plan. If operations remain, release      *)
+(* returns with phase deferred. The last operation exit moves the plan to  *)
+(* collecting. Cleanup removes ownership under the e-graph mutex, runs     *)
+(* release hooks, and finally deletes session records under the session    *)
+(* mutex. Release can begin at any time permitted by DrainOnRelease.       *)
 (***************************************************************************)
 
-\* The sessionMu section: set the released tombstone, snapshot the session's
-\* records, and delete them. Counts are untouched here. A session with no records skips the
-\* decrement section entirely - the Go still takes egraphMu for an empty
-\* loop, but that hold changes nothing observable.
-ReleaseSessionRecord(s) ==
+\* Atomic lifecycle-word update: new operation admission and tombstoning are
+\* totally ordered even though neither takes the cache-wide session mutex.
+ReleaseSessionMark(s) ==
     /\ AllowRelease
     /\ sessionRelease[s].phase = "live"
     /\ DrainOnRelease =>
          \A i \in InvocationIds :
              (invocations[i].sess = s /\ invocations[i].origin = "handler")
                  => invocations[i].phase \in TerminalPhases
-    /\ LET snap == {r \in ResultIds : <<s, r>> \in sessionEdges}
-       IN /\ sessionRelease' = [sessionRelease EXCEPT ![s] =
-                [phase |-> IF snap = {} THEN "released" ELSE "collecting",
-                 snap |-> snap]]
-          /\ sessionEdges' = {e \in sessionEdges : e[1] # s}
+    /\ sessionRelease' = [sessionRelease EXCEPT ![s].phase = "marking"]
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
-                   countedEdges, evals, epoch, flushed>>
+                   sessionEdges, countedEdges, evals, epoch, flushed>>
+
+\* The session-mutex section snapshots records. The release mutex prevents a
+\* last-operation cleanup from consuming the plan before it is published.
+ReleaseSessionSnapshot(s) ==
+    /\ sessionRelease[s].phase = "marking"
+    /\ LET snap == {r \in ResultIds : <<s, r>> \in sessionEdges}
+           old == sessionRelease[s]
+       IN /\ sessionRelease' = [sessionRelease EXCEPT ![s] =
+                [old EXCEPT !.phase = IF old.active = 0
+                                     THEN "collecting" ELSE "deferred",
+                            !.snap = snap]]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, evals, epoch, flushed>>
 
 \* The egraphMu section: remove one unit per snapshotted, still-registered
-\* result, then collect.
+\* result, then collect. Session records remain until hooks and arbitrary
+\* value cleanup complete.
 ReleaseSessionCollect(s) ==
     /\ sessionRelease[s].phase = "collecting"
+    /\ sessionRelease[s].active = 0
     /\ LET snap == sessionRelease[s].snap
            live == {r \in snap : res[r].registered}
            rf0 == [r \in DOMAIN res |->
@@ -1277,10 +1313,19 @@ ReleaseSessionCollect(s) ==
                      ELSE res[r]]
        IN /\ res' = Cascade(rf0)
           /\ countedEdges' = countedEdges \ {<<s, r>> : r \in snap}
-          /\ sessionRelease' = [sessionRelease EXCEPT ![s] =
-                [phase |-> "released", snap |-> {}]]
+          /\ sessionRelease' = [sessionRelease EXCEPT ![s].phase = "deleting"]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, evals, epoch, flushed>>
+
+\* Release hooks and arbitrary-value cleanup run before this final
+\* session-mutex section deletes every per-session record.
+ReleaseSessionDelete(s) ==
+    /\ sessionRelease[s].phase = "deleting"
+    /\ sessionEdges' = {e \in sessionEdges : e[1] # s}
+    /\ sessionRelease' = [sessionRelease EXCEPT ![s] =
+         [sessionRelease[s] EXCEPT !.phase = "released", !.snap = {}]]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   countedEdges, evals, epoch, flushed>>
 
 (***************************************************************************)
 (* PruneCut: cut one persisted root edge and let the normal cascade        *)
@@ -1300,16 +1345,12 @@ PruneCut(r) ==
                    sessionRelease, evals, epoch, flushed>>
 
 (***************************************************************************)
-(* FLUSH AND RESTART. Graceful shutdown removes every                      *)
-(* session (each release preceded by the server's drain when the server    *)
-(* behaves), then Cache.Close snapshots the retained graph in one          *)
-(* egraphMu hold and writes it out (persistCurrentState ->                 *)
-(* snapshotPersistState, cache_persistence_worker.go:14/:27; ordering in   *)
-(* GracefulStop, engine/server/server.go:799). The model requires only     *)
-(* what GracefulStop's structure guarantees - all sessions released -      *)
-(* NOT that in-flight work has finished: the cache does not enforce        *)
-(* that, so a snapshot racing an unfinished publication is a reachable    *)
-(* capture and the FlushCleanCapture property judges it.                   *)
+(* FLUSH AND RESTART. Graceful shutdown calls ReleaseSession for every     *)
+(* session before Cache.Close begins. A returned release may still have a  *)
+(* deferred cleanup plan. Close atomically refuses new operations, waits   *)
+(* until all session and cache-wide operations and deferred cleanups are    *)
+(* quiescent, and only then snapshots the retained graph. If its context    *)
+(* expires first, no Flush action occurs and the store remains dirty.       *)
 (*                                                                         *)
 (* Snapshot selection starts at persisted roots. A root is kept only when  *)
 (* its entire transitive dependency closure is registered and cleanly      *)
@@ -1340,14 +1381,30 @@ KeptByPersistedRoot(r) ==
     \E root \in ResultIds :
         CleanPersistedRoot(root) /\ DepReachable(res, root, r)
 
+\* GracefulStop has called every ReleaseSession to its non-blocking return
+\* point. This atomic closing flag rejects every later cache admission.
+BeginClose ==
+    /\ ModelPersistence
+    /\ epoch = 1
+    /\ ~flushed.done
+    /\ ~flushed.closing
+    /\ \A s \in Sessions :
+         sessionRelease[s].phase \in {"deferred", "collecting", "deleting", "released"}
+    /\ flushed' = [flushed EXCEPT !.closing = TRUE]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, sessionRelease, evals, epoch>>
+
 Flush ==
     /\ ModelPersistence
     /\ epoch = 1
     /\ ~flushed.done
-    \* GracefulStop runs each session's release to completion (both
-    \* critical sections) before Cache.Close snapshots.
+    /\ flushed.closing
+    \* Quiescence includes the operation counters and completed deferred
+    \* cleanup, not merely ReleaseSession's return.
+    /\ \A s \in Sessions : sessionRelease[s].active = 0
     /\ \A s \in Sessions : sessionRelease[s].phase = "released"
-    /\ flushed' = [done |-> TRUE, rows |-> [r \in 1..Len(res) |->
+    /\ flushed' = [flushed EXCEPT !.done = TRUE,
+         !.rows = [r \in 1..Len(res) |->
          [keep      |-> KeptByPersistedRoot(r),
           call      |-> res[r].call,
           persisted |-> res[r].persisted,
@@ -1367,7 +1424,8 @@ Flush ==
 (* row was dirty. Imported results come back with ownership recomputed     *)
 (* from their persisted + dependency edges (importPersistedState's         *)
 (* increments), payloads nondeterministically decoded-eagerly or left as   *)
-(* envelopes, and IDs preserved (collected slots stay as dead husks).      *)
+(* envelopes, and numeric IDs rebuilt from retained row IDs. Omitted       *)
+(* record slots stay as dead husks for property bookkeeping.               *)
 (* The laundered flag carries each row's dirty verdict forward so the      *)
 (* NoLaunderedServe property can see what the restarted engine cannot.     *)
 (***************************************************************************)
@@ -1388,9 +1446,7 @@ Restart ==
                     pm[x],
                     flushed.rows[x].dirty)
              ELSE DeadHusk]
-    /\ invocations' = [i \in InvocationIds |->
-         IF invocations[i].phase \in TerminalPhases THEN invocations[i]
-         ELSE [invocations[i] EXCEPT !.phase = "canceled"]]
+    /\ invocations' = invocations
     /\ ongoingCalls' = [o \in OngoingCallIds |->
          \* "exited", not "canceled": a restart kills the process, so no
          \* executor is winding down and no nested call can spawn from it
@@ -1411,8 +1467,9 @@ Restart ==
     /\ evals' = <<>>
     /\ sessionEdges' = {}
     /\ countedEdges' = {}
-    /\ sessionRelease' = [s \in Sessions |-> [phase |-> "live", snap |-> {}]]
-    /\ UNCHANGED flushed
+    /\ sessionRelease' = [s \in Sessions |->
+         [phase |-> "live", snap |-> {}, active |-> 0, exitingLazy |-> 0]]
+    /\ flushed' = [flushed EXCEPT !.closing = FALSE]
 
 ---------------------------------------------------------------------------
 (***************************************************************************)
@@ -1443,12 +1500,12 @@ Restart ==
 (* intermediate retry outcome, not a returned error. Its own cancellation  *)
 (* remains terminal, and a genuine callback failure still propagates.      *)
 (*                                                                         *)
-(* Evaluators here are modeled independently of the GetOrInitCall          *)
-(* invocations: in the engine, Evaluate is called by code already          *)
-(* holding the result, at any later time. Configurations that enable       *)
-(* lazy evaluation keep ReleaseSession and PruneCut off: what happens      *)
-(* when a result is collected while its callback runs belongs with the     *)
-(* release-during-in-flight investigations, not here.                      *)
+(* Each Evaluate caller holds one session operation token. Starting a      *)
+(* callback takes a second token for the callback goroutine. Callback       *)
+(* completion retires the attempt and closes its done channel before that   *)
+(* second token exits, so exitingLazy represents the small but real tail.   *)
+(* It is a saturating 0/1 abstraction: several overlapping tails still     *)
+(* retain one release hold, and their final exit clears it.                 *)
 (*                                                                         *)
 (* One attempt has two stages, and evaluateOne consults them before any    *)
 (* object-side lazy state: callback bodies (Directory/File/Container)      *)
@@ -1481,26 +1538,35 @@ LatchEvalOutcomes(r, outcome) ==
                                   !.foreignCancel = (outcome = "latchedCancel")]
         ELSE evals[e]]
 
-\* A new Evaluate caller appears, demanding some registered result it
-\* holds. A caller can only hold a result whose attachment barrier is not
-\* open and not errored: every result-returning API waits at the barrier
-\* and returns errors instead of values. Lazy callbacks are registered at
-\* attachment completion (registerLazyEvaluation, immediately before the
-\* barrier closes) and again when a persisted hit's value is loaded; both
-\* sites run after the barrier settles. "none" covers results that never
-\* armed a fresh barrier, such as imported rows and adopted cache-backed
-\* values.
+\* A new Evaluate caller appears, demanding some registered result its
+\* session owns. A caller can only hold a result whose attachment barrier
+\* is not open and not errored: every result-returning API waits at the
+\* barrier and returns errors instead of values. Lazy callbacks are
+\* registered at attachment completion (registerLazyEvaluation,
+\* immediately before the barrier closes) and again when a persisted hit's
+\* value is loaded; both sites run after the barrier settles. "none"
+\* covers results that never armed a fresh barrier, such as imported rows
+\* and adopted cache-backed values. Admission is atomic with the session
+\* tombstone check: a caller reaching the cache after release is refused
+\* without increasing the count.
 EvalSpawn ==
     /\ ModelLazy
     /\ Len(evals) < MaxEvals
-    /\ \E r \in ResultIds :
+    /\ ~flushed.closing
+    /\ \E r \in ResultIds, s \in Sessions :
         /\ res[r].registered
         /\ res[r].barrier \notin {"open", "closedErr"}
-        /\ evals' = Append(evals,
-             [target |-> r, phase |-> "demand", foreignCancel |-> FALSE])
+        /\ <<s, r>> \in sessionEdges
+        /\ LET admitted == sessionRelease[s].phase = "live" IN
+           /\ evals' = Append(evals,
+                [target |-> r, sess |-> s,
+                 phase |-> IF admitted THEN "demand" ELSE "refused",
+                 opActive |-> admitted, foreignCancel |-> FALSE])
+           /\ sessionRelease' = IF admitted
+                THEN [sessionRelease EXCEPT ![s].active = @ + 1]
+                ELSE sessionRelease
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease,
-                   epoch, flushed>>
+                   sessionEdges, countedEdges, epoch, flushed>>
 
 \* A hit loads an imported result's value and registers its lazy work:
 \* ensurePersistedHitValueLoaded calls registerLazyEvaluation after the
@@ -1543,7 +1609,7 @@ EvalNoWork(e) ==
              /\ res[r].lazyCb = "none"
              /\ ~res[r].lazySyncPending
        /\ res' = [res EXCEPT ![r].lazyComplete = TRUE]
-    /\ evals' = [evals EXCEPT ![e].phase = "done",
+    /\ evals' = [evals EXCEPT ![e].phase = "returnDone",
                               ![e].foreignCancel = FALSE]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
@@ -1561,19 +1627,39 @@ EvalNoWork(e) ==
 \* not depend on implementations clearing their callback.
 EvalStartAttempt(e) ==
     /\ evals[e].phase = "demand"
-    /\ LET r == evals[e].target IN
+    /\ LET r == evals[e].target
+           s == evals[e].sess
+       IN
        /\ ~res[r].lazyComplete
        /\ res[r].lazyPhase = "idle"
        /\ res[r].lazyCb = "armed" \/ res[r].lazySyncPending
+       /\ sessionRelease[s].phase = "live"
        /\ res' = [res EXCEPT
             ![r].lazyPhase = IF res[r].lazyCb = "armed"
                              THEN "running" ELSE "syncing",
             ![r].lazyCancel = FALSE,
             ![r].lazyWaiters = @ + 1,
-            ![r].lazyRunning = @ + 1]
+            ![r].lazyRunning = @ + 1,
+            ![r].lazyTokenSession = s]
        /\ evals' = [evals EXCEPT ![e].phase = "waiting",
                                  ![e].foreignCancel = FALSE]
+       /\ sessionRelease' = [sessionRelease EXCEPT ![s].active = @ + 1]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, epoch, flushed>>
+
+\* Release may win after the Evaluate waiter entered but before it tries to
+\* create an attempt. Callback-token admission then refuses the start.
+EvalStartAttemptRefused(e) ==
+    /\ evals[e].phase = "demand"
+    /\ LET r == evals[e].target
+           s == evals[e].sess
+       IN /\ res[r].lazyCb = "armed" \/ res[r].lazySyncPending
+          /\ ~res[r].lazyComplete
+          /\ res[r].lazyPhase = "idle"
+          /\ sessionRelease[s].phase # "live"
+          /\ evals' = [evals EXCEPT ![e].phase = "returnRefused",
+                                    ![e].foreignCancel = FALSE]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
 
@@ -1607,24 +1693,31 @@ EvalBodyFinish(r) ==
     /\ r \in ResultIds
     /\ res[r].lazyPhase = "running"
     /\ res[r].lazyRunning > 0
-    /\ \E outcome \in ({"bodyOk"}
+    /\ res[r].lazyTokenSession \in Sessions
+    /\ LET s == res[r].lazyTokenSession IN
+       \E outcome \in ({"bodyOk"}
             \cup (IF LazyCanFail THEN {"bodyFail"} ELSE {})
             \cup (IF res[r].lazyCancel THEN {"bodyCancel"} ELSE {})) :
         IF outcome = "bodyOk"
         THEN /\ res' = [res EXCEPT ![r].lazyCb = "none",
                                    ![r].lazyPhase = "syncing"]
-             /\ UNCHANGED evals
+             \* The same goroutine continues into bookkeeping, so the
+             \* callback token stays held and no exit is staged.
+             /\ UNCHANGED <<evals, sessionRelease>>
         ELSE /\ res' = [res EXCEPT
                   ![r].lazyRunning = @ - 1,
                   ![r].lazyPhase = "idle",
                   ![r].lazyCancel = FALSE,
-                  ![r].lazyWaiters = 0]
+                  ![r].lazyWaiters = 0,
+                  ![r].lazyTokenSession = 0]
              /\ evals' = LatchEvalOutcomes(r,
                   IF outcome = "bodyFail"
                   THEN "latchedFail" ELSE "latchedCancel")
+             /\ sessionRelease' = IF sessionRelease[s].exitingLazy = 0
+                  THEN [sessionRelease EXCEPT ![s].exitingLazy = 1]
+                  ELSE FinishSessionOperation(sessionRelease, s)
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease,
-                   epoch, flushed>>
+                   sessionEdges, countedEdges, epoch, flushed>>
 
 \* The cache-side bookkeeping finishes and the attempt is retired under
 \* lazyMu. Success marks evaluation complete. Any failure here records
@@ -1639,7 +1732,9 @@ EvalSyncFinish(r) ==
     /\ r \in ResultIds
     /\ res[r].lazyPhase = "syncing"
     /\ res[r].lazyRunning > 0
-    /\ \E outcome \in ({"syncOk"}
+    /\ res[r].lazyTokenSession \in Sessions
+    /\ LET s == res[r].lazyTokenSession IN
+       \E outcome \in ({"syncOk"}
             \cup (IF LazyCanFail THEN {"syncFail"} ELSE {})
             \cup (IF res[r].lazyCancel THEN {"syncCancel"} ELSE {})) :
         /\ res' = [res EXCEPT
@@ -1648,14 +1743,28 @@ EvalSyncFinish(r) ==
              ![r].lazyCancel = FALSE,
              ![r].lazyWaiters = 0,
              ![r].lazyComplete = @ \/ outcome = "syncOk",
-             ![r].lazySyncPending = outcome # "syncOk"]
+             ![r].lazySyncPending = outcome # "syncOk",
+             ![r].lazyTokenSession = 0]
         /\ evals' = LatchEvalOutcomes(r,
              CASE outcome = "syncOk" -> "latchedDone"
                [] outcome = "syncFail" -> "latchedFail"
                [] OTHER -> "latchedCancel")
+        /\ sessionRelease' = IF sessionRelease[s].exitingLazy = 0
+             THEN [sessionRelease EXCEPT ![s].exitingLazy = 1]
+             ELSE FinishSessionOperation(sessionRelease, s)
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
-                   sessionEdges, countedEdges, sessionRelease,
-                   epoch, flushed>>
+                   sessionEdges, countedEdges, epoch, flushed>>
+
+\* The callback goroutine's deferred token release occurs after done closes.
+\* Multiple completed attempts may be in this tail at once. The saturating
+\* flag represents their shared release hold; this action is their final exit.
+EvalCallbackTokenExit(s) ==
+    /\ sessionRelease[s].exitingLazy > 0
+    /\ sessionRelease[s].active > 0
+    /\ LET finished == FinishSessionOperation(sessionRelease, s) IN
+       sessionRelease' = [finished EXCEPT ![s].exitingLazy = @ - 1]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, evals, epoch, flushed>>
 
 \* Closing the retired attempt's done channel is the lock-free region after
 \* callback finish. Each transition below represents that broadcast becoming
@@ -1678,8 +1787,8 @@ EvalCallbackClose(e) ==
 EvalWake(e) ==
     /\ evals[e].phase \in EvalWakePhases
     /\ evals' = [evals EXCEPT
-         ![e].phase = CASE @ = "wakeDone" -> "done"
-                           [] @ = "wakeFail" -> "failedCallback"
+         ![e].phase = CASE @ = "wakeDone" -> "returnDone"
+                           [] @ = "wakeFail" -> "returnFailed"
                            [] OTHER -> "demand",
          ![e].foreignCancel = (evals[e].phase = "wakeCancel")]
     /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
@@ -1701,11 +1810,32 @@ EvalAbandon(e) ==
                          ![r].lazyWaiters = @ - 1,
                          ![r].lazyCancel = @ \/ last]
                     ELSE res
-          /\ evals' = [evals EXCEPT ![e].phase = "abandoned",
+          /\ evals' = [evals EXCEPT ![e].phase = "returnAbandoned",
                                      ![e].foreignCancel = FALSE]
     /\ UNCHANGED <<invocations, ongoingCalls, ongoingCallIndex,
                    sessionEdges, countedEdges, sessionRelease,
                    epoch, flushed>>
+
+\* Evaluate's outer operation exits after its final return decision. A
+\* successful Evaluate is changed to a released-session refusal if release
+\* began while it was active.
+EvalOperationExit(e) ==
+    /\ evals[e].phase \in EvalExitPhases
+    /\ evals[e].opActive
+    /\ LET s == evals[e].sess
+           success == evals[e].phase = "returnDone"
+           lateRefusal == success /\ sessionRelease[s].phase # "live"
+           terminal == CASE lateRefusal -> "refused"
+                         [] evals[e].phase = "returnDone" -> "done"
+                         [] evals[e].phase = "returnFailed" -> "failedCallback"
+                         [] evals[e].phase = "returnAbandoned" -> "abandoned"
+                         [] OTHER -> "refused"
+       IN /\ sessionRelease[s].active > 0
+          /\ sessionRelease' = FinishSessionOperation(sessionRelease, s)
+          /\ evals' = [evals EXCEPT ![e].phase = terminal,
+                                    ![e].opActive = FALSE]
+    /\ UNCHANGED <<invocations, res, ongoingCalls, ongoingCallIndex,
+                   sessionEdges, countedEdges, epoch, flushed>>
 
 ---------------------------------------------------------------------------
 \* Everything that can happen, from any state: some invocation takes its
@@ -1726,20 +1856,26 @@ Next ==
          \/ ReadBarrierCancelHit(i) \/ ReadBarrierCancelWait(i)
          \/ DecodeLead(i) \/ DecodeLeadFinish(i) \/ DecodeJoin(i)
          \/ DecodeWake(i) \/ DecodeFailHit(i) \/ DecodeFailWait(i)
+         \/ InvocationOperationExit(i)
     \/ \E o \in OngoingCallIds :
          \/ FnComplete(o) \/ PubBegin(o)
          \/ PubIndexFresh(o) \/ PubAdopt(o) \/ PubIndexReuse(o)
          \/ PubAttachAddDep(o) \/ PubFinishOk(o)
          \/ PubAttachFailDropHold(o) \/ PubAttachFailCloseBarrier(o)
          \/ PubUnregister(o) \/ FnWindDown(o)
-    \/ \E s \in Sessions : ReleaseSessionRecord(s) \/ ReleaseSessionCollect(s)
+    \/ \E s \in Sessions :
+         ReleaseSessionMark(s) \/ ReleaseSessionSnapshot(s)
+           \/ ReleaseSessionCollect(s) \/ ReleaseSessionDelete(s)
     \/ \E r \in 1..Len(res) : PruneCut(r)
     \/ EvalSpawn
     \/ \E e \in EvalIds :
-         \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalJoin(e)
-         \/ EvalCallbackClose(e) \/ EvalWake(e) \/ EvalAbandon(e)
+         \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalStartAttemptRefused(e)
+         \/ EvalJoin(e) \/ EvalCallbackClose(e) \/ EvalWake(e)
+         \/ EvalAbandon(e) \/ EvalOperationExit(e)
     \/ \E r \in 1..Len(res) :
          EvalBodyFinish(r) \/ EvalSyncFinish(r) \/ ImportedLazyArm(r)
+    \/ \E s \in Sessions : EvalCallbackTokenExit(s)
+    \/ BeginClose
     \/ Flush
     \/ Restart
 
@@ -1761,9 +1897,9 @@ Spec == Init /\ [][Next]_vars
 (*   - WaiterCancel, WaiterCancelLate, ReadBarrierCancelHit/Wait, and      *)
 (*     every failure-injection branch: possibilities, not obligations      *)
 (*   - ReleaseSession and PruneCut: external events                        *)
-(*   - FnWindDown: how long a canceled executor unwinds is external.       *)
-(*     (No liveness configuration enables ModelNestedCalls, so this        *)
-(*     cannot mask a wedge today.)                                         *)
+(*   - FnWindDown: how long a canceled executor unwinds is external. The   *)
+(*     deferred-release property is conditional on the cache operation     *)
+(*     count, so it does not assume a canceled executor itself unwinds.     *)
 (*                                                                         *)
 (* Two placement subtleties:                                               *)
 (*   - FnComplete's fairness guarantees SOME outcome, not a successful     *)
@@ -1790,11 +1926,13 @@ WaiterProgress(i) ==
     \/ ReadBarrierErrHit(i) \/ ReadBarrierErrWait(i)
     \/ DecodeLead(i) \/ DecodeLeadFinish(i) \/ DecodeJoin(i)
     \/ DecodeWake(i) \/ DecodeFailHit(i) \/ DecodeFailWait(i)
+    \/ InvocationOperationExit(i)
 
 \* An evaluator's own forward steps. Abandoning is deliberately NOT here:
 \* giving up is a caller's choice, never an obligation.
 EvalProgress(e) ==
-    \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalJoin(e) \/ EvalWake(e)
+    \/ EvalNoWork(e) \/ EvalStartAttempt(e) \/ EvalStartAttemptRefused(e)
+    \/ EvalJoin(e) \/ EvalWake(e) \/ EvalOperationExit(e)
 
 \* Callback completion always proceeds to close the retired attempt's done
 \* channel. This fairness covers the lock-free close becoming observable to
@@ -1807,6 +1945,14 @@ LazyCallbackCloseProgress(e) == EvalCallbackClose(e)
 \* alone would wrongly forbid persistent failure.
 LazyCallbackProgress(r) ==
     EvalBodyFinish(r) \/ EvalSyncFinish(r)
+
+\* Publishing a release plan and consuming assigned cleanup are system
+\* progress. ReleaseSessionMark itself remains an external event.
+ReleaseProgress(s) ==
+    ReleaseSessionSnapshot(s) \/ ReleaseSessionCollect(s) \/ ReleaseSessionDelete(s)
+
+\* The callback goroutine releases its attempt token after closing done.
+LazyCallbackTokenProgress(s) == EvalCallbackTokenExit(s)
 
 LiveSpec ==
     /\ Spec
@@ -1822,17 +1968,28 @@ LiveSpec ==
          WF_vars(e \in EvalIds /\ LazyCallbackCloseProgress(e))
     /\ \A r \in 1..MaxResults :
          WF_vars(r \in ResultIds /\ LazyCallbackProgress(r))
+    /\ \A s \in Sessions : WF_vars(ReleaseProgress(s))
+    /\ \A s \in Sessions : WF_vars(LazyCallbackTokenProgress(s))
 
 ---------------------------------------------------------------------------
 (***************************************************************************)
-(* PROPERTIES. All but the last are safety invariants: TLC checks them in  *)
-(* every reachable state. EventuallyTerminal is the one liveness           *)
-(* property, checked against LiveSpec. Each .cfg selects only the subset   *)
+(* PROPERTIES. The invariants below are checked in every reachable state.  *)
+(* EvalEventuallyTerminal, DeferredReleaseEventuallyCompletes, and         *)
+(* EventuallyTerminal are liveness properties checked against LiveSpec.    *)
+(* Each .cfg selects only the subset                                       *)
 (* that isolates its question - checking every property in every           *)
 (* configuration would conflate independent questions: a scenario that     *)
 (* exercises one failure could drown the property under test in violations *)
 (* of unrelated properties.                                                *)
 (***************************************************************************)
+
+DerivedSessionActive(s) ==
+    Cardinality({i \in InvocationIds :
+        invocations[i].sess = s /\ invocations[i].opActive})
+      + Cardinality({e \in EvalIds :
+        evals[e].sess = s /\ evals[e].opActive})
+      + Cardinality({r \in ResultIds : res[r].lazyTokenSession = s})
+      + sessionRelease[s].exitingLazy
 
 \* Basic shape sanity: bounds respected, counts non-negative, and no
 \* counted edge without its record.
@@ -1840,14 +1997,21 @@ TypeOK ==
     /\ Len(invocations) <= MaxInvocations
     /\ Len(res) <= MaxResults
     /\ Len(evals) <= MaxEvals
-    \* A counted edge's record can be gone only while its session's
-    \* release is between its two critical sections (records wiped,
-    \* decrements pending).
-    /\ \A e \in countedEdges :
-         e \in sessionEdges
-           \/ (sessionRelease[e[1]].phase = "collecting"
-                 /\ e[2] \in sessionRelease[e[1]].snap)
+    /\ countedEdges \subseteq sessionEdges
     /\ epoch \in {1, 2}
+    /\ flushed.closing \in BOOLEAN
+    /\ \A s \in Sessions :
+         /\ sessionRelease[s].phase \in
+              {"live", "marking", "deferred", "collecting", "deleting", "released"}
+         /\ sessionRelease[s].active \in Nat
+         /\ sessionRelease[s].exitingLazy \in 0..1
+         /\ sessionRelease[s].exitingLazy <= sessionRelease[s].active
+         /\ sessionRelease[s].active = DerivedSessionActive(s)
+         /\ sessionRelease[s].phase = "deferred" => sessionRelease[s].active > 0
+         /\ sessionRelease[s].phase \in {"collecting", "deleting", "released"}
+              => sessionRelease[s].active = 0
+         /\ sessionRelease[s].phase = "released"
+              => sessionRelease[s].snap = {}
     /\ \A o \in OngoingCallIds : ongoingCalls[o].waiters >= 0
     /\ \A r \in ResultIds :
          /\ res[r].lazyWaiters >= 0 /\ res[r].lazyRunning >= 0
@@ -1856,18 +2020,22 @@ TypeOK ==
          /\ res[r].lazyCb \in {"none", "armed"}
          /\ res[r].lazyCancel \in BOOLEAN
          /\ res[r].lazySyncPending \in BOOLEAN
+         /\ res[r].lazyTokenSession \in Sessions \cup {0}
+         /\ (res[r].lazyRunning = 0) = (res[r].lazyTokenSession = 0)
          /\ res[r].lazyWaiters = Cardinality(
               {e \in EvalIds :
                   evals[e].target = r /\ evals[e].phase = "waiting"})
     /\ \A e \in EvalIds :
          /\ evals[e].phase \in EvalPhaseDomain
          /\ evals[e].foreignCancel \in BOOLEAN
+         /\ evals[e].sess \in Sessions
+         /\ evals[e].opActive \in BOOLEAN
     /\ \A i \in InvocationIds :
          /\ invocations[i].origin \in {"handler", "nested"}
+         /\ invocations[i].opActive \in BOOLEAN
          /\ invocations[i].refusedEpoch \in 0..epoch
          /\ invocations[i].lookupBarrierAtSelection
               \in {"none", "open", "closedOk", "closedErr"}
-
 \* Ownership accounting is exact: for every registered result, the
 \* incrementally-maintained counter equals the recount of its edges
 \* (counted session edges + dependency parents + handoff holds +
@@ -1920,7 +2088,7 @@ PersistableIntentDurable ==
 LeaseFailureClean ==
     \A i \in InvocationIds :
         invocations[i].path = "leaseFailure" =>
-            /\ invocations[i].phase = "failed"
+            /\ invocations[i].phase \in {"failing", "failed"}
             /\ invocations[i].oc = 0
             /\ invocations[i].resId = 0
 
@@ -2003,6 +2171,15 @@ LazyCompleteSettled ==
 LazySuccessPermanent ==
     \A r \in ResultIds : res[r].lazyComplete => res[r].lazyRunning = 0
 
+\* A running callback or its post-close token tail keeps its owner session
+\* out of collection. This is the attempt-lifetime guarantee: waiter exit
+\* alone cannot make release eligible while the callback goroutine remains.
+LazyAttemptDefersCollection ==
+    \A s \in Sessions :
+        (\/ sessionRelease[s].exitingLazy > 0
+         \/ \E r \in ResultIds : res[r].lazyTokenSession = s)
+            => sessionRelease[s].phase \notin {"collecting", "deleting", "released"}
+
 \* An Evaluate caller never returns a cancellation error caused by another
 \* waiter. foreignCancel becomes true when the canceled callback's outcome is
 \* latched on its retained waiters and remains true as a healthy waiter returns
@@ -2028,12 +2205,10 @@ DecodeMutualExclusion ==
             invocations[i].phase = "decoding"
               /\ invocations[i].resId = r}) <= 1
 
-\* The graceful-shutdown snapshot captures only clean, fully-retained
-\* state: every kept row had a cleanly-closed (or never-armed) attach
-\* barrier and ownership fully explained by persisted + dependency edges.
-\* Violated when the flush races an unfinished publication - reachable
-\* because the cache itself never waits for in-flight work; only the
-\* server's drain does.
+\* The graceful-shutdown snapshot captures only clean, fully-retained state:
+\* every kept row had a cleanly-closed (or never-armed) attach barrier and
+\* ownership fully explained by persisted and dependency edges. Flush is
+\* enabled only after operation and deferred-cleanup quiescence.
 FlushCleanCapture ==
     flushed.done =>
         \A r \in DOMAIN flushed.rows :
@@ -2069,6 +2244,15 @@ EvalEventuallyTerminal ==
     \A e \in 1..MaxEvals :
         (e \in EvalIds) ~>
             (e \in EvalIds /\ evals[e].phase \in EvalTerminalPhases)
+
+\* Once a release has a quiescent operation count, fair system progress
+\* eventually consumes its cleanup plan and deletes the session records.
+\* This is deliberately conditional: a genuinely wedged operation keeps
+\* active nonzero and causes shutdown-context failure instead of a snapshot.
+DeferredReleaseEventuallyCompletes ==
+    \A s \in Sessions :
+        (sessionRelease[s].phase # "live" /\ sessionRelease[s].active = 0)
+          ~> (sessionRelease[s].phase = "released")
 
 \* Liveness (against LiveSpec): every issued call eventually terminates -
 \* served, failed, or canceled, never wedged forever.

--- a/dagql/tla/CacheLifecycle_drain_escape.cfg
+++ b/dagql/tla/CacheLifecycle_drain_escape.cfg
@@ -25,5 +25,5 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK ReturnedLive
+INVARIANTS TypeOK ReturnedLive OwnershipExact
 PROPERTY DeferredReleaseEventuallyCompletes

--- a/dagql/tla/CacheLifecycle_drain_escape.cfg
+++ b/dagql/tla/CacheLifecycle_drain_escape.cfg
@@ -1,10 +1,8 @@
-\* The release_inflight outcome with the server's drain HONORED: the drain
-\* (dagqlInFlight, session.go:603-608) counts only serveQuery handlers,
-\* while a canceled call's executor keeps issuing nested cache calls with
-\* the same session ID as it winds down. The drain passes, release runs
-\* mid-claim, and the nested caller is handed a collected result.
-\* Expected: ReturnedLive violated.
-SPECIFICATION Spec
+\* The server drain is honored while a canceled executor issues a nested
+\* cache call. The cache count covers that nested call, late success is
+\* refused, and deferred cleanup eventually completes.
+\* Expected: pass.
+SPECIFICATION LiveSpec
 CONSTANTS
     Sessions = {s1}
     s1 = s1
@@ -27,4 +25,5 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS ReturnedLive
+INVARIANTS TypeOK ReturnedLive
+PROPERTY DeferredReleaseEventuallyCompletes

--- a/dagql/tla/CacheLifecycle_drain_orphan.cfg
+++ b/dagql/tla/CacheLifecycle_drain_orphan.cfg
@@ -23,4 +23,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease ReturnedLive

--- a/dagql/tla/CacheLifecycle_flush_closure.cfg
+++ b/dagql/tla/CacheLifecycle_flush_closure.cfg
@@ -25,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushReferentialIntegrity NoLaunderedServe NoRetainedPoisonedEntry NoErroredLookupSelection
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushReferentialIntegrity NoLaunderedServe NoRetainedPoisonedEntry NoErroredLookupSelection ReturnedLive

--- a/dagql/tla/CacheLifecycle_flush_drained.cfg
+++ b/dagql/tla/CacheLifecycle_flush_drained.cfg
@@ -25,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK FlushCleanCapture
+INVARIANTS TypeOK FlushCleanCapture ReturnedLive

--- a/dagql/tla/CacheLifecycle_flush_drained.cfg
+++ b/dagql/tla/CacheLifecycle_flush_drained.cfg
@@ -1,8 +1,7 @@
-\* The flush_inflight outcome with every session released and the drain
-\* honored: an executor-nested call can still adopt a clean persisted result
-\* and hold transient publication ownership because the drain does not cover
-\* the executor.
-\* Expected: FlushCleanCapture violated.
+\* The handler drain is honored while detached executor work remains. Cache
+\* operation quiescence, not the drain, prevents a transient publication hold
+\* from entering the shutdown snapshot.
+\* Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}
@@ -26,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS FlushCleanCapture
+INVARIANTS TypeOK FlushCleanCapture

--- a/dagql/tla/CacheLifecycle_flush_inflight.cfg
+++ b/dagql/tla/CacheLifecycle_flush_inflight.cfg
@@ -1,6 +1,6 @@
-\* Flush racing an unfinished publication: a clean persisted result can be
-\* adopted by redundant execution and carry a transient handoff hold when the
-\* shutdown snapshot captures it. Expected: FlushCleanCapture violated.
+\* Shutdown begins during publication. The cache refuses new operations and
+\* waits for operation and deferred-cleanup quiescence before snapshotting.
+\* Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
     Sessions = {s1}
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS FlushCleanCapture
+INVARIANTS TypeOK FlushCleanCapture

--- a/dagql/tla/CacheLifecycle_flush_inflight.cfg
+++ b/dagql/tla/CacheLifecycle_flush_inflight.cfg
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK FlushCleanCapture
+INVARIANTS TypeOK FlushCleanCapture ReturnedLive

--- a/dagql/tla/CacheLifecycle_flush_roundtrip.cfg
+++ b/dagql/tla/CacheLifecycle_flush_roundtrip.cfg
@@ -26,4 +26,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushCleanCapture FlushReferentialIntegrity NoLaunderedServe
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection FlushCleanCapture FlushReferentialIntegrity NoLaunderedServe ReturnedLive

--- a/dagql/tla/CacheLifecycle_lazy.cfg
+++ b/dagql/tla/CacheLifecycle_lazy.cfg
@@ -1,6 +1,10 @@
 \* Lazy evaluation with callback failures injected: at most one callback per
 \* result, success permanent, failure and foreign cancellation retryable,
-\* accounting exact.
+\* accounting exact. Two callers cover leader/joiner exclusion; the separate
+\* stale-cancellation gate retains its three-caller scenario. A one-time
+\* exhaustive three-caller run of this configuration on the merged model
+\* passed at 78,792,507 distinct states (2026-08-21); it stays at two
+\* callers here because that cost is disproportionate for CI.
 \* Expected: pass.
 SPECIFICATION Spec
 CONSTANTS
@@ -15,7 +19,7 @@ CONSTANTS
     DrainOnRelease = FALSE
     AllowPruneCut = FALSE
     ModelLazy = TRUE
-    MaxEvals = 3
+    MaxEvals = 2
     ModelPersistence = FALSE
     ImportInit = FALSE
     ModelNestedCalls = FALSE

--- a/dagql/tla/CacheLifecycle_lazy_import.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_import.cfg
@@ -30,4 +30,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = TRUE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact LazyMutualExclusion LazySuccessPermanent NoStaleCancelError EvalDoneComplete LazyCompleteSettled
+INVARIANTS TypeOK OwnershipExact LazyMutualExclusion LazySuccessPermanent NoStaleCancelError EvalDoneComplete LazyCompleteSettled ReturnedLive NoUnderflow LazyAttemptDefersCollection

--- a/dagql/tla/CacheLifecycle_lazy_release.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_release.cfg
@@ -1,6 +1,6 @@
-\* Session release while a cache operation is between claiming its edge and
-\* returning. Release defers collection, operation exit refuses the doomed
-\* success, and the assigned cleanup eventually completes.
+\* A lazy callback outlives its waiter while the callback's session is
+\* released. The attempt token defers collection until the callback goroutine
+\* exits; the outer Evaluate operation also obeys late-success refusal.
 \* Expected: pass.
 SPECIFICATION LiveSpec
 CONSTANTS
@@ -9,13 +9,13 @@ CONSTANTS
     Calls = {cA}
     cA = cA
     ClassOf <- OneClass
-    MaxInvocations = 2
+    MaxInvocations = 1
     MaxResults = 1
     AllowRelease = TRUE
     DrainOnRelease = FALSE
     AllowPruneCut = FALSE
-    ModelLazy = FALSE
-    MaxEvals = 0
+    ModelLazy = TRUE
+    MaxEvals = 1
     ModelPersistence = FALSE
     ImportInit = FALSE
     ModelNestedCalls = FALSE
@@ -25,5 +25,5 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK ReturnedLive
+INVARIANTS TypeOK ReturnedLive LazyAttemptDefersCollection
 PROPERTY DeferredReleaseEventuallyCompletes

--- a/dagql/tla/CacheLifecycle_lazy_release.cfg
+++ b/dagql/tla/CacheLifecycle_lazy_release.cfg
@@ -25,5 +25,5 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK ReturnedLive LazyAttemptDefersCollection
+INVARIANTS TypeOK ReturnedLive LazyAttemptDefersCollection OwnershipExact EvalDoneComplete LazyCompleteSettled LazyMutualExclusion
 PROPERTY DeferredReleaseEventuallyCompletes

--- a/dagql/tla/CacheLifecycle_orphan_edges.cfg
+++ b/dagql/tla/CacheLifecycle_orphan_edges.cfg
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease PersistableIntentDurable
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease PersistableIntentDurable ReturnedLive

--- a/dagql/tla/CacheLifecycle_poisoned_restart.cfg
+++ b/dagql/tla/CacheLifecycle_poisoned_restart.cfg
@@ -25,4 +25,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection NoLaunderedServe FlushReferentialIntegrity NoRetainedPoisonedEntry NoErroredLookupSelection
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection NoLaunderedServe FlushReferentialIntegrity NoRetainedPoisonedEntry NoErroredLookupSelection ReturnedLive

--- a/dagql/tla/CacheLifecycle_release_prune.cfg
+++ b/dagql/tla/CacheLifecycle_release_prune.cfg
@@ -28,4 +28,4 @@ CONSTANTS
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
 SYMMETRY Symm
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoResurrection NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease ReturnedLive

--- a/dagql/tla/CacheLifecycle_release_steal.cfg
+++ b/dagql/tla/CacheLifecycle_release_steal.cfg
@@ -24,4 +24,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease ReturnedLive

--- a/dagql/tla/CacheLifecycle_rollback.cfg
+++ b/dagql/tla/CacheLifecycle_rollback.cfg
@@ -23,4 +23,4 @@ CONSTANTS
     ReaderCanCancel = TRUE
     LazyCanFail = FALSE
     DecodeCanFail = FALSE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease NoRetainedPoisonedEntry NoErroredLookupSelection
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease NoRetainedPoisonedEntry NoErroredLookupSelection ReturnedLive

--- a/dagql/tla/CacheLifecycle_rollback_decode.cfg
+++ b/dagql/tla/CacheLifecycle_rollback_decode.cfg
@@ -23,4 +23,4 @@ CONSTANTS
     ReaderCanCancel = FALSE
     LazyCanFail = FALSE
     DecodeCanFail = TRUE
-INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease
+INVARIANTS TypeOK OwnershipExact NoUnderflow NoOrphanEdgesAtQuiescence RefusedOnlyAfterRelease ReturnedLive

--- a/dagql/tla/README.md
+++ b/dagql/tla/README.md
@@ -10,8 +10,8 @@ explains the modeling rules, and every action's comment names the Go code
 it models. Each `CacheLifecycle_*.cfg` checks one scenario; the comment
 at the top of each config says what the scenario is and whether the run
 is expected to pass or to violate one named invariant. Expected
-violations reproduce known deficiencies in the current code, so the check
-fails if a deficiency silently disappears or changes shape.
+violations are reserved for deliberately accepted model findings; the
+current configuration set consists entirely of green regression gates.
 
 Run the check:
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -660,9 +660,12 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	// cleanup analytics and telemetry
 	errs = errors.Join(errs, sess.analytics.Close())
 
-	// (queries were already drained above, before the completeness stamp + telemetry
-	// shutdown, so dagql is quiescent here for the cache release.)
+	// Handler-origin queries were drained above for telemetry completeness. A
+	// canceled handler's detached cache executor may still be unwinding, so the
+	// cache provides its own operation accounting and deferred cleanup safety.
 
+	// ReleaseSession may assign cleanup to an active detached cache operation,
+	// so these immediate before/after values are an approximate debug snapshot.
 	beforeDagqlEntries := srv.engineCache.Size()
 	beforeDagqlStats := srv.engineCache.EntryStats()
 	if err := srv.engineCache.ReleaseSession(ctx, sess.sessionID); err != nil {


### PR DESCRIPTION
## Summary

The dagql cache could not see its own in-flight work. Session release could therefore collect a result after a cache operation claimed it but before that operation returned, including work from detached executors that the server handler drain cannot count. The same gap allowed shutdown persistence to observe transient publication ownership.

This is layer four of the cache-remediation stack and depends on #13938, #13936, and #13934.

## Design

- Add a per-session lifecycle record that packs the released tombstone and active-operation count into one atomic word. Operation admission and release are linearized with compare-and-swap without taking a cache-wide mutex.
- Count operations at every value-bearing cache boundary, including call lookup/initialization, result attachment and ID loads, Evaluate waiters, each lazy callback attempt, snapshot lease synchronization, and the arbitrary-value cache.
- Mark a session dead immediately in ReleaseSession. If work is active, cleanup is irrevocably assigned to the last exiting operation; if no work is active, release performs cleanup immediately.
- Refuse a value-bearing success at operation exit when release won the race, so detached work cannot return a result whose cleanup is eligible.
- Make Cache.Close reject new work, wait for operation and deferred-cleanup quiescence on its caller context, and fail dirty if the context expires or deferred cleanup failed. It never takes a timed-out snapshot or writes a clean marker after such a failure.
- Give lazy callbacks their own attempt-lifetime token, held until the callback goroutine actually exits rather than only until its waiters return. The token covers both stages of an attempt (callback body, then cache-side bookkeeping) and bookkeeping-only retry attempts.
- Refuse telemetry span capture for released sessions. The two span writers now match the other per-session map writers, so no writer can recreate a released session's maps. Under this layer's operation accounting every current caller is already enclosed by a counted operation; the guards keep that safe independent of future callers.
- Check mutation-helper registration by ID membership. Numeric result IDs are engine-lifetime unique (#13934), so the four e-graph mutation helpers guard against operating on a collected result with a plain registration check instead of pointer identity.

## Contract and cost

- ReleaseSession returning now means the session is dead and cleanup is complete or irrevocably assigned. Cleanup hooks may run later on another caller goroutine.
- Deferred cleanup errors are logged when observed, accumulated by the cache, and returned from Cache.Close.
- New claims and late value-bearing returns for released sessions fail with ErrCacheSessionReleased.
- Immediate before/after cache-size logging during session teardown is approximate because cleanup may be deferred.
- The uncontended hot path adds one per-session map lookup and two atomic compare-and-swaps per counted operation, with no cache-wide mutex acquisition.
- Per-session lifecycle records remain for the engine lifetime. This is intentional because server session IDs are single-use and retaining the tombstone closes the admission race.

## Model

The TLA+ model now faithfully represents operation admission and exit, deferred release, shutdown quiescence, and lazy callback attempt tokens, layered over the current two-stage lazy attempt model (callback body, then cache-side bookkeeping). The four former expected-failure configurations for release-in-flight, drain escape, flush-in-flight, and flush-with-drain are strengthened green gates, with a conditional liveness property that assigned cleanup eventually completes. A new lazy_release configuration gates callback-token deferral.

Invariant coverage was widened after review: every release-enabled configuration now checks the live-return property, and the lazy_import configuration (the only one combining release, lazy work, import, and flush) gates the return-boundary and token-deferral properties.

All 25 configurations are green. A one-time exhaustive three-evaluator run of the lazy configuration also passed, at 78,792,507 distinct states; the configuration stays at two evaluators for CI cost.

## Validation

- `go test ./dagql -count=1`
- `go test ./engine/server -count=1`
- Targeted `go test -race ./dagql` coverage for operation counting, deferred release, lazy callback lifetime, arbitrary-value cleanup, shutdown cancellation, and released-session span capture
- `go vet ./dagql ./engine/server` — the dagql package was clean; engine/server reported one pre-existing unrelated context-cancel finding
- `dagger check tla-check:cache-lifecycle` — 25 configurations green
- `dagger check dagger-go-sdk:generate`

No integration test suite was run.
