### PR TITLE
Workspace.withNewDirectory replaces, and a new Workspace.withDirectory merges

### DIFF
--- a/.changes/unreleased/Changed-20260824-163000.yaml
+++ b/.changes/unreleased/Changed-20260824-163000.yaml
@@ -1,0 +1,17 @@
+kind: Changed
+body: |
+  `Workspace.withNewDirectory` now replaces whatever a path already held on
+  every kind of workspace, and the new `Workspace.withDirectory` merges into it
+  instead. Which of the two you got depended only on where the workspace came
+  from: a host-backed checkout replaced, while one loaded from a `Directory` or
+  from git merged.
+
+  Reach for `withDirectory` when the path's existing files have to survive —
+  scaffolding a module beside the config the engine just wrote, say — and for
+  `withNewDirectory` when the source is meant to become the path's entire
+  contents. Either one now reads the same against a local checkout as against a
+  git-loaded workspace.
+time: 2026-08-24T16:30:00Z
+custom:
+  Author: eunomie
+  PR: "13956"

--- a/core/integration/workspace_synthetic_test.go
+++ b/core/integration/workspace_synthetic_test.go
@@ -51,6 +51,7 @@ func (WorkspaceSuite) TestSyntheticWorkspaceSourceIsPrivateInSchema(ctx context.
 	requireGraphQLField(t, res.GitRef.Fields, "asWorkspace")
 	requireGraphQLField(t, res.Workspace.Fields, "withNewFile")
 	requireGraphQLField(t, res.Workspace.Fields, "withNewDirectory")
+	requireGraphQLField(t, res.Workspace.Fields, "withDirectory")
 	requireGraphQLField(t, res.Workspace.Fields, "withChanges")
 	requireGraphQLField(t, res.Workspace.Fields, "changes")
 

--- a/core/integration/workspace_write_directory_test.go
+++ b/core/integration/workspace_write_directory_test.go
@@ -1,0 +1,264 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dagger.io/dagger"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// workspaceWriteKind is one way a workspace comes into existence, prepared so
+// that "target" already holds keep.txt. Writing a directory over a path has to
+// mean the same thing on all of them, and the overlay underneath differs: a
+// host-backed workspace accumulates its edits on an empty delta root diffed
+// against a sparse host base, while value and git workspaces edit their full
+// in-engine tree (see overlayEdit).
+type workspaceWriteKind struct {
+	name  string
+	setup func(ctx context.Context, t *testctx.T) (*dagger.Client, *dagger.Workspace)
+}
+
+func workspaceWriteKinds() []workspaceWriteKind {
+	return []workspaceWriteKind{
+		{
+			name: "host-backed",
+			setup: func(ctx context.Context, t *testctx.T) (*dagger.Client, *dagger.Workspace) {
+				workdir := t.TempDir()
+				initGitRepo(ctx, t, workdir)
+				require.NoError(t, os.MkdirAll(filepath.Join(workdir, "target"), 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(workdir, "target", "keep.txt"), []byte("keep"), 0o644))
+				c := connect(ctx, t, dagger.WithWorkdir(workdir))
+				return c, c.CurrentWorkspace()
+			},
+		},
+		{
+			name: "value",
+			setup: func(ctx context.Context, t *testctx.T) (*dagger.Client, *dagger.Workspace) {
+				c := connect(ctx, t)
+				return c, c.Directory().WithNewFile("target/keep.txt", "keep").AsWorkspace()
+			},
+		},
+		{
+			name: "git",
+			setup: func(ctx context.Context, t *testctx.T) (*dagger.Client, *dagger.Workspace) {
+				c := connect(ctx, t)
+				content := c.Directory().WithNewFile("target/keep.txt", "keep")
+				gitDaemon, repoURL := gitService(ctx, t, c, content)
+				return c, c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
+					Head().AsWorkspace()
+			},
+		},
+	}
+}
+
+// TestWorkspaceWithDirectoryMerges covers the field callers reach for when they
+// want Directory.withDirectory's merge on a workspace: writing into a path
+// without discarding what is already there. That is what an SDK needs to
+// scaffold a module beside the config the engine just wrote, and before this
+// field existed the only spelling for it — withNewDirectory — merged on a value
+// or git workspace but replaced on a host-backed one (dagger/dagger#13955).
+func (WorkspaceSuite) TestWorkspaceWithDirectoryMerges(ctx context.Context, t *testctx.T) {
+	for _, kind := range workspaceWriteKinds() {
+		t.Run(kind.name, func(ctx context.Context, t *testctx.T) {
+			c, ws := kind.setup(ctx, t)
+			source := c.Directory().WithNewFile("new.txt", "new")
+
+			t.Run("layers onto what the path already holds", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithDirectory("target", source)
+
+				entries, err := written.Directory("target").Entries(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"keep.txt", "new.txt"}, entries)
+
+				changes := written.Changes(dagger.WorkspaceChangesOpts{From: ws})
+				removed, err := changes.RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Empty(t, removed)
+
+				// Exactly the one file the source carries: no ancestor
+				// directory the workspace already has may be reported as
+				// added either.
+				added, err := changes.AddedPaths(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"target/new.txt"}, added)
+
+				// Reporting a file the caller never wrote is the same defect
+				// wearing a different mask: an SDK is told it changed content
+				// it only happened to be standing next to.
+				modified, err := changes.ModifiedPaths(ctx)
+				require.NoError(t, err)
+				require.Empty(t, modified)
+			})
+
+			t.Run("layers onto the workspace root", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithDirectory("/", source)
+
+				contents, err := written.File("new.txt").Contents(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "new", contents)
+
+				keep, err := written.File("target/keep.txt").Contents(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "keep", keep)
+
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Empty(t, removed)
+			})
+
+			t.Run("creates a path the workspace does not have", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithDirectory("fresh/nested", source)
+
+				contents, err := written.File("fresh/nested/new.txt").Contents(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "new", contents)
+
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Empty(t, removed)
+			})
+
+			// A host-backed workspace applies the edit to its delta root, which
+			// holds only what earlier edits wrote rather than the workspace's
+			// own content. Both of these read that base, so they are where the
+			// seeding it needs is visible.
+			t.Run("keeps earlier edits under the path", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithNewFile("target/staged.txt", "staged").
+					WithDirectory("target", source)
+
+				entries, err := written.Directory("target").Entries(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"keep.txt", "new.txt", "staged.txt"}, entries)
+
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Empty(t, removed)
+			})
+
+			t.Run("does not resurrect removed content", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithoutFile("target/keep.txt").WithDirectory("target", source)
+
+				entries, err := written.Directory("target").Entries(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"new.txt"}, entries)
+
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"target/keep.txt"}, removed)
+			})
+		})
+	}
+}
+
+// workspaceInitOverExistingFixture is an SDK module whose module-init scaffolds
+// through Workspace.withDirectory, which is what an SDK needs once its
+// destination may already hold something: the user's own files, and the module
+// config the engine writes in the same init. dagger/go-sdk#30 pinned that
+// guarantee from the SDK side by reading the destination back and layering onto
+// it by hand; withDirectory is that read-back moved into the API.
+func workspaceInitOverExistingFixture(t testing.TB, c *dagger.Client) *dagger.Container {
+	t.Helper()
+	return goGitBase(t, c).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", testCLIBinPath).
+		With(nonNestedDevEngine(c)).
+		WithNewFile("dagger.toml", `[modules.init-fixture]
+source = "sdk/init-fixture"
+
+[modules.init-fixture.as-sdk]
+name = "fixture"
+`).
+		WithNewFile("sdk/init-fixture/dagger.json", `{
+  "name": "init-fixture",
+  "engineVersion": "latest",
+  "sdk": { "source": "go" },
+  "source": "."
+}`).
+		WithNewFile("sdk/init-fixture/main.go", `package main
+
+import (
+	"context"
+
+	"dagger/init-fixture/internal/dagger"
+)
+
+type InitFixture struct{}
+
+// InitModule scaffolds the SDK-owned files for a new module, onto whatever the
+// destination already holds.
+func (m *InitFixture) InitModule(ctx context.Context, ws *dagger.Workspace, name string, path string) (*dagger.Changeset, error) {
+	scaffold := dag.Directory().WithNewFile("scaffold.txt", name+"\n")
+	return ws.WithDirectory(path, scaffold).Changes(dagger.WorkspaceChangesOpts{From: ws}), nil
+}
+`)
+}
+
+// TestModuleInitScaffoldsOverExistingContent is the flow the split was found
+// in: `dagger module init` against a real checkout, where the destination is
+// not empty. The engine's dagger-module.toml and the SDK's scaffold arrive in
+// the same apply, and neither may take the user's files with it.
+func (WorkspaceSuite) TestModuleInitScaffoldsOverExistingContent(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	initialized := workspaceInitOverExistingFixture(t, c).
+		WithNewFile(".dagger/modules/newmod/keep.txt", "written before init\n").
+		With(daggerExec("module", "init", "fixture", "newmod", "--no-generate", "--auto-apply"))
+
+	out, err := initialized.CombinedOutput(ctx)
+	require.NoError(t, err, out)
+
+	keep, err := initialized.File(".dagger/modules/newmod/keep.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "written before init\n", keep)
+
+	scaffold, err := initialized.File(".dagger/modules/newmod/scaffold.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "newmod\n", scaffold)
+
+	_, err = initialized.File(".dagger/modules/newmod/dagger-module.toml").Contents(ctx)
+	require.NoError(t, err)
+}
+
+// A host-backed overlay's changeset is diffed against a host base re-read at
+// diff time, while its other side accumulates across edits. Nothing the caller
+// never wrote may end up pinned on that accumulating side, or a file the user
+// edits on disk mid-session comes back reported as modified — and exporting
+// then writes the stale bytes over their edit.
+func (WorkspaceSuite) TestWorkspaceWithDirectoryDoesNotPinHostContent(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+	require.NoError(t, os.MkdirAll(filepath.Join(workdir, "target"), 0o755))
+	keepPath := filepath.Join(workdir, "target", "keep.txt")
+	require.NoError(t, os.WriteFile(keepPath, []byte("keep"), 0o644))
+
+	c := connect(ctx, t, dagger.WithWorkdir(workdir))
+	ws := c.CurrentWorkspace()
+	source := c.Directory().WithNewFile("new.txt", "new")
+
+	merged := ws.WithDirectory("target", source)
+	_, err := merged.Changes(dagger.WorkspaceChangesOpts{From: ws}).AddedPaths(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(keepPath, []byte("edited on disk"), 0o644))
+
+	t.Run("a later edit", func(ctx context.Context, t *testctx.T) {
+		changes := merged.WithNewFile("elsewhere.txt", "x").
+			Changes(dagger.WorkspaceChangesOpts{From: ws})
+		modified, err := changes.ModifiedPaths(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, modified, "target/keep.txt")
+	})
+
+	t.Run("a later edit after reloading", func(ctx context.Context, t *testctx.T) {
+		changes := merged.Reloaded().WithNewFile("elsewhere.txt", "x").
+			Changes(dagger.WorkspaceChangesOpts{From: ws})
+		modified, err := changes.ModifiedPaths(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, modified, "target/keep.txt")
+	})
+}

--- a/core/integration/workspace_write_directory_test.go
+++ b/core/integration/workspace_write_directory_test.go
@@ -224,6 +224,106 @@ func (WorkspaceSuite) TestModuleInitScaffoldsOverExistingContent(ctx context.Con
 	require.NoError(t, err)
 }
 
+// The comparison dagger/dagger#13955 was reported with: one call, one source,
+// one path, put to a host-backed workspace and to the synthetic workspace made
+// out of that same workspace's own content. They answered differently about
+// what they had removed.
+func (WorkspaceSuite) TestWorkspaceWithNewDirectoryAgreesWithSyntheticCopy(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+	require.NoError(t, os.MkdirAll(filepath.Join(workdir, "target"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workdir, "target", "keep.txt"), []byte("do not delete me\n"), 0o644))
+
+	c := connect(ctx, t, dagger.WithWorkdir(workdir))
+	source := c.Directory().WithNewFile("new.txt", "written by withNewDirectory")
+
+	hostBacked := c.CurrentWorkspace()
+	synthetic := hostBacked.Directory("/").AsWorkspace()
+
+	hostRemoved, err := hostBacked.WithNewDirectory("/target", source).
+		Changes(dagger.WorkspaceChangesOpts{From: hostBacked}).RemovedPaths(ctx)
+	require.NoError(t, err)
+	syntheticRemoved, err := synthetic.WithNewDirectory("/target", source).
+		Changes(dagger.WorkspaceChangesOpts{From: synthetic}).RemovedPaths(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"target/keep.txt"}, hostRemoved)
+	require.Equal(t, hostRemoved, syntheticRemoved)
+}
+
+// TestWorkspaceWithNewDirectoryReplaces pins withNewDirectory to replacement on
+// every workspace kind. dagger/dagger#13955: it replaced on a host-backed
+// workspace and merged on a value or git one, so the same call meant two
+// different things depending only on where the workspace came from.
+func (WorkspaceSuite) TestWorkspaceWithNewDirectoryReplaces(ctx context.Context, t *testctx.T) {
+	for _, kind := range workspaceWriteKinds() {
+		t.Run(kind.name, func(ctx context.Context, t *testctx.T) {
+			c, ws := kind.setup(ctx, t)
+			source := c.Directory().WithNewFile("new.txt", "new")
+
+			t.Run("replaces what the path already holds", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithNewDirectory("target", source)
+
+				entries, err := written.Directory("target").Entries(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"new.txt"}, entries)
+
+				changes := written.Changes(dagger.WorkspaceChangesOpts{From: ws})
+				removed, err := changes.RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"target/keep.txt"}, removed)
+
+				added, err := changes.AddedPaths(ctx)
+				require.NoError(t, err)
+				require.Contains(t, added, "target/new.txt")
+			})
+
+			t.Run("replaces the workspace root", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithNewDirectory("/", source)
+
+				entries, err := written.Directory("/").Entries(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"new.txt"}, entries)
+
+				// The whole directory goes, so it is reported as the directory
+				// rather than file by file.
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Contains(t, removed, "target/")
+			})
+
+			t.Run("creates a path the workspace does not have", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithNewDirectory("fresh/nested", source)
+
+				contents, err := written.File("fresh/nested/new.txt").Contents(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "new", contents)
+
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Empty(t, removed)
+			})
+
+			// Replacement covers the overlay's own earlier writes at the path,
+			// not just the workspace's base content: on a host-backed workspace
+			// those live in the delta root the edit is applied to.
+			t.Run("drops earlier edits under the path", func(ctx context.Context, t *testctx.T) {
+				written := ws.WithNewFile("target/staged.txt", "staged").
+					WithNewDirectory("target", source)
+
+				entries, err := written.Directory("target").Entries(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"new.txt"}, entries)
+
+				removed, err := written.Changes(dagger.WorkspaceChangesOpts{From: ws}).RemovedPaths(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{"target/keep.txt"}, removed)
+			})
+		})
+	}
+}
+
 // A host-backed overlay's changeset is diffed against a host base re-read at
 // diff time, while its other side accumulates across edits. Nothing the caller
 // never wrote may end up pinned on that accumulating side, or a file the user

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -142,10 +142,11 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("withNewDirectory", s.withNewDirectory).
 			View(AfterVersion("v1.0.0-0")).
-			Doc("Return this workspace with a directory added, without mutating the source.").
+			Doc("Return this workspace with the given path replaced by a directory, without mutating the source.",
+				"The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.").
 			Args(
-				dagql.Arg("path").Doc("Path of the added directory. Relative paths resolve from the workspace cwd."),
-				dagql.Arg("source").Doc("Directory to add."),
+				dagql.Arg("path").Doc("Path to replace. Relative paths resolve from the workspace cwd."),
+				dagql.Arg("source").Doc("Directory to write there."),
 			),
 		dagql.NodeFunc("withDirectory", s.withDirectory).
 			View(AfterVersion("v1.0.0-0")).
@@ -1536,8 +1537,15 @@ func (s *workspaceSchema) withNewDirectory(
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+		// Clearing first is what lets both overlay branches share this edit:
+		// an edit that ignores whatever the base holds at the path reads the
+		// same on a full read root as on a host overlay's delta root.
+		cleared, err := clearedForWrite(ctx, srv, base, resolvedPath)
+		if err != nil {
+			return cleared, err
+		}
 		var updated dagql.ObjectResult[*core.Directory]
-		err := srv.Select(ctx, base, &updated, dagql.Selector{
+		err = srv.Select(ctx, cleared, &updated, dagql.Selector{
 			Field: "withDirectory",
 			Args: []dagql.NamedInput{
 				{Name: "path", Value: dagql.NewString(resolvedPath)},
@@ -1581,6 +1589,28 @@ func (s *workspaceSchema) withDirectory(
 		})
 		return updated, err
 	}, nil)
+}
+
+// clearedForWrite returns base holding nothing at path, ready for a write that
+// replaces what was there. Clearing the workspace root starts from an empty
+// directory instead: Directory.withoutDirectory removes the path itself, which
+// at the root is the tree rather than its contents.
+func clearedForWrite(
+	ctx context.Context,
+	srv *dagql.Server,
+	base dagql.ObjectResult[*core.Directory],
+	resolvedPath string,
+) (dagql.ObjectResult[*core.Directory], error) {
+	var cleared dagql.ObjectResult[*core.Directory]
+	if resolvedPath == "." {
+		err := srv.Select(ctx, srv.Root(), &cleared, dagql.Selector{Field: "directory"})
+		return cleared, err
+	}
+	err := srv.Select(ctx, base, &cleared, dagql.Selector{
+		Field: "withoutDirectory",
+		Args:  []dagql.NamedInput{{Name: "path", Value: dagql.NewString(resolvedPath)}},
+	})
+	return cleared, err
 }
 
 type workspaceWithoutFileArgs struct {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -147,6 +147,14 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 				dagql.Arg("path").Doc("Path of the added directory. Relative paths resolve from the workspace cwd."),
 				dagql.Arg("source").Doc("Directory to add."),
 			),
+		dagql.NodeFunc("withDirectory", s.withDirectory).
+			View(AfterVersion("v1.0.0-0")).
+			Doc("Return this workspace with a directory merged into the given path, without mutating the source.",
+				"Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.").
+			Args(
+				dagql.Arg("path").Doc("Path to merge into. Relative paths resolve from the workspace cwd."),
+				dagql.Arg("source").Doc("Directory to merge there."),
+			),
 		dagql.NodeFunc("withoutFile", s.withoutFile).
 			View(AfterVersion("v1.0.0-0")).
 			Doc("Return this workspace with a file removed, without mutating the source.").
@@ -1129,7 +1137,7 @@ func (s *workspaceSchema) withNewFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withNewFile",
@@ -1502,7 +1510,7 @@ func mergeGlobMatches(base, winning []string, claimed func(string) bool) []strin
 	return merged
 }
 
-type workspaceWithNewDirectoryArgs struct {
+type workspaceWriteDirectoryArgs struct {
 	Path   string
 	Source core.DirectoryID
 }
@@ -1510,7 +1518,7 @@ type workspaceWithNewDirectoryArgs struct {
 func (s *workspaceSchema) withNewDirectory(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
-	args workspaceWithNewDirectoryArgs,
+	args workspaceWriteDirectoryArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
 	resolvedPath, err := resolveWorkspacePath(args.Path, parent.Self().Cwd)
 	if err != nil {
@@ -1527,7 +1535,42 @@ func (s *workspaceSchema) withNewDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+		var updated dagql.ObjectResult[*core.Directory]
+		err := srv.Select(ctx, base, &updated, dagql.Selector{
+			Field: "withDirectory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.NewString(resolvedPath)},
+				{Name: "source", Value: dagql.NewID[*core.Directory](sourceID)},
+			},
+		})
+		return updated, err
+	}, nil)
+}
+
+func (s *workspaceSchema) withDirectory(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	args workspaceWriteDirectoryArgs,
+) (dagql.ObjectResult[*core.Workspace], error) {
+	resolvedPath, err := resolveWorkspacePath(args.Path, parent.Self().Cwd)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	if err := guardMountedPath(parent.Self(), resolvedPath); err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	sourceID, err := args.Source.ID()
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+	// The edit layers onto what the path already holds, so the base has to
+	// carry it — see overlayEdit's readsExisting.
+	return s.overlayEdit(ctx, parent, []string{resolvedPath}, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withDirectory",
@@ -1561,7 +1604,7 @@ func (s *workspaceSchema) withoutFile(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withoutFile",
@@ -1594,7 +1637,7 @@ func (s *workspaceSchema) withoutDirectory(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, []string{resolvedPath}, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, []string{resolvedPath}, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withoutDirectory",
@@ -1669,7 +1712,7 @@ func (s *workspaceSchema) applyChangeset(
 			return dagql.ObjectResult[*core.Workspace]{}, err
 		}
 	}
-	return s.overlayEdit(ctx, parent, touched, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, touched, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withChanges",
@@ -2161,7 +2204,7 @@ func (s *workspaceSchema) overlayWorkspaceWithMutation(
 	ws.SetRootfs(dagql.ObjectResult[*core.Directory]{})
 	// Value/git/rootless workspaces diff full in-engine trees (no TouchedPaths);
 	// the sparse delta-native path is host-only (see overlayEdit).
-	ws.SetSource(core.NewWorkspaceSourceOverlay(parent.Self().Source(), nil, changesResult))
+	ws.SetSource(core.NewWorkspaceSourceOverlay(parent.Self().Source(), nil, nil, changesResult))
 	if mutate != nil {
 		mutate(ws)
 	}
@@ -2175,6 +2218,14 @@ func (s *workspaceSchema) overlayWorkspaceWithMutation(
 // empty base, stored as the overlay changeset's After side, which never
 // references the host tree. `touched` are the workspace-relative paths this
 // edit affects.
+//
+// `readsExisting` names the touched paths whose current content the edit builds
+// on, rather than overwriting outright. Those two bases hold different things
+// at a path — the full read root has the workspace's content, the delta root
+// only what earlier edits wrote — so an edit that reads the base means two
+// different things across workspace kinds unless the delta root is first seeded
+// with what the workspace holds there (dagger/dagger#13955). Leave it empty
+// whenever the edit's result at `touched` is independent of what was there.
 //
 // Host-backed overlays store no full read root at all: Directory.withChanges
 // must materialize its base, so a host-tree root would force the whole
@@ -2191,6 +2242,7 @@ func (s *workspaceSchema) overlayEdit(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
 	touched []string,
+	readsExisting []string,
 	edit func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error),
 	mutate func(*core.Workspace),
 ) (dagql.ObjectResult[*core.Workspace], error) {
@@ -2217,9 +2269,25 @@ func (s *workspaceSchema) overlayEdit(
 	// Host-backed: apply the edit to the accumulated empty-based delta root, so
 	// neither the overlay build nor computing changes/export ever references the
 	// full host tree.
+	touchedAll := unionPaths(ws.OverlayTouchedPaths(), touched)
+	seededAll := unionPaths(ws.OverlaySeededPaths(), readsExisting)
+	// Resolved before the edit so the seed below comes out of the very base the
+	// changeset is diffed against: one host read on both sides means seeded
+	// content can never read as a change.
+	sparseBase, err := s.sparseHostBase(ctx, ws, touchedAll)
+	if err != nil {
+		return dagql.ObjectResult[*core.Workspace]{}, err
+	}
+
 	deltaBase, ok := ws.OverlayDeltaRoot()
 	if !ok {
 		if err := srv.Select(ctx, srv.Root(), &deltaBase, dagql.Selector{Field: "directory"}); err != nil {
+			return dagql.ObjectResult[*core.Workspace]{}, err
+		}
+	}
+	if len(seededAll) > 0 {
+		deltaBase, err = s.seedDeltaRoot(ctx, srv, ws, deltaBase, sparseBase, seededAll)
+		if err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
 		}
 	}
@@ -2228,11 +2296,6 @@ func (s *workspaceSchema) overlayEdit(
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
 
-	touchedAll := unionPaths(ws.OverlayTouchedPaths(), touched)
-	sparseBase, err := s.sparseHostBase(ctx, ws, touchedAll)
-	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
-	}
 	sparseBaseID, err := sparseBase.ID()
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
@@ -2247,11 +2310,86 @@ func (s *workspaceSchema) overlayEdit(
 
 	newWS := ws.Clone()
 	newWS.SetRootfs(dagql.ObjectResult[*core.Directory]{})
-	newWS.SetSource(core.NewWorkspaceSourceOverlay(ws.Source(), touchedAll, changesResult))
+	newWS.SetSource(core.NewWorkspaceSourceOverlay(ws.Source(), touchedAll, seededAll, changesResult))
 	if mutate != nil {
 		mutate(newWS)
 	}
 	return dagql.NewObjectResultForCurrentCall(ctx, srv, newWS)
+}
+
+// seedDeltaRoot layers the workspace's current content at the given paths onto
+// the delta root, for edits that build on what a path already holds. The delta
+// root carries only what overlay edits wrote, so such an edit would otherwise
+// find the path empty and — once the delta root is diffed against the sparse
+// host base, which does carry the host's content there — read as having
+// replaced it.
+//
+// The seed comes out of `base`, the very sparse host base the resulting
+// changeset is diffed against, with the overlay's own changeset applied so that
+// earlier edits still win and earlier removals stay removed. Taking it from
+// there rather than from a host read of its own is what keeps seeded content
+// from ever reading as a change: both sides of the diff see one host snapshot,
+// and because every later edit re-seeds these paths from its own base, content
+// the caller never wrote is never pinned to a stale one. Layering onto the
+// delta root rather than replacing it keeps edits outside these paths intact.
+//
+// Sizing the sparse base to the paths the source writes, instead of seeding,
+// would also stop the removals — but a path the host does not have yet matches
+// nothing, so its parent directories are absent from the base and the changeset
+// reports directories the workspace already has as added.
+func (s *workspaceSchema) seedDeltaRoot(
+	ctx context.Context,
+	srv *dagql.Server,
+	ws *core.Workspace,
+	delta dagql.ObjectResult[*core.Directory],
+	base dagql.ObjectResult[*core.Directory],
+	paths []string,
+) (dagql.ObjectResult[*core.Directory], error) {
+	existing := base
+	if changes, ok := ws.OverlayChanges(); ok {
+		changesID, err := changes.ID()
+		if err != nil {
+			return delta, err
+		}
+		if err := srv.Select(ctx, base, &existing, dagql.Selector{
+			Field: "withChanges",
+			Args:  []dagql.NamedInput{{Name: "changes", Value: dagql.NewID[*core.Changeset](changesID)}},
+		}); err != nil {
+			return delta, fmt.Errorf("seed overlay delta root: %w", err)
+		}
+	}
+	existingID, err := existing.ID()
+	if err != nil {
+		return delta, err
+	}
+	// The base spans every touched path, not just the seeded ones; trim to the
+	// seeded paths so the rest of the delta root stays the caller's own writes.
+	var scoped dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, srv.Root(), &scoped,
+		dagql.Selector{Field: "directory"},
+		dagql.Selector{Field: "withDirectory", Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.NewString("/")},
+			{Name: "source", Value: dagql.NewID[*core.Directory](existingID)},
+			{Name: "include", Value: sparseIncludePatterns(paths)},
+		}},
+	); err != nil {
+		return delta, fmt.Errorf("seed overlay delta root: %w", err)
+	}
+	scopedID, err := scoped.ID()
+	if err != nil {
+		return delta, err
+	}
+	var seeded dagql.ObjectResult[*core.Directory]
+	if err := srv.Select(ctx, delta, &seeded, dagql.Selector{
+		Field: "withDirectory",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.NewString("/")},
+			{Name: "source", Value: dagql.NewID[*core.Directory](scopedID)},
+		},
+	}); err != nil {
+		return delta, fmt.Errorf("seed overlay delta root: %w", err)
+	}
+	return seeded, nil
 }
 
 // unionPaths returns the ordered union of two path slices, preserving first-seen
@@ -2292,11 +2430,7 @@ func (s *workspaceSchema) sparseHostBase(
 		return empty, nil
 	}
 
-	includes := make(dagql.ArrayInput[dagql.String], 0, len(touched)*2)
-	for _, p := range touched {
-		p = strings.TrimSuffix(p, "/")
-		includes = append(includes, dagql.String(p), dagql.String(p+"/**"))
-	}
+	includes := sparseIncludePatterns(touched)
 
 	ctx, err = s.withWorkspaceHostReadContext(ctx, ws)
 	if err != nil {
@@ -2317,6 +2451,17 @@ func (s *workspaceSchema) sparseHostBase(
 		return dagql.ObjectResult[*core.Directory]{}, fmt.Errorf("sparse host base: %w", err)
 	}
 	return out, nil
+}
+
+// sparseIncludePatterns turns workspace-relative paths into include patterns
+// covering each path and everything under it.
+func sparseIncludePatterns(paths []string) dagql.ArrayInput[dagql.String] {
+	includes := make(dagql.ArrayInput[dagql.String], 0, len(paths)*2)
+	for _, p := range paths {
+		p = strings.TrimSuffix(p, "/")
+		includes = append(includes, dagql.String(p), dagql.String(p+"/**"))
+	}
+	return includes
 }
 
 // changesetTouchedPaths returns the workspace-relative paths a changeset affects

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -112,7 +112,7 @@ func (s *workspaceSchema) stageWorkspaceConfigAndLock(
 	if lockChanged {
 		touched = append(touched, filepath.ToSlash(lockPath))
 	}
-	return s.overlayEdit(ctx, parent, touched, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, touched, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		updated, err := workspaceWithFile(ctx, dag, base, configPath, data)
 		if err != nil {
 			return dagql.ObjectResult[*core.Directory]{}, fmt.Errorf("stage workspace config update: %w", err)
@@ -365,7 +365,7 @@ func (s *workspaceSchema) withoutModule(
 	if removeManagedModuleDir {
 		touched = append(touched, managedDirPath)
 	}
-	return s.overlayEdit(ctx, parent, touched, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, touched, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		updatedRoot, err := workspaceWithFile(ctx, dag, base, configPath, updatedConfig)
 		if err != nil {
 			return dagql.ObjectResult[*core.Directory]{}, fmt.Errorf("stage workspace config update: %w", err)
@@ -457,7 +457,7 @@ func (s *workspaceSchema) workspaceWithChangeset(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	return s.overlayEdit(ctx, parent, touched, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
+	return s.overlayEdit(ctx, parent, touched, nil, func(base dagql.ObjectResult[*core.Directory]) (dagql.ObjectResult[*core.Directory], error) {
 		var updated dagql.ObjectResult[*core.Directory]
 		err := srv.Select(ctx, base, &updated, dagql.Selector{
 			Field: "withChanges",

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -208,7 +208,14 @@ type WorkspaceSourceOverlay struct {
 	// uploading the whole workspace. Value/git/rootless overlays leave this nil
 	// and diff full in-engine trees (nothing to upload).
 	TouchedPaths []string
-	Changes      dagql.ObjectResult[*Changeset]
+	// SeededPaths is the subset of TouchedPaths whose pre-existing workspace
+	// content the overlay folded into Changes.After, for edits that build on
+	// what a path already holds (see overlayEdit's readsExisting). Every later
+	// edit re-seeds them from the base it diffs against: content the caller
+	// never wrote, left pinned here, comes back reported as modified the moment
+	// they edit that file on disk.
+	SeededPaths []string
+	Changes     dagql.ObjectResult[*Changeset]
 }
 
 func (*WorkspaceSourceOverlay) workspaceSource() {}
@@ -241,16 +248,19 @@ func NewWorkspaceSourceGitRef(ref dagql.Result[*GitRef], explicitCommit bool) Wo
 func NewWorkspaceSourceOverlay(
 	base WorkspaceSource,
 	touchedPaths []string,
+	seededPaths []string,
 	changes dagql.ObjectResult[*Changeset],
 ) WorkspaceSource {
 	if overlay, ok := base.(*WorkspaceSourceOverlay); ok {
 		base = overlay.Base
 	}
-	// The caller accumulates TouchedPaths (union with the parent overlay's)
-	// before constructing, so they are already cumulative here.
+	// The caller accumulates TouchedPaths and SeededPaths (union with the
+	// parent overlay's) before constructing, so they are already cumulative
+	// here.
 	return &WorkspaceSourceOverlay{
 		Base:         base,
 		TouchedPaths: touchedPaths,
+		SeededPaths:  seededPaths,
 		Changes:      changes,
 	}
 }
@@ -370,6 +380,17 @@ func (ws *Workspace) OverlayTouchedPaths() []string {
 		return nil
 	}
 	return overlay.TouchedPaths
+}
+
+// OverlaySeededPaths returns the cumulative set of workspace-relative paths
+// whose pre-existing content the overlay folded into its changeset's after
+// side, which every later edit has to refresh from the base it diffs against.
+func (ws *Workspace) OverlaySeededPaths() []string {
+	overlay, ok := ws.Source().(*WorkspaceSourceOverlay)
+	if !ok {
+		return nil
+	}
+	return overlay.SeededPaths
 }
 
 // OverlayPathTouched reports whether the overlay's edits affect the given
@@ -598,6 +619,7 @@ type persistedWorkspaceSource struct {
 	ExplicitCommit bool                      `json:"explicitCommit,omitempty"`
 	ChangesID      uint64                    `json:"changesID,omitempty"`
 	TouchedPaths   []string                  `json:"touchedPaths,omitempty"`
+	SeededPaths    []string                  `json:"seededPaths,omitempty"`
 	HostPath       string                    `json:"hostPath,omitempty"`
 	Base           *persistedWorkspaceSource `json:"base,omitempty"`
 }
@@ -649,6 +671,7 @@ func encodePersistedWorkspaceSource(cache dagql.PersistedObjectCache, src Worksp
 			payload.Base = base
 		}
 		payload.TouchedPaths = src.TouchedPaths
+		payload.SeededPaths = src.SeededPaths
 		if src.Changes.Self() != nil {
 			changesID, err := encodePersistedObjectRef(cache, src.Changes, "workspace overlay changes")
 			if err != nil {
@@ -712,7 +735,7 @@ func decodePersistedWorkspaceSource(
 				return nil, err
 			}
 		}
-		return NewWorkspaceSourceOverlay(base, persisted.TouchedPaths, changes), nil
+		return NewWorkspaceSourceOverlay(base, persisted.TouchedPaths, persisted.SeededPaths, changes), nil
 	default:
 		return nil, fmt.Errorf("decode persisted workspace source: unsupported source kind %q", persisted.Kind)
 	}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5912,6 +5912,20 @@ type Workspace implements Node {
   ): Workspace!
 
   """
+  Return this workspace with a directory merged into the given path, without mutating the source.
+
+  Anything already at the path stays, and files the source carries win, as with
+  Directory.withDirectory. Use withNewDirectory to replace the path instead.
+  """
+  withDirectory(
+    """Path to merge into. Relative paths resolve from the workspace cwd."""
+    path: String!
+
+    """Directory to merge there."""
+    source: ID! @expectedType(name: "Directory")
+  ): Workspace!
+
+  """
   Return this workspace with a generated API client initialized.
 
   The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
@@ -6027,15 +6041,17 @@ type Workspace implements Node {
   ): Workspace!
 
   """
-  Return this workspace with a directory added, without mutating the source.
+  Return this workspace with the given path replaced by a directory, without mutating the source.
+
+  The source becomes the entire contents of the path: anything already there
+  that the source does not carry is removed. Use withDirectory to keep it
+  instead.
   """
   withNewDirectory(
-    """
-    Path of the added directory. Relative paths resolve from the workspace cwd.
-    """
+    """Path to replace. Relative paths resolve from the workspace cwd."""
     path: String!
 
-    """Directory to add."""
+    """Directory to write there."""
     source: ID! @expectedType(name: "Directory")
   ): Workspace!
 

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -436,6 +436,16 @@
                     <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
                 </div>
                 <div class="col-md-8">
+                    <a href="#method_withDirectory">withDirectory</a>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
+        
+                                            <p><p>Return this workspace with a directory merged into the given path, without mutating the source.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
                     <a href="#method_withInitClient">withInitClient</a>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         
                                             <p><p>Return this workspace with a generated API client initialized.</p></p>                </div>
@@ -488,7 +498,7 @@
                 <div class="col-md-8">
                     <a href="#method_withNewDirectory">withNewDirectory</a>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         
-                                            <p><p>Return this workspace with a directory added, without mutating the source.</p></p>                </div>
+                                            <p><p>Return this workspace with the given path replaced by a directory, without mutating the source.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -1918,8 +1928,55 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_withInitClient">
+                    <h3 id="method_withDirectory">
         <div class="location">at line 442</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Return this workspace with a directory merged into the given path, without mutating the source.</p></p>                <p><p>Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.</p></p>        
+        </div>
+        <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string</td>
+                <td>$path</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td><a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a></td>
+                <td>$source</td>
+                <td></td>
+            </tr>
+            </table>
+
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_withInitClient">
+        <div class="location">at line 455</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -1986,7 +2043,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 471</div>
+        <div class="location">at line 484</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -2063,7 +2120,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 510</div>
+        <div class="location">at line 523</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -2115,7 +2172,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 528</div>
+        <div class="location">at line 541</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2162,7 +2219,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 541</div>
+        <div class="location">at line 554</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
         </code>
@@ -2209,7 +2266,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 552</div>
+        <div class="location">at line 567</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2219,7 +2276,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return this workspace with a directory added, without mutating the source.</p></p>                        
+                            <p><p>Return this workspace with the given path replaced by a directory, without mutating the source.</p></p>                <p><p>The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.</p></p>        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -2256,7 +2313,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 563</div>
+        <div class="location">at line 578</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2308,7 +2365,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 577</div>
+        <div class="location">at line 592</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2365,7 +2422,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 596</div>
+        <div class="location">at line 611</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2397,7 +2454,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 605</div>
+        <div class="location">at line 620</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2439,7 +2496,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 615</div>
+        <div class="location">at line 630</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2486,7 +2543,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 632</div>
+        <div class="location">at line 647</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2534,7 +2591,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 645</div>
+        <div class="location">at line 660</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2576,7 +2633,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 655</div>
+        <div class="location">at line 670</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2618,7 +2675,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 667</div>
+        <div class="location">at line 682</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2665,7 +2722,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 680</div>
+        <div class="location">at line 695</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -2178,7 +2178,9 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::withConfigEnv</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a named config environment created.</p></dd><dt><a href="Dagger/Workspace.html#method_withConfigValue">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withConfigValue</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a configuration value written.</p></dd><dt><a href="Dagger/Workspace.html#method_withInitClient">
+                    <dd><p>Return this workspace with a configuration value written.</p></dd><dt><a href="Dagger/Workspace.html#method_withDirectory">
+<abbr title="Dagger\Workspace">Workspace</abbr>::withDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
+                    <dd><p>Return this workspace with a directory merged into the given path, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withInitClient">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withInitClient</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a generated API client initialized.</p></dd><dt><a href="Dagger/Workspace.html#method_withInitModule">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withInitModule</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
@@ -2190,7 +2192,7 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::withMountedFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a file mounted read-only at the given path, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewDirectory">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withNewDirectory</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Return this workspace with a directory added, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewFile">
+                    <dd><p>Return this workspace with the given path replaced by a directory, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withNewFile">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withNewFile</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Return this workspace with a new or replaced file, without mutating the source.</p></dd><dt><a href="Dagger/Workspace.html#method_withSDK">
 <abbr title="Dagger\Workspace">Workspace</abbr>::withSDK</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -7454,6 +7454,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Workspace::withDirectory",
+			"p": "Dagger/Workspace.html#method_withDirectory",
+			"d": "<p>Return this workspace with a directory merged into the given path, without mutating the source.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Workspace::withInitClient",
 			"p": "Dagger/Workspace.html#method_withInitClient",
 			"d": "<p>Return this workspace with a generated API client initialized.</p>"
@@ -7486,7 +7492,7 @@
 			"t": "M",
 			"n": "Dagger\\Workspace::withNewDirectory",
 			"p": "Dagger/Workspace.html#method_withNewDirectory",
-			"d": "<p>Return this workspace with a directory added, without mutating the source.</p>"
+			"d": "<p>Return this workspace with the given path replaced by a directory, without mutating the source.</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -544,6 +544,25 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
+  Return this workspace with a directory merged into the given path, without mutating the source.
+
+  Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.
+  """
+  @spec with_directory(t(), String.t(), Dagger.Directory.t()) :: Dagger.Workspace.t()
+  def with_directory(%__MODULE__{} = workspace, path, source) do
+    query_builder =
+      workspace.query_builder
+      |> QB.select("withDirectory")
+      |> QB.put_arg("path", path)
+      |> QB.put_arg("source", Dagger.ID.id!(source))
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: workspace.client
+    }
+  end
+
+  @doc """
   Return this workspace with a generated API client initialized.
 
   The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
@@ -662,7 +681,9 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
-  Return this workspace with a directory added, without mutating the source.
+  Return this workspace with the given path replaced by a directory, without mutating the source.
+
+  The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.
   """
   @spec with_new_directory(t(), String.t(), Dagger.Directory.t()) :: Dagger.Workspace.t()
   def with_new_directory(%__MODULE__{} = workspace, path, source) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16913,7 +16913,9 @@ func (r *Workspace) WithMountedFile(path string, source *File) *Workspace {
 	}
 }
 
-// Return this workspace with a directory added, without mutating the source.
+// Return this workspace with the given path replaced by a directory, without mutating the source.
+//
+// The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.
 func (r *Workspace) WithNewDirectory(path string, source *Directory) *Workspace {
 	assertNotNil("source", source)
 	q := r.query.Select("withNewDirectory")

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16748,6 +16748,20 @@ func (r *Workspace) WithConfigValue(key string, value string, opts ...WorkspaceW
 	}
 }
 
+// Return this workspace with a directory merged into the given path, without mutating the source.
+//
+// Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.
+func (r *Workspace) WithDirectory(path string, source *Directory) *Workspace {
+	assertNotNil("source", source)
+	q := r.query.Select("withDirectory")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // WorkspaceWithInitClientOpts contains options for Workspace.WithInitClient
 type WorkspaceWithInitClientOpts struct {
 	// SDK-specific init arguments.

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -435,6 +435,19 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
+     * Return this workspace with a directory merged into the given path, without mutating the source.
+     *
+     * Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.
+     */
+    public function withDirectory(string $path, Directory $source): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDirectory');
+        $innerQueryBuilder->setArgument('path', $path);
+        $innerQueryBuilder->setArgument('source', $source);
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Return this workspace with a generated API client initialized.
      *
      * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
@@ -547,7 +560,9 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
-     * Return this workspace with a directory added, without mutating the source.
+     * Return this workspace with the given path replaced by a directory, without mutating the source.
+     *
+     * The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.
      */
     public function withNewDirectory(string $path, Directory $source): Workspace
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15665,6 +15665,28 @@ class Workspace(Type):
         _ctx = self._select("withConfigValue", _args)
         return Workspace(_ctx)
 
+    def with_directory(self, path: str, source: Directory) -> Self:
+        """Return this workspace with a directory merged into the given path,
+        without mutating the source.
+
+        Anything already at the path stays, and files the source carries win,
+        as with Directory.withDirectory. Use withNewDirectory to replace the
+        path instead.
+
+        Parameters
+        ----------
+        path:
+            Path to merge into. Relative paths resolve from the workspace cwd.
+        source:
+            Directory to merge there.
+        """
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withDirectory", _args)
+        return Workspace(_ctx)
+
     def with_init_client(
         self,
         path: str,
@@ -15837,16 +15859,19 @@ class Workspace(Type):
         return Workspace(_ctx)
 
     def with_new_directory(self, path: str, source: Directory) -> Self:
-        """Return this workspace with a directory added, without mutating the
-        source.
+        """Return this workspace with the given path replaced by a directory,
+        without mutating the source.
+
+        The source becomes the entire contents of the path: anything already
+        there that the source does not carry is removed. Use withDirectory to
+        keep it instead.
 
         Parameters
         ----------
         path:
-            Path of the added directory. Relative paths resolve from the
-            workspace cwd.
+            Path to replace. Relative paths resolve from the workspace cwd.
         source:
-            Directory to add.
+            Directory to write there.
         """
         _args = [
             Arg("path", path),

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -15969,6 +15969,29 @@ impl Workspace {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Return this workspace with a directory merged into the given path, without mutating the source.
+    /// Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to merge into. Relative paths resolve from the workspace cwd.
+    /// * `source` - Directory to merge there.
+    pub fn with_directory(&self, path: impl Into<String>, source: impl IntoID<Id>) -> Workspace {
+        let mut query = self.selection.select("withDirectory");
+        query = query.arg("path", path.into());
+        query = query.arg_lazy(
+            "source",
+            Box::new(move || {
+                let source = source.clone();
+                Box::pin(async move { source.into_id().await.unwrap().quote() })
+            }),
+        );
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// Return this workspace with a generated API client initialized.
     /// The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
     ///
@@ -16180,12 +16203,13 @@ impl Workspace {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    /// Return this workspace with a directory added, without mutating the source.
+    /// Return this workspace with the given path replaced by a directory, without mutating the source.
+    /// The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.
     ///
     /// # Arguments
     ///
-    /// * `path` - Path of the added directory. Relative paths resolve from the workspace cwd.
-    /// * `source` - Directory to add.
+    /// * `path` - Path to replace. Relative paths resolve from the workspace cwd.
+    /// * `source` - Directory to write there.
     pub fn with_new_directory(
         &self,
         path: impl Into<String>,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -15453,6 +15453,18 @@ export class Workspace extends BaseClient {
   }
 
   /**
+   * Return this workspace with a directory merged into the given path, without mutating the source.
+   *
+   * Anything already at the path stays, and files the source carries win, as with Directory.withDirectory. Use withNewDirectory to replace the path instead.
+   * @param path Path to merge into. Relative paths resolve from the workspace cwd.
+   * @param source Directory to merge there.
+   */
+  withDirectory = (path: string, source: Directory): Workspace => {
+    const ctx = this._ctx.select("withDirectory", { path, source })
+    return new Workspace(ctx)
+  }
+
+  /**
    * Return this workspace with a generated API client initialized.
    *
    * The SDK's generators run for the new client, so the returned workspace carries its generated bindings.
@@ -15538,9 +15550,11 @@ export class Workspace extends BaseClient {
   }
 
   /**
-   * Return this workspace with a directory added, without mutating the source.
-   * @param path Path of the added directory. Relative paths resolve from the workspace cwd.
-   * @param source Directory to add.
+   * Return this workspace with the given path replaced by a directory, without mutating the source.
+   *
+   * The source becomes the entire contents of the path: anything already there that the source does not carry is removed. Use withDirectory to keep it instead.
+   * @param path Path to replace. Relative paths resolve from the workspace cwd.
+   * @param source Directory to write there.
    */
   withNewDirectory = (path: string, source: Directory): Workspace => {
     const ctx = this._ctx.select("withNewDirectory", { path, source })


### PR DESCRIPTION
Fixes #13955.

Same call, same source, same path — two different answers depending on where the
workspace came from:

```
$ dagger call probe compare
host-backed removed:
target/keep.txt
synthetic removed:
```

A host-backed checkout replaced whatever was at the path; a workspace loaded from
a `Directory` or from git merged into it. Every SDK writes its scaffolding and its
generated clients through `Workspace.withNewDirectory`, so on a real checkout
`dagger module init` deleted whatever was already at the destination — the user's
files, and the module config the engine itself had just written. It was found and
worked around separately in dagger/go-sdk#30, dagger/python-sdk#14 and
dagger/typescript-sdk#35, each time by reading the destination back and layering
onto it by hand.

The split also hides in the other direction: a guard that leans on the
replacement passes locally and quietly stops asserting anything in CI, where the
same repo arrives as a git workspace.

## What changes

`Workspace.withNewDirectory` now replaces on every kind of workspace, and the new
`Workspace.withDirectory` merges on every kind — the same contract
`Directory.withDirectory` has. Callers pick the one they mean instead of the one
their workspace happens to give them:

```graphql
# the source becomes the path's entire contents
withNewDirectory(path: "mod", source: $scaffold)

# the source lands on top of what the path already holds
withDirectory(path: "mod", source: $scaffold)
```

The read-back the three SDKs each wrote by hand is now the second field.

## Where the split came from

`overlayEdit` hands the edit two different bases. A value or git workspace edits
its full read root, where the path holds the workspace's own content. A
host-backed one edits a *delta root* holding only what earlier edits wrote — it
never references the host tree, which is what keeps an edit from uploading the
whole checkout — and its changeset comes from diffing that against a host base
scoped to the touched paths. An edit that layers onto the path finds it empty
there, so everything the host has under it diffs against nothing and reads as
removed.

So:

- `withNewDirectory` clears the path before it copies, on either branch. An edit
  whose result owes nothing to what the base held reads the same on both.
- `overlayEdit` gained an explicit `readsExisting` — the touched paths whose
  existing content an edit builds on — and seeds the host-backed delta root with
  them first. That invariant is what was missing.

The seed comes out of the very base the changeset is diffed against, and the
overlay records which paths it seeded so every later edit re-seeds them from its
own base. Content the caller never wrote must not sit pinned on the after side: a
file they edit on disk meanwhile would come back reported as modified to whatever
the host held at seeding time, and exporting would write that over their edit.

## Tests

Both fields, against all three workspace kinds (host-backed, value, git): writing
over existing content, writing to a path that does not exist, composing with
earlier overlay edits, and not resurrecting content an earlier edit removed. Plus
the issue's own comparison, the host-content-staleness regression above, and
`dagger module init` end to end against a destination that already holds a file.

Reverting the fix fails exactly the predicted subtests — `withNewDirectory`
merging on value and git, `withDirectory` replacing on host-backed — and the
module-init test deletes the user's file.
