### PR TITLE
fix(core): harden changeset merges against stat-only phantom diffs

### DIFF
--- a/.changes/unreleased/Fixed-20260831-000000.yaml
+++ b/.changes/unreleased/Fixed-20260831-000000.yaml
@@ -1,0 +1,16 @@
+kind: Fixed
+body: |
+  Changeset merges no longer corrupt under stat-only snapshot differences.
+
+  A changeset's materialized diff could carry files whose content was
+  identical but whose timestamps diverged between content-deduplicated
+  snapshots — entries its declared paths never reported. When such a phantom
+  entry fell under `.git`, applying it clobbered the merge's temporary
+  repository mid-flight and one side of the merge was silently dropped; this
+  was the cause of flaky `dagger module init` results under concurrent
+  identical initializations. Changeset content is now kept out of the merge's
+  `.git`, and the merge verifies that every declared change survives instead
+  of reporting success on a wrong result.
+custom:
+    Author: vito
+    PR: "14012"

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -1404,21 +1404,21 @@ func gitMetaPath(p string) bool {
 	return p == ".git" || strings.HasPrefix(p, ".git/")
 }
 
-// withoutGitMeta returns a copy of p with all entries under the workspace-root
-// .git directory removed.
-func (p *ChangesetPaths) withoutGitMeta() *ChangesetPaths {
+// withoutGitMeta returns a copy of ch with all entries under the
+// workspace-root .git directory removed.
+func (ch *ChangesetPaths) withoutGitMeta() *ChangesetPaths {
 	dropGitMeta := func(paths []string) []string {
 		return slices.DeleteFunc(slices.Clone(paths), gitMetaPath)
 	}
 	filtered := &ChangesetPaths{
-		Added:      dropGitMeta(p.Added),
-		Modified:   dropGitMeta(p.Modified),
-		Removed:    dropGitMeta(p.Removed),
-		AllRemoved: dropGitMeta(p.AllRemoved),
+		Added:      dropGitMeta(ch.Added),
+		Modified:   dropGitMeta(ch.Modified),
+		Removed:    dropGitMeta(ch.Removed),
+		AllRemoved: dropGitMeta(ch.AllRemoved),
 	}
-	if p.Renamed != nil {
-		filtered.Renamed = make(map[string]string, len(p.Renamed))
-		for newPath, oldPath := range p.Renamed {
+	if ch.Renamed != nil {
+		filtered.Renamed = make(map[string]string, len(ch.Renamed))
+		for newPath, oldPath := range ch.Renamed {
 			if gitMetaPath(newPath) || gitMetaPath(oldPath) {
 				continue
 			}

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -1391,6 +1391,42 @@ func (ch *Changeset) content(ctx context.Context) (*changesetContent, error) {
 	return content, nil
 }
 
+// gitMetaPath reports whether p is the workspace-root .git directory or a
+// path inside it. The merge workspace's temporary repository lives at that
+// path, so changeset content must never be applied there;
+// mergeBeforeDirectories excludes the same path from the merge base. Stat-only
+// snapshot differences can plant such entries in a changeset's materialized
+// diff without ComputePaths ever reporting them, and applying a stale
+// .git/HEAD mid-merge silently redirects branch commits.
+func gitMetaPath(p string) bool {
+	p = strings.TrimPrefix(path.Clean(p), "/")
+	return p == ".git" || strings.HasPrefix(p, ".git/")
+}
+
+// withoutGitMeta returns a copy of p with all entries under the workspace-root
+// .git directory removed.
+func (p *ChangesetPaths) withoutGitMeta() *ChangesetPaths {
+	dropGitMeta := func(paths []string) []string {
+		return slices.DeleteFunc(slices.Clone(paths), gitMetaPath)
+	}
+	filtered := &ChangesetPaths{
+		Added:      dropGitMeta(p.Added),
+		Modified:   dropGitMeta(p.Modified),
+		Removed:    dropGitMeta(p.Removed),
+		AllRemoved: dropGitMeta(p.AllRemoved),
+	}
+	if p.Renamed != nil {
+		filtered.Renamed = make(map[string]string, len(p.Renamed))
+		for newPath, oldPath := range p.Renamed {
+			if gitMetaPath(newPath) || gitMetaPath(oldPath) {
+				continue
+			}
+			filtered.Renamed[newPath] = oldPath
+		}
+	}
+	return filtered
+}
+
 // gitMergeWorkspace is a mounted scratch copy of the merge base that git
 // branches are built in.
 type gitMergeWorkspace struct {
@@ -1404,7 +1440,10 @@ type gitMergeWorkspace struct {
 // directories are recreated (the diff snapshot does not carry them). This
 // mirrors Directory.WithChanges' application of the same content.
 func (ws *gitMergeWorkspace) applyContent(ctx context.Context, content *changesetContent) error {
-	if err := removeChangesetPaths(ws.root, ws.dir, content.paths.Removed); err != nil {
+	// Never let changeset content reach the temporary repository's .git.
+	paths := content.paths.withoutGitMeta()
+
+	if err := removeChangesetPaths(ws.root, ws.dir, paths.Removed); err != nil {
 		return fmt.Errorf("remove paths: %w", err)
 	}
 
@@ -1445,6 +1484,15 @@ func (ws *gitMergeWorkspace) applyContent(ctx context.Context, content *changese
 						// work tree crosses devices, so every attempt would
 						// just fail into the copy fallback.
 						DisableSourceHardlinks: true,
+						// The diff snapshot can carry .git entries that
+						// ComputePaths never reported: the stat-sensitive
+						// differ flags files whose content is identical but
+						// whose timestamps diverge across content-deduped
+						// snapshots. Overlaying those onto the temporary
+						// repository corrupts the merge.
+						Filter: layercopy.Filter{
+							Exclude: []string{".git"},
+						},
 					},
 				)
 			}, mountRefAsReadOnly)
@@ -1454,10 +1502,10 @@ func (ws *gitMergeWorkspace) applyContent(ctx context.Context, content *changese
 		}
 	}
 
-	if err := mkdirChangesetAddedDirs(ctx, copier, ws.dir, content.paths); err != nil {
+	if err := mkdirChangesetAddedDirs(ctx, copier, ws.dir, paths); err != nil {
 		return err
 	}
-	return ws.touchAppliedPaths(content.paths)
+	return ws.touchAppliedPaths(paths)
 }
 
 // touchAppliedPaths bumps the mtime of every path the changeset wrote so git

--- a/core/changeset.go
+++ b/core/changeset.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1532,6 +1533,40 @@ func (ws *gitMergeWorkspace) touchAppliedPaths(paths *ChangesetPaths) error {
 	return nil
 }
 
+// verifyMergedPaths confirms that every file-level path the given changesets
+// declared as added or modified exists in the merged worktree. A conflict-free
+// merge has no legitimate way to drop one; a missing path means the temporary
+// repository lost applied content (a lost path here once meant a stale
+// .git/HEAD from a changeset diff had redirected the ours commit onto the
+// wrong branch, letting the merge silently resolve to one side).
+func (ws *gitMergeWorkspace) verifyMergedPaths(contents ...*changesetContent) error {
+	var missing []string
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		paths := content.paths.withoutGitMeta()
+		for _, p := range slices.Concat(paths.Added, paths.Modified) {
+			if strings.HasSuffix(p, "/") {
+				continue
+			}
+			full, err := RootPathWithoutFinalSymlink(ws.root, path.Join(ws.dir, p))
+			if err != nil {
+				return err
+			}
+			if _, err := os.Lstat(full); errors.Is(err, os.ErrNotExist) {
+				missing = append(missing, p)
+			} else if err != nil {
+				return TrimErrPathPrefix(err, ws.root)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("merge dropped declared changes: %s (engine bug: the merge workspace lost applied content)", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
 // withGitMergeWorkspace sets up a workspace for git merge operations, runs the provided
 // function, then commits and returns the resulting directory.
 func withGitMergeWorkspace(ctx context.Context, base dagql.ObjectResult[*Directory], description string, fn func(ws *gitMergeWorkspace) error) (*Directory, error) {
@@ -1644,6 +1679,12 @@ func gitMergeChangesets(
 			}
 		}
 
+		if mergeErr == nil && conflicts.IsEmpty() {
+			if err := ws.verifyMergedPaths(ours, theirs); err != nil {
+				return err
+			}
+		}
+
 		if err := os.RemoveAll(filepath.Join(ws.workDir, ".git")); err != nil {
 			return fmt.Errorf("remove temporary merge git repository: %w", err)
 		}
@@ -1695,6 +1736,12 @@ func gitOctopusMergeChangesets(
 			return err
 		}
 
+		// An octopus merge refuses to run with conflicts, so on success every
+		// declared path must have survived.
+		if err := ws.verifyMergedPaths(append([]*changesetContent{ourContent}, otherContents...)...); err != nil {
+			return err
+		}
+
 		if err := os.RemoveAll(filepath.Join(ws.workDir, ".git")); err != nil {
 			return fmt.Errorf("remove temporary octopus merge git repository: %w", err)
 		}
@@ -1722,7 +1769,7 @@ var gitEphemeralConfig = []string{
 	"-c", "core.trustctime=false",
 }
 
-func runGit(ctx context.Context, dir string, args ...string) error {
+func gitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	gitArgs := make([]string, 0, len(gitEphemeralConfig)+len(args))
 	gitArgs = append(gitArgs, gitEphemeralConfig...)
 	gitArgs = append(gitArgs, args...)
@@ -1737,10 +1784,26 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 		"GIT_COMMITTER_NAME=Dagger",
 		"GIT_COMMITTER_EMAIL=dagger@localhost",
 	}
-	if output, err := cmd.CombinedOutput(); err != nil {
+	return cmd
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	if output, err := gitCmd(ctx, dir, args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("git %v: %w: %s", args, err, output)
 	}
 	return nil
+}
+
+// runGitOutput runs git and returns its stdout.
+func runGitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := gitCmd(ctx, dir, args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %v: %w: %s", args, err, stderr.String())
+	}
+	return string(out), nil
 }
 
 func initGitRepo(ctx context.Context, dir string) error {
@@ -1766,15 +1829,205 @@ func createBranchWithContent(ctx context.Context, ws *gitMergeWorkspace, branchN
 	if err := ws.applyContent(ctx, content); err != nil {
 		return fmt.Errorf("apply %s changes: %w", branchName, err)
 	}
-	// Always commit (even if empty) to ensure consistent commit structure
-	// This is needed so that HEAD~1 references work correctly
 	if err := runGit(ctx, ws.workDir, "add", "-A"); err != nil {
 		return err
 	}
-	if err := runGit(ctx, ws.workDir, "commit", "--allow-empty", "-m", branchName); err != nil {
+	staged, err := runGitOutput(ctx, ws.workDir, "diff", "--cached", "--name-only")
+	if err != nil {
+		return err
+	}
+	// Each branch must contribute exactly one commit so HEAD~1 resolves to the
+	// base, so genuinely empty branches (empty or directory-only changesets,
+	// or changes the merge base already carries) still commit with
+	// --allow-empty. But an empty commit where git *should* have staged
+	// something silently erases the changeset from the merge, so before
+	// permitting one, verify the applied content actually reached the
+	// worktree.
+	commitArgs := []string{"commit", "-m", branchName}
+	if strings.TrimSpace(staged) == "" {
+		if err := ws.verifyBranchContentLanded(ctx, content); err != nil {
+			return fmt.Errorf("branch %s staged no changes: %w", branchName, err)
+		}
+		commitArgs = []string{"commit", "--allow-empty", "-m", branchName}
+	}
+	if err := runGit(ctx, ws.workDir, commitArgs...); err != nil {
 		return err
 	}
 	return nil
+}
+
+// verifyBranchContentLanded discriminates the legitimate reasons a branch can
+// stage nothing (empty or directory-only changeset, changes the merge base
+// already carries, gitignored paths) from the silent-corruption ones: applied
+// content that never reached the worktree, or a stale index stat-cache making
+// git skip a real edit. Both corruption modes have produced wrong merges that
+// reported success (see the touchAppliedPaths comment for the stat-cache
+// history), so failing here is what keeps them from escaping as merged
+// results.
+func (ws *gitMergeWorkspace) verifyBranchContentLanded(ctx context.Context, content *changesetContent) error {
+	paths := content.paths.withoutGitMeta()
+
+	var files []string
+	for _, p := range slices.Concat(paths.Added, paths.Modified) {
+		if !strings.HasSuffix(p, "/") {
+			files = append(files, p)
+		}
+	}
+
+	// A tracked file whose worktree bytes differ from HEAD must stage; if git
+	// saw nothing, its stat cache lied about the file being clean.
+	for _, p := range paths.Modified {
+		if strings.HasSuffix(p, "/") {
+			continue
+		}
+		wt, err := ws.readWorktreePath(p)
+		if err != nil {
+			return err
+		}
+		headBytes, tracked := gitBlobBytes(ctx, ws.workDir, p)
+		if !tracked {
+			// Untracked (e.g. gitignored in the base); the diff comparison
+			// below still validates that the content landed.
+			continue
+		}
+		if wt == nil || !bytes.Equal(wt, headBytes) {
+			return fmt.Errorf("worktree content for %q differs from HEAD but git staged nothing (index stat cache failure)", p)
+		}
+	}
+
+	for _, p := range paths.AllRemoved {
+		if strings.HasSuffix(p, "/") {
+			// A removed directory can coexist with paths the same changeset
+			// re-adds beneath it; only file removals are checkable here.
+			continue
+		}
+		full, err := RootPathWithoutFinalSymlink(ws.root, path.Join(ws.dir, p))
+		if err != nil {
+			return err
+		}
+		if _, err := os.Lstat(full); !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removal of %q was not applied to the merge worktree", p)
+		}
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+	if content.diff.Self() == nil {
+		return fmt.Errorf("changeset declared file changes %v but materialized no diff content", files)
+	}
+	return ws.withDiffDir(ctx, content, func(diffDir string) error {
+		for _, p := range files {
+			same, err := ws.worktreeMatchesDiff(p, diffDir)
+			if err != nil {
+				return err
+			}
+			if !same {
+				return fmt.Errorf("applied content for %q did not land in the merge worktree", p)
+			}
+		}
+		return nil
+	})
+}
+
+// readWorktreePath returns the worktree content for a changeset path: file
+// bytes for regular files, the target for symlinks, nil if the path does not
+// exist.
+func (ws *gitMergeWorkspace) readWorktreePath(p string) ([]byte, error) {
+	full, err := RootPathWithoutFinalSymlink(ws.root, path.Join(ws.dir, p))
+	if err != nil {
+		return nil, err
+	}
+	fi, err := os.Lstat(full)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, TrimErrPathPrefix(err, ws.root)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(full)
+		if err != nil {
+			return nil, TrimErrPathPrefix(err, ws.root)
+		}
+		return []byte(target), nil
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		return nil, TrimErrPathPrefix(err, ws.root)
+	}
+	return data, nil
+}
+
+// worktreeMatchesDiff reports whether the worktree content for p matches the
+// materialized diff's copy of it.
+func (ws *gitMergeWorkspace) worktreeMatchesDiff(p, diffDir string) (bool, error) {
+	wt, err := ws.readWorktreePath(p)
+	if err != nil {
+		return false, err
+	}
+	if wt == nil {
+		return false, nil
+	}
+	full, err := RootPathWithoutFinalSymlink(diffDir, p)
+	if err != nil {
+		return false, err
+	}
+	fi, err := os.Lstat(full)
+	if errors.Is(err, os.ErrNotExist) {
+		// The path is declared but absent from the diff snapshot; nothing to
+		// compare against, and its presence in the worktree is all that can
+		// be verified.
+		return true, nil
+	} else if err != nil {
+		return false, TrimErrPathPrefix(err, diffDir)
+	}
+	var want []byte
+	if fi.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(full)
+		if err != nil {
+			return false, TrimErrPathPrefix(err, diffDir)
+		}
+		want = []byte(target)
+	} else {
+		want, err = os.ReadFile(full)
+		if err != nil {
+			return false, TrimErrPathPrefix(err, diffDir)
+		}
+	}
+	return bytes.Equal(wt, want), nil
+}
+
+// withDiffDir mounts the changeset's materialized diff snapshot read-only and
+// hands its directory to fn.
+func (ws *gitMergeWorkspace) withDiffDir(ctx context.Context, content *changesetContent, fn func(diffDir string) error) error {
+	diffRef, err := content.diff.Self().Snapshot.GetOrEval(ctx, content.diff.Result)
+	if err != nil {
+		return fmt.Errorf("diff snapshot: %w", err)
+	}
+	diffPath, err := content.diff.Self().Dir.GetOrEval(ctx, content.diff.Result)
+	if err != nil {
+		return fmt.Errorf("diff path: %w", err)
+	}
+	if diffPath == "" {
+		diffPath = "/"
+	}
+	return MountRef(ctx, diffRef, func(srcRoot string, _ *mount.Mount) error {
+		dir, err := containerdfs.RootPath(srcRoot, diffPath)
+		if err != nil {
+			return err
+		}
+		return fn(dir)
+	}, mountRefAsReadOnly)
+}
+
+// gitBlobBytes returns the HEAD blob for path p, or tracked=false if HEAD has
+// no such blob (untracked or gitignored paths).
+func gitBlobBytes(ctx context.Context, workDir, p string) (data []byte, tracked bool) {
+	out, err := runGitOutput(ctx, workDir, "cat-file", "blob", "HEAD:"+p)
+	if err != nil {
+		return nil, false
+	}
+	return []byte(out), true
 }
 
 // resolveModifyDeleteConflicts handles conflicts where one side modified and the other deleted.

--- a/core/integration/changeset_test.go
+++ b/core/integration/changeset_test.go
@@ -2188,3 +2188,77 @@ func (ChangesetSuite) TestSameFileRegionMerge(ctx context.Context, t *testctx.T)
 		require.Error(t, err)
 	})
 }
+
+// TestMergePhantomStatOnlyChanges pins that stat-only differences between
+// content-identical snapshots cannot corrupt the git-backed changeset merge.
+//
+// A changeset's declared paths come from a content comparison, but its
+// materialized diff comes from the stat-sensitive snapshot differ, so a file
+// whose content is identical yet whose timestamps diverge (as happens when
+// content-addressed caching pairs physically different materializations of
+// the same tree) rides along in the diff without ever being declared. When
+// the changeset's before directory carries a .git directory, that phantom
+// used to include .git/HEAD, and applying it mid-merge clobbered the
+// temporary repository's HEAD: the ours commit landed on the wrong branch
+// and the merge silently resolved to the other side. This was the root cause
+// of flaky workspace module inits under concurrent identical initializations.
+func (ChangesetSuite) TestMergePhantomStatOnlyChanges(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	baseDir := c.Directory().
+		WithNewFile(".git/HEAD", "ref: refs/heads/master\n").
+		WithNewFile("app.txt", "original app content").
+		WithNewFile("other.txt", "untouched content")
+
+	// Restamping changes every file's mtime while leaving content identical,
+	// standing in for dedup handing Before and After physically different but
+	// content-equal snapshots.
+	restamped := baseDir.WithTimestamps(1700000000)
+
+	// Precondition: the snapshot differ flags stat-only changes, so the
+	// phantom entries exist for the merge to defend against. If this ever
+	// fails, diffs became content-defined and this scenario is obsolete.
+	diffEntries, err := baseDir.Diff(restamped).Entries(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, diffEntries)
+
+	ours := restamped.
+		WithNewFile("app.txt", "app edited in ours").
+		Changes(baseDir)
+
+	// The declared paths stay clean: content comparison sees only the real
+	// edit, none of the phantom entries.
+	modified, err := ours.ModifiedPaths(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"app.txt"}, modified)
+	added, err := ours.AddedPaths(ctx)
+	require.NoError(t, err)
+	require.Empty(t, added)
+
+	theirs := baseDir.
+		WithNewFile("added.txt", "added in theirs").
+		Changes(baseDir)
+
+	merged := ours.WithChangeset(theirs)
+
+	modified, err = merged.ModifiedPaths(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"app.txt"}, modified)
+	added, err = merged.AddedPaths(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"added.txt"}, added)
+
+	result := baseDir.WithChanges(merged)
+	appContent, err := result.File("app.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "app edited in ours", appContent)
+	addedContent, err := result.File("added.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "added in theirs", addedContent)
+	otherContent, err := result.File("other.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "untouched content", otherContent)
+	headContent, err := result.File(".git/HEAD").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "ref: refs/heads/master\n", headContent)
+}

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -541,3 +541,35 @@ func readInstalledWorkspaceConfig(t *testctx.T, workdir string) *workspacecfg.Co
 	require.NoError(t, err)
 	return cfg
 }
+
+// TestWorkspaceModuleInitConcurrent stresses many identical SDK-managed
+// module initializations racing in one engine. Identical workspaces are what
+// let content-addressed caching pair physically different materializations of
+// the same tree, which is the precondition for stat-only phantom diff entries
+// reaching the init changeset merge (see ChangesetSuite's
+// TestMergePhantomStatOnlyChanges for the distilled mechanism). Losing the
+// engine-owned changes here — dagger-module.toml missing, or myapp absent
+// from dagger.toml — is the historical failure shape.
+func (WorkspaceModulesSuite) TestWorkspaceModuleInitConcurrent(ctx context.Context, t *testctx.T) {
+	for i := range 12 {
+		t.Run(fmt.Sprintf("init %d", i), func(ctx context.Context, t *testctx.T) {
+			workdir := t.TempDir()
+			initGitRepo(ctx, t, workdir)
+
+			_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "go")
+			require.NoError(t, err)
+
+			_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+			require.NoError(t, err)
+
+			_, err = os.Stat(filepath.Join(workdir, ".dagger", "modules", "myapp", "dagger-module.toml"))
+			require.NoError(t, err, "engine-owned dagger-module.toml must survive init")
+
+			cfg := readInstalledWorkspaceConfig(t, workdir)
+			require.Contains(t, cfg.Modules, "myapp", "engine-owned dagger.toml modification must survive init")
+			goSDK := cfg.Modules["dagger-go-sdk"]
+			require.NotNil(t, goSDK.AsSDK)
+			require.Equal(t, []workspacecfg.SDKManagedModule{{Path: ".dagger/modules/myapp"}}, goSDK.AsSDK.Modules)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes this flake: https://dagger.cloud/dagger/checks/github.com/dagger/dagger@d1530975578c97af3a33e6459233b6262fe5819a?check=test-split:test-workspaces

The changeset merge could lose all changes from one changeset and report success. This PR removes the cause and adds checks that make this type of failure loud.

- The merge does not apply changeset content to the `.git` directory of its temporary repository.
- The merge makes an empty branch commit only after it makes sure that the branch is correctly empty.
- After a merge with no conflicts, the merge makes sure that the result contains each declared path.

## Cause

A changeset has two views of its changes. The two views do not always agree:

- `ComputePaths` compares file content. It supplies the declared paths.
- The materialized diff compares file metadata, which includes the modification time.

The cache can supply two different copies of a directory that have the same content. The two copies have different timestamps. The diff of the two copies then contains files that have the same content but different timestamps. The declared paths do not show these files.

A workspace snapshot contains the `.git` directory of the client. Thus the diff of a workspace changeset can contain an old `.git/HEAD` file. The merge applied that file into its temporary repository. The old `HEAD` pointed git to a different branch. Git put the commit for one changeset on that branch. The merge result then contained only the other changeset. Each git command completed without an error.

This condition occurred when many `module init` commands ran at the same time with the same content, because only then does the cache pair different copies of the same tree. See this [instrumented failure trace](https://dagger.cloud/dagger/traces/1c7ce9be4c93d6daeca108b335f5e408) for the step-by-step evidence.

## Changes

1. `applyContent` removes all `.git` entries from the content that it applies. This is the same exclusion that `mergeBeforeDirectories` applies to the merge base.
2. The blanket `--allow-empty` on branch commits is removed. If git stages no changes but the changeset declares file changes, the merge compares the worktree with `HEAD` and with the diff content. If the applied content is not present, the merge stops with an error. After a merge with no conflicts, the merge also makes sure that each declared path is present in the worktree. If a path is missing, the merge stops with an error that names the path.
3. Two regression tests. `TestMergePhantomStatOnlyChanges` causes the failure without concurrency: it merges a changeset that has `.git` in its before-directory and timestamp-only differences in its diff. `TestWorkspaceModuleInitConcurrent` runs 12 `module init` flows with the same content at the same time.

## Tests

- `go test ./core`
- Changeset merge integration tests: [44 passed](https://dagger.cloud/dagger/traces/a77616d972ec4ed6aff812d647282b84).
- Workspace stress profile (six suites, five repetitions): [1,645 passed, 0 failures](https://dagger.cloud/dagger/traces/537bf4acdd829026e12532ea5c75857f). Before the fix, the same profile caused approximately 20 failures in each run.
- Negative control: `TestMergePhantomStatOnlyChanges` fails on an engine that does not have the fix.

## Future work

- Make `Directory.diff` compare content, not metadata. Then timestamp-only entries cannot occur. This changes public API behavior and needs a design proposal.
- Remove `.git` from workspace snapshots after #14000, which rebuilds git state from client packs.
