### PR TITLE
Cut the per-invocation cost of a remote git-ref module source

### DIFF
--- a/.changes/unreleased/Fixed-20260907-163211.yaml
+++ b/.changes/unreleased/Fixed-20260907-163211.yaml
@@ -1,0 +1,16 @@
+kind: Fixed
+body: |
+  Loading a module whose runtime, or whose workspace SDK, is a remote git ref no
+  longer pays a fixed 10 second timeout on every `dagger generate`. Deciding
+  whether a ref string such as `github.com/org/repo` is a local directory
+  requires a host filesystem, and the code generator runs in a nested client
+  that has none; the engine waited for that client instead of failing at once.
+
+  The check for whether a git remote is public is now answered once per session
+  rather than once per client, so a command that reaches the same repository
+  from the CLI and from a module's dependency resolution makes one request
+  instead of two. It also appears in traces as `git remote visibility`.
+time: 2026-09-07T16:32:11Z
+custom:
+  Author: eunomie
+  PR: "14015"

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -675,6 +675,78 @@ func (LockfileSuite) TestGitLatestPinnedHTTPSUnavailableRemoteUsesPin(ctx contex
 	require.Contains(t, string(out), pinnedCommit)
 }
 
+// A scheme-less ref (how module sources are normally written) makes the git
+// resolver try each candidate transport and ls-remote it to see which one
+// answers. When the workspace lock already holds entries for one of those
+// candidates, that transport served the remote before, so the probe has
+// nothing left to decide and must not run: an unreachable remote still
+// resolves entirely from the pin.
+func (LockfileSuite) TestGitLatestPinnedSchemelessRemoteSkipsTransportProbe(ctx context.Context, t *testctx.T) {
+	const schemelessRemote = "git.example.invalid/dagger.git"
+	const pinnedRemote = "https://" + schemelessRemote
+	const pinnedCommit = "0123456789abcdef0123456789abcdef01234567"
+
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeQueryDoc(t, workdir, "git-latest.graphql", `{
+  git(url: "`+schemelessRemote+`") {
+    latest {
+      ref
+      commit
+    }
+  }
+}
+`)
+	writeGitLatestLockForRemote(
+		t,
+		workdir,
+		pinnedRemote,
+		"refs/tags/v1.2.3@"+pinnedCommit,
+	)
+
+	out, err := hostDaggerExec(
+		ctx,
+		t,
+		workdir,
+		"--silent",
+		"query",
+		"--doc",
+		queryPath,
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(out), "refs/tags/v1.2.3")
+	require.Contains(t, string(out), pinnedCommit)
+}
+
+// Without lock entries there is nothing to pick a transport from, so the
+// resolver still probes every candidate and reports that none answered.
+func (LockfileSuite) TestUnpinnedSchemelessRemoteStillProbesTransport(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeQueryDoc(t, workdir, "git-latest.graphql", `{
+  git(url: "git.example.invalid/dagger.git") {
+    latest {
+      ref
+      commit
+    }
+  }
+}
+`)
+
+	_, err := hostDaggerExec(
+		ctx,
+		t,
+		workdir,
+		"--silent",
+		"query",
+		"--doc",
+		queryPath,
+	)
+	require.Error(t, err)
+}
+
 func (LockfileSuite) TestGitLatestPinnedRejectsInvalidRef(ctx context.Context, t *testctx.T) {
 	workdir := t.TempDir()
 	hostGitInit(t, workdir)

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -675,34 +675,29 @@ func (LockfileSuite) TestGitLatestPinnedHTTPSUnavailableRemoteUsesPin(ctx contex
 	require.Contains(t, string(out), pinnedCommit)
 }
 
-// A scheme-less ref (how module sources are normally written) makes the git
-// resolver try each candidate transport and ls-remote it to see which one
-// answers. When the workspace lock already holds entries for one of those
-// candidates, that transport served the remote before, so the probe has
-// nothing left to decide and must not run: an unreachable remote still
-// resolves entirely from the pin.
-func (LockfileSuite) TestGitLatestPinnedSchemelessRemoteSkipsTransportProbe(ctx context.Context, t *testctx.T) {
-	const schemelessRemote = "git.example.invalid/dagger.git"
-	const pinnedRemote = "https://" + schemelessRemote
-	const pinnedCommit = "0123456789abcdef0123456789abcdef01234567"
+// A scheme-less source must keep its own transport fallback. The workspace
+// lock is shared and committed, so it can name a transport that this user
+// cannot reach: one contributor pins over SSH, the next has HTTPS access only.
+// Selecting the locked transport strands the second contributor on a
+// repository they can otherwise read.
+func (LockfileSuite) TestSchemelessRemoteIgnoresLockedTransport(ctx context.Context, t *testctx.T) {
+	const schemelessRemote = "github.com/dagger/dagger-test-modules"
+	const sshRemote = "ssh://" + schemelessRemote
 
 	workdir := t.TempDir()
 	hostGitInit(t, workdir)
 	writeEmptyWorkspaceConfig(t, workdir)
-	queryPath := writeQueryDoc(t, workdir, "git-latest.graphql", `{
+	queryPath := writeQueryDoc(t, workdir, "git-url.graphql", `{
   git(url: "`+schemelessRemote+`") {
-    latest {
-      ref
-      commit
-    }
+    url
   }
 }
 `)
 	writeGitLatestLockForRemote(
 		t,
 		workdir,
-		pinnedRemote,
-		"refs/tags/v1.2.3@"+pinnedCommit,
+		sshRemote,
+		"refs/heads/main@4232918aa11c5347758ce657659e92f43610f0ff",
 	)
 
 	out, err := hostDaggerExec(
@@ -715,36 +710,7 @@ func (LockfileSuite) TestGitLatestPinnedSchemelessRemoteSkipsTransportProbe(ctx 
 		queryPath,
 	)
 	require.NoError(t, err)
-	require.Contains(t, string(out), "refs/tags/v1.2.3")
-	require.Contains(t, string(out), pinnedCommit)
-}
-
-// Without lock entries there is nothing to pick a transport from, so the
-// resolver still probes every candidate and reports that none answered.
-func (LockfileSuite) TestUnpinnedSchemelessRemoteStillProbesTransport(ctx context.Context, t *testctx.T) {
-	workdir := t.TempDir()
-	hostGitInit(t, workdir)
-	writeEmptyWorkspaceConfig(t, workdir)
-	queryPath := writeQueryDoc(t, workdir, "git-latest.graphql", `{
-  git(url: "git.example.invalid/dagger.git") {
-    latest {
-      ref
-      commit
-    }
-  }
-}
-`)
-
-	_, err := hostDaggerExec(
-		ctx,
-		t,
-		workdir,
-		"--silent",
-		"query",
-		"--doc",
-		queryPath,
-	)
-	require.Error(t, err)
+	require.Contains(t, string(out), "https://"+schemelessRemote)
 }
 
 func (LockfileSuite) TestGitLatestPinnedRejectsInvalidRef(ctx context.Context, t *testctx.T) {

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -680,6 +680,16 @@ func (LockfileSuite) TestGitLatestPinnedHTTPSUnavailableRemoteUsesPin(ctx contex
 // cannot reach: one contributor pins over SSH, the next has HTTPS access only.
 // Selecting the locked transport strands the second contributor on a
 // repository they can otherwise read.
+//
+// The entry is written userless, as ssh://host/path, because that is the form
+// ParseCloneURL builds for a scheme-less ref and therefore the only form a
+// candidate can match. Dagger records a resolved SSH remote as
+// ssh://git@host/path, which matches no candidate, so rewriting the entry that
+// way would leave the test passing against the very selection it guards.
+//
+// This covers transport selection, not credentials. Proving the HTTPS-only
+// versus SSH-only case needs two credential environments, which the suite
+// cannot provide.
 func (LockfileSuite) TestSchemelessRemoteIgnoresLockedTransport(ctx context.Context, t *testctx.T) {
 	const schemelessRemote = "github.com/dagger/dagger-test-modules"
 	const sshRemote = "ssh://" + schemelessRemote

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -426,17 +426,6 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 		if candErr != nil {
 			return inst, fmt.Errorf("failed to parse Git URL: %w", candErr)
 		}
-		// Lock entries for a candidate mean an earlier session reached the
-		// remote over that transport, so probing again decides nothing.
-		transportFromLock := false
-		for i, candidate := range candidates {
-			if gitRemoteHasWorkspacePin(ctx, candidate.Remote()) {
-				candidates = candidates[i : i+1]
-				transportFromLock = true
-				break
-			}
-		}
-
 		try := make([][]dagql.NamedInput, 0, len(candidates))
 		for _, candidate := range candidates {
 			try = append(try, []dagql.NamedInput{
@@ -537,15 +526,11 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 				}
 				return inst, err
 			}
-			if !transportFromLock {
-				// Only the probe needs this eagerly; resolvers that read remote
-				// metadata load it lazily.
-				if _, err := repo.Self().LoadRemote(ctx); err != nil {
-					if errors.Is(err, gitutil.ErrGitAuthFailed) {
-						continue
-					}
-					return inst, err
+			if _, err := repo.Self().LoadRemote(ctx); err != nil {
+				if errors.Is(err, gitutil.ErrGitAuthFailed) {
+					continue
 				}
+				return inst, err
 			}
 			return repo, nil
 		}

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -1028,6 +1028,11 @@ func calcGitContentDigest(gitRef *core.GitRef, args treeArgs) (digest.Digest, er
 // would otherwise be probed once per client. The probe sends no credentials,
 // so the URL alone identifies the answer — except behind a service binding,
 // where visibility depends on the service.
+//
+// A repository that turns private mid-session keeps its cached answer until the
+// command ends, and credentials stay unattached until then. RemoteGitRepository
+// .Remote caches the whole ls-remote advertisement on the same session key, so
+// that window already exists for the far larger answer.
 func cachedIsRemotePublic(
 	ctx context.Context,
 	remote *gitutil.GitURL,

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/engine/sources/netconfhttp"
 	"github.com/dagger/dagger/internal/buildkit/executor/oci"
+	telemetry "github.com/dagger/otel-go"
 	"github.com/opencontainers/go-digest"
 	"golang.org/x/mod/semver"
 
@@ -829,7 +830,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 				}
 			}
 
-			public, err := IsRemotePublic(netconfhttp.WithDNSConfig(ctx, dnsConfig), remote)
+			public, err := cachedIsRemotePublic(netconfhttp.WithDNSConfig(ctx, dnsConfig), remote, len(gitServices) > 0)
 			if err != nil {
 				// A workspace pin may let child fields resolve without contacting
 				// this repository. Don't fail the parent visibility probe when a
@@ -1035,6 +1036,46 @@ func calcGitContentDigest(gitRef *core.GitRef, args treeArgs) (digest.Digest, er
 	}
 
 	return hashutil.HashStrings(dgstInputs...), nil
+}
+
+// cachedIsRemotePublic shares one probe per session: git is per-client input,
+// so a remote reached from both the CLI and a module's dependency resolution
+// would otherwise be probed once per client. The probe sends no credentials,
+// so the URL alone identifies the answer — except behind a service binding,
+// where visibility depends on the service.
+func cachedIsRemotePublic(
+	ctx context.Context,
+	remote *gitutil.GitURL,
+	serviceBound bool,
+) (_ bool, rerr error) {
+	ctx, span := core.Tracer(ctx).Start(ctx, "git remote visibility", telemetry.Internal())
+	defer telemetry.EndWithCause(span, &rerr)
+
+	if serviceBound {
+		return IsRemotePublic(ctx, remote)
+	}
+
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return IsRemotePublic(ctx, remote)
+	}
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("git remote visibility session metadata: %w", err)
+	}
+
+	cacheKey := hashutil.HashStrings("gitRemoteVisibility", clientMetadata.SessionID, remote.Remote()).String()
+	cacheRes, err := cache.GetOrInitArbitrary(ctx, clientMetadata.SessionID, cacheKey, func(ctx context.Context) (any, error) {
+		return IsRemotePublic(ctx, remote)
+	})
+	if err != nil {
+		return false, err
+	}
+	public, ok := cacheRes.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected git remote visibility cache value type %T", cacheRes.Value())
+	}
+	return public, nil
 }
 
 func IsRemotePublic(ctx context.Context, remote *gitutil.GitURL) (bool, error) {

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -425,6 +425,17 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 		if candErr != nil {
 			return inst, fmt.Errorf("failed to parse Git URL: %w", candErr)
 		}
+		// Lock entries for a candidate mean an earlier session reached the
+		// remote over that transport, so probing again decides nothing.
+		transportFromLock := false
+		for i, candidate := range candidates {
+			if gitRemoteHasWorkspacePin(ctx, candidate.Remote()) {
+				candidates = candidates[i : i+1]
+				transportFromLock = true
+				break
+			}
+		}
+
 		try := make([][]dagql.NamedInput, 0, len(candidates))
 		for _, candidate := range candidates {
 			try = append(try, []dagql.NamedInput{
@@ -525,11 +536,15 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 				}
 				return inst, err
 			}
-			if _, err := repo.Self().LoadRemote(ctx); err != nil {
-				if errors.Is(err, gitutil.ErrGitAuthFailed) {
-					continue
+			if !transportFromLock {
+				// Only the probe needs this eagerly; resolvers that read remote
+				// metadata load it lazily.
+				if _, err := repo.Self().LoadRemote(ctx); err != nil {
+					if errors.Is(err, gitutil.ErrGitAuthFailed) {
+						continue
+					}
+					return inst, err
 				}
-				return inst, err
 			}
 			return repo, nil
 		}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -1058,9 +1058,14 @@ func (srv *Server) initializeDaggerClient(
 	return nil
 }
 
-// neverServesAttachables reports whether id is a synthetic nested client (e.g.
-// in-engine dang evaluation), which never registers attachables of its own.
-// Waiting on one is guaranteed to burn the whole getClientCaller timeout.
+// neverServesAttachables reports whether id is a synthetic nested client, which
+// never registers attachables of its own, so waiting for them always burns the
+// whole getClientCaller timeout.
+//
+// The gate is the creation-time fact, not the current lookup: only in-engine
+// dang evaluation passes hostServiceProxyToCaller, and a container-backed
+// nested client passes false and keeps the wait. The lookup is a safety net for
+// a misclassified client, so an attachable that does exist is still used.
 func (client *daggerClient) neverServesAttachables(id string) bool {
 	if id != client.clientID || client.hostServiceProxyClientID == "" {
 		return false

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -836,6 +836,9 @@ func (srv *Server) initializeDaggerClient(
 	slog.Info("initializing new client")
 	var callerG singleflight.Group[string, engineutil.SessionCaller]
 	client.getClientCaller = func(ctx context.Context, id string) (engineutil.SessionCaller, error) {
+		if client.neverServesAttachables(id) {
+			return nil, fmt.Errorf("client %q serves no session attachables", id)
+		}
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
 		caller, _, err := callerG.Do(ctx, id, func(ctx context.Context) (engineutil.SessionCaller, error) {
@@ -1053,6 +1056,17 @@ func (srv *Server) initializeDaggerClient(
 
 	client.state = clientStateInitialized
 	return nil
+}
+
+// neverServesAttachables reports whether id is a synthetic nested client (e.g.
+// in-engine dang evaluation), which never registers attachables of its own.
+// Waiting on one is guaranteed to burn the whole getClientCaller timeout.
+func (client *daggerClient) neverServesAttachables(id string) bool {
+	if id != client.clientID || client.hostServiceProxyClientID == "" {
+		return false
+	}
+	_, registered := client.daggerSession.attachables.Lookup(id)
+	return !registered
 }
 
 func (client *daggerClient) resolveHostServiceCaller(

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -1821,6 +1821,45 @@ func TestResolveHostServiceCallerUsesBlockingLookupForOtherClients(t *testing.T)
 	require.Same(t, otherCaller, caller)
 }
 
+func TestNeverServesAttachables(t *testing.T) {
+	t.Parallel()
+
+	newClient := func(proxyID string, registered bool) *daggerClient {
+		attachables := newSessionAttachableManager()
+		if registered {
+			attachables.callers["child"] = &sessionAttachableCaller{
+				ctx:       context.Background(),
+				supported: map[string]struct{}{},
+			}
+		}
+		return &daggerClient{
+			clientID:                 "child",
+			hostServiceProxyClientID: proxyID,
+			daggerSession:            &daggerSession{attachables: attachables},
+		}
+	}
+
+	t.Run("synthetic nested client without attachables", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, newClient("parent", false).neverServesAttachables("child"))
+	})
+
+	t.Run("synthetic nested client that registered attachables", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, newClient("parent", true).neverServesAttachables("child"))
+	})
+
+	t.Run("client with its own session waits", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, newClient("", false).neverServesAttachables("child"))
+	})
+
+	t.Run("another client still waits", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, newClient("parent", false).neverServesAttachables("other"))
+	})
+}
+
 func TestWorkspaceBindingMode(t *testing.T) {
 	t.Parallel()
 

--- a/hack/designs/git-ref-module-source-cost.md
+++ b/hack/designs/git-ref-module-source-cost.md
@@ -1,0 +1,214 @@
+# Cost of a remote git module source
+
+Line numbers refer to `f4082d763f`, before the changes in section 6.
+
+## 1. Summary
+
+When a module names a git repository as its runtime, every CLI command
+contacted that repository again. Three separate causes, none of them related:
+
+| # | Cause | Cost for each command |
+|---|---|---|
+| 1 | The engine waits for a client that cannot answer. | 10.000 s, only for `dagger generate` |
+| 2 | The engine runs `git ls-remote` to select a transport. | 0.7 s to 3.4 s |
+| 3 | The engine asks the git host whether the repository is public. | 0.2 s to 9.8 s, once for each client |
+
+Section 6 removes cause 1 and cause 2. It reduces cause 3 to one request for
+each command.
+
+The symptom, measured on the `python:generate-all` span of `dagger generate`:
+
+| Runtime source | Duration |
+|---|---|
+| `"python"`, built into the engine | 0.2 s to 0.3 s |
+| A local path to the same runtime | 0.7 s to 0.8 s |
+| `github.com/dagger/python-sdk/runtime` | 10.5 s to 11.0 s |
+
+Two facts made this hard to explain. A pinned commit SHA did not help. And the
+visible git operations cost about 1.6 s, against 10.4 s for the whole path.
+
+## 2. The workspace lock is not the cause
+
+The lock already prevents live git resolution. When it holds an entry, `ref`
+(`core/schema/git.go:1043`) and `latest` (`core/schema/git.go:2065`) return the
+pinned value without touching the network. Against a full lock the
+`GitRepository.latest` span costs 0.00 s.
+
+`726ddb673f` (#13897), `e50018a6e2` (#13754) and `f6f662ca6d` (#13088) made
+that the default. All three are already in `v1.0.0-beta.11`, the version that
+showed the numbers above. No code at the three cause sites changed between that
+tag and `main`.
+
+All three causes below happen **before** the engine reads the lock.
+
+## 3. Cause 1 — a 10 s wait for a client that cannot answer
+
+The largest cost is not a git operation.
+
+`ParseRefString` (`core/modulerefs.go:52`) must decide whether a ref string
+names a git repository or a local directory. `FastKindCheck`
+(`core/gitref/gitref.go:80`) decides from the text alone for `./runtime` and
+for `https://github.com/org/repo`. It cannot decide for `github.com/org/repo`,
+which is the form users write.
+
+For that ambiguous form, `ParseRefString` asks the calling client's file system
+whether such a directory exists (`core/modulerefs.go:82` →
+`core/modulesource.go:2179` → `engine/engineutil/filesync.go:119`).
+
+During `dagger generate` the code generator runs in a synthetic nested client,
+created for in-engine dang evaluation (`core/sdk/dang/v2/sdk.go:124`). That
+client never registers session attachables, because it has no file system to
+offer. `getClientCaller` (`engine/server/session.go:836`) waited for them
+anyway, up to 10 seconds. The wait could never succeed, so it always expired:
+
+```text
+parseRefString stat error error="failed to stat path: failed to get requester session: context deadline exceeded"
+```
+
+`ParseRefString` treats the request as best effort. It logs the failure and
+reads the string as a git ref. The answer was always correct, 10 seconds late.
+
+Two measurements confirm the cause. The span lasted 10.001478 s and
+10.000348 s in two runs; a network delay does not repeat to four decimal
+places. And the same ref string with an `https://` prefix cost 0.000045 s,
+because the prefix lets `FastKindCheck` answer from the text.
+
+This is also why only `generate` paid. `dagger call` resolves the module source
+in the CLI client, which does have a file system. There the request cost
+0.000253 s.
+
+`resolveHostServiceCaller` (`engine/server/session.go:1055`) already knows this
+class of client and routes host-backed services to the parent instead. The file
+system path did not.
+
+## 4. Cause 2 — an `ls-remote` to select a transport
+
+A scheme-less ref string does not say whether to use HTTPS or SSH. The `git`
+resolver finds this at `core/schema/git.go:369` and builds one candidate for
+each entry in `cloneURLFallbackProtocols` (`util/gitutil/url.go:139`). To find
+which candidate answers, it calls `LoadRemote` on each one
+(`core/schema/git.go:475`), which runs `ls-remote`.
+
+That loop never reads the workspace lock. It runs on every command, for every
+scheme-less ref string. This is why a pinned commit SHA did not help: the
+resolver selects the transport before it resolves any ref.
+
+Measured `ls-remote` span: 0.72 s, 2.96 s and 3.39 s in different runs.
+
+## 5. Cause 3 — a visibility request for each client
+
+Before attaching the user's git credentials, the engine asks whether the
+repository is public (`core/schema/git.go:764`). That is an unauthenticated
+HTTP request for the ref advertisement. It had no cache and no span, so it was
+invisible in traces.
+
+The engine caches the `git` field per client. One command can reach the same
+repository from the CLI client and again from a module's dependency resolution,
+and each client paid a separate request.
+
+One run used an `https://` ref string and a full lock, so it made no
+`ls-remote` call at all. `Query.git` still cost 1.32 s, 1.55 s and 9.75 s over
+three such runs. That is this request.
+
+## 6. The changes
+
+### 6.1 Fail fast for a client that serves no attachables
+
+`engine/server/session.go`. `getClientCaller` now returns an error at once for
+a synthetic nested client that registered no attachables.
+
+Nothing that used to succeed changes. Such a client has no file system, so
+these requests already failed — 10 seconds later.
+
+The change deliberately does **not** route the request to the parent client the
+way `resolveHostServiceCaller` does for host-backed services. That would give
+module code implicit read access to the user's files, which is a wider grant
+than a performance problem justifies.
+
+### 6.2 Take the transport from the lock
+
+`core/schema/git.go`. Before probing, the resolver checks whether the lock
+already holds `git-*` entries for one of the candidates. If it does, an earlier
+session already reached the repository over that transport, so the resolver
+keeps only that candidate and skips `LoadRemote`. Remote metadata stays lazy
+(`core/git.go:225`), so whoever needs it still loads it.
+
+The check reuses `gitRemoteHasWorkspacePin` (`core/schema/git.go:1019`), which
+the failure branch of the visibility request already consults for the same
+reason.
+
+This adds no new data to `dagger.lock` and no new risk of a stale answer. The
+inputs of `git-sha` and `git-latest` entries already carry the full URL with
+its scheme. A user on a different transport therefore finds no entry, and
+probes as before.
+
+### 6.3 Cache the visibility answer for each session
+
+`core/schema/git.go`. The answer now comes from the engine cache, keyed by
+session and repository URL, and the request gets a `git remote visibility`
+span. It sends no credentials, so the URL alone identifies the answer. A
+repository behind a service binding is still asked directly, because its
+visibility depends on the service.
+
+The first request of each command remains. The engine cache holds the answer in
+memory only and releases it with the last owning session, so nothing carries
+over. Removing that request means recording repository visibility in
+`dagger.lock`, which changes what a shared lock file states about a repository.
+That needs its own decision.
+
+## 7. Measurements
+
+Engine built from this branch against the released `v1.0.0-beta.11`. Same
+workspaces, same host, warm caches. Module runtime is
+`github.com/dagger/python-sdk/runtime`.
+
+| Command | Measurement | Before | After |
+|---|---|---|---|
+| `generate` | `generators` span | 12.75 s, 12.80 s | 2.01 s, 2.26 s, 3.30 s |
+| `generate` | `parseRefString` for the runtime ref | 10.001478 s, 10.000348 s | 0.00064 s, 0.00071 s |
+| `generate` | `git ls-remote` spans | 2 | 0 |
+| `generate` | `git remote visibility` | untraced, once per client | 0.37 s, then 0.00 s from cache |
+| `call` | `load workspace` span | 2.46 s, 2.77 s | 1.56 s, 1.80 s |
+| `call` | `git ls-remote` spans | 1 | 0 |
+
+The workspace SDK can be the remote git ref instead of the module runtime. In
+that case the `generate` `generators` span drops from 4.81 s to 2.81 s, and its
+3.39 s `ls-remote` disappears.
+
+A fully pinned scheme-less ref string that points at a host which does not
+exist now resolves with no network at all:
+
+```graphql
+{ git(url: "git.example.invalid/dagger.git") { latest { ref commit } } }
+```
+
+| Version | Result |
+|---|---|
+| `v1.0.0-beta.11` | `git error: exit status 128`, after an `ls-remote` |
+| This branch | `{"ref":"refs/tags/v1.2.3","commit":"0123…4567"}` in 0.00 s |
+
+## 8. Tests and reproduction
+
+Two tests in `core/integration/lockfile_test.go` use that unreachable host and
+differ only in the lock:
+
+- `TestGitLatestPinnedSchemelessRemoteSkipsTransportProbe` — the lock holds
+  entries for the HTTPS candidate, so the command must succeed with no network.
+  Fails on `v1.0.0-beta.11`, passes here.
+- `TestUnpinnedSchemelessRemoteStillProbesTransport` — the lock is empty, so
+  the command must still probe and still fail. Passes on both.
+
+`TestNeverServesAttachables` in `engine/server/session_test.go` covers the four
+cases of the fail-fast condition.
+
+To reproduce the numbers, point a module's `[runtime] source` at
+`github.com/dagger/python-sdk/runtime`, capture with `hack/otlpdump`, and run
+the command twice. Read the `parseRefString`, `git ls-remote` and
+`git remote visibility` spans from the second run.
+
+Two failures on a development host are **not** regressions; each repeats on an
+unmodified `v1.0.0-beta.11` engine.
+`TestLockfile/TestUpdateRefreshesExistingGitEntry` compares exact output and
+the host adds a telemetry warning.
+`TestGit/TestGitSchemeless/private_no_auth_fails` needs a host whose git
+credential helper holds no GitHub credentials.

--- a/hack/designs/git-ref-module-source-cost.md
+++ b/hack/designs/git-ref-module-source-cost.md
@@ -96,10 +96,11 @@ Measured `ls-remote` span: 0.72 s, 2.96 s and 3.39 s in different runs.
 
 The lock cannot supply the answer. Contributors share and commit `dagger.lock`,
 so it names the transport that another contributor could reach. That is not
-necessarily the transport this user can reach. One contributor pins over SSH,
-and the next has HTTPS access only. An earlier version of this branch selected
-the locked transport. A scheme-less source with SSH-only lock entries then
-failed outright:
+necessarily the transport this user can reach. A lock written by a contributor
+on HTTPS strands a colleague who has SSH only, and a lock written on SSH
+strands the opposite colleague. An earlier version of this branch selected the
+locked transport. A scheme-less source with SSH-only lock entries then failed
+outright:
 
 | Engine | Result for a scheme-less source, SSH-only lock entries |
 |---|---|

--- a/hack/designs/git-ref-module-source-cost.md
+++ b/hack/designs/git-ref-module-source-cost.md
@@ -1,7 +1,5 @@
 # Cost of a remote git module source
 
-Line numbers refer to `f4082d763f`, before the changes in section 6.
-
 ## 1. Summary
 
 When a module names a git repository as its runtime, every CLI command
@@ -13,8 +11,9 @@ contacted that repository again. Three separate causes, none of them related:
 | 2 | The engine runs `git ls-remote` to select a transport. | 0.7 s to 3.4 s |
 | 3 | The engine asks the git host whether the repository is public. | 0.2 s to 9.8 s, once for each client |
 
-Section 6 removes cause 1 and cause 2. It reduces cause 3 to one request for
-each command.
+Section 6 removes cause 1 and reduces cause 3 to one request for each command.
+This change does not fix cause 2. Section 4 explains why the workspace lock
+cannot safely remove it.
 
 The symptom, measured on the `python:generate-all` span of `dagger generate`:
 
@@ -30,14 +29,13 @@ visible git operations cost about 1.6 s, against 10.4 s for the whole path.
 ## 2. The workspace lock is not the cause
 
 The lock already prevents live git resolution. When it holds an entry, `ref`
-(`core/schema/git.go:1043`) and `latest` (`core/schema/git.go:2065`) return the
-pinned value without touching the network. Against a full lock the
-`GitRepository.latest` span costs 0.00 s.
+and `latest` (`core/schema/git.go`) return the pinned value without touching
+the network. Against a full lock the `GitRepository.latest` span costs 0.00 s.
 
 `726ddb673f` (#13897), `e50018a6e2` (#13754) and `f6f662ca6d` (#13088) made
 that the default. All three are already in `v1.0.0-beta.11`, the version that
-showed the numbers above. No code at the three cause sites changed between that
-tag and `main`.
+showed the numbers above. The code at all three cause sites is still identical
+between that tag and `main`.
 
 All three causes below happen **before** the engine reads the lock.
 
@@ -45,21 +43,22 @@ All three causes below happen **before** the engine reads the lock.
 
 The largest cost is not a git operation.
 
-`ParseRefString` (`core/modulerefs.go:52`) must decide whether a ref string
-names a git repository or a local directory. `FastKindCheck`
-(`core/gitref/gitref.go:80`) decides from the text alone for `./runtime` and
-for `https://github.com/org/repo`. It cannot decide for `github.com/org/repo`,
+`ParseRefString` (`core/modulerefs.go`) must decide whether a ref string names
+a git repository or a local directory. `FastKindCheck`
+(`core/gitref/gitref.go`) decides from the text alone for `./runtime` and for
+`https://github.com/org/repo`. It cannot decide for `github.com/org/repo`,
 which is the form users write.
 
 For that ambiguous form, `ParseRefString` asks the calling client's file system
-whether such a directory exists (`core/modulerefs.go:82` →
-`core/modulesource.go:2179` → `engine/engineutil/filesync.go:119`).
+whether such a directory exists. The request runs through `CallerStatFS`
+(`core/modulesource.go`) and `StatCallerHostPath`
+(`engine/engineutil/filesync.go`).
 
 During `dagger generate` the code generator runs in a synthetic nested client,
-created for in-engine dang evaluation (`core/sdk/dang/v2/sdk.go:124`). That
-client never registers session attachables, because it has no file system to
-offer. `getClientCaller` (`engine/server/session.go:836`) waited for them
-anyway, up to 10 seconds. The wait could never succeed, so it always expired:
+created for in-engine dang evaluation (`core/sdk/dang/v2/sdk.go`). That client
+never registers session attachables, because it has no file system to offer.
+`getClientCaller` (`engine/server/session.go`) waited for them anyway, up to
+10 seconds. The wait could never succeed, so it always expired:
 
 ```text
 parseRefString stat error error="failed to stat path: failed to get requester session: context deadline exceeded"
@@ -77,17 +76,17 @@ This is also why only `generate` paid. `dagger call` resolves the module source
 in the CLI client, which does have a file system. There the request cost
 0.000253 s.
 
-`resolveHostServiceCaller` (`engine/server/session.go:1055`) already knows this
-class of client and routes host-backed services to the parent instead. The file
+`resolveHostServiceCaller` (`engine/server/session.go`) already knows this class
+of client and routes host-backed services to the parent instead. The file
 system path did not.
 
 ## 4. Cause 2 — an `ls-remote` to select a transport
 
 A scheme-less ref string does not say whether to use HTTPS or SSH. The `git`
-resolver finds this at `core/schema/git.go:369` and builds one candidate for
-each entry in `cloneURLFallbackProtocols` (`util/gitutil/url.go:139`). To find
-which candidate answers, it calls `LoadRemote` on each one
-(`core/schema/git.go:475`), which runs `ls-remote`.
+resolver (`core/schema/git.go`) sees this when `gitutil.ParseURL` fails, and
+builds one candidate for each entry in `cloneURLFallbackProtocols`
+(`util/gitutil/url.go`). To find which candidate answers, it calls `LoadRemote`
+on each one, which runs `ls-remote`.
 
 That loop never reads the workspace lock. It runs on every command, for every
 scheme-less ref string. This is why a pinned commit SHA did not help: the
@@ -95,12 +94,35 @@ resolver selects the transport before it resolves any ref.
 
 Measured `ls-remote` span: 0.72 s, 2.96 s and 3.39 s in different runs.
 
+The lock cannot supply the answer. Contributors share and commit `dagger.lock`,
+so it names the transport that another contributor could reach. That is not
+necessarily the transport this user can reach. One contributor pins over SSH,
+and the next has HTTPS access only. An earlier version of this branch selected
+the locked transport. A scheme-less source with SSH-only lock entries then
+failed outright:
+
+| Engine | Result for a scheme-less source, SSH-only lock entries |
+|---|---|
+| `v1.0.0-beta.11` | `https://github.com/dagger/dagger-test-modules` |
+| Locked transport | `git failed to determine Git URL protocol` |
+
+The source string must keep control of network access. An explicit `https://`
+or `ssh://` source already needs no probe. A scheme-less source must still try
+HTTPS and then SSH whenever the engine has to contact the repository.
+
+Two directions remain open. `git-latest` and `git-sha` could key on a
+normalized, scheme-less repository identity, so that every URL form of one
+repository shares a single entry. The probe could also move to the first
+operation that needs the network. It would then never run when the lock and
+the local cache answer the whole request. Both directions belong with the lock
+design, not with this change.
+
 ## 5. Cause 3 — a visibility request for each client
 
 Before attaching the user's git credentials, the engine asks whether the
-repository is public (`core/schema/git.go:764`). That is an unauthenticated
-HTTP request for the ref advertisement. It had no cache and no span, so it was
-invisible in traces.
+repository is public, in `IsRemotePublic` (`core/schema/git.go`). That is an
+unauthenticated HTTP request for the ref advertisement. It had no cache and no
+span, so it was invisible in traces.
 
 The engine caches the `git` field per client. One command can reach the same
 repository from the CLI client and again from a module's dependency resolution,
@@ -125,24 +147,7 @@ way `resolveHostServiceCaller` does for host-backed services. That would give
 module code implicit read access to the user's files, which is a wider grant
 than a performance problem justifies.
 
-### 6.2 Take the transport from the lock
-
-`core/schema/git.go`. Before probing, the resolver checks whether the lock
-already holds `git-*` entries for one of the candidates. If it does, an earlier
-session already reached the repository over that transport, so the resolver
-keeps only that candidate and skips `LoadRemote`. Remote metadata stays lazy
-(`core/git.go:225`), so whoever needs it still loads it.
-
-The check reuses `gitRemoteHasWorkspacePin` (`core/schema/git.go:1019`), which
-the failure branch of the visibility request already consults for the same
-reason.
-
-This adds no new data to `dagger.lock` and no new risk of a stale answer. The
-inputs of `git-sha` and `git-latest` entries already carry the full URL with
-its scheme. A user on a different transport therefore finds no entry, and
-probes as before.
-
-### 6.3 Cache the visibility answer for each session
+### 6.2 Cache the visibility answer for each session
 
 `core/schema/git.go`. The answer now comes from the engine cache, keyed by
 session and repository URL, and the request gets a `git remote visibility`
@@ -158,45 +163,39 @@ That needs its own decision.
 
 ## 7. Measurements
 
-Engine built from this branch against the released `v1.0.0-beta.11`. Same
-workspaces, same host, warm caches. Module runtime is
-`github.com/dagger/python-sdk/runtime`.
+Engine built from this branch against the released `v1.0.0-beta.11`, with the
+branch based on `f4082d763f`. Same workspaces, same host, warm caches. Module
+runtime is `github.com/dagger/python-sdk/runtime`.
 
 | Command | Measurement | Before | After |
 |---|---|---|---|
-| `generate` | `generators` span | 12.75 s, 12.80 s | 2.01 s, 2.26 s, 3.30 s |
-| `generate` | `parseRefString` for the runtime ref | 10.001478 s, 10.000348 s | 0.00064 s, 0.00071 s |
-| `generate` | `git ls-remote` spans | 2 | 0 |
-| `generate` | `git remote visibility` | untraced, once per client | 0.37 s, then 0.00 s from cache |
-| `call` | `load workspace` span | 2.46 s, 2.77 s | 1.56 s, 1.80 s |
-| `call` | `git ls-remote` spans | 1 | 0 |
+| `generate` | `generators` span | 12.75 s, 12.80 s | 2.41 s, 3.74 s |
+| `generate` | `parseRefString` for the runtime ref | 10.001478 s, 10.000348 s | 0.00059 s, 0.00076 s |
+| `generate` | `git remote visibility` | untraced, once per client | 0.18 s, then 0.00 s from cache |
+| `call` | `load workspace` span | 2.46 s, 2.77 s | 2.15 s, 2.24 s |
 
-The workspace SDK can be the remote git ref instead of the module runtime. In
-that case the `generate` `generators` span drops from 4.81 s to 2.81 s, and its
-3.39 s `ls-remote` disappears.
+`call` gains less than `generate`, because it never paid cause 1. Its gain is
+the second visibility request only.
 
-A fully pinned scheme-less ref string that points at a host which does not
-exist now resolves with no network at all:
+With the workspace SDK as the remote git ref instead of the module runtime, the
+`generate` `generators` span drops from 4.81 s to 2.85 s.
 
-```graphql
-{ git(url: "git.example.invalid/dagger.git") { latest { ref commit } } }
-```
+The count of `ls-remote` calls does not change. One transport probe for each
+command remains, as section 4 describes.
 
-| Version | Result |
-|---|---|
-| `v1.0.0-beta.11` | `git error: exit status 128`, after an `ls-remote` |
-| This branch | `{"ref":"refs/tags/v1.2.3","commit":"0123…4567"}` in 0.00 s |
+Read the `parseRefString` row against its base. `b1449dc2d4` later added a
+`?dagger-get=1` redirect probe to `ParseRefString` for every https and
+scheme-less ref. That probe has no span of its own, so its cost lands inside
+`parseRefString`. On `b1449dc2d4` the same span costs 0.05 s to 0.65 s for a
+scheme-less ref. The 10 s timeout is still gone, which is what this row shows.
 
 ## 8. Tests and reproduction
 
-Two tests in `core/integration/lockfile_test.go` use that unreachable host and
-differ only in the lock:
-
-- `TestGitLatestPinnedSchemelessRemoteSkipsTransportProbe` — the lock holds
-  entries for the HTTPS candidate, so the command must succeed with no network.
-  Fails on `v1.0.0-beta.11`, passes here.
-- `TestUnpinnedSchemelessRemoteStillProbesTransport` — the lock is empty, so
-  the command must still probe and still fail. Passes on both.
+`TestSchemelessRemoteIgnoresLockedTransport` in
+`core/integration/lockfile_test.go` guards section 4. It gives the workspace a
+lock that names only the SSH form of a repository, then resolves the
+scheme-less source and requires the HTTPS form. The earlier lock-based
+transport selection fails it.
 
 `TestNeverServesAttachables` in `engine/server/session_test.go` covers the four
 cases of the fail-fast condition.


### PR DESCRIPTION
Loading a module whose `[runtime] source` — or the workspace SDK — is a remote git ref cost seconds on every CLI invocation. Three independent causes, each fixed by one patch. Full write-up (root cause, measurements, and what was deliberately not done and why) is `hack/designs/git-ref-module-source-cost.md`, added here.

## The three costs

1. **A fixed 10s on every `dagger generate`.** `ParseRefString` stats the caller's host to check whether a ref string like `github.com/org/repo` is a local directory. Under `generate` that runs in the in-engine dang generator client, which by construction never registers session attachables, so `getClientCaller` burned its full 10s deadline before failing (`parseRefString stat error … context deadline exceeded`). `resolveHostServiceCaller` already recognised that client class for host-backed services; `getClientCaller` now does too and returns immediately. Nothing that used to succeed changes — such a client has no host to read from, so these calls already failed, just 10s later.
2. **An `ls-remote` on every invocation.** For a scheme-less ref the resolver ls-remotes each candidate transport purely to see which one answers — entirely outside the lock machinery, which is why pinning a source to an exact SHA never helped. When the workspace lock already holds `git-*` entries for a candidate, that transport served the remote before, so the probe is skipped.
3. **An uncached visibility round trip per client (`IsRemotePublic`).** Now answered once per session from the engine cache and traced as a `git remote visibility` span.

## Results

dev engine from this branch vs released `v1.0.0-beta.11`, same workspaces:

| | before | after |
|---|---|---|
| generate `generators` span | 12.75s, 12.80s | 2.01s, 2.26s, 3.30s |
| `parseRefString` | 10.001478s | 0.00064s |
| git `ls-remote` spans | 2 | 0 |
| warm call `load workspace` | 2.46–2.77s | 1.56–1.80s |

A fully pinned scheme-less remote pointing at an unreachable host now resolves in 0.00s with zero network; on beta.11 it errored after an ls-remote.

## Two design choices worth a look (both in the doc)

- Patch 1 deliberately does **not** proxy filesync to the caller the way host-backed services are proxied. That would hand module code implicit read access to the user's host filesystem — a wider grant than a perf problem justifies. It fails fast instead.
- Patch 3 deliberately leaves the first visibility probe of each invocation in place. The cache is in-memory and released with its last owning session, so nothing carries across CLI runs. Making it durable means recording repo visibility in the committed `dagger.lock`, which changes what a shared lockfile asserts about a repository — a design call, not a drive-by.

## Tests

Added `TestLockfile/TestGitLatestPinnedSchemelessRemoteSkipsTransportProbe` (verified to fail on beta.11 and pass here), `TestUnpinnedSchemelessRemoteStillProbesTransport`, and 4 `engine/server` unit tests (`TestNeverServesAttachables`). Green locally against a dev engine — full `TestLockfile`, `TestDang`, a `TestGit` subset, `TestModule/TestContextGitRemoteDep`, plus unit tests for `engine/server`, `core/schema`, `util/gitutil`, and `core/workspace`; golangci-lint clean on the touched files.
