### PR TITLE
fix: improve error surfacing for generate

### DIFF
--- a/core/generated_files.go
+++ b/core/generated_files.go
@@ -1,0 +1,24 @@
+package core
+
+import "fmt"
+
+// MissingGeneratedFileError reports a module whose config format builds from
+// committed generated files (dagger-module.toml) but is missing one, so its
+// runtime cannot be built from source. SDK runtimes return it from their load
+// path so callers can tell "needs generation" apart from a genuine build
+// failure — best-effort `dagger generate` in particular, which is often the fix
+// and must not parrot the "run `dagger generate`" hint back at the user.
+type MissingGeneratedFileError struct {
+	Module string
+	Path   string
+}
+
+func (e *MissingGeneratedFileError) Error() string {
+	return e.Reason() + "; run `dagger generate` and commit the generated files"
+}
+
+// Reason is the hint-free message: what is missing, without the advice to run
+// `dagger generate`, for contexts where that is exactly what is running.
+func (e *MissingGeneratedFileError) Reason() string {
+	return fmt.Sprintf("module %q: generated file %q is missing", e.Module, e.Path)
+}

--- a/core/generators.go
+++ b/core/generators.go
@@ -260,10 +260,6 @@ func (gg *GeneratorGroup) Changes(ctx context.Context, conflictStrategy WithChan
 	return merged, nil
 }
 
-// RegeneratedModuleMessage is what the report says about a skipped module that
-// loads once the run's changes are applied.
-const RegeneratedModuleMessage = "could not load before this run's changes; loads with them applied"
-
 // verifySkippedModules settles the modules this group skipped at load time.
 // A module that failed to load because its generated files were missing or
 // stale is often repaired by the very run that skipped it — which can only be
@@ -353,8 +349,9 @@ func (gg *GeneratorGroup) generatedWorkspaceRoot(ctx context.Context, changes []
 }
 
 // verifySkippedModule loads one skipped module from the generated workspace
-// root and records the outcome on its "regenerated" span: OK with
-// RegeneratedModuleMessage, or the described post-generation load error.
+// root and records the outcome on its "regenerated" span: OK, or the described
+// post-generation load error. The span's status is the whole answer; the
+// report words a success itself (idtui regeneratedModuleMessage).
 func verifySkippedModule(ctx context.Context, generated dagql.ObjectResult[*Directory], failure ModuleLoadFailure) {
 	var rerr error
 	ctx, span := Tracer(ctx).Start(ctx, failure.Name,
@@ -385,7 +382,6 @@ func verifySkippedModule(ctx context.Context, generated dagql.ObjectResult[*Dire
 		rerr = LoadFailureCause("still fails to load with this run's changes: ", err)
 		return
 	}
-	span.SetAttributes(attribute.String(telemetry.UIMessageAttr, RegeneratedModuleMessage))
 }
 
 func (gg *GeneratorGroup) Clone() *GeneratorGroup {

--- a/core/generators.go
+++ b/core/generators.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/telemetryattrs"
 	"github.com/dagger/dagger/util/parallel"
+	telemetry "github.com/dagger/otel-go"
 	"github.com/vektah/gqlparser/v2/ast"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Generator represents a generator function
@@ -73,13 +80,46 @@ func (g *Generator) RequireChanges(field string) (*Changeset, error) {
 	return changes.Self(), nil
 }
 
+// ModuleLoadFailure is a workspace module that best-effort `dagger generate`
+// could not load and skipped.
+type ModuleLoadFailure struct {
+	// Name is the module's workspace name (what the skipped-module span is
+	// called).
+	Name string `json:"name"`
+	// Dir is the module's workspace-root-relative directory, or "" when it
+	// has none (a git source). Changes tells whether the run regenerated
+	// files under it, which is often exactly what repairs a failed load.
+	Dir string `json:"dir,omitempty"`
+	// Message is the described load error (see the engine's
+	// describeLoadFailure).
+	Message string `json:"message"`
+}
+
+// Regenerated reports whether any of the run's changed paths (workspace-root
+// relative) fall under the module's directory — i.e. whether this run
+// rewrote (part of) the module, so its load failure may already be fixed.
+func (f ModuleLoadFailure) Regenerated(changed []string) bool {
+	if f.Dir == "" {
+		return false
+	}
+	dir := path.Clean(filepath.ToSlash(f.Dir))
+	for _, p := range changed {
+		p = path.Clean(filepath.ToSlash(p))
+		if dir == "." || p == dir || strings.HasPrefix(p, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 type GeneratorGroup struct {
 	Node       *ModTreeNode `json:"node"`
 	Generators []*Generator `json:"generators"`
-	// LoadFailures carries the per-module load-failure messages tolerated during
-	// an unscoped 'dagger generate' (empty when strict, or when every module
-	// loaded). Surfaced on the API so the CLI can warn and honor --require-load.
-	LoadFailures []string `json:"loadFailures,omitempty"`
+	// LoadFailures carries the per-module load failures tolerated during an
+	// unscoped 'dagger generate' (empty when strict, or when every module
+	// loaded). Surfaced on the API (as messages) so the CLI can warn and honor
+	// --require-load, and classified against the run's changes (see Changes).
+	LoadFailures []ModuleLoadFailure `json:"loadFailures,omitempty"`
 	// BoundWorkspace is the Workspace this group was rolled up from — the one
 	// `Workspace.generators` was called on, including any overlay edits. Run
 	// threads it into the context (WorkspaceToContext) so each generator leaf's
@@ -113,7 +153,7 @@ type persistedGeneratorGroupPayload struct {
 	Tree                   persistedModTree            `json:"tree"`
 	NodeID                 int                         `json:"nodeID,omitempty"`
 	Generators             []persistedGeneratorPayload `json:"generators,omitempty"`
-	LoadFailures           []string                    `json:"loadFailures,omitempty"`
+	LoadFailures           []ModuleLoadFailure         `json:"loadFailures,omitempty"`
 	BoundWorkspaceResultID uint64                      `json:"boundWorkspaceResultID,omitempty"`
 }
 
@@ -200,15 +240,152 @@ func (gg *GeneratorGroup) Changes(ctx context.Context, conflictStrategy WithChan
 	if err != nil {
 		return nil, err
 	}
+	results := make([]dagql.ObjectResult[*Changeset], 0, len(gg.Generators))
 	cs := make([]*Changeset, 0, len(gg.Generators))
 	for _, g := range gg.Generators {
-		changes, err := g.RequireChanges("changes")
+		changes, err := g.RequireChangesResult("changes")
 		if err != nil {
 			return nil, err
 		}
-		cs = append(cs, changes)
+		results = append(results, changes)
+		cs = append(cs, changes.Self())
 	}
-	return res.WithChangesets(ctx, cs, conflictStrategy)
+	merged, err := res.WithChangesets(ctx, cs, conflictStrategy)
+	if err != nil {
+		return nil, err
+	}
+	if err := gg.verifySkippedModules(ctx, results); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// RegeneratedModuleMessage is what the report says about a skipped module that
+// loads once the run's changes are applied.
+const RegeneratedModuleMessage = "could not load before this run's changes; loads with them applied"
+
+// verifySkippedModules settles the modules this group skipped at load time.
+// A module that failed to load because its generated files were missing or
+// stale is often repaired by the very run that skipped it — which can only be
+// told after generating, and only for sure by trying. For each skipped module
+// whose directory the run's changes touch, load it again against the
+// workspace with those changes applied, under a "regenerated" span named like
+// the skipped-module span (GenerateRegeneratedAttr). The span's outcome is the
+// answer the report shows in place of the pre-generation error: it loads, or
+// it still fails — with the post-generation error, which is the one the user
+// has to fix. Untouched modules are left alone: nothing in this run could have
+// changed their outcome, so their load error stands.
+//
+// The changed paths and the overlay come from the per-generator changesets
+// rather than the merged one: those are attached results, while the merged
+// changeset is only attached once Changes returns. Their union is what the
+// merge contains anyway (a conflict would have failed the merge above).
+func (gg *GeneratorGroup) verifySkippedModules(ctx context.Context, changes []dagql.ObjectResult[*Changeset]) error {
+	if len(gg.LoadFailures) == 0 || gg.BoundWorkspace.Self() == nil {
+		return nil
+	}
+	var changed []string
+	for _, cs := range changes {
+		paths, err := cs.Self().ComputePaths(ctx)
+		if err != nil {
+			return fmt.Errorf("verify skipped modules: compute changed paths: %w", err)
+		}
+		changed = append(changed, paths.Added...)
+		changed = append(changed, paths.Modified...)
+		changed = append(changed, paths.Removed...)
+	}
+
+	// Resolve the modules (and their workspace-installed dependencies)
+	// against the bound workspace, as the generators themselves ran.
+	ctx = WorkspaceToContext(ctx, gg.BoundWorkspace)
+
+	var generated dagql.ObjectResult[*Directory]
+	for _, failure := range gg.LoadFailures {
+		if !failure.Regenerated(changed) {
+			continue
+		}
+		if generated.Self() == nil {
+			var err error
+			generated, err = gg.generatedWorkspaceRoot(ctx, changes)
+			if err != nil {
+				return fmt.Errorf("verify skipped modules: %w", err)
+			}
+		}
+		// Each module's outcome is its own span's status; a failure here is the
+		// report's answer, not a reason to fail the run (the skipped module was
+		// already tolerated at load time).
+		verifySkippedModule(ctx, generated, failure)
+	}
+	return nil
+}
+
+// generatedWorkspaceRoot is the bound workspace's full root with the run's
+// changesets applied, in generator order — what the workspace holds once the
+// changes are applied. It goes through Directory.withChanges on a full read
+// rather than Workspace.withChanges: a host-backed workspace overlay reads
+// sparsely (only the touched paths, and a changeset touches its parent
+// directories), which is not a tree a module can be loaded from.
+func (gg *GeneratorGroup) generatedWorkspaceRoot(ctx context.Context, changes []dagql.ObjectResult[*Changeset]) (dagql.ObjectResult[*Directory], error) {
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*Directory]{}, err
+	}
+	var root dagql.ObjectResult[*Directory]
+	if err := dag.Select(ctx, gg.BoundWorkspace, &root, dagql.Selector{
+		Field: "directory",
+		Args:  []dagql.NamedInput{{Name: "path", Value: dagql.NewString("/")}},
+	}); err != nil {
+		return dagql.ObjectResult[*Directory]{}, fmt.Errorf("read workspace root: %w", err)
+	}
+	for _, cs := range changes {
+		csID, err := cs.ID()
+		if err != nil {
+			return dagql.ObjectResult[*Directory]{}, fmt.Errorf("changeset ID: %w", err)
+		}
+		if err := dag.Select(ctx, root, &root, dagql.Selector{
+			Field: "withChanges",
+			Args:  []dagql.NamedInput{{Name: "changes", Value: dagql.NewID[*Changeset](csID)}},
+		}); err != nil {
+			return dagql.ObjectResult[*Directory]{}, fmt.Errorf("apply changes to workspace root: %w", err)
+		}
+	}
+	return root, nil
+}
+
+// verifySkippedModule loads one skipped module from the generated workspace
+// root and records the outcome on its "regenerated" span: OK with
+// RegeneratedModuleMessage, or the described post-generation load error.
+func verifySkippedModule(ctx context.Context, generated dagql.ObjectResult[*Directory], failure ModuleLoadFailure) {
+	var rerr error
+	ctx, span := Tracer(ctx).Start(ctx, failure.Name,
+		telemetry.Reveal(),
+		trace.WithAttributes(
+			attribute.Bool(telemetryattrs.GenerateRegeneratedAttr, true),
+			attribute.Bool(telemetry.UIRollUpLogsAttr, true),
+			attribute.Bool(telemetry.UIRollUpSpansAttr, true),
+		),
+	)
+	defer telemetry.EndWithCause(span, &rerr)
+
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		rerr = err
+		return
+	}
+	var src dagql.ObjectResult[*ModuleSource]
+	if err := dag.Select(ctx, generated, &src, dagql.Selector{
+		Field: "asModuleSource",
+		Args:  []dagql.NamedInput{{Name: "sourceRootPath", Value: dagql.NewString(filepath.ToSlash(failure.Dir))}},
+	}); err != nil {
+		rerr = LoadFailureCause("still fails to load with this run's changes: ", err)
+		return
+	}
+	var mod dagql.ObjectResult[*Module]
+	if err := dag.Select(ctx, src, &mod, dagql.Selector{Field: "asModule"}); err != nil {
+		rerr = LoadFailureCause("still fails to load with this run's changes: ", err)
+		return
+	}
+	span.SetAttributes(attribute.String(telemetry.UIMessageAttr, RegeneratedModuleMessage))
 }
 
 func (gg *GeneratorGroup) Clone() *GeneratorGroup {
@@ -221,7 +398,7 @@ func (gg *GeneratorGroup) Clone() *GeneratorGroup {
 		c.Generators[i] = gg.Generators[i].Clone()
 	}
 	if gg.LoadFailures != nil {
-		c.LoadFailures = append([]string(nil), gg.LoadFailures...)
+		c.LoadFailures = append([]ModuleLoadFailure(nil), gg.LoadFailures...)
 	}
 	return &c
 }

--- a/core/generators_test.go
+++ b/core/generators_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleLoadFailureRegenerated(t *testing.T) {
+	t.Parallel()
+
+	changed := []string{".dagger/modules/stale/dagger.gen.go", "internal/dagger/client.go"}
+
+	require.True(t, ModuleLoadFailure{Dir: ".dagger/modules/stale"}.Regenerated(changed))
+	require.True(t, ModuleLoadFailure{Dir: ".dagger/modules/stale/"}.Regenerated(changed), "trailing slash")
+	require.True(t, ModuleLoadFailure{Dir: "./.dagger/modules/stale"}.Regenerated(changed), "unclean dir")
+	require.True(t, ModuleLoadFailure{Dir: "internal"}.Regenerated(changed), "nested change")
+	require.True(t, ModuleLoadFailure{Dir: "."}.Regenerated(changed), "root module owns every path")
+
+	require.False(t, ModuleLoadFailure{Dir: ".dagger/modules/stale-other"}.Regenerated(changed), "sibling prefix is not a parent")
+	require.False(t, ModuleLoadFailure{Dir: ".dagger/modules/other"}.Regenerated(changed))
+	require.False(t, ModuleLoadFailure{Dir: ""}.Regenerated(changed), "no directory (git source) is never regenerated")
+	require.False(t, ModuleLoadFailure{Dir: "."}.Regenerated(nil), "no changes")
+}

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -1286,6 +1286,113 @@ func (GeneratorsSuite) TestWorkspaceGenerateSkipsBrokenEntrypoint(ctx context.Co
 	})
 }
 
+// TestWorkspaceGenerateReportsLoadFailureDetail covers what best-effort
+// `dagger generate` says about the modules it skips
+// (https://github.com/dagger/dagger/issues/13973): the skip must carry the
+// reason a user can act on, not a bare exit code, and must not tell them to run
+// the command they are running.
+//
+//   - broken-build: a Go module whose source does not compile. The compiler
+//     output lives in the SDK runtime's `go build` exec, hidden under the
+//     internal module-load spans; the skipped-module report inlines it.
+//   - ungenerated: a dagger-module.toml Go module with no committed generated
+//     files. Its strict-load error says "run `dagger generate`" — generate
+//     itself reports it as skipped until generated.
+//   - stale-build: does not compile either, and the regen generator writes
+//     into its directory this run — so generate loads it again with the
+//     changes applied. It still does not compile: the report shows the
+//     post-generation error, not a hedge.
+//   - fixable: does not compile until the fixer generator rewrites its
+//     main.go this run. Loaded again with the changes applied it works: the
+//     report says so and drops its pre-generation compiler output.
+func (GeneratorsSuite) TestWorkspaceGenerateReportsLoadFailureDetail(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := workspaceFixture(t, c, "generate-load-failures")
+
+	requireSkipDetail := func(t *testctx.T, out string) {
+		t.Helper()
+		// The compile error is the reason broken-build was skipped: the go
+		// build output follows the load error.
+		require.Contains(t, out, "modules/broken-build")
+		require.Contains(t, out, "exit code: 1")
+		require.Contains(t, out, "undefined: intentionallyUndefinedSymbol")
+		// Missing generated files: skipped, without the misleading hint.
+		require.Contains(t, out, "modules/ungenerated")
+		require.Contains(t, out, `generated file ".dagger/modules/ungenerated/dagger.gen.go" is missing (skipped until it is generated)`)
+	}
+
+	t.Run("report", func(ctx context.Context, t *testctx.T) {
+		// The default non-interactive frontend renders the persisted SKIPPED
+		// MODULES report section after the generators.
+		out, err := base.
+			With(daggerExec("generate", "--no-apply")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "good:generate")
+		require.Contains(t, out, "SKIPPED MODULES")
+		requireSkipDetail(t, out)
+		// Only the skipped-module rows describe the failures, and they never
+		// tell the user to run the command they are running.
+		require.NotContains(t, out, "run `dagger generate`")
+		// fixable was rewritten by the fixer generator and loads with the
+		// changes applied: reported as such, pre-generation error dropped.
+		require.Contains(t, out, "REGENERATED")
+		require.Contains(t, out, "could not load before this run's changes; loads with them applied")
+		require.NotContains(t, out, "fixableUndefinedSymbol")
+		// stale-build was touched too but still does not compile: the report
+		// carries the post-generation error (same compiler output, once) next
+		// to the untouched broken-build's original one.
+		require.Contains(t, out, "still fails to load with this run's changes")
+		require.Equal(t, 2, strings.Count(out, "undefined: intentionallyUndefinedSymbol"), out)
+	})
+
+	t.Run("listing cannot classify, so it reports every skip", func(ctx context.Context, t *testctx.T) {
+		out, err := base.
+			With(daggerExec("generate", "-l")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "good:generate")
+		require.Contains(t, out, "modules/stale-build")
+		require.Equal(t, 2, strings.Count(out, "undefined: intentionallyUndefinedSymbol"), out)
+		require.Contains(t, out, "fixableUndefinedSymbol")
+		require.NotContains(t, out, "REGENERATED")
+	})
+
+	t.Run("plain progress", func(ctx context.Context, t *testctx.T) {
+		// Plain progress prints the skipped-module span's status inline on the
+		// run path (the listing never shows skips). It also streams the raw
+		// load spans as they fail, so the SDK's own message is visible too;
+		// what matters is that the skip row carries the detail.
+		out, err := base.
+			With(daggerExec("generate", "--no-apply", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		requireSkipDetail(t, out)
+	})
+
+	t.Run("--require-load reports the detail through the API", func(ctx context.Context, t *testctx.T) {
+		// loadFailures carries the same described messages, so an API consumer
+		// (or --require-load's telemetry) sees the compiler output too.
+		out, err := base.
+			With(daggerExecFail("generate", "-l", "--require-load", "--progress=plain")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "require-load")
+		require.Contains(t, out, "undefined: intentionallyUndefinedSymbol")
+	})
+
+	t.Run("strict load keeps the run-dagger-generate hint", func(ctx context.Context, t *testctx.T) {
+		// Only generate rewrites the hint; a call that needs the module loaded
+		// should still point the user at generate.
+		out, err := base.
+			With(daggerExecFail("call", "ungenerated", "hello")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "run `dagger generate`")
+	})
+}
+
 // TestWorkspaceCheckNarrowsToRequestedModule mirrors
 // TestWorkspaceGenerateNarrowsToRequestedModule for `dagger check`: an unrelated
 // broken/stale workspace module must not be loaded just to enumerate or run a

--- a/core/integration/module_runtime_codegen_test.go
+++ b/core/integration/module_runtime_codegen_test.go
@@ -43,6 +43,58 @@ func (RuntimeCodegenSuite) TestMissingGeneratedFiles(ctx context.Context, t *tes
 	requireErrOut(t, err, "run `dagger generate`")
 }
 
+// A dagger-module.toml module with a configured client and no committed
+// generated files must still generate on the first run: client generation
+// needs the module's schema, i.e. the module built, and the files it builds
+// from are exactly what the preceding codegen step produced. Loading the
+// module from the original source instead used to fail every first
+// `dagger generate` of such a module with the SDK's "generated file is
+// missing; run `dagger generate`" hint — from inside `dagger generate`
+// (https://github.com/dagger/dagger/issues/13973, "broken state 1").
+func (RuntimeCodegenSuite) TestClientGenerationFollowsCodegen(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	withClient := moduleFixture(t, c, "go/minimal").
+		With(configFile(".", &modules.ModuleConfig{
+			Name:          "minimal",
+			EngineVersion: modules.EngineVersionLatest,
+			SDK:           &modules.SDK{Source: "go"},
+			Clients:       []*modules.ModuleConfigClient{{Generator: "go", Directory: "./client"}},
+		}))
+
+	t.Run("generates module and client", func(ctx context.Context, t *testctx.T) {
+		generated := withClient.
+			With(daggerQuery(`{moduleSource(refString:"."){generatedContextDirectory{export(path:".")}}}`))
+
+		entries, err := generated.Directory(".").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, entries, "dagger.gen.go")
+		require.Contains(t, entries, "client/")
+		clientEntries, err := generated.Directory("client").Entries(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, clientEntries)
+	})
+
+	t.Run("a build failure is the error, not the missing-files hint", func(ctx context.Context, t *testctx.T) {
+		// With the module loaded from the generated context, the only thing
+		// that can stop client generation is the module itself not building —
+		// and that is what the user has to see.
+		_, err := withClient.
+			WithNewFile("main.go", `package main
+
+type Minimal struct{}
+
+func (m *Minimal) Hello() string {
+	return intentionallyUndefinedSymbol()
+}
+`).
+			With(daggerQuery(`{moduleSource(refString:"."){generatedContextDirectory{export(path:".")}}}`)).
+			Sync(ctx)
+		requireErrOut(t, err, "undefined: intentionallyUndefinedSymbol")
+		require.NotContains(t, err.Error(), "run `dagger generate`")
+	})
+}
+
 // Legacy dagger.json modules keep runtime codegen unconditionally; a stale
 // codegen.automaticGitignore=false opt-out is not read anymore. Nothing is
 // committed here, so success requires runtime regeneration.

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/broken-build/dagger.json
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/broken-build/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "broken-build",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  },
+  "source": "."
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/broken-build/main.go
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/broken-build/main.go
@@ -1,0 +1,9 @@
+package main
+
+// BrokenBuild does not compile: it references a symbol that does not exist,
+// standing in for a module whose source no longer matches its SDK's API.
+type BrokenBuild struct{}
+
+func (m *BrokenBuild) Hello() string {
+	return intentionallyUndefinedSymbol()
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixable/dagger.json
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixable/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixable",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  },
+  "source": "."
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixable/main.go
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixable/main.go
@@ -1,0 +1,9 @@
+package main
+
+// Fixable does not compile as committed; the fixer generator rewrites this
+// file, standing in for a run that regenerates what a module needs to build.
+type Fixable struct{}
+
+func (m *Fixable) Hello() string {
+	return fixableUndefinedSymbol()
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixer/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixer/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "fixer"
+engineVersion = "v0.21.5"
+
+[runtime]
+  source = "dang"

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixer/main.dang
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/fixer/main.dang
@@ -1,0 +1,12 @@
+type Fixer {
+  """
+  Rewrite the fixable module's source so it compiles, standing in for a run
+  that regenerates what a module needs to build.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile(
+      ".dagger/modules/fixable/main.go",
+      "package main\n\n// Fixable compiles once the fixer generator has rewritten it.\ntype Fixable struct{}\n\nfunc (m *Fixable) Hello() string {\n\treturn \"fixed\"\n}\n",
+    ).changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/good/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/good/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "good"
+engineVersion = "v0.21.5"
+
+[runtime]
+  source = "dang"

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/good/main.dang
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/good/main.dang
@@ -1,0 +1,26 @@
+type Good {
+  """
+  Regenerate by writing a marker file. Used to prove the module loaded.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "hello from good").changes(workdir)
+  }
+
+  """
+  A trivial check. Used to prove the module loaded for `dagger check`.
+  """
+  pub verify: Void @check {
+    null
+  }
+
+  """
+  A trivial service. Used to prove the module loaded for `dagger up`.
+  """
+  @up
+  pub web: Service! {
+    container
+      .from("nginx:alpine")
+      .withExposedPort(80)
+      .asService
+  }
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/regen/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/regen/dagger-module.toml
@@ -1,0 +1,5 @@
+name = "regen"
+engineVersion = "v0.21.5"
+
+[runtime]
+  source = "dang"

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/regen/main.dang
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/regen/main.dang
@@ -1,0 +1,9 @@
+type Regen {
+  """
+  Write into the stale-build module's directory, standing in for an SDK
+  generator regenerating a module's files.
+  """
+  pub generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile(".dagger/modules/stale-build/generated.txt", "regenerated").changes(workdir)
+  }
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/stale-build/dagger.json
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/stale-build/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "stale-build",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  },
+  "source": "."
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/stale-build/main.go
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/stale-build/main.go
@@ -1,0 +1,9 @@
+package main
+
+// StaleBuild does not compile either, but the regen generator rewrites its directory,
+// standing in for a module whose stale generated files this run regenerates.
+type StaleBuild struct{}
+
+func (m *StaleBuild) Hello() string {
+	return intentionallyUndefinedSymbol()
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/ungenerated/dagger-module.toml
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/ungenerated/dagger-module.toml
@@ -1,0 +1,6 @@
+name = "ungenerated"
+engineVersion = "v0.21.5"
+source = "."
+
+[runtime]
+  source = "go"

--- a/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/ungenerated/main.go
+++ b/core/integration/testdata/workspaces/generate-load-failures/.dagger/modules/ungenerated/main.go
@@ -1,0 +1,9 @@
+package main
+
+// Ungenerated has no committed generated files, so its runtime cannot be
+// built until `dagger generate` produces them.
+type Ungenerated struct{}
+
+func (m *Ungenerated) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/workspaces/generate-load-failures/dagger.toml
+++ b/core/integration/testdata/workspaces/generate-load-failures/dagger.toml
@@ -1,0 +1,20 @@
+[modules.good]
+source = ".dagger/modules/good"
+
+[modules.broken-build]
+source = ".dagger/modules/broken-build"
+
+[modules.ungenerated]
+source = ".dagger/modules/ungenerated"
+
+[modules.stale-build]
+source = ".dagger/modules/stale-build"
+
+[modules.regen]
+source = ".dagger/modules/regen"
+
+[modules.fixable]
+source = ".dagger/modules/fixable"
+
+[modules.fixer]
+source = ".dagger/modules/fixer"

--- a/core/load_failure.go
+++ b/core/load_failure.go
@@ -47,7 +47,7 @@ func DescribeLoadFailure(err error) string {
 // with the original error's origins so EndWithCause still links the span to
 // the failing exec.
 func LoadFailureCause(prefix string, err error) error {
-	var cause error = errors.New(prefix + DescribeLoadFailure(err))
+	cause := errors.New(prefix + DescribeLoadFailure(err))
 	for _, origin := range telemetry.ParseErrorOrigins(err.Error()) {
 		cause = telemetry.TrackOrigin(cause, origin)
 	}

--- a/core/load_failure.go
+++ b/core/load_failure.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"errors"
+	"strings"
+
+	telemetry "github.com/dagger/otel-go"
+)
+
+// DescribeLoadFailure renders a module load failure the way best-effort
+// `dagger generate` should report it. The raw error is what a strict load
+// (dagger call, check, up) surfaces and stays recorded as-is; generate skips
+// the module instead, so its report needs two adjustments:
+//
+//   - A module missing its generated files can't load until they're generated.
+//     The SDK's advice is to run `dagger generate` — which is what's running —
+//     so say the module is skipped until generation instead of parroting the
+//     hint back.
+//   - An exec failure (typically the SDK runtime's build, e.g. `go build`
+//     rejecting the module source, or its constructor crashing) carries the
+//     compiler/runtime output only in the failing span's logs. That span sits
+//     under the internal module-load spans the frontends hide, and the API's
+//     loadFailures strings can't reach it at all, so without this the user is
+//     left with a bare "exit code: 1". Inline the captured output.
+//
+// The [traceparent:...] error-origin markers are stripped: they are
+// span-attribution plumbing, not part of the message (see LoadFailureCause).
+func DescribeLoadFailure(err error) string {
+	msg := StripErrorOrigins(err.Error())
+
+	var missing *MissingGeneratedFileError
+	if errors.As(err, &missing) {
+		msg = strings.Replace(msg, missing.Error(), missing.Reason()+" (skipped until it is generated)", 1)
+	}
+
+	var execErr *ExecError
+	if errors.As(err, &execErr) {
+		if out := execErrorOutput(execErr); out != "" {
+			msg += "\n" + out
+		}
+	}
+	return msg
+}
+
+// LoadFailureCause is the error to report on a span for a load failure: the
+// described message (DescribeLoadFailure), optionally prefixed, re-stamped
+// with the original error's origins so EndWithCause still links the span to
+// the failing exec.
+func LoadFailureCause(prefix string, err error) error {
+	var cause error = errors.New(prefix + DescribeLoadFailure(err))
+	for _, origin := range telemetry.ParseErrorOrigins(err.Error()) {
+		cause = telemetry.TrackOrigin(cause, origin)
+	}
+	return cause
+}
+
+// execErrorOutput is the output worth showing for a failed exec: stderr (where
+// compilers and runtimes report errors), falling back to stdout.
+func execErrorOutput(execErr *ExecError) string {
+	if out := strings.TrimSpace(execErr.Stderr); out != "" {
+		return out
+	}
+	return strings.TrimSpace(execErr.Stdout)
+}

--- a/core/load_failure_test.go
+++ b/core/load_failure_test.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	telemetry "github.com/dagger/otel-go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestDescribeLoadFailure(t *testing.T) {
+	t.Parallel()
+
+	origin := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1, 2, 3},
+		SpanID:  trace.SpanID{4, 5, 6},
+	})
+
+	t.Run("inlines the failing exec's stderr", func(t *testing.T) {
+		t.Parallel()
+
+		execErr := &ExecError{
+			Err:      telemetry.TrackOrigin(errors.New("exit code: 1"), origin),
+			ExitCode: 1,
+			Stderr:   "# dagger/broken\n./main.go:8:9: undefined: nope\n",
+		}
+		err := fmt.Errorf("loading module %q: %w", "modules/broken",
+			fmt.Errorf("failed to call module %q to get functions: %w", "broken",
+				fmt.Errorf("call constructor: %w", execErr)))
+
+		got := DescribeLoadFailure(err)
+		require.Equal(t,
+			"loading module \"modules/broken\": failed to call module \"broken\" to get functions: call constructor: exit code: 1\n"+
+				"# dagger/broken\n./main.go:8:9: undefined: nope",
+			got)
+		require.NotContains(t, got, "traceparent")
+
+		// The span cause keeps the message and re-stamps the origin so the
+		// skipped-module row still links to the failing exec.
+		cause := LoadFailureCause("", err)
+		require.Equal(t, got, StripErrorOrigins(cause.Error()))
+		origins := telemetry.ParseErrorOrigins(cause.Error())
+		require.Len(t, origins, 1)
+		require.Equal(t, origin.SpanID(), origins[0].SpanID())
+	})
+
+	t.Run("falls back to stdout when stderr is empty", func(t *testing.T) {
+		t.Parallel()
+
+		execErr := &ExecError{Err: errors.New("exit code: 2"), ExitCode: 2, Stdout: "only on stdout"}
+		require.Equal(t, "boom: exit code: 2\nonly on stdout",
+			DescribeLoadFailure(fmt.Errorf("boom: %w", execErr)))
+	})
+
+	t.Run("replaces the run-dagger-generate hint for missing generated files", func(t *testing.T) {
+		t.Parallel()
+
+		missing := &MissingGeneratedFileError{Module: "ungenerated", Path: "dagger.gen.go"}
+		err := fmt.Errorf("loading module %q: failed to get module runtime: %w", "modules/ungenerated",
+			telemetry.TrackOrigin(missing, origin))
+
+		got := DescribeLoadFailure(err)
+		require.Equal(t,
+			"loading module \"modules/ungenerated\": failed to get module runtime: "+
+				"module \"ungenerated\": generated file \"dagger.gen.go\" is missing (skipped until it is generated)",
+			got)
+		require.NotContains(t, got, "run `dagger generate`")
+		// The strict-load error the module records is untouched: `dagger call`
+		// should still tell the user to generate.
+		require.Contains(t, err.Error(), "run `dagger generate`")
+	})
+
+	t.Run("leaves other errors alone", func(t *testing.T) {
+		t.Parallel()
+
+		err := telemetry.TrackOrigin(errors.New("no match found"), origin)
+		require.Equal(t, "no match found", DescribeLoadFailure(err))
+	})
+}

--- a/core/query.go
+++ b/core/query.go
@@ -90,7 +90,7 @@ type Server interface {
 	// warning instead of failing the operation, and their failure messages are
 	// returned for the caller to surface (e.g. GeneratorGroup.loadFailures) —
 	// for operations like generate that may be exactly what repairs the module.
-	EnsureWorkspaceModules(ctx context.Context, include []string, bestEffort bool) (loadFailures []string, _ error)
+	EnsureWorkspaceModules(ctx context.Context, include []string, bestEffort bool) (loadFailures []ModuleLoadFailure, _ error)
 
 	// A snapshot of the current workspace lockfile. When requireWritable is
 	// true, returns ok=false for read-only workspace lock sources.

--- a/core/schema/generators.go
+++ b/core/schema/generators.go
@@ -68,7 +68,11 @@ func (s generatorsSchema) list(ctx context.Context, parent *core.GeneratorGroup,
 }
 
 func (s generatorsSchema) loadFailures(_ context.Context, parent *core.GeneratorGroup, args struct{}) ([]string, error) {
-	return parent.LoadFailures, nil
+	messages := make([]string, 0, len(parent.LoadFailures))
+	for _, failure := range parent.LoadFailures {
+		messages = append(messages, failure.Message)
+	}
+	return messages, nil
 }
 
 func (s generatorsSchema) run(ctx context.Context, parent *core.GeneratorGroup, args struct{}) (*core.GeneratorGroup, error) {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2802,7 +2802,19 @@ func (s *moduleSourceSchema) runClientGenerator(
 		return genDirInst, fmt.Errorf("failed to add module source required files: %w", err)
 	}
 
-	schemaJSONFile, err := s.clientSchemaIntrospectionJSONFile(ctx, dag, srcInst)
+	// The client's schema comes from loading the module, which for a
+	// dagger-module.toml module means building it from its committed generated
+	// files. Those are exactly what the codegen step just wrote into genDirInst
+	// — and, on a first `dagger generate`, exactly what the original source
+	// still lacks. Load the module from the generated context, not the
+	// original one, so client generation follows codegen instead of failing
+	// with "generated file is missing; run `dagger generate`" from inside
+	// `dagger generate` itself.
+	schemaSrc, err := s.generatedModuleSource(ctx, dag, srcInst, genDirInst)
+	if err != nil {
+		return genDirInst, fmt.Errorf("failed to load generated module source for client generation: %w", err)
+	}
+	schemaJSONFile, err := s.clientSchemaIntrospectionJSONFile(ctx, dag, schemaSrc)
 	if err != nil {
 		return genDirInst, fmt.Errorf("failed to get schema for client generation: %w", err)
 	}
@@ -2841,6 +2853,33 @@ func (s *moduleSourceSchema) runClientGenerator(
 	}
 
 	return genDirInst, nil
+}
+
+// generatedModuleSource re-loads srcInst from genDirInst — its context
+// directory with the run's generated files applied — at the same source root,
+// so consumers that need the module built (client schema introspection) see
+// the freshly generated code. A source without an SDK has no codegen output to
+// pick up and is returned as-is.
+func (s *moduleSourceSchema) generatedModuleSource(
+	ctx context.Context,
+	dag *dagql.Server,
+	srcInst dagql.ObjectResult[*core.ModuleSource],
+	genDirInst dagql.ObjectResult[*core.Directory],
+) (dagql.ObjectResult[*core.ModuleSource], error) {
+	src := srcInst.Self()
+	if src.SDK == nil || src.SDK.Source == "" {
+		return srcInst, nil
+	}
+	var generatedSrc dagql.ObjectResult[*core.ModuleSource]
+	if err := dag.Select(ctx, genDirInst, &generatedSrc, dagql.Selector{
+		Field: "asModuleSource",
+		Args: []dagql.NamedInput{
+			{Name: "sourceRootPath", Value: dagql.String(filepath.ToSlash(src.SourceRootSubpath))},
+		},
+	}); err != nil {
+		return srcInst, err
+	}
+	return generatedSrc, nil
 }
 
 // runGeneratedContext runs codegen, client generation, and module config writing for the given
@@ -3519,10 +3558,14 @@ func (s *moduleSourceSchema) generateOneLocalDependency(
 
 func validateDependencyGeneratorGroup(owner, depPath string, generators *core.GeneratorGroup) error {
 	if len(generators.LoadFailures) > 0 {
+		messages := make([]string, 0, len(generators.LoadFailures))
+		for _, failure := range generators.LoadFailures {
+			messages = append(messages, failure.Message)
+		}
 		return fmt.Errorf(
 			"load owning SDK %q generators: %s",
 			owner,
-			strings.Join(generators.LoadFailures, "; "),
+			strings.Join(messages, "; "),
 		)
 	}
 	if len(generators.Generators) == 0 {

--- a/core/schema/modulesource_test.go
+++ b/core/schema/modulesource_test.go
@@ -244,7 +244,7 @@ func TestValidateDependencyGeneratorGroup(t *testing.T) {
 
 	t.Run("rejects SDK load failures", func(t *testing.T) {
 		err := validateDependencyGeneratorGroup("go-sdk", "modules/dep", &core.GeneratorGroup{
-			LoadFailures: []string{"failed to load go-sdk", "missing dependency"},
+			LoadFailures: []core.ModuleLoadFailure{{Message: "failed to load go-sdk"}, {Message: "missing dependency"}},
 		})
 		require.EqualError(t, err, `load owning SDK "go-sdk" generators: failed to load go-sdk; missing dependency`)
 	})

--- a/core/schema/test_server_test.go
+++ b/core/schema/test_server_test.go
@@ -51,7 +51,7 @@ func (s *currentTypeDefsTestServer) CurrentWorkspace(context.Context) (*core.Wor
 	return nil, nil
 }
 
-func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []string, bool) ([]string, error) {
+func (s *currentTypeDefsTestServer) EnsureWorkspaceModules(context.Context, []string, bool) ([]core.ModuleLoadFailure, error) {
 	return nil, nil
 }
 

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -3742,7 +3742,7 @@ func matchWorkspaceIncludePath(
 // core schema, so loading can wait until resolution. With bestEffort, per-module
 // load failures are collected and returned instead of aborting (used by unscoped
 // 'dagger generate'); the check/up resolvers pass false to stay strict.
-func ensureWorkspaceModulesLoaded(ctx context.Context, include []string, bestEffort bool) ([]string, error) {
+func ensureWorkspaceModulesLoaded(ctx context.Context, include []string, bestEffort bool) ([]core.ModuleLoadFailure, error) {
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return nil, err

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -425,9 +425,7 @@ func requireGeneratedFiles(
 		if bool(exists) {
 			continue
 		}
-		return fmt.Errorf(
-			"module %q: generated file %q is missing; run `dagger generate` and commit the generated files",
-			modName, rel)
+		return &core.MissingGeneratedFileError{Module: modName, Path: rel}
 	}
 	return nil
 }

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -55,7 +55,7 @@ func (ms *mockServer) ServeModule(ctx context.Context, mod dagql.ObjectResult[*M
 	return nil
 }
 
-func (ms *mockServer) EnsureWorkspaceModules(context.Context, []string, bool) ([]string, error) {
+func (ms *mockServer) EnsureWorkspaceModules(context.Context, []string, bool) ([]ModuleLoadFailure, error) {
 	return nil, nil
 }
 

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -284,6 +284,10 @@ type SpanSnapshot struct {
 	// Set on a span reporting a workspace module that best-effort generate
 	// skipped because it could not be loaded.
 	GenerateSkipped bool `json:",omitempty"`
+	// GenerateRegenerated marks the span `dagger generate` emits when its
+	// changes touch a module it skipped, so the report can show it as
+	// regenerated instead of failed.
+	GenerateRegenerated bool `json:",omitempty"`
 
 	// Service marks the long-lived exec span of a started service instance
 	// (running exactly while the service is up; cause-links to the API spans
@@ -449,6 +453,9 @@ func (snapshot *SpanSnapshot) ProcessAttribute(name string, val any) { //nolint:
 
 	case telemetryattrs.GenerateSkippedAttr:
 		snapshot.GenerateSkipped = val.(bool)
+
+	case telemetryattrs.GenerateRegeneratedAttr:
+		snapshot.GenerateRegenerated = val.(bool)
 
 	case telemetryattrs.ServiceAttr:
 		snapshot.Service = val.(bool)

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -95,6 +95,22 @@ func (db *DB) SkippedModuleSpans() []*Span {
 	return out
 }
 
+// RegeneratedModuleSpans returns the spans `dagger generate` emitted for
+// skipped modules whose directory its changes touched, keyed by the module
+// name they share with the skipped-module span. Each records the outcome of
+// loading the module again with the changes applied: OK (it loads) or failed
+// (the post-generation error). The report shows that outcome instead of the
+// pre-generation load error it supersedes.
+func (db *DB) RegeneratedModuleSpans() map[string]*Span {
+	out := map[string]*Span{}
+	for _, span := range db.Spans.Order {
+		if span.GenerateRegenerated {
+			out[span.Name] = span
+		}
+	}
+	return out
+}
+
 func (db *DB) RowsView(opts FrontendOpts) *RowsView {
 	view := &RowsView{
 		BySpan: make(map[SpanID]*TraceTree),

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -3803,6 +3803,9 @@ func (fe *frontendPretty) promoteGeneratorsLocked() {
 	for _, skip := range fe.db.SkippedModuleSpans() {
 		host.RevealedSpans.Add(skip)
 	}
+	for _, regen := range fe.db.RegeneratedModuleSpans() {
+		host.RevealedSpans.Add(regen)
+	}
 	host.Passthrough = true
 	if !fe.ZoomedSpan.IsValid() {
 		fe.ZoomedSpan = fe.db.PrimarySpan

--- a/dagql/idtui/generate_report.go
+++ b/dagql/idtui/generate_report.go
@@ -26,21 +26,58 @@ func (fe *frontendPretty) generateReport(_ tuist.Context, r *renderer, zoomed bo
 		return nil
 	}
 
+	regenerated := fe.db.RegeneratedModuleSpans()
+
 	buf := new(strings.Builder)
 	out := NewOutput(buf, termenv.WithProfile(fe.profile))
 	for _, span := range spans {
 		dur := dagui.FormatDuration(span.Activity.Duration(r.now))
-		fmt.Fprintf(out, "%s %s %s %s\n",
-			out.String(IconFailure).Foreground(termenv.ANSIRed).String(),
-			span.Name,
-			out.String(dur).Faint().String(),
-			out.String("ERROR").Foreground(termenv.ANSIRed).String(),
-		)
-		if span.Status.Description != "" {
-			fmt.Fprintf(out, "  %s\n",
-				out.String("! "+span.Status.Description).Foreground(termenv.ANSIYellow).String())
+		if regen := regenerated[span.Name]; regen != nil {
+			// The run changed files under this module and the engine loaded it
+			// again with those changes applied: that outcome supersedes the
+			// pre-generation load error, which would only send the user chasing
+			// a problem this run fixed (or hide the one it didn't).
+			dur = dagui.FormatDuration(regen.Activity.Duration(r.now))
+			if regen.IsFailed() {
+				writeSkippedModuleError(out, span.Name, dur, regen.Status.Description)
+			} else {
+				fmt.Fprintf(out, "%s %s %s %s\n",
+					out.String(IconSuccess).Foreground(termenv.ANSIGreen).String(),
+					span.Name,
+					out.String(dur).Faint().String(),
+					out.String("REGENERATED").Foreground(termenv.ANSIGreen).String(),
+				)
+				if regen.Message != "" {
+					fmt.Fprintf(out, "  %s\n", out.String(regen.Message).Faint().String())
+				}
+			}
+			continue
 		}
+		writeSkippedModuleError(out, span.Name, dur, span.Status.Description)
 	}
 	rows := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
 	return append([]string{reportHeadingLine(out, fe.agentStyle(), "SKIPPED MODULES")}, rows...)
+}
+
+// writeSkippedModuleError renders a skipped module's failed status line and
+// its error. The error may carry the failure detail on further lines (e.g.
+// the SDK runtime's compiler output); those stay aligned under the "! ".
+func writeSkippedModuleError(out TermOutput, name, dur, description string) {
+	fmt.Fprintf(out, "%s %s %s %s\n",
+		out.String(IconFailure).Foreground(termenv.ANSIRed).String(),
+		name,
+		out.String(dur).Faint().String(),
+		out.String("ERROR").Foreground(termenv.ANSIRed).String(),
+	)
+	for i, line := range strings.Split(description, "\n") {
+		if line == "" && i == 0 {
+			continue
+		}
+		marker := "  "
+		if i == 0 {
+			marker = "! "
+		}
+		fmt.Fprintf(out, "  %s\n",
+			out.String(marker+line).Foreground(termenv.ANSIYellow).String())
+	}
 }

--- a/dagql/idtui/generate_report.go
+++ b/dagql/idtui/generate_report.go
@@ -10,6 +10,11 @@ import (
 	"github.com/dagger/dagger/dagql/dagui"
 )
 
+// regeneratedModuleMessage is what the report says about a skipped module that
+// loads once the run's changes are applied. A successful regenerated span
+// carries no message of its own: its OK status is the whole outcome.
+const regeneratedModuleMessage = "could not load before this run's changes; loads with them applied"
+
 // generateReport renders the SKIPPED MODULES section for the final report: the
 // workspace modules best-effort `dagger generate` could not load and skipped,
 // each as a failed status line with its load error nested. It mirrors the
@@ -47,9 +52,7 @@ func (fe *frontendPretty) generateReport(_ tuist.Context, r *renderer, zoomed bo
 					out.String(dur).Faint().String(),
 					out.String("REGENERATED").Foreground(termenv.ANSIGreen).String(),
 				)
-				if regen.Message != "" {
-					fmt.Fprintf(out, "  %s\n", out.String(regen.Message).Faint().String())
-				}
+				fmt.Fprintf(out, "  %s\n", out.String(regeneratedModuleMessage).Faint().String())
 			}
 			continue
 		}

--- a/dagql/idtui/generate_report_test.go
+++ b/dagql/idtui/generate_report_test.go
@@ -184,7 +184,6 @@ func TestGenerateReportShowsRegeneratedModules(t *testing.T) {
 			EndTime:             start.Add(3 * time.Second),
 			ParentID:            rootID,
 			GenerateRegenerated: true,
-			Message:             "could not load before this run's changes; loads with them applied",
 			Final:               true,
 		},
 		{

--- a/dagql/idtui/generate_report_test.go
+++ b/dagql/idtui/generate_report_test.go
@@ -62,3 +62,188 @@ func TestGenerateReportPersistsSkippedModules(t *testing.T) {
 		t.Fatalf("final render missing skipped module name/error:\n%s", got)
 	}
 }
+
+// TestGenerateReportKeepsMultiLineLoadError covers a skipped module whose load
+// error carries its detail on further lines -- the engine inlines the SDK
+// runtime's compiler output under the message (see describeLoadFailure) so the
+// user learns WHY the module was skipped, not just that it was. Every line must
+// survive into the persisted section, aligned under the "! " marker.
+func TestGenerateReportKeepsMultiLineLoadError(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	db := dagui.NewDB()
+	rootID := prettyTestSpanID(1)
+	skipID := prettyTestSpanID(2)
+	start := time.Unix(100, 0)
+	db.ImportSnapshots([]dagui.SpanSnapshot{
+		{
+			ID:        rootID,
+			TraceID:   prettyTestTraceID(),
+			Name:      "generate",
+			StartTime: start,
+			EndTime:   start.Add(2 * time.Second),
+			Final:     true,
+		},
+		{
+			ID:              skipID,
+			TraceID:         prettyTestTraceID(),
+			Name:            "broken-build",
+			StartTime:       start.Add(time.Second),
+			EndTime:         start.Add(2 * time.Second),
+			ParentID:        rootID,
+			GenerateSkipped: true,
+			Status: sdktrace.Status{
+				Code: codes.Error,
+				Description: "loading module \"modules/broken-build\": call constructor: exit code: 1\n" +
+					"# dagger/broken-build\n" +
+					"./main.go:8:9: undefined: intentionallyUndefinedSymbol",
+			},
+			Final: true,
+		},
+	})
+	db.SetPrimarySpan(rootID)
+
+	fe := NewWithDB(io.Discard, db)
+	fe.recalculateViewLocked()
+
+	var buf bytes.Buffer
+	if err := fe.FinalRender(&buf); err != nil {
+		t.Fatalf("FinalRender: %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		"  ! loading module \"modules/broken-build\": call constructor: exit code: 1\n",
+		"    # dagger/broken-build\n",
+		"    ./main.go:8:9: undefined: intentionallyUndefinedSymbol\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("final render missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateReportShowsRegeneratedModules covers the outcome a run can only
+// settle after generating: the engine re-loads each skipped module whose
+// directory the changes touched, with the changes applied, under a
+// "regenerated" span. That span's status supersedes the pre-generation load
+// error in the report -- a module that now loads gets a REGENERATED row and its
+// old compiler output is NOT repeated; one that still fails shows the
+// post-generation error instead of the stale one. An untouched skipped module
+// keeps its original error.
+func TestGenerateReportShowsRegeneratedModules(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	db := dagui.NewDB()
+	rootID := prettyTestSpanID(1)
+	staleID := prettyTestSpanID(2)
+	brokenID := prettyTestSpanID(3)
+	regenID := prettyTestSpanID(4)
+	stillID := prettyTestSpanID(5)
+	stillRegenID := prettyTestSpanID(6)
+	start := time.Unix(100, 0)
+	skipStatus := func(name string) sdktrace.Status {
+		return sdktrace.Status{
+			Code:        codes.Error,
+			Description: "loading module \"modules/" + name + "\": call constructor: exit code: 1\n./main.go:8:9: undefined: " + name,
+		}
+	}
+	db.ImportSnapshots([]dagui.SpanSnapshot{
+		{
+			ID:        rootID,
+			TraceID:   prettyTestTraceID(),
+			Name:      "generate",
+			StartTime: start,
+			EndTime:   start.Add(3 * time.Second),
+			Final:     true,
+		},
+		{
+			ID:              staleID,
+			TraceID:         prettyTestTraceID(),
+			Name:            "stale",
+			StartTime:       start.Add(time.Second),
+			EndTime:         start.Add(time.Second),
+			ParentID:        rootID,
+			GenerateSkipped: true,
+			Status:          skipStatus("stale"),
+			Final:           true,
+		},
+		{
+			ID:              brokenID,
+			TraceID:         prettyTestTraceID(),
+			Name:            "broken",
+			StartTime:       start.Add(time.Second),
+			EndTime:         start.Add(time.Second),
+			ParentID:        rootID,
+			GenerateSkipped: true,
+			Status:          skipStatus("broken"),
+			Final:           true,
+		},
+		{
+			ID:                  regenID,
+			TraceID:             prettyTestTraceID(),
+			Name:                "stale",
+			StartTime:           start.Add(2 * time.Second),
+			EndTime:             start.Add(3 * time.Second),
+			ParentID:            rootID,
+			GenerateRegenerated: true,
+			Message:             "could not load before this run's changes; loads with them applied",
+			Final:               true,
+		},
+		{
+			ID:              stillID,
+			TraceID:         prettyTestTraceID(),
+			Name:            "still",
+			StartTime:       start.Add(time.Second),
+			EndTime:         start.Add(time.Second),
+			ParentID:        rootID,
+			GenerateSkipped: true,
+			Status:          skipStatus("still"),
+			Final:           true,
+		},
+		{
+			ID:                  stillRegenID,
+			TraceID:             prettyTestTraceID(),
+			Name:                "still",
+			StartTime:           start.Add(2 * time.Second),
+			EndTime:             start.Add(3 * time.Second),
+			ParentID:            rootID,
+			GenerateRegenerated: true,
+			Status: sdktrace.Status{
+				Code:        codes.Error,
+				Description: "still fails to load with this run's changes: call constructor: exit code: 1\n./main.go:9:9: undefined: stillAfter",
+			},
+			Final: true,
+		},
+	})
+	db.SetPrimarySpan(rootID)
+
+	fe := NewWithDB(io.Discard, db)
+	fe.recalculateViewLocked()
+
+	var buf bytes.Buffer
+	if err := fe.FinalRender(&buf); err != nil {
+		t.Fatalf("FinalRender: %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		"✔ stale 1.0s REGENERATED\n",
+		"  could not load before this run's changes; loads with them applied\n",
+		"✘ broken 0.0s ERROR\n",
+		"    ./main.go:8:9: undefined: broken\n",
+		"✘ still 1.0s ERROR\n",
+		"  ! still fails to load with this run's changes: call constructor: exit code: 1\n",
+		"    ./main.go:9:9: undefined: stillAfter\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("final render missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"✘ stale",
+		"undefined: stale",
+		// the pre-generation error is superseded by the post-generation one
+		"undefined: still\n",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("final render repeats a superseded load error (%q):\n%s", unwanted, got)
+		}
+	}
+}

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -434,6 +434,11 @@ type pendingModule struct {
 	// Name override (empty = derive from module).
 	Name string
 
+	// WorkspaceDir is the module's workspace-root-relative directory for
+	// local sources ("" otherwise). Best-effort loads report it with a load
+	// failure so generate can tell whether the run regenerated the module.
+	WorkspaceDir string
+
 	// If true, this module is the workspace entrypoint: its main-object
 	// methods are proxied onto the Query root in addition to its namespaced
 	// constructor.
@@ -562,6 +567,7 @@ func workspaceConfigPendingModules(
 				mod.Ref = resolved
 			} else {
 				mod.Ref = resolveLocalRef(ws, resolved)
+				mod.WorkspaceDir = resolved
 			}
 		}
 		if mod.LegacyDefaultPath {
@@ -602,6 +608,9 @@ func pendingLegacyModule(
 	mod.DefaultPathContextSourceRef = defaultPathContextRefForWorkspace(ws, resolveLocalRef)
 	if kind == core.ModuleSourceKindLocal {
 		mod.RefPin = ""
+		if !filepath.IsAbs(source) {
+			mod.WorkspaceDir = filepath.Clean(source)
+		}
 	}
 	return mod
 }
@@ -843,6 +852,7 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 			mod := pendingModule{
 				Kind:              moduleLoadKindAmbient,
 				Ref:               resolveLocalRef(ws, rel),
+				WorkspaceDir:      rel,
 				Name:              compatWorkspace.MainModule.Name,
 				Entrypoint:        compatWorkspace.MainModule.Entry.Entrypoint,
 				legacyFieldPolicy: legacyWorkspaceFieldPolicyStripCompatMain,
@@ -1112,14 +1122,14 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 // generator runs. The skipped modules' failure messages are returned so the
 // caller can surface them (e.g. GeneratorGroup.loadFailures). Genuine engine
 // errors (batch resolution, arbitration, serving) stay fatal regardless.
-func (srv *Server) ensureModulesLoadedMode(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool) (loadFailures []string, _ error) {
+func (srv *Server) ensureModulesLoadedMode(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool) (loadFailures []core.ModuleLoadFailure, _ error) {
 	return srv.ensureModulesLoadedModeWithSuccess(ctx, client, filter, bestEffort, nil)
 }
 
 // ensureModulesLoadedModeWithSuccess runs onSuccessLocked after a successful
 // load while modulesMu is still held. Callers use it for state transitions
 // that must be atomic with the load becoming visible to another request.
-func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool, onSuccessLocked func()) (loadFailures []string, rerr error) {
+func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, client *daggerClient, filter func([]pendingModule) []pendingModule, bestEffort bool, onSuccessLocked func()) (loadFailures []core.ModuleLoadFailure, rerr error) {
 	client.modulesMu.Lock()
 	defer client.modulesMu.Unlock()
 	defer func() {
@@ -1152,7 +1162,7 @@ func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, clien
 		kept := make([]pendingModule, 0, len(demand))
 		for _, mod := range demand {
 			if err, ok := client.failedModules[moduleProgressName(mod)]; ok {
-				loadFailures = append(loadFailures, loadFailureMessage(err))
+				loadFailures = append(loadFailures, moduleLoadFailure(mod, err))
 				continue
 			}
 			kept = append(kept, mod)
@@ -1189,8 +1199,8 @@ func (srv *Server) ensureModulesLoadedModeWithSuccess(ctx context.Context, clien
 			loadErr := moduleLoadErr(load, resolveErrs[i])
 			client.recordFailedModule(load.mod, loadErr)
 			if bestEffort {
-				reportSkippedModule(ctx, moduleProgressName(load.mod), loadErr)
-				loadFailures = append(loadFailures, loadFailureMessage(loadErr))
+				reportSkippedModule(ctx, moduleProgressName(load.mod), core.LoadFailureCause("", loadErr))
+				loadFailures = append(loadFailures, moduleLoadFailure(load.mod, loadErr))
 				continue
 			}
 			if firstErr == nil {
@@ -1383,7 +1393,7 @@ func (client *daggerClient) removePendingModules(served []pendingModule) {
 // With bestEffort, modules that fail to load are skipped with a warning instead
 // of failing the operation, and their failure messages are returned for the
 // caller to surface (see ensureModulesLoadedMode).
-func (srv *Server) EnsureWorkspaceModules(ctx context.Context, include []string, bestEffort bool) ([]string, error) {
+func (srv *Server) EnsureWorkspaceModules(ctx context.Context, include []string, bestEffort bool) ([]core.ModuleLoadFailure, error) {
 	client, err := srv.clientFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -1866,6 +1876,11 @@ func moduleLoadJobName(load moduleLoadRequest) string {
 // the row stays terse. GenerateSkippedAttr collects it into the persisted
 // "SKIPPED MODULES" final report so it survives the live tree collapsing when
 // generate exits 0.
+//
+// cause should come from core.LoadFailureCause so the row carries the failure
+// detail (compiler output, corrected hint) itself: its error origins still
+// link to the failing exec, but that span is hidden under the internal load
+// spans and the plain frontend never follows origins.
 func reportSkippedModule(ctx context.Context, name string, cause error) {
 	_, span := core.Tracer(ctx).Start(ctx, name,
 		telemetry.Reveal(),
@@ -1878,11 +1893,15 @@ func reportSkippedModule(ctx context.Context, name string, cause error) {
 	telemetry.EndWithCause(span, &cause)
 }
 
-// loadFailureMessage renders a load error as a display string, stripping the
-// [traceparent:...] error-origin markers — they are span-attribution plumbing,
-// not part of the message.
-func loadFailureMessage(err error) string {
-	return core.StripErrorOrigins(err.Error())
+// moduleLoadFailure is the API-facing record of a skipped module: its name
+// (matching the skipped-module span), its workspace directory (so generate
+// can tell whether the run regenerated it) and the described message.
+func moduleLoadFailure(mod pendingModule, err error) core.ModuleLoadFailure {
+	return core.ModuleLoadFailure{
+		Name:    moduleProgressName(mod),
+		Dir:     mod.WorkspaceDir,
+		Message: core.DescribeLoadFailure(err),
+	}
 }
 
 func moduleLoadErr(load moduleLoadRequest, err error) error {

--- a/engine/telemetryattrs/attrs.go
+++ b/engine/telemetryattrs/attrs.go
@@ -10,6 +10,14 @@ const (
 	// on a successful run. (bool)
 	GenerateSkippedAttr = "dagger.io/generate.skipped"
 
+	// GenerateRegeneratedAttr marks a span (named like the skipped-module span)
+	// under which `dagger generate` loaded a module it had skipped again, with
+	// the run's changes applied, because those changes touched the module. The
+	// span's status is the outcome -- it loads, or it still fails with the
+	// post-generation error -- and the TUI's SKIPPED MODULES report shows that
+	// in place of the pre-generation load error. (bool)
+	GenerateRegeneratedAttr = "dagger.io/generate.regenerated"
+
 	// DagBlockedAttr marks a lazy-evaluation resume span that aborted because a
 	// prerequisite result's evaluation failed, rather than because the result's
 	// own deferred work failed. The UI treats a blocked resumption as if the


### PR DESCRIPTION
Fixes #13973

This improves how errors from generate are surfaced to the user.

When dagger generate tolerates a module that fails to load, the engine now records why in a form the user can act on: the exec's compiler output is inlined into the skipped-module span and the loadFailures API, and a typed missing-generated-files error lets it say "skipped until generated" instead of "run dagger generate". After the generators run, any skipped module whose directory the changes touched is loaded again from the workspace root with those changes applied, and that outcome — it loads, or it still fails with the post-generation error — replaces the pre-generation error in the SKIPPED MODULES report. Separately, client generation now builds its schema from the freshly generated context rather than the original source, so a first dagger generate on a module with [[clients]] reaches the real build errors instead of dying on the file codegen just produced.

I don't fully know how this is impacted with parts of codegen moving to SDK modules, so I could use a thorough review @eunomie @TomChv 

## Before:

```
> DAGGER_X_RELEASE=v1.0.0-beta.11 dagger generate
[dagger x-release] running dagger from v1.0.0-beta.11; using release v1.0.0-beta.11
TRACE  ✘ FAILED
dagger-1.0.0-beta.11 generate  3.9s
! failed to generate client go: failed to get schema for client generation: failed to transform module source into module: failed to get module runtime: module "barge-dev": generated file ".dagger/dagger.gen.go" is missing; run `dagger generate` and commit the generated files

GENERATORS  ✘ 1 failed  ✔ 3 passed
✘ dagger-go-sdk:generate 1.4s ERROR
  ✘ go SDK: load runtime 0.0s ERROR
  ! module "barge-dev": generated file ".dagger/dagger.gen.go" is missing; run `dagger generate` and commit the generated files
✔ dagger-go-sdk:generate-all-client 0.1s OK
✔ go:fmt 0.7s OK
✔ go:tidy 0.6s OK

SKIPPED MODULES
✘ barge-dev 0.0s ERROR
  ! loading module "/Users/kylepenfound/github.com/nil/barge": failed to get module runtime: module "barge-dev": generated file ".dagger/dagger.gen.go" is missing; run `dagger generate` and commit the generated files
```

## After

```
> dagger-dev generate
TRACE  ✘ FAILED
dagger generate  2m47s
! failed to generate client go: failed to get schema for client generation: failed to transform module source into module: failed to call module "barge-dev" to get functions: call constructor: exit code: 1

GENERATORS  ✘ 1 failed  ✔ 3 passed
✘ dagger-go-sdk:generate 8.3s ERROR
  ✘ withExec go build -ldflags '-s -w' -o /runtime . 0.5s ERROR
  ┃ # github.com/frantjc/barge/.dagger
  ┃ ./main.go:31:16: cannot use dagger.GoOpts{…} (value of struct type dagger.GoOpts) as *dagger.Workspace value in argument to dag.Go
  ┃ ./main.go:32:3: unknown field Workspace in struct literal of type dagger.GoOpts
  ┃ ./main.go:33:23: cannot use dagger.MiseOpts{…} (value of struct type dagger.MiseOpts) as *dagger.Workspace value in argument to dag.Mise
  ┃ ./main.go:34:4: unknown field Workspace in struct literal of type dagger.MiseOpts
  ┃ ./main.go:83:16: cannot use dagger.GoOpts{…} (value of struct type dagger.GoOpts) as *dagger.Workspace value in argument to dag.Go
  ┃ ./main.go:84:3: unknown field Workspace in struct literal of type dagger.GoOpts
  ┃ ./main.go:101:36: workspace.Directory(".").AsGit().LatestVersion undefined (type *dagger.GitRepository has no field or method LatestVersion)
  ! exit code: 1
✔ dagger-go-sdk:generate-all-client 0.2s OK
✔ go:fmt 37.9s OK
✔ go:tidy 43.3s OK

SKIPPED MODULES
✘ barge-dev 0.0s ERROR
  ! loading module "/Users/kylepenfound/github.com/nil/barge": failed to get module runtime: module "barge-dev": generated file ".dagger/dagger.gen.go" is missing (skipped until it is generated)
```