### PR TITLE
chore: bump go-sdk pin to 902440e3

### DIFF
--- a/dagger.lock
+++ b/dagger.lock
@@ -4,7 +4,7 @@
 ["","git-latest",["https://github.com/vito/editor"],"refs/heads/main"]
 ["","git-sha",["https://github.com/containernetworking/plugins","refs/tags/v1.9.0"],"9b3772e1a7abf93cbb7c6526a28bc0d27b830e02"]
 ["","git-sha",["https://github.com/dagger/dang-sdk","refs/heads/main"],"5da26366fca40ccbb66ac2f97f57ed95a8f3c17a"]
-["","git-sha",["https://github.com/dagger/go-sdk","refs/heads/main"],"9b6c556101f8fdace897aa3ed1ff9e3efb344e34"]
+["","git-sha",["https://github.com/dagger/go-sdk","refs/heads/main"],"902440e3e097a42cf16354e5eba6b2f0b86194e3"]
 ["","git-sha",["https://github.com/gogo/googleapis.git","refs/tags/v1.4.1"],"1f0e43f50bc0606e385ffae1bc80b5b231dcd042"]
 ["","git-sha",["https://github.com/gogo/protobuf.git","refs/tags/v1.3.2"],"b03c65ea87cdc3521ede29f62fe3ce239267c1bc"]
 ["","git-sha",["https://github.com/libfuse/sshfs.git","refs/tags/sshfs-3.7.6"],"7a2d988775446ebe7af9b01c99b3b8e86bddb05a"]


### PR DESCRIPTION
Draft on purpose — this exists to get a full CI run on the bumped `github.com/dagger/go-sdk` pin.

## Context

#13982 ended with `d31e7387` ("chore: revert go sdk pin update"), holding `github.com/dagger/go-sdk` at `9b6c5561` because `902440e3` (the go-sdk polyfill removal) appeared to lose the `myapp` SDK-managed module registration during `module init`, breaking `TestWorkspaceModuleGenerate` and the SDK-managed subtest of `TestWorkspaceModuleUninstall`.

Re-investigated, that doesn't hold — and the pin never gated those tests in the first place:

- Both tests build their workspace with `t.TempDir()` and no lockfile, so `dagger sdk install go` resolves `github.com/dagger/go-sdk` at `refs/heads/main` live and writes its own lock. The repo's pin is not consulted.
- `902440e3` became go-sdk `main` HEAD on 2026-08-24 15:56 UTC — two days *before* `d31e7387` was authored (2026-08-26 23:07 UTC). Those tests were already running against the polyfill-free SDK regardless of the pin.
- No test workflow ran on the pre-revert commit `8937eddf` (only DCO and a skipped changelog check), so the failure was never reproduced in CI.

Re-running both with `902440e3` pinned, against `v1.0.0-beta.11` (tag = `a4e1e4ff`, the merge commit of #13982 itself, which `main` differs from only by version-string bumps):

```
--- PASS: TestWorkspaceModules/TestWorkspaceModuleUninstall/uninstall_removes_an_SDK-managed_default-path_module (495.31s)
--- PASS: TestWorkspaceModules/TestWorkspaceModuleGenerate (498.70s)
```

The manual flow is clean end to end on both `beta.11` and `beta.10`: `module init` writes `[[modules.dagger-go-sdk.as-sdk.modules]] path = ".dagger/modules/myapp"`, `dagger generate` emits `internal/dagger/dagger.gen.go` under the module, and `uninstall` clears both the registration and the directory.

## Changes

- advance the `github.com/dagger/go-sdk` pin from `9b6c5561` to `902440e3`

Running `dagger generate dagger-go-sdk:generate dagger-go-sdk:generate-all-client` against `902440e3` reports no changes, so the checked-in Go clients need no update — #13982 already regenerated them.
