### PR TITLE
dagql: define recipe replay semantics

### DIFF
--- a/core/schema/llm.go
+++ b/core/schema/llm.go
@@ -372,12 +372,18 @@ func (s *llmSchema) withTools(ctx context.Context, llm *core.LLM, args struct {
 		return nil, err
 	}
 	// Resolve the bound object's type from its ID without evaluating it, so the
-	// toolset can be built lazily. The object itself is loaded only when a tool
-	// is actually invoked on it (see MCP.boundToolObject). This is what lets a
+	// toolset can be built lazily. For a user-module type absent from the current
+	// bootstrap schema, ObjectTypeForID rebuilds its defining schema from the
+	// call's module provenance. The object itself is loaded only when a tool is
+	// actually invoked on it (see MCP.boundToolObject). This is what lets a
 	// persisted session restore a binding whose object has side effects or is no
 	// longer reproducible without re-running its construction.
 	if id.Type() != nil {
-		if objType, ok := srv.ObjectType(id.Type().NamedType()); ok {
+		objType, ok, err := srv.ObjectTypeForID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return llm.WithLazyTools(id, objType, args.Except), nil
 		}
 	}

--- a/dagql/call/id_test.go
+++ b/dagql/call/id_test.go
@@ -363,6 +363,7 @@ func TestBytesRoundTripUsesRawBytesForIdentity(t *testing.T) {
 }
 
 func TestDigestedStringRoundTrip(t *testing.T) {
+	const canary = "CHECKPOINT-CANARY-raw-recipe-only"
 	typ := &ast.Type{
 		NamedType: "String",
 		NonNull:   true,
@@ -371,8 +372,23 @@ func TestDigestedStringRoundTrip(t *testing.T) {
 	orig := New().Append(
 		typ,
 		"withExec",
-		WithArgs(NewArgument("execMD", NewLiteralDigestedString(`{"nested":true}`, execMDDigest), false)),
+		WithArgs(NewArgument("execMD", NewLiteralDigestedString(canary, execMDDigest), false)),
 	)
+
+	for name, display := range map[string]string{
+		"ID display":      orig.Display(),
+		"literal display": orig.Arg("execMD").Value().Display(),
+		"literal AST":     orig.Arg("execMD").Value().ToAST().String(),
+	} {
+		if strings.Contains(display, canary) {
+			t.Fatalf("%s exposed digested-string value: %q", name, display)
+		}
+		for _, want := range []string{"digested-string", execMDDigest.String(), "size=33B"} {
+			if !strings.Contains(display, want) {
+				t.Errorf("%s = %q, missing %q", name, display, want)
+			}
+		}
+	}
 
 	enc, err := orig.Encode()
 	if err != nil {
@@ -396,7 +412,10 @@ func TestDigestedStringRoundTrip(t *testing.T) {
 	if lit.Digest() != execMDDigest {
 		t.Fatalf("digested-string digest mismatch after round-trip: got %s, want %s", lit.Digest(), execMDDigest)
 	}
-	if lit.Value() != `{"nested":true}` {
+	if lit.Value() != canary {
 		t.Fatalf("digested-string value mismatch after round-trip: got %q", lit.Value())
+	}
+	if got := decoded.Call().GetArgs()[0].GetValue().GetDigestedString().GetValue(); got != canary {
+		t.Fatalf("raw recipe lost digested-string value: got %q", got)
 	}
 }

--- a/dagql/call/literal.go
+++ b/dagql/call/literal.go
@@ -155,11 +155,18 @@ func (lit *LiteralDigestedString) Modules() []*Module {
 	return nil
 }
 
-func (lit *LiteralDigestedString) Display() string {
-	if lit.digest == "" {
-		return "<digested-string>"
+// DisplayDigestedString renders a value's identity and byte size without
+// exposing its serialized contents.
+func DisplayDigestedString(value string, dgst digest.Digest) string {
+	digestLabel := dgst.String()
+	if digestLabel == "" {
+		digestLabel = "none"
 	}
-	return fmt.Sprintf("<digested-string:%s>", lit.digest)
+	return fmt.Sprintf("<digested-string digest=%s size=%dB>", digestLabel, len(value))
+}
+
+func (lit *LiteralDigestedString) Display() string {
+	return DisplayDigestedString(lit.value, lit.digest)
 }
 
 func (lit *LiteralDigestedString) ToInput() any {
@@ -167,12 +174,8 @@ func (lit *LiteralDigestedString) ToInput() any {
 }
 
 func (lit *LiteralDigestedString) ToAST() *ast.Value {
-	raw := "<digested-string>"
-	if lit.digest != "" {
-		raw = fmt.Sprintf("<digested-string:%s>", lit.digest)
-	}
 	return &ast.Value{
-		Raw:  strconv.Quote(raw),
+		Raw:  strconv.Quote(lit.Display()),
 		Kind: ast.StringValue,
 	}
 }

--- a/dagql/dagui/dot.go
+++ b/dagql/dagui/dot.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 )
@@ -299,6 +301,11 @@ func displayLit(lit *callpbv1.Literal) string {
 		return fmt.Sprintf("%q", val.String_)
 	case *callpbv1.Literal_Bytes:
 		return call.DisplayBytes(val.Bytes)
+	case *callpbv1.Literal_DigestedString:
+		return call.DisplayDigestedString(
+			val.DigestedString.GetValue(),
+			digest.Digest(val.DigestedString.GetDigest()),
+		)
 	case *callpbv1.Literal_CallDigest:
 		return "<input>"
 	case *callpbv1.Literal_Enum:

--- a/dagql/dagui/extract.go
+++ b/dagql/dagui/extract.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 )
@@ -222,7 +224,10 @@ func literalLabel(lit *callpbv1.Literal) string {
 	case *callpbv1.Literal_String_:
 		return strconv.Quote(truncateLiteral(v.String_))
 	case *callpbv1.Literal_DigestedString:
-		return strconv.Quote(truncateLiteral(v.DigestedString.GetValue()))
+		return call.DisplayDigestedString(
+			v.DigestedString.GetValue(),
+			digest.Digest(v.DigestedString.GetDigest()),
+		)
 	case *callpbv1.Literal_Bytes:
 		return call.DisplayBytes(v.Bytes)
 	case *callpbv1.Literal_List:

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/iancoleman/strcase"
 	"github.com/muesli/termenv"
+	"github.com/opencontainers/go-digest"
 	"github.com/vito/tuist"
 	"go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -721,6 +722,11 @@ func (r *renderer) renderLiteral(out TermOutput, lit *callpbv1.Literal) {
 		fmt.Fprint(out, out.String(fmt.Sprintf("%q", val.String_)).Foreground(termenv.ANSIYellow))
 	case *callpbv1.Literal_Bytes:
 		fmt.Fprint(out, out.String(call.DisplayBytes(val.Bytes)).Foreground(termenv.ANSIYellow))
+	case *callpbv1.Literal_DigestedString:
+		fmt.Fprint(out, out.String(call.DisplayDigestedString(
+			val.DigestedString.GetValue(),
+			digest.Digest(val.DigestedString.GetDigest()),
+		)).Foreground(termenv.ANSIYellow))
 	case *callpbv1.Literal_CallDigest:
 		fmt.Fprint(out, out.String(val.CallDigest).Foreground(termenv.ANSIMagenta))
 	case *callpbv1.Literal_Enum:

--- a/dagql/idtui/frontend_pretty_test.go
+++ b/dagql/idtui/frontend_pretty_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dagger/dagger/engine/telemetryattrs"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/muesli/termenv"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/require"
 	"github.com/vito/tuist"
 	"go.opentelemetry.io/otel/codes"
@@ -133,6 +134,30 @@ func TestCallPayloadRecordsExcludedFromFrontendLogs(t *testing.T) {
 		require.NotNil(t, spanLogs)
 		require.Equal(t, "before\nafter\n", spanLogs.rawBuf.String())
 	})
+}
+
+func TestRenderDigestedLiteralIsOpaque(t *testing.T) {
+	const canary = "CHECKPOINT-CANARY-tui-raw-only"
+	payloadDigest := digest.FromString("checkpoint-chunk")
+	lit := &callpbv1.Literal{Value: &callpbv1.Literal_DigestedString{
+		DigestedString: &callpbv1.DigestedString{
+			Value:  canary,
+			Digest: payloadDigest.String(),
+		},
+	}}
+
+	var buf strings.Builder
+	out := termenv.NewOutput(&buf, termenv.WithProfile(termenv.Ascii))
+	newRenderer(dagui.NewDB(), 0, dagui.FrontendOpts{}, true).renderLiteral(out, lit)
+	rendered := buf.String()
+	if strings.Contains(rendered, canary) {
+		t.Fatalf("TUI exposed digested value: %q", rendered)
+	}
+	for _, want := range []string{"digested-string", payloadDigest.String(), fmt.Sprintf("size=%dB", len(canary))} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("TUI rendering %q missing %q", rendered, want)
+		}
+	}
 }
 
 func TestSortErrorOriginsUsesCurrentSpanData(t *testing.T) {

--- a/dagql/lazy_ref_arg_test.go
+++ b/dagql/lazy_ref_arg_test.go
@@ -4,12 +4,62 @@ import (
 	"context"
 	"testing"
 
+	"github.com/vektah/gqlparser/v2/ast"
 	"gotest.tools/v3/assert"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/dagql/internal/points"
 )
+
+type moduleToolSet struct{}
+
+func (*moduleToolSet) Type() *ast.Type {
+	return &ast.Type{NamedType: "ModuleToolSet", NonNull: true}
+}
+
+// TestObjectTypeForIDUsesModuleProvenance covers lazy references to user-module
+// objects when the loading server only has the bootstrap schema. The object's
+// recipe deliberately names no real field: resolving its type can only succeed
+// by loading its module provenance and must never evaluate the object recipe.
+func TestObjectTypeForIDUsesModuleProvenance(t *testing.T) {
+	cache := newCache(t)
+	ctx := dagql.ContextWithCache(testContext(), cache)
+
+	bootstrap := newExternalDagqlServerForTest(t, Query{})
+	points.Install[Query](bootstrap)
+	var moduleRef dagql.ObjectResult[*points.Point]
+	assert.NilError(t, bootstrap.Select(ctx, bootstrap.Root(), &moduleRef,
+		dagql.Selector{Field: "point"},
+	))
+	moduleRefID, err := moduleRef.RecipeID(ctx)
+	assert.NilError(t, err)
+
+	moduleSchema := newExternalDagqlServerForTest(t, Query{})
+	moduleSchema.InstallObject(dagql.NewClass[*moduleToolSet](moduleSchema))
+	dagql.Fields[*moduleToolSet]{
+		dagql.Func("check", func(context.Context, *moduleToolSet, struct{}) (string, error) {
+			return "ok", nil
+		}),
+	}.Install(moduleSchema)
+
+	bootstrap.SetResultServerForCall(func(_ context.Context, frame *dagql.ResultCall) (*dagql.Server, error) {
+		assert.Assert(t, frame.Module != nil)
+		assert.Assert(t, frame.Module.ResultRef != nil)
+		assert.Assert(t, frame.Module.ResultRef.ResultID != 0)
+		return moduleSchema, nil
+	})
+
+	objectID := call.New().Append((&moduleToolSet{}).Type(), "missingConstructor",
+		call.WithModule(call.NewModule(moduleRefID, "tools", "", "")),
+	)
+	objType, ok, err := bootstrap.ObjectTypeForID(ctx, objectID)
+	assert.NilError(t, err)
+	assert.Assert(t, ok)
+	assert.Equal(t, "ModuleToolSet", objType.TypeName())
+	_, ok = objType.FieldSpec("check", "")
+	assert.Assert(t, ok)
+}
 
 // TestLazyRefArgNotEvaluatedOnLoad reproduces the failure mode where
 // restoring a persisted session re-evaluated a side-effecting tool call that had

--- a/dagql/recipe_replay_test.go
+++ b/dagql/recipe_replay_test.go
@@ -15,8 +15,96 @@ import (
 	"github.com/dagger/dagger/engine"
 )
 
-// This file measures what the recipe loader actually does when it is forced to
-// re-execute a recorded call, rather than what it is documented to do.
+const recipeClassificationReason = "test: value is bound to its producing session"
+
+func newRecipeClassificationServer(t *testing.T) *dagql.Server {
+	t.Helper()
+	srv := newExternalDagqlServerForTest(t, Query{})
+	points.Install[Query](srv)
+	dagql.Fields[Query]{
+		dagql.Func("unsafePoint", func(context.Context, Query, struct{}) (*points.Point, error) {
+			t.Fatal("recipe classification must not evaluate fields")
+			return nil, nil
+		}).NotReplayable(recipeClassificationReason),
+		dagql.Func("pointFromObject", func(context.Context, Query, struct {
+			Object dagql.AnyID
+		}) (*points.Point, error) {
+			t.Fatal("recipe classification must not evaluate fields")
+			return nil, nil
+		}).Args(dagql.Arg("object")),
+		dagql.Func("pointFromLazyObject", func(context.Context, Query, struct {
+			Object dagql.AnyID
+		}) (*points.Point, error) {
+			t.Fatal("recipe classification must not evaluate fields")
+			return nil, nil
+		}).Args(dagql.Arg("object").LazyRef()),
+	}.Install(srv)
+	return srv
+}
+
+func requireNotReplayableCall(t *testing.T, got dagql.RecipeClassification, want *call.ID) {
+	t.Helper()
+	require.NotNil(t, got.NotReplayable)
+	require.Equal(t, want.Field(), got.NotReplayable.Field)
+	require.Equal(t, want.Digest(), got.NotReplayable.Digest)
+	require.Equal(t, recipeClassificationReason, got.NotReplayable.Reason)
+}
+
+func TestClassifyRecipeNotReplayable(t *testing.T) {
+	srv := newRecipeClassificationServer(t)
+	pointType := (&points.Point{}).Type()
+	unsafe := call.New().Append(pointType, "unsafePoint")
+
+	t.Run("direct", func(t *testing.T) {
+		requireNotReplayableCall(t, srv.ClassifyRecipe(unsafe), unsafe)
+	})
+
+	t.Run("receiver", func(t *testing.T) {
+		recipe := unsafe.Append(pointType, "shiftLeft")
+		requireNotReplayableCall(t, srv.ClassifyRecipe(recipe), unsafe)
+	})
+
+	t.Run("ID argument", func(t *testing.T) {
+		recipe := call.New().Append(pointType, "pointFromObject",
+			call.WithArgs(call.NewArgument("object", call.NewLiteralID(unsafe), false)),
+		)
+		requireNotReplayableCall(t, srv.ClassifyRecipe(recipe), unsafe)
+	})
+}
+
+func TestClassifyRecipeReplayableAndLazyRefs(t *testing.T) {
+	srv := newRecipeClassificationServer(t)
+	pointType := (&points.Point{}).Type()
+	replayable := call.New().Append(pointType, "point").Append(pointType, "shiftLeft")
+	require.Nil(t, srv.ClassifyRecipe(replayable).NotReplayable)
+
+	unsafe := call.New().Append(pointType, "unsafePoint")
+	lazyRecipe := call.New().Append(pointType, "pointFromLazyObject",
+		call.WithArgs(call.NewArgument("object", call.NewLiteralID(unsafe), false)),
+	)
+	require.Nil(t, srv.ClassifyRecipe(lazyRecipe).NotReplayable,
+		"lazy-ref arguments are not evaluated during recipe loading")
+}
+
+func TestClassifyRecipeUnknownFieldsAreBestEffort(t *testing.T) {
+	srv := newRecipeClassificationServer(t)
+	pointType := (&points.Point{}).Type()
+
+	unknown := call.New().Append(pointType, "fieldNotInSchema")
+	require.Nil(t, srv.ClassifyRecipe(unknown).NotReplayable)
+	require.Nil(t, srv.ClassifyRecipe(nil).NotReplayable)
+
+	// An unresolved field cannot declare an argument lazy, so its ID arguments
+	// are traversed as normal, just as they are by recipe loading.
+	unsafe := call.New().Append(pointType, "unsafePoint")
+	unknownWithArg := call.New().Append(pointType, "fieldNotInSchema",
+		call.WithArgs(call.NewArgument("object", call.NewLiteralID(unsafe), false)),
+	)
+	requireNotReplayableCall(t, srv.ClassifyRecipe(unknownWithArg), unsafe)
+}
+
+// This file also measures what the recipe loader actually does when it is forced
+// to re-execute a recorded call, rather than what it is documented to do.
 //
 // Background (internal-docs/recipe_replay.md): a field marked
 // [dagql.Field.NotReplayable] taints itself and every recorded call above it

--- a/dagql/recipe_replay_test.go
+++ b/dagql/recipe_replay_test.go
@@ -1,0 +1,431 @@
+package dagql_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/dagql/internal/points"
+	"github.com/dagger/dagger/engine"
+)
+
+// This file measures what the recipe loader actually does when it is forced to
+// re-execute a recorded call, rather than what it is documented to do.
+//
+// Background (internal-docs/recipe_replay.md): a field marked
+// [dagql.Field.NotReplayable] taints itself and every recorded call above it
+// when the recipe is loaded by a session other than the one that recorded it.
+// A tainted vertex skips BOTH of loadRecipeVertex's cache lookups
+// (dagql/server.go ~1530-1610) and falls through to baseObj.Select — the
+// ordinary call path.
+//
+// The part that is not documented, and is the subject of these tests: that
+// fall-through re-resolves the field's implicit inputs from scratch
+// (dagql/objects.go:566, FieldSpec.resolveImplicitInputCallArgs). The recorded
+// implicit inputs are copied verbatim only into the *frame* used for the
+// lookups that taint just skipped; they never reach the executed call. So a
+// field carrying dagql.PerCallInput mints a brand new nonce on every load
+// (dagql/cache_inputs.go:70-77), which means:
+//
+//   - the value the load returns has an identity nobody recorded, and
+//   - the entry it caches is keyed under that fresh identity, so the NEXT load
+//     cannot find it and executes again, forever.
+//
+// That is the shape of the reported bug: a module function declared
+// @cache(policy: Never) — which is exactly dagql.PerCallInput and nothing else
+// (core/modfunc.go:124-139) — spawned a live agent every time a saved session
+// recipe was resumed, instead of once.
+//
+// The fixture below models the three field shapes that matter:
+//
+//	liveBase  NotReplayable + PerSessionInput   (host.directory / currentWorkspace)
+//	pure      plain cacheable                   (withEnvVariable, withPrompt, ...)
+//	nonced    PerCallInput                      (@cache(policy: Never) module function)
+//	spawned   PerCallInput + DoNotCache         (core LLM.spawn)
+
+type replayFixture struct {
+	t     *testing.T
+	srv   *dagql.Server
+	cache *dagql.Cache
+
+	// Every counter is bumped by its field's resolver, so it counts real
+	// executions rather than cache hits.
+	liveReads   atomic.Int64
+	pureCalls   atomic.Int64
+	noncedCalls atomic.Int64
+	spawnCalls  atomic.Int64
+}
+
+func newReplayFixture(t *testing.T) *replayFixture {
+	f := &replayFixture{
+		t:     t,
+		srv:   newExternalDagqlServerForTest(t, Query{}),
+		cache: newCache(t),
+	}
+	points.Install[Query](f.srv)
+
+	dagql.Fields[Query]{
+		// liveBase stands in for Host.directory / Query.currentWorkspace: a
+		// value that is only meaningful to the session that read it, so a
+		// recorded call to it must be re-executed by any other session.
+		dagql.Func("liveBase", func(ctx context.Context, _ Query, _ struct{}) (*points.Point, error) {
+			return &points.Point{X: int(f.liveReads.Add(1))}, nil
+		}).
+			WithInput(dagql.PerSessionInput).
+			NotReplayable("test: the recorded digest is a stable key for an unstable value"),
+	}.Install(f.srv)
+
+	dagql.Fields[*points.Point]{
+		// pure stands in for the ordinary reproducible calls a recipe is
+		// mostly made of. Replaying these from cache is correct.
+		dagql.Func("pure", func(ctx context.Context, self *points.Point, _ struct{}) (*points.Point, error) {
+			f.pureCalls.Add(1)
+			return &points.Point{X: self.X, Y: self.Y + 1}, nil
+		}),
+		// nonced is precisely a module function declared @cache(policy:
+		// Never): dagql.PerCallInput as its only implicit input, and no
+		// DoNotCache (core/modfunc.go:132-133). Its result IS cached — under a
+		// key containing the nonce minted for that one invocation.
+		dagql.Func("nonced", func(ctx context.Context, self *points.Point, _ struct{}) (*points.Point, error) {
+			return &points.Point{X: self.X, Y: int(f.noncedCalls.Add(1))}, nil
+		}).
+			WithInput(dagql.PerCallInput),
+		// spawned is the core LLM.spawn shape: a per-call nonce AND
+		// DoNotCache, so nothing is ever stored under the recorded digest.
+		dagql.Func("spawned", func(ctx context.Context, self *points.Point, _ struct{}) (*points.Point, error) {
+			return &points.Point{X: self.X, Y: int(f.spawnCalls.Add(1))}, nil
+		}).
+			WithInput(dagql.PerCallInput).
+			DoNotCache("test: every spawn mints a distinct instance"),
+	}.Install(f.srv)
+
+	return f
+}
+
+func (f *replayFixture) ctxFor(sessionID string) context.Context {
+	ctx := engine.ContextWithClientMetadata(context.Background(), &engine.ClientMetadata{
+		ClientID:  "same-client",
+		SessionID: sessionID,
+	})
+	return dagql.ContextWithCache(ctx, f.cache)
+}
+
+// record builds a chain in the given session and returns its recipe-form ID,
+// the way LLM.portableID hands one to a session save file.
+func (f *replayFixture) record(ctx context.Context, sels ...dagql.Selector) *call.ID {
+	f.t.Helper()
+	var base dagql.ObjectResult[*points.Point]
+	require.NoError(f.t, f.srv.Select(ctx, f.srv.Root(), &base, dagql.Selector{Field: "liveBase"}))
+	var chain dagql.ObjectResult[*points.Point]
+	require.NoError(f.t, f.srv.Select(ctx, base, &chain, sels...))
+	id, err := chain.RecipeID(ctx)
+	require.NoError(f.t, err)
+	require.False(f.t, id.IsHandle(), "the saved ID must be recipe-form")
+	return id
+}
+
+// loadObj replays a recorded ID the way Server.LoadType does for a saved
+// session file.
+func (f *replayFixture) loadObj(ctx context.Context, id *call.ID) dagql.AnyObjectResult {
+	f.t.Helper()
+	res, err := f.srv.LoadType(ctx, id)
+	require.NoError(f.t, err)
+	obj, ok := res.(dagql.AnyObjectResult)
+	require.True(f.t, ok)
+	return obj
+}
+
+// load replays a recorded ID and returns the recipe ID of what came back, so a
+// caller can compare the loaded call's identity against the recorded one.
+func (f *replayFixture) load(ctx context.Context, id *call.ID) *call.ID {
+	f.t.Helper()
+	got, err := f.loadObj(ctx, id).RecipeID(ctx)
+	require.NoError(f.t, err)
+	return got
+}
+
+// implicitInputValue reads a recorded implicit input off a call, the same way
+// recipeLoadState.recordedSessionStamp does (dagql/server.go:1516).
+func implicitInputValue(t *testing.T, id *call.ID, name string) string {
+	t.Helper()
+	for _, in := range id.ImplicitInputs() {
+		if in == nil || in.Name() != name {
+			continue
+		}
+		lit, ok := in.Value().(*call.LiteralString)
+		require.True(t, ok, "implicit input %q is not a string literal", name)
+		return lit.Value()
+	}
+	t.Fatalf("no implicit input %q on %s", name, id.Field())
+	return ""
+}
+
+// TestRecipeLoadSameSessionServesTheRecordedCall pins claim 4: inside the
+// session that recorded it, a recipe carrying a per-call nonce loads straight
+// off the cache. Nothing re-executes and the loaded value's identity is bit
+// for bit the recorded one — the recorded nonce is still a live cache key
+// here, so neither lookup in loadRecipeVertex is skipped.
+//
+// This is correct behaviour, and it is the control for the cross-session
+// measurements below: the difference they show is caused by the session
+// boundary, not by the nonce alone.
+func TestRecipeLoadSameSessionServesTheRecordedCall(t *testing.T) {
+	f := newReplayFixture(t)
+	ctxA := f.ctxFor("session-a")
+
+	// liveBase -> nonced -> pure: a per-call-nonce call sitting above a
+	// NotReplayable read, with an ordinary recorded call above it.
+	recorded := f.record(ctxA,
+		dagql.Selector{Field: "nonced"},
+		dagql.Selector{Field: "pure"},
+	)
+	recordedNonce := implicitInputValue(t, recorded.Receiver(), dagql.PerCallInput.Name)
+
+	const loads = 5
+	for range loads {
+		got := f.load(ctxA, recorded)
+		assert.Check(t, cmp.Equal(got.Digest(), recorded.Digest()),
+			"a same-session load must return the recorded call, not a new one")
+		assert.Check(t, cmp.Equal(
+			implicitInputValue(t, got.Receiver(), dagql.PerCallInput.Name), recordedNonce),
+			"a same-session load must not re-mint the recorded nonce")
+	}
+
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(1)), "liveBase executions")
+	assert.Check(t, cmp.Equal(f.noncedCalls.Load(), int64(1)), "nonced executions")
+	assert.Check(t, cmp.Equal(f.pureCalls.Load(), int64(1)), "pure executions")
+}
+
+// TestRecipeLoadCrossSessionCachesTheTaintForcedExecution pins claim 1 for
+// ordinary, reproducible calls: the taint costs exactly one re-execution per
+// loading session, not one per load.
+//
+// The first load in a new session re-executes liveBase (its recorded
+// cachePerSession stamp names another session) and re-executes the pure call
+// above it, because that call's receiver is now a different value. Both
+// results are then cached under the new session's digests, and the four
+// remaining loads are served from them even though the vertices are still
+// tainted — taint only skips the *recipe loader's* lookups; the re-issued call
+// still consults the ordinary cache, and for a field with no per-call input it
+// hits.
+//
+// This is correct behaviour, and it is what makes the failure in
+// TestRecipeLoadTaintedNonceReExecutesOnEveryLoad specific to the nonce rather
+// than inherent to the taint path.
+func TestRecipeLoadCrossSessionCachesTheTaintForcedExecution(t *testing.T) {
+	f := newReplayFixture(t)
+
+	recorded := f.record(f.ctxFor("session-a"), dagql.Selector{Field: "pure"})
+
+	ctxB := f.ctxFor("session-b")
+	var first *call.ID
+	const loads = 5
+	for i := range loads {
+		got := f.load(ctxB, recorded)
+		if i == 0 {
+			first = got
+			assert.Check(t, got.Digest() != recorded.Digest(),
+				"the re-executed chain is re-recorded under the loading session")
+			continue
+		}
+		assert.Check(t, cmp.Equal(got.Digest(), first.Digest()),
+			"repeated loads in one session must converge on a single identity")
+	}
+
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)),
+		"liveBase: once when recorded, once when the new session first loads it")
+	assert.Check(t, cmp.Equal(f.pureCalls.Load(), int64(2)),
+		"pure: once when recorded, once on top of the re-read base")
+}
+
+// TestRecipeLoadTaintedNonceReExecutesOnEveryLoad pins the hazard that makes
+// "an effectful call must never enter a persisted recipe" a RULE rather than a
+// preference. It characterizes the loader as it stands; it is not a wish.
+//
+// Setup mirrors the reported failure: a saved recipe whose chain contains a
+// module function declared @cache(policy: Never) (here `nonced`, carrying only
+// dagql.PerCallInput) that transitively depends on a NotReplayable read, then
+// resumed in a different session. Loading it five times in one new session:
+//
+//	liveBase executions   2  (1 recorded + 1 forced)
+//	nonced   executions   6  (1 recorded + 5 forced)
+//	pure     executions   6  (1 recorded + 5 forced)
+//	distinct loaded IDs   5
+//
+// Every load re-enters loadRecipeVertex with the taint set, skips both
+// lookups, and re-issues the call — at which point
+// FieldSpec.resolveImplicitInputCallArgs mints a fresh cachePerCall nonce
+// (dagql/cache_inputs.go:72-77). The executed call therefore has an identity
+// no load can predict, so the result it caches is unreachable to the next
+// load, which executes again. Three recorded spawns replayed across eleven
+// loads is thirty-three live agents.
+//
+// Note the cascade: `pure` sits ABOVE `nonced` and is an ordinary cacheable
+// field, yet it also re-executes on every load, because its receiver is a
+// different value each time. A single per-call nonce buried in a recipe
+// invalidates every recorded call above it, on every load.
+//
+// THE FIX IS NOT HERE, deliberately. Making the loader identity-stable (replay
+// the recorded cachePerCall inputs, or memoize the forced execution per
+// loading session) would turn 33 agents into 3 — quieter, not smaller in kind,
+// and three agents wearing the user's workers' names with none of their
+// history is the failure this defect was already misdiagnosed as once. The fix
+// is at the API layer: keep effectful calls out of persisted recipes, so a
+// resumed chain re-executes nothing worth re-executing. This test exists so
+// that the cost of breaking that rule stays measured and visible, and it
+// should be UPDATED, not deleted, if the loader ever does change.
+func TestRecipeLoadTaintedNonceReExecutesOnEveryLoad(t *testing.T) {
+	f := newReplayFixture(t)
+
+	recorded := f.record(f.ctxFor("session-a"),
+		dagql.Selector{Field: "nonced"},
+		dagql.Selector{Field: "pure"},
+	)
+	recordedNonce := implicitInputValue(t, recorded.Receiver(), dagql.PerCallInput.Name)
+
+	ctxB := f.ctxFor("session-b")
+	const loads = 5
+	seen := map[string]int{}
+	for range loads {
+		got := f.load(ctxB, recorded)
+		seen[got.Digest().String()]++
+
+		// Measurement, not a wish: the re-executed call is minted with a new
+		// nonce rather than the recorded one. A fix may legitimately either
+		// replay the recorded nonce or mint one nonce per loading session —
+		// what it must not do is mint a new one per load, which is what the
+		// identity-stability assertion below pins.
+		assert.Check(t,
+			implicitInputValue(t, got.Receiver(), dagql.PerCallInput.Name) != recordedNonce,
+			"the taint path re-resolves implicit inputs instead of replaying them")
+	}
+
+	// The cost of one nonce in a recipe: the effectful call runs once per
+	// LOAD, not once per loading session. This is the number that turned 3
+	// recorded spawns into 33 live agents.
+	assert.Check(t, cmp.Equal(f.noncedCalls.Load(), int64(1+loads)),
+		"a nonce-bearing call under a taint re-executes on every load")
+
+	// The same cause, one level up: every recorded call above the nonce
+	// loses its cache too, because its receiver has a fresh identity on
+	// each load. The blast radius of one effectful call is the whole chain
+	// recorded above it.
+	assert.Check(t, cmp.Equal(f.pureCalls.Load(), int64(1+loads)),
+		"an ordinary cacheable call above the nonce is dragged into "+
+			"re-executing on every load")
+
+	// Identity never converges: each load produces a distinct ID, so a
+	// caller that saves the loaded ID saves a value nothing else can
+	// address — which is also why the next load cannot reuse the last
+	// load's cached result.
+	assert.Check(t, cmp.Equal(len(seen), loads),
+		"repeated loads of one recorded ID produce one identity each")
+
+	// The contrast that localizes the cause to the nonce and not the taint:
+	// the NotReplayable read is re-executed once for the new session and
+	// then served from cache, exactly as
+	// TestRecipeLoadCrossSessionCachesTheTaintForcedExecution shows for a
+	// nonce-free chain.
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)),
+		"liveBase: once when recorded, once when the new session first loads it")
+}
+
+// TestRecipeLoadTaintIsScopedNotPermanent pins claim 2: the taint is recomputed
+// per load against the loading session, so it does not accumulate.
+//
+// A chain re-recorded by the new session carries that session's cachePerSession
+// stamp, and fieldNotReplayable compares the recorded stamp to the loading
+// session (dagql/server.go:1506-1511). Loading it — or a longer chain built on
+// top of it — inside that same session is therefore clean: nothing re-executes,
+// including the per-call-nonce call underneath, whose recorded nonce is a live
+// cache key again. A previous session's input does not confer permanent taint.
+//
+// Crossing another boundary re-taints, exactly once for the NotReplayable read.
+func TestRecipeLoadTaintIsScopedNotPermanent(t *testing.T) {
+	f := newReplayFixture(t)
+
+	recorded := f.record(f.ctxFor("session-a"), dagql.Selector{Field: "nonced"})
+
+	// One tainted load. Everything below is measured against the chain this
+	// produces, which session B recorded itself.
+	ctxB := f.ctxFor("session-b")
+	loadedInB := f.load(ctxB, recorded)
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)))
+	assert.Check(t, cmp.Equal(f.noncedCalls.Load(), int64(2)))
+
+	// Extend it, the way a resumed conversation keeps making calls.
+	obj := f.loadObj(ctxB, loadedInB)
+	var extended dagql.ObjectResult[*points.Point]
+	require.NoError(t, f.srv.Select(ctxB, obj, &extended, dagql.Selector{Field: "pure"}))
+	extendedID, err := extended.RecipeID(ctxB)
+	require.NoError(t, err)
+
+	before := [3]int64{f.liveReads.Load(), f.pureCalls.Load(), f.noncedCalls.Load()}
+	for range 3 {
+		got := f.load(ctxB, extendedID)
+		assert.Check(t, cmp.Equal(got.Digest(), extendedID.Digest()),
+			"a chain recorded by this session loads as itself")
+	}
+	after := [3]int64{f.liveReads.Load(), f.pureCalls.Load(), f.noncedCalls.Load()}
+	assert.Check(t, cmp.Equal(after, before),
+		"a chain recorded in the loading session must not inherit taint from "+
+			"the previous-session input it was derived from")
+
+	// A third session re-taints the same chain — once for the NotReplayable
+	// read, which is the scoping working as intended. (The calls above it do
+	// re-execute per load, for the reason
+	// TestRecipeLoadTaintedNonceReExecutesOnEveryLoad pins.)
+	ctxC := f.ctxFor("session-c")
+	for range 3 {
+		f.load(ctxC, extendedID)
+	}
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(3)),
+		"the taint is evaluated against the loading session, not remembered")
+}
+
+// TestRecipeLoadDoNotCacheReExecutesOnEveryLoad records the neighbouring
+// behaviour of the core LLM.spawn shape — dagql.PerCallInput plus DoNotCache —
+// which needs no taint at all to re-execute.
+//
+// Because nothing is stored under the recorded digest, both of
+// loadRecipeVertex's lookups miss even inside the recording session, and the
+// call is re-issued with a fresh nonce. So a recipe whose top call is
+// DoNotCache re-executes on EVERY load, in EVERY session, forever.
+//
+// Asserted as current behaviour rather than as a defect: DoNotCache does say
+// "never serve this from cache". core/schema/llm.go avoids the consequence by
+// pinning spawn's result identity through the cached `agent(id:)` lookup, so a
+// saved conversation's recipe never contains a bare spawn. A module function
+// has no such mitigation, which is why the defect above bites at
+// @cache(policy: Never).
+func TestRecipeLoadDoNotCacheReExecutesOnEveryLoad(t *testing.T) {
+	f := newReplayFixture(t)
+	ctxA := f.ctxFor("session-a")
+
+	recorded := f.record(ctxA, dagql.Selector{Field: "spawned"})
+	assert.Check(t, cmp.Equal(f.spawnCalls.Load(), int64(1)))
+
+	const loads = 5
+	for range loads {
+		f.load(ctxA, recorded)
+	}
+	assert.Check(t, cmp.Equal(f.spawnCalls.Load(), int64(1+loads)),
+		"a DoNotCache call is re-executed by every load, even in its own session")
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(1)),
+		"the untainted NotReplayable read below it stays on the cache path")
+
+	ctxB := f.ctxFor("session-b")
+	for range loads {
+		f.load(ctxB, recorded)
+	}
+	assert.Check(t, cmp.Equal(f.spawnCalls.Load(), int64(1+2*loads)),
+		"crossing the session boundary adds taint but changes nothing here")
+	assert.Check(t, cmp.Equal(f.liveReads.Load(), int64(2)),
+		"the NotReplayable read is still re-executed exactly once per session")
+}

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1299,6 +1299,116 @@ func (s *Server) ObjectTypeForID(ctx context.Context, id *call.ID) (ObjectType, 
 	return objType, ok, nil
 }
 
+// RecipeClassification describes the structural replay properties of a recipe.
+// A nil NotReplayable means every field reachable through the inputs that recipe
+// loading evaluates is replayable.
+type RecipeClassification struct {
+	NotReplayable *NotReplayableCall
+}
+
+// NotReplayableCall identifies a field that makes a recipe non-replayable.
+type NotReplayableCall struct {
+	Field  string
+	Digest digest.Digest
+	Reason string
+}
+
+// ClassifyRecipe structurally classifies id without evaluating it. The first
+// NotReplayable field is reported in recipe-loading traversal order. Lazy-ref
+// arguments are carried by reference during replay, so recipes reachable only
+// through those arguments do not affect the classification.
+//
+// Classification is best-effort. Handles, malformed recipes, and fields or
+// parent types that are not present in the current schema are not themselves
+// classified as non-replayable. Unknown fields' arguments are treated as
+// non-lazy, matching recipe loading behavior.
+func (s *Server) ClassifyRecipe(id *call.ID) RecipeClassification {
+	if c := s.canonical; c != nil {
+		return c.ClassifyRecipe(id)
+	}
+	classifier := newRecipeClassifier(s, func(_ *call.ID, fieldSpec FieldSpec) string {
+		return fieldSpec.NotReplayable
+	})
+	return RecipeClassification{NotReplayable: classifier.classify(id)}
+}
+
+type recipeClassifier struct {
+	srv   *Server
+	match func(*call.ID, FieldSpec) string
+
+	mu   sync.Mutex
+	memo map[string]*NotReplayableCall
+}
+
+func newRecipeClassifier(srv *Server, match func(*call.ID, FieldSpec) string) *recipeClassifier {
+	return &recipeClassifier{
+		srv:   srv,
+		match: match,
+		memo:  make(map[string]*NotReplayableCall),
+	}
+}
+
+func (classifier *recipeClassifier) classify(id *call.ID) *NotReplayableCall {
+	if id == nil || id.IsHandle() {
+		return nil
+	}
+	key := id.Digest().String()
+	classifier.mu.Lock()
+	if cached, ok := classifier.memo[key]; ok {
+		classifier.mu.Unlock()
+		return cached
+	}
+	// A provisional replayable entry guards against cycles in malformed recipes.
+	classifier.memo[key] = nil
+	classifier.mu.Unlock()
+
+	var first *NotReplayableCall
+	if fieldSpec, ok := classifier.srv.recipeFieldSpec(id); ok {
+		if reason := classifier.match(id, fieldSpec); reason != "" {
+			first = &NotReplayableCall{
+				Field:  id.Field(),
+				Digest: id.Digest(),
+				Reason: reason,
+			}
+		}
+	}
+
+	lazyRefs := classifier.srv.lazyRefArgNames(id)
+	for _, input := range classifier.srv.directRecipeInputIDs(id, lazyRefs) {
+		inputMatch := classifier.classify(input)
+		if first == nil && inputMatch != nil {
+			first = inputMatch
+		}
+	}
+
+	classifier.mu.Lock()
+	classifier.memo[key] = first
+	classifier.mu.Unlock()
+	return first
+}
+
+func (s *Server) recipeFieldSpec(id *call.ID) (FieldSpec, bool) {
+	if id == nil || id.IsHandle() {
+		return FieldSpec{}, false
+	}
+	parentType := "Query"
+	if receiver := id.Receiver(); receiver != nil {
+		if t := receiver.Type(); t != nil {
+			parentType = t.NamedType()
+		} else {
+			return FieldSpec{}, false
+		}
+	}
+	if parentType == "" {
+		return FieldSpec{}, false
+	}
+	objType, ok := s.ObjectType(parentType)
+	if !ok {
+		return FieldSpec{}, false
+	}
+	return objType.FieldSpec(id.Field(), id.View())
+}
+
 // Load loads the object with the given ID.
 func (s *Server) Load(ctx context.Context, id *call.ID) (AnyObjectResult, error) {
 	ctx = srvToContext(ctx, s)
@@ -1415,9 +1525,8 @@ func (s *Server) LoadType(ctx context.Context, id *call.ID) (_ AnyResult, rerr e
 		cache:     cache,
 		sessionID: clientMetadata.SessionID,
 		loads:     make(map[string]*recipeLoadFuture),
-
-		notReplayableMemo: make(map[string]bool),
 	}
+	state.notReplayable = newRecipeClassifier(s, state.notReplayableReason)
 	return state.load(id)
 }
 
@@ -1436,8 +1545,7 @@ type recipeLoadState struct {
 	mu    sync.Mutex
 	loads map[string]*recipeLoadFuture
 
-	notReplayableMu   sync.Mutex
-	notReplayableMemo map[string]bool
+	notReplayable *recipeClassifier
 }
 
 func (state *recipeLoadState) load(id *call.ID) (AnyResult, error) {
@@ -1467,98 +1575,21 @@ func (state *recipeLoadState) load(id *call.ID) (AnyResult, error) {
 	return future.res, future.err
 }
 
-// notReplayable reports whether this recorded call must be re-executed rather
-// than resolved from the cache, because its own field is marked
-// [FieldSpec.NotReplayable] or because some recorded call it depends on is.
-//
-// The taint has to propagate upward, not just apply to the marked node: the
-// digest lookup in loadRecipeVertex happens BEFORE the call's inputs are
-// loaded, so a hit short-circuits the whole subtree beneath it. Without
-// propagation, an ancestor whose digest is still in the cache would be served
-// wholesale and the marked call underneath it would never be reached.
-//
-// Structural only — nothing is evaluated, and results are memoized per load.
-//
-// Concurrency: the provisional-false entry planted below is only observable
-// while the DFS that planted it is still running. That is safe because the
-// root vertex computes its full transitive closure here — synchronously,
-// before loadRecipeVertex fans out any concurrent input loads — so by the
-// time another goroutine consults the memo, every entry it can reach is
-// finalized. A vertex that starts a fresh traversal only does so for IDs
-// already finalized by the root's pass.
-func (state *recipeLoadState) notReplayable(id *call.ID) bool {
-	if id == nil || id.IsHandle() {
-		return false
-	}
-	key := id.Digest().String()
-	state.notReplayableMu.Lock()
-	if cached, ok := state.notReplayableMemo[key]; ok {
-		state.notReplayableMu.Unlock()
-		return cached
-	}
-	// Provisional false guards against cycles in a malformed recipe.
-	state.notReplayableMemo[key] = false
-	state.notReplayableMu.Unlock()
-
-	tainted := state.fieldNotReplayable(id)
-	if !tainted {
-		for _, input := range state.directRecipeInputIDs(id, state.lazyRefArgNames(id)) {
-			if state.notReplayable(input) {
-				tainted = true
-				break
-			}
-		}
-	}
-
-	state.notReplayableMu.Lock()
-	state.notReplayableMemo[key] = tainted
-	state.notReplayableMu.Unlock()
-	return tainted
-}
-
-// fieldNotReplayable resolves the recorded call's own field spec from the
-// schema, the same way lazyRefArgNames does, without evaluating anything.
-// Best-effort: a field that can't be resolved (e.g. a module type not
-// currently installed) is treated as replayable, preserving prior behavior.
-func (state *recipeLoadState) fieldNotReplayable(id *call.ID) bool {
-	parentType := "Query"
-	if receiver := id.Receiver(); receiver != nil {
-		if t := receiver.Type(); t != nil {
-			parentType = t.NamedType()
-		} else {
-			return false
-		}
-	}
-	if parentType == "" {
-		return false
-	}
-	objType, ok := state.srv.ObjectType(parentType)
-	if !ok {
-		return false
-	}
-	fieldSpec, ok := objType.FieldSpec(id.Field(), id.View())
-	if !ok {
-		return false
-	}
+// notReplayableReason reports whether the recorded call's own field must be
+// re-executed in this loading session. The shared recipeClassifier propagates
+// that classification through every input recipe loading evaluates.
+func (state *recipeLoadState) notReplayableReason(id *call.ID, fieldSpec FieldSpec) string {
 	if fieldSpec.NotReplayable == "" {
-		return false
+		return ""
 	}
-	// Marked, but only actually unsafe when this recorded call came from a
-	// different session. Replaying a host read or a client-bound value inside
-	// the session that produced it is fine: the client is still alive and its
-	// view of the host has not been swapped out from under the recipe. It is
-	// crossing the session boundary that turns the recorded digest into a
-	// stable key for a value that no longer means anything here.
-	//
-	// Scoping on the recorded session stamp keeps ordinary same-session recipe
-	// loads — container chains built from a host directory, and every other ID
-	// threaded through the API — on their normal cache path.
+	// A marked call is only unsafe when it came from another session.
+	// Same-session recipe loads can still use the value while its client and
+	// view of the host are alive. Without a recorded stamp, stay conservative.
 	recorded, ok := recordedSessionStamp(id)
-	if !ok {
-		// No stamp to compare: stay conservative and re-execute.
-		return true
+	if !ok || recorded != state.sessionID {
+		return fieldSpec.NotReplayable
 	}
-	return recorded != state.sessionID
+	return ""
 }
 
 // recordedSessionStamp returns the session ID baked into the recorded call by
@@ -1579,7 +1610,7 @@ func recordedSessionStamp(id *call.ID) (string, bool) {
 
 func (state *recipeLoadState) loadRecipeVertex(id *call.ID) (AnyResult, error) {
 	callCtx := state.ctx
-	replayable := !state.notReplayable(id)
+	replayable := state.notReplayable.classify(id) == nil
 	if replayable {
 		if hit, ok, err := state.cache.lookupCacheForDigests(callCtx, state.sessionID, state.srv, id.Digest(), id.ExtraDigests()); err != nil {
 			return nil, fmt.Errorf("load %s: fast cache lookup: %w", idInputDebugString(id), err)
@@ -1603,9 +1634,9 @@ func (state *recipeLoadState) loadRecipeVertex(id *call.ID) (AnyResult, error) {
 	// Lazy-ref args (e.g. LLM.withTools(object:)) are carried by reference:
 	// not evaluated here, and reconstructed into the frame/selector as
 	// unevaluated recipe IDs. Computed once and threaded through.
-	lazyRefs := state.lazyRefArgNames(id)
+	lazyRefs := state.srv.lazyRefArgNames(id)
 
-	inputIDs := state.directRecipeInputIDs(id, lazyRefs)
+	inputIDs := state.srv.directRecipeInputIDs(id, lazyRefs)
 	loadedInputs := make(map[string]AnyResult, len(inputIDs))
 	var loadedMu sync.Mutex
 	eg, _ := errgroup.WithContext(state.ctx)
@@ -1659,7 +1690,7 @@ func (state *recipeLoadState) loadRecipeVertex(id *call.ID) (AnyResult, error) {
 	return baseObj.Select(callCtx, state.srv, sel)
 }
 
-func (state *recipeLoadState) directRecipeInputIDs(id *call.ID, lazyRefs map[string]bool) []*call.ID {
+func (s *Server) directRecipeInputIDs(id *call.ID, lazyRefs map[string]bool) []*call.ID {
 	if id == nil || id.IsHandle() {
 		return nil
 	}
@@ -1698,26 +1729,11 @@ func (state *recipeLoadState) directRecipeInputIDs(id *call.ID, lazyRefs map[str
 // without evaluating anything. Best-effort: if the field or its type can't be
 // resolved from the schema (e.g. a module type not currently installed), the
 // arguments are treated as normal (evaluated), preserving prior behavior.
-func (state *recipeLoadState) lazyRefArgNames(id *call.ID) map[string]bool {
+func (s *Server) lazyRefArgNames(id *call.ID) map[string]bool {
 	if id == nil || id.IsHandle() || len(id.Args()) == 0 {
 		return nil
 	}
-	var parentType string
-	if receiver := id.Receiver(); receiver != nil {
-		if t := receiver.Type(); t != nil {
-			parentType = t.NamedType()
-		}
-	} else {
-		parentType = "Query"
-	}
-	if parentType == "" {
-		return nil
-	}
-	objType, ok := state.srv.ObjectType(parentType)
-	if !ok {
-		return nil
-	}
-	fieldSpec, ok := objType.FieldSpec(id.Field(), id.View())
+	fieldSpec, ok := s.recipeFieldSpec(id)
 	if !ok {
 		return nil
 	}

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -1249,6 +1249,56 @@ func interfaceFieldsPresent(iface *Interface, objectType ObjectType, view call.V
 	return true
 }
 
+// ObjectTypeForID resolves the object type named by id without evaluating the
+// object itself. When the current schema does not carry the type, a recipe's
+// module provenance is loaded and used to rebuild the dependency-aware schema
+// that defined it.
+func (s *Server) ObjectTypeForID(ctx context.Context, id *call.ID) (ObjectType, bool, error) {
+	if id == nil || id.Type() == nil {
+		return nil, false, nil
+	}
+	typeName := id.Type().NamedType()
+	if objType, ok := s.ObjectType(typeName); ok {
+		return objType, true, nil
+	}
+	if id.IsHandle() || id.Module() == nil || id.Module().ID() == nil || s.resultServerForCall == nil {
+		return nil, false, nil
+	}
+
+	moduleResult, err := s.LoadType(ctx, id.Module().ID())
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve object type %q module: %w", typeName, err)
+	}
+	if moduleResult == nil {
+		return nil, false, fmt.Errorf("resolve object type %q module: result is null", typeName)
+	}
+	shared := moduleResult.cacheSharedResult()
+	if shared == nil || shared.id == 0 {
+		return nil, false, fmt.Errorf("resolve object type %q module: result is not attached", typeName)
+	}
+	resultCall := &ResultCall{
+		Kind:  ResultCallKindField,
+		Type:  NewResultCallType(id.Type().ToAST()),
+		Field: id.Field(),
+		View:  id.View(),
+		Module: &ResultCallModule{
+			ResultRef: &ResultCallRef{ResultID: uint64(shared.id), shared: shared},
+			Name:      id.Module().Name(),
+			Ref:       id.Module().Ref(),
+			Pin:       id.Module().Pin(),
+		},
+	}
+	resolved, err := s.resultServerForCall(ctx, resultCall)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve object type %q schema: %w", typeName, err)
+	}
+	if resolved == nil {
+		return nil, false, nil
+	}
+	objType, ok := resolved.ObjectType(typeName)
+	return objType, ok, nil
+}
+
 // Load loads the object with the given ID.
 func (s *Server) Load(ctx context.Context, id *call.ID) (AnyObjectResult, error) {
 	ctx = srvToContext(ctx, s)


### PR DESCRIPTION
Extracted from the `llm-workspace-dev-env` stack (PR A of the extraction series; independent of the others).

Makes recipe loading and re-execution behavior explicit in DagQL: defines recipe replay semantics with coverage for the call-ID, literal, and UI extraction cases that depend on it, and adds `NotReplayable` recipe classification (`Server.ClassifyRecipe`) so a caller can find the first field that makes a recorded recipe unsafe to replay. `Host.directory`, `CacheVolume` reads, and the current-client workspace are marked non-replayable.

No public GraphQL API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgJumuDQNviWmF35dMxsEm
