### PR TITLE
setup: record migrated toolchains as module dependencies

### DIFF
--- a/.changes/unreleased/Fixed-20260825-120000.yaml
+++ b/.changes/unreleased/Fixed-20260825-120000.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: |
+  `dagger setup` now records a legacy module's toolchains as dependencies in
+  the migrated `dagger-module.toml`, in addition to installing them into
+  `dagger.toml`. In 0.21 a module's toolchains were also loaded into its own
+  API, so module code that called a toolchain (e.g. `dag.Go()`) kept
+  compiling; migration preserves that by adding the dependency install.
+time: 2026-08-25T12:00:00Z
+custom:
+  Author: kpenfound
+  PR: ""

--- a/.changes/unreleased/Fixed-20260825-120000.yaml
+++ b/.changes/unreleased/Fixed-20260825-120000.yaml
@@ -8,4 +8,4 @@ body: |
 time: 2026-08-25T12:00:00Z
 custom:
   Author: kpenfound
-  PR: ""
+  PR: 13974

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -430,10 +430,14 @@ type Myapp {
   "source": "ci",
   "toolchains": [{"name": "tc", "source": "./toolchain"}]
 }`, func(ctr *dagger.Container) *dagger.Container {
+			// In 0.21 a module's toolchains were also loaded into its own API,
+			// so module code could call them like dependencies. This module
+			// does exactly that and must keep working after migration.
 			return ctr.
 				WithNewFile("ci/main.dang", `
 type Myapp {
   pub greet: String! { "hello from root" }
+  pub viaToolchain: String! { tc.message }
 }
 `).
 				With(legacyDangModule("toolchain", "tc", "Tc", "hello from toolchain"))
@@ -459,10 +463,23 @@ type Myapp {
 		require.Contains(t, wsOut, `[modules.dagger-dang-sdk]`)
 		require.Contains(t, wsOut, `path = "toolchain"`)
 
+		// The toolchain is also a dependency of the migrated root module, so
+		// code that called it in 0.21 still resolves.
+		mainCfg, err := ctr.WithExec([]string{"cat", "dagger-module.toml"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, mainCfg, `name = "tc"`)
+		require.Contains(t, mainCfg, `source = "./toolchain"`)
+		require.NotContains(t, mainCfg, "toolchains")
+
 		// The converted module loads from its own runtime field.
 		callOut, err := ctr.With(daggerCallAt("toolchain", "message")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "hello from toolchain", strings.TrimSpace(callOut))
+
+		// The root module can still reach the toolchain as a dependency.
+		viaOut, err := ctr.With(daggerCall("via-toolchain")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hello from toolchain", strings.TrimSpace(viaOut))
 	})
 
 	t.Run("local dependency migrates in place behind rebased reference", func(ctx context.Context, t *testctx.T) {

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -150,6 +150,9 @@ type MigrationPlan struct {
 // (toolchains) are installed into a dagger.toml at the workspace root with
 // their local sources rebased, while the module config still converts in
 // place at its own directory and the module itself is not installed.
+//
+// When the config has an SDK, its toolchains are also recorded as
+// dependencies of the migrated module config (see buildMigratedModuleConfig).
 func PlanMigration(compatWorkspace *CompatWorkspace, workspaceRoot string) (*MigrationPlan, error) {
 	if compatWorkspace == nil || compatWorkspace.Config == nil {
 		return nil, fmt.Errorf("compat workspace is required")
@@ -300,6 +303,13 @@ func renderMigrationWorkspaceConfig(cfg *Config, mainModule *CompatMainModule) (
 // source, dependency, and include paths are preserved as-is; only the
 // workspace-level fields (toolchains, blueprint, customizations) are dropped —
 // those migrate into dagger.toml instead.
+//
+// Toolchains are additionally recorded as plain dependencies of the migrated
+// module: in 0.21 a module's toolchains were also loaded into its own API, so
+// module code could call them (e.g. dag.Go) exactly like a dependency. Keeping
+// them as dependencies is what keeps that code compiling after migration. The
+// workspace-only fields of a toolchain (customizations, ignore lists, port
+// mappings) belong to the dagger.toml install and are not carried over.
 func buildMigratedModuleConfig(cfg *modules.ModuleConfig) ([]byte, error) {
 	if cfg.Source != "" && filepath.IsAbs(cfg.Source) {
 		return nil, fmt.Errorf("source path %q is absolute", cfg.Source)
@@ -313,7 +323,8 @@ func buildMigratedModuleConfig(cfg *modules.ModuleConfig) ([]byte, error) {
 		source = ""
 	}
 
-	deps := make([]*modules.ModuleConfigDependency, 0, len(cfg.Dependencies))
+	deps := make([]*modules.ModuleConfigDependency, 0, len(cfg.Dependencies)+len(cfg.Toolchains))
+	depNames := make(map[string]struct{}, len(cfg.Dependencies)+len(cfg.Toolchains))
 	for _, dep := range cfg.Dependencies {
 		if dep == nil {
 			continue
@@ -326,6 +337,23 @@ func buildMigratedModuleConfig(cfg *modules.ModuleConfig) ([]byte, error) {
 			IgnoreChecks:     append([]string(nil), dep.IgnoreChecks...),
 			IgnoreGenerators: append([]string(nil), dep.IgnoreGenerators...),
 		})
+		depNames[dep.Name] = struct{}{}
+	}
+	for _, tc := range cfg.Toolchains {
+		if tc == nil {
+			continue
+		}
+		if _, dup := depNames[tc.Name]; dup {
+			// Already an explicit dependency under the same name; the
+			// dependency entry wins so the module keeps the ref it declared.
+			continue
+		}
+		deps = append(deps, &modules.ModuleConfigDependency{
+			Name:   tc.Name,
+			Source: tc.Source,
+			Pin:    tc.Pin,
+		})
+		depNames[tc.Name] = struct{}{}
 	}
 
 	newCfg := modules.ModuleConfig{

--- a/core/workspace/migrate_test.go
+++ b/core/workspace/migrate_test.go
@@ -184,6 +184,90 @@ func TestPlanMigrationModuleRepoSkipsSDKInstall(t *testing.T) {
 	require.Contains(t, configData, "[modules.tools]")
 }
 
+// TestPlanMigrationRecordsToolchainsAsModuleDependencies covers the 0.21
+// semantics where a module's toolchains were also loaded into its own API:
+// module code could call them like dependencies (e.g. dag.Go). Migration must
+// therefore install the toolchains into dagger.toml AND record them as
+// dependencies of the migrated dagger-module.toml, or that code stops
+// compiling after `dagger setup`.
+func TestPlanMigrationRecordsToolchainsAsModuleDependencies(t *testing.T) {
+	t.Parallel()
+
+	plan := testMigrationPlan(t, "repo", `{
+  "name": "myapp",
+  "sdk": {"source": "go"},
+  "source": ".dagger",
+  "dependencies": [
+    {"name": "lib", "source": "./libs/lib"},
+    {"name": "shared", "source": "github.com/acme/shared@main", "pin": "aaaaaaa"}
+  ],
+  "toolchains": [
+    {"name": "go", "source": "github.com/acme/go@main", "pin": "1111111",
+     "customizations": [{"argument": "version", "default": "1.22"}],
+     "ignoreChecks": ["lint"]},
+    {"name": "local-tc", "source": "./toolchain"},
+    {"name": "shared", "source": "github.com/acme/shared@main", "pin": "bbbbbbb"}
+  ]
+}`)
+
+	require.Equal(t, ModuleConfigFileName, plan.MigratedModuleConfigPath)
+	cfg, err := modules.ParseModuleConfigForFilename(plan.MigratedModuleConfigData, ModuleConfigFileName)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Toolchains, "toolchains never survive as a module config field")
+
+	byName := map[string]*modules.ModuleConfigDependency{}
+	for _, dep := range cfg.Dependencies {
+		byName[dep.Name] = dep
+	}
+	require.Len(t, cfg.Dependencies, 4, "explicit deps plus each toolchain, deduplicated by name")
+
+	require.Equal(t, "./libs/lib", byName["lib"].Source)
+
+	goDep := byName["go"]
+	require.NotNil(t, goDep, "a toolchain becomes a dependency of the migrated module")
+	require.Equal(t, "github.com/acme/go@main", goDep.Source)
+	require.Equal(t, "1111111", goDep.Pin, "the toolchain pin is preserved on the dependency")
+	require.Empty(t, goDep.Customizations, "toolchain customizations belong to the dagger.toml install")
+	require.Empty(t, goDep.IgnoreChecks)
+
+	localTC := byName["local-tc"]
+	require.NotNil(t, localTC)
+	require.Equal(t, "./toolchain", localTC.Source,
+		"the module config does not move, so a local toolchain ref is preserved as-is")
+
+	shared := byName["shared"]
+	require.NotNil(t, shared)
+	require.Equal(t, "aaaaaaa", shared.Pin,
+		"an explicit dependency wins over a same-named toolchain")
+
+	// The toolchains are still installed into the workspace with their
+	// workspace-only settings.
+	wsCfg, err := ParseConfig(plan.WorkspaceConfigData)
+	require.NoError(t, err)
+	require.Equal(t, "github.com/acme/go@1111111", wsCfg.Modules["go"].Source)
+	require.Equal(t, []string{"lint"}, wsCfg.Modules["go"].Check.Skip)
+	require.Contains(t, wsCfg.Modules, "local-tc")
+	require.Contains(t, wsCfg.Modules, "shared")
+}
+
+// TestPlanMigrationToolchainsWithoutSDKWriteNoModuleConfig verifies that a
+// toolchains-only dagger.json (no sdk, so no module code that could have
+// called them) still produces no dagger-module.toml.
+func TestPlanMigrationToolchainsWithoutSDKWriteNoModuleConfig(t *testing.T) {
+	t.Parallel()
+
+	plan := testMigrationPlan(t, "repo", `{
+  "name": "myapp",
+  "toolchains": [
+    {"name": "go", "source": "github.com/acme/go@main", "pin": "1111111"}
+  ]
+}`)
+
+	require.Empty(t, plan.MigratedModuleConfigPath)
+	require.Empty(t, plan.MigratedModuleConfigData)
+	require.Contains(t, string(plan.WorkspaceConfigData), "[modules.go]")
+}
+
 func TestPlanMigrationRejectsAbsoluteMainModuleSource(t *testing.T) {
 	t.Parallel()
 

--- a/docs/current_docs/cli/reference/index.mdx
+++ b/docs/current_docs/cli/reference/index.mdx
@@ -2609,6 +2609,10 @@ config lists toolchains, they are installed into a dagger.toml at the
 repository root — never a nested one. A subdirectory config with a
 blueprint is left as legacy with a warning.
 
+Toolchains of a module with an SDK are also added as dependencies in the
+migrated dagger-module.toml, since 0.21 exposed toolchains to module code
+the same way as dependencies. Remove any the module code does not use.
+
 Idempotent: safe to run anytime. No-ops what's already in good shape.
 Each step can be skipped at the prompt. With --auto-apply, workspace
 changes and module recommendations are applied without prompting. Cloud

--- a/docs/current_docs/config/migrate-dagger-json.mdx
+++ b/docs/current_docs/config/migrate-dagger-json.mdx
@@ -30,6 +30,7 @@ A few behaviors worth knowing:
 - If your repo *is* a module — the root `dagger.json` describes a module whose source lives at the repo root — migration converts the config in place and writes a minimal `dagger.toml` that only pins the module's SDK. The module isn't installed into the workspace, so load it explicitly: `dagger -m . call --help`.
 - Run from a module subdirectory, migration converts just that module — `dagger.json` becomes `dagger-module.toml` in place, along with any local dependencies it references — and creates no workspace. Module recommendations are skipped.
 - Nested `dagger.toml` files are never created. Toolchains listed in a subdirectory `dagger.json` are installed into the workspace at the repository root, with local source paths rebased. A subdirectory `dagger.json` with a `blueprint` is left as legacy, with a warning.
+- When a `dagger.json` has both an `sdk` and `toolchains`, the toolchains are installed into `dagger.toml` **and** recorded as dependencies in the migrated `dagger-module.toml`. In 0.21 a module could call its toolchains from code the same way as dependencies (for example `dag.Go()`), so this keeps that code working. Remove any dependency the module code does not use.
 - Modules now commit their generated code (`dagger.gen.go` and friends) instead of regenerating it at runtime. Migration removes the `.gitignore` rules that used to exclude it — afterwards, run `dagger generate` and commit the output.
 - Applying a migration ends the setup run. Run `dagger setup` again for module recommendations.
 

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -55,6 +55,10 @@ config lists toolchains, they are installed into a dagger.toml at the
 repository root — never a nested one. A subdirectory config with a
 blueprint is left as legacy with a warning.
 
+Toolchains of a module with an SDK are also added as dependencies in the
+migrated dagger-module.toml, since 0.21 exposed toolchains to module code
+the same way as dependencies. Remove any the module code does not use.
+
 Idempotent: safe to run anytime. No-ops what's already in good shape.
 Each step can be skipped at the prompt. With --auto-apply, workspace
 changes and module recommendations are applied without prompting. Cloud


### PR DESCRIPTION
Refs #13973 (broken state 4 — does not close it; states 1–3 are separate).

## Problem

In 0.21 a module's toolchains were also loaded into its own API (`moduleSourceAsModule` appended each toolchain module to the schema deps), so module code could call them exactly like dependencies — e.g. `dag.Go()`. `dagger setup` only installed toolchains into `dagger.toml`, so after migration that code no longer resolved (`dag.Go undefined`).

## Fix

When the legacy `dagger.json` has an `sdk` (i.e. a `dagger-module.toml` is written), each toolchain is now **also** recorded as a dependency of the migrated module, in addition to the `dagger.toml` install.

- Only `name`/`source`/`pin` are carried onto the dependency; workspace-only toolchain fields (customizations, ignore lists, port mappings) stay on the `dagger.toml` install (`dagger-module.toml` rejects them on deps anyway).
- An explicit dependency with the same name wins over the toolchain.
- `dagger.toml` output is unchanged; toolchains-only configs (no `sdk`) still produce no module config.
- The hoisted-subdirectory path needs nothing special: the module config stays in place, so toolchain source paths remain valid dependency refs.

This is deliberately conservative — every toolchain becomes a dependency whether or not the code used it. The `setup` help text and migration docs note that unused ones can be removed.

## Tests

- New unit tests in `core/workspace/migrate_test.go` covering dep recording, pin preservation, field stripping, name-collision precedence, and the no-sdk case.
- Extended the `local toolchain migrates in place` integration subtest: the root dang module calls `tc.message`, and `dagger call via-toolchain` works after `setup --auto-apply`.
- `TestWorkspaceMigrateOutcomes` + `TestWorkspaceMigrateScope` (25 tests) and `golang:lint-all` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
