### PR TITLE
core: wire files, directories, and workspaces between modules

### DIFF
--- a/core/integration/testdata/services/container-provider/dagger.json
+++ b/core/integration/testdata/services/container-provider/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "container-provider",
-  "engineVersion": "v0.20.1",
+  "engineVersion": "v1.0.0",
   "sdk": {
     "source": "go"
   }

--- a/core/integration/testdata/services/container-provider/main.go
+++ b/core/integration/testdata/services/container-provider/main.go
@@ -23,3 +23,20 @@ func (m *ContainerProvider) Image() *dagger.Container {
 	}
 	return base.WithEnvVariable("PROVIDED_BY", "container-provider")
 }
+
+// Returns a directory for consumers.
+func (m *ContainerProvider) Directory() *dagger.Directory {
+	return dag.Directory().WithNewFile("provided-by", "container-provider")
+}
+
+// Returns a file for consumers.
+func (m *ContainerProvider) File() *dagger.File {
+	return m.Directory().File("provided-by")
+}
+
+// Returns a workspace for consumers.
+func (m *ContainerProvider) Workspace() *dagger.Workspace {
+	return dag.Directory().
+		WithNewFile("marker.txt", "container-provider").
+		AsWorkspace()
+}

--- a/core/integration/testdata/services/service-ref-consumer/main.go
+++ b/core/integration/testdata/services/service-ref-consumer/main.go
@@ -1,5 +1,5 @@
-// A module whose constructor accepts optional core-type args (Service,
-// Container), used to test wiring another module's function output in via
+// A module whose constructor accepts optional core-type args, used to test
+// wiring another module's function output in via
 // workspace settings.
 package main
 
@@ -11,8 +11,11 @@ import (
 )
 
 type ServiceRefConsumer struct {
-	App  *dagger.Service
-	Base *dagger.Container
+	App             *dagger.Service
+	Base            *dagger.Container
+	Directory       *dagger.Directory
+	File            *dagger.File
+	WorkspaceMarker *dagger.File
 }
 
 func New(
@@ -20,8 +23,21 @@ func New(
 	app *dagger.Service,
 	// +optional
 	base *dagger.Container,
+	// +optional
+	directory *dagger.Directory,
+	// +optional
+	file *dagger.File,
+	// +optional
+	sourceWorkspace *dagger.Workspace,
 ) *ServiceRefConsumer {
-	return &ServiceRefConsumer{App: app, Base: base}
+	var workspaceMarker *dagger.File
+	if sourceWorkspace != nil {
+		workspaceMarker = sourceWorkspace.File("marker.txt")
+	}
+	return &ServiceRefConsumer{
+		App: app, Base: base, Directory: directory, File: file,
+		WorkspaceMarker: workspaceMarker,
+	}
 }
 
 // Returns "true" if a Service was provided, "false" otherwise.
@@ -39,6 +55,33 @@ func (m *ServiceRefConsumer) ContainerProvidedBy(ctx context.Context) (string, e
 		return "none", nil
 	}
 	return m.Base.EnvVariable(ctx, "PROVIDED_BY")
+}
+
+// Returns the contents of the marker in the provided directory, or "none" if
+// no directory was provided.
+func (m *ServiceRefConsumer) DirectoryProvidedBy(ctx context.Context) (string, error) {
+	if m.Directory == nil {
+		return "none", nil
+	}
+	return m.Directory.File("provided-by").Contents(ctx)
+}
+
+// Returns the contents of the provided file, or "none" if no file was
+// provided.
+func (m *ServiceRefConsumer) FileProvidedBy(ctx context.Context) (string, error) {
+	if m.File == nil {
+		return "none", nil
+	}
+	return m.File.Contents(ctx)
+}
+
+// Returns the contents of the marker in the provided workspace, or "none" if
+// no workspace was provided.
+func (m *ServiceRefConsumer) WorkspaceProvidedBy(ctx context.Context) (string, error) {
+	if m.WorkspaceMarker == nil {
+		return "none", nil
+	}
+	return m.WorkspaceMarker.Contents(ctx)
 }
 
 // CheckService passes only when a Service was provided, used to test that

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -206,12 +207,18 @@ func (UpSuite) TestUpModuleWiring(ctx context.Context, t *testctx.T) {
 	// plain-string module reference in workspace settings:
 	// settings.<arg> = "<module>:<function>". These strings route through the
 	// Address decoders (see core/schema/address.go: resolveModuleRef, wired
-	// into .service() and .container()). Supported for Service (+up functions)
-	// and Container. The same decoders back CLI object flags, so a constructor
-	// arg like --app=<module>:<function> resolves identically.
+	// into the corresponding Address object decoders). Supported for Service
+	// (+up functions), Container, Directory, File, and Workspace. The same
+	// decoders back CLI object flags, so a constructor arg like
+	// --app=<module>:<function> resolves identically.
 	c := connect(ctx, t)
 	modGen, err := upTestEnv(t, c)
 	require.NoError(t, err)
+	// Optional Workspace args inherit the ambient workspace when no setting is
+	// configured. Keep its marker valid so the shared consumer fixture can
+	// derive a File in every subtest; the wiring case overrides this workspace
+	// with container-provider:workspace and observes a different marker.
+	modGen = modGen.WithNewFile("app/marker.txt", "ambient")
 
 	t.Run("without refs", func(ctx context.Context, t *testctx.T) {
 		ctr := modGen.
@@ -262,6 +269,38 @@ settings.base = "container-provider:image"
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "container-provider")
+	})
+
+	t.Run("artifact refs via settings", func(ctx context.Context, t *testctx.T) {
+		ctr := modGen.
+			WithWorkdir("app").
+			WithNewFile("dagger.toml", `[modules.container-provider]
+source = "../container-provider"
+
+[modules.service-ref-consumer]
+source = "../service-ref-consumer"
+settings.directory = "container-provider:directory"
+settings.file = "container-provider:file"
+settings.sourceWorkspace = "container-provider:workspace"
+`)
+
+		out, err := ctr.
+			With(daggerExec("call", "service-ref-consumer", "directory-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "container-provider", strings.TrimSpace(out))
+
+		out, err = ctr.
+			With(daggerExec("call", "service-ref-consumer", "file-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "container-provider", strings.TrimSpace(out))
+
+		out, err = ctr.
+			With(daggerExec("call", "service-ref-consumer", "workspace-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "container-provider", strings.TrimSpace(out))
 	})
 
 	t.Run("provider with required Workspace arg", func(ctx context.Context, t *testctx.T) {

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -677,11 +677,6 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 			//  3) "workspace args" that are automatically injected
 			continue
 		}
-		// Check for Workspace arguments first - they're always injected
-		if argMetadata.IsWorkspace() {
-			workspaceArgs = append(workspaceArgs, argMetadata)
-			continue
-		}
 		userDefault, hasUserDefault, err := fn.UserDefault(ctx, argMetadata.Name)
 		if err != nil {
 			return fmt.Errorf("%s.%s(%s=): load user default: %w",
@@ -693,6 +688,12 @@ func (fn *ModuleFunction) DynamicInputsForCall(
 		}
 		if hasUserDefault {
 			userDefaults = append(userDefaults, userDefault)
+		} else if argMetadata.IsWorkspace() {
+			// Workspace args inherit the workspace in scope only when the user
+			// did not configure one explicitly. A settings value may itself be
+			// a module reference, so it must go through the ordinary object
+			// default resolver above instead of being shadowed by injection.
+			workspaceArgs = append(workspaceArgs, argMetadata)
 		} else if argMetadata.isContextual() {
 			ctxArgs = append(ctxArgs, argMetadata)
 		}

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -299,6 +299,10 @@ func (s *addressSchema) Install(srv *dagql.Server) {
 			View(AfterVersion("v1.0.0-0")).
 			WithInput(dagql.PerCallInput).
 			Doc(`Load a volume from the address.`),
+		dagql.NodeFunc("workspace", s.workspace).
+			View(AfterVersion("v1.0.0-0")).
+			WithInput(dagql.PerCallInput).
+			Doc(`Load a workspace from a module reference.`),
 	}.Install(srv)
 }
 
@@ -334,6 +338,9 @@ func (s *addressSchema) file(
 ) {
 	var q []dagql.Selector
 	addr := r.Self().Value
+	if matched, err := resolveModuleRef(ctx, addr, &inst); matched {
+		return inst, err
+	}
 	gitURL, err := gitutil.ParseURL(addr)
 	if err == nil {
 		// Remote file
@@ -423,6 +430,9 @@ func (s *addressSchema) directory(
 ) {
 	var q []dagql.Selector
 	addr := r.Self().Value
+	if matched, err := resolveModuleRef(ctx, addr, &inst); matched {
+		return inst, err
+	}
 	gitURL, err := gitutil.ParseURL(addr)
 	if err == nil {
 		// Remote directory (using git remote)
@@ -823,6 +833,21 @@ func (s *addressSchema) service(
 		return inst, err
 	}
 	return inst, nil
+}
+
+func (s *addressSchema) workspace(
+	ctx context.Context,
+	r dagql.ObjectResult[*core.Address],
+	args struct{},
+) (
+	inst dagql.ObjectResult[*core.Workspace],
+	err error,
+) {
+	addr := r.Self().Value
+	if matched, err := resolveModuleRef(ctx, addr, &inst); matched {
+		return inst, err
+	}
+	return inst, fmt.Errorf("workspace address %q must reference an installed module as <module>:<function>", addr)
 }
 
 func (s *addressSchema) volume(

--- a/docs/current_docs/config/module-wiring.mdx
+++ b/docs/current_docs/config/module-wiring.mdx
@@ -47,6 +47,19 @@ way:
 baseCtr = "base-images:chromium"
 ```
 
+## Wire a file, directory, or workspace
+
+Build artifacts and workspaces can be passed between modules in the same way.
+A function returning a `File`, `Directory`, or `Workspace` can be referenced by
+a matching constructor argument:
+
+```toml
+[modules.packager.settings]
+binary = "builder:binary"
+assets = "frontend:assets"
+source = "source-prep:workspace"
+```
+
 ## Use a reference on the command line
 
 A module reference is an ordinary address string, so it also works as a CLI
@@ -75,8 +88,12 @@ dagger api call playwright --service=myapp:serve test
 If you author modules, wiring changes how you shape a constructor:
 
 - **Accept collaborators as optional constructor arguments.** An optional
-  `Service` or `Container` argument is a wiring point. Without one, users
-  need a glue module to connect yours to anything.
+  `Service`, `Container`, `File`, `Directory`, or `Workspace` argument is a
+  wiring point. Without one, users need a glue module to connect yours to
+  anything.
+- **Consume workspaces in the constructor.** A module object cannot retain a
+  `Workspace` as a field. Derive and store the `File`, `Directory`, or other
+  value your module needs from the wired workspace instead.
 - **Put workspace-level configuration on the constructor, not on function
   arguments.** Settings map to constructor arguments. A shard count, a
   service, or a base image belongs there if the workspace should configure it

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -94,6 +94,9 @@ type Address implements Node {
 
   """Load a volume from the address."""
   volume: Volume!
+
+  """Load a workspace from a module reference."""
+  workspace: Workspace!
 }
 
 type Agent implements Node {

--- a/docs/static/reference/php/Dagger/Address.html
+++ b/docs/static/reference/php/Dagger/Address.html
@@ -251,6 +251,16 @@
                                             <p><p>Load a volume from the address.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
+                    <div class="row">
+                <div class="col-md-2 type">
+                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_workspace">workspace</a>()
+        
+                                            <p><p>Load a workspace from a module reference.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
             </div>
 
 
@@ -737,6 +747,38 @@
                     <table class="table table-condensed">
         <tr>
             <td><a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a></td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_workspace">
+        <div class="location">at line 150</div>
+        <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
+    <strong>workspace</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Load a workspace from a module reference.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td><a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></td>
             <td></td>
         </tr>
     </table>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1705,7 +1705,9 @@
                     <dd><p>A filesystem volume that can be mounted into containers.</p></dd><dt><a href="Dagger/WorkspaceModuleSetting.html#method_value">
 <abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::value</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
                     <dd><p>The configured value after applying the selected workspace environment, or empty when unset.</p></dd>        </dl><h2 id="letterW">W</h2>
-        <dl id="indexW"><dt><a href="Dagger/Changeset.html#method_withChangeset">
+        <dl id="indexW"><dt><a href="Dagger/Address.html#method_workspace">
+<abbr title="Dagger\Address">Address</abbr>::workspace</a>() &mdash; <em>Method in class <a href="Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a></em></dt>
+                    <dd><p>Load a workspace from a module reference.</p></dd><dt><a href="Dagger/Changeset.html#method_withChangeset">
 <abbr title="Dagger\Changeset">Changeset</abbr>::withChangeset</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>
                     <dd><p>Add changes to an existing changeset</p></dd><dt><a href="Dagger/Changeset.html#method_withChangesets">
 <abbr title="Dagger\Changeset">Changeset</abbr>::withChangesets</a>() &mdash; <em>Method in class <a href="Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2000,6 +2000,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\Address::workspace",
+			"p": "Dagger/Address.html#method_workspace",
+			"d": "<p>Load a workspace from a module reference.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\Agent::description",
 			"p": "Dagger/Agent.html#method_description",
 			"d": "<p>The description of the agent</p>"

--- a/hack/designs/module-wiring.md
+++ b/hack/designs/module-wiring.md
@@ -20,14 +20,17 @@ together, defeating the purpose of reusable modules.
 
 Extend the address mechanism that already backs `settings.*` values and CLI flags to
 support **module wiring**: a value that resolves to the output of a function on
-another installed workspace module. Two types are supported today:
+another installed workspace module. Five types are supported today:
 
 - **`Service`** — conventionally referencing a `+up` function (the original
   motivation), though any `Service`-returning function resolves.
 - **`Container`** — referencing any function that returns a `Container`.
+- **`Directory`** — referencing any function that returns a `Directory`.
+- **`File`** — referencing any function that returns a `File`.
+- **`Workspace`** — referencing any function that returns a `Workspace`.
 
-Other core types (`Directory`, `File`, `Secret`) may follow; the resolution
-mechanism is type-agnostic.
+Other core types (`Secret`, for example) may follow; the resolution mechanism
+is type-agnostic.
 
 ### Config Syntax
 
@@ -105,11 +108,16 @@ service addresses are `tcp://`/`udp://` URLs, so the `://` alone disambiguates.
   module prefix followed by extra colons (e.g. `docusaurus:sites:serve`) is rejected
   with a clear error, not silently treated as an image ref. Deeper traversal is a
   forward-compatibility concern, addressed below.
-- Supported arg types are scoped to `Service` and `Container` by documentation and
-  test coverage, not by an engine-side type check. It is not (yet) a general-purpose
-  cross-module reference for arbitrary types.
-- The target constructor argument must accept `*dagger.Service` or `*dagger.Container`
-  (typically optional).
+- Supported arg types are scoped to `Service`, `Container`, `Directory`, `File`,
+  and `Workspace` by documentation and test coverage, not by an engine-side type
+  check. It is not (yet) a general-purpose cross-module reference for arbitrary
+  types.
+- The target constructor argument must accept `*dagger.Service`, `*dagger.Container`,
+  `*dagger.Directory`, `*dagger.File`, or `*dagger.Workspace` (typically optional).
+- A constructor must consume a wired `Workspace` rather than storing it directly on
+  the returned module object; module object fields cannot have the core `Workspace`
+  type. It can store values derived from that workspace, such as a `File` or
+  `Directory`.
 - Referenced functions take no arguments; a provider is parameterized via its own
   `settings.*` block, not at the reference site.
 - Invalid references (nonexistent function on a matched module, type mismatch, cycle)
@@ -198,16 +206,19 @@ The mechanics:
   carry the module entrypoints.)
 - **Typed Select for mismatch errors.** Once committed, resolution runs a two-step
   dagql `Select` from the `Query` root — module field, then function field — into the
-  **typed** destination (`*dagql.ObjectResult[*core.Service]` /
-  `[*core.Container]`). dagql's own typed Select produces the type-mismatch error when
-  the function's return type doesn't match, so the error message is dagql-native.
+  **typed** destination (for example, `*dagql.ObjectResult[*core.Service]` or
+  `*dagql.ObjectResult[*core.Directory]`). dagql's own typed Select produces the
+  type-mismatch error when the function's return type doesn't match, so the error
+  message is dagql-native.
 - **Context-chain cycle guard.** The chain of in-flight module-ref strings is
   carried on the `context.Context`. Context values propagate through dagql `Select`
   into nested module construction, so re-entry of an in-flight ref is detectable, and
   a cycle fails fast with a clean `a -> b -> a` error rather than hanging the engine
   with unbounded goroutine growth.
-Only `.container()` and `.service()` decode module refs today; the same hook can be
-added to `.directory()`, `.file()`, `.secret()` when those target types are in scope.
+
+The `.container()`, `.service()`, `.directory()`, `.file()`, and `.workspace()`
+decoders resolve module refs today; the same hook can be added to `.secret()` when
+that target type is in scope.
 
 ### Lint: shadowing warning
 
@@ -247,8 +258,9 @@ fully-qualified registry path is the documented remedy.
 - **Service groups / profiles**: Running a named subset of services via `dagger up` is
   out of scope for this design. Will be addressed separately.
 - **General-purpose cross-module wiring**: today's references are scoped to
-  `Service` (via `+up`) and `Container`. Wiring other types (Directory, File, Secret)
-  across modules is a natural follow-up but not in scope yet.
+  `Service` (via `+up`), `Container`, `Directory`, `File`, and `Workspace`. Wiring
+  other types (such as `Secret`) across modules is a natural follow-up but not in
+  scope yet.
 - **Config-time validation**: References are validated at runtime. Static config
   validation may be added later.
 - **Deep / collection traversal**: only two segments are accepted. Deeper paths and

--- a/sdk/elixir/lib/dagger/gen/address.ex
+++ b/sdk/elixir/lib/dagger/gen/address.ex
@@ -182,6 +182,20 @@ defmodule Dagger.Address do
       client: address.client
     }
   end
+
+  @doc """
+  Load a workspace from a module reference.
+  """
+  @spec workspace(t()) :: Dagger.Workspace.t()
+  def workspace(%__MODULE__{} = address) do
+    query_builder =
+      address.query_builder |> QB.select("workspace")
+
+    %Dagger.Workspace{
+      query_builder: query_builder,
+      client: address.client
+    }
+  end
 end
 
 defimpl Jason.Encoder, for: Dagger.Address do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -410,6 +410,15 @@ func (r *Address) Volume() *Volume {
 	}
 }
 
+// Load a workspace from a module reference.
+func (r *Address) Workspace() *Workspace {
+	q := r.query.Select("workspace")
+
+	return &Workspace{
+		query: q,
+	}
+}
+
 // AsNode returns this Address as a Node.
 // This is a local type conversion — no GraphQL call.
 func (r *Address) AsNode() Node {

--- a/sdk/php/generated/Address.php
+++ b/sdk/php/generated/Address.php
@@ -143,4 +143,13 @@ class Address extends Client\AbstractObject implements Client\IdAble, Node
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('volume');
         return new \Dagger\Volume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
+
+    /**
+     * Load a workspace from a module reference.
+     */
+    public function workspace(): Workspace
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('workspace');
+        return new \Dagger\Workspace($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -698,6 +698,12 @@ class Address(Type):
         _ctx = self._select("volume", _args)
         return Volume(_ctx)
 
+    def workspace(self) -> "Workspace":
+        """Load a workspace from a module reference."""
+        _args: list[Arg] = []
+        _ctx = self._select("workspace", _args)
+        return Workspace(_ctx)
+
 
 @typecheck
 class Agent(Type):

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -480,6 +480,15 @@ impl Address {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Load a workspace from a module reference.
+    pub fn workspace(&self) -> Workspace {
+        let query = self.selection.select("workspace");
+        Workspace {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
 }
 impl Node for Address {
     fn id(&self) -> impl core::future::Future<Output = Result<Id, DaggerError>> + Send {

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3523,6 +3523,14 @@ export class Address extends BaseClient {
     const ctx = this._ctx.select("volume")
     return new Volume(ctx)
   }
+
+  /**
+   * Load a workspace from a module reference.
+   */
+  workspace = (): Workspace => {
+    const ctx = this._ctx.select("workspace")
+    return new Workspace(ctx)
+  }
 }
 
 export class Agent extends BaseClient {


### PR DESCRIPTION
Allow File, Directory, and Workspace constructor arguments to resolve module:function references through the shared Address module-reference resolver, matching the existing Container and Service behavior.

Workspace settings now take precedence over ambient Workspace injection. Constructors consume wired workspaces and retain derived values, preserving the rule that Workspace itself cannot be stored on a module object.

Add integration coverage that wires all three object types through workspace settings and verifies their contents, update the module wiring documentation, and regenerate the schema and SDK clients for Address.workspace.

Tested with:
- env -u SSH_AUTH_SOCK dagger api call engine-dev test --pkg ./core/integration --run=TestUp/TestUpModuleWiring
- env -u SSH_AUTH_SOCK dagger generate -y

Fixes #13979