### PR TITLE
llm: resolve subscription OAuth credentials per request

### DIFF
--- a/core/llm.go
+++ b/core/llm.go
@@ -133,6 +133,16 @@ type LLMEndpoint struct {
 	AuthToken string
 	IsOAuth   bool
 
+	// AuthTokenSource, when set, supersedes AuthToken at request time: the
+	// endpoint's HTTP client asks it for the current bearer token before
+	// every provider request and overwrites the Authorization header with
+	// the result. Subscription OAuth access tokens expire within the hour
+	// and are rotated behind the session, so the snapshot AuthToken holds
+	// goes stale in any long-running conversation. AuthToken is kept as the
+	// value observed when the endpoint was routed (used for the SDK's own
+	// construction-time setup and as the fallback when no source is set).
+	AuthTokenSource *CredentialSource
+
 	// ReasoningEffort is the reasoning level (e.g. "low"/"medium"/"high",
 	// sourced from catwalk's per-model levels) for providers that support
 	// reasoning. Each provider maps it onto its native effort parameter
@@ -608,6 +618,15 @@ type LLMRouter struct {
 	// (see LLM.Endpoint) must run through that client's session. Set by
 	// loadLLMRouter; nil when the router was built for a single client.
 	localClient *engine.ClientMetadata
+
+	// reloadAnthropicAuthToken / reloadCodexAuthToken re-run the lookup that
+	// supplied each subscription OAuth token, against the client that
+	// supplied it. They are what makes a token a live credential rather than
+	// a snapshot: the client's secret provider re-reads (and, for the CLI,
+	// refreshes) the token on every resolution, so asking again at request
+	// time yields the current one. Nil when no token was configured.
+	reloadAnthropicAuthToken credentialResolver
+	reloadCodexAuthToken     credentialResolver
 }
 
 func (r *LLMRouter) isAnthropicModel(model string) bool {
@@ -664,6 +683,7 @@ func (r *LLMRouter) routeAnthropicModel() *LLMEndpoint {
 		Provider:        Anthropic,
 		AuthToken:       r.AnthropicAuthToken,
 		IsOAuth:         r.AnthropicIsOAuth,
+		AuthTokenSource: newCredentialSource(r.reloadAnthropicAuthToken),
 		ReasoningEffort: r.AnthropicReasoningEffort,
 	}
 	endpoint.Client = newAnthropicClient(endpoint)
@@ -689,6 +709,7 @@ func (r *LLMRouter) routeCodexModel() *LLMEndpoint {
 		Provider:        OpenAICodex,
 		AuthToken:       r.OpenAICodexAuthToken,
 		IsOAuth:         true,
+		AuthTokenSource: newCredentialSource(r.reloadCodexAuthToken),
 		ReasoningEffort: r.OpenAICodexReasoningEffort,
 	}
 	endpoint.Client = newOpenAICodexClient(endpoint)
@@ -872,7 +893,7 @@ func (r *LLMRouter) Route(model, provider string) (*LLMEndpoint, error) {
 
 func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context, string) (string, error)) (suppliedLocal bool, _ error) {
 	if getenv == nil {
-		getenv = func(_ context.Context, key string) (string, error) { //nolint:unparam
+		getenv = func(_ context.Context, key string) (string, error) {
 			return os.Getenv(key), nil
 		}
 	}
@@ -916,6 +937,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 		}
 		if v != "" {
 			r.AnthropicAuthToken = v
+			r.reloadAnthropicAuthToken = credentialReloader(getenv, "ANTHROPIC_AUTH_TOKEN")
 			anthropicTokenSet = true
 		}
 		return nil
@@ -940,7 +962,15 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	eg.Go(func() error {
 		// OAuth (ChatGPT subscription) bearer token for the Codex Responses API,
 		// exported client-side from the persisted llmconfig by `dagger llm`.
-		return save("OPENAI_CODEX_AUTH_TOKEN", &r.OpenAICodexAuthToken)
+		var v string
+		if err := save("OPENAI_CODEX_AUTH_TOKEN", &v); err != nil {
+			return err
+		}
+		if v != "" {
+			r.OpenAICodexAuthToken = v
+			r.reloadCodexAuthToken = credentialReloader(getenv, "OPENAI_CODEX_AUTH_TOKEN")
+		}
+		return nil
 	})
 	eg.Go(func() error {
 		return save("OPENAI_CODEX_MODEL", &r.OpenAICodexModel)
@@ -1010,6 +1040,7 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 	// the Anthropic client prefers OAuth whenever a token is present.
 	if anthropicKeySet && !anthropicTokenSet {
 		r.AnthropicAuthToken = ""
+		r.reloadAnthropicAuthToken = nil
 	}
 	if anthropicTokenSet && !anthropicKeySet {
 		r.AnthropicAPIKey = ""
@@ -1027,6 +1058,19 @@ func (r *LLMRouter) LoadConfig(ctx context.Context, getenv func(context.Context,
 // set on the router, so configuration can be layered — e.g. the session's main
 // client as the base with the calling client's own values on top.
 func (r *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) (suppliedLocal bool, _ error) {
+	// Pin the client whose configuration this load reads. The getenv closure
+	// below outlives this call — a credential reloader keeps it to re-resolve
+	// a rotated OAuth token at request time — and by then the ambient context
+	// belongs to whichever client is making the LLM call, which may be a
+	// different (e.g. nested) client that cannot see this one's environment.
+	loadClient, clientErr := engine.ClientMetadataFromContext(ctx)
+	bindClient := func(ctx context.Context) context.Context {
+		if clientErr != nil {
+			return ctx
+		}
+		return engine.ContextWithClientMetadata(ctx, loadClient)
+	}
+
 	// Get the secret plaintext, from either a URI (provider lookup) or a plaintext (no-op)
 	loadSecret := func(ctx context.Context, uriOrPlaintext string) (string, error) {
 		if _, _, err := secretprovider.ResolverForID(uriOrPlaintext); err == nil {
@@ -1056,6 +1100,7 @@ func (r *LLMRouter) LoadClientConfig(ctx context.Context, srv *dagql.Server) (su
 		}
 	}
 	return r.LoadConfig(ctx, func(ctx context.Context, k string) (string, error) {
+		ctx = bindClient(ctx)
 		// First lookup in the .env file
 		if v, ok := env[k]; ok {
 			return loadSecret(ctx, v)
@@ -1149,6 +1194,24 @@ func loadLLMRouter(ctx context.Context, query *Query) (_ *LLMRouter, rerr error)
 	if err := loadFrom(parentClient); err != nil {
 		return nil, err
 	}
+
+	// Re-resolution of a credential must outlive this call. The endpoint this
+	// router routes is memoized for the whole conversation and re-asked on
+	// every provider request — including by an agent loop still stepping long
+	// after the request that first routed it completed — so binding resolution
+	// to this call's context would make the credential die with it. Scope it
+	// to the session instead, the same way the local-LLM tunnel is (see
+	// LLM.Endpoint), so it lives exactly as long as the client that supplies
+	// it. The scope is taken against the parent client, which is a session
+	// client by construction, rather than the possibly-module ambient one.
+	sessionCtx, err := query.Server.SessionScopedContext(
+		engine.ContextWithClientMetadata(ctx, parentClient))
+	if err != nil {
+		return nil, fmt.Errorf("LLM credentials: session context: %w", err)
+	}
+	router.reloadAnthropicAuthToken = router.reloadAnthropicAuthToken.detach(sessionCtx)
+	router.reloadCodexAuthToken = router.reloadCodexAuthToken.detach(sessionCtx)
+
 	return router, nil
 }
 
@@ -1184,13 +1247,18 @@ func (*LLM) Type() *ast.Type {
 }
 
 func (llm *LLM) Clone() *LLM {
+	// Read under the lock: llm may be a persistent, shared value whose
+	// endpoint another goroutine is resolving right now — a detached agent
+	// loop cloning per step against the CLI's status line resolving the model
+	// on the same node.
+	llm.endpointMtx.Lock()
 	cp := *llm
+	llm.endpointMtx.Unlock()
 	// The messages themselves stay shared with the receiver and any other
 	// clones, so they must be treated as immutable: copy-on-write via
 	// LLMMessage.Clone before modifying one.
 	cp.Messages = slices.Clone(cp.Messages)
 	cp.mcp = cp.mcp.Clone()
-	cp.endpoint = llm.endpoint
 	cp.endpointMtx = &sync.Mutex{}
 	return &cp
 }
@@ -1355,9 +1423,8 @@ func (llm *LLM) WithModel(model, provider string) *LLM {
 	llm = llm.Clone()
 	llm.model = model
 	llm.provider = provider
-
-	llm.endpointMtx.Lock()
-	defer llm.endpointMtx.Unlock()
+	// No lock: the clone is not shared with anyone yet, and locking its own
+	// fresh mutex would protect nothing.
 	llm.endpoint = nil
 
 	return llm
@@ -1369,9 +1436,6 @@ func (llm *LLM) WithModel(model, provider string) *LLM {
 func (llm *LLM) WithReasoningEffort(effort string) *LLM {
 	llm = llm.Clone()
 	llm.reasoningEffort = effort
-
-	llm.endpointMtx.Lock()
-	defer llm.endpointMtx.Unlock()
 	llm.endpoint = nil
 
 	return llm
@@ -1768,10 +1832,14 @@ func (llm *LLM) sendQueryWithRetry(ctx context.Context, messages []*LLMMessage, 
 	if err != nil {
 		return nil, err
 	}
-	client := ep.Client
 
 	var res *LLMResponse
+	var authRetried bool
 	err = backoff.Retry(func() error {
+		// Read the client inside the retry: recovering from a rejected
+		// credential is only worth anything if the next attempt picks up what
+		// the recovery changed.
+		client := ep.Client
 		var sendErr error
 		// The provider streams this turn's content into its own per-block display
 		// spans (thinking, response, tool calls); it sets the call digest on them
@@ -1786,6 +1854,20 @@ func (llm *LLM) sendQueryWithRetry(ctx context.Context, messages []*LLMMessage, 
 			if errors.As(sendErr, &finished) {
 				// Don't retry if the model finished explicitly, treat as permanent.
 				return backoff.Permanent(sendErr)
+			}
+			if isAuthFailure(sendErr) {
+				// A credential that rotated out from under a long conversation
+				// is worth exactly one retry: drop the cached one so the next
+				// attempt resolves a fresh token from the client. Exactly one,
+				// because a login that is really revoked would otherwise spin
+				// the backoff for its full MaxElapsedTime before telling the
+				// user the one thing they can act on.
+				if authRetried || ep.AuthTokenSource == nil {
+					return backoff.Permanent(ep.credentialError(sendErr))
+				}
+				authRetried = true
+				ep.AuthTokenSource.Invalidate()
+				return sendErr
 			}
 			if !client.IsRetryable(sendErr) {
 				// Maybe an invalid request - give up.

--- a/core/llm_anthropic.go
+++ b/core/llm_anthropic.go
@@ -26,7 +26,10 @@ func newAnthropicClient(endpoint *LLMEndpoint) *AnthropicClient {
 	case endpoint.IsOAuth:
 		// Claude Code subscription OAuth: bearer token + Claude Code identity
 		// headers. The endpoint rejects requests that don't look like Claude
-		// Code (see also the system-prompt injection in SendQuery).
+		// Code (see also the system-prompt injection in SendQuery). The token
+		// baked in here is only the value observed at construction; when the
+		// endpoint carries a credential source, credentialTransport overwrites
+		// the header with the current token on every request.
 		opts = append(opts,
 			option.WithAuthToken(endpoint.AuthToken),
 			option.WithHeader("anthropic-beta", "claude-code-20250219,oauth-2025-04-20"),
@@ -58,6 +61,10 @@ var anthropicRetryable = []string{
 	"Internal server error",
 }
 
+// IsRetryable reports whether a failed turn is worth resending. A rejected
+// credential is deliberately absent from the list: it is only retryable once
+// the credential has been re-resolved, so that case is handled centrally (see
+// sendQueryWithRetry).
 func (c *AnthropicClient) IsRetryable(err error) bool {
 	msg := err.Error()
 	for _, retryable := range anthropicRetryable {

--- a/core/llm_auth_test.go
+++ b/core/llm_auth_test.go
@@ -1,0 +1,535 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+)
+
+// llmEndpointTestServer is the minimal Query.Server an LLM.Endpoint()
+// resolution needs: a dagql server to run the `secret(uri:){plaintext}`
+// lookups against, and one client identity to load config from (so
+// loadLLMRouter's main-client/parent-client layering collapses to a single
+// load).
+type llmEndpointTestServer struct {
+	*mockServer
+	srv *dagql.Server
+	md  *engine.ClientMetadata
+}
+
+func (s *llmEndpointTestServer) Server(context.Context) (*dagql.Server, error) {
+	return s.srv, nil
+}
+
+func (s *llmEndpointTestServer) MainClientCallerMetadata(context.Context) (*engine.ClientMetadata, error) {
+	return s.md, nil
+}
+
+func (s *llmEndpointTestServer) NonModuleParentClientMetadata(context.Context) (*engine.ClientMetadata, error) {
+	return s.md, nil
+}
+
+// llmEnv is a mutable stand-in for the client's environment, so a test can
+// rotate ANTHROPIC_AUTH_TOKEN mid-"session" the way the CLI's env refresher
+// does when the OAuth access token expires.
+type llmEnv struct {
+	mu   sync.Mutex
+	vars map[string]string
+	// reads counts env:// lookups, i.e. how often the engine actually went
+	// back to the client for a value.
+	reads map[string]int
+}
+
+func (e *llmEnv) get(uri string) string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.reads[uri]++
+	return e.vars[uri]
+}
+
+func (e *llmEnv) set(uri, val string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.vars[uri] = val
+}
+
+func (e *llmEnv) readCount(uri string) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.reads[uri]
+}
+
+// newLLMEndpointTestCtx wires a context in which (*LLM).Endpoint resolves for
+// real: it routes through loadLLMRouter -> LoadClientConfig -> the mocked
+// `secret(uri:){plaintext}` selection, reading from the returned llmEnv.
+func newLLMEndpointTestCtx(t *testing.T) (context.Context, *llmEnv) {
+	t.Helper()
+
+	env := &llmEnv{
+		vars: map[string]string{
+			"file://.env":                "",
+			"env://ANTHROPIC_AUTH_TOKEN": "token-v1",
+			"env://ANTHROPIC_MODEL":      "claude-sonnet-4-5",
+		},
+		reads: map[string]int{},
+	}
+
+	// Mirror the real secret schema's cache semantics (core/schema/secret.go):
+	// `secret(uri:)` is PerCallInput and `plaintext` is DoNotCache, so every
+	// resolution really does go back to the client — which is what the CLI's
+	// env refresher hook relies on.
+	srv := newCoreDagqlServerForTest(t, LLMTestQuery{})
+	dagql.Fields[LLMTestQuery]{
+		dagql.Func("secret", func(_ context.Context, _ LLMTestQuery, args struct {
+			URI string
+		}) (mockSecret, error) {
+			return mockSecret{uri: args.URI}, nil
+		}).WithInput(dagql.PerCallInput),
+	}.Install(srv)
+	dagql.Fields[mockSecret]{
+		dagql.Func("plaintext", func(_ context.Context, self mockSecret, _ struct{}) (string, error) {
+			return env.get(self.uri), nil
+		}).DoNotCache("plaintext is read fresh from the client"),
+	}.Install(srv)
+
+	cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+	require.NoError(t, err)
+
+	md := &engine.ClientMetadata{ClientID: "llm-test-client", SessionID: "llm-test-session"}
+	query := &Query{Server: &llmEndpointTestServer{
+		mockServer: &mockServer{clientMetadata: md},
+		srv:        srv,
+		md:         md,
+	}}
+
+	ctx := dagql.ContextWithCache(engine.ContextWithClientMetadata(t.Context(), md), cache)
+	return ContextWithQuery(ctx, query), env
+}
+
+// anthropic401Server is a stand-in provider that rejects everything, recording
+// the credential each request carried. A 401 body is all the SDK needs to
+// produce a typed API error, and it keeps the tests off the streaming happy
+// path — what is under test is which token went out, not what came back.
+func anthropic401Server(t *testing.T, onRequest func(auth string)) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		onRequest(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		//nolint:errcheck
+		w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired"}}`))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func llmTestHistory() []*LLMMessage {
+	return []*LLMMessage{{
+		Role:    LLMMessageRoleUser,
+		Content: []*LLMContentBlock{{Kind: LLMContentText, Text: "hi"}},
+	}}
+}
+
+// TestLLMEndpointResolvesCredentialPerRequest is the core of the fix. The
+// endpoint stays memoized — re-routing costs a full config load, ~21 variables
+// at two client round-trips each — but the credential is no longer part of
+// what gets memoized: the endpoint's transport asks its source per request, so
+// a token the client rotated mid-session reaches the provider without anything
+// rebuilding the endpoint or the SDK client.
+func TestLLMEndpointResolvesCredentialPerRequest(t *testing.T) {
+	ctx, env := newLLMEndpointTestCtx(t)
+	query, err := CurrentQuery(ctx)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var seen []string
+	ts := anthropic401Server(t, func(auth string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, auth)
+	})
+	env.set("env://ANTHROPIC_BASE_URL", ts.URL)
+
+	llm, err := query.NewLLM(ctx, "claude-sonnet-4-5", "")
+	require.NoError(t, err)
+
+	ep, err := llm.Endpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, Anthropic, ep.Provider)
+	require.True(t, ep.IsOAuth)
+	require.NotNil(t, ep.AuthTokenSource)
+	assert.Equal(t, "token-v1", ep.AuthToken, "the snapshot observed at routing time")
+
+	clk := newTestClock()
+	ep.AuthTokenSource.now = clk.Now
+
+	_, err = ep.Client.SendQuery(ctx, llmTestHistory(), nil, &LLMCallOpts{})
+	require.Error(t, err)
+
+	// The client refreshes the expired access token (secretprovider's
+	// EnvRefresher hook + os.Setenv, engine/client/secretprovider/env.go).
+	env.set("env://ANTHROPIC_AUTH_TOKEN", "token-v2")
+	clk.Advance(credentialRefreshTTL + time.Second)
+
+	_, err = ep.Client.SendQuery(ctx, llmTestHistory(), nil, &LLMCallOpts{})
+	require.Error(t, err)
+
+	mu.Lock()
+	require.Equal(t, []string{"Bearer token-v1", "Bearer token-v2"}, seen)
+	mu.Unlock()
+
+	// The memo is intact — that is deliberate, and no longer costs freshness.
+	again, err := llm.Endpoint(ctx)
+	require.NoError(t, err)
+	assert.Same(t, ep, again)
+	assert.Equal(t, "token-v1", again.AuthToken,
+		"the routing-time snapshot is unchanged; only the transport is live")
+
+	// Clone() copies the endpoint pointer, and every LLM transition —
+	// withPrompt, withResponse, withToolResult, step, loop, fork — goes
+	// through it, so the whole conversation shares the one live source.
+	t.Run("clones share the live credential", func(t *testing.T) {
+		next := llm.WithPrompt("hello").
+			WithResponse([]*LLMContentBlock{{Kind: LLMContentText, Text: "hi"}}, LLMTokenUsage{}).
+			WithToolResult("call_1", "ok", false).
+			Clone()
+		epNext, err := next.Endpoint(ctx)
+		require.NoError(t, err)
+		assert.Same(t, ep, epNext)
+
+		env.set("env://ANTHROPIC_AUTH_TOKEN", "token-v3")
+		clk.Advance(credentialRefreshTTL + time.Second)
+		_, err = epNext.Client.SendQuery(ctx, llmTestHistory(), nil, &LLMCallOpts{})
+		require.Error(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, "Bearer token-v3", seen[len(seen)-1])
+	})
+
+	// withModel/withReasoningEffort still drop the memo (the route itself
+	// changes), and re-derive against the current environment.
+	t.Run("withModel re-routes", func(t *testing.T) {
+		ep, err := llm.WithModel("claude-sonnet-4-5", "").Endpoint(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "token-v3", ep.AuthToken)
+	})
+}
+
+// TestLLMEndpointHonorsReportedExpiry runs the *_EXPIRES_AT contract
+// end-to-end: the client exports the token's true expiry beside it, and the
+// engine holds the credential until one margin before that instant — far past
+// the blind 30s TTL, which is all it can do when the expiry is unknown.
+func TestLLMEndpointHonorsReportedExpiry(t *testing.T) {
+	ctx, env := newLLMEndpointTestCtx(t)
+	query, err := CurrentQuery(ctx)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var seen []string
+	ts := anthropic401Server(t, func(auth string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, auth)
+	})
+	env.set("env://ANTHROPIC_BASE_URL", ts.URL)
+
+	// The login has three minutes left on it: short of credentialMaxTTL, so
+	// the reported expiry is what governs the horizon here.
+	clk := newTestClock()
+	const lifetime = 3 * time.Minute
+	env.set("env://ANTHROPIC_AUTH_TOKEN_EXPIRES_AT",
+		clk.Now().Add(lifetime).Format(time.RFC3339))
+
+	llm, err := query.NewLLM(ctx, "claude-sonnet-4-5", "")
+	require.NoError(t, err)
+	ep, err := llm.Endpoint(ctx)
+	require.NoError(t, err)
+	ep.AuthTokenSource.now = clk.Now
+
+	send := func() {
+		_, err := ep.Client.SendQuery(ctx, llmTestHistory(), nil, &LLMCallOpts{})
+		require.Error(t, err)
+	}
+	send()
+
+	// A rotation nobody announced stays invisible until the cached credential
+	// reaches its horizon, which is a whole margin before the expiry and many
+	// TTLs after the resolution.
+	env.set("env://ANTHROPIC_AUTH_TOKEN", "token-v2")
+	clk.Advance(lifetime - credentialExpiryMargin - time.Second)
+	send()
+	clk.Advance(2 * time.Second)
+	send()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{
+		"Bearer token-v1",
+		"Bearer token-v1",
+		"Bearer token-v2",
+	}, seen)
+
+	reads := env.readCount("env://ANTHROPIC_AUTH_TOKEN_EXPIRES_AT")
+	assert.Positive(t, reads, "the expiry must be read alongside the token")
+}
+
+// TestLLMAuthFailureRetriesOnceWithFreshToken covers 401 recovery: the token
+// died mid-conversation, the client already has its replacement, and the turn
+// should survive. Exactly one retry — a login that is genuinely revoked must
+// fail fast with something the user can act on, not spin the backoff for two
+// minutes and then report "401 authentication_error".
+func TestLLMAuthFailureRetriesOnceWithFreshToken(t *testing.T) {
+	ctx, env := newLLMEndpointTestCtx(t)
+	query, err := CurrentQuery(ctx)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var seen []string
+	ts := anthropic401Server(t, func(auth string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, auth)
+		// The CLI refreshed in the background; the engine is still holding
+		// the token it cached before that happened.
+		env.set("env://ANTHROPIC_AUTH_TOKEN", "token-v2")
+	})
+	env.set("env://ANTHROPIC_BASE_URL", ts.URL)
+
+	llm, err := query.NewLLM(ctx, "claude-sonnet-4-5", "")
+	require.NoError(t, err)
+
+	_, err = llm.sendQueryWithRetry(ctx, llmTestHistory(), nil, "", 0)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "dagger llm setup",
+		"an expired subscription login must say what to do about it")
+	assert.ErrorContains(t, err, string(Anthropic))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"Bearer token-v1", "Bearer token-v2"}, seen,
+		"the retry must carry the re-resolved token, and there must be only one")
+}
+
+// TestLLMAuthFailureWithoutSourceIsPermanent: with no credential source there
+// is nothing to re-resolve, so a 401 fails immediately — an API-key setup and
+// CI behave exactly as before.
+func TestLLMAuthFailureWithoutSourceIsPermanent(t *testing.T) {
+	var mu sync.Mutex
+	var requests int
+	ts := anthropic401Server(t, func(string) {
+		mu.Lock()
+		defer mu.Unlock()
+		requests++
+	})
+
+	endpoint := &LLMEndpoint{
+		Model:    "claude-sonnet-4-5",
+		BaseURL:  ts.URL,
+		Provider: Anthropic,
+		Key:      "sk-plain",
+	}
+	endpoint.Client = newAnthropicClient(endpoint)
+
+	llm := &LLM{endpoint: endpoint, endpointMtx: &sync.Mutex{}, mcp: newMCP()}
+	_, err := llm.sendQueryWithRetry(t.Context(), llmTestHistory(), nil, "", 0)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "dagger llm setup",
+		"an API key is the user's own env var; don't send them to the OAuth flow")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, requests)
+}
+
+// TestAnthropicClientWithoutSourceKeepsBakedToken is the invariant behind the
+// whole design: an SDK client captures its credential at construction, so an
+// endpoint without a source sends the token it was routed with forever, no
+// matter what is assigned to LLMEndpoint.AuthToken afterwards.
+func TestAnthropicClientWithoutSourceKeepsBakedToken(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	ts := anthropic401Server(t, func(auth string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, auth)
+	})
+
+	endpoint := &LLMEndpoint{
+		Model:     "claude-sonnet-4-5",
+		BaseURL:   ts.URL,
+		Provider:  Anthropic,
+		AuthToken: "token-v1",
+		IsOAuth:   true,
+	}
+	client := newAnthropicClient(endpoint)
+
+	_, err := client.SendQuery(t.Context(), llmTestHistory(), nil, &LLMCallOpts{})
+	require.Error(t, err)
+	assert.True(t, isAuthFailure(err), "a 401 must be recognizable as such: %v", err)
+	assert.False(t, client.IsRetryable(err),
+		"resending is only worth it once the credential has been re-resolved")
+
+	endpoint.AuthToken = "token-v2"
+	_, err = client.SendQuery(t.Context(), llmTestHistory(), nil, &LLMCallOpts{})
+	require.Error(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, 2)
+	assert.Equal(t, "Bearer token-v1", seen[0])
+	assert.Equal(t, "Bearer token-v1", seen[1],
+		"the bearer token is captured at client construction, not read per request")
+}
+
+// TestCodexClientRotatesAccountIDWithToken is the Codex (ChatGPT subscription)
+// twin. Codex needs more than the header swapped: the required
+// chatgpt-account-id header is derived from the token's own JWT claims, so it
+// has to be recomputed whenever the token rotates.
+func TestCodexClientRotatesAccountIDWithToken(t *testing.T) {
+	type request struct{ auth, account string }
+	var mu sync.Mutex
+	var seen []request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, request{
+			auth:    r.Header.Get("Authorization"),
+			account: r.Header.Get("chatgpt-account-id"),
+		})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		//nolint:errcheck
+		w.Write([]byte(`{"detail":"Your authentication token has expired."}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	tokenV1 := codexTestToken(t, "acct-old")
+	tokenV2 := codexTestToken(t, "acct-new")
+
+	var current atomic.Pointer[string]
+	current.Store(&tokenV1)
+	clk := newTestClock()
+	endpoint := &LLMEndpoint{
+		Model:     "gpt-5.5",
+		BaseURL:   ts.URL,
+		Provider:  OpenAICodex,
+		AuthToken: tokenV1,
+		IsOAuth:   true,
+		AuthTokenSource: newTestCredentialSource(clk, func(context.Context) (Credential, error) {
+			return Credential{Token: *current.Load()}, nil
+		}),
+	}
+	client := newOpenAICodexClient(endpoint)
+
+	_, err := client.SendQuery(t.Context(), llmTestHistory(), nil, &LLMCallOpts{})
+	require.Error(t, err)
+	assert.True(t, isAuthFailure(err),
+		"the Codex error wrapper must keep the status classifiable: %v", err)
+
+	current.Store(&tokenV2)
+	clk.Advance(credentialRefreshTTL + time.Second)
+	_, err = client.SendQuery(t.Context(), llmTestHistory(), nil, &LLMCallOpts{})
+	require.Error(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, 2)
+	assert.Equal(t, "Bearer "+tokenV1, seen[0].auth)
+	assert.Equal(t, "acct-old", seen[0].account)
+	assert.Equal(t, "Bearer "+tokenV2, seen[1].auth)
+	assert.Equal(t, "acct-new", seen[1].account,
+		"the account id is derived from the token, so it must rotate with it")
+}
+
+// TestLLMCredentialResolvesAgainstLoadingClient guards the property that lets
+// a nested `dagger agent` use the session's LLM auth without ever holding
+// credentials: the reload runs against the client whose configuration supplied
+// the token, whoever happens to be making the request.
+func TestLLMCredentialResolvesAgainstLoadingClient(t *testing.T) {
+	srv := newCoreDagqlServerForTest(t, LLMTestQuery{})
+	dagql.Fields[LLMTestQuery]{
+		dagql.Func("secret", func(_ context.Context, _ LLMTestQuery, args struct {
+			URI string
+		}) (mockSecret, error) {
+			return mockSecret{uri: args.URI}, nil
+		}).WithInput(dagql.PerCallInput),
+	}.Install(srv)
+	dagql.Fields[mockSecret]{
+		dagql.Func("plaintext", func(ctx context.Context, self mockSecret, _ struct{}) (string, error) {
+			md, err := engine.ClientMetadataFromContext(ctx)
+			if err != nil {
+				return "", err
+			}
+			if self.uri == "env://ANTHROPIC_AUTH_TOKEN" {
+				return "token-of-" + md.ClientID, nil
+			}
+			return "", nil
+		}).DoNotCache("plaintext is read fresh from the client"),
+	}.Install(srv)
+
+	cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+	require.NoError(t, err)
+	withClient := func(id string) context.Context {
+		return dagql.ContextWithCache(engine.ContextWithClientMetadata(t.Context(),
+			&engine.ClientMetadata{ClientID: id, SessionID: "llm-test-session"}), cache)
+	}
+
+	router := new(LLMRouter)
+	_, err = router.LoadClientConfig(withClient("host"), srv)
+	require.NoError(t, err)
+	require.Equal(t, "token-of-host", router.AnthropicAuthToken)
+	require.NotNil(t, router.reloadAnthropicAuthToken)
+
+	// The request that needs the credential comes from a nested client, which
+	// has no login of its own. Resolution must still land on the host's.
+	cred, err := router.reloadAnthropicAuthToken(withClient("nested-agent"))
+	require.NoError(t, err)
+	assert.Equal(t, "token-of-host", cred.Token)
+}
+
+// TestLLMEndpointConcurrentCloneAndResolve exercises the Clone()/Endpoint()
+// pair the way a session actually does: a detached agent loop cloning per step
+// while the CLI's status line resolves the model on the same persistent node.
+// Worth little without -race, and worth a lot with it.
+func TestLLMEndpointConcurrentCloneAndResolve(t *testing.T) {
+	ctx, _ := newLLMEndpointTestCtx(t)
+	query, err := CurrentQuery(ctx)
+	require.NoError(t, err)
+
+	llm, err := query.NewLLM(ctx, "claude-sonnet-4-5", "")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := llm.Endpoint(ctx)
+			assert.NoError(t, err)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			clone := llm.Clone().WithPrompt("hi")
+			_, err := clone.Endpoint(ctx)
+			assert.NoError(t, err)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = llm.WithModel("claude-sonnet-4-5", "")
+		}()
+	}
+	wg.Wait()
+}

--- a/core/llm_credential.go
+++ b/core/llm_credential.go
@@ -1,0 +1,361 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go"
+)
+
+// Per-request credential resolution for LLM providers.
+//
+// A subscription OAuth access token lives about an hour and is rotated behind
+// the session by the CLI, but everything downstream of routing captures it:
+// a provider SDK client bakes the credential into its request options at
+// construction (option.WithAuthToken / option.WithAPIKey), and (*LLM).Endpoint
+// memoizes the routed endpoint for the life of a conversation. That memo is
+// deliberate — re-routing means reloading the whole router, ~21 variables at
+// two client round-trips each — so the fix is not to re-route more often but
+// to stop treating the credential as part of the route: the endpoint carries a
+// credential *source*, and the endpoint's HTTP transport asks it for the
+// current token before every provider request.
+//
+// The source caches, so the common case costs nothing extra, and exposes an
+// invalidation entry point so a 401 can force the next attempt back to the
+// client (see sendQueryWithRetry).
+
+const (
+	// credentialRefreshTTL bounds how long a credential of *unknown* expiry is
+	// reused. Resolving one round-trips to the client's session (env:// ->
+	// secret provider -> the CLI's OAuth refresher), which is cheap next to an
+	// LLM call but not free, and a streaming turn can issue several requests
+	// back-to-back. Short enough that a rotation is picked up within seconds,
+	// long enough to collapse a burst onto one resolution.
+	credentialRefreshTTL = 30 * time.Second
+
+	// credentialExpiryMargin is subtracted from a known expiry, so a token is
+	// replaced slightly before the provider stops accepting it. It covers the
+	// clock skew between client and engine plus the time between authenticating
+	// a request and the provider reading it.
+	credentialExpiryMargin = time.Minute
+
+	// credentialMaxTTL caps how long a credential is cached even when its
+	// expiry is an hour off. Expiry is not the only reason a token changes: a
+	// fresh `dagger llm setup`, or another process re-logging in, rotates it
+	// early, and a live session should follow within minutes rather than at the
+	// old token's expiry.
+	credentialMaxTTL = 5 * time.Minute
+
+	// credentialResolveTimeout bounds a single resolution. It runs detached
+	// from the request that needs it (see credentialResolver.detach) and the
+	// client's refresher hook may do a network round trip inside it, so without
+	// a bound a wedged token endpoint would hang the LLM call indefinitely.
+	credentialResolveTimeout = 30 * time.Second
+
+	// credentialExpiryEnvSuffix names the variable carrying a token's expiry:
+	// ANTHROPIC_AUTH_TOKEN -> ANTHROPIC_AUTH_TOKEN_EXPIRES_AT. The value is RFC
+	// 3339 UTC and is the true expiry with no safety margin baked in (the
+	// margin is applied here, at check time, so it can be tuned without
+	// rewriting what the client persisted). Absent, empty or unparseable means
+	// "unknown".
+	credentialExpiryEnvSuffix = "_EXPIRES_AT"
+)
+
+// Credential is a provider credential as observed at one point in time.
+type Credential struct {
+	// Token authenticates the request, as a bearer token.
+	Token string
+
+	// ExpiresAt is when the provider stops accepting Token, with no safety
+	// margin applied. Zero means the supplier didn't say — a plain API key, or
+	// a client that predates the expiry contract — in which case the cache
+	// falls back to credentialRefreshTTL instead of assuming a lifetime.
+	ExpiresAt time.Time
+}
+
+// credentialResolver fetches the current credential from its origin. For a
+// subscription OAuth token that origin is the client's session, so a
+// resolution is an RPC that also gives the client's refresher hook its chance
+// to run.
+type credentialResolver func(ctx context.Context) (Credential, error)
+
+// CredentialSource is an endpoint's live credential: it resolves the current
+// one on demand and caches it until shortly before it expires.
+//
+// Concurrent resolutions collapse onto one — parallel agents share an endpoint
+// and a streaming turn issues bursts — and a resolution that fails while a
+// previously resolved credential is in hand serves that one rather than
+// failing the request: a client that is momentarily unreachable (a nested
+// client whose parent session is mid-reconnect) is transient, and the token we
+// already hold is very likely still valid.
+type CredentialSource struct {
+	resolve credentialResolver
+
+	mu        sync.Mutex
+	cached    Credential
+	goodUntil time.Time
+
+	// now is this source's clock. Tests replace it to exercise the expiry
+	// horizon without sleeping through it.
+	now func() time.Time
+}
+
+// newCredentialSource wraps a resolver in the cache. A nil resolver yields a
+// nil source, so callers can pass an unconfigured credential slot through
+// unconditionally: a nil source resolves to the empty credential and leaves
+// the transport chain untouched.
+func newCredentialSource(resolve credentialResolver) *CredentialSource {
+	if resolve == nil {
+		return nil
+	}
+	return &CredentialSource{resolve: resolve, now: time.Now}
+}
+
+// Credential returns the credential to authenticate with right now, going back
+// to the origin when the cached one has reached its validity horizon.
+func (src *CredentialSource) Credential(ctx context.Context) (Credential, error) {
+	if src == nil {
+		return Credential{}, nil
+	}
+
+	// The lock is held across the resolution on purpose: that is what makes
+	// concurrent requests share one round-trip instead of stampeding the
+	// client. credentialResolveTimeout bounds how long a straggler can hold it.
+	src.mu.Lock()
+	defer src.mu.Unlock()
+
+	now := src.now()
+	if src.cached.Token != "" && now.Before(src.goodUntil) {
+		return src.cached, nil
+	}
+
+	cred, err := src.resolve(ctx)
+	if err != nil {
+		if src.cached.Token != "" {
+			return src.cached, nil
+		}
+		return Credential{}, err
+	}
+	if cred.Token != "" {
+		src.cached = cred
+		src.goodUntil = credentialHorizon(now, cred)
+	}
+	return cred, nil
+}
+
+// Invalidate drops the cached credential, the stale-fallback copy included, so
+// the next resolution goes back to the origin. Called when a provider rejects
+// the credential: what we hold is known bad, and re-serving it — even as a
+// fallback — would only waste the retry.
+func (src *CredentialSource) Invalidate() {
+	if src == nil {
+		return
+	}
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	src.cached = Credential{}
+	src.goodUntil = time.Time{}
+}
+
+// credentialHorizon is how long a freshly resolved credential may be reused:
+// min(expiry - margin, now + maxTTL), or a short TTL when the expiry is
+// unknown. A horizon already in the past — the client handed us an expired
+// token — means every request re-resolves, which is exactly what gives the
+// client's refresher its chance to produce a live one.
+func credentialHorizon(now time.Time, cred Credential) time.Time {
+	if cred.ExpiresAt.IsZero() {
+		return now.Add(credentialRefreshTTL)
+	}
+	capped := now.Add(credentialMaxTTL)
+	if safe := cred.ExpiresAt.Add(-credentialExpiryMargin); safe.Before(capped) {
+		return safe
+	}
+	return capped
+}
+
+// credentialReloader re-runs getenv for an OAuth token variable and for the
+// companion variable carrying its expiry.
+//
+// The two are read in that order, in one resolution, on purpose: the client's
+// refresher hook fires on the *token* lookup and rewrites both variables, so
+// reading the expiry first would pair a fresh token with the outgoing one's
+// expiry — expiring the cache an hour early at best, and pinning a stale
+// lifetime onto a new token at worst.
+//
+// The returned resolver carries no client identity of its own: LoadClientConfig
+// binds getenv to the client whose configuration supplied the token, so a
+// reload resolves against that same client. That is what lets a nested `dagger
+// agent` use the session's LLM auth without ever holding credentials itself.
+func credentialReloader(getenv func(context.Context, string) (string, error), tokenKey string) credentialResolver {
+	return func(ctx context.Context) (Credential, error) {
+		token, err := getenv(ctx, tokenKey)
+		if err != nil {
+			return Credential{}, fmt.Errorf("get %q: %w", tokenKey, err)
+		}
+		if token == "" {
+			return Credential{}, nil
+		}
+		// An expiry we cannot read is "unknown", not "expired": the token is
+		// the credential, and failing an LLM request over its metadata would
+		// break every client older than the expiry contract.
+		expiry, expiryErr := getenv(ctx, tokenKey+credentialExpiryEnvSuffix)
+		if expiryErr != nil {
+			expiry = ""
+		}
+		return Credential{Token: token, ExpiresAt: parseCredentialExpiry(expiry)}, nil
+	}
+}
+
+// parseCredentialExpiry reads a *_EXPIRES_AT value: RFC 3339, UTC, the true
+// expiry. Anything unreadable is reported as unknown rather than as expired —
+// a malformed value must degrade to the TTL fallback, not turn every single
+// request into a resolution (and, client-side, a refresh attempt).
+func parseCredentialExpiry(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	expiresAt, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return expiresAt.UTC()
+}
+
+// detach re-bases resolution onto base, dropping the requesting context's
+// cancellation.
+//
+// A credential is resolved from whichever request happens to need one, but the
+// endpoint holding the source is memoized for the whole conversation and can
+// outlive that request by hours — a detached agent loop keeps stepping long
+// after the API call that routed its endpoint returned. Resolving against that
+// call's context would start failing the moment it completed. loadLLMRouter
+// passes a session-scoped base instead, so resolution stays alive for exactly
+// as long as the client's session; the timeout keeps one hung resolution from
+// hanging the LLM request behind it.
+func (resolve credentialResolver) detach(base context.Context) credentialResolver {
+	if resolve == nil {
+		return nil
+	}
+	return func(context.Context) (Credential, error) {
+		ctx, cancel := context.WithTimeout(base, credentialResolveTimeout)
+		defer cancel()
+		return resolve(ctx)
+	}
+}
+
+// applyCredential writes a resolved credential onto an outgoing request.
+// Providers differ in more than the header name: Codex also derives a required
+// account-id header from the token's JWT claims, so that has to be recomputed
+// whenever the token rotates rather than pinned at client construction.
+type applyCredential func(req *http.Request, token string)
+
+func applyBearer(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+}
+
+func applyCodexBearer(req *http.Request, token string) {
+	applyBearer(req, token)
+	if accountID := extractChatGPTAccountID(token); accountID != "" {
+		req.Header.Set("chatgpt-account-id", accountID)
+	}
+}
+
+// credentialTransport re-authenticates every request from a CredentialSource,
+// overwriting whatever the SDK baked in at construction. This is the single
+// choke point that makes credential freshness a property of the transport
+// rather than of each provider client: every provider is built with
+// option.WithHTTPClient(endpoint.otelHTTPClient(...)).
+type credentialTransport struct {
+	base  http.RoundTripper
+	src   *CredentialSource
+	apply applyCredential
+}
+
+// newCredentialTransport inserts credential handling into a transport chain,
+// or returns base untouched when there is no source. Plain API keys and CI
+// runs have no source and must be exactly unaffected.
+func newCredentialTransport(base http.RoundTripper, src *CredentialSource, apply applyCredential) http.RoundTripper {
+	if src == nil {
+		return base
+	}
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if apply == nil {
+		apply = applyBearer
+	}
+	return &credentialTransport{base: base, src: src, apply: apply}
+}
+
+func (t *credentialTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cred, err := t.src.Credential(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("resolve LLM credential: %w", err)
+	}
+	if cred.Token != "" {
+		// RoundTrippers must not mutate the request they are handed.
+		req = req.Clone(req.Context())
+		t.apply(req, cred.Token)
+	}
+	// An empty resolution leaves the SDK's own header in place: the variable
+	// may simply have gone missing from the client's environment, and the
+	// credential the endpoint was routed with is a better guess than none.
+	return t.base.RoundTrip(req)
+}
+
+// credentialApplier returns how this endpoint's provider carries its
+// credential on the wire.
+func (endpoint *LLMEndpoint) credentialApplier() applyCredential {
+	if endpoint.Provider == OpenAICodex {
+		return applyCodexBearer
+	}
+	return applyBearer
+}
+
+// isAuthFailure reports whether err is the provider rejecting our credential
+// (HTTP 401) rather than any other failure. Both SDKs surface the status on a
+// typed API error, and the Codex client preserves it through its own error
+// wrapper (see codexAPIError).
+func isAuthFailure(err error) bool {
+	var anthropicErr *anthropic.Error
+	if errors.As(err, &anthropicErr) {
+		return anthropicErr.StatusCode == http.StatusUnauthorized
+	}
+	var openaiErr *openai.Error
+	if errors.As(err, &openaiErr) {
+		return openaiErr.StatusCode == http.StatusUnauthorized
+	}
+	return false
+}
+
+// credentialError turns a provider's rejection of our credential into
+// something the user can act on. Only a subscription login gets rewritten: a
+// rejected API key is a variable the user exported themselves and the
+// provider's own message names it well enough, whereas an OAuth login lives in
+// the CLI's config and is refreshed behind the session, so "401
+// authentication_error" tells its owner nothing about what to do next.
+func (endpoint *LLMEndpoint) credentialError(err error) error {
+	if !endpoint.IsOAuth {
+		return err
+	}
+	return &expiredLoginError{provider: endpoint.Provider, err: err}
+}
+
+type expiredLoginError struct {
+	provider LLMProvider
+	err      error
+}
+
+func (e *expiredLoginError) Error() string {
+	return fmt.Sprintf("%s rejected the subscription login: it has expired or been revoked — "+
+		"re-run `dagger llm setup` to log in again (%v)", e.provider, e.err)
+}
+
+func (e *expiredLoginError) Unwrap() error { return e.err }

--- a/core/llm_credential_test.go
+++ b/core/llm_credential_test.go
@@ -1,0 +1,472 @@
+package core
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// codexTestToken builds a minimal JWT-shaped token carrying the given
+// chatgpt_account_id claim, matching what extractChatGPTAccountID parses.
+func codexTestToken(t *testing.T, accountID string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id": accountID,
+		},
+	})
+	require.NoError(t, err)
+	return "hdr." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+// testClock is a hand-advanced clock, so the cache's expiry horizon can be
+// walked across precisely instead of slept through.
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newTestClock() *testClock {
+	return &testClock{now: time.Date(2026, 1, 2, 15, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestCredentialSource(clk *testClock, resolve credentialResolver) *CredentialSource {
+	src := newCredentialSource(resolve)
+	src.now = clk.Now
+	return src
+}
+
+// rotatingCredential hands out a fresh token on every resolution, so a test
+// can tell which resolution a request's header came from.
+func rotatingCredential(expiresAt time.Time) (credentialResolver, *atomic.Int64) {
+	var n atomic.Int64
+	return func(context.Context) (Credential, error) {
+		return Credential{
+			Token:     fmt.Sprintf("token-%d", n.Add(1)),
+			ExpiresAt: expiresAt,
+		}, nil
+	}, &n
+}
+
+// TestCredentialTransportRefreshesPerRequest is the point of the whole
+// mechanism: a provider SDK client bakes its credential in at construction, so
+// the only way a rotated token reaches the wire without rebuilding the client
+// is for the transport to re-authenticate each request.
+func TestCredentialTransportRefreshesPerRequest(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	clk := newTestClock()
+	resolve, _ := rotatingCredential(time.Time{})
+	endpoint := &LLMEndpoint{
+		Provider: Anthropic,
+		IsOAuth:  true,
+		// The stale snapshot the SDK would have pinned.
+		AuthToken:       "token-0",
+		AuthTokenSource: newTestCredentialSource(clk, resolve),
+	}
+	client := endpoint.otelHTTPClient("anthropic")
+
+	for range 3 {
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		// What the SDK baked in at construction time.
+		req.Header.Set("Authorization", "Bearer token-0")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		// Outlive the cache, so each request really does re-resolve.
+		clk.Advance(credentialRefreshTTL + time.Second)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{
+		"Bearer token-1",
+		"Bearer token-2",
+		"Bearer token-3",
+	}, seen)
+}
+
+// TestCredentialTransportLeavesRequestUnmodified locks in the RoundTripper
+// contract: the request handed to RoundTrip must not be mutated (the SDK may
+// reuse it across its own retries).
+func TestCredentialTransportLeavesRequestUnmodified(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	rt := newCredentialTransport(nil, newCredentialSource(func(context.Context) (Credential, error) {
+		return Credential{Token: "fresh"}, nil
+	}), applyBearer)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer stale")
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, "Bearer stale", req.Header.Get("Authorization"))
+}
+
+// TestCredentialTransportNoSourceIsPassthrough covers the plain-API-key path
+// (`dagger call` in CI): no source, no interception, no behavior change.
+func TestCredentialTransportNoSourceIsPassthrough(t *testing.T) {
+	base := http.DefaultTransport
+	require.Equal(t, base, newCredentialTransport(base, nil, applyBearer))
+	require.Nil(t, newCredentialTransport(nil, nil, applyBearer))
+	// An unconfigured credential slot passes through the whole chain as nil,
+	// so routing a plain API key builds exactly the transport it always did.
+	require.Nil(t, newCredentialSource(nil))
+	ep := &LLMEndpoint{Provider: Anthropic, Key: "sk-plain"}
+	require.Nil(t, ep.AuthTokenSource)
+	cred, err := ep.AuthTokenSource.Credential(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, cred.Token)
+}
+
+// TestCredentialSourceCollapsesBursts checks the cache: a streaming turn that
+// issues several requests back-to-back resolves the credential once, and
+// concurrent requests (parallel agents sharing an endpoint) single-flight onto
+// one round-trip rather than stampeding the client.
+func TestCredentialSourceCollapsesBursts(t *testing.T) {
+	clk := newTestClock()
+	var calls atomic.Int64
+	release := make(chan struct{})
+	src := newTestCredentialSource(clk, func(context.Context) (Credential, error) {
+		calls.Add(1)
+		<-release
+		return Credential{Token: "tok"}, nil
+	})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cred, err := src.Credential(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, "tok", cred.Token)
+		}()
+	}
+	close(release)
+	wg.Wait()
+	require.Equal(t, int64(1), calls.Load())
+
+	for range 5 {
+		cred, err := src.Credential(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "tok", cred.Token)
+	}
+	require.Equal(t, int64(1), calls.Load())
+}
+
+// TestCredentialSourceExpiresAtHorizon walks the cache across the expiry the
+// client reported: a credential is replaced one margin *before* it dies, and
+// not a moment earlier.
+func TestCredentialSourceExpiresAtHorizon(t *testing.T) {
+	clk := newTestClock()
+	expiresAt := clk.Now().Add(2 * time.Minute)
+	resolve, calls := rotatingCredential(expiresAt)
+	src := newTestCredentialSource(clk, resolve)
+
+	cred, err := src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+	require.Equal(t, expiresAt, cred.ExpiresAt)
+
+	// Right up to the margin, the cached credential stands — this is the
+	// property that keeps a busy conversation off the client's back.
+	clk.Advance(2*time.Minute - credentialExpiryMargin - time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+	require.Equal(t, int64(1), calls.Load())
+
+	// One margin before the true expiry, it is replaced.
+	clk.Advance(2 * time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-2", cred.Token)
+}
+
+// TestCredentialSourceMaxTTL: expiry is not the only reason a token changes —
+// a re-login rotates it early — so a long-lived credential is still re-read
+// periodically.
+func TestCredentialSourceMaxTTL(t *testing.T) {
+	clk := newTestClock()
+	resolve, _ := rotatingCredential(clk.Now().Add(time.Hour))
+	src := newTestCredentialSource(clk, resolve)
+
+	cred, err := src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+
+	clk.Advance(credentialMaxTTL - time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+
+	clk.Advance(2 * time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-2", cred.Token)
+}
+
+// TestCredentialSourceUnknownExpiryFallsBackToTTL covers a client that says
+// nothing about expiry — one older than the *_EXPIRES_AT contract, or an
+// OAuth response that omitted expires_in. Unknown must mean "re-read soon",
+// never "expired" (which would re-resolve, and client-side re-refresh, on
+// every single request).
+func TestCredentialSourceUnknownExpiryFallsBackToTTL(t *testing.T) {
+	clk := newTestClock()
+	resolve, _ := rotatingCredential(time.Time{})
+	src := newTestCredentialSource(clk, resolve)
+
+	cred, err := src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+
+	clk.Advance(credentialRefreshTTL - time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+
+	clk.Advance(2 * time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-2", cred.Token)
+}
+
+// TestParseCredentialExpiry pins the wire format the client half exports:
+// RFC 3339, UTC, the true expiry with no margin baked in. Anything else is
+// unknown — a garbage value must not read as "expired".
+func TestParseCredentialExpiry(t *testing.T) {
+	require.Equal(t,
+		time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC),
+		parseCredentialExpiry("2026-01-02T15:04:05Z"))
+	// An offset is still RFC 3339; normalize it to UTC.
+	require.Equal(t,
+		time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC),
+		parseCredentialExpiry("2026-01-02T16:04:05+01:00"))
+	require.True(t, parseCredentialExpiry(" \n").IsZero())
+	require.True(t, parseCredentialExpiry("").IsZero())
+	require.True(t, parseCredentialExpiry("1767366245").IsZero(), "unix seconds are not the contract")
+	require.True(t, parseCredentialExpiry("not a timestamp").IsZero())
+}
+
+// TestCredentialSourceFallsBackToStale: a transient failure to reach the
+// client (a nested session mid-reconnect) must not fail the LLM request when a
+// previously resolved token is still in hand.
+func TestCredentialSourceFallsBackToStale(t *testing.T) {
+	clk := newTestClock()
+	var fail atomic.Bool
+	src := newTestCredentialSource(clk, func(context.Context) (Credential, error) {
+		if fail.Load() {
+			return Credential{}, context.DeadlineExceeded
+		}
+		return Credential{Token: "tok"}, nil
+	})
+	cred, err := src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "tok", cred.Token)
+
+	fail.Store(true)
+	clk.Advance(credentialRefreshTTL + time.Second)
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "tok", cred.Token)
+
+	// With nothing cached, the failure is the caller's problem.
+	empty := newTestCredentialSource(clk, func(context.Context) (Credential, error) {
+		return Credential{}, context.DeadlineExceeded
+	})
+	_, err = empty.Credential(t.Context())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestCredentialSourceInvalidate is the entry point 401 recovery uses: after a
+// provider rejects the credential, the cached copy must be gone — including as
+// the stale fallback, since re-serving a token the provider just refused would
+// waste the one retry that recovery gets.
+func TestCredentialSourceInvalidate(t *testing.T) {
+	clk := newTestClock()
+	var fail atomic.Bool
+	resolve, calls := rotatingCredential(time.Time{})
+	src := newTestCredentialSource(clk, func(ctx context.Context) (Credential, error) {
+		if fail.Load() {
+			return Credential{}, context.DeadlineExceeded
+		}
+		return resolve(ctx)
+	})
+
+	cred, err := src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-1", cred.Token)
+
+	src.Invalidate()
+	cred, err = src.Credential(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "token-2", cred.Token, "invalidation re-resolves inside the TTL")
+	require.Equal(t, int64(2), calls.Load())
+
+	src.Invalidate()
+	fail.Store(true)
+	_, err = src.Credential(t.Context())
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"an invalidated credential must not come back as the stale fallback")
+}
+
+// TestCredentialReloaderReadsTokenBeforeExpiry pins the ordering the two
+// halves agreed on: the client's refresher hook fires on the *token* lookup
+// and rewrites both variables, so reading the expiry first would pair a fresh
+// token with the outgoing one's expiry.
+func TestCredentialReloaderReadsTokenBeforeExpiry(t *testing.T) {
+	var order []string
+	token, expiry := "token-v1", "2026-01-02T15:04:05Z"
+	getenv := func(_ context.Context, key string) (string, error) {
+		order = append(order, key)
+		switch key {
+		case "ANTHROPIC_AUTH_TOKEN":
+			// The refresher hook runs inside this lookup and updates both.
+			token, expiry = "token-v2", "2026-01-02T16:04:05Z"
+			return token, nil
+		case "ANTHROPIC_AUTH_TOKEN_EXPIRES_AT":
+			return expiry, nil
+		}
+		return "", nil
+	}
+
+	cred, err := credentialReloader(getenv, "ANTHROPIC_AUTH_TOKEN")(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN_EXPIRES_AT"}, order)
+	require.Equal(t, "token-v2", cred.Token)
+	require.Equal(t, time.Date(2026, 1, 2, 16, 4, 5, 0, time.UTC), cred.ExpiresAt)
+}
+
+func TestCredentialReloaderTolerance(t *testing.T) {
+	t.Run("no token means no credential and no expiry lookup", func(t *testing.T) {
+		var lookups []string
+		cred, err := credentialReloader(func(_ context.Context, key string) (string, error) {
+			lookups = append(lookups, key)
+			return "", nil
+		}, "OPENAI_CODEX_AUTH_TOKEN")(t.Context())
+		require.NoError(t, err)
+		require.Empty(t, cred.Token)
+		require.Equal(t, []string{"OPENAI_CODEX_AUTH_TOKEN"}, lookups)
+	})
+
+	t.Run("unreadable expiry is unknown, not fatal", func(t *testing.T) {
+		cred, err := credentialReloader(func(_ context.Context, key string) (string, error) {
+			if key == "ANTHROPIC_AUTH_TOKEN" {
+				return "tok", nil
+			}
+			return "", fmt.Errorf("client went away")
+		}, "ANTHROPIC_AUTH_TOKEN")(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "tok", cred.Token)
+		require.True(t, cred.ExpiresAt.IsZero())
+	})
+
+	t.Run("garbage expiry is unknown, not expired", func(t *testing.T) {
+		cred, err := credentialReloader(func(_ context.Context, key string) (string, error) {
+			if key == "ANTHROPIC_AUTH_TOKEN" {
+				return "tok", nil
+			}
+			return "sometime next week", nil
+		}, "ANTHROPIC_AUTH_TOKEN")(t.Context())
+		require.NoError(t, err)
+		require.True(t, cred.ExpiresAt.IsZero())
+
+		// Unknown expiry caches for the TTL, rather than re-resolving forever.
+		clk := newTestClock()
+		require.Equal(t, clk.Now().Add(credentialRefreshTTL), credentialHorizon(clk.Now(), cred))
+	})
+
+	t.Run("failed token lookup is fatal", func(t *testing.T) {
+		_, err := credentialReloader(func(context.Context, string) (string, error) {
+			return "", fmt.Errorf("client went away")
+		}, "ANTHROPIC_AUTH_TOKEN")(t.Context())
+		require.ErrorContains(t, err, "ANTHROPIC_AUTH_TOKEN")
+	})
+}
+
+// TestCredentialResolverDetach: resolution must survive the request that
+// happened to trigger it — the endpoint holding the resolver outlives that
+// request by the whole conversation — while still dying with the session it
+// was scoped to.
+func TestCredentialResolverDetach(t *testing.T) {
+	var nilResolver credentialResolver
+	require.Nil(t, nilResolver.detach(t.Context()))
+
+	sessionCtx, closeSession := context.WithCancel(t.Context())
+	defer closeSession()
+
+	var hadDeadline bool
+	resolve := credentialResolver(func(ctx context.Context) (Credential, error) {
+		if err := ctx.Err(); err != nil {
+			return Credential{}, err
+		}
+		_, hadDeadline = ctx.Deadline()
+		return Credential{Token: "tok"}, nil
+	}).detach(sessionCtx)
+
+	// The request that asks for the credential may already be over.
+	requestCtx, cancelRequest := context.WithCancel(t.Context())
+	cancelRequest()
+	cred, err := resolve(requestCtx)
+	require.NoError(t, err)
+	require.Equal(t, "tok", cred.Token)
+	require.True(t, hadDeadline, "a resolution must be bounded, or a hung client hangs the LLM call")
+
+	// The session going away does end it.
+	closeSession()
+	_, err = resolve(t.Context())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestCredentialApplierCodex checks that the Codex account-id header, which
+// is derived from the token's JWT claims, follows the token when it rotates
+// instead of staying pinned from client construction.
+func TestCredentialApplierCodex(t *testing.T) {
+	endpoint := &LLMEndpoint{Provider: OpenAICodex}
+	apply := endpoint.credentialApplier()
+
+	req, err := http.NewRequest(http.MethodGet, "https://chatgpt.com/backend-api/codex/responses", nil)
+	require.NoError(t, err)
+	apply(req, codexTestToken(t, "acct-abc"))
+	require.Equal(t, "acct-abc", req.Header.Get("chatgpt-account-id"))
+
+	apply(req, codexTestToken(t, "acct-xyz"))
+	require.Equal(t, "acct-xyz", req.Header.Get("chatgpt-account-id"))
+}

--- a/core/llm_openai_codex.go
+++ b/core/llm_openai_codex.go
@@ -37,7 +37,10 @@ func newOpenAICodexClient(endpoint *LLMEndpoint) *OpenAICodexClient {
 	// Use the OAuth access token as the API key (sets Authorization: Bearer <token>)
 	opts = append(opts, option.WithAPIKey(endpoint.AuthToken))
 
-	// Extract chatgpt_account_id from JWT for required header
+	// Extract chatgpt_account_id from JWT for required header. Both this and
+	// the bearer token above are only the values observed at construction:
+	// when the endpoint carries a credential source, credentialTransport
+	// recomputes both from the current token on every request.
 	if accountID := extractChatGPTAccountID(endpoint.AuthToken); accountID != "" {
 		opts = append(opts, option.WithHeader("chatgpt-account-id", accountID))
 	}
@@ -54,6 +57,11 @@ func newOpenAICodexClient(endpoint *LLMEndpoint) *OpenAICodexClient {
 
 var _ LLMClient = (*OpenAICodexClient)(nil)
 
+// IsRetryable reports whether a failed turn is worth resending. The ChatGPT
+// backend gives no reliable signal to key off, so nothing is retried here; a
+// rejected credential is the one exception and is handled centrally, since
+// resending only helps once the credential has been re-resolved (see
+// sendQueryWithRetry).
 func (c *OpenAICodexClient) IsRetryable(err error) bool {
 	return false
 }
@@ -456,10 +464,25 @@ func codexAPIError(err error) error {
 		}
 	}
 	if msg := llmErrorMessage([]byte(body)); msg != "" {
-		return fmt.Errorf("codex API error (HTTP %d): %s", aerr.StatusCode, msg)
+		return &codexError{statusCode: aerr.StatusCode, message: msg, err: err}
 	}
 	return err
 }
+
+// codexError carries the backend's own explanation as the message while
+// keeping the SDK error reachable underneath, so status-based classification
+// (isAuthFailure) still works on it.
+type codexError struct {
+	statusCode int
+	message    string
+	err        error
+}
+
+func (e *codexError) Error() string {
+	return fmt.Sprintf("codex API error (HTTP %d): %s", e.statusCode, e.message)
+}
+
+func (e *codexError) Unwrap() error { return e.err }
 
 // extractChatGPTAccountID extracts the chatgpt_account_id from a JWT token.
 func extractChatGPTAccountID(token string) string {

--- a/core/llm_otel.go
+++ b/core/llm_otel.go
@@ -22,6 +22,13 @@ const maxBodyCapture = 256 * 1024 // 256 KiB
 // the endpoint has a dial override (local endpoints tunneled through the
 // client's session), connections go through it while requests keep using
 // BaseURL's host for TLS verification/SNI and the Host header.
+//
+// When the endpoint carries a credential source, the transport chain also
+// re-authenticates every request from it, so a rotated OAuth bearer token
+// takes effect without rebuilding the provider's SDK client (which bakes the
+// credential in at construction). Credential handling sits *below* the OTel
+// transport, which logs bodies and never headers — a bearer token must not
+// reach telemetry.
 func (endpoint *LLMEndpoint) otelHTTPClient(provider string) *http.Client {
 	var base http.RoundTripper
 	if endpoint.dial != nil {
@@ -29,6 +36,7 @@ func (endpoint *LLMEndpoint) otelHTTPClient(provider string) *http.Client {
 		transport.DialContext = endpoint.dial
 		base = transport
 	}
+	base = newCredentialTransport(base, endpoint.AuthTokenSource, endpoint.credentialApplier())
 	return &http.Client{
 		Transport: newLLMOTelTransport(base, provider),
 	}

--- a/engine/client/secretprovider/env.go
+++ b/engine/client/secretprovider/env.go
@@ -5,14 +5,20 @@ import (
 	"fmt"
 	"os"
 	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/dagger/dagger/engine/slog"
 )
 
 // EnvRefresher is an optional hook, consulted by envProvider before it reads a
 // requested variable from the process environment. It lets a higher layer keep
 // a dynamically-managed env var (e.g. a short-lived OAuth bearer token) fresh:
 // the hook may refresh the credential and update os.Setenv for name before the
-// value is read. It is best-effort — errors and a nil hook are ignored, and
-// envProvider still reads whatever value is present afterwards.
+// value is read. It is best-effort — a nil hook is ignored, and envProvider
+// still reads whatever value is present after a failed refresh — but failures
+// are logged and recorded on the current span rather than dropped.
 //
 // This indirection avoids a dependency from this low-level provider package on
 // the CLI's llmconfig package (which owns OAuth refresh); the CLI registers the
@@ -44,17 +50,33 @@ func envProvider(ctx context.Context, name string) ([]byte, error) {
 	// read whatever is currently set, which yields the usual not-found or
 	// (possibly stale) value rather than masking the original request.
 	if r := currentEnvRefresher(); r != nil {
-		_ = r(ctx, name)
+		if err := r(ctx, name); err != nil {
+			// Don't degrade silently, though: a revoked credential or an
+			// unwritable config otherwise surfaces much later as an
+			// unexplained 401 from the provider. The span event puts it in
+			// `dagger trace`, where the failing resolution actually is.
+			slog.WarnContext(ctx, "failed to refresh secret env var",
+				"name", redactEnvName(name), "error", err)
+			trace.SpanFromContext(ctx).AddEvent("secret env var refresh failed",
+				trace.WithAttributes(
+					attribute.String("env.name", redactEnvName(name)),
+					attribute.String("error", err.Error()),
+				))
+		}
 	}
 	v, ok := os.LookupEnv(name)
 	if !ok {
-		// Don't show the entire env var name, in case the user accidentally passed the value instead...
-		// This is important because users originally *did* have to pass the value, before we changed to
-		// passing by name instead.
-		if len(name) >= 4 {
-			name = name[:3] + "..."
-		}
-		return nil, fmt.Errorf("secret env var not found: %q", name)
+		return nil, fmt.Errorf("secret env var not found: %q", redactEnvName(name))
 	}
 	return []byte(v), nil
+}
+
+// redactEnvName shortens a requested variable name for display. Users
+// originally had to pass the secret *value* here rather than its name, and
+// some still do by accident, so the name itself may be a credential.
+func redactEnvName(name string) string {
+	if len(name) >= 4 {
+		return name[:3] + "..."
+	}
+	return name
 }

--- a/engine/client/secretprovider/env_test.go
+++ b/engine/client/secretprovider/env_test.go
@@ -1,0 +1,46 @@
+package secretprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestEnvProviderRefresherError verifies that a failing refresher does not
+// mask the variable that is actually set: refresh is best-effort, so a stale
+// (or explicitly exported) value still resolves. The failure is reported
+// through the logger and the current span instead of being swallowed.
+func TestEnvProviderRefresherError(t *testing.T) {
+	t.Setenv("DAGGER_TEST_SECRET_ENV", "stale-but-usable")
+
+	var called int
+	RegisterEnvRefresher(func(context.Context, string) error {
+		called++
+		return errors.New("token endpoint unreachable")
+	})
+	t.Cleanup(func() { RegisterEnvRefresher(nil) })
+
+	got, err := envProvider(t.Context(), "DAGGER_TEST_SECRET_ENV")
+	if err != nil {
+		t.Fatalf("envProvider() failed: %v", err)
+	}
+	if string(got) != "stale-but-usable" {
+		t.Errorf("envProvider() = %q, want %q", got, "stale-but-usable")
+	}
+	if called != 1 {
+		t.Errorf("refresher called %d times, want 1", called)
+	}
+}
+
+// TestEnvProviderRedactsName guards the not-found message: users originally
+// passed the secret value here rather than its name, so the name may itself be
+// a credential and must not be echoed in full.
+func TestEnvProviderRedactsName(t *testing.T) {
+	_, err := envProvider(t.Context(), "DAGGER_TEST_SECRET_ENV_MISSING")
+	if err == nil {
+		t.Fatal("envProvider() succeeded for a missing variable")
+	}
+	if got, want := err.Error(), `secret env var not found: "DAG..."`; got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}

--- a/hack/designs/llm-oauth-token-lifecycle.md
+++ b/hack/designs/llm-oauth-token-lifecycle.md
@@ -1,0 +1,312 @@
+# LLM subscription OAuth: token lifecycle cleanup
+
+Status: **implemented**. All four steps below have landed; what remains is the
+end-to-end confirmation noted at the bottom (a real session outliving its
+access token) and a `-race` run in an environment with a C compiler. The audit
+and the reasoning are kept as-is, because they are why the code looks the way
+it does.
+
+## The symptom
+
+A user running a long `dagger agent` / `dagger shell` session against Claude
+Code (Anthropic) or Codex (ChatGPT) subscription auth starts getting `401
+authentication_error` partway through, and stays broken until they restart
+the CLI. A client-side refresh mechanism already exists and is correctly
+wired; it just never gets a chance to fire.
+
+## How it works today
+
+| Step | Where |
+|---|---|
+| Creds persisted in `~/.config/dagger/config.toml` (`auth_token`, `refresh_token`, `token_expiry`) | `internal/cmd/dagger/llmconfig/config.go` `Provider` |
+| Refresh-if-expired at CLI start, then `os.Setenv("ANTHROPIC_AUTH_TOKEN", …)` | `internal/cmd/dagger/llm_config.go` `applyLLMConfigEnv` (via `cobra.OnInitialize`) |
+| Refresh-on-demand hook | `internal/cmd/dagger/llm_config.go` `secretprovider.RegisterEnvRefresher(…)` |
+| Hook fires inside every `env://` resolution | `engine/client/secretprovider/env.go` `envProvider` |
+| Engine asks the client `secret(uri:"env://X"){plaintext}` | `core/llm.go` `LLMRouter.LoadClientConfig` → `loadSecret` |
+| Resolution RPC engine→client | `core/secret.go` `Secret.plaintext` → `secrets.GetSecret` |
+| Lands as a plain string on the router | `core/llm.go` `LLMRouter.AnthropicAuthToken` / `OpenAICodexAuthToken` |
+| Router → endpoint | `core/llm.go` `routeAnthropicModel` / `routeCodexModel` |
+| **Baked into the SDK client at construction** | `core/llm_anthropic.go` `option.WithAuthToken`; `core/llm_openai_codex.go` `option.WithAPIKey` + `chatgpt-account-id` from the JWT |
+| **Memoized for the rest of the conversation** | `core/llm.go` `(*LLM).Endpoint`, and `Clone` copies the pointer |
+
+Everything *upstream* of the last two rows already re-resolves correctly:
+`secret` is `dagql.PerCallInput` (`core/schema/secret.go`), `plaintext` is
+`DoNotCache`, so every `LoadClientConfig` genuinely round-trips to the client
+and the CLI-side refresher genuinely runs.
+
+## Root cause
+
+Two lines, both in `core/llm.go`:
+
+1. `(*LLM).Endpoint` short-circuits on `llm.endpoint != nil`.
+2. `Clone()` does `cp.endpoint = llm.endpoint`.
+
+The router load is the *only* thing that consults the refresher hook. After
+the first `Endpoint()` call on a persistent node, the router is never loaded
+again, so the token is frozen for the session.
+
+Fixing the memo alone is not enough: the token is captured inside the
+provider SDK client at construction, so mutating `LLMEndpoint.AuthToken` in
+place would still send the old value.
+
+### Which call sites pin it
+
+Not `step()` — it does `llm = llm.Clone()` first, so its memo lands on a
+throwaway and dies. The culprits are the *observation* fields in
+`core/schema/llm.go`: `model`, `provider`, `contextWindow`, `reasoningEffort`
+all call `llm.Endpoint(ctx)` on the receiver with no clone, memoizing onto
+the dagql-cached node. The CLI calls them constantly —
+`internal/cmd/dagger/llm.go` (session construction) and
+`internal/cmd/dagger/session_agent.go` (`setLLM`, `updateStatusLine`, and
+before *every* prompt turn).
+
+Sequence: CLI starts → refresh+export token T once → `.Model()` builds the
+endpoint and SDK client with T → `withPrompt` clones, inheriting the endpoint
+→ every turn for the rest of the session sends T.
+
+Only `WithModel` and `WithReasoningEffort` reset the memo — which is why
+typing `.model` appears to fix it.
+
+### Parallel agents
+
+Workers are **correct today by accident**. `modules/staff` / `modules/delegate`
+compose from the bare `llm()` node (`core/schema/agents.go`), whose endpoint
+is usually still nil, so each worker's `step()` re-resolves per turn and does
+pick up refreshes. But `llm` is `WithInput(dagql.PerSessionInput)` and not
+`DoNotCache` (`core/schema/llm.go`) — one shared `*LLM` per session. The
+moment anything resolves `model` on that bare node, the chief and every
+worker share one `*LLMEndpoint`, one SDK client, one frozen token. There is
+no propagation mechanism either way.
+
+## Defect inventory
+
+Ordered by severity. Everything below was confirmed by reading the code;
+items marked (T) were additionally reproduced by a test.
+
+### Permanent logout — loses the *refresh* token, not just the access token
+
+- **Cross-process clobber (T).** `oauthRefreshMu` (`llmconfig/config.go`) is
+  process-local; the flock is taken *inside* `Save`, not around
+  load→refresh→persist. `Save` rewrites the whole `[llm]` section from a
+  stale snapshot. Two `dagger` processes — a `dagger call` beside a live
+  `dagger agent`, a Makefile, a CI matrix — and one reverts the other's
+  rotated token. Next refresh: `invalid_grant`, permanently. Easy to hit
+  because `applyLLMConfigEnv` runs on *every* command via
+  `cobra.OnInitialize`.
+- **Refresh token erased when the response omits it (T).**
+  `oauth.go` `RefreshOAuthToken` and `oauth_openai.go`
+  `RefreshOpenAIOAuthToken` both do `updated.RefreshToken =
+  tokenResp.RefreshToken` unconditionally. RFC 6749 §5.1 makes the field
+  optional; endpoints that don't rotate omit it. Result: `""`, then
+  `"no refresh token available"` forever.
+- **`RefreshOAuthTokensIfNeeded` drops successful work (T).** It returns on
+  the first provider's error *before* `cfg.Save()`, so a provider that
+  already spent its one-time grant loses the result. Which provider loses is
+  decided by Go's randomized map order.
+- **`Save` mkdirs the wrong directory (T).** It creates `ConfigRoot` instead
+  of `filepath.Dir(ConfigFile)` — wrong whenever `DAGGER_CONFIG` points
+  outside the XDG root. `UpdateFile` gets this right. Such a user's *first*
+  refresh spends the grant and fails to persist.
+
+### Refresh storm
+
+- **`expires_in` absent or ≤ 300 (T).** The 5-minute margin is baked into the
+  persisted value at write time: `TokenExpiry = now + expires_in*1000 -
+  300000`. With `expires_in` omitted that is `now − 300000`, and
+  `IsTokenExpired` (`now >= TokenExpiry`) is true immediately → a refresh on
+  every secret resolution, each rotating the refresh token. Note a single
+  resolution costs **two** hook invocations: `secretSchema.secret` resolves
+  the plaintext once to derive the argon2 cache-key handle, then `.plaintext`
+  resolves again.
+
+### Hangs and silence
+
+- **No timeout, no context.** Bare `http.Post` with the default client in
+  both refresh paths, while holding `oauthRefreshMu`. `envProvider` awaits
+  the hook synchronously inside the client's `GetSecret` handler; the engine
+  is blocked on that RPC; `LoadConfig` `eg.Wait()`s on ~21 lookups. A hung
+  token endpoint hangs the session, uncancellably — the hook signature
+  discards its `ctx` and `RefreshOAuthProviderIfNeeded` takes none.
+  (`FetchSubscriptionType` *does* use a 10s client, so this looks like an
+  oversight.)
+- **Errors swallowed (T).** `envProvider` does `_ = r(ctx, name)`. A revoked
+  token, unwritable config, or network blip all degrade to "serve the stale
+  token, return nil". No logging on that path at all.
+  `applyLLMConfigEnv`'s `slog.Warn` covers startup only and fires before any
+  `slog.SetDefault`, so it goes to raw stderr outside the frontend — never a
+  span, never in `dagger trace`.
+- **401 is permanent, and a retry could not help.** Neither `IsRetryable`
+  matches 401 (`llm_anthropic.go`, `llm_openai_codex.go`), and
+  `sendQueryWithRetry` hoists `client := ep.Client` *outside* the backoff
+  closure, so every attempt would reuse the dead token. No "your login
+  expired" hint anywhere.
+
+### Smaller
+
+- **Explicit env token clobbered (T).** `applyLLMConfigEnv` honors a
+  user-exported `ANTHROPIC_AUTH_TOKEN` via `setIfEmpty`, then the refresher
+  hook `os.Setenv`s unconditionally with the config's token — even when
+  nothing was refreshed (`RefreshOAuthProviderIfNeeded` returns the stored
+  token when `changed` is false).
+- **`Enabled` ignored (T).** `RefreshOAuthProviderIfNeeded` never checks it,
+  unlike `applyLLMConfigEnv`. And an injected OAuth token *clears*
+  `ANTHROPIC_API_KEY` (`core/llm.go` `LoadConfig`, the
+  `anthropicTokenSet && !anthropicKeySet` branch), so a disabled subscription
+  hijacks an API-key setup.
+- **`("", nil)` conflates** "provider absent", "not OAuth", and "OAuth with
+  no token", so nothing can distinguish a broken config from an
+  inapplicable one.
+- **Provider dispatch is by literal name** (`refreshProviderToken`): anything
+  not named `openai-codex` gets the Anthropic client ID and JSON flow.
+- **`Remove()` leaves a stray `config.toml.lock`.**
+- **Unsynchronized read of `llm.endpoint` in `Clone()`** against the mutexed
+  write in `Endpoint()` — a real race between a detached agent loop and the
+  status-line path. (`WithModel`/`WithReasoningEffort` lock the *clone's*
+  brand-new mutex, which protects nothing.)
+- **Stale comment**: `applyLLMConfigEnv`'s doc says Codex "is not yet wired…
+  so its token is not exported". It is exported.
+- **Out of scope but same bug class**: `internal/cloud/auth` `Token()` has
+  the same cross-process race, and worse — it builds a fresh
+  `authConfig.TokenSource(...)` per call, so there is no in-process dedupe
+  either.
+
+## What landed
+
+The three commits this document was handed with (a `core/llm_credential.go`
+spike, its lint fallout, and `core/llm_auth_test.go` demonstrating the pin)
+are still in the history; the work below builds on them.
+
+> Note: a fourth worker produced ~15 client-side tests (including two
+> real-subprocess cross-process ones) that asserted the intended behavior and
+> therefore failed against today's code. Its sandbox snapshot became
+> unreplayable (overlay mount options too long) and the tests were lost.
+> They were rewritten alongside the fixes they should pass, which is better
+> anyway. The defect inventory above records exactly what they covered.
+
+### Step 1 — cross-process refresh race (client) — DONE
+
+`withConfigLock` (`llmconfig/config.go`) now runs load→refresh→persist as one
+critical section, **re-reading the config after taking the flock** so a process
+that lost the race adopts the winner's rotated token instead of spending a dead
+one. `oauthRefreshMu` stays as the in-process dedupe. The rest of the
+permanent-logout class went with it, each as its own commit: the refresh token
+is kept when the response omits it; providers that already succeeded are
+persisted even when a later one fails (`errors.Join`); `Save` mkdirs
+`filepath.Dir(ConfigFile)`; every OAuth request is bound to a `context.Context`
+with a 10s timeout, plumbed from the env-refresher hook; `envProvider` logs and
+records a span event instead of swallowing the error; `Enabled` is honored; and
+an explicitly-exported token is never clobbered (we track what we exported).
+
+### Step 2 — de-prototype the credential source (engine) — DONE
+
+The TTL closure became a `CredentialSource` value with an `Invalidate` entry
+point, resolution yields a `Credential{Token, ExpiresAt}`, and `loadLLMRouter`
+re-bases resolvers onto a `SessionScopedContext` with a per-resolution timeout —
+so a detached agent loop no longer depends on the context of whichever request
+first routed the endpoint. The `bindClient` pinning is intact. An auth 401 is
+now recoverable exactly once: `sendQueryWithRetry` reads `ep.Client` *inside*
+the backoff closure, invalidates the cached credential, and retries; a genuinely
+revoked login fails fast with a message pointing at `dagger llm setup`. The
+`Clone()`/`Endpoint()` race is fixed (and `WithModel`/`WithReasoningEffort` no
+longer lock a mutex that protects nothing). The router is still **not** reloaded
+per request.
+
+### Step 3 — expiry alongside the token — DONE
+
+`token_expires_at` (unix ms, true expiry, no margin) is persisted; the margin is
+applied at check time; legacy `token_expiry` is read *and still written*, since
+an older CLI sharing the file reads only that field and would otherwise loop
+refreshing. Unknown expiry means unknown, not expired. The client exports
+`ANTHROPIC_AUTH_TOKEN_EXPIRES_AT` / `OPENAI_CODEX_AUTH_TOKEN_EXPIRES_AT` in RFC
+3339 UTC from both the startup export and the hook — which answers to either of
+a provider's variables and always updates both, because the engine resolves the
+token first and the expiry second within one resolution. The engine derives the
+expiry variable by `_EXPIRES_AT` suffix, treats absent/empty/unparseable as
+unknown (never as expired), and caches to
+`min(expiresAt − 1m, now + 5m)`, falling back to the 30s TTL when unknown.
+A 30s per-provider refresh floor keeps a token whose whole lifetime is shorter
+than the margin from refreshing on every resolution.
+
+### Step 4 — proactive refresh — DONE
+
+A background goroutine started from `rootCmd.PersistentPreRunE` (stopped via
+`cobra.OnFinalize`) refreshes each enabled OAuth provider ~5 minutes before
+expiry and updates both exported variables. It re-reads the persisted expiry
+every cycle (so a config another process rewrote is respected, and a long idle
+period resumes correctly), polls every 10 minutes when the expiry is unknown,
+floors the delay at 30s, and starts no goroutine at all unless a subscription
+provider is configured and enabled. The push design was **not** built, per the
+decision recorded above. The on-demand hook remains the fallback.
+
+## Options considered and rejected
+
+- **Push the refreshed token into the live session** (the original sketch for
+  "Option 2"): the CLI refreshes on a timer and rebinds a `setSecret` handle,
+  which is already a mutable, session-resident, name-keyed credential slot
+  (`SetSecretHandle` is `HMAC(scope, name)`, content independent, and
+  `BindSessionResource` overwrites). Rejected in favour of pull + exact-expiry
+  caching (steps 3 and 4), which gets the same properties for far less
+  surface: the engine caches the credential until its real expiry, so it
+  re-pulls roughly once per token lifetime rather than per request; a
+  client-side timer that refreshes *before* expiry means that pull returns an
+  already-fresh token instead of triggering an inline refresh on the critical
+  path; every agent sharing an endpoint shares the cache; and nested clients,
+  CI and plain API keys keep working with **zero** new API surface. Push's only
+  real win is eliminating a ~1-per-hour RPC, and it costs a new session-mutable
+  credential slot plus care about which module scope owns the name. Revisit
+  only if profiling says otherwise.
+- **Proxy all LLM traffic through the client** (so the engine never sees the
+  token). Mechanically feasible reusing the local-LLM tunnel's
+  `SocketKindHostIP` + `sshforward` machinery, but that tunnel is a *raw TCP
+  forward* with TLS end-to-end, so you would have to invert it: the client
+  runs a `ReverseProxy` and the engine points `BaseURL` at loopback.
+  Rejected: `dagger call` in CI and headless/remote engines have no client to
+  proxy through, so you maintain two credential architectures forever; and it
+  puts an extra hop on the SSE streaming hot path to harden one token when
+  the engine already holds every registry credential and `env://` secret.
+  Revisit only for a shared/hosted engine serving multiple users'
+  subscriptions.
+- **Move refresh engine-side.** Rejected: the refresh token is the
+  longer-lived, higher-value credential, and it is single-use and rotating —
+  if the engine refreshes, the client's `config.toml` holds a dead token and
+  the next `dagger` invocation logs the user out. The good part (a proper
+  expiry-aware `TokenSource`) is step 3, without moving the refresh token.
+
+## Invariants to preserve
+
+- Plain API keys and CI must be **exactly** unaffected:
+  `newCredentialTransport` returns the base transport unchanged when there is
+  no source. There is a test for this; keep it.
+- Nothing credential-related may enter a dagql ID or content digest. Replay
+  (`routeReplayModel`) has no credential and must stay that way.
+- `loadLLMRouter` seeds from the main client first so a nested `dagger agent`
+  never holds credentials — the reloader must resolve against **the same**
+  client that supplied the value, via `bindClient` in `LoadClientConfig`; do
+  not regress it.
+- Bearer tokens must not reach telemetry. `llmOTelTransport` logs bodies, not
+  headers — keep it that way.
+
+## Verification
+
+```console
+go build ./...
+go test ./core/ -count=1
+go test ./internal/cmd/dagger/llmconfig/ ./engine/client/secretprovider/ -count=1
+go test ./internal/cmd/dagger/ -count=1
+```
+
+All green as of the implementation. (`TestDaggerCMD/TestShellAutocomplete` in
+`./internal/cmd/dagger/` fails in a sandbox without an engine driver — that is
+environmental and unrelated.)
+
+`-race` could not be run in either sandbox (`CGO_ENABLED=0`, no C compiler).
+Run it where possible — specifically against the `Clone()`/`Endpoint()` race,
+which now has a dedicated concurrency test. The `os.Setenv` concern turned out
+*not* to be a data race (`os.Setenv`/`LookupEnv` are serialized by
+`syscall.envLock`); it was a lost-update/TOCTOU between the hook's `Setenv`
+and `applyLLMConfigEnv`'s `LookupEnv`-then-`Setenv`, which the export-tracking
+in step 1 closes.
+
+End-to-end, the thing still to actually confirm against a live subscription: a
+session that outlives its access token keeps working, and a token refreshed by
+one agent is observed by all the others.

--- a/internal/cmd/dagger/llm_config.go
+++ b/internal/cmd/dagger/llm_config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,13 +20,223 @@ import (
 	"github.com/dagger/dagger/util/cleanups"
 )
 
-// oauthEnvProviders maps the auth-token environment variable the engine
-// resolves against the client to the llmconfig provider that owns it. Used to
-// refresh a subscription OAuth bearer token on demand (see the env refresher
-// registered below), so long-running sessions don't outlive the token.
-var oauthEnvProviders = map[string]string{
-	"ANTHROPIC_AUTH_TOKEN":    "anthropic",
-	"OPENAI_CODEX_AUTH_TOKEN": "openai-codex",
+// oauthEnvVars maps each subscription OAuth provider to the environment
+// variables the engine resolves against the client: the bearer token, and the
+// true access-token expiry (RFC 3339, UTC; absent or empty means unknown), so
+// the engine can cache the credential until it actually expires. The token is
+// refreshed on demand behind these lookups (see the env refresher registered
+// below), so long-running sessions don't outlive it.
+var oauthEnvVars = map[string]struct{ token, expiresAt string }{
+	"anthropic":    {"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN_EXPIRES_AT"},
+	"openai-codex": {"OPENAI_CODEX_AUTH_TOKEN", "OPENAI_CODEX_AUTH_TOKEN_EXPIRES_AT"},
+}
+
+// oauthEnvProviders maps either of a provider's variables back to the provider
+// that owns it. The engine resolves the token first and the expiry second
+// within one credential resolution and the refresher hook fires on each, so it
+// has to answer to both names.
+var oauthEnvProviders = func() map[string]string {
+	providers := make(map[string]string, 2*len(oauthEnvVars))
+	for provider, vars := range oauthEnvVars {
+		providers[vars.token] = provider
+		providers[vars.expiresAt] = provider
+	}
+	return providers
+}()
+
+// llmEnvExports records the values applyLLMConfigEnv and the OAuth refresher
+// hook exported, keyed by variable name, so a refresh can update its own
+// variables without clobbering one the user exported explicitly. An explicit
+// `export ANTHROPIC_AUTH_TOKEN=...` wins for the whole session, not just at
+// startup.
+var (
+	llmEnvMu      sync.Mutex
+	llmEnvExports = map[string]string{}
+)
+
+// exportLLMEnv sets key to val unless the variable already holds a value we
+// did not put there. Values we do export are remembered, so a later refresh
+// can replace its own. An empty val exports nothing: callers pass whatever the
+// config holds, and a provider that leaves a field unset must not undo a value
+// exported for it earlier in the same pass (the default model, say).
+func exportLLMEnv(key, val string) {
+	if val == "" {
+		return
+	}
+	llmEnvMu.Lock()
+	defer llmEnvMu.Unlock()
+	if cur, set := os.LookupEnv(key); set {
+		if exported, ours := llmEnvExports[key]; !ours || exported != cur {
+			return
+		}
+	}
+	os.Setenv(key, val)
+	llmEnvExports[key] = val
+}
+
+// clearLLMEnv drops a variable we exported earlier, leaving one the user
+// exported explicitly alone.
+func clearLLMEnv(key string) {
+	llmEnvMu.Lock()
+	defer llmEnvMu.Unlock()
+	cur, set := os.LookupEnv(key)
+	if !set {
+		return
+	}
+	if exported, ours := llmEnvExports[key]; !ours || exported != cur {
+		return
+	}
+	os.Unsetenv(key)
+	delete(llmEnvExports, key)
+}
+
+// exportOAuthCredential exports a provider's bearer token together with the
+// expiry that belongs to it. Together, always: the engine resolves the token
+// and the expiry as two lookups of one credential, so leaving a stale expiry
+// next to a fresh token would have it cache the new credential against the old
+// deadline. An expiry we no longer know is cleared rather than left behind.
+func exportOAuthCredential(provider string, p *llmconfig.Provider) {
+	vars, ok := oauthEnvVars[provider]
+	if !ok {
+		return
+	}
+	// Never overwrite credentials the user exported explicitly, even when the
+	// refresh was a no-op and these are just the stored values.
+	exportLLMEnv(vars.token, p.AuthToken)
+	if expiresAt := p.TokenExpiresAtRFC3339(); expiresAt != "" {
+		exportLLMEnv(vars.expiresAt, expiresAt)
+	} else {
+		clearLLMEnv(vars.expiresAt)
+	}
+}
+
+// exportOAuthEnv refreshes provider's token if it is due and exports the
+// result.
+func exportOAuthEnv(ctx context.Context, provider string) error {
+	if _, ok := oauthEnvVars[provider]; !ok {
+		return nil
+	}
+	p, err := llmconfig.RefreshOAuthProviderIfNeeded(ctx, provider)
+	if err != nil {
+		return err
+	}
+	if p == nil {
+		return nil
+	}
+	exportOAuthCredential(provider, p)
+	return nil
+}
+
+// Timings for the background refresher. Vars, not consts, so tests can shrink
+// them — the same reason llmconfig's endpoint URLs are vars.
+var (
+	// oauthRefreshLead is how far ahead of a token's true expiry the refresher
+	// wakes up. It matches the margin the expiry check applies, so the wake-up
+	// finds the token due rather than just short of it.
+	oauthRefreshLead = 5 * time.Minute
+	// oauthRefreshUnknownInterval is the poll interval for a provider whose
+	// token endpoint never said when the token expires. Unknown must not mean
+	// "hot loop", nor "never look again".
+	oauthRefreshUnknownInterval = 10 * time.Minute
+	// oauthRefreshMinDelay keeps a token that is already past its refresh point
+	// (a failing endpoint, a lifetime shorter than the lead) from spinning the
+	// loop.
+	oauthRefreshMinDelay = 30 * time.Second
+)
+
+// startOAuthTokenRefresher runs a goroutine that refreshes each enabled
+// subscription OAuth provider shortly before its access token expires and
+// updates the exported token and expiry variables. A `dagger shell` or `dagger
+// agent` session easily outlives an hour-long access token, and refreshing
+// ahead of expiry keeps the round-trip off the critical path: the engine's
+// next pull already finds a fresh token.
+//
+// It returns a stop function, and is a no-op — no goroutine at all — unless a
+// subscription provider is actually configured and enabled. The on-demand
+// refresher hook remains the safety net; it is what covers a laptop that slept
+// through the timer.
+func startOAuthTokenRefresher(ctx context.Context) func() {
+	providers := enabledOAuthProviders()
+	if len(providers) == 0 {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(nextOAuthRefreshDelay(providers)):
+			}
+			for _, provider := range providers {
+				if err := exportOAuthEnv(ctx, provider); err != nil && ctx.Err() == nil {
+					slog.WarnContext(ctx, "failed to refresh LLM OAuth token",
+						"provider", provider, "error", err)
+				}
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+// enabledOAuthProviders lists the configured, enabled subscription OAuth
+// providers. One config read, no network — cheap enough to run for every
+// command, including the ones that never talk to an LLM.
+func enabledOAuthProviders() []string {
+	cfg, err := llmconfig.Load()
+	if err != nil || cfg == nil {
+		return nil
+	}
+	var names []string
+	for name := range oauthEnvVars {
+		if p, ok := cfg.LLM.Providers[name]; ok && p.Enabled && p.IsOAuth() {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// nextOAuthRefreshDelay returns how long to wait before the next refresh pass.
+// It re-reads the persisted config on every cycle rather than arming once from
+// a remembered expiry, so a token another dagger process refreshed — and the
+// expiry it wrote — is respected here too.
+func nextOAuthRefreshDelay(providers []string) time.Duration {
+	cfg, err := llmconfig.Load()
+	if err != nil || cfg == nil {
+		return oauthRefreshUnknownInterval
+	}
+	var (
+		delay time.Duration
+		found bool
+	)
+	for _, name := range providers {
+		p, ok := cfg.LLM.Providers[name]
+		if !ok || !p.Enabled || !p.IsOAuth() {
+			continue
+		}
+		next := oauthRefreshUnknownInterval
+		if expiresAt := p.TokenExpiresAtTime(); !expiresAt.IsZero() {
+			// May be negative for a token that is already overdue; the floor
+			// below turns that into a prompt retry rather than a spin.
+			next = time.Until(expiresAt.Add(-oauthRefreshLead))
+		}
+		if !found || next < delay {
+			delay, found = next, true
+		}
+	}
+	if !found {
+		// Every provider was removed or disabled while we were sleeping. Keep
+		// looking cheaply in case one comes back (`dagger llm setup` in another
+		// terminal) rather than pinning the goroutine forever.
+		return oauthRefreshUnknownInterval
+	}
+	return max(delay, oauthRefreshMinDelay)
 }
 
 func init() {
@@ -51,19 +263,12 @@ func init() {
 	// env://<KEY> against the client on each LLM router config load, so hook
 	// that resolution: when the engine asks for an OAuth auth-token var, refresh
 	// it if expired and update the process env before it's read.
-	secretprovider.RegisterEnvRefresher(func(_ context.Context, name string) error {
+	secretprovider.RegisterEnvRefresher(func(ctx context.Context, name string) error {
 		provider, ok := oauthEnvProviders[name]
 		if !ok {
 			return nil
 		}
-		token, err := llmconfig.RefreshOAuthProviderIfNeeded(provider)
-		if err != nil {
-			return err
-		}
-		if token != "" {
-			os.Setenv(name, token)
-		}
-		return nil
+		return exportOAuthEnv(ctx, provider)
 	})
 }
 
@@ -74,27 +279,19 @@ func init() {
 // env:// against the client.
 //
 // OAuth subscription tokens are refreshed first (client-side, and only when
-// expired). Anthropic (Claude Code) OAuth is wired end-to-end; Codex is not
-// yet, so its token is not exported.
+// expired). Both Anthropic (Claude Code) and OpenAI Codex (ChatGPT) OAuth are
+// wired end-to-end, so both tokens are exported.
 func applyLLMConfigEnv() {
 	// Refresh any expired OAuth tokens before exporting them. A failure here is
 	// non-fatal (we fall back to whatever token is persisted), but warn so an
-	// otherwise-silent 401 later on has a breadcrumb.
-	if err := llmconfig.RefreshOAuthTokensIfNeeded(); err != nil {
+	// otherwise-silent 401 later on has a breadcrumb. cobra initializers get no
+	// context; the refresh bounds itself with its own timeout.
+	if err := llmconfig.RefreshOAuthTokensIfNeeded(context.Background()); err != nil {
 		slog.Warn("failed to refresh LLM OAuth tokens", "error", err)
 	}
 	cfg, err := llmconfig.Load()
 	if err != nil || cfg == nil {
 		return
-	}
-	setIfEmpty := func(key, val string) {
-		if val == "" {
-			return
-		}
-		if _, ok := os.LookupEnv(key); ok {
-			return
-		}
-		os.Setenv(key, val)
 	}
 	// Honor the configured default model (`dagger llm set-default`), which lives
 	// in cfg.LLM.DefaultModel/DefaultProvider rather than any provider's own
@@ -103,19 +300,19 @@ func applyLLMConfigEnv() {
 	// default is written to config but never reaches the engine, which then
 	// falls back to its hardcoded default. Done before the provider loop so it
 	// wins over a stale per-provider model; explicit env vars still win via
-	// setIfEmpty.
+	// exportLLMEnv.
 	if cfg.LLM.DefaultModel != "" {
 		switch cfg.LLM.DefaultProvider {
 		case "anthropic":
-			setIfEmpty("ANTHROPIC_MODEL", cfg.LLM.DefaultModel)
+			exportLLMEnv("ANTHROPIC_MODEL", cfg.LLM.DefaultModel)
 		case "openai", "openrouter":
-			setIfEmpty("OPENAI_MODEL", cfg.LLM.DefaultModel)
+			exportLLMEnv("OPENAI_MODEL", cfg.LLM.DefaultModel)
 		case "openai-codex":
-			setIfEmpty("OPENAI_CODEX_MODEL", cfg.LLM.DefaultModel)
+			exportLLMEnv("OPENAI_CODEX_MODEL", cfg.LLM.DefaultModel)
 		case "google", "gemini":
-			setIfEmpty("GEMINI_MODEL", cfg.LLM.DefaultModel)
+			exportLLMEnv("GEMINI_MODEL", cfg.LLM.DefaultModel)
 		case "local":
-			setIfEmpty("LOCAL_MODEL", cfg.LLM.DefaultModel)
+			exportLLMEnv("LOCAL_MODEL", cfg.LLM.DefaultModel)
 		}
 	}
 	// The openai and openrouter providers share the OPENAI_* variables. Pick a
@@ -136,57 +333,58 @@ func applyLLMConfigEnv() {
 		}
 		if p.IsOAuth() {
 			// OAuth subscription providers export a bearer token that the
-			// engine's router picks up. Anthropic (Claude Code) and OpenAI
-			// Codex (ChatGPT subscription) are wired through the engine.
+			// engine's router picks up, plus the token's true expiry so the
+			// engine can cache the credential exactly that long. Anthropic
+			// (Claude Code) and OpenAI Codex (ChatGPT subscription) are wired
+			// through the engine.
+			exportOAuthCredential(name, &p)
 			switch name {
 			case "anthropic":
-				setIfEmpty("ANTHROPIC_AUTH_TOKEN", p.AuthToken)
-				setIfEmpty("ANTHROPIC_REASONING_EFFORT", p.ReasoningEffort)
+				exportLLMEnv("ANTHROPIC_REASONING_EFFORT", p.ReasoningEffort)
 			case "openai-codex":
-				setIfEmpty("OPENAI_CODEX_AUTH_TOKEN", p.AuthToken)
-				setIfEmpty("OPENAI_CODEX_MODEL", p.Model)
-				setIfEmpty("OPENAI_CODEX_REASONING_EFFORT", p.ReasoningEffort)
+				exportLLMEnv("OPENAI_CODEX_MODEL", p.Model)
+				exportLLMEnv("OPENAI_CODEX_REASONING_EFFORT", p.ReasoningEffort)
 			}
 			continue
 		}
 		switch name {
 		case "anthropic":
-			setIfEmpty("ANTHROPIC_API_KEY", p.APIKey)
-			setIfEmpty("ANTHROPIC_BASE_URL", p.BaseURL)
-			setIfEmpty("ANTHROPIC_MODEL", p.Model)
-			setIfEmpty("ANTHROPIC_REASONING_EFFORT", p.ReasoningEffort)
+			exportLLMEnv("ANTHROPIC_API_KEY", p.APIKey)
+			exportLLMEnv("ANTHROPIC_BASE_URL", p.BaseURL)
+			exportLLMEnv("ANTHROPIC_MODEL", p.Model)
+			exportLLMEnv("ANTHROPIC_REASONING_EFFORT", p.ReasoningEffort)
 		case "openai":
 			if name != openAISlotOwner {
 				continue
 			}
-			setIfEmpty("OPENAI_API_KEY", p.APIKey)
-			setIfEmpty("OPENAI_BASE_URL", p.BaseURL)
-			setIfEmpty("OPENAI_MODEL", p.Model)
+			exportLLMEnv("OPENAI_API_KEY", p.APIKey)
+			exportLLMEnv("OPENAI_BASE_URL", p.BaseURL)
+			exportLLMEnv("OPENAI_MODEL", p.Model)
 		case "google", "gemini":
-			setIfEmpty("GEMINI_API_KEY", p.APIKey)
-			setIfEmpty("GEMINI_BASE_URL", p.BaseURL)
-			setIfEmpty("GEMINI_MODEL", p.Model)
-			setIfEmpty("GEMINI_REASONING_EFFORT", p.ReasoningEffort)
+			exportLLMEnv("GEMINI_API_KEY", p.APIKey)
+			exportLLMEnv("GEMINI_BASE_URL", p.BaseURL)
+			exportLLMEnv("GEMINI_MODEL", p.Model)
+			exportLLMEnv("GEMINI_REASONING_EFFORT", p.ReasoningEffort)
 		case "openrouter":
 			// OpenRouter is OpenAI-compatible; route it through the OpenAI vars.
 			if name != openAISlotOwner {
 				continue
 			}
-			setIfEmpty("OPENAI_API_KEY", p.APIKey)
-			setIfEmpty("OPENAI_MODEL", p.Model)
+			exportLLMEnv("OPENAI_API_KEY", p.APIKey)
+			exportLLMEnv("OPENAI_MODEL", p.Model)
 			base := p.BaseURL
 			if base == "" {
 				base = "https://openrouter.ai/api/v1"
 			}
-			setIfEmpty("OPENAI_BASE_URL", base)
+			exportLLMEnv("OPENAI_BASE_URL", base)
 		case "local":
 			// A self-hosted, OpenAI- or Anthropic-compatible endpoint. The engine
 			// tunnels to it through this client, so it need only be reachable from
 			// here (e.g. Ollama on localhost).
-			setIfEmpty("LOCAL_BASE_URL", p.BaseURL)
-			setIfEmpty("LOCAL_MODEL", p.Model)
-			setIfEmpty("LOCAL_API_COMPAT", p.APICompat)
-			setIfEmpty("LOCAL_API_KEY", p.APIKey)
+			exportLLMEnv("LOCAL_BASE_URL", p.BaseURL)
+			exportLLMEnv("LOCAL_MODEL", p.Model)
+			exportLLMEnv("LOCAL_API_COMPAT", p.APICompat)
+			exportLLMEnv("LOCAL_API_KEY", p.APIKey)
 		}
 	}
 }

--- a/internal/cmd/dagger/llm_config.go
+++ b/internal/cmd/dagger/llm_config.go
@@ -127,6 +127,10 @@ func exportOAuthEnv(ctx context.Context, provider string) error {
 	return nil
 }
 
+// backgroundOAuthRefresh is replaceable so the refresher's scheduling and
+// terminal-error behavior can be tested without a provider endpoint.
+var backgroundOAuthRefresh = exportOAuthEnv
+
 // Timings for the background refresher. Vars, not consts, so tests can shrink
 // them — the same reason llmconfig's endpoint URLs are vars.
 var (
@@ -170,11 +174,24 @@ func startOAuthTokenRefresher(ctx context.Context) func() {
 				return
 			case <-time.After(nextOAuthRefreshDelay(providers)):
 			}
+			remaining := providers[:0]
 			for _, provider := range providers {
-				if err := exportOAuthEnv(ctx, provider); err != nil && ctx.Err() == nil {
+				err := backgroundOAuthRefresh(ctx, provider)
+				if err != nil && ctx.Err() == nil {
 					slog.WarnContext(ctx, "failed to refresh LLM OAuth token",
 						"provider", provider, "error", err)
+					if llmconfig.IsTerminalOAuthRefreshError(err) {
+						// invalid_grant and a missing refresh token cannot recover on
+						// the next 30-second tick. Warn once and leave on-demand
+						// refreshes to surface the reauthentication requirement.
+						continue
+					}
 				}
+				remaining = append(remaining, provider)
+			}
+			providers = remaining
+			if len(providers) == 0 {
+				return
 			}
 		}
 	}()

--- a/internal/cmd/dagger/llm_config_test.go
+++ b/internal/cmd/dagger/llm_config_test.go
@@ -1,9 +1,12 @@
 package daggercmd
 
 import (
+	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -354,6 +357,85 @@ func TestStartOAuthTokenRefresher(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got != "second-token" {
 		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q after stop, want the refresher to have stopped at %q", got, "second-token")
+	}
+}
+
+func TestOAuthTokenRefresherErrorScheduling(t *testing.T) {
+	tempDir := t.TempDir()
+	origConfigRoot, origConfigFile := llmconfig.ConfigRoot, llmconfig.ConfigFile
+	t.Cleanup(func() {
+		llmconfig.ConfigRoot, llmconfig.ConfigFile = origConfigRoot, origConfigFile
+	})
+	llmconfig.ConfigRoot = filepath.Join(tempDir, "dagger")
+	llmconfig.ConfigFile = filepath.Join(llmconfig.ConfigRoot, llmconfig.ConfigFileName)
+
+	cfg := &llmconfig.Config{
+		LLM: llmconfig.LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]llmconfig.Provider{
+				"anthropic": {
+					AuthType:       "oauth",
+					AuthToken:      "stale-token",
+					RefreshToken:   "invalid-refresh-token",
+					TokenExpiresAt: time.Now().Add(-time.Hour).UnixMilli(),
+					Enabled:        true,
+				},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	origRefresh := backgroundOAuthRefresh
+	origInterval, origMin := oauthRefreshUnknownInterval, oauthRefreshMinDelay
+	t.Cleanup(func() {
+		backgroundOAuthRefresh = origRefresh
+		oauthRefreshUnknownInterval, oauthRefreshMinDelay = origInterval, origMin
+	})
+	oauthRefreshUnknownInterval = time.Millisecond
+	oauthRefreshMinDelay = time.Millisecond
+
+	var calls atomic.Int32
+	backgroundOAuthRefresh = func(context.Context, string) error {
+		calls.Add(1)
+		return llmconfig.ErrOAuthReauthenticationRequired
+	}
+
+	stop := startOAuthTokenRefresher(t.Context())
+	t.Cleanup(stop)
+	deadline := time.Now().Add(10 * time.Second)
+	for calls.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("background refresh calls = %d, want 1", got)
+	}
+
+	// An overdue token normally re-arms at oauthRefreshMinDelay. A terminal
+	// failure must retire it from the background scheduler instead.
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("background refresh calls after terminal error = %d, want 1", got)
+	}
+	stop()
+
+	// A transient failure stays scheduled and is attempted again on the next
+	// minimum-delay tick.
+	calls.Store(0)
+	backgroundOAuthRefresh = func(context.Context, string) error {
+		calls.Add(1)
+		return errors.New("temporary refresh failure")
+	}
+	stopTransient := startOAuthTokenRefresher(t.Context())
+	t.Cleanup(stopTransient)
+	deadline = time.Now().Add(10 * time.Second)
+	for calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	stopTransient()
+	if got := calls.Load(); got < 2 {
+		t.Errorf("background transient refresh calls = %d, want at least 2", got)
 	}
 }
 

--- a/internal/cmd/dagger/llm_config_test.go
+++ b/internal/cmd/dagger/llm_config_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/dagger/dagger/engine/client/secretprovider"
 	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 )
 
@@ -51,6 +53,352 @@ func TestRemoveKeyClearsDefaultModel(t *testing.T) {
 	}
 	if loaded.LLM.DefaultModel != "" {
 		t.Errorf("DefaultModel = %q, want empty after removing the default provider", loaded.LLM.DefaultModel)
+	}
+}
+
+// TestExplicitAuthTokenNotClobbered verifies that a user-exported
+// ANTHROPIC_AUTH_TOKEN survives both the startup export and the on-demand
+// refresher hook. applyLLMConfigEnv already deferred to explicit env vars, but
+// the hook then overwrote the variable with the config's token on every secret
+// resolution — even when nothing was refreshed.
+func TestExplicitAuthTokenNotClobbered(t *testing.T) {
+	tempDir := t.TempDir()
+	origConfigRoot := llmconfig.ConfigRoot
+	origConfigFile := llmconfig.ConfigFile
+	t.Cleanup(func() {
+		llmconfig.ConfigRoot = origConfigRoot
+		llmconfig.ConfigFile = origConfigFile
+	})
+	llmconfig.ConfigRoot = filepath.Join(tempDir, "dagger")
+	llmconfig.ConfigFile = filepath.Join(llmconfig.ConfigRoot, llmconfig.ConfigFileName)
+
+	cfg := &llmconfig.Config{
+		LLM: llmconfig.LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]llmconfig.Provider{
+				"anthropic": {
+					AuthType:  "oauth",
+					AuthToken: "config-token",
+					// Far enough out that nothing tries to refresh it.
+					TokenExpiry:  time.Now().Add(time.Hour).UnixMilli(),
+					RefreshToken: "rt-0",
+					Enabled:      true,
+				},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "user-token")
+
+	applyLLMConfigEnv()
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got != "user-token" {
+		t.Fatalf("after applyLLMConfigEnv, ANTHROPIC_AUTH_TOKEN = %q, want the explicit %q", got, "user-token")
+	}
+
+	// Resolve the secret the way the engine does, which runs the refresher
+	// hook registered in this package's init.
+	resolver, name, err := secretprovider.ResolverForID("env://ANTHROPIC_AUTH_TOKEN")
+	if err != nil {
+		t.Fatalf("ResolverForID() failed: %v", err)
+	}
+	val, err := resolver(t.Context(), name)
+	if err != nil {
+		t.Fatalf("resolving env://ANTHROPIC_AUTH_TOKEN failed: %v", err)
+	}
+	if string(val) != "user-token" {
+		t.Errorf("resolved token = %q, want the explicit %q", val, "user-token")
+	}
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got != "user-token" {
+		t.Errorf("refresher hook overwrote ANTHROPIC_AUTH_TOKEN with %q", got)
+	}
+}
+
+// TestOAuthExpiryEnvExported pins the env contract the engine depends on: the
+// access token's true expiry travels next to the token as RFC 3339 UTC, and
+// the refresher hook updates both variables whichever one the engine asks for
+// — it resolves the token first and the expiry second within one credential
+// resolution, so updating only the requested variable would pair a fresh token
+// with a stale deadline.
+func TestOAuthExpiryEnvExported(t *testing.T) {
+	tempDir := t.TempDir()
+	origConfigRoot := llmconfig.ConfigRoot
+	origConfigFile := llmconfig.ConfigFile
+	t.Cleanup(func() {
+		llmconfig.ConfigRoot = origConfigRoot
+		llmconfig.ConfigFile = origConfigFile
+	})
+	llmconfig.ConfigRoot = filepath.Join(tempDir, "dagger")
+	llmconfig.ConfigFile = filepath.Join(llmconfig.ConfigRoot, llmconfig.ConfigFileName)
+
+	for _, key := range []string{"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN_EXPIRES_AT"} {
+		if val, ok := os.LookupEnv(key); ok {
+			t.Cleanup(func() { os.Setenv(key, val) })
+			os.Unsetenv(key)
+		} else {
+			t.Cleanup(func() { os.Unsetenv(key) })
+		}
+	}
+
+	// Truncated to the second: RFC 3339 without sub-second digits is what we
+	// promise to write.
+	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	save := func(token string, expiresAt time.Time) {
+		t.Helper()
+		cfg := &llmconfig.Config{
+			LLM: llmconfig.LLMConfig{
+				DefaultProvider: "anthropic",
+				Providers: map[string]llmconfig.Provider{
+					"anthropic": {
+						AuthType:       "oauth",
+						AuthToken:      token,
+						RefreshToken:   "rt-0",
+						TokenExpiresAt: expiresAt.UnixMilli(),
+						Enabled:        true,
+					},
+				},
+			},
+		}
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("Save() failed: %v", err)
+		}
+	}
+
+	save("config-token", expiresAt)
+	applyLLMConfigEnv()
+
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got != "config-token" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q, want %q", got, "config-token")
+	}
+	if got, want := os.Getenv("ANTHROPIC_AUTH_TOKEN_EXPIRES_AT"), expiresAt.Format(time.RFC3339); got != want {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN_EXPIRES_AT = %q, want %q", got, want)
+	}
+
+	// Another dagger process refreshes the token and rewrites the config.
+	rotatedAt := expiresAt.Add(time.Hour)
+	save("rotated-token", rotatedAt)
+
+	// The engine asks for the expiry variable; the hook must update both.
+	resolver, name, err := secretprovider.ResolverForID("env://ANTHROPIC_AUTH_TOKEN_EXPIRES_AT")
+	if err != nil {
+		t.Fatalf("ResolverForID() failed: %v", err)
+	}
+	val, err := resolver(t.Context(), name)
+	if err != nil {
+		t.Fatalf("resolving env://ANTHROPIC_AUTH_TOKEN_EXPIRES_AT failed: %v", err)
+	}
+	if want := rotatedAt.Format(time.RFC3339); string(val) != want {
+		t.Errorf("resolved expiry = %q, want %q", val, want)
+	}
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got != "rotated-token" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q, want the hook to have updated it to %q", got, "rotated-token")
+	}
+}
+
+// TestNextOAuthRefreshDelay covers the re-arming rule: the delay is derived
+// from the *currently persisted* expiry every cycle, so a token another dagger
+// process refreshed is respected, an unknown expiry falls back to a periodic
+// check instead of hot-looping, and an overdue token can't spin the loop.
+func TestNextOAuthRefreshDelay(t *testing.T) {
+	tempDir := t.TempDir()
+	origConfigRoot := llmconfig.ConfigRoot
+	origConfigFile := llmconfig.ConfigFile
+	t.Cleanup(func() {
+		llmconfig.ConfigRoot = origConfigRoot
+		llmconfig.ConfigFile = origConfigFile
+	})
+	llmconfig.ConfigRoot = filepath.Join(tempDir, "dagger")
+	llmconfig.ConfigFile = filepath.Join(llmconfig.ConfigRoot, llmconfig.ConfigFileName)
+
+	save := func(p llmconfig.Provider) {
+		t.Helper()
+		cfg := &llmconfig.Config{
+			LLM: llmconfig.LLMConfig{
+				DefaultProvider: "anthropic",
+				Providers:       map[string]llmconfig.Provider{"anthropic": p},
+			},
+		}
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("Save() failed: %v", err)
+		}
+	}
+	oauth := func(expiresAt int64) llmconfig.Provider {
+		return llmconfig.Provider{
+			AuthType:       "oauth",
+			AuthToken:      "config-token",
+			RefreshToken:   "rt-0",
+			TokenExpiresAt: expiresAt,
+			Enabled:        true,
+		}
+	}
+
+	providers := []string{"anthropic"}
+
+	save(oauth(time.Now().Add(time.Hour).UnixMilli()))
+	got := nextOAuthRefreshDelay(providers)
+	if want := time.Hour - oauthRefreshLead; got > want || got < want-time.Minute {
+		t.Errorf("delay for a token expiring in an hour = %v, want about %v", got, want)
+	}
+
+	// A refresh elsewhere pushed the expiry out; the next cycle must see it.
+	save(oauth(time.Now().Add(3 * time.Hour).UnixMilli()))
+	if got := nextOAuthRefreshDelay(providers); got < 2*time.Hour {
+		t.Errorf("delay after the config was rewritten = %v, want it re-armed from the new expiry", got)
+	}
+
+	save(oauth(0))
+	if got := nextOAuthRefreshDelay(providers); got != oauthRefreshUnknownInterval {
+		t.Errorf("delay for an unknown expiry = %v, want the periodic %v", got, oauthRefreshUnknownInterval)
+	}
+
+	save(oauth(time.Now().Add(-time.Hour).UnixMilli()))
+	if got := nextOAuthRefreshDelay(providers); got != oauthRefreshMinDelay {
+		t.Errorf("delay for an overdue token = %v, want the floor %v", got, oauthRefreshMinDelay)
+	}
+
+	disabled := oauth(time.Now().Add(time.Hour).UnixMilli())
+	disabled.Enabled = false
+	save(disabled)
+	if got := nextOAuthRefreshDelay(providers); got != oauthRefreshUnknownInterval {
+		t.Errorf("delay once every provider is disabled = %v, want the periodic %v", got, oauthRefreshUnknownInterval)
+	}
+	if names := enabledOAuthProviders(); len(names) != 0 {
+		t.Errorf("enabledOAuthProviders() = %v, want none once the provider is disabled", names)
+	}
+}
+
+// TestStartOAuthTokenRefresher exercises the background refresher end to end:
+// it starts only when a subscription provider is configured, keeps the
+// exported variables in step with the persisted config across cycles (which is
+// what makes an idle `dagger shell` survive a token rotation), and stops when
+// its context is cancelled.
+func TestStartOAuthTokenRefresher(t *testing.T) {
+	tempDir := t.TempDir()
+	origConfigRoot := llmconfig.ConfigRoot
+	origConfigFile := llmconfig.ConfigFile
+	t.Cleanup(func() {
+		llmconfig.ConfigRoot = origConfigRoot
+		llmconfig.ConfigFile = origConfigFile
+	})
+	llmconfig.ConfigRoot = filepath.Join(tempDir, "dagger")
+	llmconfig.ConfigFile = filepath.Join(llmconfig.ConfigRoot, llmconfig.ConfigFileName)
+
+	for _, key := range []string{"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN_EXPIRES_AT"} {
+		if val, ok := os.LookupEnv(key); ok {
+			t.Cleanup(func() { os.Setenv(key, val) })
+			os.Unsetenv(key)
+		} else {
+			t.Cleanup(func() { os.Unsetenv(key) })
+		}
+	}
+
+	// No config at all: nothing to keep fresh, so nothing starts.
+	stop := startOAuthTokenRefresher(t.Context())
+	stop()
+
+	save := func(token string) {
+		t.Helper()
+		cfg := &llmconfig.Config{
+			LLM: llmconfig.LLMConfig{
+				DefaultProvider: "anthropic",
+				Providers: map[string]llmconfig.Provider{
+					"anthropic": {
+						AuthType:     "oauth",
+						AuthToken:    token,
+						RefreshToken: "rt-0",
+						// Unknown expiry: the loop polls on its fallback
+						// interval and never needs the token endpoint.
+						Enabled: true,
+					},
+				},
+			},
+		}
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("Save() failed: %v", err)
+		}
+	}
+
+	origInterval, origMin := oauthRefreshUnknownInterval, oauthRefreshMinDelay
+	t.Cleanup(func() {
+		oauthRefreshUnknownInterval, oauthRefreshMinDelay = origInterval, origMin
+	})
+	oauthRefreshUnknownInterval = 5 * time.Millisecond
+	oauthRefreshMinDelay = time.Millisecond
+
+	save("first-token")
+	stop = startOAuthTokenRefresher(t.Context())
+	t.Cleanup(stop)
+
+	waitForEnv := func(key, want string) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if os.Getenv(key) == want {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatalf("%s = %q, want %q", key, os.Getenv(key), want)
+	}
+	waitForEnv("ANTHROPIC_AUTH_TOKEN", "first-token")
+
+	// Another dagger process rotates the token; the refresher picks it up on
+	// its next cycle without being told.
+	save("second-token")
+	waitForEnv("ANTHROPIC_AUTH_TOKEN", "second-token")
+
+	stop()
+	save("third-token")
+	time.Sleep(50 * time.Millisecond)
+	if got := os.Getenv("ANTHROPIC_AUTH_TOKEN"); got != "second-token" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q after stop, want the refresher to have stopped at %q", got, "second-token")
+	}
+}
+
+// TestApplyLLMConfigEnvKeepsDefaultModel guards the interaction between the
+// default-model export and the provider loop: the provider's own model field
+// is usually empty, and exporting "nothing" for it must not undo the default
+// model exported moments earlier.
+func TestApplyLLMConfigEnvKeepsDefaultModel(t *testing.T) {
+	tempDir := t.TempDir()
+	origConfigRoot := llmconfig.ConfigRoot
+	origConfigFile := llmconfig.ConfigFile
+	t.Cleanup(func() {
+		llmconfig.ConfigRoot = origConfigRoot
+		llmconfig.ConfigFile = origConfigFile
+	})
+	llmconfig.ConfigRoot = filepath.Join(tempDir, "dagger")
+	llmconfig.ConfigFile = filepath.Join(llmconfig.ConfigRoot, llmconfig.ConfigFileName)
+
+	for _, key := range []string{"ANTHROPIC_MODEL", "ANTHROPIC_API_KEY"} {
+		if val, ok := os.LookupEnv(key); ok {
+			t.Cleanup(func() { os.Setenv(key, val) })
+			os.Unsetenv(key)
+		} else {
+			t.Cleanup(func() { os.Unsetenv(key) })
+		}
+	}
+
+	cfg := &llmconfig.Config{
+		LLM: llmconfig.LLMConfig{
+			DefaultProvider: "anthropic",
+			DefaultModel:    "claude-sonnet-4.5",
+			Providers: map[string]llmconfig.Provider{
+				// No Model of its own, which is the common case.
+				"anthropic": {APIKey: "sk-ant", Enabled: true},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	applyLLMConfigEnv()
+
+	if got := os.Getenv("ANTHROPIC_MODEL"); got != "claude-sonnet-4.5" {
+		t.Errorf("ANTHROPIC_MODEL = %q, want the configured default %q", got, "claude-sonnet-4.5")
 	}
 }
 

--- a/internal/cmd/dagger/llmconfig/config.go
+++ b/internal/cmd/dagger/llmconfig/config.go
@@ -1,10 +1,13 @@
 package llmconfig
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/adrg/xdg"
 	"github.com/gofrs/flock"
@@ -16,6 +19,19 @@ import (
 // token (providers rotate them), or clobber another provider's freshly
 // rotated token via Save's whole-section rewrite.
 var oauthRefreshMu sync.Mutex
+
+// oauthRefreshFloor bounds how often a single provider is refreshed in this
+// process, whatever its persisted expiry says. A token whose whole lifetime is
+// shorter than the safety margin sits inside that margin from the moment it is
+// issued, so the expiry check alone would refresh — and rotate the single-use
+// refresh token — on every secret resolution, twice per credential.
+const oauthRefreshFloor = 30 * time.Second
+
+// lastOAuthRefresh records when each provider was last refreshed. Keyed by
+// config file as well as provider name, so pointing DAGGER_CONFIG at a
+// different credential store starts from a clean slate. Guarded by
+// oauthRefreshMu.
+var lastOAuthRefresh = map[string]time.Time{}
 
 const (
 	ConfigFileName = "config.toml"
@@ -56,10 +72,20 @@ type Provider struct {
 	Enabled          bool   `toml:"enabled"`
 
 	// OAuth fields for Claude Code subscription auth
-	AuthType         string `toml:"auth_type,omitempty"`         // "oauth" for Claude Code OAuth
-	AuthToken        string `toml:"auth_token,omitempty"`        // OAuth access token
-	RefreshToken     string `toml:"refresh_token,omitempty"`     // OAuth refresh token
-	TokenExpiry      int64  `toml:"token_expiry,omitempty"`      // Unix timestamp (ms) when access token expires
+	AuthType     string `toml:"auth_type,omitempty"`     // "oauth" for Claude Code OAuth
+	AuthToken    string `toml:"auth_token,omitempty"`    // OAuth access token
+	RefreshToken string `toml:"refresh_token,omitempty"` // OAuth refresh token
+	// TokenExpiresAt is when the access token truly expires, in unix
+	// milliseconds, with no safety margin baked in. The margin is applied when
+	// the value is checked (IsTokenExpired), so an absent or short expires_in
+	// can't persist an already-expired value.
+	TokenExpiresAt int64 `toml:"token_expires_at,omitempty"`
+	// TokenExpiry is the legacy expiry: the same instant with the safety margin
+	// already subtracted. Still written so that an older CLI sharing this config
+	// file keeps working — it reads only this field and treats 0 as expired,
+	// which would put it in a refresh loop rotating the token out from under
+	// this one. TokenExpiresAt wins when both are present.
+	TokenExpiry      int64  `toml:"token_expiry,omitempty"`
 	SubscriptionType string `toml:"subscription_type,omitempty"` // "pro", "max", "team", "enterprise"
 
 	// ReasoningEffort is the reasoning level for the provider's model, taken
@@ -105,8 +131,9 @@ func Load() (*Config, error) {
 // config file is shared with other subsystems, so the section is merged into
 // the existing document rather than replacing the whole file.
 func (c *Config) Save() error {
-	// Create directory if needed
-	if err := os.MkdirAll(ConfigRoot, 0755); err != nil {
+	// Create the directory the config file actually lives in, which is not
+	// ConfigRoot when DAGGER_CONFIG points somewhere else.
+	if err := os.MkdirAll(filepath.Dir(ConfigFile), 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -118,6 +145,14 @@ func (c *Config) Save() error {
 	}
 	defer lock.Unlock()
 
+	return c.write()
+}
+
+// write merges the [llm] section into the config document on disk and rewrites
+// it atomically. The caller must already hold the cross-process lock: flock is
+// per open file description, so re-taking it here would deadlock a caller that
+// holds it (withConfigLock).
+func (c *Config) write() error {
 	// Initialize providers map if nil
 	if c.LLM.Providers == nil {
 		c.LLM.Providers = make(map[string]Provider)
@@ -152,6 +187,46 @@ func (c *Config) Save() error {
 	}
 
 	return nil
+}
+
+// withConfigLock runs fn against the config as it exists on disk *right now* —
+// re-read after the cross-process lock is taken — and persists the result
+// before releasing the lock, so load→modify→persist is a single critical
+// section.
+//
+// Re-reading is the point. OAuth refresh tokens are single-use and rotating:
+// a process that loaded the config before another process refreshed would
+// otherwise spend a dead refresh token (invalid_grant, i.e. a permanent
+// logout) and then write its stale snapshot back over the winner's rotated
+// token. fn reports whether it changed anything; nothing is written when it
+// did not.
+func withConfigLock(fn func(cfg *Config) (changed bool, err error)) error {
+	if err := os.MkdirAll(filepath.Dir(ConfigFile), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	lock := flock.New(ConfigFile + ".lock")
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	defer lock.Unlock()
+
+	cfg, err := Load()
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		cfg = &Config{LLM: LLMConfig{Providers: make(map[string]Provider)}}
+	}
+
+	changed, fnErr := fn(cfg)
+	if !changed {
+		return fnErr
+	}
+	if err := cfg.write(); err != nil {
+		return errors.Join(fnErr, err)
+	}
+	return fnErr
 }
 
 // UpdateFile applies fn to the current config file contents under the
@@ -291,18 +366,30 @@ func Remove() error {
 // refreshProviderToken refreshes an expired OAuth provider in place, dispatching
 // to the provider-specific refresh flow. It returns the (possibly updated)
 // provider and whether it changed.
-func refreshProviderToken(name string, provider Provider) (Provider, bool, error) {
-	if !provider.IsOAuth() || !IsTokenExpired(&provider) {
+func refreshProviderToken(ctx context.Context, name string, provider Provider) (Provider, bool, error) {
+	// A disabled provider's credentials are never exported (applyLLMConfigEnv
+	// skips it), so refreshing it would spend its single-use grant for nothing
+	// — and rotate a refresh token the user still expects to work when they
+	// re-enable the provider.
+	if !provider.Enabled || !provider.IsOAuth() || !IsTokenExpired(&provider) {
 		return provider, false, nil
 	}
+	// Rate-limit per provider, so a pathologically short-lived token can't turn
+	// every resolution into another rotation. The caller holds oauthRefreshMu.
+	floorKey := ConfigFile + "\x00" + name
+	if time.Since(lastOAuthRefresh[floorKey]) < oauthRefreshFloor {
+		return provider, false, nil
+	}
+	lastOAuthRefresh[floorKey] = time.Now()
+
 	var refreshed *Provider
 	var err error
 	switch name {
 	case "openai-codex":
-		refreshed, err = RefreshOpenAIOAuthToken(&provider)
+		refreshed, err = RefreshOpenAIOAuthToken(ctx, &provider)
 	default:
 		// Anthropic and other providers use the standard refresh
-		refreshed, err = RefreshOAuthToken(&provider)
+		refreshed, err = RefreshOAuthToken(ctx, &provider)
 	}
 	if err != nil {
 		return provider, false, fmt.Errorf("failed to refresh OAuth token for %s: %w", name, err)
@@ -313,63 +400,69 @@ func refreshProviderToken(name string, provider Provider) (Provider, bool, error
 // RefreshOAuthTokensIfNeeded checks all OAuth providers in the config and
 // refreshes any expired tokens. This should be called client-side before
 // connecting to the engine.
-func RefreshOAuthTokensIfNeeded() error {
+func RefreshOAuthTokensIfNeeded(ctx context.Context) error {
 	oauthRefreshMu.Lock()
 	defer oauthRefreshMu.Unlock()
 
-	cfg, err := Load()
-	if err != nil || cfg == nil {
-		// a missing or unreadable config is non-fatal here
+	// Nothing to refresh, and no reason to create the config directory (or its
+	// lock file) for a user who has no config at all.
+	if !ConfigExists() {
 		return nil
 	}
 
-	var changed bool
-	for name, provider := range cfg.LLM.Providers {
-		refreshed, didChange, err := refreshProviderToken(name, provider)
-		if err != nil {
-			return err
+	return withConfigLock(func(cfg *Config) (bool, error) {
+		var changed bool
+		var errs []error
+		for name, provider := range cfg.LLM.Providers {
+			refreshed, didChange, err := refreshProviderToken(ctx, name, provider)
+			if err != nil {
+				// Keep going: a refresh grant is single-use, so a provider
+				// that already spent its own must not lose the result because
+				// a later provider failed — and which provider that is was
+				// decided by Go's randomized map order.
+				errs = append(errs, err)
+				continue
+			}
+			if didChange {
+				cfg.LLM.Providers[name] = refreshed
+				changed = true
+			}
 		}
-		if didChange {
-			cfg.LLM.Providers[name] = refreshed
-			changed = true
-		}
-	}
-
-	if changed {
-		if err := cfg.Save(); err != nil {
-			return fmt.Errorf("failed to save refreshed tokens: %w", err)
-		}
-	}
-
-	return nil
+		return changed, errors.Join(errs...)
+	})
 }
 
 // RefreshOAuthProviderIfNeeded refreshes a single OAuth provider by name if its
-// token has expired, persisting the result. It returns the current access token
-// for the provider (refreshed or not), or "" if the provider is absent or not
-// an OAuth provider. Used to keep a long-running session's bearer token fresh:
-// the client re-resolves the token on demand rather than only at startup.
-func RefreshOAuthProviderIfNeeded(name string) (string, error) {
+// token has expired, persisting the result. It returns the provider as it now
+// stands (refreshed or not), or nil if it is absent, disabled, or not an OAuth
+// provider. Used to keep a long-running session's bearer token fresh: the
+// client re-resolves the token on demand rather than only at startup.
+func RefreshOAuthProviderIfNeeded(ctx context.Context, name string) (*Provider, error) {
 	oauthRefreshMu.Lock()
 	defer oauthRefreshMu.Unlock()
 
-	cfg, err := Load()
-	if err != nil || cfg == nil {
-		return "", err
+	if !ConfigExists() {
+		return nil, nil
 	}
-	provider, ok := cfg.LLM.Providers[name]
-	if !ok || !provider.IsOAuth() {
-		return "", nil
-	}
-	refreshed, changed, err := refreshProviderToken(name, provider)
-	if err != nil {
-		return "", err
-	}
-	if changed {
-		cfg.LLM.Providers[name] = refreshed
-		if err := cfg.Save(); err != nil {
-			return "", fmt.Errorf("failed to save refreshed tokens: %w", err)
+
+	var current *Provider
+	err := withConfigLock(func(cfg *Config) (bool, error) {
+		provider, ok := cfg.LLM.Providers[name]
+		if !ok || !provider.IsOAuth() || !provider.Enabled {
+			return false, nil
 		}
+		refreshed, changed, err := refreshProviderToken(ctx, name, provider)
+		if err != nil {
+			return false, err
+		}
+		current = &refreshed
+		if changed {
+			cfg.LLM.Providers[name] = refreshed
+		}
+		return changed, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return refreshed.AuthToken, nil
+	return current, nil
 }

--- a/internal/cmd/dagger/llmconfig/config.go
+++ b/internal/cmd/dagger/llmconfig/config.go
@@ -392,7 +392,11 @@ func refreshProviderToken(ctx context.Context, name string, provider Provider) (
 		refreshed, err = RefreshOAuthToken(ctx, &provider)
 	}
 	if err != nil {
-		return provider, false, fmt.Errorf("failed to refresh OAuth token for %s: %w", name, err)
+		refreshErr := fmt.Errorf("failed to refresh OAuth token for %s: %w", name, err)
+		if isTerminalOAuthTokenError(err) {
+			return provider, false, fmt.Errorf("%w: %w; run 'dagger llm setup' to reauthenticate", ErrOAuthReauthenticationRequired, refreshErr)
+		}
+		return provider, false, refreshErr
 	}
 	return *refreshed, true, nil
 }

--- a/internal/cmd/dagger/llmconfig/config_test.go
+++ b/internal/cmd/dagger/llmconfig/config_test.go
@@ -287,6 +287,49 @@ func TestLLMConfigured(t *testing.T) {
 	}
 }
 
+// TestConfigSaveOutsideConfigRoot verifies that Save creates the directory the
+// config file actually lives in. DAGGER_CONFIG can point anywhere, and a Save
+// that only mkdirs ConfigRoot fails for such a user — which for an OAuth
+// refresh means the one-time refresh token is spent and the result is lost.
+func TestConfigSaveOutsideConfigRoot(t *testing.T) {
+	tempDir := t.TempDir()
+
+	origConfigRoot := ConfigRoot
+	origConfigFile := ConfigFile
+	t.Cleanup(func() {
+		ConfigRoot = origConfigRoot
+		ConfigFile = origConfigFile
+	})
+
+	// The XDG root and the config file deliberately live in different trees,
+	// as they do when DAGGER_CONFIG is set.
+	ConfigRoot = filepath.Join(tempDir, "xdg", "dagger")
+	ConfigFile = filepath.Join(tempDir, "elsewhere", "nested", "dagger.toml")
+
+	cfg := &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": {APIKey: "sk-ant-test", Enabled: true},
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+	if !ConfigExists() {
+		t.Fatalf("Save() did not create %s", ConfigFile)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if diff := cmp.Diff(cfg, loaded); diff != "" {
+		t.Errorf("Loaded config differs from original (-want +got):\n%s", diff)
+	}
+}
+
 func TestConfigConcurrentWrites(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -550,7 +593,11 @@ func TestRefreshOAuthProviderConcurrent(t *testing.T) {
 	for i := 0; i < workers; i++ {
 		go func() {
 			<-start
-			token, err := RefreshOAuthProviderIfNeeded("anthropic")
+			refreshed, err := RefreshOAuthProviderIfNeeded(t.Context(), "anthropic")
+			var token string
+			if refreshed != nil {
+				token = refreshed.AuthToken
+			}
 			results <- result{token, err}
 		}()
 	}

--- a/internal/cmd/dagger/llmconfig/oauth.go
+++ b/internal/cmd/dagger/llmconfig/oauth.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,6 +45,57 @@ const oauthHTTPTimeout = 10 * time.Second
 
 var oauthHTTPClient = &http.Client{Timeout: oauthHTTPTimeout}
 
+// oauthTokenError is the safe, structured form of an OAuth token endpoint
+// failure. Token endpoint bodies are untrusted and can contain credentials, so
+// errors retain only a recognized OAuth error code and the HTTP status.
+type oauthTokenError struct {
+	status int
+	code   string
+}
+
+func (e *oauthTokenError) Error() string {
+	if e.code != "" {
+		return fmt.Sprintf("OAuth error %s (HTTP %d)", e.code, e.status)
+	}
+	return fmt.Sprintf("OAuth token endpoint returned HTTP %d", e.status)
+}
+
+// recognizedOAuthErrorCode returns code only for the error identifiers defined
+// by RFC 6749. Never putting arbitrary response text in an error keeps token
+// endpoint failures from leaking credentials into logs or the TUI.
+func recognizedOAuthErrorCode(code string) string {
+	switch code {
+	case "invalid_request", "invalid_client", "invalid_grant", "unauthorized_client", "unsupported_grant_type", "invalid_scope":
+		return code
+	default:
+		return ""
+	}
+}
+
+// ErrOAuthReauthenticationRequired marks refresh failures that cannot succeed
+// again until the user replaces the OAuth grant.
+var ErrOAuthReauthenticationRequired = errors.New("OAuth reauthentication required")
+
+// errNoRefreshToken is terminal until the provider is authorized again.
+var errNoRefreshToken = errors.New("no OAuth refresh token available")
+
+// isTerminalOAuthTokenError reports low-level failures for which retrying the
+// same refresh credential cannot succeed. Transient HTTP and network failures
+// must remain retryable.
+func isTerminalOAuthTokenError(err error) bool {
+	if errors.Is(err, errNoRefreshToken) {
+		return true
+	}
+	var tokenErr *oauthTokenError
+	return errors.As(err, &tokenErr) && tokenErr.code == "invalid_grant"
+}
+
+// IsTerminalOAuthRefreshError reports a refresh failure that requires the user
+// to authenticate again instead of retrying the same credential.
+func IsTerminalOAuthRefreshError(err error) bool {
+	return errors.Is(err, ErrOAuthReauthenticationRequired)
+}
+
 // postOAuthToken posts body to an OAuth token endpoint and decodes the JSON
 // response into out. what names the operation in error messages, e.g. "token
 // refresh". The request is bound to ctx and to oauthHTTPTimeout, whichever
@@ -65,8 +117,16 @@ func postOAuthToken(ctx context.Context, url, what, contentType string, body io.
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s failed (HTTP %d): %s", what, resp.StatusCode, string(respBody))
+		var payload struct {
+			Error string `json:"error"`
+		}
+		// The body is used only to classify a standard OAuth error. Do not
+		// propagate it (or error_description): providers may echo credentials.
+		_ = json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload)
+		return fmt.Errorf("%s failed: %w", what, &oauthTokenError{
+			status: resp.StatusCode,
+			code:   recognizedOAuthErrorCode(payload.Error),
+		})
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
@@ -147,7 +207,7 @@ func ExchangeOAuthCode(ctx context.Context, authCode, verifier string) (*Provide
 // RefreshOAuthToken refreshes an expired OAuth token.
 func RefreshOAuthToken(ctx context.Context, provider *Provider) (*Provider, error) {
 	if provider.RefreshToken == "" {
-		return nil, fmt.Errorf("no refresh token available")
+		return nil, errNoRefreshToken
 	}
 
 	body, err := json.Marshal(map[string]string{

--- a/internal/cmd/dagger/llmconfig/oauth.go
+++ b/internal/cmd/dagger/llmconfig/oauth.go
@@ -2,6 +2,7 @@ package llmconfig
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -35,6 +36,45 @@ type OAuthTokenResponse struct {
 	ExpiresIn    int    `json:"expires_in"`
 }
 
+// oauthHTTPTimeout bounds every call to a provider's OAuth endpoints. Refresh
+// runs inside the client's GetSecret handler while the engine blocks on that
+// RPC, so an unresponsive token endpoint would otherwise wedge the whole
+// session with nothing to cancel.
+const oauthHTTPTimeout = 10 * time.Second
+
+var oauthHTTPClient = &http.Client{Timeout: oauthHTTPTimeout}
+
+// postOAuthToken posts body to an OAuth token endpoint and decodes the JSON
+// response into out. what names the operation in error messages, e.g. "token
+// refresh". The request is bound to ctx and to oauthHTTPTimeout, whichever
+// comes first.
+func postOAuthToken(ctx context.Context, url, what, contentType string, body io.Reader, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, oauthHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", what, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s failed (HTTP %d): %s", what, resp.StatusCode, string(respBody))
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed to decode %s response: %w", what, err)
+	}
+	return nil
+}
+
 // GenerateOAuthURL generates a PKCE-protected OAuth authorization URL.
 // Returns the URL the user should visit and the PKCE verifier for later use.
 func GenerateOAuthURL() (authURL, verifier string, err error) {
@@ -59,7 +99,7 @@ func GenerateOAuthURL() (authURL, verifier string, err error) {
 
 // ExchangeOAuthCode exchanges an authorization code for tokens.
 // The authCode should be in the format "code#state" as provided by the callback.
-func ExchangeOAuthCode(authCode, verifier string) (*Provider, error) {
+func ExchangeOAuthCode(ctx context.Context, authCode, verifier string) (*Provider, error) {
 	// The auth code may include a state suffix separated by #
 	code := authCode
 	state := ""
@@ -83,35 +123,21 @@ func ExchangeOAuthCode(authCode, verifier string) (*Provider, error) {
 		return nil, err
 	}
 
-	resp, err := http.Post(oauthTokenURL, "application/json", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("token exchange request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token exchange failed (HTTP %d): %s", resp.StatusCode, string(respBody))
-	}
-
 	var tokenResp OAuthTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	if err := postOAuthToken(ctx, oauthTokenURL, "token exchange", "application/json", bytes.NewReader(body), &tokenResp); err != nil {
+		return nil, err
 	}
-
-	// Subtract 5 minutes from expiry for safety margin
-	expiryMs := time.Now().UnixMilli() + int64(tokenResp.ExpiresIn)*1000 - 5*60*1000
 
 	provider := &Provider{
 		AuthType:     "oauth",
 		AuthToken:    tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
-		TokenExpiry:  expiryMs,
 		Enabled:      true,
 	}
+	provider.setTokenExpiry(tokenResp.ExpiresIn)
 
 	// Fetch subscription type from profile (best-effort)
-	if subType, err := FetchSubscriptionType(tokenResp.AccessToken); err == nil {
+	if subType, err := FetchSubscriptionType(ctx, tokenResp.AccessToken); err == nil {
 		provider.SubscriptionType = subType
 	}
 
@@ -119,7 +145,7 @@ func ExchangeOAuthCode(authCode, verifier string) (*Provider, error) {
 }
 
 // RefreshOAuthToken refreshes an expired OAuth token.
-func RefreshOAuthToken(provider *Provider) (*Provider, error) {
+func RefreshOAuthToken(ctx context.Context, provider *Provider) (*Provider, error) {
 	if provider.RefreshToken == "" {
 		return nil, fmt.Errorf("no refresh token available")
 	}
@@ -133,57 +159,107 @@ func RefreshOAuthToken(provider *Provider) (*Provider, error) {
 		return nil, err
 	}
 
-	resp, err := http.Post(oauthTokenURL, "application/json", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("token refresh request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token refresh failed (HTTP %d): %s", resp.StatusCode, string(respBody))
-	}
-
 	var tokenResp OAuthTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode refresh response: %w", err)
+	if err := postOAuthToken(ctx, oauthTokenURL, "token refresh", "application/json", bytes.NewReader(body), &tokenResp); err != nil {
+		return nil, err
 	}
-
-	expiryMs := time.Now().UnixMilli() + int64(tokenResp.ExpiresIn)*1000 - 5*60*1000
 
 	updated := *provider
 	updated.AuthToken = tokenResp.AccessToken
-	updated.RefreshToken = tokenResp.RefreshToken
-	updated.TokenExpiry = expiryMs
+	// RFC 6749 §5.1 makes refresh_token optional in a refresh response;
+	// endpoints that don't rotate simply omit it. Overwriting unconditionally
+	// would erase the only credential that can mint new access tokens, leaving
+	// "no refresh token available" forever.
+	if tokenResp.RefreshToken != "" {
+		updated.RefreshToken = tokenResp.RefreshToken
+	}
+	updated.setTokenExpiry(tokenResp.ExpiresIn)
 
 	// Refresh subscription type (best-effort)
-	if subType, err := FetchSubscriptionType(tokenResp.AccessToken); err == nil {
+	if subType, err := FetchSubscriptionType(ctx, tokenResp.AccessToken); err == nil {
 		updated.SubscriptionType = subType
 	}
 
 	return &updated, nil
 }
 
-// IsTokenExpired checks if the OAuth token has expired.
-func IsTokenExpired(provider *Provider) bool {
-	if provider.TokenExpiry == 0 {
-		return true
+// tokenExpiryMargin is how long before an access token's true expiry it is
+// treated as expired, so a request made now can't outlive it in flight.
+//
+// It is applied when the expiry is *checked*, never baked into what is
+// persisted: a stored "now + expires_in - margin" reads as already expired
+// whenever expires_in is absent or short, and since the on-demand refresher
+// runs on every secret resolution (twice, in fact — the plaintext is resolved
+// once more to derive the cache-key handle), that means a refresh storm
+// rotating the single-use refresh token over and over.
+const tokenExpiryMargin = 5 * time.Minute
+
+// TokenExpiresAtTime returns the true access-token expiry, or the zero time
+// when it is unknown. Configs written before token_expires_at existed carry
+// only token_expiry, which had the margin subtracted at write time — add it
+// back to recover the real instant.
+func (p *Provider) TokenExpiresAtTime() time.Time {
+	switch {
+	case p.TokenExpiresAt != 0:
+		return time.UnixMilli(p.TokenExpiresAt)
+	case p.TokenExpiry != 0:
+		return time.UnixMilli(p.TokenExpiry).Add(tokenExpiryMargin)
+	default:
+		return time.Time{}
 	}
-	return time.Now().UnixMilli() >= provider.TokenExpiry
+}
+
+// TokenExpiresAtRFC3339 formats the true access-token expiry as RFC 3339 in
+// UTC — the wire format of the *_AUTH_TOKEN_EXPIRES_AT variables the engine
+// reads alongside the token — or "" when the expiry is unknown.
+func (p *Provider) TokenExpiresAtRFC3339() string {
+	expiresAt := p.TokenExpiresAtTime()
+	if expiresAt.IsZero() {
+		return ""
+	}
+	return expiresAt.UTC().Format(time.RFC3339)
+}
+
+// setTokenExpiry records the true expiry derived from a token response's
+// expires_in (seconds). A missing or non-positive expires_in means "unknown",
+// not "expired".
+func (p *Provider) setTokenExpiry(expiresIn int) {
+	if expiresIn <= 0 {
+		p.TokenExpiresAt = 0
+		p.TokenExpiry = 0
+		return
+	}
+	expiresAt := time.Now().Add(time.Duration(expiresIn) * time.Second)
+	p.TokenExpiresAt = expiresAt.UnixMilli()
+	p.TokenExpiry = expiresAt.Add(-tokenExpiryMargin).UnixMilli()
+}
+
+// IsTokenExpired reports whether the OAuth access token has expired, or is
+// close enough to expiring to be worth replacing now. An unknown expiry is not
+// expired: the refresher runs on every secret resolution, so guessing here
+// would rotate the refresh token continuously.
+func IsTokenExpired(provider *Provider) bool {
+	expiresAt := provider.TokenExpiresAtTime()
+	if expiresAt.IsZero() {
+		return false
+	}
+	return !time.Now().Before(expiresAt.Add(-tokenExpiryMargin))
 }
 
 // FetchSubscriptionType queries the Anthropic OAuth profile endpoint to
 // determine the user's subscription type (pro, max, team, enterprise).
-func FetchSubscriptionType(accessToken string) (string, error) {
-	req, err := http.NewRequest("GET", oauthProfileURL, nil)
+func FetchSubscriptionType(ctx context.Context, accessToken string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, oauthHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, oauthProfileURL, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("profile request failed: %w", err)
 	}

--- a/internal/cmd/dagger/llmconfig/oauth_openai.go
+++ b/internal/cmd/dagger/llmconfig/oauth_openai.go
@@ -1,25 +1,25 @@
 package llmconfig
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 const (
 	// OpenAI Codex OAuth configuration
 	openaiClientID    = "app_EMoamEEZ73f0CkXaXp7hrann"
 	openaiAuthorize   = "https://auth.openai.com/oauth/authorize"
-	openaiTokenURL    = "https://auth.openai.com/oauth/token" //nolint:gosec // OAuth token endpoint URL, not a credential
 	openaiRedirectURI = "http://localhost:1455/auth/callback"
 	openaiScopes      = "openid profile email offline_access"
 )
+
+// var (not a const) so tests can point it at a local server, mirroring the
+// ConfigRoot/ConfigFile override pattern.
+var openaiTokenURL = "https://auth.openai.com/oauth/token" //nolint:gosec // OAuth token endpoint URL, not a credential
 
 // OpenAITokenResponse represents the OpenAI token endpoint response.
 type OpenAITokenResponse struct {
@@ -60,7 +60,7 @@ func GenerateOpenAIOAuthURL() (authURL, verifier, state string, err error) {
 }
 
 // ExchangeOpenAIOAuthCode exchanges an authorization code for OpenAI tokens.
-func ExchangeOpenAIOAuthCode(code, verifier string) (*Provider, error) {
+func ExchangeOpenAIOAuthCode(ctx context.Context, code, verifier string) (*Provider, error) {
 	body := url.Values{
 		"grant_type":    {"authorization_code"},
 		"client_id":     {openaiClientID},
@@ -69,35 +69,23 @@ func ExchangeOpenAIOAuthCode(code, verifier string) (*Provider, error) {
 		"redirect_uri":  {openaiRedirectURI},
 	}
 
-	resp, err := http.Post(openaiTokenURL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("token exchange request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token exchange failed (HTTP %d): %s", resp.StatusCode, string(respBody))
-	}
-
 	var tokenResp OpenAITokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	if err := postOAuthToken(ctx, openaiTokenURL, "token exchange", "application/x-www-form-urlencoded", strings.NewReader(body.Encode()), &tokenResp); err != nil {
+		return nil, err
 	}
 
-	expiryMs := time.Now().UnixMilli() + int64(tokenResp.ExpiresIn)*1000 - 5*60*1000
-
-	return &Provider{
+	provider := &Provider{
 		AuthType:     "oauth",
 		AuthToken:    tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
-		TokenExpiry:  expiryMs,
 		Enabled:      true,
-	}, nil
+	}
+	provider.setTokenExpiry(tokenResp.ExpiresIn)
+	return provider, nil
 }
 
 // RefreshOpenAIOAuthToken refreshes an expired OpenAI OAuth token.
-func RefreshOpenAIOAuthToken(provider *Provider) (*Provider, error) {
+func RefreshOpenAIOAuthToken(ctx context.Context, provider *Provider) (*Provider, error) {
 	if provider.RefreshToken == "" {
 		return nil, fmt.Errorf("no refresh token available")
 	}
@@ -108,27 +96,18 @@ func RefreshOpenAIOAuthToken(provider *Provider) (*Provider, error) {
 		"client_id":     {openaiClientID},
 	}
 
-	resp, err := http.Post(openaiTokenURL, "application/x-www-form-urlencoded", strings.NewReader(body.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("token refresh request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token refresh failed (HTTP %d): %s", resp.StatusCode, string(respBody))
-	}
-
 	var tokenResp OpenAITokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode refresh response: %w", err)
+	if err := postOAuthToken(ctx, openaiTokenURL, "token refresh", "application/x-www-form-urlencoded", strings.NewReader(body.Encode()), &tokenResp); err != nil {
+		return nil, err
 	}
-
-	expiryMs := time.Now().UnixMilli() + int64(tokenResp.ExpiresIn)*1000 - 5*60*1000
 
 	updated := *provider
 	updated.AuthToken = tokenResp.AccessToken
-	updated.RefreshToken = tokenResp.RefreshToken
-	updated.TokenExpiry = expiryMs
+	// Keep the stored refresh token when the response omits it: RFC 6749 §5.1
+	// makes the field optional, and erasing it locks the user out for good.
+	if tokenResp.RefreshToken != "" {
+		updated.RefreshToken = tokenResp.RefreshToken
+	}
+	updated.setTokenExpiry(tokenResp.ExpiresIn)
 	return &updated, nil
 }

--- a/internal/cmd/dagger/llmconfig/oauth_openai.go
+++ b/internal/cmd/dagger/llmconfig/oauth_openai.go
@@ -87,7 +87,7 @@ func ExchangeOpenAIOAuthCode(ctx context.Context, code, verifier string) (*Provi
 // RefreshOpenAIOAuthToken refreshes an expired OpenAI OAuth token.
 func RefreshOpenAIOAuthToken(ctx context.Context, provider *Provider) (*Provider, error) {
 	if provider.RefreshToken == "" {
-		return nil, fmt.Errorf("no refresh token available")
+		return nil, errNoRefreshToken
 	}
 
 	body := url.Values{

--- a/internal/cmd/dagger/llmconfig/oauth_refresh_test.go
+++ b/internal/cmd/dagger/llmconfig/oauth_refresh_test.go
@@ -1,0 +1,621 @@
+package llmconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeOAuthServer stands in for a provider's token endpoint. It rotates the
+// refresh token on every successful grant and rejects a replayed one with
+// invalid_grant, mirroring the single-use refresh tokens Anthropic and OpenAI
+// issue: replaying a spent token is precisely the permanent logout the refresh
+// path has to avoid.
+type fakeOAuthServer struct {
+	mu sync.Mutex
+	// refreshToken is the only refresh token the endpoint accepts.
+	refreshToken string
+	// grants counts successful refresh grants.
+	grants int
+	// expiresIn is the expires_in returned with each grant; negative omits the
+	// field, as endpoints that don't advertise a lifetime do.
+	expiresIn int
+	// omitRefreshToken drops refresh_token from the response, which RFC 6749
+	// §5.1 permits for endpoints that don't rotate.
+	omitRefreshToken bool
+	// fail rejects every grant, standing in for a revoked or already-spent
+	// token.
+	fail bool
+
+	url string
+}
+
+func newFakeOAuthServer(t *testing.T, refreshToken string) *fakeOAuthServer {
+	t.Helper()
+	s := &fakeOAuthServer{refreshToken: refreshToken, expiresIn: 3600}
+	srv := httptest.NewServer(http.HandlerFunc(s.serve))
+	t.Cleanup(srv.Close)
+	s.url = srv.URL
+	return s
+}
+
+// install points the package's token and profile endpoints at this server for
+// the duration of the test.
+func (s *fakeOAuthServer) install(t *testing.T) {
+	t.Helper()
+	origToken, origProfile, origOpenAI := oauthTokenURL, oauthProfileURL, openaiTokenURL
+	t.Cleanup(func() {
+		oauthTokenURL, oauthProfileURL, openaiTokenURL = origToken, origProfile, origOpenAI
+	})
+	oauthTokenURL = s.url + "/token"
+	openaiTokenURL = s.url + "/token"
+	oauthProfileURL = s.url + "/profile"
+}
+
+func (s *fakeOAuthServer) state() (grants int, refreshToken string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.grants, s.refreshToken
+}
+
+func (s *fakeOAuthServer) serve(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/profile":
+		// Best-effort subscription lookup; serve a minimal valid response so
+		// it never reaches the real network.
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"organization":{"organization_type":"claude_max"}}`)
+		return
+	case "/token":
+	default:
+		http.NotFound(w, r)
+		return
+	}
+
+	// Anthropic posts JSON, OpenAI posts a form; accept both.
+	var grantType, refreshToken string
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var req struct {
+			GrantType    string `json:"grant_type"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+			return
+		}
+		grantType, refreshToken = req.GrantType, req.RefreshToken
+	} else {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+			return
+		}
+		grantType, refreshToken = r.PostFormValue("grant_type"), r.PostFormValue("refresh_token")
+	}
+	if grantType != "refresh_token" {
+		http.Error(w, `{"error":"unsupported_grant_type"}`, http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail || refreshToken != s.refreshToken {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+		return
+	}
+	s.grants++
+	resp := map[string]any{"access_token": fmt.Sprintf("access-%d", s.grants)}
+	if !s.omitRefreshToken {
+		s.refreshToken = fmt.Sprintf("rt-%d", s.grants)
+		resp["refresh_token"] = s.refreshToken
+	}
+	if s.expiresIn >= 0 {
+		resp["expires_in"] = s.expiresIn
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// useTempConfig points ConfigRoot/ConfigFile at a fresh temp directory and
+// seeds the config file with cfg.
+func useTempConfig(t *testing.T, cfg *Config) {
+	t.Helper()
+	origConfigRoot, origConfigFile := ConfigRoot, ConfigFile
+	t.Cleanup(func() {
+		ConfigRoot, ConfigFile = origConfigRoot, origConfigFile
+	})
+	ConfigRoot = filepath.Join(t.TempDir(), "dagger")
+	ConfigFile = filepath.Join(ConfigRoot, ConfigFileName)
+	if cfg != nil {
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("seeding config failed: %v", err)
+		}
+	}
+}
+
+// expiredOAuthProvider is an OAuth provider whose access token expired long
+// ago, so any refresh path will act on it.
+func expiredOAuthProvider(refreshToken string) Provider {
+	return Provider{
+		AuthType:     "oauth",
+		AuthToken:    "stale-access",
+		RefreshToken: refreshToken,
+		TokenExpiry:  1,
+		Enabled:      true,
+	}
+}
+
+// TestRefreshKeepsRefreshTokenWhenOmitted covers the RFC 6749 §5.1 case: the
+// refresh response may omit refresh_token when the endpoint doesn't rotate.
+// Copying the empty field over the stored one erases the only credential that
+// can mint access tokens, so the next refresh reports "no refresh token
+// available" and the user is logged out for good.
+func TestRefreshKeepsRefreshTokenWhenOmitted(t *testing.T) {
+	// Both flows have their own response handling, and both got this wrong.
+	for _, provider := range []string{"anthropic", "openai-codex"} {
+		t.Run(provider, func(t *testing.T) {
+			srv := newFakeOAuthServer(t, "rt-keep")
+			srv.omitRefreshToken = true
+			srv.install(t)
+
+			useTempConfig(t, &Config{
+				LLM: LLMConfig{
+					DefaultProvider: provider,
+					Providers: map[string]Provider{
+						provider: expiredOAuthProvider("rt-keep"),
+					},
+				},
+			})
+
+			refreshed, err := RefreshOAuthProviderIfNeeded(t.Context(), provider)
+			if err != nil {
+				t.Fatalf("RefreshOAuthProviderIfNeeded() failed: %v", err)
+			}
+			if refreshed == nil || refreshed.AuthToken != "access-1" {
+				t.Errorf("returned provider = %+v, want AuthToken %q", refreshed, "access-1")
+			}
+
+			loaded, err := Load()
+			if err != nil {
+				t.Fatalf("Load() failed: %v", err)
+			}
+			if got := loaded.LLM.Providers[provider].RefreshToken; got != "rt-keep" {
+				t.Errorf("persisted RefreshToken = %q, want the stored %q kept", got, "rt-keep")
+			}
+		})
+	}
+}
+
+// TestRefreshTokensKeepsSucceededProviders verifies that one provider's
+// failure doesn't discard another's refreshed credentials. The grant is
+// single-use, so a result that isn't persisted is a permanent logout for that
+// provider — and returning early meant which provider lost was decided by Go's
+// randomized map order.
+func TestRefreshTokensKeepsSucceededProviders(t *testing.T) {
+	srv := newFakeOAuthServer(t, "rt-0")
+	srv.install(t)
+
+	useTempConfig(t, &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": expiredOAuthProvider("rt-0"),
+				// Already spent its grant elsewhere: the endpoint answers
+				// invalid_grant.
+				"openai-codex": expiredOAuthProvider("rt-spent"),
+			},
+		},
+	})
+
+	err := RefreshOAuthTokensIfNeeded(t.Context())
+	if err == nil {
+		t.Fatal("RefreshOAuthTokensIfNeeded() succeeded, want the failing provider reported")
+	}
+	if !strings.Contains(err.Error(), "openai-codex") {
+		t.Errorf("error %v does not name the failing provider", err)
+	}
+
+	loaded, loadErr := Load()
+	if loadErr != nil {
+		t.Fatalf("Load() failed: %v", loadErr)
+	}
+	anthropic := loaded.LLM.Providers["anthropic"]
+	if anthropic.AuthToken != "access-1" {
+		t.Errorf("persisted anthropic AuthToken = %q, want the refreshed %q", anthropic.AuthToken, "access-1")
+	}
+	if anthropic.RefreshToken != "rt-1" {
+		t.Errorf("persisted anthropic RefreshToken = %q, want the rotated %q", anthropic.RefreshToken, "rt-1")
+	}
+}
+
+// TestRefreshSkipsDisabledProvider verifies that a disabled provider is left
+// alone. Its credentials are never exported, so refreshing it spends a
+// single-use grant for nothing and rotates a refresh token the user still
+// expects to work when they re-enable it.
+func TestRefreshSkipsDisabledProvider(t *testing.T) {
+	srv := newFakeOAuthServer(t, "rt-0")
+	srv.install(t)
+
+	disabled := expiredOAuthProvider("rt-0")
+	disabled.Enabled = false
+	useTempConfig(t, &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers:       map[string]Provider{"anthropic": disabled},
+		},
+	})
+
+	refreshed, err := RefreshOAuthProviderIfNeeded(t.Context(), "anthropic")
+	if err != nil {
+		t.Fatalf("RefreshOAuthProviderIfNeeded() failed: %v", err)
+	}
+	if refreshed != nil {
+		t.Errorf("RefreshOAuthProviderIfNeeded() returned %+v for a disabled provider, want none", refreshed)
+	}
+
+	if err := RefreshOAuthTokensIfNeeded(t.Context()); err != nil {
+		t.Fatalf("RefreshOAuthTokensIfNeeded() failed: %v", err)
+	}
+
+	if grants, _ := srv.state(); grants != 0 {
+		t.Errorf("token endpoint granted %d refreshes for a disabled provider, want 0", grants)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if got := loaded.LLM.Providers["anthropic"].RefreshToken; got != "rt-0" {
+		t.Errorf("stored RefreshToken = %q, want it untouched at %q", got, "rt-0")
+	}
+}
+
+// TestRefreshHonorsContext verifies that a hung token endpoint doesn't wedge
+// the caller. Refresh runs inside the client's GetSecret handler with the
+// engine blocked on that RPC, so an unbounded request would take the whole
+// session down with it — and the process-wide refresh mutex with it.
+func TestRefreshHonorsContext(t *testing.T) {
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(blocked)
+		<-release
+	}))
+	t.Cleanup(srv.Close)
+	// Runs before srv.Close (cleanups are LIFO), so the handler is never left
+	// holding the server open.
+	t.Cleanup(func() { close(release) })
+
+	origToken, origProfile := oauthTokenURL, oauthProfileURL
+	t.Cleanup(func() { oauthTokenURL, oauthProfileURL = origToken, origProfile })
+	oauthTokenURL = srv.URL + "/token"
+	oauthProfileURL = srv.URL + "/profile"
+
+	useTempConfig(t, &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": expiredOAuthProvider("rt-0"),
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		<-blocked
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := RefreshOAuthProviderIfNeeded(ctx, "anthropic")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("RefreshOAuthProviderIfNeeded() succeeded against a hung endpoint")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("RefreshOAuthProviderIfNeeded() ignored the cancelled context")
+	}
+}
+
+// TestTokenExpiryMigration covers reading configs written before
+// token_expires_at existed: they carry token_expiry, which had the safety
+// margin subtracted at write time, so the true expiry is that value plus the
+// margin.
+func TestTokenExpiryMigration(t *testing.T) {
+	legacy := time.Now().Add(time.Hour).Truncate(time.Millisecond)
+	for _, tc := range []struct {
+		name     string
+		provider Provider
+		want     time.Time
+	}{
+		{
+			name:     "legacy field only",
+			provider: Provider{TokenExpiry: legacy.UnixMilli()},
+			want:     legacy.Add(tokenExpiryMargin),
+		},
+		{
+			name: "new field wins",
+			provider: Provider{
+				TokenExpiry:    legacy.UnixMilli(),
+				TokenExpiresAt: legacy.Add(time.Hour).UnixMilli(),
+			},
+			want: legacy.Add(time.Hour),
+		},
+		{
+			name:     "neither is unknown",
+			provider: Provider{},
+			want:     time.Time{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.provider.TokenExpiresAtTime(); !got.Equal(tc.want) {
+				t.Errorf("TokenExpiresAtTime() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsTokenExpired(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name     string
+		provider Provider
+		want     bool
+	}{
+		{
+			name:     "unknown expiry is not expired",
+			provider: Provider{},
+			// Otherwise every secret resolution refreshes, rotating the
+			// single-use refresh token each time.
+			want: false,
+		},
+		{
+			name:     "well before expiry",
+			provider: Provider{TokenExpiresAt: now.Add(time.Hour).UnixMilli()},
+			want:     false,
+		},
+		{
+			name:     "inside the safety margin",
+			provider: Provider{TokenExpiresAt: now.Add(time.Minute).UnixMilli()},
+			want:     true,
+		},
+		{
+			name:     "past",
+			provider: Provider{TokenExpiresAt: now.Add(-time.Minute).UnixMilli()},
+			want:     true,
+		},
+		{
+			name:     "legacy expiry in the past",
+			provider: Provider{TokenExpiry: now.Add(-time.Hour).UnixMilli()},
+			want:     true,
+		},
+		{
+			name: "legacy expiry still ahead of the margin",
+			// The legacy value already had the margin subtracted, so this is a
+			// true expiry an hour and five minutes out.
+			provider: Provider{TokenExpiry: now.Add(time.Hour).UnixMilli()},
+			want:     false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTokenExpired(&tc.provider); got != tc.want {
+				t.Errorf("IsTokenExpired() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRefreshWithoutExpiresIn covers a token endpoint that omits expires_in.
+// Baking the safety margin into the persisted value turned that into "expired
+// 5 minutes ago", so every secret resolution refreshed — and each refresh
+// rotated the single-use refresh token.
+func TestRefreshWithoutExpiresIn(t *testing.T) {
+	srv := newFakeOAuthServer(t, "rt-0")
+	srv.expiresIn = -1 // omit the field entirely
+	srv.install(t)
+
+	useTempConfig(t, &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": expiredOAuthProvider("rt-0"),
+			},
+		},
+	})
+
+	// A single credential resolution already costs two hook invocations.
+	for i := range 4 {
+		refreshed, err := RefreshOAuthProviderIfNeeded(t.Context(), "anthropic")
+		if err != nil {
+			t.Fatalf("RefreshOAuthProviderIfNeeded() call %d failed: %v", i, err)
+		}
+		if refreshed == nil || refreshed.AuthToken != "access-1" {
+			t.Fatalf("call %d returned provider %+v, want AuthToken %q", i, refreshed, "access-1")
+		}
+	}
+
+	if grants, _ := srv.state(); grants != 1 {
+		t.Errorf("token endpoint granted %d refreshes, want exactly 1", grants)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	provider := loaded.LLM.Providers["anthropic"]
+	if provider.TokenExpiresAt != 0 || provider.TokenExpiry != 0 {
+		t.Errorf("persisted expiry = (%d, %d), want both zero for an unknown expiry",
+			provider.TokenExpiresAt, provider.TokenExpiry)
+	}
+	if IsTokenExpired(&provider) {
+		t.Error("provider with an unknown expiry reads as expired")
+	}
+}
+
+// TestRefreshWithShortExpiresIn checks that a lifetime shorter than the safety
+// margin still persists a real, future expiry rather than a value that is
+// already in the past — and that the resulting "always inside the margin"
+// token is refreshed at most once per floor interval instead of on every
+// resolution.
+func TestRefreshWithShortExpiresIn(t *testing.T) {
+	srv := newFakeOAuthServer(t, "rt-0")
+	srv.expiresIn = 60
+	srv.install(t)
+
+	useTempConfig(t, &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": expiredOAuthProvider("rt-0"),
+			},
+		},
+	})
+
+	for i := range 4 {
+		if _, err := RefreshOAuthProviderIfNeeded(t.Context(), "anthropic"); err != nil {
+			t.Fatalf("RefreshOAuthProviderIfNeeded() call %d failed: %v", i, err)
+		}
+	}
+
+	if grants, _ := srv.state(); grants != 1 {
+		t.Errorf("token endpoint granted %d refreshes, want exactly 1", grants)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	provider := loaded.LLM.Providers["anthropic"]
+	if provider.TokenExpiresAt <= time.Now().UnixMilli() {
+		t.Errorf("persisted TokenExpiresAt %d is not in the future", provider.TokenExpiresAt)
+	}
+}
+
+// Environment used to drive the re-executed test binary in
+// TestRefreshOAuthProviderCrossProcess.
+const (
+	crossProcessEnv        = "DAGGER_TEST_OAUTH_REFRESH_CHILD"
+	crossProcessTokenURL   = "DAGGER_TEST_OAUTH_TOKEN_URL"
+	crossProcessProfileURL = "DAGGER_TEST_OAUTH_PROFILE_URL"
+	crossProcessStartAt    = "DAGGER_TEST_OAUTH_START_AT"
+)
+
+// TestRefreshOAuthProviderCrossProcess runs several real dagger-sized
+// processes at the refresh at once — a `dagger call` next to a live `dagger
+// agent` is enough to hit this. The in-process mutex says nothing about them,
+// so only the file lock plus a re-read under it keeps one process from
+// spending an already-rotated refresh token and writing its stale snapshot
+// back over the winner's.
+func TestRefreshOAuthProviderCrossProcess(t *testing.T) {
+	srv := newFakeOAuthServer(t, "rt-0")
+	srv.install(t)
+
+	configFile := filepath.Join(t.TempDir(), "nested", ConfigFileName)
+	origConfigFile := ConfigFile
+	t.Cleanup(func() { ConfigFile = origConfigFile })
+	ConfigFile = configFile
+
+	cfg := &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": expiredOAuthProvider("rt-0"),
+			},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() failed: %v", err)
+	}
+
+	// Children start together rather than as they happen to be scheduled, so
+	// they actually race for the lock.
+	startAt := time.Now().Add(750 * time.Millisecond)
+
+	const children = 4
+	type childResult struct {
+		out []byte
+		err error
+	}
+	results := make(chan childResult, children)
+	for range children {
+		go func() {
+			cmd := exec.Command(self, "-test.run=^TestRefreshOAuthProviderChild$", "-test.v")
+			cmd.Env = append(os.Environ(),
+				crossProcessEnv+"=1",
+				"DAGGER_CONFIG="+configFile,
+				crossProcessTokenURL+"="+srv.url+"/token",
+				crossProcessProfileURL+"="+srv.url+"/profile",
+				crossProcessStartAt+"="+strconv.FormatInt(startAt.UnixNano(), 10),
+			)
+			out, err := cmd.CombinedOutput()
+			results <- childResult{out, err}
+		}()
+	}
+	for range children {
+		res := <-results
+		if res.err != nil {
+			t.Errorf("child refresh failed: %v\n%s", res.err, res.out)
+		}
+	}
+
+	grants, serverRefreshToken := srv.state()
+	if grants != 1 {
+		t.Errorf("token endpoint granted %d refreshes, want exactly 1", grants)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() after cross-process refresh failed: %v", err)
+	}
+	provider := loaded.LLM.Providers["anthropic"]
+	if provider.RefreshToken != serverRefreshToken {
+		t.Errorf("persisted RefreshToken = %q, want the endpoint's current %q", provider.RefreshToken, serverRefreshToken)
+	}
+	if provider.AuthToken != "access-1" {
+		t.Errorf("persisted AuthToken = %q, want %q", provider.AuthToken, "access-1")
+	}
+}
+
+// TestRefreshOAuthProviderChild is the child half of
+// TestRefreshOAuthProviderCrossProcess: it refreshes the provider once and
+// fails if that refresh does not come back with a usable token.
+func TestRefreshOAuthProviderChild(t *testing.T) {
+	if os.Getenv(crossProcessEnv) == "" {
+		t.Skip("child process of TestRefreshOAuthProviderCrossProcess")
+	}
+	oauthTokenURL = os.Getenv(crossProcessTokenURL)
+	oauthProfileURL = os.Getenv(crossProcessProfileURL)
+	if raw := os.Getenv(crossProcessStartAt); raw != "" {
+		nanos, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			t.Fatalf("bad %s: %v", crossProcessStartAt, err)
+		}
+		time.Sleep(time.Until(time.Unix(0, nanos)))
+	}
+
+	token, err := RefreshOAuthProviderIfNeeded(t.Context(), "anthropic")
+	if err != nil {
+		t.Fatalf("RefreshOAuthProviderIfNeeded() failed: %v", err)
+	}
+	if token == nil || token.AuthToken == "" {
+		t.Fatal("RefreshOAuthProviderIfNeeded() returned no token")
+	}
+}

--- a/internal/cmd/dagger/llmconfig/oauth_refresh_test.go
+++ b/internal/cmd/dagger/llmconfig/oauth_refresh_test.go
@@ -25,6 +25,8 @@ type fakeOAuthServer struct {
 	mu sync.Mutex
 	// refreshToken is the only refresh token the endpoint accepts.
 	refreshToken string
+	// requests counts all refresh requests, including rejected grants.
+	requests int
 	// grants counts successful refresh grants.
 	grants int
 	// expiresIn is the expires_in returned with each grant; negative omits the
@@ -68,6 +70,12 @@ func (s *fakeOAuthServer) state() (grants int, refreshToken string) {
 	return s.grants, s.refreshToken
 }
 
+func (s *fakeOAuthServer) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests
+}
+
 func (s *fakeOAuthServer) serve(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/profile":
@@ -108,8 +116,9 @@ func (s *fakeOAuthServer) serve(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.requests++
 	if s.fail || refreshToken != s.refreshToken {
-		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+		http.Error(w, `{"error":"invalid_grant","error_description":"credential-leak-marker"}`, http.StatusBadRequest)
 		return
 	}
 	s.grants++
@@ -192,6 +201,117 @@ func TestRefreshKeepsRefreshTokenWhenOmitted(t *testing.T) {
 				t.Errorf("persisted RefreshToken = %q, want the stored %q kept", got, "rt-keep")
 			}
 		})
+	}
+}
+
+func TestTerminalRefreshErrorRequiresReauthentication(t *testing.T) {
+	for _, providerName := range []string{"anthropic", "openai-codex"} {
+		t.Run(providerName, func(t *testing.T) {
+			srv := newFakeOAuthServer(t, "rt-reauthorized")
+			srv.install(t)
+
+			useTempConfig(t, &Config{
+				LLM: LLMConfig{
+					DefaultProvider: providerName,
+					Providers: map[string]Provider{
+						providerName: expiredOAuthProvider("rt-permanently-invalid"),
+					},
+				},
+			})
+
+			_, err := RefreshOAuthProviderIfNeeded(t.Context(), providerName)
+			if err == nil {
+				t.Fatal("first refresh succeeded with an invalid refresh token")
+			}
+			if !IsTerminalOAuthRefreshError(err) {
+				t.Errorf("first refresh error %q is not marked terminal", err)
+			}
+			if !strings.Contains(err.Error(), "invalid_grant") {
+				t.Errorf("first refresh error %q does not identify invalid_grant", err)
+			}
+			if !strings.Contains(err.Error(), "dagger llm setup") {
+				t.Errorf("first refresh error %q has no reauthentication hint", err)
+			}
+			for _, secret := range []string{"rt-permanently-invalid", "credential-leak-marker"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("first refresh error exposed token endpoint content %q: %v", secret, err)
+				}
+			}
+
+			// Move beyond the ordinary rate limit and verify an on-demand call
+			// still surfaces the failure. Only the background scheduler should
+			// retire terminal credentials; an explicit credential resolution must
+			// not silently return the stale token.
+			refreshKey := ConfigFile + "\x00" + providerName
+			lastOAuthRefresh[refreshKey] = time.Now().Add(-2 * oauthRefreshFloor)
+			_, err = RefreshOAuthProviderIfNeeded(t.Context(), providerName)
+			if err == nil || !IsTerminalOAuthRefreshError(err) {
+				t.Fatalf("second on-demand refresh error = %v, want terminal failure", err)
+			}
+			if got := srv.requestCount(); got != 2 {
+				t.Errorf("token endpoint received %d on-demand requests, want 2", got)
+			}
+
+			// Reauthorization replaces the failed credential and permits refresh.
+			cfg, loadErr := Load()
+			if loadErr != nil {
+				t.Fatalf("Load() failed: %v", loadErr)
+			}
+			provider := cfg.LLM.Providers[providerName]
+			provider.RefreshToken = "rt-reauthorized"
+			cfg.LLM.Providers[providerName] = provider
+			if saveErr := cfg.Save(); saveErr != nil {
+				t.Fatalf("Save() failed: %v", saveErr)
+			}
+			lastOAuthRefresh[refreshKey] = time.Now().Add(-2 * oauthRefreshFloor)
+			current, err := RefreshOAuthProviderIfNeeded(t.Context(), providerName)
+			if err != nil {
+				t.Fatalf("refresh after reauthorization failed: %v", err)
+			}
+			if current == nil || current.AuthToken != "access-1" {
+				t.Errorf("refresh after reauthorization returned %+v, want access-1", current)
+			}
+			if got := srv.requestCount(); got != 3 {
+				t.Errorf("token endpoint received %d total requests, want two invalid then reauthorized", got)
+			}
+		})
+	}
+}
+
+func TestTransientRefreshErrorIsRetried(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "credential-leak-marker", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	origToken, origProfile := oauthTokenURL, oauthProfileURL
+	t.Cleanup(func() { oauthTokenURL, oauthProfileURL = origToken, origProfile })
+	oauthTokenURL = srv.URL
+	oauthProfileURL = srv.URL
+
+	useTempConfig(t, &Config{
+		LLM: LLMConfig{
+			DefaultProvider: "anthropic",
+			Providers: map[string]Provider{
+				"anthropic": expiredOAuthProvider("rt-secret"),
+			},
+		},
+	})
+
+	for i := range 2 {
+		_, err := RefreshOAuthProviderIfNeeded(t.Context(), "anthropic")
+		if err == nil {
+			t.Fatalf("refresh %d succeeded against a failing endpoint", i)
+		}
+		if strings.Contains(err.Error(), "credential-leak-marker") || strings.Contains(err.Error(), "rt-secret") {
+			t.Errorf("refresh %d error exposed endpoint or credential content: %v", i, err)
+		}
+		lastOAuthRefresh[ConfigFile+"\x00anthropic"] = time.Now().Add(-2 * oauthRefreshFloor)
+	}
+	if requests != 2 {
+		t.Errorf("transient endpoint received %d requests, want 2", requests)
 	}
 }
 

--- a/internal/cmd/dagger/llmconfig/setup.go
+++ b/internal/cmd/dagger/llmconfig/setup.go
@@ -551,7 +551,7 @@ func setupClaudeCodeOAuth(ctx context.Context, ph PromptHandler) (string, *Provi
 		return "", nil, "", ErrAborted
 	}
 
-	providerCfg, err := ExchangeOAuthCode(authCode, verifier)
+	providerCfg, err := ExchangeOAuthCode(ctx, authCode, verifier)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("OAuth token exchange failed: %w", err)
 	}
@@ -685,7 +685,7 @@ func setupOpenAICodexOAuth(ctx context.Context, ph PromptHandler) (string, *Prov
 		return "", nil, "", fmt.Errorf("no authorization code received")
 	}
 
-	providerCfg, err := ExchangeOpenAIOAuthCode(code, verifier)
+	providerCfg, err := ExchangeOpenAIOAuthCode(ctx, code, verifier)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("OAuth token exchange failed: %w", err)
 	}

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -297,6 +297,13 @@ var rootCmd = &cobra.Command{
 			t.Close()
 		})
 
+		// Keep subscription OAuth tokens fresh for as long as this command
+		// runs: `dagger shell`/`agent` sessions outlive an hour-long access
+		// token, and refreshing ahead of expiry keeps the round-trip off the
+		// critical path. No-op unless a subscription provider is configured;
+		// the on-demand refresher hook stays the fallback.
+		cobra.OnFinalize(startOAuthTokenRefresher(cmd.Context()))
+
 		checkForUpdates(cmd.Context(), cmd.ErrOrStderr())
 
 		if err := checkCloudToken(cmd.Context(), cmd.OutOrStdout()); err != nil {


### PR DESCRIPTION
## Problem

A long `dagger agent` / `dagger shell` session using Claude Code (Anthropic) or Codex (ChatGPT) subscription OAuth starts failing with `401 authentication_error` partway through and stays broken until the CLI restarts. The client-side refresh hook exists and is wired, but it never fires: `(*LLM).Endpoint` memoizes the router and `Clone()` copies it, so after the first `Endpoint()` call the token is frozen for the session, and the token is captured inside the provider SDK client at construction so mutating it in place wouldn't help either.

## What this does

**Engine (`core/llm.go`, `core/llm_credential.go`)** — the model credential is resolved per request instead of once per LLM object. The TTL closure becomes a `CredentialSource` with `Invalidate`; resolution yields `Credential{Token, ExpiresAt}`; the router re-bases resolvers onto a session-scoped context with a per-resolution timeout, so a detached agent loop no longer depends on whichever request first routed the endpoint. A 401 is recoverable exactly once: the send path invalidates the cached credential and retries; a genuinely revoked login fails fast with a message pointing at `dagger llm setup`. Expiry travels with the token (`*_AUTH_TOKEN_EXPIRES_AT`, derived by suffix; absent/unparseable means unknown, never expired) and the cache lifetime is `min(expiresAt − 1m, now + 5m)`, with a 30s refresh floor.

**Client (`internal/cmd/dagger/llmconfig`, `secretprovider/env.go`)** — load→refresh→persist runs as one flock critical section that re-reads the config after taking the lock, so a process that lost a cross-process refresh race adopts the winner's rotated token instead of spending a dead one. The refresh token is kept when a response omits it; already-refreshed providers are persisted even if a later one fails; OAuth requests are bound to a 10s context; `envProvider` logs and records a span event instead of swallowing errors; an explicitly exported token is never clobbered. A background goroutine refreshes each enabled OAuth provider ~5 minutes before expiry (no goroutine at all unless a subscription provider is configured). `token_expires_at` is persisted alongside legacy `token_expiry` so an older CLI sharing the file keeps working.

**Second commit** — an invalid or missing refresh grant is classified as a reauthentication requirement rather than retried forever; untrusted response bodies are kept out of the error; the background scheduler warns once and retires a terminal failure while still retrying transient ones.

The design and defect inventory are in `hack/designs/llm-oauth-token-lifecycle.md`.

## Not in this PR

`LLM.withSmallModel` (small-model routing), which sat next to these commits, has its only consumer in the agent session CLI and will land with that.

No public GraphQL API changes.

Extracted from the `llm-workspace-dev-env` stack; independent of the other extractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgJumuDQNviWmF35dMxsEm
