### PR TITLE
fix(engine): keep same-source workspace modules under each configured name

### DIFF
--- a/.changes/unreleased/Fixed-20260901-114500.yaml
+++ b/.changes/unreleased/Fixed-20260901-114500.yaml
@@ -1,0 +1,12 @@
+kind: Fixed
+body: |
+  A workspace that installs one module source several times under different
+  names now shows every one of them. `dagger check -l` and the function listing
+  `dagger call` builds identified a module by its source alone, so two
+  `dagger.toml` entries sharing a `source` collapsed into one and only the
+  first-named survived discovery, even though each was configured with its own
+  settings and calling either one directly still worked.
+time: 2026-09-01T11:45:00Z
+custom:
+  Author: eunomie
+  PR: 14017

--- a/core/integration/module_loading_test.go
+++ b/core/integration/module_loading_test.go
@@ -119,6 +119,50 @@ entrypoint = true
 		require.Equal(t, "hello", strings.TrimSpace(string(out)))
 	})
 
+	t.Run("same source installed twice under different names stays two modules", func(ctx context.Context, t *testctx.T) {
+		// dagger/dagger#14013
+		workdir := t.TempDir()
+		initGitRepo(ctx, t, workdir)
+
+		copyTestdataFixture(ctx, t, filepath.Join(workdir, "shared"), "modules", "dang", "settings-check")
+		writeWorkspaceConfigFile(t, workdir, `[modules.rust]
+source = "shared"
+settings.version = "1.98"
+
+[modules.msrv]
+source = "shared"
+settings.version = "1.97"
+`)
+
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "check", "-l")
+		require.NoError(t, err)
+		require.Contains(t, string(out), "rust:version-check")
+		require.Contains(t, string(out), "msrv:version-check")
+
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "call", "--help")
+		require.NoError(t, err)
+		require.Regexp(t, `(?m)^\s+rust\s`, string(out))
+		require.Regexp(t, `(?m)^\s+msrv\s`, string(out))
+
+		// Both in one session: a request naming a single module loads only that
+		// module, so separate calls would pass even unfixed.
+		queryPath := writeQueryDoc(t, t.TempDir(), "same-source.graphql", `{
+  rust {
+    reportVersion
+  }
+  msrv {
+    reportVersion
+  }
+}
+`)
+		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"rust": {"reportVersion": "1.98"},
+			"msrv": {"reportVersion": "1.97"}
+		}`, string(out))
+	})
+
 	t.Run("source may point to ancestor within context", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 

--- a/core/integration/testdata/modules/dang/settings-check/dagger.json
+++ b/core/integration/testdata/modules/dang/settings-check/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "settings-check",
+  "engineVersion": "v0.21.9",
+  "sdk": {
+    "source": "dang"
+  }
+}

--- a/core/integration/testdata/modules/dang/settings-check/main.dang
+++ b/core/integration/testdata/modules/dang/settings-check/main.dang
@@ -1,0 +1,26 @@
+"""
+A settings-dependent module, so two workspace entries installing this one
+source under different names stay tellable apart.
+"""
+type SettingsCheck {
+  let version: String! = "unset"
+
+  new(version: String! = "unset") {
+    self.version = version
+    self
+  }
+
+  """
+  The version this instance was configured with.
+  """
+  pub reportVersion: String! {
+    version
+  }
+
+  """
+  A check that always passes.
+  """
+  pub versionCheck: Void @check {
+    null
+  }
+}

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -2202,6 +2202,87 @@ func TestDedupeResolvedModuleLoads(t *testing.T) {
 	require.False(t, dedupResolved[1].primaryEntrypoint)
 }
 
+// dagger/dagger#14013
+func TestDedupeResolvedModuleLoadsKeepsSameSourceUnderDifferentNames(t *testing.T) {
+	t.Parallel()
+
+	const cloneRef = "github.com/acme/rust"
+	const commit = "deadbeef"
+
+	loads := []moduleLoadRequest{
+		{mod: pendingModule{Kind: moduleLoadKindAmbient, Ref: cloneRef, Name: "msrv"}},
+		{mod: pendingModule{Kind: moduleLoadKindAmbient, Ref: cloneRef, Name: "rust"}},
+	}
+	resolved := []resolvedModuleLoad{
+		{primary: sessionTestModuleResultWithGitSource(t, "msrv", cloneRef, commit)},
+		{primary: sessionTestModuleResultWithGitSource(t, "rust", cloneRef, commit)},
+	}
+
+	dedupLoads, dedupResolved := dedupeResolvedModuleLoads(loads, resolved)
+	require.Len(t, dedupLoads, 2)
+	require.Equal(t, "msrv", dedupLoads[0].mod.Name)
+	require.Equal(t, "rust", dedupLoads[1].mod.Name)
+	require.Len(t, dedupResolved, 2)
+}
+
+func TestResolvedModuleLoadIdentity(t *testing.T) {
+	t.Parallel()
+
+	const cloneRef = "github.com/acme/rust"
+	const commit = "deadbeef"
+
+	rust := resolvedModuleLoadIdentity(sessionTestModuleResultWithGitSource(t, "rust", cloneRef, commit))
+	msrv := resolvedModuleLoadIdentity(sessionTestModuleResultWithGitSource(t, "msrv", cloneRef, commit))
+	require.NotEqual(t, rust, msrv, "same source under different names must be distinct instances")
+
+	other := resolvedModuleLoadIdentity(sessionTestModuleResultWithGitSource(t, "rust", "github.com/acme/other", commit))
+	require.NotEqual(t, rust, other)
+
+	// Spelling variants are one CLI command name, so one instance.
+	kebab := resolvedModuleLoadIdentity(sessionTestModuleResultWithGitSource(t, "my-mod", cloneRef, commit))
+	camel := resolvedModuleLoadIdentity(sessionTestModuleResultWithGitSource(t, "myMod", cloneRef, commit))
+	require.Equal(t, kebab, camel)
+}
+
+func TestArbitrateSameSourceEntrypointNominations(t *testing.T) {
+	t.Parallel()
+
+	const cloneRef = "github.com/acme/app"
+	const commit = "deadbeef"
+
+	sameSourceTwice := func(canonicalDefaults, realDefaults map[string]any) ([]moduleLoadRequest, []resolvedModuleLoad) {
+		loads := []moduleLoadRequest{
+			{mod: pendingModule{Kind: moduleLoadKindAmbient, Ref: cloneRef, Name: "canonical", Entrypoint: true, ConfigDefaults: canonicalDefaults}},
+			{mod: pendingModule{Kind: moduleLoadKindAmbient, Ref: cloneRef, Name: "real", Entrypoint: true, ConfigDefaults: realDefaults}},
+		}
+		resolved := []resolvedModuleLoad{
+			{primary: sessionTestModuleResultWithGitSource(t, "canonical", cloneRef, commit), primaryEntrypoint: true},
+			{primary: sessionTestModuleResultWithGitSource(t, "real", cloneRef, commit), primaryEntrypoint: true},
+		}
+		return loads, resolved
+	}
+
+	t.Run("same settings under two names collapse to one nomination", func(t *testing.T) {
+		t.Parallel()
+
+		loads, resolved := sameSourceTwice(nil, nil)
+		require.NoError(t, arbitrateResolvedModuleLoads(loads, resolved))
+		require.True(t, resolved[0].primaryEntrypoint)
+		require.False(t, resolved[1].primaryEntrypoint)
+	})
+
+	t.Run("different settings under two names stay a conflict", func(t *testing.T) {
+		t.Parallel()
+
+		loads, resolved := sameSourceTwice(
+			map[string]any{"version": "1.98"},
+			map[string]any{"version": "1.97"},
+		)
+		err := arbitrateResolvedModuleLoads(loads, resolved)
+		require.EqualError(t, err, "invalid workspace configuration: multiple distinct ambient entrypoint modules: canonical, real")
+	})
+}
+
 func TestArbitrateResolvedModuleLoads(t *testing.T) {
 	t.Parallel()
 
@@ -2328,6 +2409,37 @@ func sessionTestModuleResult(t *testing.T, name string) dagql.ObjectResult[*core
 	require.NoError(t, err)
 	res, err := dagql.NewObjectResultForCall(
 		&core.Module{NameField: name},
+		dag,
+		&dagql.ResultCall{SyntheticOp: "session-test-module-" + name},
+	)
+	require.NoError(t, err)
+	return res
+}
+
+func sessionTestModuleResultWithGitSource(t *testing.T, name, cloneRef, commit string) dagql.ObjectResult[*core.Module] {
+	t.Helper()
+
+	dag, err := dagql.NewServer(t.Context(), &core.Module{})
+	require.NoError(t, err)
+	dag.InstallObject(dagql.NewClass(dag, dagql.ClassOpts[*core.ModuleSource]{Typed: &core.ModuleSource{}}))
+	src, err := dagql.NewObjectResultForCall(
+		&core.ModuleSource{
+			Kind: core.ModuleSourceKindGit,
+			Git: &core.GitModuleSource{
+				CloneRef: cloneRef,
+				Commit:   commit,
+			},
+			SourceRootSubpath: ".",
+		},
+		dag,
+		&dagql.ResultCall{SyntheticOp: "session-test-module-source-" + name},
+	)
+	require.NoError(t, err)
+	res, err := dagql.NewObjectResultForCall(
+		&core.Module{
+			NameField: name,
+			Source:    dagql.NonNull(src),
+		},
 		dag,
 		&dagql.ResultCall{SyntheticOp: "session-test-module-" + name},
 	)

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -1307,6 +1307,8 @@ func (srv *Server) resolveModuleLoadBatch(
 // candidate wins: only when none is served yet (extras outrank ambient).
 // Multiple candidates in one batch are a workspace configuration error.
 func (client *daggerClient) arbitrateAmbientEntrypoints(loads []moduleLoadRequest, resolved []resolvedModuleLoad) error {
+	collapseSameSourceEntrypointNominations(loads, resolved)
+
 	var candidates []int
 	for i := range resolved {
 		if resolved[i].primaryEntrypoint {
@@ -1973,6 +1975,33 @@ func dedupeResolvedModuleLoads(
 	return dedupLoads, dedupResolved
 }
 
+// Nominating one module through several config entries — a symlinked or
+// differently spelled path — is redundant, not a conflict, so arbitration must
+// not see it as one. Demoted entries stay served under their own names.
+func collapseSameSourceEntrypointNominations(loads []moduleLoadRequest, resolved []resolvedModuleLoad) {
+	nominated := make(map[string]int, len(resolved))
+	for i := range resolved {
+		if !resolved[i].primaryEntrypoint {
+			continue
+		}
+		key, collapsible := entrypointNominationIdentity(loads[i], resolved[i])
+		if !collapsible {
+			continue
+		}
+		winner, ok := nominated[key]
+		if !ok {
+			nominated[key] = i
+			continue
+		}
+		if shouldPreferEntrypointNomination(loads[winner], resolved[winner], loads[i], resolved[i]) {
+			resolved[winner].primaryEntrypoint = false
+			nominated[key] = i
+			continue
+		}
+		resolved[i].primaryEntrypoint = false
+	}
+}
+
 func arbitrateResolvedModuleLoads(
 	loads []moduleLoadRequest,
 	resolved []resolvedModuleLoad,
@@ -1980,6 +2009,7 @@ func arbitrateResolvedModuleLoads(
 	if len(loads) == 0 {
 		return nil
 	}
+	collapseSameSourceEntrypointNominations(loads, resolved)
 
 	candidatesByTier := map[moduleLoadKind][]int{
 		moduleLoadKindAmbient: nil,
@@ -2028,15 +2058,43 @@ func entrypointConflictError(kind moduleLoadKind, indexes []int, loads []moduleL
 	}
 }
 
+// Redundant only if the nominations would produce the same module apart from
+// its name, so settings are in the key: differently configured entries are
+// distinct roots and must still conflict. False keeps a nomination whose key
+// can't be built, rather than silently demoting it.
+func entrypointNominationIdentity(load moduleLoadRequest, resolved resolvedModuleLoad) (string, bool) {
+	self := resolved.primary.Self()
+	if self == nil || self.GetSource() == nil {
+		return "", false
+	}
+	mod := load.mod
+	// The name override is the one asModule arg that must not affect the key.
+	mod.Name = ""
+	args, err := asModuleArgsForPendingModule(mod)
+	if err != nil {
+		return "", false
+	}
+	parts := make([]string, 0, len(args)+2)
+	parts = append(parts, canonicalModuleReference(self.GetSource()), self.GetSource().Pin())
+	for _, arg := range args {
+		parts = append(parts, arg.String())
+	}
+	return strings.Join(parts, "|"), true
+}
+
+// One source installed under several names is several instances, all of which
+// must be served (#14013). Canonicalized as the CLI compares names, so `-m` and
+// the workspace entry naming the same module still collapse.
 func resolvedModuleLoadIdentity(mod dagql.ObjectResult[*core.Module]) string {
 	self := mod.Self()
-	if self == nil || self.GetSource() == nil {
-		if self == nil {
-			return ""
-		}
-		return "name:" + self.Name()
+	if self == nil {
+		return ""
 	}
-	return canonicalModuleReference(self.GetSource()) + "|" + self.GetSource().Pin()
+	name := canonicalWorkspaceModuleName(self.Name())
+	if self.GetSource() == nil {
+		return "name:" + name
+	}
+	return canonicalModuleReference(self.GetSource()) + "|" + self.GetSource().Pin() + "|" + name
 }
 
 // resolveModule resolves a module through the dagql pipeline.


### PR DESCRIPTION
Fixes #14013

## Problem

A `dagger.toml` may install one module source several times under different local names, each with its own settings:

```toml
[modules.rust]
source = "github.com/sagikazarmark/daggerverse-beta/rust"
settings.version = "1.98-slim-trixie"

[modules.msrv]
source = "github.com/sagikazarmark/daggerverse-beta/rust"
settings.version = "1.97-slim-trixie"
```

Only one of the two ever appeared in `dagger check -l` or in the function and command listing `dagger call` builds. The other was absent from discovery entirely, as if it had never been configured. Calling either one directly still worked.

## Cause

`resolvedModuleLoadIdentity` identified a served module by its resolved source ref and pin alone. That key gates both `dedupeResolvedModuleLoads`, within one load batch, and `client.servedModuleKeys`, across batches, so two entries pointing at the same source collapsed into one. Ambient workspace modules load in config-name order, so the alphabetically first name won — `msrv` shadowed `rust` in the report.

Invocation kept working because a request that names a module loads only that module: a single-entry batch has nothing to collide with. Listing loads every configured module in one batch, which is where the collision bit.

## Fix

The configured name — canonicalized the way the CLI already compares module names — is now part of a served module's identity, so both entries are served, each under its own name and honoring its own settings.

Nominating one source as the entrypoint through several entries stays redundant rather than a conflict, which is what a symlinked or differently spelled path needs, but only when those entries would produce the same module apart from the name it is installed under. Nominations are keyed on the resolved source plus the args that configure it, and redundant ones collapse to the highest-priority nomination before arbitration. Entries that configure one source differently are distinct roots and still conflict.

## Tests

`engine/server/session_test.go`: the same source under two names stays two served instances; identity comparison follows the CLI's name canonicalization; same-source entrypoint nominations collapse when identically configured and conflict when not.

`core/integration/module_loading_test.go`: the reported shape end to end. One source installed twice under different names with different settings must appear under both names in `dagger check -l` and in the `dagger call` listing, and a single session selecting both proves the two instances coexist with their own settings. Verified red before this change with exactly the reported symptom — only `msrv` listed.

## Verification

- `go test ./engine/server/...` green
- `TestModuleLoading` — 40 passed
- `TestChecks | TestWorkspaceModules | TestWorkspace` — 295 passed
- new integration test confirmed red without the fix, green with it
