### PR TITLE
Workspace.export: write to the current client only (like other export functions)

### DIFF
--- a/.changes/unreleased/Changed-20260830-000000.yaml
+++ b/.changes/unreleased/Changed-20260830-000000.yaml
@@ -1,0 +1,11 @@
+kind: Changed
+body: |
+  `Workspace.export` now writes to the host of the current client — the client
+  that makes the call — like `Directory.export`. It no longer writes to the
+  client that created the workspace, so a module can no longer write files onto
+  its caller's host through a received `Workspace`. CLI export flows
+  (`dagger install`, `dagger generate`, `dagger ws config`, …) are unchanged.
+time: 2026-08-30T00:00:00.000000000-07:00
+custom:
+    Author: shykes
+    PR: "14008"

--- a/core/integration/testdata/modules/go/workspace-export-sandbox/dagger.json
+++ b/core/integration/testdata/modules/go/workspace-export-sandbox/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "engineVersion": "latest",
+  "sdk": {
+    "source": "go"
+  }
+}

--- a/core/integration/testdata/modules/go/workspace-export-sandbox/main.go
+++ b/core/integration/testdata/modules/go/workspace-export-sandbox/main.go
@@ -8,13 +8,11 @@ import (
 
 type Test struct{}
 
-// TryExport stages a file on the received workspace and attempts to export it
-// from inside the module sandbox. It reports the outcome instead of failing so
-// the test can assert on it.
+// TryExport stages a file on the received workspace and exports it from
+// inside the module sandbox.
 func (m *Test) TryExport(ctx context.Context, workspace *dagger.Workspace) (string, error) {
-	err := workspace.WithNewFile("sneaky.txt", "written from inside a module").Export(ctx)
-	if err != nil {
-		return "export error: " + err.Error(), nil
+	if err := workspace.WithNewFile("sneaky.txt", "written from inside a module").Export(ctx); err != nil {
+		return "", err
 	}
 	return "exported", nil
 }

--- a/core/integration/testdata/modules/go/workspace-export-sandbox/main.go
+++ b/core/integration/testdata/modules/go/workspace-export-sandbox/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+
+	"dagger/test/internal/dagger"
+)
+
+type Test struct{}
+
+// TryExport stages a file on the received workspace and attempts to export it
+// from inside the module sandbox. It reports the outcome instead of failing so
+// the test can assert on it.
+func (m *Test) TryExport(ctx context.Context, workspace *dagger.Workspace) (string, error) {
+	err := workspace.WithNewFile("sneaky.txt", "written from inside a module").Export(ctx)
+	if err != nil {
+		return "export error: " + err.Error(), nil
+	}
+	return "exported", nil
+}

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -914,10 +914,8 @@ func (WorkspaceAPISuite) TestHostWorkspaceExportFromGitWorktree(ctx context.Cont
 }
 
 // TestWorkspaceExportStaysOnCurrentClient locks in the Workspace.export
-// contract from dagger/dagger#14007: like Directory.export, export is a side
-// effect on the client that makes the call, never on the client that created
-// the workspace. A module handed the caller's workspace must not be able to
-// write onto the caller's host through it.
+// contract from dagger/dagger#14007: a module handed the caller's workspace
+// exports into its own sandbox, never onto the caller's host.
 func (WorkspaceAPISuite) TestWorkspaceExportStaysOnCurrentClient(ctx context.Context, t *testctx.T) {
 	workdir := t.TempDir()
 	initGitRepo(ctx, t, workdir)
@@ -926,7 +924,8 @@ func (WorkspaceAPISuite) TestWorkspaceExportStaysOnCurrentClient(ctx context.Con
 
 	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "-m", "./sandbox", "try-export")
 	require.NoError(t, err, string(out))
-	t.Logf("module export outcome: %s", strings.TrimSpace(string(out)))
+	require.Equal(t, "exported", strings.TrimSpace(string(out)),
+		"a module's export succeeds against its own sandboxed environment")
 
 	_, err = os.Stat(filepath.Join(workdir, "sneaky.txt"))
 	require.ErrorIs(t, err, os.ErrNotExist,

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -913,6 +913,26 @@ func (WorkspaceAPISuite) TestHostWorkspaceExportFromGitWorktree(ctx context.Cont
 	require.Equal(t, "staged", string(got))
 }
 
+// TestWorkspaceExportStaysOnCurrentClient locks in the Workspace.export
+// contract from dagger/dagger#14007: like Directory.export, export is a side
+// effect on the client that makes the call, never on the client that created
+// the workspace. A module handed the caller's workspace must not be able to
+// write onto the caller's host through it.
+func (WorkspaceAPISuite) TestWorkspaceExportStaysOnCurrentClient(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+	moduleDir := filepath.Join(workdir, "sandbox")
+	copyTestdataFixture(ctx, t, moduleDir, "modules", "go", "workspace-export-sandbox")
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "-m", "./sandbox", "try-export")
+	require.NoError(t, err, string(out))
+	t.Logf("module export outcome: %s", strings.TrimSpace(string(out)))
+
+	_, err = os.Stat(filepath.Join(workdir, "sneaky.txt"))
+	require.ErrorIs(t, err, os.ErrNotExist,
+		"a module must not write to its caller's workspace through Workspace.export")
+}
+
 // TestHostWorkspaceGitLog covers workspace.git.head.log against a host
 // checkout: the workspace's git ref is an ordinary GitRef, so it lists commits
 // like any other.

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -2131,12 +2131,9 @@ func (s *workspaceSchema) export(
 		return core.Void{}, nil
 	}
 
-	// Export through the calling client's own session, like Directory.export:
-	// the write is a side effect on the current client, never on the client
-	// that created the workspace. A module that received this workspace from
-	// its caller therefore cannot reach the caller's host through export — the
-	// write resolves against the module's own sandboxed environment instead
-	// (dagger/dagger#14007).
+	// Deliberately no withWorkspaceClientContext here: export is a side
+	// effect on the calling client, like Directory.export — never on the
+	// client that created the workspace (dagger/dagger#14007).
 	if err := changes.Self().Export(ctx, hostPath); err != nil {
 		return core.Void{}, err
 	}
@@ -2148,8 +2145,11 @@ func (s *workspaceSchema) export(
 	// they are cached per client for the client's whole lifetime
 	// (dagql.PerClientInput). Bump the client's read epoch so subsequent reads
 	// land in a fresh per-client cache namespace and re-read the live host.
-	// Best-effort, like the invalidation above: a bookkeeping failure must not
-	// fail an export that already succeeded.
+	// Like the invalidation above, this only matters when the caller owns the
+	// workspace: a non-owner's export never touched the owner's host, and this
+	// workspace's reads resolve under the owner's epoch, so the bump is a
+	// harmless no-op. Best-effort: a bookkeeping failure must not fail an
+	// export that already succeeded.
 	if err := core.BumpWorkspaceReadEpoch(ctx); err != nil {
 		slog.Warn("could not bump workspace read epoch after export", "error", err)
 	}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -334,8 +334,9 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 			),
 		dagql.NodeFunc("export", s.export).
 			View(AfterVersion("v1.0.0-0")).
-			DoNotCache("Writes pending workspace changes to the local Git workspace").
-			Doc("Write this workspace's pending changes to its local Git workspace."),
+			DoNotCache("Writes pending workspace changes to the calling client's host").
+			Doc("Write this workspace's pending changes to its local Git workspace on the current client's host.",
+				"Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host."),
 		dagql.NodeFunc("reloaded", s.reloaded).
 			View(AfterVersion("v1.0.0-0")).
 			WithInput(dagql.PerCallInput).
@@ -2130,14 +2131,16 @@ func (s *workspaceSchema) export(
 		return core.Void{}, nil
 	}
 
-	exportCtx, err := s.withWorkspaceClientContext(ctx, ws)
-	if err != nil {
+	// Export through the calling client's own session, like Directory.export:
+	// the write is a side effect on the current client, never on the client
+	// that created the workspace. A module that received this workspace from
+	// its caller therefore cannot reach the caller's host through export — the
+	// write resolves against the module's own sandboxed environment instead
+	// (dagger/dagger#14007).
+	if err := changes.Self().Export(ctx, hostPath); err != nil {
 		return core.Void{}, err
 	}
-	if err := changes.Self().Export(exportCtx, hostPath); err != nil {
-		return core.Void{}, err
-	}
-	if err := core.InvalidateCurrentWorkspace(exportCtx); err != nil {
+	if err := core.InvalidateCurrentWorkspace(ctx); err != nil {
 		slog.Warn("could not invalidate workspace after export", "error", err)
 	}
 	// The export just changed the workspace's on-disk content, so host reads
@@ -2147,7 +2150,7 @@ func (s *workspaceSchema) export(
 	// land in a fresh per-client cache namespace and re-read the live host.
 	// Best-effort, like the invalidation above: a bookkeeping failure must not
 	// fail an export that already succeeded.
-	if err := core.BumpWorkspaceReadEpoch(exportCtx); err != nil {
+	if err := core.BumpWorkspaceReadEpoch(ctx); err != nil {
 		slog.Warn("could not bump workspace read epoch after export", "error", err)
 	}
 	return core.Void{}, nil
@@ -2174,8 +2177,8 @@ func (s *workspaceSchema) reloaded(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	// Bump under the workspace's owning client, the same context export bumps
-	// in and the one withWorkspaceHostReadContext reads the epoch from — a
+	// Bump under the workspace's owning client, the context
+	// withWorkspaceHostReadContext reads the epoch from — a
 	// bump under the caller's own client would be a silent no-op whenever the
 	// caller is not the owner (e.g. a module handed the workspace). A value
 	// workspace has no owning client and no host reads to invalidate, so the

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -5710,7 +5710,13 @@ type Workspace implements Node {
   """List named environments defined in the workspace configuration."""
   envList: [String!]!
 
-  """Write this workspace's pending changes to its local Git workspace."""
+  """
+  Write this workspace's pending changes to its local Git workspace on the current client's host.
+
+  Like Directory.export, the write is a side effect on the client that makes the
+  call — never on the client that created the workspace. Inside a module, this
+  cannot reach the caller's host.
+  """
   export: Void!
 
   """

--- a/docs/static/reference/php/Dagger/Workspace.html
+++ b/docs/static/reference/php/Dagger/Workspace.html
@@ -238,7 +238,7 @@
                 <div class="col-md-8">
                     <a href="#method_export">export</a>()
         
-                                            <p><p>Write this workspace's pending changes to its local Git workspace.</p></p>                </div>
+                                            <p><p>Write this workspace's pending changes to its local Git workspace on the current client's host.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -1069,7 +1069,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_export">
-        <div class="location">at line 153</div>
+        <div class="location">at line 155</div>
         <code>                    void
     <strong>export</strong>()
         </code>
@@ -1079,7 +1079,7 @@
             
 
         <div class="method-description">
-                            <p><p>Write this workspace's pending changes to its local Git workspace.</p></p>                        
+                            <p><p>Write this workspace's pending changes to its local Git workspace on the current client's host.</p></p>                <p><p>Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host.</p></p>        
         </div>
         <div class="tags">
             
@@ -1101,7 +1101,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_file">
-        <div class="location">at line 164</div>
+        <div class="location">at line 166</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>file</strong>(string $path)
         </code>
@@ -1143,7 +1143,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_findRoots">
-        <div class="location">at line 178</div>
+        <div class="location">at line 180</div>
         <code>                    array
     <strong>findRoots</strong>(array $markers, string|null $start = &#039;.&#039;, array|null $exclude = [])
         </code>
@@ -1196,7 +1196,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_findUp">
-        <div class="location">at line 200</div>
+        <div class="location">at line 202</div>
         <code>                    string
     <strong>findUp</strong>(string $name, string|null $from = &#039;.&#039;)
         </code>
@@ -1245,7 +1245,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_generators">
-        <div class="location">at line 213</div>
+        <div class="location">at line 215</div>
         <code>                    <a href="../Dagger/GeneratorGroup.html"><abbr title="Dagger\GeneratorGroup">GeneratorGroup</abbr></a>
     <strong>generators</strong>(array|null $include = null)
         </code>
@@ -1287,7 +1287,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_git">
-        <div class="location">at line 225</div>
+        <div class="location">at line 227</div>
         <code>                    <a href="../Dagger/WorkspaceGit.html"><abbr title="Dagger\WorkspaceGit">WorkspaceGit</abbr></a>
     <strong>git</strong>()
         </code>
@@ -1319,7 +1319,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_glob">
-        <div class="location">at line 236</div>
+        <div class="location">at line 238</div>
         <code>                    array
     <strong>glob</strong>(string $pattern)
         </code>
@@ -1361,7 +1361,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 246</div>
+        <div class="location">at line 248</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1393,7 +1393,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_migrate">
-        <div class="location">at line 257</div>
+        <div class="location">at line 259</div>
         <code>                    <a href="../Dagger/WorkspaceMigration.html"><abbr title="Dagger\WorkspaceMigration">WorkspaceMigration</abbr></a>
     <strong>migrate</strong>()
         </code>
@@ -1425,7 +1425,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_module">
-        <div class="location">at line 268</div>
+        <div class="location">at line 270</div>
         <code>                    <a href="../Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a>
     <strong>module</strong>(string $name)
         </code>
@@ -1467,7 +1467,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_moduleSource">
-        <div class="location">at line 282</div>
+        <div class="location">at line 284</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
     <strong>moduleSource</strong>(string $path)
         </code>
@@ -1510,7 +1510,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_modules">
-        <div class="location">at line 294</div>
+        <div class="location">at line 296</div>
         <code>                    array
     <strong>modules</strong>()
         </code>
@@ -1542,7 +1542,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_reloaded">
-        <div class="location">at line 303</div>
+        <div class="location">at line 305</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>reloaded</strong>()
         </code>
@@ -1574,7 +1574,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdk">
-        <div class="location">at line 312</div>
+        <div class="location">at line 314</div>
         <code>                    <a href="../Dagger/WorkspaceSDK.html"><abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr></a>
     <strong>sdk</strong>(string $name)
         </code>
@@ -1616,7 +1616,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sdks">
-        <div class="location">at line 322</div>
+        <div class="location">at line 324</div>
         <code>                    array
     <strong>sdks</strong>()
         </code>
@@ -1648,7 +1648,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_search">
-        <div class="location">at line 335</div>
+        <div class="location">at line 337</div>
         <code>                    array
     <strong>search</strong>(string $pattern, array|null $paths = [], array|null $globs = [], bool|null $literal = false, bool|null $multiline = false, bool|null $dotall = false, bool|null $insensitive = false, bool|null $skipIgnored = false, bool|null $skipHidden = false, bool|null $filesOnly = false, int|null $limit = null)
         </code>
@@ -1741,7 +1741,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_services">
-        <div class="location">at line 386</div>
+        <div class="location">at line 388</div>
         <code>                    <a href="../Dagger/UpGroup.html"><abbr title="Dagger\UpGroup">UpGroup</abbr></a>
     <strong>services</strong>(array|null $include = null)
         </code>
@@ -1783,7 +1783,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withChanges">
-        <div class="location">at line 398</div>
+        <div class="location">at line 400</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withChanges</strong>(<a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a> $changes)
         </code>
@@ -1825,7 +1825,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConfigEnv">
-        <div class="location">at line 408</div>
+        <div class="location">at line 410</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -1872,7 +1872,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withConfigValue">
-        <div class="location">at line 423</div>
+        <div class="location">at line 425</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withConfigValue</strong>(string $key, string $value, array|null $values = null, bool|null $here = false)
         </code>
@@ -1929,7 +1929,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 442</div>
+        <div class="location">at line 444</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -1976,7 +1976,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitClient">
-        <div class="location">at line 455</div>
+        <div class="location">at line 457</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitClient</strong>(string $path, string $sdk, string $module, <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -2043,7 +2043,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withInitModule">
-        <div class="location">at line 484</div>
+        <div class="location">at line 486</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withInitModule</strong>(string $name, string $sdk, string|null $path = &#039;&#039;, string|null $source = &#039;&#039;, array|null $include = [], <abbr title="Dagger\Dagger\Json">Json</abbr>|null $args = null, bool|null $here = false, bool|null $noGenerate = false)
         </code>
@@ -2120,7 +2120,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withModule">
-        <div class="location">at line 523</div>
+        <div class="location">at line 525</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withModule</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false)
         </code>
@@ -2172,7 +2172,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 541</div>
+        <div class="location">at line 543</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2219,7 +2219,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 554</div>
+        <div class="location">at line 556</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source)
         </code>
@@ -2266,7 +2266,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewDirectory">
-        <div class="location">at line 567</div>
+        <div class="location">at line 569</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source)
         </code>
@@ -2313,7 +2313,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 578</div>
+        <div class="location">at line 580</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420)
         </code>
@@ -2365,7 +2365,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSDK">
-        <div class="location">at line 592</div>
+        <div class="location">at line 594</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withSDK</strong>(string $ref, string|null $name = &#039;&#039;, bool|null $here = false, string|null $asSdkName = &#039;&#039;)
         </code>
@@ -2422,7 +2422,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUpdatedLock">
-        <div class="location">at line 611</div>
+        <div class="location">at line 613</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withUpdatedLock</strong>()
         </code>
@@ -2454,7 +2454,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 620</div>
+        <div class="location">at line 622</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withWorkdir</strong>(string $path)
         </code>
@@ -2496,7 +2496,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigEnv">
-        <div class="location">at line 630</div>
+        <div class="location">at line 632</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigEnv</strong>(string $name, bool|null $here = false)
         </code>
@@ -2543,7 +2543,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutConfigValue">
-        <div class="location">at line 647</div>
+        <div class="location">at line 649</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutConfigValue</strong>(string $key, bool|null $here = false)
         </code>
@@ -2591,7 +2591,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 660</div>
+        <div class="location">at line 662</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutDirectory</strong>(string $path)
         </code>
@@ -2633,7 +2633,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 670</div>
+        <div class="location">at line 672</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutFile</strong>(string $path)
         </code>
@@ -2675,7 +2675,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutModule">
-        <div class="location">at line 682</div>
+        <div class="location">at line 684</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutModule</strong>(string $name, bool|null $here = false)
         </code>
@@ -2722,7 +2722,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSDK">
-        <div class="location">at line 695</div>
+        <div class="location">at line 697</div>
         <code>                    <a href="../Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a>
     <strong>withoutSDK</strong>(string $name, bool|null $here = false)
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -680,7 +680,7 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::envList</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>List named environments defined in the workspace configuration.</p></dd><dt><a href="Dagger/Workspace.html#method_export">
 <abbr title="Dagger\Workspace">Workspace</abbr>::export</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Write this workspace's pending changes to its local Git workspace.</p></dd><dt><a href="Dagger/WorkspaceModule.html#method_entrypoint">
+                    <dd><p>Write this workspace's pending changes to its local Git workspace on the current client's host.</p></dd><dt><a href="Dagger/WorkspaceModule.html#method_entrypoint">
 <abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr>::entrypoint</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a></em></dt>
                     <dd><p>Whether the module is the workspace entrypoint (functions aliased to Query root).</p></dd>        </dl><h2 id="letterF">F</h2>
         <dl id="indexF"><dt><a href="Dagger/Address.html#method_file">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -7358,7 +7358,7 @@
 			"t": "M",
 			"n": "Dagger\\Workspace::export",
 			"p": "Dagger/Workspace.html#method_export",
-			"d": "<p>Write this workspace's pending changes to its local Git workspace.</p>"
+			"d": "<p>Write this workspace's pending changes to its local Git workspace on the current client's host.</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/elixir/lib/dagger/gen/workspace.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace.ex
@@ -169,7 +169,9 @@ defmodule Dagger.Workspace do
   end
 
   @doc """
-  Write this workspace's pending changes to its local Git workspace.
+  Write this workspace's pending changes to its local Git workspace on the current client's host.
+
+  Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host.
   """
   @spec export(t()) :: :ok | {:error, term()}
   def export(%__MODULE__{} = workspace) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -16300,7 +16300,9 @@ func (r *Workspace) EnvList(ctx context.Context) ([]string, error) {
 	return response, q.Execute(ctx)
 }
 
-// Write this workspace's pending changes to its local Git workspace.
+// Write this workspace's pending changes to its local Git workspace on the current client's host.
+//
+// Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host.
 func (r *Workspace) Export(ctx context.Context) error {
 	if r.export != nil {
 		return nil

--- a/sdk/php/generated/Workspace.php
+++ b/sdk/php/generated/Workspace.php
@@ -148,7 +148,9 @@ class Workspace extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
-     * Write this workspace's pending changes to its local Git workspace.
+     * Write this workspace's pending changes to its local Git workspace on the current client's host.
+     *
+     * Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host.
      */
     public function export(): void
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -15254,7 +15254,12 @@ class Workspace(Type):
         return await _ctx.execute(list[str])
 
     async def export(self) -> Void:
-        """Write this workspace's pending changes to its local Git workspace.
+        """Write this workspace's pending changes to its local Git workspace on
+        the current client's host.
+
+        Like Directory.export, the write is a side effect on the client that
+        makes the call — never on the client that created the workspace.
+        Inside a module, this cannot reach the caller's host.
 
         Returns
         -------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -15564,7 +15564,8 @@ impl Workspace {
         let query = self.selection.select("envList");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Write this workspace's pending changes to its local Git workspace.
+    /// Write this workspace's pending changes to its local Git workspace on the current client's host.
+    /// Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host.
     pub async fn export(&self) -> Result<Void, DaggerError> {
         let query = self.selection.select("export");
         query.execute(self.graphql_client.clone()).await

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -15220,7 +15220,9 @@ export class Workspace extends BaseClient {
   }
 
   /**
-   * Write this workspace's pending changes to its local Git workspace.
+   * Write this workspace's pending changes to its local Git workspace on the current client's host.
+   *
+   * Like Directory.export, the write is a side effect on the client that makes the call — never on the client that created the workspace. Inside a module, this cannot reach the caller's host.
    */
   export = async (): Promise<void> => {
     if (this._export) {


### PR DESCRIPTION
Fixes #14007

`Workspace.export` now writes to the current client — the client that makes the call. It behaves like `Directory.export`.

Before, `export` routed the write through the client that created the workspace. So a module that received a `Workspace` argument could write files onto its caller's host. That broke the sandbox.

The fix removes one context override in the export resolver. The write now runs in the caller's own session.

- The CLI behaves the same. In every CLI flow, the caller is also the client that created the workspace.
- A module's export now lands in the module's own sandbox, not on the caller's disk. This is the same limitation as `Directory.export` in a module.
- A module that wants to hand changes back returns a `Changeset`. The caller decides to apply it.

All other changed files are `dagger generate` output for the updated doc string.

**Tests**

- New: `TestWorkspaceExportStaysOnCurrentClient`. A module exports a staged file; the file must not appear in the caller's workdir. This test fails on main.
- All existing export tests pass unchanged (16 tests, run against a dev engine).
