### PR TITLE
document breaking change in Workspace migration

### DIFF
--- a/docs/current_docs/config/migrate-dagger-json.mdx
+++ b/docs/current_docs/config/migrate-dagger-json.mdx
@@ -51,6 +51,36 @@ goVersion = "1.22"
 
 **Modules are managed from the top level.** `dagger search` finds them, `dagger install` and `dagger uninstall` update `dagger.toml`. A module's own source metadata lives in `dagger-module.toml` — edit that directly when authoring a module or adding code dependencies.
 
+## Workspace arguments in generated Go bindings
+
+A `*dagger.Workspace` argument that isn't marked `// +optional` used to be published as optional in the module's API, because Dagger fills it in automatically. It is now published as required, matching the declaration. Nothing changes when you call such a function from the CLI, a check, or a generator — Dagger still supplies the current workspace.
+
+What does change is calling that function **from another module's Go code**. The Go SDK puts required arguments in the function signature and optional ones in an `Opts` struct, so after `dagger generate` the workspace moves out of the options struct and into the argument list. Code that used to pass it through `Opts` (or not at all) fails to compile with errors like:
+
+```
+unknown field Workspace in struct literal of type dagger.FooOpts
+cannot use dagger.FooOpts{…} (value of struct type dagger.FooOpts) as *dagger.Workspace value in argument to dag.Foo
+not enough arguments in call to dag.Foo
+```
+
+To fix it, pass the workspace positionally. Take a `*dagger.Workspace` in your own constructor and hand it to the dependency:
+
+```go
+func New(ws *dagger.Workspace) *MyModule {
+	return &MyModule{Workspace: ws}
+}
+
+func (m *MyModule) Build(ctx context.Context) (string, error) {
+	// Before: dag.Foo(dagger.FooOpts{Workspace: m.Workspace})
+	// or:     dag.Foo()
+	return dag.Foo(m.Workspace).Build(ctx)
+}
+```
+
+If `Foo` has other optional arguments, they stay in the options struct: `dag.Foo(m.Workspace, dagger.FooOpts{...})`.
+
+This only surfaces at compile time what was already true at runtime: a workspace is never inherited across a module-to-module call, so a dependency that needs one has to be given it explicitly.
+
 ## Quick reference
 
 | Before | Now |


### PR DESCRIPTION
Part of issue #13973

This documents the breaking change introduced in #13850 which ends up leaving a module broken upon upgrading to dagger v1