### PR TITLE
cli: compose dagger setup progress

### DIFF
--- a/dagql/idtui/explicit_choice.go
+++ b/dagql/idtui/explicit_choice.go
@@ -1,0 +1,181 @@
+package idtui
+
+import (
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ExplicitChoice renders a select as a row of plainly labeled choices with a
+// textual focus marker. It is the multi-option counterpart to ExplicitConfirm.
+type ExplicitChoice[T comparable] struct {
+	selectField *huh.Select[T]
+	options     []huh.Option[T]
+	value       *T
+	focused     bool
+	title       string
+	titleLink   string
+	description string
+	theme       *huh.Theme
+	keymap      huh.SelectKeyMap
+}
+
+var _ huh.Field = (*ExplicitChoice[string])(nil)
+
+func NewExplicitChoice[T comparable](value *T, options ...huh.Option[T]) *ExplicitChoice[T] {
+	field := &ExplicitChoice[T]{
+		options: options,
+		value:   value,
+		keymap:  huh.NewDefaultKeyMap().Select,
+	}
+	field.selectField = huh.NewSelect[T]().Options(options...).Value(value).Inline(true)
+	return field
+}
+
+func (field *ExplicitChoice[T]) Title(title string) *ExplicitChoice[T] {
+	field.title = title
+	field.selectField.Title(title)
+	return field
+}
+
+func (field *ExplicitChoice[T]) TitleLink(url string) *ExplicitChoice[T] {
+	field.titleLink = url
+	return field
+}
+
+func (field *ExplicitChoice[T]) Description(description string) *ExplicitChoice[T] {
+	field.description = description
+	field.selectField.Description(description)
+	return field
+}
+
+func (field *ExplicitChoice[T]) Init() tea.Cmd { return field.selectField.Init() }
+
+func (field *ExplicitChoice[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	model, cmd := field.selectField.Update(msg)
+	field.selectField = model.(*huh.Select[T])
+	return field, cmd
+}
+
+func (field *ExplicitChoice[T]) View() string {
+	theme := field.theme
+	if theme == nil {
+		theme = huh.ThemeBase16()
+	}
+	styles := &theme.Blurred
+	if field.focused {
+		styles = &theme.Focused
+	}
+
+	var view strings.Builder
+	if field.title != "" {
+		title := explicitConfirmTitleStyle(styles).Render(field.title)
+		if field.titleLink != "" {
+			title = ansi.SetHyperlink(field.titleLink) + title + ansi.ResetHyperlink()
+		}
+		view.WriteString(title)
+	}
+	if field.description != "" {
+		view.WriteByte('\n')
+		view.WriteString(styles.Description.Render(field.description))
+	}
+	if view.Len() > 0 {
+		view.WriteString("\n\n")
+	}
+
+	for i, option := range field.options {
+		if i > 0 {
+			view.WriteString("     ")
+		}
+		selected := field.value != nil && option.Value == *field.value
+		marker := "  "
+		style := styles.BlurredButton
+		if field.focused && selected {
+			marker = "▶ "
+			style = styles.FocusedButton
+		}
+		view.WriteString(marker + style.Render(option.Key))
+	}
+	return styles.Base.Render(view.String())
+}
+
+func (field *ExplicitChoice[T]) Blur() tea.Cmd {
+	field.focused = false
+	return field.selectField.Blur()
+}
+
+func (field *ExplicitChoice[T]) Focus() tea.Cmd {
+	field.focused = true
+	return field.selectField.Focus()
+}
+
+func (field *ExplicitChoice[T]) Error() error { return field.selectField.Error() }
+func (field *ExplicitChoice[T]) Skip() bool   { return field.selectField.Skip() }
+func (field *ExplicitChoice[T]) Zoom() bool   { return field.selectField.Zoom() }
+func (field *ExplicitChoice[T]) KeyBinds() []key.Binding {
+	choose := key.NewBinding(
+		key.WithKeys("left", "right", "h", "l"),
+		key.WithHelp("←/→", "choose"),
+	)
+	return []key.Binding{choose, field.keymap.Submit}
+}
+func (field *ExplicitChoice[T]) GetKey() string { return field.selectField.GetKey() }
+func (field *ExplicitChoice[T]) GetValue() any  { return field.selectField.GetValue() }
+func (field *ExplicitChoice[T]) Run() error     { return field.selectField.Run() }
+func (field *ExplicitChoice[T]) RunAccessible(w io.Writer, r io.Reader) error {
+	return field.selectField.RunAccessible(w, r)
+}
+
+func (field *ExplicitChoice[T]) WithTheme(theme *huh.Theme) huh.Field {
+	local := *theme
+	button := local.Focused.FocusedButton.
+		UnsetBackground().
+		Foreground(lipgloss.Color("8")).
+		Padding(0).
+		MarginRight(0).
+		Bold(false).
+		Faint(false)
+	local.Focused.FocusedButton = button.Bold(true)
+	local.Focused.BlurredButton = button
+	local.Blurred.FocusedButton = button
+	local.Blurred.BlurredButton = button
+	field.theme = &local
+	field.selectField.WithTheme(&local)
+	return field
+}
+
+func (field *ExplicitChoice[T]) WithAccessible(accessible bool) huh.Field {
+	field.selectField.WithAccessible(accessible)
+	return field
+}
+
+func (field *ExplicitChoice[T]) WithKeyMap(keymap *huh.KeyMap) huh.Field {
+	local := *keymap
+	local.Select.Left.SetEnabled(true)
+	local.Select.Right.SetEnabled(true)
+	local.Select.Up.SetEnabled(false)
+	local.Select.Down.SetEnabled(false)
+	field.keymap = local.Select
+	field.selectField.WithKeyMap(&local)
+	return field
+}
+
+func (field *ExplicitChoice[T]) WithWidth(width int) huh.Field {
+	field.selectField.WithWidth(width)
+	return field
+}
+
+func (field *ExplicitChoice[T]) WithHeight(height int) huh.Field {
+	field.selectField.WithHeight(height)
+	return field
+}
+
+func (field *ExplicitChoice[T]) WithPosition(position huh.FieldPosition) huh.Field {
+	field.selectField.WithPosition(position)
+	return field
+}

--- a/dagql/idtui/explicit_choice.go
+++ b/dagql/idtui/explicit_choice.go
@@ -150,7 +150,8 @@ func (field *ExplicitChoice[T]) WithTheme(theme *huh.Theme) huh.Field {
 }
 
 func (field *ExplicitChoice[T]) WithAccessible(accessible bool) huh.Field {
-	field.selectField.WithAccessible(accessible)
+	// Huh calls RunAccessible directly; its old WithAccessible toggle is
+	// deprecated and no longer needs to be forwarded.
 	return field
 }
 

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // ExplicitConfirm wraps huh.Confirm with a textual focus marker. Huh's stock
@@ -64,6 +65,9 @@ func (field *ExplicitConfirm) syncLabels() {
 func (field *ExplicitConfirm) Init() tea.Cmd { return field.confirm.Init() }
 
 func (field *ExplicitConfirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "up" {
+		return field, huh.PrevField
+	}
 	model, cmd := field.confirm.Update(msg)
 	field.confirm = model.(*huh.Confirm)
 	field.syncLabels()
@@ -108,8 +112,12 @@ func (field *ExplicitConfirm) RunAccessible(w io.Writer, r io.Reader) error {
 
 func (field *ExplicitConfirm) WithTheme(theme *huh.Theme) huh.Field {
 	local := *theme
-	button := local.Focused.FocusedButton.UnsetBackground().Bold(true).Faint(false)
-	local.Focused.FocusedButton = button
+	button := local.Focused.FocusedButton.
+		UnsetBackground().
+		Foreground(lipgloss.Color("15")).
+		Bold(false).
+		Faint(false)
+	local.Focused.FocusedButton = button.Bold(true)
 	local.Focused.BlurredButton = button
 	local.Blurred.FocusedButton = button
 	local.Blurred.BlurredButton = button

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -185,7 +185,8 @@ func (field *ExplicitConfirm) WithTheme(theme *huh.Theme) huh.Field {
 }
 
 func (field *ExplicitConfirm) WithAccessible(accessible bool) huh.Field {
-	field.confirm.WithAccessible(accessible)
+	// Huh calls RunAccessible directly; its old WithAccessible toggle is
+	// deprecated and no longer needs to be forwarded.
 	return field
 }
 

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -131,9 +131,7 @@ func (field *ExplicitConfirm) KeyBinds() []key.Binding {
 	reject.SetHelp("n", field.negative)
 	return []key.Binding{
 		field.keymap.Toggle,
-		field.keymap.Prev,
 		field.keymap.Submit,
-		field.keymap.Next,
 		accept,
 		reject,
 	}

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -3,6 +3,7 @@ package idtui
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -20,6 +21,11 @@ type ExplicitConfirm struct {
 	affirmative string
 	negative    string
 	focused     bool
+	inline      bool
+	title       string
+	description string
+	theme       *huh.Theme
+	keymap      huh.ConfirmKeyMap
 }
 
 var _ huh.Field = (*ExplicitConfirm)(nil)
@@ -30,36 +36,28 @@ func NewExplicitConfirm(affirmative, negative string, value *bool) *ExplicitConf
 		value:       value,
 		affirmative: affirmative,
 		negative:    negative,
+		keymap:      huh.NewDefaultKeyMap().Confirm,
 	}
-	field.syncLabels()
+	field.confirm.Affirmative(affirmative).Negative(negative)
 	return field
 }
 
 func (field *ExplicitConfirm) Title(title string) *ExplicitConfirm {
+	field.title = title
 	field.confirm.Title(title)
 	return field
 }
 
 func (field *ExplicitConfirm) Description(description string) *ExplicitConfirm {
+	field.description = description
 	field.confirm.Description(description)
 	return field
 }
 
 func (field *ExplicitConfirm) Inline(inline bool) *ExplicitConfirm {
+	field.inline = inline
 	field.confirm.Inline(inline)
 	return field
-}
-
-func (field *ExplicitConfirm) syncLabels() {
-	affirmative := "[ " + field.affirmative + " ]"
-	negative := "[ " + field.negative + " ]"
-	if !field.focused {
-		field.confirm.Affirmative("  " + affirmative).Negative("  " + negative)
-	} else if field.value != nil && *field.value {
-		field.confirm.Affirmative("▶ " + affirmative).Negative("  " + negative)
-	} else {
-		field.confirm.Affirmative("  " + affirmative).Negative("▶ " + negative)
-	}
 }
 
 func (field *ExplicitConfirm) Init() tea.Cmd { return field.confirm.Init() }
@@ -70,42 +68,84 @@ func (field *ExplicitConfirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	model, cmd := field.confirm.Update(msg)
 	field.confirm = model.(*huh.Confirm)
-	field.syncLabels()
 	return field, cmd
 }
 
 func (field *ExplicitConfirm) View() string {
-	field.syncLabels()
-	return field.confirm.View()
+	theme := field.theme
+	if theme == nil {
+		theme = huh.ThemeBase16()
+	}
+	styles := &theme.Blurred
+	if field.focused {
+		styles = &theme.Focused
+	}
+
+	var view strings.Builder
+	if field.title != "" {
+		view.WriteString(styles.Title.Render(field.title))
+	}
+	if field.description != "" {
+		if !field.inline {
+			view.WriteByte('\n')
+		}
+		view.WriteString(styles.Description.Render(field.description))
+	}
+	if !field.inline && view.Len() > 0 {
+		view.WriteString("\n\n")
+	}
+
+	selected := field.value != nil && *field.value
+	view.WriteString(field.renderChoice(styles, field.affirmative, selected))
+	view.WriteString("     ")
+	view.WriteString(field.renderChoice(styles, field.negative, !selected))
+	return styles.Base.Render(view.String())
+}
+
+func (field *ExplicitConfirm) renderChoice(styles *huh.FieldStyles, label string, selected bool) string {
+	marker := "  "
+	style := styles.BlurredButton
+	if field.focused && selected {
+		marker = "▶ "
+		style = styles.FocusedButton
+	}
+	return marker + style.Render(label)
 }
 
 func (field *ExplicitConfirm) Blur() tea.Cmd {
 	field.focused = false
-	field.syncLabels()
 	return field.confirm.Blur()
 }
 
 func (field *ExplicitConfirm) Focus() tea.Cmd {
 	field.focused = true
-	field.syncLabels()
 	return field.confirm.Focus()
 }
 func (field *ExplicitConfirm) Error() error { return field.confirm.Error() }
 func (field *ExplicitConfirm) Skip() bool   { return field.confirm.Skip() }
 func (field *ExplicitConfirm) Zoom() bool   { return field.confirm.Zoom() }
 func (field *ExplicitConfirm) KeyBinds() []key.Binding {
-	return field.confirm.KeyBinds()
+	accept := field.keymap.Accept
+	accept.SetHelp("y", field.affirmative)
+	reject := field.keymap.Reject
+	reject.SetHelp("n", field.negative)
+	return []key.Binding{
+		field.keymap.Toggle,
+		field.keymap.Prev,
+		field.keymap.Submit,
+		field.keymap.Next,
+		accept,
+		reject,
+	}
 }
 func (field *ExplicitConfirm) GetKey() string { return field.confirm.GetKey() }
 func (field *ExplicitConfirm) GetValue() any  { return field.confirm.GetValue() }
 
 func (field *ExplicitConfirm) Run() error {
-	field.syncLabels()
 	return field.confirm.Run()
 }
 
 func (field *ExplicitConfirm) RunAccessible(w io.Writer, r io.Reader) error {
-	field.syncLabels()
 	field.confirm.Title(fmt.Sprintf("%s? (No: %s)", field.affirmative, field.negative))
 	return field.confirm.RunAccessible(w, r)
 }
@@ -115,12 +155,15 @@ func (field *ExplicitConfirm) WithTheme(theme *huh.Theme) huh.Field {
 	button := local.Focused.FocusedButton.
 		UnsetBackground().
 		Foreground(lipgloss.Color("8")).
+		Padding(0).
+		MarginRight(0).
 		Bold(false).
 		Faint(false)
 	local.Focused.FocusedButton = button.Bold(true)
 	local.Focused.BlurredButton = button
 	local.Blurred.FocusedButton = button
 	local.Blurred.BlurredButton = button
+	field.theme = &local
 	field.confirm.WithTheme(&local)
 	return field
 }
@@ -131,6 +174,7 @@ func (field *ExplicitConfirm) WithAccessible(accessible bool) huh.Field {
 }
 
 func (field *ExplicitConfirm) WithKeyMap(keymap *huh.KeyMap) huh.Field {
+	field.keymap = keymap.Confirm
 	field.confirm.WithKeyMap(keymap)
 	return field
 }

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -114,7 +114,7 @@ func (field *ExplicitConfirm) WithTheme(theme *huh.Theme) huh.Field {
 	local := *theme
 	button := local.Focused.FocusedButton.
 		UnsetBackground().
-		Foreground(lipgloss.Color("15")).
+		Foreground(lipgloss.Color("8")).
 		Bold(false).
 		Faint(false)
 	local.Focused.FocusedButton = button.Bold(true)

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // ExplicitConfirm wraps huh.Confirm with a textual focus marker. Huh's stock
@@ -23,6 +24,7 @@ type ExplicitConfirm struct {
 	focused     bool
 	inline      bool
 	title       string
+	titleLink   string
 	description string
 	theme       *huh.Theme
 	keymap      huh.ConfirmKeyMap
@@ -45,6 +47,11 @@ func NewExplicitConfirm(affirmative, negative string, value *bool) *ExplicitConf
 func (field *ExplicitConfirm) Title(title string) *ExplicitConfirm {
 	field.title = title
 	field.confirm.Title(title)
+	return field
+}
+
+func (field *ExplicitConfirm) TitleLink(url string) *ExplicitConfirm {
+	field.titleLink = url
 	return field
 }
 
@@ -83,7 +90,11 @@ func (field *ExplicitConfirm) View() string {
 
 	var view strings.Builder
 	if field.title != "" {
-		view.WriteString(styles.Title.Render(field.title))
+		title := explicitConfirmTitleStyle(styles).Render(field.title)
+		if field.titleLink != "" {
+			title = ansi.SetHyperlink(field.titleLink) + title + ansi.ResetHyperlink()
+		}
+		view.WriteString(title)
 	}
 	if field.description != "" {
 		if !field.inline {
@@ -100,6 +111,13 @@ func (field *ExplicitConfirm) View() string {
 	view.WriteString("     ")
 	view.WriteString(field.renderChoice(styles, field.negative, !selected))
 	return styles.Base.Render(view.String())
+}
+
+func explicitConfirmTitleStyle(styles *huh.FieldStyles) lipgloss.Style {
+	return styles.Title.
+		Foreground(lipgloss.Color("8")).
+		Bold(true).
+		Italic(true)
 }
 
 func (field *ExplicitConfirm) renderChoice(styles *huh.FieldStyles, label string, selected bool) string {

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -1,0 +1,128 @@
+package idtui
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+)
+
+// ExplicitConfirm wraps huh.Confirm with a textual focus marker. Huh's stock
+// confirm communicates the current choice through color inversion alone,
+// which is ambiguous in low-color terminals and absent from copied or spoken
+// output.
+type ExplicitConfirm struct {
+	confirm     *huh.Confirm
+	value       *bool
+	affirmative string
+	negative    string
+}
+
+var _ huh.Field = (*ExplicitConfirm)(nil)
+
+func NewExplicitConfirm(affirmative, negative string, value *bool) *ExplicitConfirm {
+	field := &ExplicitConfirm{
+		confirm:     huh.NewConfirm().Value(value),
+		value:       value,
+		affirmative: affirmative,
+		negative:    negative,
+	}
+	field.syncLabels()
+	return field
+}
+
+func (field *ExplicitConfirm) Title(title string) *ExplicitConfirm {
+	field.confirm.Title(title)
+	return field
+}
+
+func (field *ExplicitConfirm) Description(description string) *ExplicitConfirm {
+	field.confirm.Description(description)
+	return field
+}
+
+func (field *ExplicitConfirm) Inline(inline bool) *ExplicitConfirm {
+	field.confirm.Inline(inline)
+	return field
+}
+
+func (field *ExplicitConfirm) syncLabels() {
+	if field.value != nil && *field.value {
+		field.confirm.Affirmative("▶ " + field.affirmative).Negative("  " + field.negative)
+	} else {
+		field.confirm.Affirmative("  " + field.affirmative).Negative("▶ " + field.negative)
+	}
+}
+
+func (field *ExplicitConfirm) Init() tea.Cmd { return field.confirm.Init() }
+
+func (field *ExplicitConfirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	model, cmd := field.confirm.Update(msg)
+	field.confirm = model.(*huh.Confirm)
+	field.syncLabels()
+	return field, cmd
+}
+
+func (field *ExplicitConfirm) View() string {
+	field.syncLabels()
+	return field.confirm.View()
+}
+
+func (field *ExplicitConfirm) Blur() tea.Cmd  { return field.confirm.Blur() }
+func (field *ExplicitConfirm) Focus() tea.Cmd { return field.confirm.Focus() }
+func (field *ExplicitConfirm) Error() error   { return field.confirm.Error() }
+func (field *ExplicitConfirm) Skip() bool     { return field.confirm.Skip() }
+func (field *ExplicitConfirm) Zoom() bool     { return field.confirm.Zoom() }
+func (field *ExplicitConfirm) KeyBinds() []key.Binding {
+	return field.confirm.KeyBinds()
+}
+func (field *ExplicitConfirm) GetKey() string { return field.confirm.GetKey() }
+func (field *ExplicitConfirm) GetValue() any  { return field.confirm.GetValue() }
+
+func (field *ExplicitConfirm) Run() error {
+	field.syncLabels()
+	return field.confirm.Run()
+}
+
+func (field *ExplicitConfirm) RunAccessible(w io.Writer, r io.Reader) error {
+	field.syncLabels()
+	field.confirm.Title(fmt.Sprintf("%s? (No: %s)", field.affirmative, field.negative))
+	return field.confirm.RunAccessible(w, r)
+}
+
+func (field *ExplicitConfirm) WithTheme(theme *huh.Theme) huh.Field {
+	local := *theme
+	local.Focused.FocusedButton = local.Focused.FocusedButton.UnsetBackground().Bold(true)
+	local.Focused.BlurredButton = local.Focused.BlurredButton.UnsetBackground().Bold(false)
+	local.Blurred.FocusedButton = local.Blurred.FocusedButton.UnsetBackground().Bold(false)
+	local.Blurred.BlurredButton = local.Blurred.BlurredButton.UnsetBackground().Bold(false)
+	field.confirm.WithTheme(&local)
+	return field
+}
+
+func (field *ExplicitConfirm) WithAccessible(accessible bool) huh.Field {
+	field.confirm.WithAccessible(accessible)
+	return field
+}
+
+func (field *ExplicitConfirm) WithKeyMap(keymap *huh.KeyMap) huh.Field {
+	field.confirm.WithKeyMap(keymap)
+	return field
+}
+
+func (field *ExplicitConfirm) WithWidth(width int) huh.Field {
+	field.confirm.WithWidth(width)
+	return field
+}
+
+func (field *ExplicitConfirm) WithHeight(height int) huh.Field {
+	field.confirm.WithHeight(height)
+	return field
+}
+
+func (field *ExplicitConfirm) WithPosition(position huh.FieldPosition) huh.Field {
+	field.confirm.WithPosition(position)
+	return field
+}

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -18,6 +18,7 @@ type ExplicitConfirm struct {
 	value       *bool
 	affirmative string
 	negative    string
+	focused     bool
 }
 
 var _ huh.Field = (*ExplicitConfirm)(nil)
@@ -49,10 +50,14 @@ func (field *ExplicitConfirm) Inline(inline bool) *ExplicitConfirm {
 }
 
 func (field *ExplicitConfirm) syncLabels() {
-	if field.value != nil && *field.value {
-		field.confirm.Affirmative("▶ " + field.affirmative).Negative("  " + field.negative)
+	affirmative := "[ " + field.affirmative + " ]"
+	negative := "[ " + field.negative + " ]"
+	if !field.focused {
+		field.confirm.Affirmative("  " + affirmative).Negative("  " + negative)
+	} else if field.value != nil && *field.value {
+		field.confirm.Affirmative("▶ " + affirmative).Negative("  " + negative)
 	} else {
-		field.confirm.Affirmative("  " + field.affirmative).Negative("▶ " + field.negative)
+		field.confirm.Affirmative("  " + affirmative).Negative("▶ " + negative)
 	}
 }
 
@@ -70,11 +75,20 @@ func (field *ExplicitConfirm) View() string {
 	return field.confirm.View()
 }
 
-func (field *ExplicitConfirm) Blur() tea.Cmd  { return field.confirm.Blur() }
-func (field *ExplicitConfirm) Focus() tea.Cmd { return field.confirm.Focus() }
-func (field *ExplicitConfirm) Error() error   { return field.confirm.Error() }
-func (field *ExplicitConfirm) Skip() bool     { return field.confirm.Skip() }
-func (field *ExplicitConfirm) Zoom() bool     { return field.confirm.Zoom() }
+func (field *ExplicitConfirm) Blur() tea.Cmd {
+	field.focused = false
+	field.syncLabels()
+	return field.confirm.Blur()
+}
+
+func (field *ExplicitConfirm) Focus() tea.Cmd {
+	field.focused = true
+	field.syncLabels()
+	return field.confirm.Focus()
+}
+func (field *ExplicitConfirm) Error() error { return field.confirm.Error() }
+func (field *ExplicitConfirm) Skip() bool   { return field.confirm.Skip() }
+func (field *ExplicitConfirm) Zoom() bool   { return field.confirm.Zoom() }
 func (field *ExplicitConfirm) KeyBinds() []key.Binding {
 	return field.confirm.KeyBinds()
 }
@@ -94,10 +108,11 @@ func (field *ExplicitConfirm) RunAccessible(w io.Writer, r io.Reader) error {
 
 func (field *ExplicitConfirm) WithTheme(theme *huh.Theme) huh.Field {
 	local := *theme
-	local.Focused.FocusedButton = local.Focused.FocusedButton.UnsetBackground().Bold(true)
-	local.Focused.BlurredButton = local.Focused.BlurredButton.UnsetBackground().Bold(false)
-	local.Blurred.FocusedButton = local.Blurred.FocusedButton.UnsetBackground().Bold(false)
-	local.Blurred.BlurredButton = local.Blurred.BlurredButton.UnsetBackground().Bold(false)
+	button := local.Focused.FocusedButton.UnsetBackground().Bold(true).Faint(false)
+	local.Focused.FocusedButton = button
+	local.Focused.BlurredButton = button
+	local.Blurred.FocusedButton = button
+	local.Blurred.BlurredButton = button
 	field.confirm.WithTheme(&local)
 	return field
 }

--- a/dagql/idtui/explicit_confirm.go
+++ b/dagql/idtui/explicit_confirm.go
@@ -28,6 +28,7 @@ type ExplicitConfirm struct {
 	description string
 	theme       *huh.Theme
 	keymap      huh.ConfirmKeyMap
+	previous    key.Binding
 }
 
 var _ huh.Field = (*ExplicitConfirm)(nil)
@@ -39,6 +40,9 @@ func NewExplicitConfirm(affirmative, negative string, value *bool) *ExplicitConf
 		affirmative: affirmative,
 		negative:    negative,
 		keymap:      huh.NewDefaultKeyMap().Confirm,
+		previous: key.NewBinding(
+			key.WithKeys("up", "k", "ctrl+p"),
+		),
 	}
 	field.confirm.Affirmative(affirmative).Negative(negative)
 	return field
@@ -70,7 +74,7 @@ func (field *ExplicitConfirm) Inline(inline bool) *ExplicitConfirm {
 func (field *ExplicitConfirm) Init() tea.Cmd { return field.confirm.Init() }
 
 func (field *ExplicitConfirm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "up" {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && key.Matches(keyMsg, field.previous) {
 		return field, huh.PrevField
 	}
 	model, cmd := field.confirm.Update(msg)

--- a/dagql/idtui/flow_multiselect.go
+++ b/dagql/idtui/flow_multiselect.go
@@ -1,6 +1,7 @@
 package idtui
 
 import (
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 )
@@ -10,15 +11,20 @@ import (
 // boundary. All other behavior remains owned by huh.MultiSelect.
 type FlowMultiSelect[T comparable] struct {
 	*huh.MultiSelect[T]
-	last T
+	last   T
+	keymap huh.MultiSelectKeyMap
 }
 
 func NewFlowMultiSelect[T comparable](field *huh.MultiSelect[T], last T) *FlowMultiSelect[T] {
-	return &FlowMultiSelect[T]{MultiSelect: field, last: last}
+	return &FlowMultiSelect[T]{
+		MultiSelect: field,
+		last:        last,
+		keymap:      huh.NewDefaultKeyMap().MultiSelect,
+	}
 }
 
 func (field *FlowMultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "down" {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && key.Matches(keyMsg, field.keymap.Down) {
 		if hovered, ok := field.Hovered(); ok && hovered == field.last {
 			return field, huh.NextField
 		}
@@ -26,4 +32,10 @@ func (field *FlowMultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	model, cmd := field.MultiSelect.Update(msg)
 	field.MultiSelect = model.(*huh.MultiSelect[T])
 	return field, cmd
+}
+
+func (field *FlowMultiSelect[T]) WithKeyMap(keymap *huh.KeyMap) huh.Field {
+	field.keymap = keymap.MultiSelect
+	field.MultiSelect.WithKeyMap(keymap)
+	return field
 }

--- a/dagql/idtui/flow_multiselect.go
+++ b/dagql/idtui/flow_multiselect.go
@@ -1,0 +1,29 @@
+package idtui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+)
+
+// FlowMultiSelect makes a multi-select compose vertically with the field after
+// it: Down on the final option advances focus instead of stopping at the list
+// boundary. All other behavior remains owned by huh.MultiSelect.
+type FlowMultiSelect[T comparable] struct {
+	*huh.MultiSelect[T]
+	last T
+}
+
+func NewFlowMultiSelect[T comparable](field *huh.MultiSelect[T], last T) *FlowMultiSelect[T] {
+	return &FlowMultiSelect[T]{MultiSelect: field, last: last}
+}
+
+func (field *FlowMultiSelect[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "down" {
+		if hovered, ok := field.Hovered(); ok && hovered == field.last {
+			return field, huh.NextField
+		}
+	}
+	model, cmd := field.MultiSelect.Update(msg)
+	field.MultiSelect = model.(*huh.MultiSelect[T])
+	return field, cmd
+}

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -123,6 +123,36 @@ type Frontend interface {
 	prompt.PromptHandler
 }
 
+// CommandFrontend is implemented by frontends that can host a command-owned
+// Tuist screen. Commands should treat this as an optional capability and keep
+// a plain-output fallback for streaming frontends.
+type CommandFrontend interface {
+	SetView(ViewFactory) ViewHandle
+}
+
+// ViewFactory constructs a command screen using services owned by the pretty
+// frontend. It is invoked on the Tuist event loop.
+type ViewFactory func(ViewContext) CommandView
+
+// CommandView is the body of a command-owned pretty TUI. SetFinal switches the
+// view from transient progress to durable terminal output.
+type CommandView interface {
+	tuist.Component
+	Update()
+	SetFinal(bool)
+}
+
+// ViewContext provides reusable trace-backed components. The trace state is
+// intentionally not mutable by commands.
+type ViewContext interface {
+	SpanList(root func() dagui.SpanID, include func() []dagui.SpanID) *SpanListView
+}
+
+// ViewHandle serializes command model mutations with rendering.
+type ViewHandle interface {
+	Update(func())
+}
+
 // TraceFrontend is the optional interface 'dagger trace' drives for
 // incremental loading and report zooming: snapshot import, lazy span/log
 // providers, surfaced-failure prefetch, and name-based zoom targets. Only the

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -128,6 +128,7 @@ type Frontend interface {
 // a plain-output fallback for streaming frontends.
 type CommandFrontend interface {
 	SetView(ViewFactory) ViewHandle
+	Live() bool
 }
 
 // ViewFactory constructs a command screen using services owned by the pretty

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -123,6 +123,30 @@ func TestExplicitConfirmTitleLink(t *testing.T) {
 	}
 }
 
+func TestExplicitChoiceHasOneTextualSelection(t *testing.T) {
+	choice := "login"
+	field := NewExplicitChoice(&choice,
+		huh.NewOption("Log in", "login"),
+		huh.NewOption("Not now", "not-now"),
+		huh.NewOption("Never ask again", "never"),
+	)
+	field.WithTheme(frontendFormTheme())
+	field.WithKeyMap(huh.NewDefaultKeyMap())
+	field.Focus()
+	if got := field.View(); strings.Count(got, "▶") != 1 || !strings.Contains(got, "▶ Log in") {
+		t.Fatalf("choice does not identify exactly one selection:\n%s", got)
+	}
+
+	field.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := field.View(); strings.Count(got, "▶") != 1 || !strings.Contains(got, "▶ Not now") {
+		t.Fatalf("right did not move the explicit selection:\n%s", got)
+	}
+	field.Blur()
+	if got := field.View(); strings.Contains(got, "▶") {
+		t.Fatalf("blurred choice retained its selection caret:\n%s", got)
+	}
+}
+
 func TestFormFieldsFlowWithVerticalKeys(t *testing.T) {
 	var selected []string
 	multi := NewFlowMultiSelect(

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -58,17 +58,25 @@ func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
 	}
 
 	field.Focus()
-	if got := field.View(); !strings.Contains(got, "▶ [ Install selected ]") || strings.Contains(got, "▶ [ Skip ]") {
+	if got := field.View(); !strings.Contains(got, "▶ Install selected") || strings.Contains(got, "▶ Skip") || strings.Contains(got, "[") {
 		t.Fatalf("affirmative selection is not explicit:\n%s", got)
 	}
 
 	selected = false
-	if got := field.View(); !strings.Contains(got, "▶ [ Skip ]") || strings.Contains(got, "▶ [ Install selected ]") {
+	if got := field.View(); !strings.Contains(got, "▶ Skip") || strings.Contains(got, "▶ Install selected") || strings.Contains(got, "[") {
 		t.Fatalf("negative selection is not explicit:\n%s", got)
 	}
 	field.Blur()
 	if got := field.View(); strings.Contains(got, "▶") {
 		t.Fatalf("blurred confirmation retained its selection caret:\n%s", got)
+	}
+	var help strings.Builder
+	for _, binding := range field.KeyBinds() {
+		help.WriteString(binding.Help().Key)
+		help.WriteString(binding.Help().Desc)
+	}
+	if got := help.String(); strings.ContainsAny(got, "[]▶") || !strings.Contains(got, "Install selected") || !strings.Contains(got, "Skip") {
+		t.Fatalf("confirmation keymap labels are not semantic: %q", got)
 	}
 
 	var output bytes.Buffer

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -20,6 +20,9 @@ func TestFrontendFormThemeOnlyHighlightsFocusedButton(t *testing.T) {
 	if _, ok := theme.Focused.BlurredButton.GetBackground().(lipgloss.NoColor); !ok {
 		t.Fatal("inactive button still has a background")
 	}
+	if _, ok := theme.Blurred.FocusedButton.GetBackground().(lipgloss.NoColor); !ok {
+		t.Fatal("button in an unfocused confirmation still has a background")
+	}
 }
 
 type commandViewFixture struct {

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/vito/tuist"
 )
@@ -98,6 +99,27 @@ func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
 	}
 	if got := output.String(); !strings.Contains(got, "Install selected") || !strings.Contains(got, "Skip") {
 		t.Fatalf("accessible prompt does not name both actions:\n%s", got)
+	}
+}
+
+func TestExplicitConfirmTitleIsSubtleHeader(t *testing.T) {
+	theme := frontendFormTheme()
+	style := explicitConfirmTitleStyle(&theme.Focused)
+	if !style.GetBold() || !style.GetItalic() {
+		t.Fatal("confirmation title is not bold and italic")
+	}
+	if got := style.GetForeground(); got != lipgloss.Color("8") {
+		t.Fatalf("confirmation title foreground = %v, want ANSI bright black", got)
+	}
+}
+
+func TestExplicitConfirmTitleLink(t *testing.T) {
+	selected := true
+	field := NewExplicitConfirm("Yes", "No", &selected).
+		Title("Log in to Dagger Cloud?").
+		TitleLink("https://dagger.io/cloud")
+	if got := field.View(); !strings.Contains(got, ansi.SetHyperlink("https://dagger.io/cloud")) {
+		t.Fatalf("confirmation title is not linked: %q", got)
 	}
 }
 

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -23,6 +23,31 @@ func TestFrontendFormThemeOnlyHighlightsFocusedButton(t *testing.T) {
 	if _, ok := theme.Blurred.FocusedButton.GetBackground().(lipgloss.NoColor); !ok {
 		t.Fatal("button in an unfocused confirmation still has a background")
 	}
+	if theme.Focused.Base.GetBorderLeft() {
+		t.Fatal("focused form field still has a left border")
+	}
+}
+
+func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
+	selected := true
+	field := NewExplicitConfirm("Install selected", "Skip", &selected)
+	field.WithTheme(frontendFormTheme())
+	if got := field.View(); !strings.Contains(got, "▶ Install selected") || strings.Contains(got, "▶ Skip") {
+		t.Fatalf("affirmative selection is not explicit:\n%s", got)
+	}
+
+	selected = false
+	if got := field.View(); !strings.Contains(got, "▶ Skip") || strings.Contains(got, "▶ Install selected") {
+		t.Fatalf("negative selection is not explicit:\n%s", got)
+	}
+
+	var output bytes.Buffer
+	if err := field.RunAccessible(&output, strings.NewReader("n\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "Install selected") || !strings.Contains(got, "Skip") {
+		t.Fatalf("accessible prompt does not name both actions:\n%s", got)
+	}
 }
 
 type commandViewFixture struct {

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -37,6 +37,9 @@ func TestFrontendFormThemeUsesStructuralFocusMarkers(t *testing.T) {
 	if strings.Contains(theme.Blurred.MultiSelectSelector.String(), ">") {
 		t.Fatal("blurred multi-select still has a selection caret")
 	}
+	if got := theme.Focused.MultiSelectSelector.String(); got != "▶ " {
+		t.Fatalf("focused multi-select selector = %q, want %q", got, "▶ ")
+	}
 }
 
 func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -151,36 +151,51 @@ func TestExplicitChoiceHasOneTextualSelection(t *testing.T) {
 }
 
 func TestFormFieldsFlowWithVerticalKeys(t *testing.T) {
-	var selected []string
-	multi := NewFlowMultiSelect(
-		huh.NewMultiSelect[string]().
-			Options(
-				huh.NewOption("one", "one"),
-				huh.NewOption("two", "two"),
-			).
-			Value(&selected),
-		"two",
-	)
-	multi.WithKeyMap(huh.NewDefaultKeyMap())
-	multi.Focus()
-	if hovered, ok := multi.Hovered(); !ok || hovered != "one" {
-		t.Fatalf("unexpected initial option: %q, %v", hovered, ok)
+	downKeys := map[string]tea.KeyMsg{
+		"down":   {Type: tea.KeyDown},
+		"j":      {Type: tea.KeyRunes, Runes: []rune{'j'}},
+		"ctrl+n": {Type: tea.KeyCtrlN},
 	}
-	if _, cmd := multi.Update(tea.KeyMsg{Type: tea.KeyDown}); cmd != nil {
-		t.Fatal("down before the final option advanced to the next field")
-	}
-	if hovered, ok := multi.Hovered(); !ok || hovered != "two" {
-		t.Fatalf("down did not reach final option: %q, %v", hovered, ok)
-	}
-	if _, cmd := multi.Update(tea.KeyMsg{Type: tea.KeyDown}); cmd == nil {
-		t.Fatal("down on the final option did not advance to the next field")
+	for name, keyMsg := range downKeys {
+		t.Run(name, func(t *testing.T) {
+			var selected []string
+			multi := NewFlowMultiSelect(
+				huh.NewMultiSelect[string]().
+					Options(
+						huh.NewOption("one", "one"),
+						huh.NewOption("two", "two"),
+					).
+					Value(&selected),
+				"two",
+			)
+			multi.WithKeyMap(huh.NewDefaultKeyMap())
+			multi.Focus()
+			if _, cmd := multi.Update(keyMsg); cmd != nil {
+				t.Fatalf("%s before the final option advanced to the next field", name)
+			}
+			if hovered, ok := multi.Hovered(); !ok || hovered != "two" {
+				t.Fatalf("%s did not reach final option: %q, %v", name, hovered, ok)
+			}
+			if _, cmd := multi.Update(keyMsg); cmd == nil {
+				t.Fatalf("%s on the final option did not advance to the next field", name)
+			}
+		})
 	}
 
-	install := true
-	confirm := NewExplicitConfirm("Install selected", "Skip", &install)
-	confirm.Focus()
-	if _, cmd := confirm.Update(tea.KeyMsg{Type: tea.KeyUp}); cmd == nil {
-		t.Fatal("up from the confirmation did not return to the previous field")
+	upKeys := map[string]tea.KeyMsg{
+		"up":     {Type: tea.KeyUp},
+		"k":      {Type: tea.KeyRunes, Runes: []rune{'k'}},
+		"ctrl+p": {Type: tea.KeyCtrlP},
+	}
+	for name, keyMsg := range upKeys {
+		t.Run(name, func(t *testing.T) {
+			install := true
+			confirm := NewExplicitConfirm("Install selected", "Skip", &install)
+			confirm.Focus()
+			if _, cmd := confirm.Update(keyMsg); cmd == nil {
+				t.Fatalf("%s from the confirmation did not return to the previous field", name)
+			}
+		})
 	}
 }
 

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/vito/tuist"
@@ -26,8 +28,11 @@ func TestFrontendFormThemeUsesStructuralFocusMarkers(t *testing.T) {
 	if theme.Focused.Base.GetBorderLeft() {
 		t.Fatal("focused form field still has a left border")
 	}
-	if !theme.Focused.FocusedButton.GetBold() || !theme.Focused.BlurredButton.GetBold() {
-		t.Fatal("confirmation choices are not strongly styled")
+	if theme.Blurred.Base.GetBorderLeft() {
+		t.Fatal("blurred form field still reserves a left border")
+	}
+	if !theme.Focused.FocusedButton.GetBold() || theme.Focused.BlurredButton.GetBold() {
+		t.Fatal("only the focused confirmation choice should be bold")
 	}
 	if strings.Contains(theme.Blurred.MultiSelectSelector.String(), ">") {
 		t.Fatal("blurred multi-select still has a selection caret")
@@ -62,6 +67,40 @@ func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
 	}
 	if got := output.String(); !strings.Contains(got, "Install selected") || !strings.Contains(got, "Skip") {
 		t.Fatalf("accessible prompt does not name both actions:\n%s", got)
+	}
+}
+
+func TestFormFieldsFlowWithVerticalKeys(t *testing.T) {
+	var selected []string
+	multi := NewFlowMultiSelect(
+		huh.NewMultiSelect[string]().
+			Options(
+				huh.NewOption("one", "one"),
+				huh.NewOption("two", "two"),
+			).
+			Value(&selected),
+		"two",
+	)
+	multi.WithKeyMap(huh.NewDefaultKeyMap())
+	multi.Focus()
+	if hovered, ok := multi.Hovered(); !ok || hovered != "one" {
+		t.Fatalf("unexpected initial option: %q, %v", hovered, ok)
+	}
+	if _, cmd := multi.Update(tea.KeyMsg{Type: tea.KeyDown}); cmd != nil {
+		t.Fatal("down before the final option advanced to the next field")
+	}
+	if hovered, ok := multi.Hovered(); !ok || hovered != "two" {
+		t.Fatalf("down did not reach final option: %q, %v", hovered, ok)
+	}
+	if _, cmd := multi.Update(tea.KeyMsg{Type: tea.KeyDown}); cmd == nil {
+		t.Fatal("down on the final option did not advance to the next field")
+	}
+
+	install := true
+	confirm := NewExplicitConfirm("Install selected", "Skip", &install)
+	confirm.Focus()
+	if _, cmd := confirm.Update(tea.KeyMsg{Type: tea.KeyUp}); cmd == nil {
+		t.Fatal("up from the confirmation did not return to the previous field")
 	}
 }
 

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -78,6 +78,9 @@ func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
 	if got := help.String(); strings.ContainsAny(got, "[]▶") || !strings.Contains(got, "Install selected") || !strings.Contains(got, "Skip") {
 		t.Fatalf("confirmation keymap labels are not semantic: %q", got)
 	}
+	if strings.Contains(help.String(), "back") || strings.Contains(help.String(), "next") {
+		t.Fatalf("confirmation keymap includes redundant field navigation: %q", help.String())
+	}
 
 	var output bytes.Buffer
 	if err := field.RunAccessible(&output, strings.NewReader("n\n")); err != nil {

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -257,6 +257,26 @@ func TestCommandViewOwnsLiveAndFinalRendering(t *testing.T) {
 	}
 }
 
+func TestCommandViewInitializesPerRenderState(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	term := tuist.NewHeadlessTerminal(73, 19)
+	fe := newWithTerminal(io.Discard, dagui.NewDB(), term)
+	fe.reportOnly = true
+	view := &commandViewFixture{label: "setup"}
+	fe.SetView(func(ViewContext) CommandView { return view })
+
+	claimed := prettyTestSpanID(1)
+	fe.claims.claimErrorID(claimed)
+	_ = fe.tui.Frame()
+
+	if fe.claims.hasError(claimed) {
+		t.Fatal("command view retained claims from a previous render")
+	}
+	if got, want := fe.window, (windowSize{Width: 73, Height: 19}); got != want {
+		t.Fatalf("command view window = %+v, want %+v", got, want)
+	}
+}
+
 func TestSpanListSelectsCommandOwnedRoots(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	db := dagui.NewDB()

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -107,6 +107,29 @@ func TestFormFieldsFlowWithVerticalKeys(t *testing.T) {
 	}
 }
 
+func TestMountedFormUpdatesKeymapAndUsesNaturalHeight(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	fe := NewWithDB(io.Discard, dagui.NewDB())
+	fe.setupTUI()
+	if before := strings.Join(fe.tui.RenderLines(), "\n"); !strings.Contains(before, "verbosity") {
+		t.Fatalf("initial keymap did not render navigation keys:\n%s", before)
+	}
+
+	apply := true
+	form := NewForm(huh.NewGroup(
+		NewExplicitConfirm("Apply", "Discard", &apply).Title("Apply changes?"),
+	))
+	fe.window.Height = 40
+	fe.handlePromptForm(form, func(*huh.Form) {})
+	after := strings.Join(fe.tui.RenderLines(), "\n")
+	if !strings.Contains(after, "toggle") || strings.Contains(after, "verbosity") {
+		t.Fatalf("form keymap did not replace navigation keys:\n%s", after)
+	}
+	if height := strings.Count(fe.formModel.View(), "\n") + 1; height > 8 {
+		t.Fatalf("compact confirmation reserved %d lines", height)
+	}
+}
+
 type commandViewFixture struct {
 	tuist.Compo
 	final bool

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -1,0 +1,97 @@
+package idtui
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dagger/dagger/dagql/dagui"
+	"github.com/vito/tuist"
+)
+
+type commandViewFixture struct {
+	tuist.Compo
+	final bool
+	label string
+	child tuist.Component
+}
+
+func (view *commandViewFixture) SetFinal(final bool) {
+	view.final = final
+	view.Update()
+}
+
+func (view *commandViewFixture) Render(ctx tuist.Context) {
+	if view.final {
+		ctx.Line("final " + view.label)
+	} else {
+		ctx.Line("live " + view.label)
+	}
+	if view.child != nil {
+		view.RenderChild(ctx, view.child)
+	}
+}
+
+func TestCommandViewOwnsLiveAndFinalRendering(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	fe := NewWithDB(io.Discard, dagui.NewDB())
+	fe.reportOnly = true
+	view := &commandViewFixture{label: "setup"}
+	handle := fe.SetView(func(ViewContext) CommandView { return view })
+
+	live := strings.Join(fe.tui.RenderLines(), "\n")
+	if !strings.Contains(live, "live setup") {
+		t.Fatalf("live render did not use command view:\n%s", live)
+	}
+
+	handle.Update(func() { view.label = "workspace" })
+	var final bytes.Buffer
+	if err := fe.FinalRender(&final); err != nil {
+		t.Fatal(err)
+	}
+	if got := final.String(); !strings.Contains(got, "final workspace") {
+		t.Fatalf("final render did not use updated command view:\n%s", got)
+	}
+}
+
+func TestSpanListSelectsCommandOwnedRoots(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	db := dagui.NewDB()
+	rootID := prettyTestSpanID(1)
+	keepID := prettyTestSpanID(2)
+	dropID := prettyTestSpanID(3)
+	start := time.Unix(100, 0)
+	db.ImportSnapshots([]dagui.SpanSnapshot{
+		{ID: rootID, TraceID: prettyTestTraceID(), Name: "setup", StartTime: start, EndTime: start.Add(time.Second), Final: true},
+		{ID: keepID, TraceID: prettyTestTraceID(), Name: "keep install", ParentID: rootID, StartTime: start, EndTime: start.Add(time.Second), Final: true, Reveal: true},
+		{ID: dropID, TraceID: prettyTestTraceID(), Name: "drop install", ParentID: rootID, StartTime: start, EndTime: start.Add(time.Second), Final: true, Reveal: true},
+	})
+	db.SetPrimarySpan(rootID)
+
+	fe := NewWithDB(io.Discard, db)
+	fe.reportOnly = true
+	fe.FrontendOpts.Verbosity = dagui.ShowCompletedVerbosity
+	view := &commandViewFixture{label: "setup"}
+	var list *SpanListView
+	fe.SetView(func(ctx ViewContext) CommandView {
+		list = ctx.SpanList(
+			func() dagui.SpanID { return rootID },
+			func() []dagui.SpanID { return []dagui.SpanID{keepID} },
+		)
+		view.child = list
+		return view
+	})
+
+	rendered := strings.Join(fe.tui.RenderLines(), "\n")
+	if !strings.Contains(rendered, "keep install") {
+		t.Fatalf("selected span was not rendered:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "drop install") {
+		t.Fatalf("unselected span was rendered:\n%s", rendered)
+	}
+	if !list.FocusFirst() || fe.FocusedSpan != keepID {
+		t.Fatalf("span list did not focus selected root: got %s, want %s", fe.FocusedSpan, keepID)
+	}
+}

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/vito/tuist"
 )
 
-func TestFrontendFormThemeOnlyHighlightsFocusedButton(t *testing.T) {
+func TestFrontendFormThemeUsesStructuralFocusMarkers(t *testing.T) {
 	theme := frontendFormTheme()
-	if _, ok := theme.Focused.FocusedButton.GetBackground().(lipgloss.NoColor); ok {
-		t.Fatal("focused button has no background")
+	if _, ok := theme.Focused.FocusedButton.GetBackground().(lipgloss.NoColor); !ok {
+		t.Fatal("focused button still has a background")
 	}
 	if _, ok := theme.Focused.BlurredButton.GetBackground().(lipgloss.NoColor); !ok {
 		t.Fatal("inactive button still has a background")
@@ -26,19 +26,34 @@ func TestFrontendFormThemeOnlyHighlightsFocusedButton(t *testing.T) {
 	if theme.Focused.Base.GetBorderLeft() {
 		t.Fatal("focused form field still has a left border")
 	}
+	if !theme.Focused.FocusedButton.GetBold() || !theme.Focused.BlurredButton.GetBold() {
+		t.Fatal("confirmation choices are not strongly styled")
+	}
+	if strings.Contains(theme.Blurred.MultiSelectSelector.String(), ">") {
+		t.Fatal("blurred multi-select still has a selection caret")
+	}
 }
 
 func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
 	selected := true
 	field := NewExplicitConfirm("Install selected", "Skip", &selected)
 	field.WithTheme(frontendFormTheme())
-	if got := field.View(); !strings.Contains(got, "▶ Install selected") || strings.Contains(got, "▶ Skip") {
+	if got := field.View(); strings.Contains(got, "▶") {
+		t.Fatalf("unfocused confirmation has a selection caret:\n%s", got)
+	}
+
+	field.Focus()
+	if got := field.View(); !strings.Contains(got, "▶ [ Install selected ]") || strings.Contains(got, "▶ [ Skip ]") {
 		t.Fatalf("affirmative selection is not explicit:\n%s", got)
 	}
 
 	selected = false
-	if got := field.View(); !strings.Contains(got, "▶ Skip") || strings.Contains(got, "▶ Install selected") {
+	if got := field.View(); !strings.Contains(got, "▶ [ Skip ]") || strings.Contains(got, "▶ [ Install selected ]") {
 		t.Fatalf("negative selection is not explicit:\n%s", got)
+	}
+	field.Blur()
+	if got := field.View(); strings.Contains(got, "▶") {
+		t.Fatalf("blurred confirmation retained its selection caret:\n%s", got)
 	}
 
 	var output bytes.Buffer

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -42,6 +42,13 @@ func TestFrontendFormThemeUsesStructuralFocusMarkers(t *testing.T) {
 	}
 }
 
+func TestFrontendFormKeymapNamesSpaceToggle(t *testing.T) {
+	keymap := frontendFormKeyMap()
+	if got := keymap.MultiSelect.Toggle.Help().Key; got != "space" {
+		t.Fatalf("multi-select toggle key = %q, want space", got)
+	}
+}
+
 func TestExplicitConfirmHasTextualSelectionAndAccessibleLabels(t *testing.T) {
 	selected := true
 	field := NewExplicitConfirm("Install selected", "Skip", &selected)

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -33,6 +33,9 @@ func TestFrontendFormThemeUsesStructuralFocusMarkers(t *testing.T) {
 	if theme.Blurred.Base.GetBorderLeft() {
 		t.Fatal("blurred form field still reserves a left border")
 	}
+	if theme.Focused.Base.GetPaddingLeft() != 0 || theme.Blurred.Base.GetPaddingLeft() != 0 {
+		t.Fatal("form fields still reserve a leading padding column")
+	}
 	if !theme.Focused.FocusedButton.GetBold() || theme.Focused.BlurredButton.GetBold() {
 		t.Fatal("only the focused confirmation choice should be bold")
 	}
@@ -198,6 +201,11 @@ func TestMountedFormUpdatesKeymapAndUsesNaturalHeight(t *testing.T) {
 	after := strings.Join(fe.tui.RenderLines(), "\n")
 	if !strings.Contains(after, "toggle") || strings.Contains(after, "verbosity") {
 		t.Fatalf("form keymap did not replace navigation keys:\n%s", after)
+	}
+	plainAfter := ansi.Strip(after)
+	flushTitle := strings.HasPrefix(plainAfter, "Apply changes?") || strings.Contains(plainAfter, "\nApply changes?")
+	if !flushTitle || strings.HasPrefix(plainAfter, " Apply changes?") || strings.Contains(plainAfter, "\n Apply changes?") {
+		t.Fatalf("form retained a leading padding column:\n%s", plainAfter)
 	}
 	if height := strings.Count(fe.formModel.View(), "\n") + 1; height > 8 {
 		t.Fatalf("compact confirmation reserved %d lines", height)

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -2,6 +2,7 @@ package idtui
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -46,6 +47,15 @@ func TestFrontendFormKeymapNamesSpaceToggle(t *testing.T) {
 	keymap := frontendFormKeyMap()
 	if got := keymap.MultiSelect.Toggle.Help().Key; got != "space" {
 		t.Fatalf("multi-select toggle key = %q, want space", got)
+	}
+}
+
+func TestAbortedFormInterrupts(t *testing.T) {
+	form := huh.NewForm(huh.NewGroup(huh.NewConfirm()))
+	form.State = huh.StateAborted
+	err := formCompletionError(form)
+	if !errors.Is(err, ErrInterrupted) || !errors.Is(err, huh.ErrUserAborted) {
+		t.Fatalf("aborted form returned %v", err)
 	}
 }
 

--- a/dagql/idtui/frontend_command_view_test.go
+++ b/dagql/idtui/frontend_command_view_test.go
@@ -7,9 +7,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/vito/tuist"
 )
+
+func TestFrontendFormThemeOnlyHighlightsFocusedButton(t *testing.T) {
+	theme := frontendFormTheme()
+	if _, ok := theme.Focused.FocusedButton.GetBackground().(lipgloss.NoColor); ok {
+		t.Fatal("focused button has no background")
+	}
+	if _, ok := theme.Focused.BlurredButton.GetBackground().(lipgloss.NoColor); !ok {
+		t.Fatal("inactive button still has a background")
+	}
+}
 
 type commandViewFixture struct {
 	tuist.Compo

--- a/dagql/idtui/frontend_dots.go
+++ b/dagql/idtui/frontend_dots.go
@@ -226,7 +226,7 @@ func (fe *frontendDots) HandlePrompt(ctx context.Context, _, prompt string, dest
 }
 
 func (fe *frontendDots) HandleForm(ctx context.Context, form *huh.Form) error {
-	return form.RunWithContext(ctx)
+	return form.WithTheme(huh.ThemeBase16()).RunWithContext(ctx)
 }
 
 // dotsSpanExporter implements trace.SpanExporter for the dots frontend

--- a/dagql/idtui/frontend_log_pager.go
+++ b/dagql/idtui/frontend_log_pager.go
@@ -258,7 +258,7 @@ func (fe *frontendPretty) renderLogPager(ctx tuist.Context) {
 	if fe.logPager == nil {
 		return
 	}
-	height := ctx.ScreenHeight() - 1 // keymap sibling
+	height := ctx.ScreenHeight() - 2 // keymap sibling and its separating blank line
 	if fe.logSearchInput != nil {
 		height--
 	}

--- a/dagql/idtui/frontend_logs.go
+++ b/dagql/idtui/frontend_logs.go
@@ -189,7 +189,7 @@ func (fe *frontendLogs) HandlePrompt(ctx context.Context, _, prompt string, dest
 }
 
 func (fe *frontendLogs) HandleForm(ctx context.Context, form *huh.Form) error {
-	return form.RunWithContext(ctx)
+	return form.WithTheme(huh.ThemeBase16()).RunWithContext(ctx)
 }
 
 // logsSpanExporter implements trace.SpanExporter for the logs frontend

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -236,7 +236,7 @@ func (fe *frontendPlain) HandlePrompt(ctx context.Context, _, prompt string, des
 }
 
 func (fe *frontendPlain) HandleForm(ctx context.Context, form *huh.Form) error {
-	return form.RunWithContext(ctx)
+	return form.WithTheme(huh.ThemeBase16()).RunWithContext(ctx)
 }
 
 func (fe *frontendPlain) Opts() *dagui.FrontendOpts {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1364,6 +1364,8 @@ func frontendFormTheme() *huh.Theme {
 	theme := huh.ThemeBase16()
 	theme.Focused.Base = theme.Focused.Base.BorderLeft(false)
 	theme.Blurred.Base = theme.Blurred.Base.BorderLeft(false)
+	theme.Focused.SelectSelector = theme.Focused.SelectSelector.SetString("▶ ")
+	theme.Focused.MultiSelectSelector = theme.Focused.MultiSelectSelector.SetString("▶ ")
 	// ThemeBase16 copies its focused selectors into the blurred field styles,
 	// which leaves a stale caret behind after focus moves to another field.
 	theme.Blurred.SelectSelector = theme.Blurred.SelectSelector.SetString("  ")

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1381,8 +1381,8 @@ func frontendFormKeyMap() *huh.KeyMap {
 
 func frontendFormTheme() *huh.Theme {
 	theme := huh.ThemeBase16()
-	theme.Focused.Base = theme.Focused.Base.BorderLeft(false)
-	theme.Blurred.Base = theme.Blurred.Base.BorderLeft(false)
+	theme.Focused.Base = theme.Focused.Base.BorderLeft(false).PaddingLeft(0)
+	theme.Blurred.Base = theme.Blurred.Base.BorderLeft(false).PaddingLeft(0)
 	theme.Focused.SelectSelector = theme.Focused.SelectSelector.SetString("▶ ")
 	theme.Focused.MultiSelectSelector = theme.Focused.MultiSelectSelector.SetString("▶ ")
 	// ThemeBase16 copies its focused selectors into the blurred field styles,

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1372,7 +1372,7 @@ func frontendFormTheme() *huh.Theme {
 	// structural focus marker, so color and background carry no meaning here.
 	button := theme.Focused.FocusedButton.
 		UnsetBackground().
-		Foreground(lipglossv1.Color("15")).
+		Foreground(lipglossv1.Color("8")).
 		Bold(false).
 		Faint(false)
 	theme.Focused.FocusedButton = button.Bold(true)

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1361,6 +1361,7 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 
 func frontendFormTheme() *huh.Theme {
 	theme := huh.ThemeBase16()
+	theme.Focused.Base = theme.Focused.Base.BorderLeft(false)
 	// A background is the structural focus marker for confirm buttons. Leaving
 	// the inactive button's theme background in place makes both choices look
 	// selected, especially in terminals where their colors are similar.
@@ -6765,15 +6766,14 @@ func (fe *frontendPretty) handlePromptBool(ctx context.Context, title, message s
 
 	fe.dispatch(func() {
 		fe.handlePromptForm(
-			NewForm(
+			huh.NewForm(
 				huh.NewGroup(
-					huh.NewConfirm().
+					NewExplicitConfirm("Yes", "No", dest).
 						Title(title).
 						Description(strings.TrimSpace((&Markdown{
 							Content: message,
 							Width:   fe.window.Width,
-						}).View())).
-						Value(dest),
+						}).View())),
 				),
 			),
 			func(f *huh.Form) { close(done) },

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1362,12 +1362,17 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 func frontendFormTheme() *huh.Theme {
 	theme := huh.ThemeBase16()
 	theme.Focused.Base = theme.Focused.Base.BorderLeft(false)
-	// A background is the structural focus marker for confirm buttons. Leaving
-	// the inactive button's theme background in place makes both choices look
-	// selected, especially in terminals where their colors are similar.
-	theme.Focused.BlurredButton = theme.Focused.BlurredButton.UnsetBackground().Bold(false)
-	theme.Blurred.FocusedButton = theme.Blurred.FocusedButton.UnsetBackground().Bold(false)
-	theme.Blurred.BlurredButton = theme.Blurred.BlurredButton.UnsetBackground().Bold(false)
+	// ThemeBase16 copies its focused selectors into the blurred field styles,
+	// which leaves a stale caret behind after focus moves to another field.
+	theme.Blurred.SelectSelector = theme.Blurred.SelectSelector.SetString("  ")
+	theme.Blurred.MultiSelectSelector = theme.Blurred.MultiSelectSelector.SetString("  ")
+	// Give both choices the same strong treatment. ExplicitConfirm supplies the
+	// structural focus marker, so color and background carry no meaning here.
+	button := theme.Focused.FocusedButton.UnsetBackground().Bold(true).Faint(false)
+	theme.Focused.FocusedButton = button
+	theme.Focused.BlurredButton = button
+	theme.Blurred.FocusedButton = button
+	theme.Blurred.BlurredButton = button
 	return theme
 }
 
@@ -6020,7 +6025,13 @@ func (fe *frontendPretty) renderStep(ctx tuist.Context, out TermOutput, r *rende
 			// leading space.
 		}
 	} else if !fe.finalRender {
-		fe.renderToggler(out, row, focused)
+		if fe.formWrap != nil {
+			// The form owns input focus, so don't imply that its host span is also
+			// selected. Preserve the column so the title doesn't jump sideways.
+			fmt.Fprint(out, " ")
+		} else {
+			fe.renderToggler(out, row, focused)
+		}
 		fmt.Fprint(out, " ")
 	}
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -266,6 +266,13 @@ var (
 
 var _ CommandFrontend = (*frontendPretty)(nil)
 
+// Live reports whether command components are being rendered interactively.
+// Report mode still uses their final rendering, but cannot surface forms or
+// transient login instructions.
+func (fe *frontendPretty) Live() bool {
+	return !fe.reportOnly
+}
+
 type commandViewContext struct {
 	fe *frontendPretty
 }

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1378,6 +1378,8 @@ func frontendFormTheme() *huh.Theme {
 	button := theme.Focused.FocusedButton.
 		UnsetBackground().
 		Foreground(lipglossv1.Color("8")).
+		Padding(0).
+		MarginRight(0).
 		Bold(false).
 		Faint(false)
 	theme.Focused.FocusedButton = button.Bold(true)

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
+	lipglossv1 "github.com/charmbracelet/lipgloss"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/cellbuf"
@@ -1362,14 +1363,19 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 func frontendFormTheme() *huh.Theme {
 	theme := huh.ThemeBase16()
 	theme.Focused.Base = theme.Focused.Base.BorderLeft(false)
+	theme.Blurred.Base = theme.Blurred.Base.BorderLeft(false)
 	// ThemeBase16 copies its focused selectors into the blurred field styles,
 	// which leaves a stale caret behind after focus moves to another field.
 	theme.Blurred.SelectSelector = theme.Blurred.SelectSelector.SetString("  ")
 	theme.Blurred.MultiSelectSelector = theme.Blurred.MultiSelectSelector.SetString("  ")
 	// Give both choices the same strong treatment. ExplicitConfirm supplies the
 	// structural focus marker, so color and background carry no meaning here.
-	button := theme.Focused.FocusedButton.UnsetBackground().Bold(true).Faint(false)
-	theme.Focused.FocusedButton = button
+	button := theme.Focused.FocusedButton.
+		UnsetBackground().
+		Foreground(lipglossv1.Color("15")).
+		Bold(false).
+		Faint(false)
+	theme.Focused.FocusedButton = button.Bold(true)
 	theme.Focused.BlurredButton = button
 	theme.Blurred.FocusedButton = button
 	theme.Blurred.BlurredButton = button

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1295,6 +1295,7 @@ func (fe *frontendPretty) removeForm(wrap *teav1.Wrap) {
 	}
 	fe.formWrap = nil
 	fe.formModel = nil
+	fe.keymapBar.Update()
 	fe.applyTuistFocus() // restore focus to the correct SpanTreeView
 	fe.Update()
 }
@@ -1328,14 +1329,6 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 	form.SubmitCmd = tea.Quit
 	form.CancelCmd = tea.Quit
 	fe.formModel = form.WithTheme(frontendFormTheme()).WithShowHelp(false)
-	// Cap the form at half the screen so a tall field (e.g. the .resume session
-	// picker's long Select) stays scrollable instead of dominating — or
-	// overflowing — the terminal. huh propagates this to its Selects, which then
-	// scroll within the allotted height. Only applied when the window height is
-	// known (>0); otherwise huh sizes to content as before.
-	if h := fe.window.Height; h > 0 {
-		fe.formModel = fe.formModel.WithHeight(max(h/2, 3))
-	}
 	fe.formWrap = teav1.New(fe.formModel)
 	fe.formSpacer = &blankLine{}
 	wrap := fe.formWrap
@@ -1356,6 +1349,7 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 	fe.tui.AddChild(fe.formWrap)
 	fe.tui.AddChild(fe.formSpacer)
 	fe.tui.AddChild(fe.keymapBar)
+	fe.keymapBar.Update()
 	fe.tui.SetFocus(fe.formWrap)
 	return wrap
 }

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -199,9 +199,8 @@ type frontendPretty struct {
 	msgPreFinalRender strings.Builder
 
 	// Add prompt field
-	formWrap   *teav1.Wrap // bubbletea v1 adapter for huh.Form
-	formModel  *huh.Form   // direct reference for KeyBinds()
-	formSpacer *blankLine  // spacer beneath the form, removed alongside it
+	formWrap  *teav1.Wrap // bubbletea v1 adapter for huh.Form
+	formModel *huh.Form   // direct reference for KeyBinds()
 
 	// track whether we've already spawned the run function
 	spawned bool
@@ -1299,10 +1298,6 @@ func (fe *frontendPretty) removeForm(wrap *teav1.Wrap) {
 		return
 	}
 	fe.tui.RemoveChild(fe.formWrap)
-	if fe.formSpacer != nil {
-		fe.tui.RemoveChild(fe.formSpacer)
-		fe.formSpacer = nil
-	}
 	fe.formWrap = nil
 	fe.formModel = nil
 	fe.keymapBar.Update()
@@ -1328,13 +1323,6 @@ func (fe *frontendPretty) OpenBrowser(url string) error {
 	return browser.OpenURL(url)
 }
 
-// blankLine is a trivial component that renders a single empty line.
-type blankLine struct{ tuist.Compo }
-
-func (*blankLine) Render(ctx tuist.Context) {
-	ctx.Line("")
-}
-
 func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form)) *teav1.Wrap {
 	form.SubmitCmd = tea.Quit
 	form.CancelCmd = tea.Quit
@@ -1343,13 +1331,12 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 		WithKeyMap(frontendFormKeyMap()).
 		WithShowHelp(false)
 	fe.formWrap = teav1.New(fe.formModel)
-	fe.formSpacer = &blankLine{}
 	wrap := fe.formWrap
 	fe.formWrap.OnQuit(func() {
 		// Remove this form BEFORE invoking result: the callback may
 		// synchronously install a replacement form (e.g. branch()'s "custom
 		// prompt" path chains a second form via handlePromptForm), which
-		// reassigns fe.formWrap/fe.formModel/fe.formSpacer. Removing afterwards
+		// reassigns fe.formWrap/fe.formModel. Removing afterwards
 		// would then see the replacement, hit removeForm's guard and no-op,
 		// leaking this form (and its spacer) on screen. Capture the model first
 		// since removeForm nils fe.formModel.
@@ -1366,7 +1353,6 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 	// Insert before keymapBar
 	fe.tui.RemoveChild(fe.keymapBar)
 	fe.tui.AddChild(fe.formWrap)
-	fe.tui.AddChild(fe.formSpacer)
 	fe.tui.AddChild(fe.keymapBar)
 	fe.keymapBar.Update()
 	fe.tui.SetFocus(fe.formWrap)
@@ -2536,7 +2522,7 @@ func (fe *frontendPretty) Render(ctx tuist.Context) {
 	// Lines the TUI renders as siblings outside this component, which are
 	// always shown and so must be reserved out of the screen height: the keymap
 	// bar, error label, text input, form, and search input.
-	reserved := 1 // keymap bar
+	reserved := 2 // keymap bar and its separating blank line
 	reserved += fe.errorLabelHeight()
 	reserved += fe.queuedMessageHeight() // queuedMsgLabel is a sibling, not rendered here
 	reserved += fe.statusLineHeight()    // statusLine is a sibling, not rendered here

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1365,6 +1365,7 @@ func frontendFormTheme() *huh.Theme {
 	// the inactive button's theme background in place makes both choices look
 	// selected, especially in terminals where their colors are similar.
 	theme.Focused.BlurredButton = theme.Focused.BlurredButton.UnsetBackground().Bold(false)
+	theme.Blurred.FocusedButton = theme.Blurred.FocusedButton.UnsetBackground().Bold(false)
 	theme.Blurred.BlurredButton = theme.Blurred.BlurredButton.UnsetBackground().Bold(false)
 	return theme
 }

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1843,6 +1843,7 @@ func (fe *frontendPretty) setupTUI() {
 		Profile:          fe.profile,
 		UsingCloudEngine: fe.UsingCloudEngine,
 		Keys:             fe.keys,
+		Snug:             fe.keymapSnug,
 	}
 	fe.tui.AddChild(fe.keymapBar)
 	fe.tui.SetFocus(fe)
@@ -2404,6 +2405,17 @@ func (fe *frontendPretty) keys(out *termenv.Output) []key.Binding {
 	}
 }
 
+func (fe *frontendPretty) keymapSnug() bool {
+	return fe.statusLine != nil && fe.formWrap == nil && fe.searchInput == nil && fe.logSearchInput == nil
+}
+
+func (fe *frontendPretty) keymapHeight() int {
+	if fe.keymapSnug() {
+		return 1
+	}
+	return 2
+}
+
 func (fe *frontendPretty) escHelp() string {
 	if fe.searchQuery != "" {
 		return "clear search"
@@ -2522,7 +2534,7 @@ func (fe *frontendPretty) Render(ctx tuist.Context) {
 	// Lines the TUI renders as siblings outside this component, which are
 	// always shown and so must be reserved out of the screen height: the keymap
 	// bar, error label, text input, form, and search input.
-	reserved := 2 // keymap bar and its separating blank line
+	reserved := fe.keymapHeight()
 	reserved += fe.errorLabelHeight()
 	reserved += fe.queuedMessageHeight() // queuedMsgLabel is a sibling, not rendered here
 	reserved += fe.statusLineHeight()    // statusLine is a sibling, not rendered here

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -297,6 +297,9 @@ func (h *commandViewHandle) Update(fn func()) {
 		if h.fe.commandView != nil {
 			h.fe.commandView.Update()
 		}
+		if h.fe.keymapBar != nil {
+			h.fe.keymapBar.Update()
+		}
 		h.fe.Update()
 	})
 }
@@ -1257,12 +1260,12 @@ func (fe *frontendPretty) HandleForm(ctx context.Context, form *huh.Form) error 
 		return ErrNonInteractive
 	}
 
-	done := make(chan struct{}, 1)
+	done := make(chan error, 1)
 	wrapCh := make(chan *teav1.Wrap, 1)
 
 	fe.dispatch(func() {
 		wrapCh <- fe.handlePromptForm(form, func(f *huh.Form) {
-			close(done)
+			done <- formCompletionError(f)
 		})
 		fe.Update()
 	})
@@ -1276,9 +1279,16 @@ func (fe *frontendPretty) HandleForm(ctx context.Context, form *huh.Form) error 
 			fe.removeForm(wrap)
 		})
 		return ctx.Err()
-	case <-done:
-		return nil
+	case err := <-done:
+		return err
 	}
+}
+
+func formCompletionError(form *huh.Form) error {
+	if form.State == huh.StateAborted {
+		return errors.Join(ErrInterrupted, huh.ErrUserAborted)
+	}
+	return nil
 }
 
 // removeForm tears the given prompt form out of the TUI. It no-ops unless wrap
@@ -1346,6 +1356,12 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 		model := fe.formModel
 		fe.removeForm(wrap)
 		result(model)
+		if model.State == huh.StateAborted {
+			// A form owns input focus, so Ctrl+C reaches Huh instead of the
+			// frontend's navigation handler. Preserve the frontend-wide interrupt
+			// contract rather than treating the form's default value as a choice.
+			fe.quitAction(ErrInterrupted)
+		}
 	})
 	// Insert before keymapBar
 	fe.tui.RemoveChild(fe.keymapBar)
@@ -2232,6 +2248,9 @@ func (fe *frontendPretty) Background(cmd ExecCommand, raw bool) error {
 func (fe *frontendPretty) keys(out *termenv.Output) []key.Binding {
 	if fe.formModel != nil {
 		return fe.formModel.KeyBinds()
+	}
+	if view, ok := fe.commandView.(interface{ HideKeymap() bool }); ok && view.HideKeymap() {
+		return nil
 	}
 
 	if fe.editlineFocused {
@@ -6786,7 +6805,7 @@ type TermOutput interface {
 }
 
 func (fe *frontendPretty) handlePromptBool(ctx context.Context, title, message string, dest *bool) error {
-	done := make(chan struct{})
+	done := make(chan error, 1)
 
 	fe.dispatch(func() {
 		fe.handlePromptForm(
@@ -6800,7 +6819,7 @@ func (fe *frontendPretty) handlePromptBool(ctx context.Context, title, message s
 						}).View())),
 				),
 			),
-			func(f *huh.Form) { close(done) },
+			func(f *huh.Form) { done <- formCompletionError(f) },
 		)
 		fe.Update()
 	})
@@ -6808,13 +6827,13 @@ func (fe *frontendPretty) handlePromptBool(ctx context.Context, title, message s
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-done:
-		return nil
+	case err := <-done:
+		return err
 	}
 }
 
 func (fe *frontendPretty) handlePromptString(ctx context.Context, title, message string, dest *string) error {
-	done := make(chan struct{})
+	done := make(chan error, 1)
 
 	fe.dispatch(func() {
 		fe.handlePromptForm(
@@ -6829,7 +6848,7 @@ func (fe *frontendPretty) handlePromptString(ctx context.Context, title, message
 						Value(dest),
 				),
 			),
-			func(f *huh.Form) { close(done) },
+			func(f *huh.Form) { done <- formCompletionError(f) },
 		)
 		fe.Update()
 	})
@@ -6837,8 +6856,8 @@ func (fe *frontendPretty) handlePromptString(ctx context.Context, title, message
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-done:
-		return nil
+	case err := <-done:
+		return err
 	}
 }
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1328,7 +1328,10 @@ func (*blankLine) Render(ctx tuist.Context) {
 func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form)) *teav1.Wrap {
 	form.SubmitCmd = tea.Quit
 	form.CancelCmd = tea.Quit
-	fe.formModel = form.WithTheme(frontendFormTheme()).WithShowHelp(false)
+	fe.formModel = form.
+		WithTheme(frontendFormTheme()).
+		WithKeyMap(frontendFormKeyMap()).
+		WithShowHelp(false)
 	fe.formWrap = teav1.New(fe.formModel)
 	fe.formSpacer = &blankLine{}
 	wrap := fe.formWrap
@@ -1352,6 +1355,12 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 	fe.keymapBar.Update()
 	fe.tui.SetFocus(fe.formWrap)
 	return wrap
+}
+
+func frontendFormKeyMap() *huh.KeyMap {
+	keymap := huh.NewDefaultKeyMap()
+	keymap.MultiSelect.Toggle.SetHelp("space", "toggle")
+	return keymap
 }
 
 func frontendFormTheme() *huh.Theme {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -2447,11 +2447,21 @@ func (fe *frontendPretty) Render(ctx tuist.Context) {
 	if !fe.finalRender && (fe.backgrounded || fe.quitting) {
 		return
 	}
+	fe.claims = newRenderClaims()
+	if !fe.finalRender {
+		// Update window dimensions before choosing the screen body. Command-owned
+		// views embed the same trace renderers, which depend on this state for
+		// wrapping, log sizing, and resize handling.
+		fe.setWindowSizeLocked(windowSize{Width: ctx.Width, Height: ctx.ScreenHeight()})
+	} else if fe.contentWidth <= 0 {
+		// Final render without a live TUI (report mode). Set to 0
+		// so the renderer doesn't truncate (maxLiteralLen = 0).
+		fe.contentWidth = 0
+	}
 	if fe.commandView != nil {
 		fe.RenderChild(ctx, fe.commandView)
 		return
 	}
-	fe.claims = newRenderClaims()
 
 	// Coalesce deferred view updates. Multiple ExportSpans batches may
 	// have set viewDirty since the last frame — recalculate once now.
@@ -2464,15 +2474,6 @@ func (fe *frontendPretty) Render(ctx tuist.Context) {
 	// midterm's incremental search (only re-scans changed rows).
 	if fe.searchQuery != "" {
 		fe.refreshSearchMatches()
-	}
-
-	if !fe.finalRender {
-		// Update window dimensions from tuist.
-		fe.setWindowSizeLocked(windowSize{Width: ctx.Width, Height: ctx.ScreenHeight()})
-	} else if fe.contentWidth <= 0 {
-		// Final render without a live TUI (report mode). Set to 0
-		// so the renderer doesn't truncate (maxLiteralLen = 0).
-		fe.contentWidth = 0
 	}
 
 	r := newRenderer(fe.db, fe.contentWidth/2, fe.FrontendOpts, fe.finalRender)

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -249,6 +249,12 @@ type frontendPretty struct {
 	logPager       *LogPagerView
 	logPagerReturn func()
 	logSearchInput *tuist.TextInput
+
+	// commandView replaces the generic trace screen when a command wants to
+	// own the semantic layout while embedding reusable trace components.
+	commandView       CommandView
+	commandViewHandle *commandViewHandle
+	spanLists         map[*SpanListView]struct{}
 }
 
 // Verify interface compliance at compile time.
@@ -257,6 +263,56 @@ var (
 	_ tuist.Interactive = (*frontendPretty)(nil)
 	_ tuist.Mounter     = (*frontendPretty)(nil)
 )
+
+var _ CommandFrontend = (*frontendPretty)(nil)
+
+type commandViewContext struct {
+	fe *frontendPretty
+}
+
+func (ctx commandViewContext) SpanList(root func() dagui.SpanID, include func() []dagui.SpanID) *SpanListView {
+	return newSpanListView(ctx.fe, root, include)
+}
+
+type commandViewHandle struct {
+	fe *frontendPretty
+}
+
+func (h *commandViewHandle) Update(fn func()) {
+	if h == nil || h.fe == nil {
+		return
+	}
+	h.fe.dispatch(func() {
+		if fn != nil {
+			fn()
+		}
+		if h.fe.commandView != nil {
+			h.fe.commandView.Update()
+		}
+		h.fe.Update()
+	})
+}
+
+// SetView installs a command-owned body in the pretty frontend. Calls are
+// serialized with telemetry updates and rendering by the Tuist event loop.
+func (fe *frontendPretty) SetView(factory ViewFactory) ViewHandle {
+	handle := &commandViewHandle{fe: fe}
+	fe.dispatch(func() {
+		fe.commandViewHandle = handle
+		if factory == nil {
+			fe.commandView = nil
+		} else {
+			fe.commandView = factory(commandViewContext{fe: fe})
+		}
+		if fe.commandView != nil {
+			if _, interactive := fe.commandView.(tuist.Interactive); interactive {
+				fe.tui.SetFocus(fe.commandView)
+			}
+		}
+		fe.Update()
+	})
+	return handle
+}
 
 // treePrefix holds pre-computed prefix strings for a SpanTreeView.
 // These are set by the parent SpanTreeView when rendering its children.
@@ -1441,6 +1497,10 @@ func (fe *frontendPretty) setupFinalRenderLocked() {
 	// SpanTreeView and marks any changed tree dirty.
 	if !fe.finalRender {
 		fe.finalRender = true
+		if fe.commandView != nil {
+			fe.commandView.SetFinal(true)
+			fe.commandView.Update()
+		}
 		fe.Update()
 	}
 
@@ -1865,7 +1925,7 @@ func (fe *frontendPretty) FinalRender(w io.Writer) error {
 
 	out := NewOutput(w, termenv.WithProfile(fe.profile))
 
-	if fe.Debug || fe.Verbosity >= dagui.ShowCompletedVerbosity || fe.err != nil || fe.db.HasTests() || fe.db.HasChecks() || fe.db.HasGenerators() || fe.db.HasGenerateReport() {
+	if fe.commandView != nil || fe.Debug || fe.Verbosity >= dagui.ShowCompletedVerbosity || fe.err != nil || fe.db.HasTests() || fe.db.HasChecks() || fe.db.HasGenerators() || fe.db.HasGenerateReport() {
 		for _, line := range fe.tui.RenderLines() {
 			fmt.Fprintln(w, line)
 		}
@@ -1963,6 +2023,12 @@ func (fe prettySpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.R
 			}
 		}
 		fe.updateTestViews()
+		for view := range fe.spanLists {
+			view.UpdateAll()
+		}
+		if fe.commandView != nil {
+			fe.commandView.Update()
+		}
 		// Don't recalculate here — set dirty flag so Render coalesces
 		// multiple ExportSpans batches into one recalculate per frame.
 		fe.viewDirty = true
@@ -2035,6 +2101,12 @@ func (fe prettyLogExporter) Export(ctx context.Context, logs []sdklog.Record) er
 			fe.updateLogPagerForLogs(spanID)
 		}
 		fe.updateTestViews()
+		for view := range fe.spanLists {
+			view.UpdateAll()
+		}
+		if fe.commandView != nil {
+			fe.commandView.Update()
+		}
 		fe.Update()
 	})
 	return nil
@@ -2319,6 +2391,10 @@ func isEscapeKey(keyStr string) bool {
 // Render implements tuist.Component. It produces the full TUI output as lines.
 func (fe *frontendPretty) Render(ctx tuist.Context) {
 	if !fe.finalRender && (fe.backgrounded || fe.quitting) {
+		return
+	}
+	if fe.commandView != nil {
+		fe.RenderChild(ctx, fe.commandView)
 		return
 	}
 	fe.claims = newRenderClaims()
@@ -3368,6 +3444,18 @@ func (fe *frontendPretty) applyTuistFocus() {
 	}
 	if fe.testsMode && fe.fullscreenTests != nil {
 		fe.tui.SetFocus(fe.fullscreenTests)
+		return
+	}
+	if fe.commandView != nil {
+		if fe.FocusedSpan.IsValid() {
+			for view := range fe.spanLists {
+				if tree := view.scope.spanTrees[fe.FocusedSpan]; tree != nil {
+					fe.tui.SetFocus(tree)
+					return
+				}
+			}
+		}
+		fe.tui.SetFocus(fe.commandView)
 		return
 	}
 	if fe.FocusedSpan.IsValid() {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -1326,7 +1326,7 @@ func (*blankLine) Render(ctx tuist.Context) {
 func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form)) *teav1.Wrap {
 	form.SubmitCmd = tea.Quit
 	form.CancelCmd = tea.Quit
-	fe.formModel = form.WithTheme(huh.ThemeBase16()).WithShowHelp(false)
+	fe.formModel = form.WithTheme(frontendFormTheme()).WithShowHelp(false)
 	// Cap the form at half the screen so a tall field (e.g. the .resume session
 	// picker's long Select) stays scrollable instead of dominating — or
 	// overflowing — the terminal. huh propagates this to its Selects, which then
@@ -1357,6 +1357,16 @@ func (fe *frontendPretty) handlePromptForm(form *huh.Form, result func(*huh.Form
 	fe.tui.AddChild(fe.keymapBar)
 	fe.tui.SetFocus(fe.formWrap)
 	return wrap
+}
+
+func frontendFormTheme() *huh.Theme {
+	theme := huh.ThemeBase16()
+	// A background is the structural focus marker for confirm buttons. Leaving
+	// the inactive button's theme background in place makes both choices look
+	// selected, especially in terminals where their colors are similar.
+	theme.Focused.BlurredButton = theme.Focused.BlurredButton.UnsetBackground().Bold(false)
+	theme.Blurred.BlurredButton = theme.Blurred.BlurredButton.UnsetBackground().Bold(false)
+	return theme
 }
 
 func (fe *frontendPretty) Opts() *dagui.FrontendOpts {

--- a/dagql/idtui/frontend_span_list.go
+++ b/dagql/idtui/frontend_span_list.go
@@ -1,0 +1,232 @@
+package idtui
+
+import (
+	"slices"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/dagger/dagger/dagql/dagui"
+	"github.com/vito/tuist"
+)
+
+// SpanListView renders selected direct children of a trace span as normal,
+// interactive span trees. It shares the frontend's DB, rendering policy, and
+// span components; only the choice and ordering of roots belongs to the
+// command screen.
+type SpanListView struct {
+	tuist.Compo
+
+	fe      *frontendPretty
+	root    func() dagui.SpanID
+	include func() []dagui.SpanID
+
+	scope     spanTreeScope
+	container *tuist.Container
+	visible   []dagui.SpanID
+}
+
+var (
+	_ tuist.Component   = (*SpanListView)(nil)
+	_ tuist.Mounter     = (*SpanListView)(nil)
+	_ tuist.Dismounter  = (*SpanListView)(nil)
+	_ tuist.Interactive = (*SpanListView)(nil)
+)
+
+func newSpanListView(fe *frontendPretty, root func() dagui.SpanID, include func() []dagui.SpanID) *SpanListView {
+	return &SpanListView{
+		fe:        fe,
+		root:      root,
+		include:   include,
+		container: &tuist.Container{},
+		scope: spanTreeScope{
+			spanTrees: make(map[dagui.SpanID]*SpanTreeView),
+		},
+	}
+}
+
+func (v *SpanListView) OnMount(tuist.Context) {
+	if v.fe.spanLists == nil {
+		v.fe.spanLists = make(map[*SpanListView]struct{})
+	}
+	v.fe.spanLists[v] = struct{}{}
+}
+
+func (v *SpanListView) OnDismount() {
+	delete(v.fe.spanLists, v)
+}
+
+func (v *SpanListView) UpdateAll() {
+	v.Update()
+	v.container.Update()
+	for _, tree := range v.scope.spanTrees {
+		tree.Update()
+	}
+}
+
+func (v *SpanListView) Render(ctx tuist.Context) {
+	if !v.sync() {
+		return
+	}
+	v.RenderChild(ctx, v.container)
+}
+
+func (v *SpanListView) sync() bool {
+	if v.root == nil {
+		return v.clear()
+	}
+	rootID := v.root()
+	root := v.fe.db.Spans.Map[rootID]
+	if root == nil {
+		return v.clear()
+	}
+
+	opts := v.fe.FrontendOpts
+	opts.ZoomedSpan = rootID
+	rowsView := v.fe.db.RowsView(opts)
+	if len(rowsView.Body) == 0 {
+		return v.clear()
+	}
+	v.scope.rowsView = rowsView
+	v.scope.rows = rowsView.Rows(opts)
+	v.scope.opts = opts
+
+	ids := []dagui.SpanID(nil)
+	if v.include != nil {
+		ids = v.include()
+	}
+	children := make([]tuist.Component, 0, len(rowsView.Body))
+	if v.include == nil {
+		ids = make([]dagui.SpanID, 0, len(rowsView.Body))
+		for _, tree := range rowsView.Body {
+			if tree != nil && tree.Span != nil {
+				ids = append(ids, tree.Span.ID)
+			}
+		}
+	}
+	for _, id := range ids {
+		i := slices.IndexFunc(rowsView.Body, func(tree *dagui.TraceTree) bool {
+			return tree != nil && tree.Span != nil && tree.Span.ID == id
+		})
+		if i < 0 {
+			continue
+		}
+		tree := rowsView.Body[i]
+		spanTree := v.fe.getOrCreateSpanTreeInScope(tree.Span.ID, &v.scope)
+		spanTree.parent = nil
+		spanTree.indexInParent = len(children)
+		v.fe.syncTreeNodeInScope(spanTree, treePrefix{}, &v.scope)
+		children = append(children, spanTree)
+	}
+
+	if !sameComponents(v.container.Children, children) {
+		v.container.Children = children
+		v.container.Update()
+	}
+	v.visible = v.visible[:0]
+	selected := make(map[dagui.SpanID]struct{}, len(ids))
+	for _, id := range ids {
+		selected[id] = struct{}{}
+	}
+	for _, row := range v.scope.rows.Order {
+		top := row
+		for top.Parent != nil {
+			top = top.Parent
+		}
+		if _, ok := selected[top.Span.ID]; ok {
+			v.visible = append(v.visible, row.Span.ID)
+		}
+	}
+	return len(children) > 0
+}
+
+func (v *SpanListView) clear() bool {
+	v.scope.rowsView = nil
+	v.scope.rows = nil
+	v.visible = nil
+	if len(v.container.Children) > 0 {
+		v.container.Children = nil
+		v.container.Update()
+	}
+	return false
+}
+
+// Focused reports whether this list currently owns the frontend's focused
+// span. It lets an outer command screen compose navigation across lists.
+func (v *SpanListView) Focused() bool {
+	return slices.Contains(v.visible, v.fe.FocusedSpan)
+}
+
+func (v *SpanListView) FocusFirst() bool {
+	if !v.sync() || len(v.visible) == 0 {
+		return false
+	}
+	return v.focus(v.visible[0])
+}
+
+func (v *SpanListView) FocusLast() bool {
+	if !v.sync() || len(v.visible) == 0 {
+		return false
+	}
+	return v.focus(v.visible[len(v.visible)-1])
+}
+
+func (v *SpanListView) focus(id dagui.SpanID) bool {
+	tree := v.scope.spanTrees[id]
+	if tree == nil {
+		return false
+	}
+	v.fe.autoFocus = false
+	v.fe.FocusedSpan = id
+	v.fe.tui.SetFocus(tree)
+	tree.Update()
+	v.Update()
+	return true
+}
+
+func (v *SpanListView) move(delta int) bool {
+	if !v.sync() || len(v.visible) == 0 {
+		return false
+	}
+	i := slices.Index(v.visible, v.fe.FocusedSpan)
+	if i < 0 {
+		if delta > 0 {
+			return v.FocusFirst()
+		}
+		return v.FocusLast()
+	}
+	i += delta
+	if i < 0 || i >= len(v.visible) {
+		return false
+	}
+	return v.focus(v.visible[i])
+}
+
+// HandleKeyPress provides list-local navigation. Returning false at either
+// edge lets the command screen move focus into an adjacent span list.
+func (v *SpanListView) HandleKeyPress(_ tuist.Context, ev uv.KeyPressEvent) bool {
+	switch uv.Key(ev).String() {
+	case "down", "j":
+		return v.move(1)
+	case "up", "k":
+		return v.move(-1)
+	case "home":
+		return v.FocusFirst()
+	case "end", "G":
+		return v.FocusLast()
+	case "right", "l", "enter":
+		if !v.Focused() {
+			return v.FocusFirst()
+		}
+		v.fe.setExpanded(v.fe.FocusedSpan, true)
+		return true
+	case "left", "h":
+		if !v.Focused() {
+			return false
+		}
+		row := v.scope.rows.BySpan[v.fe.FocusedSpan]
+		if row != nil && row.Expanded {
+			v.fe.setExpanded(v.fe.FocusedSpan, false)
+			return true
+		}
+	}
+	return false
+}

--- a/dagql/idtui/frontend_tests.go
+++ b/dagql/idtui/frontend_tests.go
@@ -215,7 +215,7 @@ func (tv *TestView) Render(ctx tuist.Context) {
 		} else {
 			// Leave room for the keymap sibling. Filling the rest of the
 			// screen keeps Tuist's mouse coordinates aligned with rows.
-			viewportHeight = max(ctx.ScreenHeight()-1, 1)
+			viewportHeight = max(ctx.ScreenHeight()-2, 1)
 		}
 	} else if tv.MaxHeight > 0 {
 		viewportHeight = min(viewportHeight, tv.MaxHeight)

--- a/dagql/idtui/huh.go
+++ b/dagql/idtui/huh.go
@@ -3,5 +3,5 @@ package idtui
 import "github.com/charmbracelet/huh"
 
 func NewForm(groups ...*huh.Group) *huh.Form {
-	return huh.NewForm(groups...).WithTheme(huh.ThemeBase16())
+	return huh.NewForm(groups...)
 }

--- a/dagql/idtui/keymap.go
+++ b/dagql/idtui/keymap.go
@@ -61,6 +61,7 @@ func (kb *KeymapBar) Render(ctx tuist.Context) {
 	if view == "" {
 		return
 	}
+	ctx.Line("")
 	ctx.Line(view)
 }
 

--- a/dagql/idtui/keymap.go
+++ b/dagql/idtui/keymap.go
@@ -69,7 +69,10 @@ func RenderKeymap(out io.Writer, style lipgloss.Style, keys []key.Binding, press
 	w := new(strings.Builder)
 	var showedKey bool
 	for _, k := range keys {
-		mainKey := k.Keys()[0]
+		mainKey := k.Help().Key
+		if mainKey == "" {
+			mainKey = k.Keys()[0]
+		}
 		var pressed bool
 		if time.Since(pressedKeyAt) < keypressDuration {
 			pressed = slices.Contains(k.Keys(), pressedKey)

--- a/dagql/idtui/keymap.go
+++ b/dagql/idtui/keymap.go
@@ -33,6 +33,10 @@ type KeymapBar struct {
 	// Keys returns the current set of key bindings to display.
 	Keys func(out *termenv.Output) []key.Binding
 
+	// Snug reports whether the keymap should omit its usual separating line.
+	// Agent mode uses this while the status bar is directly above the keymap.
+	Snug func() bool
+
 	// PressedKey is the key string that was most recently pressed.
 	PressedKey string
 
@@ -61,7 +65,9 @@ func (kb *KeymapBar) Render(ctx tuist.Context) {
 	if view == "" {
 		return
 	}
-	ctx.Line("")
+	if kb.Snug == nil || !kb.Snug() {
+		ctx.Line("")
+	}
 	ctx.Line(view)
 }
 

--- a/dagql/idtui/keymap_test.go
+++ b/dagql/idtui/keymap_test.go
@@ -9,6 +9,8 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/vito/tuist"
 )
 
 func TestRenderKeymapUsesDisplayKey(t *testing.T) {
@@ -20,5 +22,21 @@ func TestRenderKeymapUsesDisplayKey(t *testing.T) {
 	RenderKeymap(&out, lipgloss.NewStyle(), []key.Binding{binding}, "", time.Time{})
 	if got := ansi.Strip(out.String()); !strings.Contains(got, "x toggle") {
 		t.Fatalf("keymap rendered %q, want display key", got)
+	}
+}
+
+func TestKeymapBarAlwaysHasLeadingBlankLine(t *testing.T) {
+	binding := key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "confirm"))
+	bar := &KeymapBar{
+		Profile: termenv.Ascii,
+		Keys: func(*termenv.Output) []key.Binding {
+			return []key.Binding{binding}
+		},
+	}
+	tui := tuist.New(tuist.NewHeadlessTerminal(80, 10))
+	tui.AddChild(bar)
+	lines := tui.RenderLines()
+	if len(lines) != 2 || lines[0] != "" || !strings.Contains(lines[1], "enter confirm") {
+		t.Fatalf("keymap did not render with one leading blank line: %#v", lines)
 	}
 }

--- a/dagql/idtui/keymap_test.go
+++ b/dagql/idtui/keymap_test.go
@@ -1,0 +1,24 @@
+package idtui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestRenderKeymapUsesDisplayKey(t *testing.T) {
+	binding := key.NewBinding(
+		key.WithKeys(" ", "x"),
+		key.WithHelp("x", "toggle"),
+	)
+	var out bytes.Buffer
+	RenderKeymap(&out, lipgloss.NewStyle(), []key.Binding{binding}, "", time.Time{})
+	if got := ansi.Strip(out.String()); !strings.Contains(got, "x toggle") {
+		t.Fatalf("keymap rendered %q, want display key", got)
+	}
+}

--- a/dagql/idtui/keymap_test.go
+++ b/dagql/idtui/keymap_test.go
@@ -36,7 +36,24 @@ func TestKeymapBarAlwaysHasLeadingBlankLine(t *testing.T) {
 	tui := tuist.New(tuist.NewHeadlessTerminal(80, 10))
 	tui.AddChild(bar)
 	lines := tui.RenderLines()
-	if len(lines) != 2 || lines[0] != "" || !strings.Contains(lines[1], "enter confirm") {
+	if len(lines) != 2 || lines[0] != "" || !strings.Contains(ansi.Strip(lines[1]), "enter confirm") {
 		t.Fatalf("keymap did not render with one leading blank line: %#v", lines)
+	}
+}
+
+func TestKeymapBarCanSitSnugAgainstStatusBar(t *testing.T) {
+	binding := key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "confirm"))
+	bar := &KeymapBar{
+		Profile: termenv.Ascii,
+		Keys: func(*termenv.Output) []key.Binding {
+			return []key.Binding{binding}
+		},
+		Snug: func() bool { return true },
+	}
+	tui := tuist.New(tuist.NewHeadlessTerminal(80, 10))
+	tui.AddChild(bar)
+	lines := tui.RenderLines()
+	if len(lines) != 1 || !strings.Contains(ansi.Strip(lines[0]), "enter confirm") {
+		t.Fatalf("snug keymap rendered a separating line: %#v", lines)
 	}
 }

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2610,9 +2610,9 @@ repository root — never a nested one. A subdirectory config with a
 blueprint is left as legacy with a warning.
 
 Idempotent: safe to run anytime. No-ops what's already in good shape.
-Each step can be skipped at the prompt. With --auto-apply, all steps
-are applied without prompting. In non-interactive mode (no TTY) the
-default is to skip steps that would mutate state.
+Each step can be skipped at the prompt. With --auto-apply, workspace
+changes and module recommendations are applied without prompting. Cloud
+login is skipped in non-interactive mode; run dagger login separately.
 
 ```
 dagger setup

--- a/hack/designs/composable-command-tui.md
+++ b/hack/designs/composable-command-tui.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Draft.
+In progress. The command-screen host, reusable span lists, and `dagger setup`
+screen are implemented; broader frontend extraction remains follow-up work.
 
 ## Summary
 
@@ -329,25 +330,25 @@ guards against disappearing or interleaved output.
 
 - [ ] Split `frontendPretty` into a frontend host and the default generic trace
       screen without changing existing command output.
-- [ ] Add a frontend-owned screen slot with the generic trace screen as its
+- [x] Add a frontend-owned screen slot with the generic trace screen as its
       default component.
-- [ ] Define the internal `ViewFactory`, `CommandView`, `ViewContext`, and
+- [x] Define the internal `ViewFactory`, `CommandView`, `ViewContext`, and
       `ViewHandle` contracts.
 - [ ] Extract `SpanTreeView` dependencies from `frontendPretty` into a reusable
       trace-view context.
-- [ ] Generalize `TestSpanChildrenView` into reusable `Span` and `SpanList`
-      components.
-- [ ] Add mount and dismount registration for trace-backed components.
-- [ ] Replace hard-coded trace component updates with database-driven
+- [x] Generalize the `TestSpanChildrenView` pattern into a reusable `SpanList`
+      component.
+- [x] Add mount and dismount registration for trace-backed components.
+- [x] Replace hard-coded trace component updates with database-driven
       invalidation of mounted views.
-- [ ] Route semantic model mutations through the Tuist event loop.
-- [ ] Preserve descendant focus across renders and restore focus after forms
+- [x] Route semantic model mutations through the Tuist event loop.
+- [x] Preserve descendant focus across renders and restore focus after forms
       and overlays close.
-- [ ] Add an explicit live-to-final transition for custom command screens.
-- [ ] Support deterministic final rendering for non-interactive output.
-- [ ] Implement `SetupView` with semantic workspace guidance and an embedded
+- [x] Add an explicit live-to-final transition for custom command screens.
+- [x] Support deterministic final rendering for non-interactive output.
+- [x] Implement `SetupView` with semantic workspace guidance and an embedded
       installation span checklist.
-- [ ] Remove setup-specific UI-message and span-surfacing workarounds that are
+- [x] Remove setup-specific UI-message and span-surfacing workarounds that are
       no longer needed for local presentation.
 - [ ] Add component, focus, exporter-update, final-render, and fallback tests.
 - [ ] Add end-to-end TUI coverage for `dagger setup` success and failure flows.

--- a/hack/designs/composable-command-tui.md
+++ b/hack/designs/composable-command-tui.md
@@ -118,15 +118,15 @@ normal Tuist component created with a frontend-owned view context:
 type ViewFactory func(ViewContext) CommandView
 
 type CommandView interface {
-	tuist.Component
+ tuist.Component
 
-	// SetFinal switches from transient progress to durable terminal output.
-	SetFinal(bool)
+ // SetFinal switches from transient progress to durable terminal output.
+ SetFinal(bool)
 }
 
 type Frontend interface {
-	// Existing methods omitted.
-	SetView(ViewFactory) ViewHandle
+ // Existing methods omitted.
+ SetView(ViewFactory) ViewHandle
 }
 ```
 
@@ -142,9 +142,9 @@ internals:
 
 ```go
 type ViewContext interface {
-	Trace() TraceStore
-	Span(id dagui.SpanID, opts SpanViewOpts) tuist.Component
-	SpanList(ids func() []dagui.SpanID, opts SpanListOpts) tuist.Component
+ Trace() TraceStore
+ Span(id dagui.SpanID, opts SpanViewOpts) tuist.Component
+ SpanList(ids func() []dagui.SpanID, opts SpanListOpts) tuist.Component
 }
 ```
 
@@ -177,9 +177,9 @@ For example:
 
 ```go
 type SpanListOpts struct {
-	ShowChildren   bool
-	CollapseOnDone bool
-	MaxDepth       int
+ ShowChildren   bool
+ CollapseOnDone bool
+ MaxDepth       int
 }
 ```
 
@@ -216,13 +216,13 @@ that dispatches onto the Tuist event loop:
 
 ```go
 type SetupModel struct {
-	Migration MigrationState
-	Installs  []dagui.SpanID
-	Result    SetupResult
+ Migration MigrationState
+ Installs  []dagui.SpanID
+ Result    SetupResult
 }
 
 view.Update(func(model *SetupModel) {
-	model.Migration = MigrationNotNeeded
+ model.Migration = MigrationNotNeeded
 })
 ```
 

--- a/hack/designs/composable-command-tui.md
+++ b/hack/designs/composable-command-tui.md
@@ -262,8 +262,11 @@ available.
 
 ## `dagger setup`
 
-Cloud login remains before TUI startup so that it does not begin the Cloud
-trace that login is intended to establish.
+The TUI host starts before Cloud login, but telemetry does not. Login is an
+untraced semantic phase rendered by `SetupView`; once it succeeds or is
+skipped, setup initializes telemetry and begins the traced workspace phase.
+Credentials established by login therefore apply to the entire trace without
+forcing login outside the composed screen.
 
 After login, `dagger setup` installs a `SetupView` and starts its primary setup
 span. The view owns:
@@ -345,6 +348,8 @@ guards against disappearing or interleaved output.
 - [x] Preserve descendant focus across renders and restore focus after forms
       and overlays close.
 - [x] Add an explicit live-to-final transition for custom command screens.
+- [x] Decouple the setup TUI lifetime from its traced execution lifetime so
+      Cloud login can render inside the screen before telemetry starts.
 - [x] Support deterministic final rendering for non-interactive output.
 - [x] Implement `SetupView` with semantic workspace guidance and an embedded
       installation span checklist.

--- a/hack/designs/composable-command-tui.md
+++ b/hack/designs/composable-command-tui.md
@@ -1,0 +1,353 @@
+# Composable Command TUI
+
+## Status
+
+Draft.
+
+## Summary
+
+Allow CLI commands to provide the outer structure of the pretty TUI while
+embedding reusable, interactive views of the spans they produce.
+
+The pretty frontend becomes a host for command screens. It continues to own the
+terminal, Tuist event loop, telemetry database, forms, and lifecycle. A command
+screen owns the semantic presentation of its workflow and composes trace-backed
+components supplied by the host.
+
+Commands without a custom screen continue to use the existing generic trace
+frontend.
+
+## Problem
+
+The pretty frontend currently assumes that a trace tree is the entire screen.
+This works for commands whose output is naturally a trace, but poorly for
+guided workflows such as `dagger setup`:
+
+1. **Execution structure becomes presentation structure** — commands must use
+   span names and attributes to approximate headings, instructions, checklists,
+   and summaries.
+2. **Human messages look like operations** — representing prose as spans adds
+   status icons, durations, and tree borders that have no semantic meaning.
+3. **Plain output conflicts with the TUI** — writing directly to the terminal
+   can race with live rendering and leave misplaced or disappearing text.
+4. **Commands cannot compose trace UI** — the frontend already has interactive
+   span trees, but only the monolithic frontend and test views can arrange them.
+5. **Live and final output diverge accidentally** — once execution ends, the
+   generic trace report can replace a command-specific workflow without a
+   deliberate final presentation.
+
+`dagger setup` should be able to render an ordinary workflow around real spans:
+
+```text
+Setting up this workspace
+
+✓ Cloud account                          Already logged in
+✓ Workspace                              Nothing to migrate
+
+Recommended modules
+  ✓ dagger install github.com/dagger/eslint       1.2s
+  ⠋ dagger install github.com/dagger/go
+  ○ dagger install github.com/dagger/prettier
+  ○ dagger install github.com/dagger/vitest
+
+  Enter: inspect details    Space: expand
+```
+
+The install rows should remain selectable and expandable. Their children can
+show uploads, downloads, logs, and engine operations using the normal trace
+presentation.
+
+## Goals
+
+- Let a command own the outer layout of the pretty frontend.
+- Reuse the frontend's existing `dagui.DB` and live telemetry updates.
+- Provide reusable span components with the current spinner, status, duration,
+  navigation, expansion, logs, and child-span behavior.
+- Keep terminal and focus lifecycle under frontend control.
+- Make the final durable rendering an explicit mode of the command screen.
+- Preserve the current generic trace experience as the default.
+- Provide coherent output for interactive, report, and plain frontends.
+
+## Non-goals
+
+- Defining local UI layout through telemetry attributes.
+- Letting commands manage the Tuist event loop or terminal directly.
+- Changing the telemetry sent to Dagger Cloud.
+- Making this a public GraphQL or module API.
+- Replacing the generic trace frontend for commands that do not need a custom
+  workflow.
+
+## Architecture
+
+The current `frontendPretty` responsibilities are split into a host, a default
+screen, and reusable trace components:
+
+```text
+Pretty frontend host
+├── screen slot
+│   ├── generic trace screen (default)
+│   └── command screen
+│       ├── command-owned content
+│       └── reusable span views
+├── form and modal overlays
+└── shared key bindings and frontend chrome
+```
+
+### Frontend Host
+
+The host owns:
+
+- the Tuist instance and root component
+- the shared `dagui.DB`
+- span and log exporters
+- terminal sizing and shutdown
+- forms, overlays, and focus restoration
+- switching from live to final rendering
+- the default generic trace screen
+
+Commands do not receive the Tuist root and cannot add arbitrary siblings to
+it. This keeps forms, focus, cleanup, and final rendering consistent.
+
+### Command Screen
+
+A command may install a screen before starting its traced work. The screen is a
+normal Tuist component created with a frontend-owned view context:
+
+```go
+type ViewFactory func(ViewContext) CommandView
+
+type CommandView interface {
+	tuist.Component
+
+	// SetFinal switches from transient progress to durable terminal output.
+	SetFinal(bool)
+}
+
+type Frontend interface {
+	// Existing methods omitted.
+	SetView(ViewFactory) ViewHandle
+}
+```
+
+If `SetView` is not called, the host installs the existing generic trace screen.
+
+The exact API may evolve during extraction, but the ownership boundary is
+fixed: the frontend owns the runtime; the command owns the screen body.
+
+### View Context
+
+The view context exposes frontend services without exposing mutable frontend
+internals:
+
+```go
+type ViewContext interface {
+	Trace() TraceStore
+	Span(id dagui.SpanID, opts SpanViewOpts) tuist.Component
+	SpanList(ids func() []dagui.SpanID, opts SpanListOpts) tuist.Component
+}
+```
+
+`TraceStore` is a read-only view backed by the host's existing `dagui.DB`.
+Access occurs on the Tuist event loop. Commands do not mutate the database or
+poll it from execution goroutines.
+
+`Span` and `SpanList` create components configured by stable span IDs. A command
+chooses where the spans appear; the trace database remains the source of truth
+for their names, status, timing, logs, and descendants.
+
+### Span Components
+
+The existing `SpanTreeView` becomes a reusable component independent of
+`frontendPretty`. The existing `TestSpanChildrenView` is the closest current
+precedent: it already builds a selectable container of `SpanTreeView` instances
+against the shared database.
+
+The generalized component supports:
+
+- a supplied span ID or ordered list of IDs
+- running, succeeded, failed, and pending presentation
+- selection and keyboard navigation
+- expansion and collapse
+- child spans and inline logs
+- optional depth and visibility policies
+- live and final rendering
+
+For example:
+
+```go
+type SpanListOpts struct {
+	ShowChildren   bool
+	CollapseOnDone bool
+	MaxDepth       int
+}
+```
+
+Span attributes such as reveal, passthrough, and UI message remain meaningful
+to the generic trace screen. A custom command screen does not need to use them
+to define its outer layout.
+
+## State and Updates
+
+Command screens combine two distinct sources of state.
+
+### Trace State
+
+Exporters continue to ingest spans and logs into `dagui.DB` on the Tuist event
+loop. Mounted trace components register with the host and are invalidated when
+relevant trace records change.
+
+This replaces hard-coded update paths for individual component types with a
+general mounted trace-view registry:
+
+1. A trace component registers when mounted.
+2. It unregisters when dismounted.
+3. Exporters update `dagui.DB`.
+4. The host invalidates affected mounted components.
+5. Tuist propagates dirtiness through their parents and redraws the screen.
+
+### Semantic State
+
+Some workflow state is not telemetry. For example, "no workspace was found"
+and "these modules were recommended" should not be encoded as fake spans.
+
+The command maintains a small semantic model and updates it through a handle
+that dispatches onto the Tuist event loop:
+
+```go
+type SetupModel struct {
+	Migration MigrationState
+	Installs  []dagui.SpanID
+	Result    SetupResult
+}
+
+view.Update(func(model *SetupModel) {
+	model.Migration = MigrationNotNeeded
+})
+```
+
+The concrete handle can use a typed wrapper owned by the command. The required
+property is that command goroutines do not race with component rendering.
+
+## Focus and Input
+
+The host retains global input ownership. Tuist focus may move into any
+descendant of the active command screen, including an embedded span row.
+
+The command screen handles navigation between its semantic sections and
+delegates span navigation and expansion to the reusable span components. Forms
+and modal overlays temporarily take focus through the host. Closing an overlay
+restores the previously focused command component.
+
+Commands cannot install terminal readers or bypass Tuist dispatch.
+
+## Live and Final Rendering
+
+A custom screen must deliberately support both phases:
+
+- **Live mode** may contain spinners, pending rows, key hints, and expanded
+  interactive details.
+- **Final mode** emits concise durable output with no pending animation or
+  interaction-only chrome.
+
+At command completion, the host calls `SetFinal(true)`, performs a final render,
+and then shuts down the live terminal session. It does not replace the command
+screen with the generic trace report.
+
+The same final component should be renderable without a terminal, using an
+unbounded or headless Tuist context where practical. This keeps redirected and
+report output aligned with the interactive result. The plain frontend may use
+the same semantic model with non-interactive trace summaries when Tuist is not
+available.
+
+## `dagger setup`
+
+Cloud login remains before TUI startup so that it does not begin the Cloud
+trace that login is intended to establish.
+
+After login, `dagger setup` installs a `SetupView` and starts its primary setup
+span. The view owns:
+
+- workspace migration status and guidance
+- the recommended-module section
+- the ordered list of module installation span IDs
+- the final outcome and suggested next command
+
+Each installation remains a real span named after the equivalent command:
+
+```text
+dagger install github.com/dagger/eslint
+```
+
+The screen embeds those spans as its checklist. Selecting or expanding an
+installation reveals its normal trace children. Workspace guidance is ordinary
+screen content, so it does not acquire a success icon, duration, or trace-tree
+border.
+
+On completion the view renders a durable summary such as:
+
+```text
+Workspace ready
+
+Installed eslint, go, prettier, and vitest.
+
+Try:
+  dagger check
+```
+
+The trace continues to contain the setup span and all operations, and Cloud
+continues to receive the full trace. Only local presentation changes.
+
+## Failure Behavior
+
+Failed action spans remain expandable and show their normal logs and children.
+The command screen adds workflow context around the failure without copying
+engine error text into a second state model.
+
+If a custom screen cannot be constructed before execution starts, the frontend
+falls back to the generic trace screen. A rendering failure after startup is a
+frontend error; it must not silently hide the command result.
+
+## Testing
+
+Component tests use an in-memory `dagui.DB` and a headless Tuist renderer to
+cover:
+
+- pending, running, succeeded, and failed span rows
+- live database updates invalidating mounted components
+- selection, expansion, and focus restoration
+- semantic model updates dispatched from command execution
+- transition from live to final mode
+- final rendering with and without a terminal
+- fallback to the generic trace screen
+
+`dagger setup` receives golden or snapshot coverage for its empty-workspace,
+migration, successful-install, partial-failure, and final-summary states. A TUI
+console or terminal recording test verifies the complete live transition and
+guards against disappearing or interleaved output.
+
+## Implementation Checklist
+
+- [ ] Split `frontendPretty` into a frontend host and the default generic trace
+      screen without changing existing command output.
+- [ ] Add a frontend-owned screen slot with the generic trace screen as its
+      default component.
+- [ ] Define the internal `ViewFactory`, `CommandView`, `ViewContext`, and
+      `ViewHandle` contracts.
+- [ ] Extract `SpanTreeView` dependencies from `frontendPretty` into a reusable
+      trace-view context.
+- [ ] Generalize `TestSpanChildrenView` into reusable `Span` and `SpanList`
+      components.
+- [ ] Add mount and dismount registration for trace-backed components.
+- [ ] Replace hard-coded trace component updates with database-driven
+      invalidation of mounted views.
+- [ ] Route semantic model mutations through the Tuist event loop.
+- [ ] Preserve descendant focus across renders and restore focus after forms
+      and overlays close.
+- [ ] Add an explicit live-to-final transition for custom command screens.
+- [ ] Support deterministic final rendering for non-interactive output.
+- [ ] Implement `SetupView` with semantic workspace guidance and an embedded
+      installation span checklist.
+- [ ] Remove setup-specific UI-message and span-surfacing workarounds that are
+      no longer needed for local presentation.
+- [ ] Add component, focus, exporter-update, final-render, and fallback tests.
+- [ ] Add end-to-end TUI coverage for `dagger setup` success and failure flows.

--- a/internal/cmd/dagger/cloud.go
+++ b/internal/cmd/dagger/cloud.go
@@ -139,6 +139,9 @@ func (cli *CloudCLI) Login(cmd *cobra.Command, args []string) error {
 	if err := auth.SetCurrentOrg(selectedOrg); err != nil {
 		return err
 	}
+	if err := clearSetupCloudLoginPromptPreference(); err != nil {
+		return err
+	}
 
 	fmt.Fprintln(outW, "Success.")
 

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -210,6 +210,7 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 // session would keep seeing the legacy dagger.json ("run dagger setup first").
 func withSetupSessions(
 	ctx context.Context,
+	before func(context.Context),
 	fn func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) error,
 ) (rerr error) {
 	params := client.Params{
@@ -224,7 +225,12 @@ func withSetupSessions(
 	}
 	return Frontend.Run(ctx, opts, func(ctx context.Context) (_ cleanups.CleanupF, rerr error) {
 		var cleanup cleanups.Cleanups
+		if before != nil {
+			before(ctx)
+		}
 
+		// Telemetry deliberately starts after the untraced setup phase (Cloud
+		// login), so credentials established there apply to the whole trace.
 		ctx, cleanupTelemetry := initEngineTelemetry(ctx)
 		otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 			if opts.Debug {

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -1045,12 +1045,9 @@ func handleChangesetResponseWithApply(
 		var confirm bool
 		form := idtui.NewForm(
 			huh.NewGroup(
-				huh.NewConfirm().
+				idtui.NewExplicitConfirm("Apply", "Discard", &confirm).
 					Title("Apply changes?").
-					Description(description).
-					Affirmative("Apply").
-					Negative("Discard").
-					Value(&confirm),
+					Description(description),
 			),
 		)
 		if err := Frontend.HandleForm(ctx, form); err != nil {

--- a/internal/cmd/dagger/llmconfig/setup.go
+++ b/internal/cmd/dagger/llmconfig/setup.go
@@ -252,10 +252,9 @@ func AutoSetupIfNeeded(ctx context.Context, promptHandler PromptHandler, interac
 	var runSetup bool
 	form := huh.NewForm(
 		huh.NewGroup(
-			huh.NewConfirm().
+			idtui.NewExplicitConfirm("Yes", "No", &runSetup).
 				Title("No LLM configuration found").
-				Description("Would you like to configure it now?").
-				Value(&runSetup),
+				Description("Would you like to configure it now?"),
 		),
 	)
 
@@ -718,11 +717,10 @@ func promptSetDefault(ctx context.Context, ph PromptHandler, cfg *Config, provid
 	var setDefault bool
 	form := huh.NewForm(
 		huh.NewGroup(
-			huh.NewConfirm().
+			idtui.NewExplicitConfirm("Yes", "No", &setDefault).
 				Title("Set as default provider?").
 				Description(fmt.Sprintf("Current default is %q. Use %q instead?",
-					cfg.LLM.DefaultProvider, provider)).
-				Value(&setDefault),
+					cfg.LLM.DefaultProvider, provider)),
 		),
 	)
 	if err := checkAbort(ph.HandleForm(ctx, form)); err != nil {

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -64,7 +64,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 
 	out := cmd.OutOrStdout()
 
-	if err := setupStepLogin(cmd); err != nil {
+	if err := setupStepLogin(cmd, cloudauth.GetCloudAuth); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Step 1 (login): %v\n", err)
 		// Login failures shouldn't block migration/recommend.
 	}
@@ -163,13 +163,13 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 
 // --- Step 1: Cloud login ---
 
-func setupStepLogin(cmd *cobra.Command) error {
+func setupStepLogin(cmd *cobra.Command, getCloudAuth func(context.Context) (*cloudauth.Cloud, error)) error {
 	ctx := cmd.Context()
 	out := cmd.OutOrStdout()
 
 	fmt.Fprintln(out, "Step 1: Cloud login")
 
-	if _, err := cloudauth.GetCloudAuth(ctx); err == nil {
+	if auth, err := getCloudAuth(ctx); err == nil && auth != nil {
 		fmt.Fprintln(out, "  Already logged in.")
 		return nil
 	}

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -614,8 +614,7 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 	form := idtui.NewForm(
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
-				Title("Select recommended modules to install").
-				Description("Space toggles a module. Enter installs the selected modules.").
+				Description("Space toggles · Enter installs").
 				Options(options...).
 				Value(&selected).
 				Filterable(false),

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -55,9 +55,9 @@ repository root — never a nested one. A subdirectory config with a
 blueprint is left as legacy with a warning.
 
 Idempotent: safe to run anytime. No-ops what's already in good shape.
-Each step can be skipped at the prompt. With --auto-apply, all steps
-are applied without prompting. In non-interactive mode (no TTY) the
-default is to skip steps that would mutate state.`,
+Each step can be skipped at the prompt. With --auto-apply, workspace
+changes and module recommendations are applied without prompting. Cloud
+login is skipped in non-interactive mode; run dagger login separately.`,
 	Args: cobra.NoArgs,
 	Annotations: map[string]string{
 		showFinalProgressKey: "true",
@@ -313,6 +313,16 @@ const (
 )
 
 func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (setupLoginChoice, error) {
+	return confirmSetupLoginInteractive(ctx, cmd, ui, isatty.IsTerminal(os.Stdin.Fd()))
+}
+
+func confirmSetupLoginInteractive(ctx context.Context, cmd *cobra.Command, ui *setupUI, interactive bool) (setupLoginChoice, error) {
+	if !interactive {
+		if ui != nil {
+			ui.setLoginSkipped("Skipped in non-interactive mode; run `dagger login` to log in.")
+		}
+		return setupLoginNotNow, nil
+	}
 	if ui == nil || !ui.live {
 		if confirm(cmd, "  Log in to Dagger Cloud?") {
 			return setupLogin, nil
@@ -321,10 +331,6 @@ func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (se
 	}
 	if autoApply {
 		return setupLogin, nil
-	}
-	if !isatty.IsTerminal(os.Stdin.Fd()) {
-		ui.setLoginSkipped("Skipped in non-interactive mode; use --auto-apply to accept.")
-		return setupLoginNotNow, nil
 	}
 	choice := setupLogin
 	form := huh.NewForm(huh.NewGroup(

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"text/tabwriter"
 
 	"dagger.io/dagger"
 	"github.com/charmbracelet/huh"
@@ -558,11 +557,11 @@ func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, 
 		return nil, false, nil
 	}
 
-	install, err = confirmInstallRecommended(ctx, cmd, recs, ui)
+	recs, err = selectRecommendedModules(ctx, cmd, recs, ui)
 	if err != nil {
 		return nil, false, err
 	}
-	if !install {
+	if len(recs) == 0 {
 		setupRecommendMessage(ui, messageCtx, "recommendations skipped", "Skipped.")
 		return nil, false, nil
 	}
@@ -592,44 +591,54 @@ func installRecommended(ctx context.Context, dag *dagger.Client, recs []recommen
 	return nil
 }
 
-// confirmInstallRecommended asks whether to install the recommended modules.
-// It prompts through the Frontend (a huh confirm with the recommendation table
-// as its description) so it renders inside the live progress TUI — the same
-// mechanism the migrate step uses for its apply prompt. With --auto-apply it
-// returns true without prompting; in non-interactive mode it skips (the safe
-// default — don't mutate state without a TTY).
-func confirmInstallRecommended(ctx context.Context, cmd *cobra.Command, recs []recommendation, ui *setupUI) (bool, error) {
+// selectRecommendedModules lets the user choose recommendations individually.
+// Every recommendation starts selected, preserving the old affirmative path
+// while allowing irrelevant modules to be toggled off before installation.
+func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []recommendation, ui *setupUI) ([]recommendation, error) {
 	if autoApply {
-		return true, nil
+		return recs, nil
 	}
 	if !isatty.IsTerminal(os.Stdin.Fd()) {
 		setupRecommendMessage(ui, ctx, "recommendations skipped", "Install recommended modules? Skipped in non-interactive mode; use `--auto-apply` to accept.")
-		return false, nil
+		return nil, nil
 	}
 
-	var table strings.Builder
-	w := tabwriter.NewWriter(&table, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "ADDRESS\tDESCRIPTION\tMATCHED")
+	options := make([]huh.Option[string], 0, len(recs))
+	selected := make([]string, 0, len(recs))
 	for _, r := range recs {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", r.Module.Repo, r.Module.Description, r.Match)
+		label := fmt.Sprintf("%s — matched %s", r.Module.Repo, r.Match)
+		options = append(options, huh.NewOption(label, r.Module.Repo).Selected(true))
+		selected = append(selected, r.Module.Repo)
 	}
-	_ = w.Flush()
 
-	var install bool
 	form := idtui.NewForm(
 		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Install recommended modules?").
-				Description(table.String()).
-				Affirmative("Install").
-				Negative("Skip").
-				Value(&install),
+			huh.NewMultiSelect[string]().
+				Title("Select recommended modules to install").
+				Description("Space toggles a module. Enter installs the selected modules.").
+				Options(options...).
+				Value(&selected).
+				Filterable(false),
 		),
 	)
 	if err := Frontend.HandleForm(ctx, form); err != nil {
-		return false, err
+		return nil, err
 	}
-	return install, nil
+	return filterRecommendations(recs, selected), nil
+}
+
+func filterRecommendations(recs []recommendation, selected []string) []recommendation {
+	wanted := make(map[string]struct{}, len(selected))
+	for _, repo := range selected {
+		wanted[repo] = struct{}{}
+	}
+	filtered := make([]recommendation, 0, len(selected))
+	for _, rec := range recs {
+		if _, ok := wanted[rec.Module.Repo]; ok {
+			filtered = append(filtered, rec)
+		}
+	}
+	return filtered
 }
 
 // currentWorkspaceExportPath derives the local workspace root from its file

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -69,19 +69,23 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("setup does not support --env; it configures the base workspace")
 	}
 
-	if err := setupStepLogin(cmd, cloudauth.GetCloudAuth); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Step 1 (login): %v\n", err)
-		// Login failures shouldn't block migration/recommend.
-	}
-
 	// All steps run under ONE Frontend (one live TUI) so their prompts can be
 	// huh forms the TUI renders — a raw stdin prompt would be drawn over by the
 	// progress display. withSetupSessions provides connect() so the install can
 	// run in a FRESH engine session: the per-client workspace is detected once
 	// and cached for a session's lifetime, so install must not reuse the
 	// migrate session or it would still see the legacy dagger.json.
-	return withSetupSessions(cmd.Context(), func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) (rerr error) {
-		setupUI := newSetupUI(Frontend)
+	var setupUI *setupUI
+	return withSetupSessions(cmd.Context(), func(ctx context.Context) {
+		setupUI = newSetupUI(Frontend)
+		if err := setupStepLogin(ctx, cmd, cloudauth.GetCloudAuth, setupUI); err != nil {
+			setupUI.setLoginFailed(err)
+			if setupUI == nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Step 1 (login): %v\n", err)
+			}
+			// Login failures shouldn't block migration/recommend.
+		}
+	}, func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) (rerr error) {
 		defer func() {
 			if rerr != nil {
 				setupUI.fail(rerr)
@@ -215,27 +219,76 @@ func setupMessage(ctx context.Context, name, markdown string) {
 
 // --- Step 1: Cloud login ---
 
-func setupStepLogin(cmd *cobra.Command, getCloudAuth func(context.Context) (*cloudauth.Cloud, error)) error {
-	ctx := cmd.Context()
+func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(context.Context) (*cloudauth.Cloud, error), ui *setupUI) error {
 	out := cmd.OutOrStdout()
 
-	fmt.Fprintln(out, "Step 1: Cloud login")
+	if ui == nil {
+		fmt.Fprintln(out, "Step 1: Cloud login")
+	} else {
+		ui.setLoginPending("Checking Cloud account...")
+	}
 
 	if auth, err := getCloudAuth(ctx); err == nil && auth != nil {
-		fmt.Fprintln(out, "  Already logged in.")
+		if ui == nil {
+			fmt.Fprintln(out, "  Already logged in.")
+		} else {
+			ui.setLoginComplete("Already logged in.")
+		}
 		return nil
 	}
 
-	if !confirm(cmd, "  Log in to Dagger Cloud?") {
-		fmt.Fprintln(out, "  Skipped.")
+	if ui != nil {
+		ui.setLoginPending("Waiting for login choice...")
+	}
+	if !confirmSetupLogin(ctx, cmd, ui) {
+		if ui == nil {
+			fmt.Fprintln(out, "  Skipped.")
+		} else {
+			ui.setLoginSkipped("Skipped.")
+		}
 		return nil
 	}
 
-	if err := cloudauth.Login(ctx, cmd.ErrOrStderr(), cloudauth.WithAuthGate()); err != nil {
+	loginOut := io.Writer(cmd.ErrOrStderr())
+	if ui != nil && ui.live {
+		ui.setLoginPending("Waiting for authentication...")
+		loginOut = setupLoginWriter{ui: ui}
+	}
+	if err := cloudauth.Login(ctx, loginOut, cloudauth.WithAuthGate()); err != nil {
 		return err
 	}
-	fmt.Fprintln(out, "  Logged in.")
+	if ui == nil {
+		fmt.Fprintln(out, "  Logged in.")
+	} else {
+		ui.setLoginComplete("Logged in.")
+	}
 	return nil
+}
+
+func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) bool {
+	if ui == nil || !ui.live {
+		return confirm(cmd, "  Log in to Dagger Cloud?")
+	}
+	if autoApply {
+		return true
+	}
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
+		ui.setLoginSkipped("Skipped in non-interactive mode; use --auto-apply to accept.")
+		return false
+	}
+	var accepted bool
+	if err := Frontend.HandlePrompt(ctx, "Cloud account", "Log in to Dagger Cloud?", &accepted); err != nil {
+		ui.setLoginFailed(err)
+		return false
+	}
+	return accepted
+}
+
+type setupLoginWriter struct{ ui *setupUI }
+
+func (w setupLoginWriter) Write(p []byte) (int, error) {
+	w.ui.appendLoginDetail(string(p))
+	return len(p), nil
 }
 
 // --- Step 2: Migrate ---

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -611,17 +611,26 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 		selected = append(selected, r.Module.Repo)
 	}
 
+	install := true
 	form := idtui.NewForm(
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
-				Description("Space toggles · Enter installs").
+				Description("Space toggles · Enter continues").
 				Options(options...).
 				Value(&selected).
 				Filterable(false),
+			huh.NewConfirm().
+				Affirmative("Install selected").
+				Negative("Skip").
+				Value(&install).
+				Inline(true),
 		),
 	)
 	if err := Frontend.HandleForm(ctx, form); err != nil {
 		return nil, err
+	}
+	if !install {
+		return nil, nil
 	}
 	return filterRecommendations(recs, selected), nil
 }

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -293,7 +293,7 @@ func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (bo
 		idtui.NewExplicitConfirm("Yes", "No", &accepted).
 			Title("Log in to Dagger Cloud?").
 			TitleLink("https://dagger.io/cloud").
-			Description("Observability · compute · persistence"),
+			Description("For observability, compute, and persistence. More info: https://dagger.io/cloud"),
 	))
 	if err := Frontend.HandleForm(ctx, form); err != nil {
 		return false, err

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -612,13 +612,14 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 	}
 
 	install := true
+	multiSelect := huh.NewMultiSelect[string]().
+		Description("Space toggles · Enter continues").
+		Options(options...).
+		Value(&selected).
+		Filterable(false)
 	form := huh.NewForm(
 		huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Description("Space toggles · Enter continues").
-				Options(options...).
-				Value(&selected).
-				Filterable(false),
+			idtui.NewFlowMultiSelect(multiSelect, recs[len(recs)-1].Module.Repo),
 			idtui.NewExplicitConfirm("Install selected", "Skip", &install).
 				Inline(true),
 		),

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -613,7 +613,6 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 
 	install := true
 	multiSelect := huh.NewMultiSelect[string]().
-		Description("Space toggles · Enter continues").
 		Options(options...).
 		Value(&selected).
 		Filterable(false)

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -18,8 +18,10 @@ import (
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/mattn/go-isatty"
+	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
@@ -244,15 +246,34 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 		}
 		return nil
 	}
+	if !autoApply {
+		disabled, err := setupCloudLoginPromptDisabled()
+		if err != nil {
+			return err
+		}
+		if disabled {
+			if ui == nil {
+				fmt.Fprintln(out, "  Skipped.")
+			} else {
+				ui.setLoginSkipped("Skipped.")
+			}
+			return nil
+		}
+	}
 
 	if ui != nil {
 		ui.setLoginPending("Waiting for login choice...")
 	}
-	accepted, err := confirmSetupLogin(ctx, cmd, ui)
+	choice, err := confirmSetupLogin(ctx, cmd, ui)
 	if err != nil {
 		return err
 	}
-	if !accepted {
+	if choice == setupLoginNever {
+		if err := disableSetupCloudLoginPrompt(); err != nil {
+			return err
+		}
+	}
+	if choice != setupLogin {
 		if ui == nil {
 			fmt.Fprintln(out, "  Skipped.")
 		} else {
@@ -277,28 +298,73 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 	return nil
 }
 
-func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (bool, error) {
+type setupLoginChoice string
+
+const (
+	setupLogin       setupLoginChoice = "login"
+	setupLoginNotNow setupLoginChoice = "not-now"
+	setupLoginNever  setupLoginChoice = "never"
+)
+
+func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (setupLoginChoice, error) {
 	if ui == nil || !ui.live {
-		return confirm(cmd, "  Log in to Dagger Cloud?"), nil
+		if confirm(cmd, "  Log in to Dagger Cloud?") {
+			return setupLogin, nil
+		}
+		return setupLoginNotNow, nil
 	}
 	if autoApply {
-		return true, nil
+		return setupLogin, nil
 	}
 	if !isatty.IsTerminal(os.Stdin.Fd()) {
 		ui.setLoginSkipped("Skipped in non-interactive mode; use --auto-apply to accept.")
-		return false, nil
+		return setupLoginNotNow, nil
 	}
-	var accepted bool
+	choice := setupLogin
 	form := huh.NewForm(huh.NewGroup(
-		idtui.NewExplicitConfirm("Yes", "No", &accepted).
+		idtui.NewExplicitChoice(&choice,
+			huh.NewOption("Log in", setupLogin),
+			huh.NewOption("Not now", setupLoginNotNow),
+			huh.NewOption("Never ask again", setupLoginNever),
+		).
 			Title("Log in to Dagger Cloud?").
 			TitleLink("https://dagger.io/cloud").
 			Description("For observability, compute, and persistence (ish).\nMore info: https://dagger.io/cloud"),
 	))
 	if err := Frontend.HandleForm(ctx, form); err != nil {
-		return false, err
+		return "", err
 	}
-	return accepted, nil
+	return choice, nil
+}
+
+func setupCloudLoginPromptDisabled() (bool, error) {
+	data, err := os.ReadFile(llmconfig.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read Dagger config: %w", err)
+	}
+	tree, err := toml.LoadBytes(data)
+	if err != nil {
+		return false, fmt.Errorf("parse Dagger config: %w", err)
+	}
+	return tree.GetPath([]string{"setup", "cloud_login"}) == string(setupLoginNever), nil
+}
+
+func disableSetupCloudLoginPrompt() error {
+	return llmconfig.UpdateFile(func(existing []byte) ([]byte, error) {
+		tree, err := toml.LoadBytes(existing)
+		if err != nil {
+			return nil, fmt.Errorf("parse Dagger config: %w", err)
+		}
+		tree.SetPath([]string{"setup", "cloud_login"}, string(setupLoginNever))
+		out, err := tree.ToTomlString()
+		if err != nil {
+			return nil, fmt.Errorf("serialize Dagger config: %w", err)
+		}
+		return []byte(out), nil
+	})
 }
 
 type setupLoginWriter struct{ ui *setupUI }

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -612,17 +612,14 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 	}
 
 	install := true
-	form := idtui.NewForm(
+	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Description("Space toggles · Enter continues").
 				Options(options...).
 				Value(&selected).
 				Filterable(false),
-			huh.NewConfirm().
-				Affirmative("Install selected").
-				Negative("Skip").
-				Value(&install).
+			idtui.NewExplicitConfirm("Install selected", "Skip", &install).
 				Inline(true),
 		),
 	)

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -698,7 +698,7 @@ func installRecommended(ctx context.Context, dag *dagger.Client, recs []recommen
 		err := func() (rerr error) {
 			installCtx, span := Tracer().Start(ctx, "dagger install "+r.Module.Repo,
 				telemetry.Reveal(), telemetry.Encapsulate())
-			ui.addInstall(dagui.SpanID{SpanID: span.SpanContext().SpanID()}, r.Module.Name)
+			ui.addInstall(dagui.SpanID{SpanID: span.SpanContext().SpanID()})
 			defer telemetry.EndWithCause(span, &rerr)
 
 			stdio := telemetry.SpanStdio(installCtx, InstrumentationLibrary)
@@ -708,6 +708,7 @@ func installRecommended(ctx context.Context, dag *dagger.Client, recs []recommen
 		if err != nil {
 			return fmt.Errorf("install %s: %w", r.Module.Repo, err)
 		}
+		ui.addInstalled(r.Module.Name)
 	}
 	return nil
 }

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -146,7 +146,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 				// here — even when the migration was declined.
 				return nil
 			}
-			recs, install, err = planRecommend(ctx, cmd, dag, setupUI)
+			recs, install, err = planRecommend(ctx, dag, setupUI)
 			if err != nil {
 				return fmt.Errorf("step 3 (recommend): %w", err)
 			}
@@ -286,7 +286,7 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 		return nil
 	}
 
-	loginOut := io.Writer(cmd.ErrOrStderr())
+	loginOut := cmd.ErrOrStderr()
 	if ui != nil && ui.live {
 		ui.setLoginPending("Waiting for authentication...")
 		loginOut = setupLoginWriter{ui: ui}
@@ -657,7 +657,7 @@ func resolveMigratedSDKsInConfigFile(out io.Writer, path string) error {
 // form) whether to install them. It runs in the same session as migrate and
 // returns the modules plus the user's decision; the actual install runs later
 // in a fresh session (see runSetup) so it re-detects the migrated workspace.
-func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, ui *setupUI) (recs []recommendation, install bool, rerr error) {
+func planRecommend(ctx context.Context, dag *dagger.Client, ui *setupUI) (recs []recommendation, install bool, rerr error) {
 	messageCtx := ctx
 	ctx, span := Tracer().Start(ctx, "Find recommended modules", telemetry.Reveal(), telemetry.Encapsulate())
 	ui.setRecommend(dagui.SpanID{SpanID: span.SpanContext().SpanID()})
@@ -679,7 +679,7 @@ func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, 
 		return nil, false, nil
 	}
 
-	recs, err = selectRecommendedModules(ctx, cmd, recs, ui)
+	recs, err = selectRecommendedModules(ctx, recs, ui)
 	if err != nil {
 		return nil, false, err
 	}
@@ -715,7 +715,7 @@ func installRecommended(ctx context.Context, dag *dagger.Client, recs []recommen
 // selectRecommendedModules lets the user choose recommendations individually.
 // Every recommendation starts selected, preserving the old affirmative path
 // while allowing irrelevant modules to be toggled off before installation.
-func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []recommendation, ui *setupUI) ([]recommendation, error) {
+func selectRecommendedModules(ctx context.Context, recs []recommendation, ui *setupUI) ([]recommendation, error) {
 	if autoApply {
 		return recs, nil
 	}

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -15,11 +15,15 @@ import (
 	"dagger.io/dagger"
 	"github.com/charmbracelet/huh"
 	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	telemetry "github.com/dagger/otel-go"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/log"
 )
 
 // setupCmd is the idempotent "ensure environment works" doctor verb.
@@ -54,6 +58,9 @@ Each step can be skipped at the prompt. With --auto-apply, all steps
 are applied without prompting. In non-interactive mode (no TTY) the
 default is to skip steps that would mutate state.`,
 	Args: cobra.NoArgs,
+	Annotations: map[string]string{
+		showFinalProgressKey: "true",
+	},
 	RunE: runSetup,
 }
 
@@ -61,8 +68,6 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 	if workspaceEnv != "" {
 		return fmt.Errorf("setup does not support --env; it configures the base workspace")
 	}
-
-	out := cmd.OutOrStdout()
 
 	if err := setupStepLogin(cmd, cloudauth.GetCloudAuth); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Step 1 (login): %v\n", err)
@@ -75,7 +80,21 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 	// run in a FRESH engine session: the per-client workspace is detected once
 	// and cached for a session's lifetime, so install must not reuse the
 	// migrate session or it would still see the legacy dagger.json.
-	return withSetupSessions(cmd.Context(), func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) error {
+	return withSetupSessions(cmd.Context(), func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) (rerr error) {
+		setupUI := newSetupUI(Frontend)
+		defer func() {
+			if rerr != nil {
+				setupUI.fail(rerr)
+			}
+		}()
+		ctx, setupSpan := Tracer().Start(ctx, "setup", telemetry.Passthrough())
+		defer telemetry.EndWithCause(setupSpan, &rerr)
+		setupStdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+		defer setupStdio.Close()
+		setupID := dagui.SpanID{SpanID: setupSpan.SpanContext().SpanID()}
+		Frontend.SetPrimary(setupID)
+		setupUI.setRoot(setupID)
+
 		// Session 1: migrate (apply form) or recommend (compute + install
 		// confirm form). The migrate write lands here; the session is closed
 		// before the install session opens so the workspace lock is released.
@@ -93,7 +112,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			}
 			defer closeSess()
 			dag := sess.Dagger()
-			migrated, moduleOnly, migratedConfigs, err = setupStepMigrate(ctx, cmd, dag)
+			migrated, moduleOnly, migratedConfigs, err = setupStepMigrate(ctx, dag, setupUI)
 			if err != nil {
 				return fmt.Errorf("step 2 (migrate): %w", err)
 			}
@@ -113,7 +132,7 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 				// here — even when the migration was declined.
 				return nil
 			}
-			recs, install, err = planRecommend(ctx, cmd, dag)
+			recs, install, err = planRecommend(ctx, cmd, dag, setupUI)
 			if err != nil {
 				return fmt.Errorf("step 3 (recommend): %w", err)
 			}
@@ -138,12 +157,12 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 			// Only a migration writes SDK installs by short name, so scope the
 			// resolution to that case — never rewrite an already-native config.
 			if migrated {
-				if err := setupResolveMigratedSDKs(ctx, cmd, dag, migratedConfigs); err != nil {
+				if err := setupResolveMigratedSDKs(ctx, dag, migratedConfigs); err != nil {
 					return fmt.Errorf("step 2 (resolve SDKs): %w", err)
 				}
 			}
 			if needInstall {
-				if err := installRecommended(ctx, cmd, dag, recs); err != nil {
+				if err := installRecommended(ctx, dag, recs, setupUI); err != nil {
 					return fmt.Errorf("step 3 (install): %w", err)
 				}
 			}
@@ -151,14 +170,47 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 
 		if migrated {
 			if moduleOnly {
-				fmt.Fprintln(out, "\nMigrated the module in place; no workspace config was created.")
+				setupHumanMessage(setupUI, ctx, "module migrated", "Migrated the module in place; no workspace config was created.")
 			} else {
-				fmt.Fprintln(out, "\nRun `dagger setup` again to see recommended modules for the migrated workspace.")
+				setupHumanMessage(setupUI, ctx, "migration next steps", "Run `dagger setup` again to see recommended modules for the migrated workspace.")
 			}
 		}
-		fmt.Fprintln(out, "\nSetup complete.")
+		if setupUI != nil {
+			setupUI.complete()
+		} else {
+			fmt.Fprintln(setupStdio.Stdout, "Setup complete.")
+		}
 		return nil
 	})
+}
+
+func setupHumanMessage(ui *setupUI, ctx context.Context, name, markdown string) {
+	if ui != nil {
+		ui.setMigrationMessage(markdown)
+		return
+	}
+	setupMessage(ctx, name, markdown)
+}
+
+func setupRecommendMessage(ui *setupUI, ctx context.Context, name, markdown string) {
+	if ui != nil {
+		ui.setRecommendMessage(markdown)
+		return
+	}
+	setupMessage(ctx, name, markdown)
+}
+
+// setupMessage emits human-facing Markdown as a revealed message span. The
+// stable span name remains useful in telemetry while the TUI renders the log
+// content in its place.
+func setupMessage(ctx context.Context, name, markdown string) {
+	ctx, span := Tracer().Start(ctx, name, telemetry.Reveal(), telemetry.Encapsulate())
+	span.SetAttributes(attribute.String(telemetry.UIMessageAttr, telemetry.UIMessageReceived))
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary,
+		log.String(telemetry.ContentTypeAttr, "text/markdown"))
+	_, _ = fmt.Fprintln(stdio.Stdout, markdown)
+	stdio.Close()
+	telemetry.EndWithCause(span, nil)
 }
 
 // --- Step 1: Cloud login ---
@@ -191,18 +243,13 @@ func setupStepLogin(cmd *cobra.Command, getCloudAuth func(context.Context) (*clo
 // emptyWorkspaceSetupHint is printed when `dagger setup` has nothing to migrate
 // and no workspace config exists yet: the greenfield case, where the useful
 // thing is to show how to get started rather than write an empty dagger.toml.
-const emptyWorkspaceSetupHint = `  No workspace loaded here yet — nothing to migrate.
+const emptyWorkspaceSetupHint = `No workspace loaded here yet — nothing to migrate.
 
-  To get started:
+To get started:
 
-    • Install a published module as a dependency:
-        dagger install <module>
-
-    • Install an SDK to author your own:
-        dagger sdk search
-
-    • Create a new module (after installing an SDK):
-        dagger module init <sdk> <name>
+- Install a published module as a dependency: dagger install <module>
+- Install an SDK to author your own: dagger sdk search
+- Create a new module after installing an SDK: dagger module init <sdk> <name>
 `
 
 // setupStepMigrate reports whether a migration was applied (which routes setup
@@ -216,9 +263,11 @@ const emptyWorkspaceSetupHint = `  No workspace loaded here yet — nothing to m
 // -> dagger-module.toml) and no workspace is created. It is reported whether
 // or not the migration was applied, so the caller can skip workspace-scoped
 // recommendations either way.
-func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (applied bool, moduleOnly bool, configs []string, _ error) {
-	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "\nStep 2: Workspace migration")
+func setupStepMigrate(ctx context.Context, dag *dagger.Client, ui *setupUI) (applied bool, moduleOnly bool, configs []string, rerr error) {
+	messageCtx := ctx
+	ctx, span := Tracer().Start(ctx, "Workspace migration", telemetry.Reveal(), telemetry.Encapsulate())
+	ui.setMigration(dagui.SpanID{SpanID: span.SpanContext().SpanID()})
+	defer telemetry.EndWithCause(span, &rerr)
 
 	ws := dag.CurrentWorkspace()
 	migration := ws.Migrate()
@@ -246,7 +295,7 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 		}
 		if len(skipWarnings) > 0 {
 			for _, warning := range skipWarnings {
-				fmt.Fprintf(out, "  Skipped: %s\n", warning)
+				setupHumanMessage(ui, messageCtx, "migration skipped", "Skipped: "+warning)
 			}
 			return false, true, nil, nil
 		}
@@ -259,11 +308,11 @@ func setupStepMigrate(ctx context.Context, cmd *cobra.Command, dag *dagger.Clien
 			// Nothing to migrate and no workspace config yet — don't seed an empty
 			// dagger.toml; guide the user to get started instead.
 			if !silent {
-				fmt.Fprint(out, emptyWorkspaceSetupHint)
+				setupHumanMessage(ui, messageCtx, "workspace not loaded", emptyWorkspaceSetupHint)
 			}
 			return false, false, nil, nil
 		}
-		fmt.Fprintln(out, "  No migration needed.")
+		setupHumanMessage(ui, messageCtx, "no migration needed", "No migration needed.")
 		return false, false, nil, nil
 	}
 
@@ -338,7 +387,13 @@ func migratedConfigPaths(ctx context.Context, changes *dagger.Changeset) ([]stri
 // being treated as a local path. Runs in a post-migration session where the
 // workspace is native; a no-op when nothing was recorded by short name (and
 // when the user declined migration, leaving the legacy config in place).
-func setupResolveMigratedSDKs(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, migratedConfigs []string) error {
+func setupResolveMigratedSDKs(ctx context.Context, dag *dagger.Client, migratedConfigs []string) (rerr error) {
+	ctx, span := Tracer().Start(ctx, "Resolve migrated SDKs", telemetry.Reveal(), telemetry.Encapsulate())
+	defer telemetry.EndWithCause(span, &rerr)
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+	defer stdio.Close()
+	out := stdio.Stdout
+
 	ws := dag.CurrentWorkspace()
 	raw, err := ws.ConfigRead(ctx)
 	if err != nil {
@@ -349,7 +404,6 @@ func setupResolveMigratedSDKs(ctx context.Context, cmd *cobra.Command, dag *dagg
 		return err
 	}
 
-	out := cmd.OutOrStdout()
 	fixes := planMigratedSDKFixups(cfg)
 	if len(fixes) > 0 {
 		updated := ws
@@ -429,32 +483,34 @@ func resolveMigratedSDKsInConfigFile(out io.Writer, path string) error {
 // form) whether to install them. It runs in the same session as migrate and
 // returns the modules plus the user's decision; the actual install runs later
 // in a fresh session (see runSetup) so it re-detects the migrated workspace.
-func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) (recs []recommendation, install bool, _ error) {
-	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "\nStep 3: Recommended modules")
+func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, ui *setupUI) (recs []recommendation, install bool, rerr error) {
+	messageCtx := ctx
+	ctx, span := Tracer().Start(ctx, "Find recommended modules", telemetry.Reveal(), telemetry.Encapsulate())
+	ui.setRecommend(dagui.SpanID{SpanID: span.SpanContext().SpanID()})
+	defer telemetry.EndWithCause(span, &rerr)
 
 	recs, err := runRecommend(ctx, dag)
 	if errors.Is(err, errCloudNotAuthenticated) ||
 		errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded) {
 		// Login or context issues shouldn't fail setup as a whole.
-		fmt.Fprintf(out, "  Skipped: %v\n", err)
+		setupRecommendMessage(ui, messageCtx, "recommendations skipped", "Skipped: "+err.Error())
 		return nil, false, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
 	if len(recs) == 0 {
-		fmt.Fprintln(out, "  No recommendations.")
+		setupRecommendMessage(ui, messageCtx, "no recommendations", "No recommendations.")
 		return nil, false, nil
 	}
 
-	install, err = confirmInstallRecommended(ctx, cmd, recs)
+	install, err = confirmInstallRecommended(ctx, cmd, recs, ui)
 	if err != nil {
 		return nil, false, err
 	}
 	if !install {
-		fmt.Fprintln(out, "  Skipped.")
+		setupRecommendMessage(ui, messageCtx, "recommendations skipped", "Skipped.")
 		return nil, false, nil
 	}
 	return recs, true, nil
@@ -464,11 +520,19 @@ func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client) 
 // fresh session so dag.CurrentWorkspace() re-detects the workspace migrated in
 // the migrate session as native — without this, install sees the cached legacy
 // dagger.json and fails with "run dagger setup first".
-func installRecommended(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, recs []recommendation) error {
-	out := cmd.OutOrStdout()
+func installRecommended(ctx context.Context, dag *dagger.Client, recs []recommendation, ui *setupUI) error {
 	for _, r := range recs {
-		fmt.Fprintf(out, "  Installing %s...\n", r.Module.Repo)
-		if err := installWorkspaceModule(ctx, out, dag, r.Module.Repo, "", false); err != nil {
+		err := func() (rerr error) {
+			installCtx, span := Tracer().Start(ctx, "dagger install "+r.Module.Repo,
+				telemetry.Reveal(), telemetry.Encapsulate())
+			ui.addInstall(dagui.SpanID{SpanID: span.SpanContext().SpanID()}, r.Module.Name)
+			defer telemetry.EndWithCause(span, &rerr)
+
+			stdio := telemetry.SpanStdio(installCtx, InstrumentationLibrary)
+			defer stdio.Close()
+			return installWorkspaceModule(installCtx, stdio.Stdout, dag, r.Module.Repo, "", false)
+		}()
+		if err != nil {
 			return fmt.Errorf("install %s: %w", r.Module.Repo, err)
 		}
 	}
@@ -481,12 +545,12 @@ func installRecommended(ctx context.Context, cmd *cobra.Command, dag *dagger.Cli
 // mechanism the migrate step uses for its apply prompt. With --auto-apply it
 // returns true without prompting; in non-interactive mode it skips (the safe
 // default — don't mutate state without a TTY).
-func confirmInstallRecommended(ctx context.Context, cmd *cobra.Command, recs []recommendation) (bool, error) {
+func confirmInstallRecommended(ctx context.Context, cmd *cobra.Command, recs []recommendation, ui *setupUI) (bool, error) {
 	if autoApply {
 		return true, nil
 	}
 	if !isatty.IsTerminal(os.Stdin.Fd()) {
-		fmt.Fprintln(cmd.OutOrStdout(), "  Install recommended modules? [skipped: non-interactive — use --auto-apply to accept]")
+		setupRecommendMessage(ui, ctx, "recommendations skipped", "Install recommended modules? Skipped in non-interactive mode; use `--auto-apply` to accept.")
 		return false, nil
 	}
 

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -253,9 +253,9 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 		}
 		if disabled {
 			if ui == nil {
-				fmt.Fprintln(out, "  Skipped.")
+				fmt.Fprintln(out, "  "+setupLoginSkippedHint)
 			} else {
-				ui.setLoginSkipped("Skipped.")
+				ui.setLoginSkipped(setupLoginSkippedHint)
 			}
 			return nil
 		}
@@ -274,10 +274,14 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 		}
 	}
 	if choice != setupLogin {
+		message := "Skipped."
+		if choice == setupLoginNever {
+			message = setupLoginSkippedHint
+		}
 		if ui == nil {
-			fmt.Fprintln(out, "  Skipped.")
+			fmt.Fprintln(out, "  "+message)
 		} else {
-			ui.setLoginSkipped("Skipped.")
+			ui.setLoginSkipped(message)
 		}
 		return nil
 	}
@@ -304,6 +308,8 @@ const (
 	setupLogin       setupLoginChoice = "login"
 	setupLoginNotNow setupLoginChoice = "not-now"
 	setupLoginNever  setupLoginChoice = "never"
+
+	setupLoginSkippedHint = "Skipped. (dagger login to log in)"
 )
 
 func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (setupLoginChoice, error) {
@@ -359,6 +365,34 @@ func disableSetupCloudLoginPrompt() error {
 			return nil, fmt.Errorf("parse Dagger config: %w", err)
 		}
 		tree.SetPath([]string{"setup", "cloud_login"}, string(setupLoginNever))
+		out, err := tree.ToTomlString()
+		if err != nil {
+			return nil, fmt.Errorf("serialize Dagger config: %w", err)
+		}
+		return []byte(out), nil
+	})
+}
+
+func clearSetupCloudLoginPromptPreference() error {
+	if _, err := os.Stat(llmconfig.ConfigFile); os.IsNotExist(err) {
+		return nil
+	}
+	return llmconfig.UpdateFile(func(existing []byte) ([]byte, error) {
+		tree, err := toml.LoadBytes(existing)
+		if err != nil {
+			return nil, fmt.Errorf("parse Dagger config: %w", err)
+		}
+		path := []string{"setup", "cloud_login"}
+		if tree.HasPath(path) {
+			if err := tree.DeletePath(path); err != nil {
+				return nil, fmt.Errorf("clear setup Cloud login preference: %w", err)
+			}
+		}
+		if setup, ok := tree.Get("setup").(*toml.Tree); ok && len(setup.Keys()) == 0 {
+			if err := tree.Delete("setup"); err != nil {
+				return nil, fmt.Errorf("clear empty setup config: %w", err)
+			}
+		}
 		out, err := tree.ToTomlString()
 		if err != nil {
 			return nil, fmt.Errorf("serialize Dagger config: %w", err)

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -276,7 +276,7 @@ func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) boo
 		return false
 	}
 	var accepted bool
-	if err := Frontend.HandlePrompt(ctx, "Cloud account", "Log in to Dagger Cloud?", &accepted); err != nil {
+	if err := Frontend.HandlePrompt(ctx, "", "Log in to Dagger Cloud?", &accepted); err != nil {
 		ui.setLoginFailed(err)
 		return false
 	}
@@ -360,7 +360,11 @@ func setupStepMigrate(ctx context.Context, dag *dagger.Client, ui *setupUI) (app
 			// Nothing to migrate and no workspace config yet — don't seed an empty
 			// dagger.toml; guide the user to get started instead.
 			if !silent {
-				setupHumanMessage(ui, messageCtx, "workspace not loaded", emptyWorkspaceSetupHint)
+				if ui != nil {
+					ui.setMigrationMessage("Nothing to migrate.")
+				} else {
+					setupHumanMessage(nil, messageCtx, "workspace not loaded", emptyWorkspaceSetupHint)
+				}
 			}
 			return false, false, nil, nil
 		}

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -74,17 +74,26 @@ func runSetup(cmd *cobra.Command, _ []string) error {
 	// run in a FRESH engine session: the per-client workspace is detected once
 	// and cached for a session's lifetime, so install must not reuse the
 	// migrate session or it would still see the legacy dagger.json.
-	var setupUI *setupUI
+	var (
+		setupUI       *setupUI
+		setupLoginErr error
+	)
 	return withSetupSessions(cmd.Context(), func(ctx context.Context) {
 		setupUI = newSetupUI(Frontend)
-		if err := setupStepLogin(ctx, cmd, cloudauth.GetCloudAuth, setupUI); err != nil {
-			setupUI.setLoginFailed(err)
+		setupLoginErr = setupStepLogin(ctx, cmd, cloudauth.GetCloudAuth, setupUI)
+		if setupLoginErr != nil {
+			if !errors.Is(setupLoginErr, idtui.ErrInterrupted) {
+				setupUI.setLoginFailed(setupLoginErr)
+			}
 			if setupUI == nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Step 1 (login): %v\n", err)
+				fmt.Fprintf(cmd.ErrOrStderr(), "Step 1 (login): %v\n", setupLoginErr)
 			}
 			// Login failures shouldn't block migration/recommend.
 		}
 	}, func(ctx context.Context, connect func(context.Context) (*client.Client, func(), error)) (rerr error) {
+		if errors.Is(setupLoginErr, idtui.ErrInterrupted) {
+			return setupLoginErr
+		}
 		defer func() {
 			if rerr != nil {
 				setupUI.fail(rerr)
@@ -239,7 +248,11 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 	if ui != nil {
 		ui.setLoginPending("Waiting for login choice...")
 	}
-	if !confirmSetupLogin(ctx, cmd, ui) {
+	accepted, err := confirmSetupLogin(ctx, cmd, ui)
+	if err != nil {
+		return err
+	}
+	if !accepted {
 		if ui == nil {
 			fmt.Fprintln(out, "  Skipped.")
 		} else {
@@ -253,7 +266,7 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 		ui.setLoginPending("Waiting for authentication...")
 		loginOut = setupLoginWriter{ui: ui}
 	}
-	if err := cloudauth.Login(ctx, loginOut, cloudauth.WithAuthGate()); err != nil {
+	if err := cloudauth.Login(ctx, loginOut); err != nil {
 		return err
 	}
 	if ui == nil {
@@ -264,23 +277,22 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 	return nil
 }
 
-func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) bool {
+func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (bool, error) {
 	if ui == nil || !ui.live {
-		return confirm(cmd, "  Log in to Dagger Cloud?")
+		return confirm(cmd, "  Log in to Dagger Cloud?"), nil
 	}
 	if autoApply {
-		return true
+		return true, nil
 	}
 	if !isatty.IsTerminal(os.Stdin.Fd()) {
 		ui.setLoginSkipped("Skipped in non-interactive mode; use --auto-apply to accept.")
-		return false
+		return false, nil
 	}
 	var accepted bool
 	if err := Frontend.HandlePrompt(ctx, "", "Log in to Dagger Cloud?", &accepted); err != nil {
-		ui.setLoginFailed(err)
-		return false
+		return false, err
 	}
-	return accepted
+	return accepted, nil
 }
 
 type setupLoginWriter struct{ ui *setupUI }
@@ -566,7 +578,6 @@ func planRecommend(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, 
 		return nil, false, err
 	}
 	if len(recs) == 0 {
-		setupRecommendMessage(ui, messageCtx, "recommendations skipped", "Skipped.")
 		return nil, false, nil
 	}
 	return recs, true, nil
@@ -631,9 +642,22 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 		return nil, err
 	}
 	if !install {
+		setupRecommendMessage(ui, ctx, "recommendations skipped", skippedRecommendations(recs))
 		return nil, nil
 	}
-	return filterRecommendations(recs, selected), nil
+	selectedRecs := filterRecommendations(recs, selected)
+	if len(selectedRecs) == 0 {
+		setupRecommendMessage(ui, ctx, "recommendations skipped", skippedRecommendations(recs))
+	}
+	return selectedRecs, nil
+}
+
+func skippedRecommendations(recs []recommendation) string {
+	modules := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		modules = append(modules, rec.Module.Repo)
+	}
+	return "Recommended modules skipped: " + strings.Join(modules, ", ") + "."
 }
 
 func filterRecommendations(recs []recommendation, selected []string) []recommendation {

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -486,6 +486,7 @@ func setupStepMigrate(ctx context.Context, dag *dagger.Client, ui *setupUI) (app
 			if !silent {
 				if ui != nil {
 					ui.setMigrationMessage("Nothing to migrate.")
+					ui.setMigrationFinalMessage(emptyWorkspaceSetupHint)
 				} else {
 					setupHumanMessage(nil, messageCtx, "workspace not loaded", emptyWorkspaceSetupHint)
 				}

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -289,7 +289,13 @@ func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (bo
 		return false, nil
 	}
 	var accepted bool
-	if err := Frontend.HandlePrompt(ctx, "", "Log in to Dagger Cloud?", &accepted); err != nil {
+	form := huh.NewForm(huh.NewGroup(
+		idtui.NewExplicitConfirm("Yes", "No", &accepted).
+			Title("Log in to Dagger Cloud?").
+			TitleLink("https://dagger.io/cloud").
+			Description("Observability · compute · persistence"),
+	))
+	if err := Frontend.HandleForm(ctx, form); err != nil {
 		return false, err
 	}
 	return accepted, nil
@@ -642,22 +648,18 @@ func selectRecommendedModules(ctx context.Context, cmd *cobra.Command, recs []re
 		return nil, err
 	}
 	if !install {
-		setupRecommendMessage(ui, ctx, "recommendations skipped", skippedRecommendations(recs))
+		setupRecommendMessage(ui, ctx, "recommendations skipped", skippedRecommendations())
 		return nil, nil
 	}
 	selectedRecs := filterRecommendations(recs, selected)
 	if len(selectedRecs) == 0 {
-		setupRecommendMessage(ui, ctx, "recommendations skipped", skippedRecommendations(recs))
+		setupRecommendMessage(ui, ctx, "recommendations skipped", skippedRecommendations())
 	}
 	return selectedRecs, nil
 }
 
-func skippedRecommendations(recs []recommendation) string {
-	modules := make([]string, 0, len(recs))
-	for _, rec := range recs {
-		modules = append(modules, rec.Module.Repo)
-	}
-	return "Recommended modules skipped: " + strings.Join(modules, ", ") + "."
+func skippedRecommendations() string {
+	return "Recommended modules skipped."
 }
 
 func filterRecommendations(recs []recommendation, selected []string) []recommendation {

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // setupCmd is the idempotent "ensure environment works" doctor verb.
@@ -441,7 +442,11 @@ To get started:
 // recommendations either way.
 func setupStepMigrate(ctx context.Context, dag *dagger.Client, ui *setupUI) (applied bool, moduleOnly bool, configs []string, rerr error) {
 	messageCtx := ctx
-	ctx, span := Tracer().Start(ctx, "Workspace migration", telemetry.Reveal(), telemetry.Encapsulate())
+	spanOpts := []trace.SpanStartOption{telemetry.Reveal()}
+	if ui != nil {
+		spanOpts = append(spanOpts, telemetry.Encapsulate())
+	}
+	ctx, span := Tracer().Start(ctx, "Workspace migration", spanOpts...)
 	ui.setMigration(dagui.SpanID{SpanID: span.SpanContext().SpanID()})
 	defer telemetry.EndWithCause(span, &rerr)
 

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -293,7 +293,7 @@ func confirmSetupLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI) (bo
 		idtui.NewExplicitConfirm("Yes", "No", &accepted).
 			Title("Log in to Dagger Cloud?").
 			TitleLink("https://dagger.io/cloud").
-			Description("For observability, compute, and persistence. More info: https://dagger.io/cloud"),
+			Description("For observability, compute, and persistence (ish).\nMore info: https://dagger.io/cloud"),
 	))
 	if err := Frontend.HandleForm(ctx, form); err != nil {
 		return false, err

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -40,3 +40,16 @@ func TestSetupStepLogin(t *testing.T) {
 func TestSetupShowsFinalProgress(t *testing.T) {
 	require.True(t, commandShowsFinalProgress(setupCmd))
 }
+
+func TestFilterRecommendations(t *testing.T) {
+	recs := []recommendation{
+		{Module: registryModule{Name: "eslint", Repo: "github.com/dagger/eslint"}},
+		{Module: registryModule{Name: "go", Repo: "github.com/dagger/go"}},
+		{Module: registryModule{Name: "vitest", Repo: "github.com/dagger/vitest"}},
+	}
+	got := filterRecommendations(recs, []string{
+		"github.com/dagger/vitest",
+		"github.com/dagger/eslint",
+	})
+	require.Equal(t, []recommendation{recs[0], recs[2]}, got)
+}

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -53,3 +53,14 @@ func TestFilterRecommendations(t *testing.T) {
 	})
 	require.Equal(t, []recommendation{recs[0], recs[2]}, got)
 }
+
+func TestSkippedRecommendations(t *testing.T) {
+	recs := []recommendation{
+		{Module: registryModule{Repo: "github.com/dagger/eslint"}},
+		{Module: registryModule{Repo: "github.com/dagger/go"}},
+	}
+	require.Equal(t,
+		"Recommended modules skipped: github.com/dagger/eslint, github.com/dagger/go.",
+		skippedRecommendations(recs),
+	)
+}

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -62,6 +62,15 @@ func TestDisableSetupCloudLoginPrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(data), "[unrelated]")
 	require.Contains(t, string(data), `cloud_login = "never"`)
+
+	require.NoError(t, clearSetupCloudLoginPromptPreference())
+	disabled, err = setupCloudLoginPromptDisabled()
+	require.NoError(t, err)
+	require.False(t, disabled)
+	data, err = os.ReadFile(llmconfig.ConfigFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "[unrelated]")
+	require.NotContains(t, string(data), "[setup]")
 }
 
 func TestSetupShowsFinalProgress(t *testing.T) {

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -28,9 +28,9 @@ func TestSetupStepLogin(t *testing.T) {
 			cmd.SetContext(ctx)
 			cmd.SetOut(&out)
 
-			err := setupStepLogin(cmd, func(context.Context) (*cloudauth.Cloud, error) {
+			err := setupStepLogin(ctx, cmd, func(context.Context) (*cloudauth.Cloud, error) {
 				return tt.auth, nil
-			})
+			}, nil)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantAlready, bytes.Contains(out.Bytes(), []byte("Already logged in.")))
 		})

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -36,3 +36,7 @@ func TestSetupStepLogin(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupShowsFinalProgress(t *testing.T) {
+	require.True(t, commandShowsFinalProgress(setupCmd))
+}

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -3,14 +3,21 @@ package daggercmd
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSetupStepLogin(t *testing.T) {
+	configFile := llmconfig.ConfigFile
+	llmconfig.ConfigFile = filepath.Join(t.TempDir(), "config.toml")
+	t.Cleanup(func() { llmconfig.ConfigFile = configFile })
+
 	for _, tt := range []struct {
 		name        string
 		auth        *cloudauth.Cloud
@@ -35,6 +42,26 @@ func TestSetupStepLogin(t *testing.T) {
 			require.Equal(t, tt.wantAlready, bytes.Contains(out.Bytes(), []byte("Already logged in.")))
 		})
 	}
+}
+
+func TestDisableSetupCloudLoginPrompt(t *testing.T) {
+	configFile := llmconfig.ConfigFile
+	llmconfig.ConfigFile = filepath.Join(t.TempDir(), "config.toml")
+	t.Cleanup(func() { llmconfig.ConfigFile = configFile })
+
+	require.NoError(t, os.WriteFile(llmconfig.ConfigFile, []byte("[unrelated]\nvalue = 42\n"), 0o600))
+	disabled, err := setupCloudLoginPromptDisabled()
+	require.NoError(t, err)
+	require.False(t, disabled)
+
+	require.NoError(t, disableSetupCloudLoginPrompt())
+	disabled, err = setupCloudLoginPromptDisabled()
+	require.NoError(t, err)
+	require.True(t, disabled)
+	data, err := os.ReadFile(llmconfig.ConfigFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "[unrelated]")
+	require.Contains(t, string(data), `cloud_login = "never"`)
 }
 
 func TestSetupShowsFinalProgress(t *testing.T) {

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -1,0 +1,38 @@
+package daggercmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupStepLogin(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		auth        *cloudauth.Cloud
+		wantAlready bool
+	}{
+		{name: "not logged in"},
+		{name: "logged in", auth: &cloudauth.Cloud{}, wantAlready: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			var out bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetContext(ctx)
+			cmd.SetOut(&out)
+
+			err := setupStepLogin(cmd, func(context.Context) (*cloudauth.Cloud, error) {
+				return tt.auth, nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAlready, bytes.Contains(out.Bytes(), []byte("Already logged in.")))
+		})
+	}
+}

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -55,12 +55,5 @@ func TestFilterRecommendations(t *testing.T) {
 }
 
 func TestSkippedRecommendations(t *testing.T) {
-	recs := []recommendation{
-		{Module: registryModule{Repo: "github.com/dagger/eslint"}},
-		{Module: registryModule{Repo: "github.com/dagger/go"}},
-	}
-	require.Equal(t,
-		"Recommended modules skipped: github.com/dagger/eslint, github.com/dagger/go.",
-		skippedRecommendations(recs),
-	)
+	require.Equal(t, "Recommended modules skipped.", skippedRecommendations())
 }

--- a/internal/cmd/dagger/setup_test.go
+++ b/internal/cmd/dagger/setup_test.go
@@ -44,6 +44,16 @@ func TestSetupStepLogin(t *testing.T) {
 	}
 }
 
+func TestConfirmSetupLoginSkipsNonInteractiveAutoApply(t *testing.T) {
+	previousAutoApply := autoApply
+	autoApply = true
+	t.Cleanup(func() { autoApply = previousAutoApply })
+
+	choice, err := confirmSetupLoginInteractive(t.Context(), &cobra.Command{}, nil, false)
+	require.NoError(t, err)
+	require.Equal(t, setupLoginNotNow, choice)
+}
+
 func TestDisableSetupCloudLoginPrompt(t *testing.T) {
 	configFile := llmconfig.ConfigFile
 	llmconfig.ConfigFile = filepath.Join(t.TempDir(), "config.toml")

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -48,10 +48,9 @@ func newSetupUI(frontend idtui.Frontend) *setupUI {
 		view.recommend = ctx.SpanList(
 			func() dagui.SpanID { return view.rootID },
 			func() []dagui.SpanID {
-				if len(view.installIDs) > 0 {
-					return append([]dagui.SpanID(nil), view.installIDs...)
-				}
-				return validSpanIDs(view.recommendID)
+				// Discovery is an implementation detail: retain its span for
+				// telemetry, but only render the resulting install actions.
+				return append([]dagui.SpanID(nil), view.installIDs...)
 			},
 		)
 		return view

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -228,7 +228,8 @@ func (view *setupView) renderLogin(ctx tuist.Context) {
 			"dagger login",
 			lipgloss.NewStyle().Bold(true).Render("dagger login"),
 		)
-		ctx.Line("○ " + message)
+		canceled := lipgloss.NewStyle().Foreground(lipgloss.BrightBlack).Render(idtui.IconSkipped)
+		ctx.Line("  " + canceled + " " + message)
 	case setupLoginFailed:
 		ctx.Line("✗ " + view.loginMessage)
 	}

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -123,6 +123,10 @@ func (ui *setupUI) setMigrationMessage(message string) {
 	ui.update(func(view *setupView) { view.migrationMessage = message })
 }
 
+func (ui *setupUI) setMigrationFinalMessage(message string) {
+	ui.update(func(view *setupView) { view.migrationFinal = message })
+}
+
 func (ui *setupUI) setRecommend(id dagui.SpanID) {
 	ui.update(func(view *setupView) { view.recommendID = id })
 }
@@ -170,6 +174,7 @@ type setupView struct {
 	workspace        *idtui.SpanListView
 	recommend        *idtui.SpanListView
 	migrationMessage string
+	migrationFinal   string
 	recommendMessage string
 }
 
@@ -295,11 +300,15 @@ func (view *setupView) renderFinal(ctx tuist.Context) {
 	case setupLoginFailed:
 		ctx.Line("Cloud account: " + view.loginMessage)
 	}
-	if view.migrationMessage != "" {
+	migrationMessage := view.migrationMessage
+	if view.migrationFinal != "" {
+		migrationMessage = view.migrationFinal
+	}
+	if migrationMessage != "" {
 		ctx.Line("")
 	}
-	if view.migrationMessage != "" {
-		lines(ctx, view.migrationMessage)
+	if migrationMessage != "" {
+		lines(ctx, migrationMessage)
 	}
 	if len(view.installed) > 0 {
 		ctx.Line("")

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -131,9 +131,14 @@ func (ui *setupUI) setRecommendMessage(message string) {
 	ui.update(func(view *setupView) { view.recommendMessage = message })
 }
 
-func (ui *setupUI) addInstall(id dagui.SpanID, name string) {
+func (ui *setupUI) addInstall(id dagui.SpanID) {
 	ui.update(func(view *setupView) {
 		view.installIDs = append(view.installIDs, id)
+	})
+}
+
+func (ui *setupUI) addInstalled(name string) {
+	ui.update(func(view *setupView) {
 		view.installed = append(view.installed, name)
 	})
 }

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -186,24 +186,22 @@ func (view *setupView) Render(ctx tuist.Context) {
 		return
 	}
 
-	ctx.Line("Setting up this workspace")
-	ctx.Line("")
 	ctx.Line("Cloud account")
 	view.renderLogin(ctx)
-	ctx.Line("")
-	ctx.Line("Workspace")
-	if view.migrationMessage == "" && view.migrationID.IsValid() && view.workspace != nil {
-		view.RenderChild(ctx, view.workspace)
-	} else if view.loginState == setupLoginPending {
-		ctx.Line("○ Waiting for Cloud account")
-	} else if view.workSpinner != nil {
-		view.workSpinner.Label = "Starting workspace setup..."
-		view.RenderChild(ctx, view.workSpinner)
-	}
-	if view.migrationMessage == "Nothing to migrate." || view.migrationMessage == "No migration needed." {
-		view.renderSuccess(ctx, view.migrationMessage)
-	} else {
-		lines(ctx, view.migrationMessage)
+	if view.loginState != setupLoginPending {
+		ctx.Line("")
+		ctx.Line("Workspace")
+		if view.migrationMessage == "" && view.migrationID.IsValid() && view.workspace != nil {
+			view.RenderChild(ctx, view.workspace)
+		} else if view.workSpinner != nil {
+			view.workSpinner.Label = "Starting workspace setup..."
+			view.RenderChild(ctx, view.workSpinner)
+		}
+		if view.migrationMessage == "Nothing to migrate." || view.migrationMessage == "No migration needed." {
+			view.renderSuccess(ctx, view.migrationMessage)
+		} else {
+			lines(ctx, view.migrationMessage)
+		}
 	}
 
 	if view.recommendID.IsValid() || len(view.installIDs) > 0 || view.recommendMessage != "" {
@@ -219,8 +217,10 @@ func (view *setupView) Render(ctx tuist.Context) {
 func (view *setupView) renderLogin(ctx tuist.Context) {
 	switch view.loginState {
 	case setupLoginPending:
-		view.loginSpinner.Label = view.loginMessage
-		view.RenderChild(ctx, view.loginSpinner)
+		if view.loginMessage != "Waiting for login choice..." {
+			view.loginSpinner.Label = view.loginMessage
+			view.RenderChild(ctx, view.loginSpinner)
+		}
 	case setupLoginComplete:
 		view.renderSuccess(ctx, view.loginMessage)
 	case setupLoginSkipped:

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -1,0 +1,216 @@
+package daggercmd
+
+import (
+	"fmt"
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/dagger/dagger/dagql/dagui"
+	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/vito/tuist"
+)
+
+// setupUI is the command-side controller for SetupView. Every mutation is
+// dispatched through the frontend so the model and Tuist render on the same
+// goroutine.
+type setupUI struct {
+	view   *setupView
+	handle idtui.ViewHandle
+}
+
+func newSetupUI(frontend idtui.Frontend) *setupUI {
+	host, ok := frontend.(idtui.CommandFrontend)
+	if !ok {
+		return nil
+	}
+	view := &setupView{}
+	ui := &setupUI{view: view}
+	ui.handle = host.SetView(func(ctx idtui.ViewContext) idtui.CommandView {
+		view.workspace = ctx.SpanList(
+			func() dagui.SpanID { return view.rootID },
+			func() []dagui.SpanID { return validSpanIDs(view.migrationID) },
+		)
+		view.recommend = ctx.SpanList(
+			func() dagui.SpanID { return view.rootID },
+			func() []dagui.SpanID {
+				if len(view.installIDs) > 0 {
+					return append([]dagui.SpanID(nil), view.installIDs...)
+				}
+				return validSpanIDs(view.recommendID)
+			},
+		)
+		return view
+	})
+	return ui
+}
+
+func validSpanIDs(ids ...dagui.SpanID) []dagui.SpanID {
+	valid := ids[:0]
+	for _, id := range ids {
+		if id.IsValid() {
+			valid = append(valid, id)
+		}
+	}
+	return valid
+}
+
+func (ui *setupUI) update(fn func(*setupView)) {
+	if ui == nil {
+		return
+	}
+	ui.handle.Update(func() { fn(ui.view) })
+}
+
+func (ui *setupUI) setRoot(id dagui.SpanID) {
+	ui.update(func(view *setupView) { view.rootID = id })
+}
+
+func (ui *setupUI) setMigration(id dagui.SpanID) {
+	ui.update(func(view *setupView) { view.migrationID = id })
+}
+
+func (ui *setupUI) setMigrationMessage(message string) {
+	ui.update(func(view *setupView) { view.migrationMessage = message })
+}
+
+func (ui *setupUI) setRecommend(id dagui.SpanID) {
+	ui.update(func(view *setupView) { view.recommendID = id })
+}
+
+func (ui *setupUI) setRecommendMessage(message string) {
+	ui.update(func(view *setupView) { view.recommendMessage = message })
+}
+
+func (ui *setupUI) addInstall(id dagui.SpanID, name string) {
+	ui.update(func(view *setupView) {
+		view.installIDs = append(view.installIDs, id)
+		view.installed = append(view.installed, name)
+	})
+}
+
+func (ui *setupUI) complete() {
+	ui.update(func(view *setupView) { view.complete = true })
+}
+
+func (ui *setupUI) fail(err error) {
+	ui.update(func(view *setupView) { view.failure = err.Error() })
+}
+
+type setupView struct {
+	tuist.Compo
+
+	final bool
+
+	rootID           dagui.SpanID
+	migrationID      dagui.SpanID
+	recommendID      dagui.SpanID
+	installIDs       []dagui.SpanID
+	installed        []string
+	complete         bool
+	failure          string
+	workspace        *idtui.SpanListView
+	recommend        *idtui.SpanListView
+	migrationMessage string
+	recommendMessage string
+}
+
+var _ idtui.CommandView = (*setupView)(nil)
+var _ tuist.Interactive = (*setupView)(nil)
+
+func (view *setupView) SetFinal(final bool) {
+	if view.final != final {
+		view.final = final
+		view.Update()
+	}
+}
+
+func (view *setupView) Render(ctx tuist.Context) {
+	if view.final {
+		view.renderFinal(ctx)
+		return
+	}
+
+	ctx.Line("Setting up this workspace")
+	ctx.Line("")
+	ctx.Line("Workspace")
+	if view.workspace != nil {
+		view.RenderChild(ctx, view.workspace)
+	}
+	lines(ctx, view.migrationMessage)
+
+	if view.recommendID.IsValid() || len(view.installIDs) > 0 || view.recommendMessage != "" {
+		ctx.Line("")
+		ctx.Line("Recommended modules")
+		if view.recommend != nil {
+			view.RenderChild(ctx, view.recommend)
+		}
+		lines(ctx, view.recommendMessage)
+	}
+}
+
+func (view *setupView) HandleKeyPress(ctx tuist.Context, ev uv.KeyPressEvent) bool {
+	key := uv.Key(ev).String()
+	switch key {
+	case "down", "j":
+		if view.workspace != nil && view.workspace.Focused() {
+			if view.workspace.HandleKeyPress(ctx, ev) {
+				return true
+			}
+			return view.recommend != nil && view.recommend.FocusFirst()
+		}
+		if view.recommend != nil && view.recommend.HandleKeyPress(ctx, ev) {
+			return true
+		}
+		return view.workspace != nil && view.workspace.FocusFirst()
+	case "up", "k":
+		if view.recommend != nil && view.recommend.Focused() {
+			if view.recommend.HandleKeyPress(ctx, ev) {
+				return true
+			}
+			return view.workspace != nil && view.workspace.FocusLast()
+		}
+		if view.workspace != nil && view.workspace.HandleKeyPress(ctx, ev) {
+			return true
+		}
+		return view.recommend != nil && view.recommend.FocusLast()
+	case "home":
+		return view.workspace != nil && view.workspace.FocusFirst()
+	case "end", "G":
+		return view.recommend != nil && view.recommend.FocusLast()
+	case "left", "h", "right", "l", "enter":
+		if view.recommend != nil && view.recommend.Focused() {
+			return view.recommend.HandleKeyPress(ctx, ev)
+		}
+		return view.workspace != nil && view.workspace.HandleKeyPress(ctx, ev)
+	}
+	return false
+}
+
+func (view *setupView) renderFinal(ctx tuist.Context) {
+	if view.migrationMessage != "" {
+		lines(ctx, view.migrationMessage)
+	}
+	if len(view.installed) > 0 {
+		ctx.Line("")
+		ctx.Line("Installed " + strings.Join(view.installed, ", ") + ".")
+	} else if view.recommendMessage != "" {
+		ctx.Line("")
+		lines(ctx, view.recommendMessage)
+	}
+	ctx.Line("")
+	if view.complete {
+		ctx.Line("Setup complete.")
+	} else if view.failure != "" {
+		ctx.Line(fmt.Sprintf("Setup failed: %s", view.failure))
+	} else {
+		ctx.Line("Setup did not complete.")
+	}
+}
+
+func lines(ctx tuist.Context, text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	ctx.Lines(strings.Split(text, "\n")...)
+}

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -38,7 +38,6 @@ func newSetupUI(frontend idtui.Frontend) *setupUI {
 		loginState:   setupLoginPending,
 		loginMessage: "Checking Cloud account...",
 		loginSpinner: tuist.NewSpinner(),
-		workSpinner:  tuist.NewSpinner(),
 	}
 	ui := &setupUI{view: view, live: host.Live()}
 	ui.handle = host.SetView(func(ctx idtui.ViewContext) idtui.CommandView {
@@ -155,7 +154,6 @@ type setupView struct {
 	loginMessage string
 	loginDetail  string
 	loginSpinner *tuist.Spinner
-	workSpinner  *tuist.Spinner
 
 	rootID           dagui.SpanID
 	migrationID      dagui.SpanID
@@ -197,9 +195,6 @@ func (view *setupView) Render(ctx tuist.Context) {
 		ctx.Line("Workspace")
 		if view.migrationMessage == "" && view.migrationID.IsValid() && view.workspace != nil {
 			view.RenderChild(ctx, view.workspace)
-		} else if view.workSpinner != nil {
-			view.workSpinner.Label = "Starting workspace setup..."
-			view.RenderChild(ctx, view.workSpinner)
 		}
 		if view.migrationMessage == "Nothing to migrate." || view.migrationMessage == "No migration needed." {
 			view.renderSuccess(ctx, view.migrationMessage)

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -180,6 +180,10 @@ func (view *setupView) SetFinal(final bool) {
 	}
 }
 
+func (view *setupView) HideKeymap() bool {
+	return view.loginState == setupLoginPending && view.loginMessage == "Waiting for authentication..."
+}
+
 func (view *setupView) Render(ctx tuist.Context) {
 	if view.final {
 		view.renderFinal(ctx)
@@ -217,7 +221,7 @@ func (view *setupView) Render(ctx tuist.Context) {
 func (view *setupView) renderLogin(ctx tuist.Context) {
 	switch view.loginState {
 	case setupLoginPending:
-		if view.loginMessage != "Waiting for login choice..." {
+		if view.loginMessage != "Waiting for login choice..." && view.loginMessage != "Waiting for authentication..." {
 			view.loginSpinner.Label = view.loginMessage
 			view.RenderChild(ctx, view.loginSpinner)
 		}

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -223,7 +223,12 @@ func (view *setupView) renderLogin(ctx tuist.Context) {
 	case setupLoginComplete:
 		view.renderSuccess(ctx, view.loginMessage)
 	case setupLoginSkipped:
-		ctx.Line("○ " + view.loginMessage)
+		message := strings.ReplaceAll(
+			view.loginMessage,
+			"dagger login",
+			lipgloss.NewStyle().Bold(true).Render("dagger login"),
+		)
+		ctx.Line("○ " + message)
 	case setupLoginFailed:
 		ctx.Line("✗ " + view.loginMessage)
 	}

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -16,15 +16,30 @@ import (
 type setupUI struct {
 	view   *setupView
 	handle idtui.ViewHandle
+	live   bool
 }
+
+type setupLoginState int
+
+const (
+	setupLoginPending setupLoginState = iota
+	setupLoginComplete
+	setupLoginSkipped
+	setupLoginFailed
+)
 
 func newSetupUI(frontend idtui.Frontend) *setupUI {
 	host, ok := frontend.(idtui.CommandFrontend)
 	if !ok {
 		return nil
 	}
-	view := &setupView{}
-	ui := &setupUI{view: view}
+	view := &setupView{
+		loginState:   setupLoginPending,
+		loginMessage: "Checking Cloud account...",
+		loginSpinner: tuist.NewSpinner(),
+		workSpinner:  tuist.NewSpinner(),
+	}
+	ui := &setupUI{view: view, live: host.Live()}
 	ui.handle = host.SetView(func(ctx idtui.ViewContext) idtui.CommandView {
 		view.workspace = ctx.SpanList(
 			func() dagui.SpanID { return view.rootID },
@@ -65,6 +80,42 @@ func (ui *setupUI) setRoot(id dagui.SpanID) {
 	ui.update(func(view *setupView) { view.rootID = id })
 }
 
+func (ui *setupUI) setLoginPending(message string) {
+	ui.update(func(view *setupView) {
+		view.loginState = setupLoginPending
+		view.loginMessage = message
+	})
+}
+
+func (ui *setupUI) setLoginComplete(message string) {
+	ui.update(func(view *setupView) {
+		view.loginState = setupLoginComplete
+		view.loginMessage = message
+		view.loginDetail = ""
+	})
+}
+
+func (ui *setupUI) setLoginSkipped(message string) {
+	ui.update(func(view *setupView) {
+		if view.loginState != setupLoginPending {
+			return
+		}
+		view.loginState = setupLoginSkipped
+		view.loginMessage = message
+	})
+}
+
+func (ui *setupUI) setLoginFailed(err error) {
+	ui.update(func(view *setupView) {
+		view.loginState = setupLoginFailed
+		view.loginMessage = err.Error()
+	})
+}
+
+func (ui *setupUI) appendLoginDetail(detail string) {
+	ui.update(func(view *setupView) { view.loginDetail += detail })
+}
+
 func (ui *setupUI) setMigration(id dagui.SpanID) {
 	ui.update(func(view *setupView) { view.migrationID = id })
 }
@@ -99,7 +150,12 @@ func (ui *setupUI) fail(err error) {
 type setupView struct {
 	tuist.Compo
 
-	final bool
+	final        bool
+	loginState   setupLoginState
+	loginMessage string
+	loginDetail  string
+	loginSpinner *tuist.Spinner
+	workSpinner  *tuist.Spinner
 
 	rootID           dagui.SpanID
 	migrationID      dagui.SpanID
@@ -132,9 +188,17 @@ func (view *setupView) Render(ctx tuist.Context) {
 
 	ctx.Line("Setting up this workspace")
 	ctx.Line("")
+	ctx.Line("Cloud account")
+	view.renderLogin(ctx)
+	ctx.Line("")
 	ctx.Line("Workspace")
-	if view.workspace != nil {
+	if view.migrationID.IsValid() && view.workspace != nil {
 		view.RenderChild(ctx, view.workspace)
+	} else if view.loginState == setupLoginPending {
+		ctx.Line("○ Waiting for Cloud account")
+	} else if view.workSpinner != nil {
+		view.workSpinner.Label = "Starting workspace setup..."
+		view.RenderChild(ctx, view.workSpinner)
 	}
 	lines(ctx, view.migrationMessage)
 
@@ -145,6 +209,23 @@ func (view *setupView) Render(ctx tuist.Context) {
 			view.RenderChild(ctx, view.recommend)
 		}
 		lines(ctx, view.recommendMessage)
+	}
+}
+
+func (view *setupView) renderLogin(ctx tuist.Context) {
+	switch view.loginState {
+	case setupLoginPending:
+		view.loginSpinner.Label = view.loginMessage
+		view.RenderChild(ctx, view.loginSpinner)
+	case setupLoginComplete:
+		ctx.Line("✓ " + view.loginMessage)
+	case setupLoginSkipped:
+		ctx.Line("○ " + view.loginMessage)
+	case setupLoginFailed:
+		ctx.Line("✗ " + view.loginMessage)
+	}
+	if detail := strings.TrimSpace(view.loginDetail); detail != "" {
+		ctx.Lines(strings.Split(detail, "\n")...)
 	}
 }
 
@@ -187,6 +268,17 @@ func (view *setupView) HandleKeyPress(ctx tuist.Context, ev uv.KeyPressEvent) bo
 }
 
 func (view *setupView) renderFinal(ctx tuist.Context) {
+	switch view.loginState {
+	case setupLoginComplete:
+		ctx.Line("Cloud account: " + view.loginMessage)
+	case setupLoginSkipped:
+		ctx.Line("Cloud account: " + view.loginMessage)
+	case setupLoginFailed:
+		ctx.Line("Cloud account: " + view.loginMessage)
+	}
+	if view.migrationMessage != "" {
+		ctx.Line("")
+	}
 	if view.migrationMessage != "" {
 		lines(ctx, view.migrationMessage)
 	}

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
@@ -191,7 +192,7 @@ func (view *setupView) Render(ctx tuist.Context) {
 	view.renderLogin(ctx)
 	ctx.Line("")
 	ctx.Line("Workspace")
-	if view.migrationID.IsValid() && view.workspace != nil {
+	if view.migrationMessage == "" && view.migrationID.IsValid() && view.workspace != nil {
 		view.RenderChild(ctx, view.workspace)
 	} else if view.loginState == setupLoginPending {
 		ctx.Line("○ Waiting for Cloud account")
@@ -199,7 +200,11 @@ func (view *setupView) Render(ctx tuist.Context) {
 		view.workSpinner.Label = "Starting workspace setup..."
 		view.RenderChild(ctx, view.workSpinner)
 	}
-	lines(ctx, view.migrationMessage)
+	if view.migrationMessage == "Nothing to migrate." || view.migrationMessage == "No migration needed." {
+		view.renderSuccess(ctx, view.migrationMessage)
+	} else {
+		lines(ctx, view.migrationMessage)
+	}
 
 	if view.recommendID.IsValid() || len(view.installIDs) > 0 || view.recommendMessage != "" {
 		ctx.Line("")
@@ -217,7 +222,7 @@ func (view *setupView) renderLogin(ctx tuist.Context) {
 		view.loginSpinner.Label = view.loginMessage
 		view.RenderChild(ctx, view.loginSpinner)
 	case setupLoginComplete:
-		ctx.Line("✓ " + view.loginMessage)
+		view.renderSuccess(ctx, view.loginMessage)
 	case setupLoginSkipped:
 		ctx.Line("○ " + view.loginMessage)
 	case setupLoginFailed:
@@ -226,6 +231,11 @@ func (view *setupView) renderLogin(ctx tuist.Context) {
 	if detail := strings.TrimSpace(view.loginDetail); detail != "" {
 		ctx.Lines(strings.Split(detail, "\n")...)
 	}
+}
+
+func (view *setupView) renderSuccess(ctx tuist.Context, message string) {
+	check := lipgloss.NewStyle().Foreground(lipgloss.Green).Render("✔")
+	ctx.Line("  " + check + " " + message)
 }
 
 func (view *setupView) HandleKeyPress(ctx tuist.Context, ev uv.KeyPressEvent) bool {

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -68,7 +68,6 @@ func TestSetupViewLoginChoiceHasNoTransitionalCruft(t *testing.T) {
 		loginState:   setupLoginPending,
 		loginMessage: "Waiting for login choice...",
 		loginSpinner: tuist.NewSpinner(),
-		workSpinner:  tuist.NewSpinner(),
 	}
 	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
 	tui.AddChild(view)

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
 	"github.com/spf13/cobra"
@@ -115,6 +116,19 @@ func TestSetupViewHidesKeymapDuringAuthentication(t *testing.T) {
 	if view.HideKeymap() {
 		t.Fatal("ordinary setup progress hid keymap")
 	}
+}
+
+func TestSetupUIRecordsOnlyCompletedInstalls(t *testing.T) {
+	view := &setupView{}
+	ui := &setupUI{view: view, handle: immediateViewHandle{}}
+	id := dagui.SpanID{}
+
+	ui.addInstall(id)
+	require.Equal(t, []dagui.SpanID{id}, view.installIDs)
+	require.Empty(t, view.installed)
+
+	ui.addInstalled("eslint")
+	require.Equal(t, []string{"eslint"}, view.installed)
 }
 
 type immediateViewHandle struct{}

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -47,6 +47,7 @@ func TestSetupViewRendersConciseCompletedStates(t *testing.T) {
 		loginState:       setupLoginComplete,
 		loginMessage:     "Already logged in.",
 		migrationMessage: "Nothing to migrate.",
+		migrationFinal:   emptyWorkspaceSetupHint,
 	}
 	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
 	tui.AddChild(view)
@@ -62,6 +63,19 @@ func TestSetupViewRendersConciseCompletedStates(t *testing.T) {
 	}
 	if strings.Contains(rendered, "Workspace migration") || strings.Contains(rendered, "No workspace loaded") {
 		t.Fatalf("setup view retained verbose migration detail:\n%s", rendered)
+	}
+
+	view.SetFinal(true)
+	rendered = ansi.Strip(strings.Join(tui.RenderLines(), "\n"))
+	for _, want := range []string{
+		"nothing to migrate",
+		"dagger install <module>",
+		"dagger sdk search",
+		"dagger module init <sdk> <name>",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("final setup view missing %q:\n%s", want, rendered)
+		}
 	}
 }
 

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -1,0 +1,33 @@
+package daggercmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vito/tuist"
+)
+
+func TestSetupViewFinalSummary(t *testing.T) {
+	view := &setupView{
+		complete:         true,
+		migrationMessage: "No workspace loaded here yet — nothing to migrate.",
+		installed:        []string{"eslint", "go"},
+	}
+	view.SetFinal(true)
+	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
+	tui.AddChild(view)
+
+	rendered := strings.Join(tui.RenderLines(), "\n")
+	for _, want := range []string{
+		"Setup complete.",
+		"No workspace loaded here yet",
+		"Installed eslint, go.",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("final setup view missing %q:\n%s", want, rendered)
+		}
+	}
+	if !strings.HasSuffix(strings.TrimSpace(rendered), "Setup complete.") {
+		t.Fatalf("completion message was not last:\n%s", rendered)
+	}
+}

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/dagger/dagger/dagql/idtui"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,20 @@ func TestSetupViewRendersConciseCompletedStates(t *testing.T) {
 	}
 	if strings.Contains(rendered, "Workspace migration") || strings.Contains(rendered, "No workspace loaded") {
 		t.Fatalf("setup view retained verbose migration detail:\n%s", rendered)
+	}
+}
+
+func TestSetupViewIndentsSkippedLoginAsCanceled(t *testing.T) {
+	view := &setupView{
+		loginState:   setupLoginSkipped,
+		loginMessage: setupLoginSkippedHint,
+	}
+	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
+	tui.AddChild(view)
+
+	rendered := ansi.Strip(strings.Join(tui.RenderLines(), "\n"))
+	if !strings.Contains(rendered, "  "+idtui.IconSkipped+" Skipped. (dagger login to log in)") {
+		t.Fatalf("skipped login is not indented and canceled:\n%s", rendered)
 	}
 }
 

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestSetupViewFinalSummary(t *testing.T) {
 	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
 	tui.AddChild(view)
 
-	rendered := strings.Join(tui.RenderLines(), "\n")
+	rendered := ansi.Strip(strings.Join(tui.RenderLines(), "\n"))
 	for _, want := range []string{
 		"Cloud account: Already logged in.",
 		"Setup complete.",
@@ -36,6 +37,29 @@ func TestSetupViewFinalSummary(t *testing.T) {
 	}
 	if !strings.HasSuffix(strings.TrimSpace(rendered), "Setup complete.") {
 		t.Fatalf("completion message was not last:\n%s", rendered)
+	}
+}
+
+func TestSetupViewRendersConciseCompletedStates(t *testing.T) {
+	view := &setupView{
+		loginState:       setupLoginComplete,
+		loginMessage:     "Already logged in.",
+		migrationMessage: "Nothing to migrate.",
+	}
+	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
+	tui.AddChild(view)
+
+	rendered := ansi.Strip(strings.Join(tui.RenderLines(), "\n"))
+	for _, want := range []string{
+		"  ✔ Already logged in.",
+		"  ✔ Nothing to migrate.",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("setup view missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "Workspace migration") || strings.Contains(rendered, "No workspace loaded") {
+		t.Fatalf("setup view retained verbose migration detail:\n%s", rendered)
 	}
 }
 

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -1,14 +1,20 @@
 package daggercmd
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 	"github.com/vito/tuist"
 )
 
 func TestSetupViewFinalSummary(t *testing.T) {
 	view := &setupView{
+		loginState:       setupLoginComplete,
+		loginMessage:     "Already logged in.",
 		complete:         true,
 		migrationMessage: "No workspace loaded here yet — nothing to migrate.",
 		installed:        []string{"eslint", "go"},
@@ -19,6 +25,7 @@ func TestSetupViewFinalSummary(t *testing.T) {
 
 	rendered := strings.Join(tui.RenderLines(), "\n")
 	for _, want := range []string{
+		"Cloud account: Already logged in.",
 		"Setup complete.",
 		"No workspace loaded here yet",
 		"Installed eslint, go.",
@@ -30,4 +37,22 @@ func TestSetupViewFinalSummary(t *testing.T) {
 	if !strings.HasSuffix(strings.TrimSpace(rendered), "Setup complete.") {
 		t.Fatalf("completion message was not last:\n%s", rendered)
 	}
+}
+
+type immediateViewHandle struct{}
+
+func (immediateViewHandle) Update(fn func()) { fn() }
+
+func TestSetupLoginUpdatesCommandView(t *testing.T) {
+	view := &setupView{}
+	ui := &setupUI{view: view, handle: immediateViewHandle{}, live: true}
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	err := setupStepLogin(t.Context(), cmd, func(context.Context) (*cloudauth.Cloud, error) {
+		return &cloudauth.Cloud{}, nil
+	}, ui)
+	require.NoError(t, err)
+	require.Equal(t, setupLoginComplete, view.loginState)
+	require.Equal(t, "Already logged in.", view.loginMessage)
 }

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -63,6 +63,32 @@ func TestSetupViewRendersConciseCompletedStates(t *testing.T) {
 	}
 }
 
+func TestSetupViewLoginChoiceHasNoTransitionalCruft(t *testing.T) {
+	view := &setupView{
+		loginState:   setupLoginPending,
+		loginMessage: "Waiting for login choice...",
+		loginSpinner: tuist.NewSpinner(),
+		workSpinner:  tuist.NewSpinner(),
+	}
+	tui := tuist.New(tuist.NewHeadlessTerminal(100, 20))
+	tui.AddChild(view)
+
+	rendered := ansi.Strip(strings.Join(tui.RenderLines(), "\n"))
+	for _, unwanted := range []string{
+		"Setting up this workspace",
+		"Waiting for login choice",
+		"Workspace",
+		"Waiting for Cloud account",
+	} {
+		if strings.Contains(rendered, unwanted) {
+			t.Fatalf("setup login choice retained %q:\n%s", unwanted, rendered)
+		}
+	}
+	if !strings.Contains(rendered, "Cloud account") {
+		t.Fatalf("setup login choice lost section title:\n%s", rendered)
+	}
+}
+
 type immediateViewHandle struct{}
 
 func (immediateViewHandle) Update(fn func()) { fn() }

--- a/internal/cmd/dagger/setup_tui_test.go
+++ b/internal/cmd/dagger/setup_tui_test.go
@@ -89,6 +89,20 @@ func TestSetupViewLoginChoiceHasNoTransitionalCruft(t *testing.T) {
 	}
 }
 
+func TestSetupViewHidesKeymapDuringAuthentication(t *testing.T) {
+	view := &setupView{
+		loginState:   setupLoginPending,
+		loginMessage: "Waiting for authentication...",
+	}
+	if !view.HideKeymap() {
+		t.Fatal("authentication wait did not hide keymap")
+	}
+	view.loginMessage = "Checking Cloud account..."
+	if view.HideKeymap() {
+		t.Fatal("ordinary setup progress hid keymap")
+	}
+}
+
 type immediateViewHandle struct{}
 
 func (immediateViewHandle) Update(fn func()) { fn() }


### PR DESCRIPTION
## Summary

- correctly distinguish missing Cloud auth from a successful auth lookup
- render Cloud login inside the setup screen before telemetry starts
- let commands own the outer pretty TUI while composing interactive span lists
- give `dagger setup` a semantic workspace and recommendation screen
- choose recommended modules individually from a preselected checklist
- make inactive confirmation buttons visually unfilled
- preserve clean final output in interactive and report modes

## Testing

- `go test ./dagql/idtui ./internal/cmd/dagger`
- headless `DAGGER_TUI_CONSOLE` smoke test of `dagger setup --auto-apply`
- report-mode smoke test of `dagger setup --auto-apply`
