### PR TITLE
feat(telemetry): sequence cloud exports

### DIFF
--- a/engine/telemetry/cloud.go
+++ b/engine/telemetry/cloud.go
@@ -79,6 +79,9 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 		tracesURL := cloudEndpoint.JoinPath("v1", "traces")
 		logsURL := cloudEndpoint.JoinPath("v1", "logs")
 		metricsURL := cloudEndpoint.JoinPath("v1", "metrics")
+		spanSequencer := newExportSequencer()
+		logSequencer := newExportSequencer()
+		metricSequencer := newExportSequencer()
 
 		headers := map[string]string{
 			"Authorization": authHeader,
@@ -89,7 +92,8 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 
 		configuredCloudSpanExporter, err = otlptracehttp.New(ctx,
 			otlptracehttp.WithEndpointURL(tracesURL.String()),
-			otlptracehttp.WithHeaders(headers))
+			otlptracehttp.WithHeaders(headers),
+			otlptracehttp.WithHTTPClient(spanSequencer.httpClient()))
 		if err != nil {
 			slog.Warn("failed to configure cloud tracing", "error", err)
 			return
@@ -97,7 +101,8 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 
 		configuredCloudLogsExporter, err = otlploghttp.New(ctx,
 			otlploghttp.WithEndpointURL(logsURL.String()),
-			otlploghttp.WithHeaders(headers))
+			otlploghttp.WithHeaders(headers),
+			otlploghttp.WithHTTPClient(logSequencer.httpClient()))
 		if err != nil {
 			slog.Warn("failed to configure cloud tracing", "error", err)
 			return
@@ -105,7 +110,8 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 
 		configuredCloudMetricsExporter, err = otlpmetrichttp.New(ctx,
 			otlpmetrichttp.WithEndpointURL(metricsURL.String()),
-			otlpmetrichttp.WithHeaders(headers))
+			otlpmetrichttp.WithHeaders(headers),
+			otlpmetrichttp.WithHTTPClient(metricSequencer.httpClient()))
 		if err != nil {
 			slog.Warn("failed to configure cloud metrics", "error", err)
 			return
@@ -122,7 +128,8 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 					newHeaders["Authorization"] = authHeader
 					return otlptracehttp.New(ctx,
 						otlptracehttp.WithEndpointURL(tracesURL.String()),
-						otlptracehttp.WithHeaders(newHeaders))
+						otlptracehttp.WithHeaders(newHeaders),
+						otlptracehttp.WithHTTPClient(spanSequencer.httpClient()))
 				},
 				token: token,
 				exp:   configuredCloudSpanExporter,
@@ -135,7 +142,8 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 					newHeaders["Authorization"] = authHeader
 					return otlploghttp.New(ctx,
 						otlploghttp.WithEndpointURL(logsURL.String()),
-						otlploghttp.WithHeaders(newHeaders))
+						otlploghttp.WithHeaders(newHeaders),
+						otlploghttp.WithHTTPClient(logSequencer.httpClient()))
 				},
 				token: token,
 				exp:   configuredCloudLogsExporter,
@@ -148,11 +156,25 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 					newHeaders["Authorization"] = authHeader
 					return otlpmetrichttp.New(ctx,
 						otlpmetrichttp.WithEndpointURL(metricsURL.String()),
-						otlpmetrichttp.WithHeaders(newHeaders))
+						otlpmetrichttp.WithHeaders(newHeaders),
+						otlpmetrichttp.WithHTTPClient(metricSequencer.httpClient()))
 				},
 				token: token,
 				exp:   configuredCloudMetricsExporter,
 			}
+		}
+
+		configuredCloudSpanExporter = &sequencedSpanExporter{
+			sequencer: spanSequencer,
+			exporter:  configuredCloudSpanExporter,
+		}
+		configuredCloudLogsExporter = &sequencedLogExporter{
+			sequencer: logSequencer,
+			exporter:  configuredCloudLogsExporter,
+		}
+		configuredCloudMetricsExporter = &sequencedMetricExporter{
+			sequencer: metricSequencer,
+			exporter:  configuredCloudMetricsExporter,
 		}
 
 		configuredCloudTelemetry = true

--- a/engine/telemetry/cloud_export_sequence.go
+++ b/engine/telemetry/cloud_export_sequence.go
@@ -1,0 +1,120 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+const cloudExportHeader = "X-Dagger-Export"
+
+type exportSequenceContextKey struct{}
+
+type exportSequenceMetadata struct {
+	writerID string
+	sequence uint64
+}
+
+type exportSequencer struct {
+	writerID string
+	sequence atomic.Uint64
+}
+
+func newExportSequencer() *exportSequencer {
+	return &exportSequencer{writerID: uuid.NewString()}
+}
+
+func (s *exportSequencer) nextContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, exportSequenceContextKey{}, exportSequenceMetadata{
+		writerID: s.writerID,
+		sequence: s.sequence.Add(1),
+	})
+}
+
+func (s *exportSequencer) httpClient() *http.Client {
+	return &http.Client{Transport: exportSequenceTransport{base: http.DefaultTransport}}
+}
+
+type exportSequenceTransport struct {
+	base http.RoundTripper
+}
+
+func (t exportSequenceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	metadata, ok := req.Context().Value(exportSequenceContextKey{}).(exportSequenceMetadata)
+	if !ok {
+		return t.base.RoundTrip(req)
+	}
+
+	request := req.Clone(req.Context())
+	request.Header = req.Header.Clone()
+	request.Header.Set(cloudExportHeader, fmt.Sprintf("%s/%d", metadata.writerID, metadata.sequence))
+	return t.base.RoundTrip(request)
+}
+
+type sequencedSpanExporter struct {
+	sequencer *exportSequencer
+	exporter  sdktrace.SpanExporter
+}
+
+var _ sdktrace.SpanExporter = (*sequencedSpanExporter)(nil)
+
+func (e *sequencedSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	return e.exporter.ExportSpans(e.sequencer.nextContext(ctx), spans)
+}
+
+func (e *sequencedSpanExporter) Shutdown(ctx context.Context) error {
+	return e.exporter.Shutdown(ctx)
+}
+
+type sequencedLogExporter struct {
+	sequencer *exportSequencer
+	exporter  sdklog.Exporter
+}
+
+var _ sdklog.Exporter = (*sequencedLogExporter)(nil)
+
+func (e *sequencedLogExporter) Export(ctx context.Context, logs []sdklog.Record) error {
+	return e.exporter.Export(e.sequencer.nextContext(ctx), logs)
+}
+
+func (e *sequencedLogExporter) Shutdown(ctx context.Context) error {
+	return e.exporter.Shutdown(ctx)
+}
+
+func (e *sequencedLogExporter) ForceFlush(ctx context.Context) error {
+	return e.exporter.ForceFlush(ctx)
+}
+
+type sequencedMetricExporter struct {
+	sequencer *exportSequencer
+	exporter  sdkmetric.Exporter
+}
+
+var _ sdkmetric.Exporter = (*sequencedMetricExporter)(nil)
+
+func (e *sequencedMetricExporter) Temporality(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	return e.exporter.Temporality(kind)
+}
+
+func (e *sequencedMetricExporter) Aggregation(kind sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return e.exporter.Aggregation(kind)
+}
+
+func (e *sequencedMetricExporter) Export(ctx context.Context, metrics *metricdata.ResourceMetrics) error {
+	return e.exporter.Export(e.sequencer.nextContext(ctx), metrics)
+}
+
+func (e *sequencedMetricExporter) Shutdown(ctx context.Context) error {
+	return e.exporter.Shutdown(ctx)
+}
+
+func (e *sequencedMetricExporter) ForceFlush(ctx context.Context) error {
+	return e.exporter.ForceFlush(ctx)
+}

--- a/engine/telemetry/cloud_export_sequence_test.go
+++ b/engine/telemetry/cloud_export_sequence_test.go
@@ -1,0 +1,58 @@
+package telemetry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportSequencerAddsRetryStableHeader(t *testing.T) {
+	headers := make(chan string, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers <- r.Header.Get(cloudExportHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	sequencer := newExportSequencer()
+	client := sequencer.httpClient()
+
+	firstExport := sequencer.nextContext(context.Background())
+	request := func(ctx context.Context) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	request(firstExport)
+	request(firstExport) // an OTLP retry reuses the export call's context
+	request(sequencer.nextContext(context.Background()))
+
+	first := <-headers
+	require.Equal(t, first, <-headers)
+	require.Equal(t, sequencer.writerID+"/1", first)
+	require.Equal(t, sequencer.writerID+"/2", <-headers)
+	_, err := uuid.Parse(sequencer.writerID)
+	require.NoError(t, err)
+}
+
+func TestExportSequencersAreIndependent(t *testing.T) {
+	traces := newExportSequencer()
+	logs := newExportSequencer()
+
+	require.NotEqual(t, traces.writerID, logs.writerID)
+	traceMetadata := traces.nextContext(context.Background()).Value(exportSequenceContextKey{}).(exportSequenceMetadata)
+	logMetadata := logs.nextContext(context.Background()).Value(exportSequenceContextKey{}).(exportSequenceMetadata)
+	require.Equal(t, uint64(1), traceMetadata.sequence)
+	require.Equal(t, uint64(1), logMetadata.sequence)
+}


### PR DESCRIPTION
## Why

This is the producer half of the [Cloud binary OTLP streaming cutover](https://github.com/dagger/dagger.io/pull/5226).

The migration has two primary goals:

- stream logs without materializing the full result in API memory;
- keep live logs in deterministic order even when ClickHouse async inserts become visible out of order.

This PR enables the ordering half by assigning independent writer IDs and retry-stable sequence numbers to Cloud trace, log, and metric exports. The Cloud reader gates selected rows on contiguous export prefixes. It is independent of the later raw call-payload transport work.

## Test plan

- Dagger engine telemetry tests: `TestExportSequenc*`