### PR TITLE
fix quickstart URL to redirect it to latest target

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -487,7 +487,7 @@
 
 [[redirects]]
   from = "/quickstart/*"
-  to = "/getting-started/quickstarts/basics"
+  to = "/getting-started/quickstart"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
 fixes the issue where https://docs.dagger.io/quickstart takes you to the v0.21 docs