### PR TITLE
core: replace invalid workspace lockfiles

### DIFF
--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -83,20 +83,37 @@ func hostGitInit(t *testctx.T, dir string) {
 	require.NoError(t, err, out)
 }
 
-func (LockfileSuite) TestDefaultRejectsV1Lockfile(ctx context.Context, t *testctx.T) {
-	workdir := t.TempDir()
-	hostGitInit(t, workdir)
-	writeEmptyWorkspaceConfig(t, workdir)
-	queryPath := writeContainerFromQuery(t, workdir)
-	lockPath := filepath.Join(workdir, workspace.LockFileName)
-	lockContents := strings.Join([]string{
-		`[["version","1"]]`,
-		`["","container.from",["alpine:latest"],"not-a-digest","pin"]`,
-	}, "\n")
-	require.NoError(t, os.WriteFile(lockPath, []byte(lockContents), 0o600))
+func (LockfileSuite) TestDefaultReplacesInvalidLockfile(ctx context.Context, t *testctx.T) {
+	tests := map[string]string{
+		"v1": strings.Join([]string{
+			`[["version","1"]]`,
+			`["","container.from",["alpine:latest"],"not-a-digest","pin"]`,
+		}, "\n"),
+		"malformed v2": strings.Join([]string{
+			`[["version","2"]]`,
+			`["","oci-sha"]`,
+		}, "\n"),
+	}
 
-	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
-	require.ErrorContains(t, err, `unsupported lockfile version "1"`)
+	for name, lockContents := range tests {
+		t.Run(name, func(ctx context.Context, t *testctx.T) {
+			workdir := t.TempDir()
+			hostGitInit(t, workdir)
+			writeEmptyWorkspaceConfig(t, workdir)
+			queryPath := writeContainerFromQuery(t, workdir)
+			lockPath := filepath.Join(workdir, workspace.LockFileName)
+			require.NoError(t, os.WriteFile(lockPath, []byte(lockContents), 0o600))
+
+			out, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+			require.NoError(t, err, string(out))
+			require.Contains(t, string(out), "Warning: resetting invalid workspace lockfile.")
+
+			lockBytes, err := os.ReadFile(lockPath)
+			require.NoError(t, err)
+			require.NotEqual(t, lockContents, string(lockBytes))
+			assertOCISHALockEntry(t, lockBytes)
+		})
+	}
 }
 
 func (LockfileSuite) TestDefaultRemoteCommitDoesNotMutateLock(ctx context.Context, t *testctx.T) {

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -116,6 +116,25 @@ func (LockfileSuite) TestDefaultReplacesInvalidLockfile(ctx context.Context, t *
 	}
 }
 
+func (LockfileSuite) TestDefaultRejectsFutureLockfile(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeContainerFromQuery(t, workdir)
+	lockPath := filepath.Join(workdir, workspace.LockFileName)
+	lockContents := `[["version","3"]]`
+	require.NoError(t, os.WriteFile(lockPath, []byte(lockContents), 0o600))
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.ErrorContains(t, err,
+		`lockfile version "3" is newer than supported version "2"; upgrade Dagger to continue`,
+	)
+
+	lockBytes, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr)
+	require.Equal(t, lockContents, string(lockBytes))
+}
+
 func (LockfileSuite) TestDefaultRemoteCommitDoesNotMutateLock(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	lockContents := mustMarshalOCISHALock(t, "not-a-digest")

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -116,6 +116,29 @@ func (LockfileSuite) TestDefaultReplacesInvalidLockfile(ctx context.Context, t *
 	}
 }
 
+func (LockfileSuite) TestDefaultMigratesInvalidLegacyLockfile(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeContainerFromQuery(t, workdir)
+	legacyLockPath := filepath.Join(workdir, workspace.LegacyLockFilePath)
+	legacyLockContents := []byte(`[["version","1"]]`)
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyLockPath), 0o755))
+	require.NoError(t, os.WriteFile(legacyLockPath, legacyLockContents, 0o600))
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.NoError(t, err, string(out))
+	require.Contains(t, string(out), "Warning: resetting invalid workspace lockfile.")
+
+	lockBytes, err := os.ReadFile(filepath.Join(workdir, workspace.LockFileName))
+	require.NoError(t, err)
+	assertOCISHALockEntry(t, lockBytes)
+
+	legacyLockBytes, err := os.ReadFile(legacyLockPath)
+	require.NoError(t, err)
+	require.Equal(t, legacyLockContents, legacyLockBytes)
+}
+
 func (LockfileSuite) TestDefaultRejectsFutureLockfile(ctx context.Context, t *testctx.T) {
 	workdir := t.TempDir()
 	hostGitInit(t, workdir)

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -135,6 +135,33 @@ func (LockfileSuite) TestDefaultRejectsFutureLockfile(ctx context.Context, t *te
 	require.Equal(t, lockContents, string(lockBytes))
 }
 
+func (LockfileSuite) TestDefaultRejectsConflictedLockfile(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeContainerFromQuery(t, workdir)
+	lockPath := filepath.Join(workdir, workspace.LockFileName)
+	lockContents := strings.Join([]string{
+		`<<<<<<< HEAD`,
+		`[["version","2"]]`,
+		`["","oci-sha",["alpine:latest"],"old"]`,
+		`=======`,
+		`[["version","2"]]`,
+		`["","oci-sha",["alpine:latest"],"new"]`,
+		`>>>>>>> branch`,
+	}, "\n")
+	require.NoError(t, os.WriteFile(lockPath, []byte(lockContents), 0o600))
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.ErrorContains(t, err,
+		"workspace lockfile contains merge conflict markers; resolve the conflict before running Dagger",
+	)
+
+	lockBytes, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr)
+	require.Equal(t, lockContents, string(lockBytes))
+}
+
 func (LockfileSuite) TestDefaultRemoteCommitDoesNotMutateLock(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	lockContents := mustMarshalOCISHALock(t, "not-a-digest")

--- a/core/lockfile_update.go
+++ b/core/lockfile_update.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -29,6 +30,9 @@ func UpdateWorkspaceLock(ctx context.Context, query *Query, lock *workspace.Lock
 
 		result, err := updateWorkspaceLockEntry(ctx, query, entry)
 		if err != nil {
+			if ignoreUnsupportedLockEntry(ctx, entry, err) {
+				continue
+			}
 			return err
 		}
 		if err := lock.SetLookup(entry.Namespace, entry.Operation, entry.Inputs, result); err != nil {
@@ -75,6 +79,9 @@ func UpdateWorkspaceLock(ctx context.Context, query *Query, lock *workspace.Lock
 		}
 		result, err := updateWorkspaceLockEntry(ctx, query, entry)
 		if err != nil {
+			if ignoreUnsupportedLockEntry(ctx, entry, err) {
+				continue
+			}
 			return err
 		}
 		if err := lock.SetLookup(entry.Namespace, entry.Operation, entry.Inputs, result); err != nil {
@@ -83,6 +90,22 @@ func UpdateWorkspaceLock(ctx context.Context, query *Query, lock *workspace.Lock
 	}
 
 	return nil
+}
+
+var errUnsupportedLockEntry = errors.New("unsupported lock entry")
+
+func ignoreUnsupportedLockEntry(ctx context.Context, entry workspace.LookupEntry, err error) bool {
+	if !errors.Is(err, errUnsupportedLockEntry) {
+		return false
+	}
+	slog.GlobalLogger(ctx, InstrumentationLibrary).Warn(
+		"ignoring unsupported workspace lock entry",
+		"namespace", entry.Namespace,
+		"operation", entry.Operation,
+		"inputs", entry.Inputs,
+		"error", err,
+	)
+	return true
 }
 
 func isLatestLockEntry(entry workspace.LookupEntry) bool {
@@ -172,7 +195,12 @@ func selectedSHAEntry(
 
 func updateWorkspaceLockEntry(ctx context.Context, query *Query, entry workspace.LookupEntry) (string, error) {
 	if entry.Namespace != workspace.CoreLockNamespace {
-		return "", fmt.Errorf("unsupported lock entry %q %q", entry.Namespace, entry.Operation)
+		return "", fmt.Errorf(
+			"%w %q %q",
+			errUnsupportedLockEntry,
+			entry.Namespace,
+			entry.Operation,
+		)
 	}
 
 	switch entry.Operation {
@@ -187,7 +215,12 @@ func updateWorkspaceLockEntry(ctx context.Context, query *Query, entry workspace
 	case workspace.LockOperationVanityURL:
 		return updateVanityURLLockEntry(ctx, entry)
 	default:
-		return "", fmt.Errorf("unsupported lock entry %q %q", entry.Namespace, entry.Operation)
+		return "", fmt.Errorf(
+			"%w %q %q",
+			errUnsupportedLockEntry,
+			entry.Namespace,
+			entry.Operation,
+		)
 	}
 }
 
@@ -513,8 +546,9 @@ func updateGitLatestLockEntry(ctx context.Context, entry workspace.LookupEntry) 
 
 func unsupportedLockOptionError(operation, name string) error {
 	return fmt.Errorf(
-		"cannot update %s: unsupported option %q; "+
+		"%w: cannot update %s: unsupported option %q; "+
 			"upgrade Dagger or remove the option",
+		errUnsupportedLockEntry,
 		operation,
 		name,
 	)

--- a/core/lockfile_update_test.go
+++ b/core/lockfile_update_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,6 +21,31 @@ func TestUpdateWorkspaceLockEntry(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `unsupported lock entry "acme" "resolve"`)
+	require.ErrorIs(t, err, errUnsupportedLockEntry)
+}
+
+func TestUpdateWorkspaceLockIgnoresUnsupportedEntries(t *testing.T) {
+	t.Parallel()
+
+	lock := workspace.NewLock()
+	require.NoError(t, lock.SetLookup(
+		"acme",
+		"resolve",
+		[]any{"input"},
+		"result",
+	))
+	require.NoError(t, lock.SetLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationGitSHA,
+		workspace.LookupInputs(
+			[]any{"https://example.com/repo.git", "refs/heads/main"},
+			workspace.LookupOption{Name: "futureOption", Value: true},
+		),
+		"0123456789012345678901234567890123456789",
+	))
+
+	require.NoError(t, UpdateWorkspaceLock(context.Background(), nil, lock))
+	require.Len(t, lock.Entries(), 2)
 }
 
 func TestUpdateVanityURLLockEntry(t *testing.T) {
@@ -231,6 +257,7 @@ func TestParseGitLookupInputsRejectsUnknownOption(t *testing.T) {
 		`cannot update git-sha: unsupported option "depth"; `+
 			`upgrade Dagger or remove the option`,
 	)
+	require.True(t, errors.Is(err, errUnsupportedLockEntry))
 }
 
 func TestParseOCILockInputs(t *testing.T) {

--- a/core/schema/workspace_lock.go
+++ b/core/schema/workspace_lock.go
@@ -169,6 +169,9 @@ func (s *workspaceSchema) readWorkspaceLockForOverlay(
 		if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
 			return nil, versionErr
 		}
+		if conflictErr := workspace.LockfileMergeConflictError(err); conflictErr != nil {
+			return nil, conflictErr
+		}
 		slog.WarnContext(ctx, "invalid workspace lockfile; resetting it", "path", lockPath, "error", err)
 		return workspace.NewLock(), nil
 	}

--- a/core/schema/workspace_lock.go
+++ b/core/schema/workspace_lock.go
@@ -166,6 +166,9 @@ func (s *workspaceSchema) readWorkspaceLockForOverlay(
 	}
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
+		if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
+			return nil, versionErr
+		}
 		slog.WarnContext(ctx, "invalid workspace lockfile; resetting it", "path", lockPath, "error", err)
 		return workspace.NewLock(), nil
 	}

--- a/core/schema/workspace_lock.go
+++ b/core/schema/workspace_lock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/slog"
 )
 
 type workspaceOverlayLock struct {
@@ -165,7 +166,8 @@ func (s *workspaceSchema) readWorkspaceLockForOverlay(
 	}
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
-		return nil, fmt.Errorf("parse workspace lock: %w", err)
+		slog.WarnContext(ctx, "invalid workspace lockfile; resetting it", "path", lockPath, "error", err)
+		return workspace.NewLock(), nil
 	}
 	return lock, nil
 }

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -1071,6 +1071,9 @@ func workspaceMigrationLegacyLockMoves(
 			if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
 				return nil, versionErr
 			}
+			if conflictErr := workspace.LockfileMergeConflictError(err); conflictErr != nil {
+				return nil, conflictErr
+			}
 			slog.WarnContext(ctx, "invalid legacy workspace lockfile; deleting it", "path", sourcePath, "error", err)
 			data = nil
 		}

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/slog"
 	telemetry "github.com/dagger/otel-go"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -1067,7 +1068,8 @@ func workspaceMigrationLegacyLockMoves(
 		}
 		data, err = workspaceMigrationFilterLegacyLockData(data)
 		if err != nil {
-			return nil, fmt.Errorf("filter legacy workspace lock %q: %w", sourcePath, err)
+			slog.WarnContext(ctx, "invalid legacy workspace lockfile; deleting it", "path", sourcePath, "error", err)
+			data = nil
 		}
 
 		targetPath, err := workspaceMigrationRootPathForProject(ws, projectRoot, workspace.LockFileName)

--- a/core/schema/workspace_migrate.go
+++ b/core/schema/workspace_migrate.go
@@ -1068,6 +1068,9 @@ func workspaceMigrationLegacyLockMoves(
 		}
 		data, err = workspaceMigrationFilterLegacyLockData(data)
 		if err != nil {
+			if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
+				return nil, versionErr
+			}
 			slog.WarnContext(ctx, "invalid legacy workspace lockfile; deleting it", "path", sourcePath, "error", err)
 			data = nil
 		}

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -123,6 +124,20 @@ func ParseLock(data []byte) (*Lock, error) {
 		return nil, err
 	}
 	return &Lock{file: file}, nil
+}
+
+// FutureLockfileVersionError turns an unsupported future lockfile version into
+// actionable engine upgrade guidance. It returns nil for all other parse errors.
+func FutureLockfileVersionError(err error) error {
+	var versionErr *lockfile.UnsupportedVersionError
+	if !errors.As(err, &versionErr) || !versionErr.IsNewer() {
+		return nil
+	}
+	return fmt.Errorf(
+		"lockfile version %q is newer than supported version %q; upgrade Dagger to continue",
+		versionErr.Version,
+		versionErr.Supported,
+	)
 }
 
 // NewLock returns an empty workspace lock.

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -140,6 +140,17 @@ func FutureLockfileVersionError(err error) error {
 	)
 }
 
+// LockfileMergeConflictError turns lockfile conflict markers into actionable
+// guidance. It returns nil for all other parse errors.
+func LockfileMergeConflictError(err error) error {
+	if !errors.Is(err, lockfile.ErrMergeConflict) {
+		return nil
+	}
+	return fmt.Errorf(
+		"workspace lockfile contains merge conflict markers; resolve the conflict before running Dagger",
+	)
+}
+
 // NewLock returns an empty workspace lock.
 func NewLock() *Lock {
 	return &Lock{file: lockfile.New()}

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -77,6 +77,16 @@ func TestFutureLockfileVersionError(t *testing.T) {
 	require.NoError(t, FutureLockfileVersionError(err))
 }
 
+func TestLockfileMergeConflictError(t *testing.T) {
+	_, err := ParseLock([]byte("<<<<<<< HEAD\n=======\n>>>>>>> branch\n"))
+	require.EqualError(t, LockfileMergeConflictError(err),
+		"workspace lockfile contains merge conflict markers; resolve the conflict before running Dagger",
+	)
+
+	_, err = ParseLock([]byte(`[["version","2"]]`))
+	require.NoError(t, LockfileMergeConflictError(err))
+}
+
 func TestEntries(t *testing.T) {
 	lock := NewLock()
 	inputs := []any{"alpine:latest", "linux/amd64"}

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -67,6 +67,16 @@ func TestParseLockRejectsV1(t *testing.T) {
 	require.ErrorContains(t, err, `unsupported lockfile version "1"`)
 }
 
+func TestFutureLockfileVersionError(t *testing.T) {
+	_, err := ParseLock([]byte(`[["version","3"]]`))
+	require.EqualError(t, FutureLockfileVersionError(err),
+		`lockfile version "3" is newer than supported version "2"; upgrade Dagger to continue`,
+	)
+
+	_, err = ParseLock([]byte(`[["version","1"]]`))
+	require.NoError(t, FutureLockfileVersionError(err))
+}
+
 func TestEntries(t *testing.T) {
 	lock := NewLock()
 	inputs := []any{"alpine:latest", "linux/amd64"}

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2415,6 +2415,9 @@ func readWorkspaceLockState(ctx context.Context, bk interface {
 		if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
 			return nil, versionErr
 		}
+		if conflictErr := workspace.LockfileMergeConflictError(err); conflictErr != nil {
+			return nil, conflictErr
+		}
 		console(ctx, "Warning: resetting invalid workspace lockfile.")
 		slog.WarnContext(ctx, "invalid workspace lockfile; replacing it with an empty lockfile", "path", readPath, "error", err)
 		emptyLock := workspace.NewLock()
@@ -2482,6 +2485,9 @@ func readWorkspaceLockFromRootfs(
 	if err != nil {
 		if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
 			return nil, versionErr
+		}
+		if conflictErr := workspace.LockfileMergeConflictError(err); conflictErr != nil {
+			return nil, conflictErr
 		}
 		console(ctx, "Warning: ignoring invalid workspace lockfile.")
 		slog.WarnContext(ctx, "invalid workspace lockfile in immutable Git workspace; ignoring it", "path", lockPath, "error", err)

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2412,6 +2412,9 @@ func readWorkspaceLockState(ctx context.Context, bk interface {
 
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
+		if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
+			return nil, versionErr
+		}
 		console(ctx, "Warning: resetting invalid workspace lockfile.")
 		slog.WarnContext(ctx, "invalid workspace lockfile; replacing it with an empty lockfile", "path", readPath, "error", err)
 		emptyLock := workspace.NewLock()
@@ -2477,6 +2480,9 @@ func readWorkspaceLockFromRootfs(
 	}
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
+		if versionErr := workspace.FutureLockfileVersionError(err); versionErr != nil {
+			return nil, versionErr
+		}
 		console(ctx, "Warning: ignoring invalid workspace lockfile.")
 		slog.WarnContext(ctx, "invalid workspace lockfile in immutable Git workspace; ignoring it", "path", lockPath, "error", err)
 		return workspace.NewLock(), nil

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2382,11 +2382,13 @@ func workspaceLockPath(ws *core.Workspace) (string, error) {
 
 func readWorkspaceLockState(ctx context.Context, bk interface {
 	ReadCallerHostFile(ctx context.Context, path string) ([]byte, error)
+	LocalFileExport(ctx context.Context, srcPath, filePath, destPath string, allowParentDirPath bool) error
 }, ws *core.Workspace) (*workspace.Lock, error) {
 	lockPath, err := workspaceLockPath(ws)
 	if err != nil {
 		return nil, err
 	}
+	readPath := lockPath
 
 	data, err := bk.ReadCallerHostFile(ctx, lockPath)
 	if err != nil {
@@ -2402,6 +2404,7 @@ func readWorkspaceLockState(ctx context.Context, bk interface {
 				}
 				return nil, fmt.Errorf("reading legacy lock: %w", err)
 			}
+			readPath = legacyPath
 		} else {
 			return nil, fmt.Errorf("reading lock: %w", err)
 		}
@@ -2409,7 +2412,13 @@ func readWorkspaceLockState(ctx context.Context, bk interface {
 
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
-		return nil, fmt.Errorf("parsing lock: %w", err)
+		console(ctx, "Warning: resetting invalid workspace lockfile.")
+		slog.WarnContext(ctx, "invalid workspace lockfile; replacing it with an empty lockfile", "path", readPath, "error", err)
+		emptyLock := workspace.NewLock()
+		if err := exportWorkspaceLockToHostPath(ctx, bk, readPath, emptyLock); err != nil {
+			return nil, fmt.Errorf("replacing invalid lock: %w", err)
+		}
+		return emptyLock, nil
 	}
 	return lock, nil
 }
@@ -2468,7 +2477,9 @@ func readWorkspaceLockFromRootfs(
 	}
 	lock, err := workspace.ParseLock(data)
 	if err != nil {
-		return nil, fmt.Errorf("parsing lock: %w", err)
+		console(ctx, "Warning: ignoring invalid workspace lockfile.")
+		slog.WarnContext(ctx, "invalid workspace lockfile in immutable Git workspace; ignoring it", "path", lockPath, "error", err)
+		return workspace.NewLock(), nil
 	}
 	return lock, nil
 }
@@ -2485,14 +2496,19 @@ func isWorkspaceLockNotFound(err error) bool {
 }
 
 func exportWorkspaceLockToHost(ctx context.Context, bk *engineutil.Client, ws *core.Workspace, lock *workspace.Lock) error {
-	lockBytes, err := lock.Marshal()
-	if err != nil {
-		return fmt.Errorf("marshal lock: %w", err)
-	}
-
 	lockPath, err := workspaceLockPath(ws)
 	if err != nil {
 		return err
+	}
+	return exportWorkspaceLockToHostPath(ctx, bk, lockPath, lock)
+}
+
+func exportWorkspaceLockToHostPath(ctx context.Context, bk interface {
+	LocalFileExport(ctx context.Context, srcPath, filePath, destPath string, allowParentDirPath bool) error
+}, lockPath string, lock *workspace.Lock) error {
+	lockBytes, err := lock.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal lock: %w", err)
 	}
 
 	tmpFile, err := os.CreateTemp("", "workspace-lock-*")

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -2382,7 +2382,6 @@ func workspaceLockPath(ws *core.Workspace) (string, error) {
 
 func readWorkspaceLockState(ctx context.Context, bk interface {
 	ReadCallerHostFile(ctx context.Context, path string) ([]byte, error)
-	LocalFileExport(ctx context.Context, srcPath, filePath, destPath string, allowParentDirPath bool) error
 }, ws *core.Workspace) (*workspace.Lock, error) {
 	lockPath, err := workspaceLockPath(ws)
 	if err != nil {
@@ -2419,12 +2418,8 @@ func readWorkspaceLockState(ctx context.Context, bk interface {
 			return nil, conflictErr
 		}
 		console(ctx, "Warning: resetting invalid workspace lockfile.")
-		slog.WarnContext(ctx, "invalid workspace lockfile; replacing it with an empty lockfile", "path", readPath, "error", err)
-		emptyLock := workspace.NewLock()
-		if err := exportWorkspaceLockToHostPath(ctx, bk, readPath, emptyLock); err != nil {
-			return nil, fmt.Errorf("replacing invalid lock: %w", err)
-		}
-		return emptyLock, nil
+		slog.WarnContext(ctx, "invalid workspace lockfile; using an empty lock", "path", readPath, "error", err)
+		return workspace.NewLock(), nil
 	}
 	return lock, nil
 }
@@ -2508,19 +2503,14 @@ func isWorkspaceLockNotFound(err error) bool {
 }
 
 func exportWorkspaceLockToHost(ctx context.Context, bk *engineutil.Client, ws *core.Workspace, lock *workspace.Lock) error {
-	lockPath, err := workspaceLockPath(ws)
-	if err != nil {
-		return err
-	}
-	return exportWorkspaceLockToHostPath(ctx, bk, lockPath, lock)
-}
-
-func exportWorkspaceLockToHostPath(ctx context.Context, bk interface {
-	LocalFileExport(ctx context.Context, srcPath, filePath, destPath string, allowParentDirPath bool) error
-}, lockPath string, lock *workspace.Lock) error {
 	lockBytes, err := lock.Marshal()
 	if err != nil {
 		return fmt.Errorf("marshal lock: %w", err)
+	}
+
+	lockPath, err := workspaceLockPath(ws)
+	if err != nil {
+		return err
 	}
 
 	tmpFile, err := os.CreateTemp("", "workspace-lock-*")

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -2409,7 +2409,7 @@ func TestReadWorkspaceLockStateReadsLegacyLockFallback(t *testing.T) {
 	}
 	ws.SetHostPath("/repo")
 
-	lock, err := readWorkspaceLockState(t.Context(), fakeWorkspaceLockStateReader{
+	lock, err := readWorkspaceLockState(t.Context(), &fakeWorkspaceLockStateReader{
 		files: map[string][]byte{
 			filepath.Join("/repo", ".dagger", "lock"): legacyBytes,
 		},
@@ -2421,8 +2421,32 @@ func TestReadWorkspaceLockStateReadsLegacyLockFallback(t *testing.T) {
 	require.Equal(t, "sha256:deadbeef", got)
 }
 
+func TestReadWorkspaceLockStateReplacesInvalidLock(t *testing.T) {
+	t.Parallel()
+
+	ws := &core.Workspace{
+		ConfigFile: "dagger.toml",
+		LockFile:   "dagger.lock",
+	}
+	ws.SetHostPath("/repo")
+	lockPath := filepath.Join("/repo", "dagger.lock")
+	reader := &fakeWorkspaceLockStateReader{
+		files: map[string][]byte{
+			lockPath: []byte(`[["version","1"]]`),
+		},
+	}
+
+	lock, err := readWorkspaceLockState(t.Context(), reader, ws)
+	require.NoError(t, err)
+	require.Empty(t, lock.Entries())
+	require.Contains(t, reader.files, lockPath)
+	require.Empty(t, reader.files[lockPath])
+	require.Equal(t, []string{lockPath}, reader.exported)
+}
+
 type fakeWorkspaceLockStateReader struct {
-	files map[string][]byte
+	files    map[string][]byte
+	exported []string
 }
 
 func (r fakeWorkspaceLockStateReader) ReadCallerHostFile(_ context.Context, path string) ([]byte, error) {
@@ -2430,6 +2454,21 @@ func (r fakeWorkspaceLockStateReader) ReadCallerHostFile(_ context.Context, path
 		return data, nil
 	}
 	return nil, os.ErrNotExist
+}
+
+func (r *fakeWorkspaceLockStateReader) LocalFileExport(
+	_ context.Context,
+	srcPath, _ string,
+	destPath string,
+	_ bool,
+) error {
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	r.files[destPath] = data
+	r.exported = append(r.exported, destPath)
+	return nil
 }
 
 func stringPtr(v string) *string {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -2421,7 +2421,7 @@ func TestReadWorkspaceLockStateReadsLegacyLockFallback(t *testing.T) {
 	require.Equal(t, "sha256:deadbeef", got)
 }
 
-func TestReadWorkspaceLockStateReplacesInvalidLock(t *testing.T) {
+func TestReadWorkspaceLockStateDoesNotWriteInvalidLock(t *testing.T) {
 	t.Parallel()
 
 	ws := &core.Workspace{
@@ -2430,9 +2430,10 @@ func TestReadWorkspaceLockStateReplacesInvalidLock(t *testing.T) {
 	}
 	ws.SetHostPath("/repo")
 	lockPath := filepath.Join("/repo", "dagger.lock")
+	lockContents := []byte(`[["version","1"]]`)
 	reader := &fakeWorkspaceLockStateReader{
 		files: map[string][]byte{
-			lockPath: []byte(`[["version","1"]]`),
+			lockPath: lockContents,
 		},
 	}
 
@@ -2440,13 +2441,11 @@ func TestReadWorkspaceLockStateReplacesInvalidLock(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, lock.Entries())
 	require.Contains(t, reader.files, lockPath)
-	require.Empty(t, reader.files[lockPath])
-	require.Equal(t, []string{lockPath}, reader.exported)
+	require.Equal(t, lockContents, reader.files[lockPath])
 }
 
 type fakeWorkspaceLockStateReader struct {
-	files    map[string][]byte
-	exported []string
+	files map[string][]byte
 }
 
 func (r fakeWorkspaceLockStateReader) ReadCallerHostFile(_ context.Context, path string) ([]byte, error) {
@@ -2454,21 +2453,6 @@ func (r fakeWorkspaceLockStateReader) ReadCallerHostFile(_ context.Context, path
 		return data, nil
 	}
 	return nil, os.ErrNotExist
-}
-
-func (r *fakeWorkspaceLockStateReader) LocalFileExport(
-	_ context.Context,
-	srcPath, _ string,
-	destPath string,
-	_ bool,
-) error {
-	data, err := os.ReadFile(srcPath)
-	if err != nil {
-		return err
-	}
-	r.files[destPath] = data
-	r.exported = append(r.exported, destPath)
-	return nil
 }
 
 func stringPtr(v string) *string {

--- a/util/lockfile/lockfile.go
+++ b/util/lockfile/lockfile.go
@@ -3,12 +3,17 @@ package lockfile
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
 )
+
+// ErrMergeConflict indicates that a lockfile contains unresolved Git conflict
+// markers and must be resolved by the user rather than recovered automatically.
+var ErrMergeConflict = errors.New("lockfile contains merge conflict markers")
 
 const (
 	versionKey     = "version"
@@ -82,6 +87,10 @@ func New() *Lockfile {
 // Lines starting with "#" are comments and are ignored. Non-empty files must
 // otherwise start with a supported version header line.
 func Parse(data []byte) (*Lockfile, error) {
+	if hasMergeConflictMarkers(data) {
+		return nil, ErrMergeConflict
+	}
+
 	lock := New()
 	lines := bytes.Split(data, []byte("\n"))
 
@@ -111,6 +120,17 @@ func Parse(data []byte) (*Lockfile, error) {
 	}
 
 	return lock, nil
+}
+
+func hasMergeConflictMarkers(data []byte) bool {
+	var start, separator, end bool
+	for _, rawLine := range bytes.Split(data, []byte("\n")) {
+		line := strings.TrimSpace(string(rawLine))
+		start = start || strings.HasPrefix(line, "<<<<<<< ")
+		separator = separator || line == "======="
+		end = end || strings.HasPrefix(line, ">>>>>>> ")
+	}
+	return start && separator && end
 }
 
 // Marshal encodes lockfile entries to deterministic JSON lines, preceded by

--- a/util/lockfile/lockfile.go
+++ b/util/lockfile/lockfile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -50,6 +51,25 @@ type Entry struct {
 	Operation string
 	Inputs    []any
 	Value     string
+}
+
+// UnsupportedVersionError reports a syntactically valid lockfile version that
+// this package cannot parse.
+type UnsupportedVersionError struct {
+	Version   string
+	Supported string
+}
+
+func (err *UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("unsupported lockfile version %q", err.Version)
+}
+
+// IsNewer reports whether the unsupported version is newer than the supported
+// version. Non-integer versions are not considered newer.
+func (err *UnsupportedVersionError) IsNewer() bool {
+	version, versionErr := strconv.Atoi(err.Version)
+	supported, supportedErr := strconv.Atoi(err.Supported)
+	return versionErr == nil && supportedErr == nil && version > supported
 }
 
 // New returns an empty lockfile.
@@ -213,7 +233,10 @@ func parseVersionHeader(line []byte) (string, error) {
 	}
 	version := versionPair[1]
 	if version != versionValueV2 {
-		return "", fmt.Errorf("unsupported lockfile version %q", version)
+		return "", &UnsupportedVersionError{
+			Version:   version,
+			Supported: versionValueV2,
+		}
 	}
 	return version, nil
 }

--- a/util/lockfile/lockfile_test.go
+++ b/util/lockfile/lockfile_test.go
@@ -34,6 +34,21 @@ func TestParseRejectsFutureVersion(t *testing.T) {
 	require.True(t, versionErr.IsNewer())
 }
 
+func TestParseRejectsMergeConflict(t *testing.T) {
+	input := strings.Join([]string{
+		`<<<<<<< HEAD`,
+		`[["version","2"]]`,
+		`["","oci-sha",["alpine:latest"],"old"]`,
+		`=======`,
+		`[["version","2"]]`,
+		`["","oci-sha",["alpine:latest"],"new"]`,
+		`>>>>>>> branch`,
+	}, "\n")
+
+	_, err := Parse([]byte(input))
+	require.ErrorIs(t, err, ErrMergeConflict)
+}
+
 func TestMarshalDeterministicOrdering(t *testing.T) {
 	lock := New()
 	require.NoError(t, lock.Set("b", "lookup", []any{"x"}, "r3"))

--- a/util/lockfile/lockfile_test.go
+++ b/util/lockfile/lockfile_test.go
@@ -1,6 +1,7 @@
 package lockfile
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -17,6 +18,20 @@ func TestParseRejectsV1(t *testing.T) {
 
 	_, err := Parse([]byte(input))
 	require.ErrorContains(t, err, `unsupported lockfile version "1"`)
+	var versionErr *UnsupportedVersionError
+	require.ErrorAs(t, err, &versionErr)
+	require.False(t, versionErr.IsNewer())
+}
+
+func TestParseRejectsFutureVersion(t *testing.T) {
+	_, err := Parse([]byte(`[["version","3"]]`))
+	require.ErrorContains(t, err, `unsupported lockfile version "3"`)
+
+	var versionErr *UnsupportedVersionError
+	require.True(t, errors.As(err, &versionErr))
+	require.Equal(t, "3", versionErr.Version)
+	require.Equal(t, "2", versionErr.Supported)
+	require.True(t, versionErr.IsNewer())
 }
 
 func TestMarshalDeterministicOrdering(t *testing.T) {


### PR DESCRIPTION
## Summary

- reset known legacy and malformed v2 lockfiles without failing normal execution
- reject future lockfile versions with guidance to upgrade Dagger
- preserve conflicted lockfiles and ask the user to resolve them
- preserve and skip unsupported v2 entries and options during updates
- defer invalid local lock replacement to the normal dirty-lock flush, which writes canonical `dagger.lock`

## Test plan

- `go test ./core ./core/workspace ./core/schema ./engine/server ./engine/server/resolver ./util/lockfile`
- `dagger api call engine-dev test --pkg ./core/integration --run='TestLockfile'`