### PR TITLE
core: keep git content digests type-distinct

### DIFF
--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -935,6 +935,11 @@ func calcGitContentDigest(gitRef *core.GitRef, args treeArgs) (digest.Digest, er
 	keepsGitDir := !repo.DiscardGitDir && !args.DiscardGitDir
 
 	dgstInputs := []string{
+		// The remaining inputs (url + SHA + bool) also feed the GitRef and
+		// GitCommit content digests; without a discriminator the three can
+		// collide and the cache would serve one type where another is expected.
+		"gitTree",
+
 		// A commit SHA only identifies an object inside a Git object database.
 		// The remote URL is part of the checkout source.
 		remoteRepo.URL.Remote(),
@@ -1144,6 +1149,9 @@ func (s *gitSchema) gitRefResult(ctx context.Context, parent dagql.ObjectResult[
 	// if the upstream remote changes in a ref we don't care about, it
 	// shouldn't be mixed into the cache
 	dgstInputs := []string{
+		// Discriminate from the GitCommit and tree Directory digests, which
+		// hash the same url + SHA + bool inputs for a different result type.
+		"gitRef",
 		repo.URL.Value.String(),
 		string(ref.Digest()),
 		strconv.FormatBool(repo.DiscardGitDir),
@@ -1485,6 +1493,9 @@ func (s *gitSchema) gitCommitResult(ctx context.Context, parent dagql.ObjectResu
 	}
 
 	dgstInputs := []string{
+		// Discriminate from the GitRef and tree Directory digests, which hash
+		// the same url + SHA + bool inputs for a different result type.
+		"gitCommit",
 		repo.URL.Value.String(),
 		ref.SHA,
 		strconv.FormatBool(repo.DiscardGitDir),


### PR DESCRIPTION
## Problem

Cache equivalence in DagQL is keyed on content digest, and three Git-related content digests are hashed from the same url + SHA + bool inputs while returning different types:

* https://github.com/dagger/dagger/blob/106d6283992b470d157c88e7667d88a9fbd01000/core/schema/git.go#L1147-L1149 => returns `GitRef`
* https://github.com/dagger/dagger/blob/106d6283992b470d157c88e7667d88a9fbd01000/core/schema/git.go#L1488-L1490 => returns `GitCommit`
* https://github.com/dagger/dagger/blob/106d6283992b470d157c88e7667d88a9fbd01000/core/schema/git.go#L938-L947 => returns `Directory`

When the inputs line up (e.g. `commit` digests `discardGitDir=false` while `tree` digests `keepsGitDir=false`), the digests collide and a lookup can hand back a `Directory` where a `GitCommit` was expected, or vice versa. The latter two collided in my case.

## What this does

Mixes a per-type discriminator string (`gitRef`, `gitCommit`, `gitTree`) into each digest's inputs so the three can no longer collide. Existing cache entries for these calls are invalidated once by the digest change, which is the usual cost of a cache-identity fix.

Extracted from the `llm-workspace-dev-env` stack; independent of the other extractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
