### PR TITLE
cli: clean up global flags & remote engine configuration

### DIFF
--- a/.changes/unreleased/Changed-20260903-100000.yaml
+++ b/.changes/unreleased/Changed-20260903-100000.yaml
@@ -1,0 +1,10 @@
+kind: Changed
+body: |
+  The `-i` flag is now `--shell-on-error`. It opens a shell in the failed
+  container when a container exec fails. `--shell-command-on-error` sets the
+  command that shell runs. `--interactive` and `--interactive-command` still
+  work as deprecated aliases.
+time: 2026-09-03T10:00:00Z
+custom:
+  Author: shykes
+  PR: "14027"

--- a/.changes/unreleased/Changed-20260903-100100.yaml
+++ b/.changes/unreleased/Changed-20260903-100100.yaml
@@ -1,8 +1,9 @@
 kind: Changed
 body: |
   `--engine` selects the engine that runs a command: `cloud` for Dagger Cloud,
-  or a runner host URI such as `container://NAME` or `ssh://HOST`. The `--cloud`
-  flag is deprecated: use `--engine=cloud`.
+  or a runner host URI such as `container://NAME` or `ssh://HOST`. The
+  `DAGGER_ENGINE` environment variable takes the same values. Run
+  `dagger help engine` for the full list.
 time: 2026-09-03T10:01:00Z
 custom:
   Author: shykes

--- a/.changes/unreleased/Changed-20260903-100100.yaml
+++ b/.changes/unreleased/Changed-20260903-100100.yaml
@@ -1,0 +1,9 @@
+kind: Changed
+body: |
+  `--engine` selects the engine that runs a command: `cloud` for Dagger Cloud,
+  or a runner host URI such as `container://NAME` or `ssh://HOST`. The `--cloud`
+  flag is deprecated: use `--engine=cloud`.
+time: 2026-09-03T10:01:00Z
+custom:
+  Author: shykes
+  PR: "14027"

--- a/.changes/unreleased/Deprecated-20260903-100200.yaml
+++ b/.changes/unreleased/Deprecated-20260903-100200.yaml
@@ -1,0 +1,9 @@
+kind: Deprecated
+body: |
+  `--cloud`, `DAGGER_CLOUD_ENGINE`, and `_EXPERIMENTAL_DAGGER_RUNNER_HOST` are
+  deprecated. Use `--engine=cloud` or `--engine=URI`, or set `DAGGER_ENGINE`.
+  The old inputs still work as a fallback.
+time: 2026-09-03T10:02:00Z
+custom:
+  Author: shykes
+  PR: "14027"

--- a/.changes/unreleased/Fixed-20260901-194652.yaml
+++ b/.changes/unreleased/Fixed-20260901-194652.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  `dagger settings` now truncates long values and descriptions to the terminal
+  width, so table rows stay aligned. Read one setting with
+  `dagger settings MODULE KEY` to get its full value.
+time: 2026-09-01T19:46:52Z
+custom:
+  Author: shykes
+  PR: 14027

--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -98,7 +98,7 @@ runs:
         if [[ -n "${{ inputs.workspace }}" ]]; then
           workspace_args=(-W "${{ inputs.workspace }}")
         fi
-        redirect_logs dagger --cloud "${module_args[@]}" "${workspace_args[@]}" call ${{ inputs.function }}
+        redirect_logs dagger --engine=cloud "${module_args[@]}" "${workspace_args[@]}" call ${{ inputs.function }}
       env:
         DAGGER_CLOUD_TOKEN: oidc
 

--- a/.github/workflows/alternative-ci-engines-1.yml
+++ b/.github/workflows/alternative-ci-engines-1.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           chmod +x /usr/local/bin/dagger
 
-          dagger call --cloud \
+          dagger call --engine=cloud \
             test specific \
             --race=true \
             --parallel=16 \
@@ -81,7 +81,7 @@ jobs:
         id: exec
         run: |
           chmod +x /usr/local/bin/dagger
-          dagger call --cloud test specific --race=true --parallel=16 --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava'
+          dagger call --engine=cloud test specific --race=true --parallel=16 --run='TestGo|TestPython|TestTypescript|TestElixir|TestPHP|TestJava'
         env:
           DAGGER_CLOUD_TOKEN: oidc
           DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
@@ -104,7 +104,7 @@ jobs:
           # NOTE: docker credentials are NOT injected,
           #  because .env.gha only works inside a local checkout.
           #  FIXME: get it to work with remotely loaded modules also.
-          dagger call --cloud check-go-sdk
+          dagger call --engine=cloud check-go-sdk
         env:
           DAGGER_CLOUD_TOKEN: oidc
           DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}
@@ -127,7 +127,7 @@ jobs:
           # NOTE: docker credentials are NOT injected,
           #  because .env.gha only works inside a local checkout.
           #  FIXME: get it to work with remotely loaded modules also.
-          dagger call --cloud check-go-sdk
+          dagger call --engine=cloud check-go-sdk
         env:
           DAGGER_CLOUD_TOKEN: oidc
           DAGGER_MODULE: github.com/${{ github.repository }}@${{ github.sha }}

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
@@ -734,6 +735,49 @@ func (GeneratorsSuite) TestAPIClientInitGeneratesForNewClientOnly(ctx context.Co
 		exists, err := initialized.Exists(ctx, "clients/one/generated-client.txt")
 		require.NoError(t, err)
 		require.False(t, exists)
+	})
+}
+
+func (GeneratorsSuite) TestInitWritesSelectedEnv(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := initGeneratorFixture(t, c)
+
+	t.Run("module", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"--env", "dev", "module", "init", "fixture", "envmod", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		config, err := initialized.File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		cfg, err := workspace.ParseConfig([]byte(config))
+		require.NoError(t, err)
+		require.NotContains(t, cfg.Modules, "envmod")
+		require.Equal(t, ".dagger/modules/envmod", cfg.Env["dev"].Modules["envmod"].Source)
+		require.Len(t, cfg.Modules["init-fixture"].AsSDK.Modules, 1)
+		require.Len(t, cfg.Env["dev"].Modules["init-fixture"].AsSDK.Modules, 2)
+
+		generated, err := initialized.File(".dagger/modules/envmod/generated-module.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ".dagger/modules/envmod\n", generated)
+	})
+
+	t.Run("client", func(ctx context.Context, t *testctx.T) {
+		initialized := base.With(daggerExec(
+			"--env", "dev", "api", "client", "init", "fixture", "clients/dev", "sdk/init-fixture", "--auto-apply"))
+		out, err := initialized.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+
+		config, err := initialized.File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		cfg, err := workspace.ParseConfig([]byte(config))
+		require.NoError(t, err)
+		require.Len(t, cfg.Modules["init-fixture"].AsSDK.Clients, 1)
+		require.Len(t, cfg.Env["dev"].Modules["init-fixture"].AsSDK.Clients, 2)
+
+		generated, err := initialized.File("clients/dev/generated-client.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "sdk/init-fixture\n", generated)
 	})
 }
 

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -515,7 +515,7 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 16})
 		require.NoError(t, err)
 
-		cmd := hostDaggerCommandRaw(ctx, t, modDir, "-m", ".", "--interactive", "call", "ctr")
+		cmd := hostDaggerCommandRaw(ctx, t, modDir, "-m", ".", "--shell-on-error", "call", "ctr")
 		cmd.Stdin = tty
 		cmd.Stdout = tty
 		cmd.Stderr = tty
@@ -572,8 +572,8 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		err = cmd.Wait()
 		require.Error(t, err)
 
-		// We try again with an invalid shell to confirm we replaced the default command
-		// We have to set a TTY though or else the error will just be that the --interactive flag doesn't work without a terminal
+		// Try again with an invalid shell to confirm that the command was replaced.
+		// Keep the old flag here to test the deprecated compatibility alias.
 		console, err = newTUIConsole(t, 60*time.Second)
 		require.NoError(t, err)
 		defer console.Close()

--- a/core/integration/testdata/modules/.envrc
+++ b/core/integration/testdata/modules/.envrc
@@ -1,5 +1,5 @@
 DAGGER_SRC_ROOT=$(cd ../../../../ && pwd)
 export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
-export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+export DAGGER_ENGINE=container://dagger-engine.dev
 export _DAGGER_TESTS_ENGINE_TAR=$DAGGER_SRC_ROOT/bin/engine.tar
 export PATH=$DAGGER_SRC_ROOT/bin:$PATH

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -46,6 +46,10 @@ func (s *moduleSchema) currentModuleAsSDK(
 	if err != nil {
 		return nil, err
 	}
+	cfg, _, err = effectiveWorkspaceConfig(ctx, ws, cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	var curName string
 	if mod := curMod.Module.Self(); mod != nil {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -3666,6 +3666,10 @@ func sdkOwnersByModulePath(ctx context.Context, ws *core.Workspace) (map[string]
 	if err != nil {
 		return nil, err
 	}
+	cfg, _, err = effectiveWorkspaceConfig(ctx, ws, cfg)
+	if err != nil {
+		return nil, err
+	}
 	configDir, err := workspaceConfigDirectory(ws)
 	if err != nil {
 		return nil, err

--- a/core/schema/workspace_builders.go
+++ b/core/schema/workspace_builders.go
@@ -83,6 +83,42 @@ func (s *workspaceSchema) loadWorkspaceConfigForOverlay(
 	}, nil
 }
 
+func effectiveWorkspaceConfig(ctx context.Context, ws *core.Workspace, cfg *workspace.Config) (*workspace.Config, string, error) {
+	applied, err := workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
+	if err != nil {
+		return nil, "", err
+	}
+	envName, ok := selectedWorkspaceEnv(ctx, ws)
+	if !ok {
+		return applied, "", nil
+	}
+	applied, err = workspace.ApplyEnvOverlay(applied, envName)
+	if err != nil {
+		return nil, "", err
+	}
+	return applied, envName, nil
+}
+
+func workspaceConfigForInit(ctx context.Context, ws *core.Workspace, staged *stagedWorkspaceConfig) (*workspace.Config, string, error) {
+	if envName, ok := selectedWorkspaceEnv(ctx, ws); ok {
+		workspace.EnsureEnv(staged.Config, envName)
+		return effectiveWorkspaceConfig(ctx, ws, staged.Config)
+	}
+	return staged.Config, "", nil
+}
+
+func setEnvSDKRole(cfg *workspace.Config, envName, moduleName string, role *workspace.ModuleAsSDK) {
+	workspace.EnsureEnv(cfg, envName)
+	env := cfg.Env[envName]
+	if env.Modules == nil {
+		env.Modules = map[string]workspace.EnvModuleOverlay{}
+	}
+	overlay := env.Modules[moduleName]
+	overlay.AsSDK = role
+	env.Modules[moduleName] = overlay
+	cfg.Env[envName] = env
+}
+
 func (s *workspaceSchema) stageWorkspaceConfigBytes(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
@@ -140,7 +176,7 @@ func (s *workspaceSchema) withConfigValue(
 	}
 
 	writeKey := args.Key
-	if envName, ok := selectedWorkspaceEnv(ctx); ok && !isExplicitEnvConfigKey(args.Key) {
+	if envName, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok && !isExplicitEnvConfigKey(args.Key) {
 		writeKey, err = envScopedConfigKey(staged.Config, envName, args.Key, workspaceConfigInitIfMissing)
 		if err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
@@ -177,7 +213,7 @@ func (s *workspaceSchema) withoutConfigValue(
 	}
 
 	unsetKey := args.Key
-	if envName, ok := selectedWorkspaceEnv(ctx); ok && !isExplicitEnvConfigKey(args.Key) {
+	if envName, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok && !isExplicitEnvConfigKey(args.Key) {
 		unsetKey, err = envScopedConfigKey(staged.Config, envName, args.Key, workspaceConfigMustExist)
 		if err != nil {
 			return dagql.ObjectResult[*core.Workspace]{}, err
@@ -273,7 +309,7 @@ func (s *workspaceSchema) withModuleInstall(
 	}
 
 	var plan workspaceInstallConfigPlan
-	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+	if envName, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok {
 		plan, err = planWorkspaceEnvInstallConfig(staged.Config, envName, args, resolved.Name, resolved.ConfigSource)
 	} else {
 		plan, err = planWorkspaceInstallConfig(staged.Config, args, resolved.Name, resolved.ConfigSource)
@@ -312,7 +348,7 @@ func (s *workspaceSchema) withSDK(
 ) (dagql.ObjectResult[*core.Workspace], error) {
 	// Reject before the ref is resolved and fetched; the plan keeps the same
 	// check as a backstop for other callers.
-	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+	if envName, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok {
 		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("SDKs cannot be installed in env %q; install SDKs in the base workspace config", envName)
 	}
 	return s.withModuleInstall(ctx, parent, workspaceInstallArgs{
@@ -337,7 +373,7 @@ func (s *workspaceSchema) withoutModule(
 	if err != nil {
 		return dagql.ObjectResult[*core.Workspace]{}, err
 	}
-	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+	if envName, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok {
 		return s.withoutEnvModule(ctx, parent, staged, envName, args.Name)
 	}
 	entry, ok := staged.Config.Modules[args.Name]
@@ -431,7 +467,7 @@ func (s *workspaceSchema) withoutSDK(
 	parent dagql.ObjectResult[*core.Workspace],
 	args workspaceUninstallArgs,
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	if _, ok := selectedWorkspaceEnv(ctx); ok {
+	if _, ok := selectedWorkspaceEnv(ctx, parent.Self()); ok {
 		return dagql.ObjectResult[*core.Workspace]{}, fmt.Errorf("SDKs are not env-scoped; uninstall SDKs in the base workspace config")
 	}
 	return s.withoutModule(ctx, parent, args)
@@ -542,7 +578,11 @@ func (s *workspaceSchema) sdkGenerators(
 	if err != nil {
 		return nil, err
 	}
-	sdkName, _, sdkRef, err := installedSDKSource(staged.Config, args.SDK)
+	cfg, _, err := effectiveWorkspaceConfig(ctx, parent, staged.Config)
+	if err != nil {
+		return nil, err
+	}
+	sdkName, _, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -53,7 +53,10 @@ func (s *workspaceSchema) initClientChanges(
 	if err != nil {
 		return res, scope, err
 	}
-	cfg := staged.Config
+	cfg, envName, err := workspaceConfigForInit(ctx, ws, staged)
+	if err != nil {
+		return res, scope, err
+	}
 	sdkName, sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
 		return res, scope, err
@@ -79,7 +82,8 @@ func (s *workspaceSchema) initClientChanges(
 		return res, scope, err
 	}
 
-	if err := removeClientEntryAtPath(cfg, staged.ConfigDir, clientPath); err != nil {
+	previousOwners, err := removeClientEntryAtPath(cfg, staged.ConfigDir, clientPath)
+	if err != nil {
 		return res, scope, err
 	}
 	sdkEntry = cfg.Modules[sdkName]
@@ -89,8 +93,16 @@ func (s *workspaceSchema) initClientChanges(
 		Pin:    modulePin,
 	})
 	cfg.Modules[sdkName] = sdkEntry
+	configToWrite := cfg
+	if envName != "" {
+		previousOwners = append(previousOwners, sdkName)
+		for _, moduleName := range previousOwners {
+			setEnvSDKRole(staged.Config, envName, moduleName, cfg.Modules[moduleName].AsSDK)
+		}
+		configToWrite = staged.Config
+	}
 
-	newConfigBytes, err := workspace.UpdateConfigBytes(staged.Data, cfg)
+	newConfigBytes, err := workspace.UpdateConfigBytes(staged.Data, configToWrite)
 	if err != nil {
 		return res, scope, fmt.Errorf("update workspace config: %w", err)
 	}
@@ -277,11 +289,12 @@ func workspaceClientModuleSourceSelector(ref string, pin string) dagql.Selector 
 // workspace-root-relative while the entries themselves are recorded against
 // configDir. An entry that cannot be resolved is a corruption every other
 // reader fails on, so it fails here too rather than being mistaken for a miss.
-func removeClientEntryAtPath(cfg *workspace.Config, configDir, clientPath string) error {
+func removeClientEntryAtPath(cfg *workspace.Config, configDir, clientPath string) ([]string, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil
 	}
 	cleanPath := filepath.ToSlash(cleanWorkspaceRelPath(clientPath))
+	var removedFrom []string
 	for moduleName, entry := range cfg.Modules {
 		if entry.AsSDK == nil || len(entry.AsSDK.Clients) == 0 {
 			continue
@@ -290,9 +303,10 @@ func removeClientEntryAtPath(cfg *workspace.Config, configDir, clientPath string
 		for _, client := range entry.AsSDK.Clients {
 			resolved, err := workspace.ResolveSDKManagedPath(configDir, client.Path)
 			if err != nil {
-				return fmt.Errorf("client managed by %q: %w", moduleName, err)
+				return nil, fmt.Errorf("client managed by %q: %w", moduleName, err)
 			}
 			if resolved == cleanPath {
+				removedFrom = append(removedFrom, moduleName)
 				continue
 			}
 			kept = append(kept, client)
@@ -300,5 +314,5 @@ func removeClientEntryAtPath(cfg *workspace.Config, configDir, clientPath string
 		entry.AsSDK.Clients = kept
 		cfg.Modules[moduleName] = entry
 	}
-	return nil
+	return removedFrom, nil
 }

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -178,7 +178,7 @@ func (s *workspaceSchema) configRead(
 	args configReadArgs,
 ) (dagql.String, error) {
 	if parent.ConfigFile == "" {
-		if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		if envName, ok := selectedWorkspaceEnv(ctx, parent); ok {
 			return "", fmt.Errorf("workspace env %q requires dagger.toml", envName)
 		}
 		result, err := workspace.ReadConfigValue(nil, args.Key)
@@ -188,7 +188,7 @@ func (s *workspaceSchema) configRead(
 		return dagql.String(result), nil
 	}
 
-	envName, envSelected := selectedWorkspaceEnv(ctx)
+	envName, envSelected := selectedWorkspaceEnv(ctx, parent)
 	overlay := parent.UserConfigOverlay()
 	switch {
 	case envSelected && !isExplicitEnvConfigKey(args.Key):
@@ -255,12 +255,15 @@ type workspaceConfigKeyArgs struct {
 	Here bool `default:"false"`
 }
 
-func selectedWorkspaceEnv(ctx context.Context) (string, bool) {
+func selectedWorkspaceEnv(ctx context.Context, ws *core.Workspace) (string, bool) {
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil || clientMetadata.WorkspaceEnv == nil || *clientMetadata.WorkspaceEnv == "" {
-		return "", false
+	if err == nil && clientMetadata.WorkspaceEnv != nil && *clientMetadata.WorkspaceEnv != "" {
+		return *clientMetadata.WorkspaceEnv, true
 	}
-	return *clientMetadata.WorkspaceEnv, true
+	if ws != nil && ws.SelectedEnv() != "" {
+		return ws.SelectedEnv(), true
+	}
+	return "", false
 }
 
 func isExplicitEnvConfigKey(key string) bool {

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -19,7 +19,7 @@ func (s *workspaceSchema) workspaceModules(
 	if ws.ConfigFile == "" {
 		// An env selection has nowhere to resolve from without a config, and
 		// silently listing nothing would read as "the env is empty".
-		if envName, ok := selectedWorkspaceEnv(ctx); ok {
+		if envName, ok := selectedWorkspaceEnv(ctx, ws); ok {
 			return nil, fmt.Errorf("workspace env %q requires dagger.toml", envName)
 		}
 		return dagql.ObjectResultArray[*core.WorkspaceModule]{}, nil
@@ -31,20 +31,11 @@ func (s *workspaceSchema) workspaceModules(
 	}
 	// The listing is the effective view, merged in the same order as module
 	// loading (base, user-level overlay, selected env overlay), so modules an
-	// overlay adds are discoverable — with or without an env selected, since
-	// loading applies the user overlay unconditionally too. It inherits the
-	// env overlay's strictness — a missing or broken env fails listing instead
-	// of silently falling back to the base config, deliberately matching
-	// env-selected config reads.
-	cfg, err = workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
+	// overlay adds are discoverable. A missing or broken selected env fails the
+	// read instead of falling back to the base config.
+	cfg, _, err = effectiveWorkspaceConfig(ctx, ws, cfg)
 	if err != nil {
 		return nil, err
-	}
-	if envName, ok := selectedWorkspaceEnv(ctx); ok {
-		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	configDir, err := workspaceConfigDirectory(ws)
@@ -207,15 +198,9 @@ func (s *workspaceSchema) moduleSettings(
 	// Values come from the user-level overlay and the selected env overlay,
 	// merged in the same order as module loading. The entry lookup is also
 	// effective so modules an overlay itself adds resolve their settings.
-	effectiveCfg, err := workspace.ApplyUserOverlay(cfg, ws.Self().UserConfigOverlay())
+	effectiveCfg, _, err := effectiveWorkspaceConfig(ctx, ws.Self(), cfg)
 	if err != nil {
 		return nil, err
-	}
-	if envName, ok := selectedWorkspaceEnv(ctx); ok {
-		effectiveCfg, err = workspace.ApplyEnvOverlay(effectiveCfg, envName)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	entry, ok := effectiveCfg.Modules[parent.Self().Name]

--- a/core/schema/workspace_module_init.go
+++ b/core/schema/workspace_module_init.go
@@ -93,7 +93,10 @@ func (s *workspaceSchema) initModuleChanges(
 		relPath = filepath.Join(staged.ConfigDir, ".dagger", "modules", args.Name)
 	}
 
-	cfg := staged.Config
+	cfg, envName, err := workspaceConfigForInit(ctx, ws, staged)
+	if err != nil {
+		return res, scope, err
+	}
 	sdkName, sdkEntry, sdkRef, err := installedSDKSource(cfg, args.SDK)
 	if err != nil {
 		return res, scope, err
@@ -155,9 +158,22 @@ func (s *workspaceSchema) initModuleChanges(
 	if usingDefaultPath {
 		cfg.Modules[args.Name] = workspace.ModuleEntry{Source: configPath}
 	}
+	configToWrite := cfg
+	if envName != "" {
+		setEnvSDKRole(staged.Config, envName, sdkName, cfg.Modules[sdkName].AsSDK)
+		if usingDefaultPath {
+			env := staged.Config.Env[envName]
+			if env.Modules == nil {
+				env.Modules = map[string]workspace.EnvModuleOverlay{}
+			}
+			env.Modules[args.Name] = workspace.EnvModuleOverlay{Source: configPath}
+			staged.Config.Env[envName] = env
+		}
+		configToWrite = staged.Config
+	}
 
 	// Render new dagger.toml bytes through the format-preserving editor.
-	newConfigBytes, err := workspace.UpdateConfigBytes(staged.Data, cfg)
+	newConfigBytes, err := workspace.UpdateConfigBytes(staged.Data, configToWrite)
 	if err != nil {
 		return res, scope, fmt.Errorf("update workspace config: %w", err)
 	}

--- a/core/schema/workspace_overlay_modules.go
+++ b/core/schema/workspace_overlay_modules.go
@@ -76,7 +76,7 @@ func (s *workspaceSchema) workspaceOverlayModules(
 	if err != nil {
 		return nil, err
 	}
-	if envName, ok := selectedWorkspaceEnv(ctx); ok {
+	if envName, ok := selectedWorkspaceEnv(ctx, ws); ok {
 		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
 		if err != nil {
 			return nil, err

--- a/core/schema/workspace_sdk.go
+++ b/core/schema/workspace_sdk.go
@@ -26,6 +26,10 @@ func (s *workspaceSchema) sdks(
 	if err != nil {
 		return nil, err
 	}
+	cfg, _, err = effectiveWorkspaceConfig(ctx, ws, cfg)
+	if err != nil {
+		return nil, err
+	}
 	configDir, err := workspaceConfigDirectory(ws)
 	if err != nil {
 		return nil, err
@@ -64,6 +68,10 @@ func (s *workspaceSchema) sdk(
 	if ws.ConfigFile != "" {
 		var err error
 		cfg, err = readWorkspaceConfig(ctx, ws)
+		if err != nil {
+			return dagql.ObjectResult[*core.WorkspaceSDK]{}, err
+		}
+		cfg, _, err = effectiveWorkspaceConfig(ctx, ws, cfg)
 		if err != nil {
 			return dagql.ObjectResult[*core.WorkspaceSDK]{}, err
 		}

--- a/core/schema/workspace_sdk_test.go
+++ b/core/schema/workspace_sdk_test.go
@@ -138,7 +138,9 @@ func TestRemoveClientEntryAtPathPreservesSDKMarker(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, removeClientEntryAtPath(cfg, ".", "./lib/client"))
+	owners, err := removeClientEntryAtPath(cfg, ".", "./lib/client")
+	require.NoError(t, err)
+	require.Equal(t, []string{"go"}, owners)
 
 	entry := cfg.Modules["go"]
 	require.NotNil(t, entry.AsSDK)
@@ -161,7 +163,8 @@ func TestRemoveClientEntryAtPathRejectsEscapingEntry(t *testing.T) {
 		},
 	}
 
-	require.ErrorContains(t, removeClientEntryAtPath(cfg, ".", "./lib/client"), "escapes the workspace root")
+	_, err := removeClientEntryAtPath(cfg, ".", "./lib/client")
+	require.ErrorContains(t, err, "escapes the workspace root")
 }
 
 // A client module ref is stored relative to the dagger.toml holding it, and has
@@ -226,7 +229,9 @@ func TestRootAnchoredAsSDKEntryIsMatched(t *testing.T) {
 
 	t.Run("client init replaces the entry at the same path", func(t *testing.T) {
 		c := cfg()
-		require.NoError(t, removeClientEntryAtPath(c, "common", "common/clients/one"))
+		owners, err := removeClientEntryAtPath(c, "common", "common/clients/one")
+		require.NoError(t, err)
+		require.Equal(t, []string{"go-sdk"}, owners)
 		require.Empty(t, c.Modules["go-sdk"].AsSDK.Clients)
 	})
 

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -132,6 +132,12 @@ type Workspace struct {
 	// personal values that must not surface through GraphQL or IDs.
 	userConfigOverlay *workspacepkg.UserWorkspaceOverlay
 
+	// selectedEnv is the dagger.toml environment selected when this workspace
+	// was loaded. It travels with the workspace when the workspace is passed to
+	// an SDK, whose nested client does not inherit the parent client's ambient
+	// workspace selection.
+	selectedEnv string
+
 	Address    string `field:"true" doc:"Canonical Dagger address of the workspace location, or an opaque identity for synthetic workspaces."`
 	Cwd        string
 	ConfigFile string
@@ -510,6 +516,17 @@ func (ws *Workspace) SetUserConfigOverlay(overlay *workspacepkg.UserWorkspaceOve
 	ws.userConfigOverlay = overlay
 }
 
+func (ws *Workspace) SelectedEnv() string {
+	if ws == nil {
+		return ""
+	}
+	return ws.selectedEnv
+}
+
+func (ws *Workspace) SetSelectedEnv(name string) {
+	ws.selectedEnv = name
+}
+
 // MountsDir returns the read-only directory tree holding mounted content,
 // keyed by workspace-root-relative mount path, or false when the workspace has
 // no mounts.
@@ -604,6 +621,7 @@ type persistedWorkspacePayload struct {
 	LockFile        string                        `json:"lockFile,omitempty"`
 	ClientID        string                        `json:"clientID,omitempty"`
 	HostPath        string                        `json:"hostPath,omitempty"`
+	SelectedEnv     string                        `json:"selectedEnv,omitempty"`
 
 	StagedGeneration []string `json:"stagedGeneration,omitempty"`
 
@@ -755,6 +773,7 @@ func (ws *Workspace) EncodePersistedObject(ctx context.Context, cache dagql.Pers
 		LockFile:         ws.LockFile,
 		ClientID:         ws.ClientID,
 		HostPath:         ws.hostPath,
+		SelectedEnv:      ws.selectedEnv,
 		StagedGeneration: ws.StagedGeneration,
 	}
 	if ws.rootfs.Self() != nil {
@@ -842,6 +861,7 @@ func (*Workspace) DecodePersistedObject(
 		LockFile:         lockFile,
 		ClientID:         persisted.ClientID,
 		hostPath:         persisted.HostPath,
+		selectedEnv:      persisted.SelectedEnv,
 		StagedGeneration: persisted.StagedGeneration,
 	}
 	if persisted.Source != nil {

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -113,7 +113,8 @@ type EnvOverlay struct {
 // An overlay may override the [modules.<name>.settings] of a module already
 // installed in the base config, and/or *add* a module that only exists in this
 // environment by giving it a Source (and optional Pin). An overlay that names a
-// module missing from the base config without a Source is an error.
+// module missing from the base config without a Source is an error. AsSDK, when
+// present, replaces the base module's SDK role in this environment.
 type EnvModuleOverlay struct {
 	// Source, when set, installs a module scoped to this environment. It mirrors
 	// [modules.<name>.source]: a workspace-relative path or a canonical ref.
@@ -121,6 +122,11 @@ type EnvModuleOverlay struct {
 	// Pin is the resolved version for Source, mirroring [modules.<name>.pin].
 	Pin      string         `json:"pin,omitempty" toml:"pin,omitempty"`
 	Settings map[string]any `json:"settings,omitempty" toml:"settings,omitempty"`
+	// AsSDK replaces the base SDK role in this environment. A nil value
+	// inherits the base role. This lets environment-scoped authoring commands
+	// change their managed module and client lists without changing the base
+	// workspace configuration.
+	AsSDK *ModuleAsSDK `json:"as-sdk,omitempty" toml:"as-sdk,omitempty"`
 }
 
 // ResolveModuleEntrySource converts a workspace-config module source into the
@@ -252,10 +258,10 @@ func clientOptionsFromTree(tree *toml.Tree) map[string]string {
 // ApplyEnvOverlay returns a copy of cfg with the named environment overlay
 // applied on top of the base module config.
 //
-// Environments may override [modules.<name>.settings] of an installed module
-// and may add modules that only exist in the environment (by providing a
-// source). Naming a module that is neither installed in the base config nor
-// given a source is an error.
+// Environments may override [modules.<name>.settings] and the as-sdk role of an
+// installed module. They may also add modules that only exist in the
+// environment by providing a source. Naming a module that is neither installed
+// in the base config nor given a source is an error.
 func ApplyEnvOverlay(cfg *Config, envName string) (*Config, error) {
 	if cfg == nil {
 		if envName == "" {
@@ -308,6 +314,9 @@ func applyModuleOverlays(applied *Config, overlays map[string]EnvModuleOverlay, 
 		}
 		for key, value := range overlay.Settings {
 			entry.Settings[key] = value
+		}
+		if overlay.AsSDK != nil {
+			entry.AsSDK = cloneModuleAsSDK(overlay.AsSDK)
 		}
 		applied.Modules[moduleName] = entry
 	}
@@ -476,6 +485,7 @@ func cloneConfig(cfg *Config) *Config {
 						Source:   overlay.Source,
 						Pin:      overlay.Pin,
 						Settings: cloneConfigMap(overlay.Settings),
+						AsSDK:    cloneModuleAsSDK(overlay.AsSDK),
 					}
 				}
 			}
@@ -675,6 +685,7 @@ func writeEnvEntries(b *strings.Builder, envs map[string]EnvOverlay) bool {
 			} else {
 				writeConfigTable(b, modulePath+".settings", overlay.Settings, false)
 			}
+			writeModuleAsSDK(b, modulePath, overlay.AsSDK)
 		}
 	}
 
@@ -1292,6 +1303,11 @@ func setConfigValue(cfg *Config, parts []string, value any) error { //nolint:goc
 				module.Settings = map[string]any{}
 			}
 			module.Settings[parts[5]] = value
+		case parts[4] == "as-sdk" && len(parts) == 6 && parts[5] == "name":
+			if module.AsSDK == nil {
+				module.AsSDK = &ModuleAsSDK{}
+			}
+			module.AsSDK.Name = fmt.Sprint(value)
 		default:
 			return fmt.Errorf("unknown config key %q", strings.Join(parts, "."))
 		}

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -55,7 +55,7 @@ func UpdateConfigBytes(existingData []byte, cfg *Config) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err = rewriteModuleAsSDKSections(out, cfg.Modules)
+	out, err = rewriteModuleAsSDKSections(out, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -210,8 +210,9 @@ func configDocumentMap(cfg *Config) map[string]any {
 	// The neontoml ApplyMap path can't express array-of-tables (it would
 	// emit inline arrays of inline tables and leave any pre-existing
 	// [[modules.X.as-sdk.modules]] blocks orphaned). Those sub-blocks are
-	// managed surgically by rewriteModuleAsSDKSections after the rest of
-	// the document is format-preserved.
+	// managed surgically for base and environment modules by
+	// rewriteModuleAsSDKSections after the rest of the document is
+	// format-preserved.
 
 	return values
 }
@@ -374,14 +375,13 @@ func keepEmptyConfigSectionHeaders(cfg *Config) map[string]bool {
 	return keep
 }
 
-// rewriteModuleAsSDKSections drops every existing [[modules.*.as-sdk.*]]
-// array-of-tables block from data and appends a canonical rendering of
-// each module's AsSDK entries. Format preservation inside an as-sdk
-// sub-block is intentionally given up: the block is treated as
-// CLI-managed state, not human-curated configuration. Everything outside
-// the as-sdk sub-blocks (other module fields, settings tables, comments)
+// rewriteModuleAsSDKSections drops every existing base or environment
+// module as-sdk block from data and appends a canonical rendering of the
+// desired blocks. Format preservation inside an as-sdk sub-block is
+// intentionally given up: the block is treated as CLI-managed state, not
+// human-curated configuration. Everything outside the as-sdk sub-blocks
 // passes through unchanged.
-func rewriteModuleAsSDKSections(data []byte, modules map[string]ModuleEntry) ([]byte, error) {
+func rewriteModuleAsSDKSections(data []byte, cfg *Config) ([]byte, error) {
 	doc, err := tomledit.Parse(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("parse config for as-sdk rewrite: %w", err)
@@ -396,25 +396,48 @@ func rewriteModuleAsSDKSections(data []byte, modules map[string]ModuleEntry) ([]
 	}
 	doc.Sections = kept
 
-	names := make([]string, 0, len(modules))
-	for name, entry := range modules {
+	type sdkSection struct {
+		path  string
+		asSDK *ModuleAsSDK
+	}
+	var sections []sdkSection
+	for name, entry := range cfg.Modules {
 		// Preserve the marker even when empty: presence of AsSDK = "this
 		// install is an SDK," whether or not anything is authored yet.
 		if entry.AsSDK != nil {
-			names = append(names, name)
+			sections = append(sections, sdkSection{
+				path:  "modules." + formatConfigPathSegment(name),
+				asSDK: entry.AsSDK,
+			})
 		}
 	}
-	sort.Strings(names)
+	for envName, env := range cfg.Env {
+		for moduleName, overlay := range env.Modules {
+			if overlay.AsSDK == nil {
+				continue
+			}
+			sections = append(sections, sdkSection{
+				path: strings.Join([]string{
+					"env",
+					formatConfigPathSegment(envName),
+					"modules",
+					formatConfigPathSegment(moduleName),
+				}, "."),
+				asSDK: overlay.AsSDK,
+			})
+		}
+	}
+	sort.Slice(sections, func(i, j int) bool { return sections[i].path < sections[j].path })
 
-	for _, name := range names {
+	for _, section := range sections {
 		var rendered strings.Builder
-		writeModuleAsSDK(&rendered, "modules."+formatConfigPathSegment(name), modules[name].AsSDK)
+		writeModuleAsSDK(&rendered, section.path, section.asSDK)
 		if rendered.Len() == 0 {
 			continue
 		}
 		asSDKDoc, parseErr := tomledit.Parse(strings.NewReader(rendered.String()))
 		if parseErr != nil {
-			return nil, fmt.Errorf("parse rendered as-sdk for %q: %w", name, parseErr)
+			return nil, fmt.Errorf("parse rendered as-sdk for %q: %w", section.path, parseErr)
 		}
 		doc.Sections = append(doc.Sections, asSDKDoc.Sections...)
 	}
@@ -427,18 +450,11 @@ func rewriteModuleAsSDKSections(data []byte, modules map[string]ModuleEntry) ([]
 	return buf.Bytes(), nil
 }
 
-// isModuleAsSDKHeading reports whether a section heading targets a module's
-// as-sdk sub-block (e.g. [modules.go-sdk.as-sdk], [[modules.go-sdk.as-sdk.modules]]).
+// isModuleAsSDKHeading reports whether a section heading targets a base or
+// environment module's as-sdk sub-block.
 func isModuleAsSDKHeading(key []string) bool {
-	if len(key) < 3 || key[0] != "modules" {
-		return false
-	}
-	for i := 2; i < len(key); i++ {
-		if key[i] == "as-sdk" {
-			return true
-		}
-	}
-	return false
+	return len(key) >= 3 && key[0] == "modules" && key[2] == "as-sdk" ||
+		len(key) >= 5 && key[0] == "env" && key[2] == "modules" && key[4] == "as-sdk"
 }
 
 func pruneUnwantedEmptySections(data []byte, keepEmptySections map[string]bool) ([]byte, error) {

--- a/core/workspace/config_test.go
+++ b/core/workspace/config_test.go
@@ -530,6 +530,8 @@ func TestWriteConfigValue(t *testing.T) {
 		require.NoError(t, err)
 		data, err = WriteConfigValue(data, "modules.greeter.as-sdk.name", "go")
 		require.NoError(t, err)
+		data, err = WriteConfigValue(data, "env.dev.modules.greeter.as-sdk.name", "go-dev")
+		require.NoError(t, err)
 
 		cfg, err := ParseConfig(data)
 		require.NoError(t, err)
@@ -537,6 +539,7 @@ func TestWriteConfigValue(t *testing.T) {
 		require.Equal(t, []string{"flaky-check"}, cfg.Modules["greeter"].Check.Skip)
 		require.Equal(t, []string{"redis", "infra:database"}, cfg.Modules["greeter"].Up.Skip)
 		require.Equal(t, &ModuleAsSDK{Name: "go"}, cfg.Modules["greeter"].AsSDK)
+		require.Equal(t, &ModuleAsSDK{Name: "go-dev"}, cfg.Env["dev"].Modules["greeter"].AsSDK)
 	})
 
 	t.Run("writes quoted path segments", func(t *testing.T) {
@@ -576,7 +579,7 @@ func TestWriteConfigValue(t *testing.T) {
 		require.EqualError(t, err, "invalid key \"ignore.path\"; ignore does not have sub-keys")
 
 		_, err = WriteConfigValue(nil, "env.ci.modules.greeter.unknown", "value")
-		require.EqualError(t, err, "unknown config key \"env.ci.modules.greeter.unknown\"; valid fields at this level: pin, settings, source")
+		require.EqualError(t, err, "unknown config key \"env.ci.modules.greeter.unknown\"; valid fields at this level: as-sdk, pin, settings, source")
 	})
 
 	t.Run("preserves comments and section layout", func(t *testing.T) {
@@ -913,6 +916,39 @@ func TestApplyEnvOverlay(t *testing.T) {
 			Pin:      "", // pin travels with the source it pinned
 			Settings: map[string]any{"theme": "dark"},
 		}, applied.Modules["editor"])
+	})
+
+	t.Run("env SDK role replaces the base role", func(t *testing.T) {
+		t.Parallel()
+
+		base := &Config{
+			Modules: map[string]ModuleEntry{
+				"go-sdk": {
+					Source: "github.com/dagger/go-sdk",
+					AsSDK: &ModuleAsSDK{
+						Name:    "go",
+						Modules: []SDKManagedModule{{Path: ".dagger/modules/base"}},
+					},
+				},
+			},
+			Env: map[string]EnvOverlay{
+				"dev": {
+					Modules: map[string]EnvModuleOverlay{
+						"go-sdk": {
+							AsSDK: &ModuleAsSDK{
+								Name:    "go",
+								Modules: []SDKManagedModule{{Path: ".dagger/modules/dev"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applied, err := ApplyEnvOverlay(base, "dev")
+		require.NoError(t, err)
+		require.Equal(t, []SDKManagedModule{{Path: ".dagger/modules/dev"}}, applied.Modules["go-sdk"].AsSDK.Modules)
+		require.Equal(t, []SDKManagedModule{{Path: ".dagger/modules/base"}}, base.Modules["go-sdk"].AsSDK.Modules)
 	})
 }
 

--- a/core/workspace/sdks_roundtrip_test.go
+++ b/core/workspace/sdks_roundtrip_test.go
@@ -88,6 +88,60 @@ func TestModuleAsSDKRoundTripFresh(t *testing.T) {
 	}
 }
 
+func TestEnvModuleAsSDKRoundTrip(t *testing.T) {
+	original := []byte(`# keep this comment
+[modules.go-sdk]
+source = "github.com/dagger/go-sdk"
+
+[modules.go-sdk.as-sdk]
+name = "go"
+
+[env.dev]
+`)
+	cfg, err := ParseConfig(original)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	env := cfg.Env["dev"]
+	env.Modules = map[string]EnvModuleOverlay{
+		"go-sdk": {
+			AsSDK: &ModuleAsSDK{
+				Name:    "go",
+				Modules: []SDKManagedModule{{Path: ".dagger/modules/dev"}},
+				Clients: []SDKManagedClient{{Path: "clients/dev", Module: ".dagger/modules/dev"}},
+			},
+		},
+	}
+	cfg.Env["dev"] = env
+
+	updated, err := UpdateConfigBytes(original, cfg)
+	if err != nil {
+		t.Fatalf("UpdateConfigBytes: %v", err)
+	}
+	if !strings.Contains(string(updated), "# keep this comment") {
+		t.Fatalf("comment was not preserved:\n%s", updated)
+	}
+	for _, want := range []string{
+		"[[env.dev.modules.go-sdk.as-sdk.modules]]",
+		"[[env.dev.modules.go-sdk.as-sdk.clients]]",
+		`path = ".dagger/modules/dev"`,
+		`path = "clients/dev"`,
+	} {
+		if !strings.Contains(string(updated), want) {
+			t.Errorf("missing %q in updated config:\n%s", want, updated)
+		}
+	}
+
+	parsed, err := ParseConfig(updated)
+	if err != nil {
+		t.Fatalf("ParseConfig(updated): %v", err)
+	}
+	role := parsed.Env["dev"].Modules["go-sdk"].AsSDK
+	if role == nil || len(role.Modules) != 1 || len(role.Clients) != 1 {
+		t.Fatalf("environment SDK role did not round-trip: %#v", role)
+	}
+}
+
 // TestModuleAsSDKPreservesCommentsOutside verifies that comments and
 // formatting in non-as-sdk regions survive a write that touches as-sdk.
 func TestModuleAsSDKPreservesCommentsOutside(t *testing.T) {

--- a/core/workspace/userconfig.go
+++ b/core/workspace/userconfig.go
@@ -63,14 +63,14 @@ func (c *UserConfig) MatchWorkspaceOverlay(workspaceKey string) *UserWorkspaceOv
 // merged over it.
 //
 // Module overlays follow the same value semantics as environment overlays:
-// settings shadow the base values key by key, and a source (with its pin) adds
-// or replaces a module. Unlike environment overlays, an entry naming a module
-// that is neither installed nor given a source is skipped rather than an
-// error: the same workspace key spans every checkout and branch of a repo, so
-// an always-on user entry must not break checkouts where the module does not
-// exist. Environments are added to the config's env set; a user env that
-// shares a name with a repository env is merged over it with user values
-// winning.
+// settings shadow the base values key by key, a source (with its pin) adds or
+// replaces a module, and an as-sdk value replaces the base SDK role. Unlike
+// environment overlays, an entry naming a module that is neither installed nor
+// given a source is skipped rather than an error: the same workspace key spans
+// every checkout and branch of a repo, so an always-on user entry must not
+// break checkouts where the module does not exist. Environments are added to
+// the config's env set; a user env that shares a name with a repository env is
+// merged over it with user values winning.
 func ApplyUserOverlay(cfg *Config, overlay *UserWorkspaceOverlay) (*Config, error) {
 	if cfg == nil || overlay == nil {
 		return cfg, nil
@@ -112,6 +112,7 @@ func mergeEnvOverlay(base, over EnvOverlay) EnvOverlay {
 			Source:   overlay.Source,
 			Pin:      overlay.Pin,
 			Settings: cloneConfigMap(overlay.Settings),
+			AsSDK:    cloneModuleAsSDK(overlay.AsSDK),
 		}
 	}
 	for name, overlay := range over.Modules {
@@ -129,6 +130,9 @@ func mergeEnvOverlay(base, over EnvOverlay) EnvOverlay {
 			for key, value := range overlay.Settings {
 				entry.Settings[key] = value
 			}
+		}
+		if overlay.AsSDK != nil {
+			entry.AsSDK = cloneModuleAsSDK(overlay.AsSDK)
 		}
 		merged.Modules[name] = entry
 	}

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -19,7 +19,7 @@ dagger [options] [subcommand | file...]
   -c, --command string       Execute a dagger shell command
   -d, --debug                Enable engine and trace diagnostics
       --eager-runtime        load module runtime eagerly
-      --engine string        Use the specified engine (cloud or a runner host URI)
+      --engine string        Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string           Apply a named env overlay; writes target it, creating it if missing
   -m, --load-module string   Use a one-off module (local path or git ref)
       --model string         LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
@@ -117,7 +117,7 @@ dagger agent [options] [name...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -186,7 +186,7 @@ dagger api call [options] [function]...
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -269,7 +269,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -298,7 +298,7 @@ dagger api client list
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -344,7 +344,7 @@ dagger api functions [options] [function]...
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -406,7 +406,7 @@ EOF
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -467,7 +467,7 @@ dagger api with-session python main.py
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -520,7 +520,7 @@ dagger check [options] [pattern...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1045,6 +1045,77 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 
 * [dagger cloud](#dagger-cloud)	 - Manage Dagger Cloud
 
+## dagger engine
+
+How to select the engine that runs your workflows
+
+### Synopsis
+
+Dagger runs your workflows on an engine. Use --engine to select one.
+
+VALUES
+
+  Dagger Cloud:
+    cloud
+
+  Start from an OCI image:
+    image://IMAGE
+    image+docker://IMAGE
+    image+apple://IMAGE
+    image+podman://IMAGE
+    image+finch://IMAGE
+    image+nerdctl://IMAGE
+
+  Use a running engine container:
+    container://NAME
+    container+docker://NAME
+    container+apple://NAME
+    container+podman://NAME
+    container+finch://NAME
+    container+nerdctl://NAME
+
+  Connect directly:
+    tcp://HOST:PORT (no authentication)
+    tls://HOST[:PORT]
+    ssh://[USER@]HOST[:PORT]
+    kube-pod://POD
+    unix://PATH
+
+  Legacy Docker schemes:
+    docker-image://IMAGE
+    docker-container://NAME
+
+PRIORITY
+
+  The CLI uses the first of these that is set:
+
+    1. --engine
+    2. DAGGER_CLOUD_ENGINE (any value selects Dagger Cloud)
+    3. _EXPERIMENTAL_DAGGER_RUNNER_HOST
+    4. The engine that this CLI version ships with
+
+EXAMPLES
+
+  Run on Dagger Cloud:
+    dagger call --engine=cloud build
+
+  Run on an engine container that is already running:
+    dagger call --engine=container://dagger-engine build
+
+  Run on a remote host over SSH:
+    dagger call --engine=ssh://user@host build
+
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - A tool to run composable workflows in containers
+
 ## dagger generate
 
 Generate derived files for your project — code, SDKs, types, docs, etc.
@@ -1078,7 +1149,7 @@ dagger generate [options] [pattern...]
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1129,7 +1200,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1152,7 +1223,7 @@ dagger installed
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1385,7 +1456,7 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1408,7 +1479,7 @@ dagger module deps list [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1437,7 +1508,7 @@ dagger module deps rm wolfi
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1472,7 +1543,7 @@ dagger module deps update wolfi@v0.20.2
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1519,7 +1590,7 @@ dagger module engine require v0.21.0
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1542,7 +1613,7 @@ dagger module engine require-current [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1565,7 +1636,7 @@ dagger module engine require-latest [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1588,7 +1659,7 @@ dagger module engine required [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1654,7 +1725,7 @@ dagger sdk install go && dagger module init go my-module
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1692,7 +1763,7 @@ dagger module sdk <subcommand> [args...] [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1769,7 +1840,7 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1856,7 +1927,7 @@ dagger sdk uninstall [options] <name> [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1916,7 +1987,7 @@ dagger settings [module] [key] [value...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1971,7 +2042,7 @@ dagger setup
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2009,7 +2080,7 @@ dagger terminal [options] [pattern]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -2055,7 +2126,7 @@ dagger uninstall hello
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2094,7 +2165,7 @@ dagger up [options] [pattern...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -2134,7 +2205,7 @@ dagger update
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2196,7 +2267,7 @@ dagger workspace
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2247,7 +2318,7 @@ dagger workspace config [key] [value] [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2270,7 +2341,7 @@ dagger workspace config-file [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2292,7 +2363,7 @@ dagger workspace cwd [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2333,7 +2404,7 @@ dagger workspace remotes [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2355,7 +2426,7 @@ dagger workspace root [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Use the specified engine (cloud or a runner host URI)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -168,7 +168,6 @@ See https://docs.dagger.io/api for the full overview.
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -244,7 +243,6 @@ module that generates it.
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -594,7 +592,6 @@ Manage Dagger Cloud
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -633,7 +630,6 @@ dagger cloud billing
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -667,7 +663,6 @@ dagger cloud billing manage [org]
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -693,7 +688,6 @@ dagger cloud billing plans
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -859,7 +853,6 @@ dagger cloud integration
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -900,7 +893,6 @@ dagger cloud integration create github
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -926,7 +918,6 @@ dagger cloud integration list [type]
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -952,7 +943,6 @@ dagger cloud integration rm <id>
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -983,7 +973,6 @@ dagger cloud login [options] [org]
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1008,7 +997,6 @@ dagger cloud logout
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1057,7 +1045,6 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1088,7 +1075,6 @@ dagger cloud org [flags]
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1117,7 +1103,6 @@ dagger cloud org info [org] [flags]
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1143,7 +1128,6 @@ dagger cloud org list [flags]
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1169,7 +1153,6 @@ dagger cloud org use <org> [flags]
       --json                         Print JSON output
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1374,7 +1357,6 @@ Manage LLM provider configuration, API keys, and default models.
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1417,7 +1399,6 @@ dagger llm add-key <provider>
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1442,7 +1423,6 @@ dagger llm config
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1467,7 +1447,6 @@ dagger llm remove-key <provider>
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1492,7 +1471,6 @@ dagger llm reset
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1517,7 +1495,6 @@ dagger llm set-default <provider> [model]
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1542,7 +1519,6 @@ dagger llm setup
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1567,7 +1543,6 @@ dagger llm show-config
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1594,7 +1569,6 @@ Operates on the dagger-module.toml reachable from the current directory.
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1619,7 +1593,6 @@ Manage this module's dependencies
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -1772,7 +1745,6 @@ Manage this module's required engine version
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -2026,7 +1998,6 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -2077,7 +2048,6 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2108,11 +2078,11 @@ dagger sdk installed [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
+      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -2144,7 +2114,6 @@ dagger sdk search [query] [flags]
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -2181,7 +2150,6 @@ dagger sdk uninstall [options] <name> [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2223,7 +2191,6 @@ dagger search wolfi
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -2309,7 +2276,6 @@ dagger setup
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2522,7 +2488,6 @@ dagger version
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
 
@@ -2637,7 +2602,6 @@ dagger workspace config-file [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2663,7 +2627,6 @@ dagger workspace cwd [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2714,7 +2677,6 @@ dagger workspace remotes [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2740,7 +2702,6 @@ dagger workspace root [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -24,7 +24,6 @@ dagger [options] [subcommand | file...]
       --model string         LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
   -E, --no-exit              Leave the TUI running after completion
   -M, --no-load-module       Don't load any module for this command
-      --org string           Dagger Cloud org name for Cloud-scoped commands
       --progress string      Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count          Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error       Open a shell when a container exec fails
@@ -32,7 +31,6 @@ dagger [options] [subcommand | file...]
   -v, --verbose count        Increase verbosity (use -vv or -vvv for more)
   -w, --web                  Open trace URL in a web browser
   -W, --workspace string     Select the workspace location to load from (local path or git ref)
-      --x-release string     Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -75,10 +73,8 @@ dagger activity
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -122,7 +118,6 @@ dagger agent [options] [name...]
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -130,7 +125,6 @@ dagger agent [options] [name...]
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -154,9 +148,7 @@ See https://docs.dagger.io/api for the full overview.
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -194,7 +186,6 @@ dagger api call [options] [function]...
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -202,7 +193,6 @@ dagger api call [options] [function]...
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -224,9 +214,7 @@ module that generates it.
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -279,11 +267,9 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -309,11 +295,9 @@ dagger api client list
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -356,11 +340,9 @@ dagger api functions [options] [function]...
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -420,7 +402,6 @@ EOF
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -428,7 +409,6 @@ EOF
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -482,7 +462,6 @@ dagger api with-session python main.py
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -490,7 +469,6 @@ dagger api with-session python main.py
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -536,7 +514,6 @@ dagger check [options] [pattern...]
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -544,7 +521,6 @@ dagger check [options] [pattern...]
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -558,9 +534,7 @@ Manage Dagger Cloud
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -592,9 +566,7 @@ dagger cloud billing
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -620,10 +592,8 @@ dagger cloud billing manage [org]
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -641,10 +611,8 @@ dagger cloud billing plans
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -662,10 +630,8 @@ dagger cloud check
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -693,10 +659,8 @@ dagger cloud check list [version]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -714,10 +678,8 @@ dagger cloud check off [name]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -735,10 +697,8 @@ dagger cloud check on [name]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -756,10 +716,8 @@ dagger cloud check status [name]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -783,9 +741,7 @@ dagger cloud integration
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -818,10 +774,8 @@ dagger cloud integration create github
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -839,10 +793,8 @@ dagger cloud integration list [type]
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -860,10 +812,8 @@ dagger cloud integration rm <id>
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -887,9 +837,7 @@ dagger cloud login [options] [org]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -907,9 +855,7 @@ dagger cloud logout
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -951,9 +897,7 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -977,9 +921,7 @@ dagger cloud org [flags]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1000,10 +942,8 @@ dagger cloud org info [org] [flags]
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1021,10 +961,8 @@ dagger cloud org list [flags]
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1042,10 +980,8 @@ dagger cloud org use <org> [flags]
 ### Options inherited from parent commands
 
 ```
-      --json               Print JSON output
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --json            Print JSON output
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1092,10 +1028,8 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1137,7 +1071,6 @@ dagger generate [options] [pattern...]
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -1145,7 +1078,6 @@ dagger generate [options] [pattern...]
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1188,11 +1120,9 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1212,11 +1142,9 @@ dagger installed
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1234,9 +1162,7 @@ Manage LLM provider configuration, API keys, and default models.
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1272,9 +1198,7 @@ dagger llm add-key <provider>
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1292,9 +1216,7 @@ dagger llm config
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1312,9 +1234,7 @@ dagger llm remove-key <provider>
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1332,9 +1252,7 @@ dagger llm reset
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1352,9 +1270,7 @@ dagger llm set-default <provider> [model]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1372,9 +1288,7 @@ dagger llm setup
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1392,9 +1306,7 @@ dagger llm show-config
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1414,9 +1326,7 @@ Operates on the dagger-module.toml reachable from the current directory.
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1434,9 +1344,7 @@ Manage this module's dependencies
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1466,11 +1374,9 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1490,11 +1396,9 @@ dagger module deps list [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1520,11 +1424,9 @@ dagger module deps rm wolfi
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1556,11 +1458,9 @@ dagger module deps update wolfi@v0.20.2
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1574,9 +1474,7 @@ Manage this module's required engine version
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1606,11 +1504,9 @@ dagger module engine require v0.21.0
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1630,11 +1526,9 @@ dagger module engine require-current [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1654,11 +1548,9 @@ dagger module engine require-latest [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1678,11 +1570,9 @@ dagger module engine required [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1745,11 +1635,9 @@ dagger sdk install go && dagger module init go my-module
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1785,7 +1673,6 @@ dagger module sdk <subcommand> [args...] [flags]
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -1793,7 +1680,6 @@ dagger module sdk <subcommand> [args...] [flags]
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1812,9 +1698,7 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1863,11 +1747,9 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1890,10 +1772,8 @@ dagger sdk installed [flags]
 ### Options inherited from parent commands
 
 ```
-      --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+      --env string      Apply a named env overlay; writes target it, creating it if missing
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1918,9 +1798,7 @@ dagger sdk search [query] [flags]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -1955,11 +1833,9 @@ dagger sdk uninstall [options] <name> [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1989,9 +1865,7 @@ dagger search wolfi
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -2019,11 +1893,9 @@ dagger settings [module] [key] [value...]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2074,11 +1946,9 @@ dagger setup
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2115,7 +1985,6 @@ dagger terminal [options] [pattern]
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -2123,7 +1992,6 @@ dagger terminal [options] [pattern]
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2161,11 +2029,9 @@ dagger uninstall hello
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2202,7 +2068,6 @@ dagger up [options] [pattern...]
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
-      --org string         Dagger Cloud org name for Cloud-scoped commands
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
   -i, --shell-on-error     Open a shell when a container exec fails
@@ -2210,7 +2075,6 @@ dagger up [options] [pattern...]
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2242,11 +2106,9 @@ dagger update
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2271,9 +2133,7 @@ dagger version
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
-      --x-release string   Run an experimental release from a Dagger git ref
+  -v, --verbose count   Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -2307,11 +2167,9 @@ dagger workspace
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2359,11 +2217,9 @@ dagger workspace config [key] [value] [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --env string         Apply a named env overlay; writes target it, creating it if missing
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2382,11 +2238,9 @@ dagger workspace config-file [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2405,11 +2259,9 @@ dagger workspace cwd [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2427,10 +2279,8 @@ dagger workspace remote [flags]
 ### Options inherited from parent commands
 
 ```
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2449,11 +2299,9 @@ dagger workspace remotes [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2472,11 +2320,9 @@ dagger workspace root [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --org string         Dagger Cloud org name for Cloud-scoped commands
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
-      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -1075,9 +1075,15 @@ PRIORITY
   The CLI uses the first of these that is set:
 
     1. --engine
-    2. DAGGER_CLOUD_ENGINE (any value selects Dagger Cloud)
-    3. _EXPERIMENTAL_DAGGER_RUNNER_HOST
+    2. DAGGER_CLOUD_ENGINE (deprecated; any value selects Dagger Cloud)
+    3. _EXPERIMENTAL_DAGGER_RUNNER_HOST (deprecated)
     4. The engine that this CLI version ships with
+
+  The two environment variables are soft-deprecated, like the --cloud flag.
+  They still work as a fallback, but --engine replaces them:
+
+    --engine=cloud  instead of DAGGER_CLOUD_ENGINE
+    --engine=URI    instead of _EXPERIMENTAL_DAGGER_RUNNER_HOST
 
 EXAMPLES
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -102,7 +102,7 @@ dagger agent [options] [name...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -171,7 +171,7 @@ dagger api call [options] [function]...
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -254,7 +254,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -283,7 +283,7 @@ dagger api client list
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -329,7 +329,7 @@ dagger api functions [options] [function]...
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -391,7 +391,7 @@ EOF
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -452,7 +452,7 @@ dagger api with-session python main.py
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -505,7 +505,7 @@ dagger check [options] [pattern...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1075,12 +1075,14 @@ PRIORITY
   The CLI uses the first of these that is set:
 
     1. --engine
-    2. DAGGER_CLOUD_ENGINE (deprecated; any value selects Dagger Cloud)
-    3. _EXPERIMENTAL_DAGGER_RUNNER_HOST (deprecated)
-    4. The engine that this CLI version ships with
+    2. --cloud (deprecated; the same as --engine=cloud)
+    3. DAGGER_ENGINE (takes the same values as --engine)
+    4. DAGGER_CLOUD_ENGINE (deprecated; any value selects Dagger Cloud)
+    5. _EXPERIMENTAL_DAGGER_RUNNER_HOST (deprecated)
+    6. The engine that this CLI version ships with
 
-  The two environment variables are soft-deprecated, like the --cloud flag.
-  They still work as a fallback, but --engine replaces them:
+  The two deprecated variables still work as a fallback, in the same way as
+  the deprecated --cloud flag. --engine and DAGGER_ENGINE replace them:
 
     --engine=cloud  instead of DAGGER_CLOUD_ENGINE
     --engine=URI    instead of _EXPERIMENTAL_DAGGER_RUNNER_HOST
@@ -1095,6 +1097,9 @@ EXAMPLES
 
   Run on a remote host over SSH:
     dagger call --engine=ssh://user@host build
+
+  Select an engine for every command in a shell session:
+    export DAGGER_ENGINE=cloud
 
 
 ### Options inherited from parent commands
@@ -1140,7 +1145,7 @@ dagger generate [options] [pattern...]
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1191,7 +1196,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1214,7 +1219,7 @@ dagger installed
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1447,7 +1452,7 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1470,7 +1475,7 @@ dagger module deps list [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1499,7 +1504,7 @@ dagger module deps rm wolfi
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1534,7 +1539,7 @@ dagger module deps update wolfi@v0.20.2
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1581,7 +1586,7 @@ dagger module engine require v0.21.0
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1604,7 +1609,7 @@ dagger module engine require-current [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1627,7 +1632,7 @@ dagger module engine require-latest [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1650,7 +1655,7 @@ dagger module engine required [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1716,7 +1721,7 @@ dagger sdk install go && dagger module init go my-module
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1754,7 +1759,7 @@ dagger module sdk <subcommand> [args...] [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1831,7 +1836,7 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1918,7 +1923,7 @@ dagger sdk uninstall [options] <name> [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1978,7 +1983,7 @@ dagger settings [module] [key] [value...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2033,7 +2038,7 @@ dagger setup
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2071,7 +2076,7 @@ dagger terminal [options] [pattern]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -2117,7 +2122,7 @@ dagger uninstall hello
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2156,7 +2161,7 @@ dagger up [options] [pattern...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -2196,7 +2201,7 @@ dagger update
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2258,7 +2263,7 @@ dagger workspace
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2309,7 +2314,7 @@ dagger workspace config [key] [value] [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2332,7 +2337,7 @@ dagger workspace config-file [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2354,7 +2359,7 @@ dagger workspace cwd [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2395,7 +2400,7 @@ dagger workspace remotes [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2417,7 +2422,7 @@ dagger workspace root [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
-      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -79,7 +79,6 @@ dagger activity
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -165,7 +164,6 @@ See https://docs.dagger.io/api for the full overview.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -242,7 +240,6 @@ module that generates it.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -593,7 +590,6 @@ Manage Dagger Cloud
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -633,7 +629,6 @@ dagger cloud billing
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -667,7 +662,6 @@ dagger cloud billing manage [org]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -694,7 +688,6 @@ dagger cloud billing plans
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -721,7 +714,6 @@ dagger cloud check
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -757,7 +749,6 @@ dagger cloud check list [version]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -783,7 +774,6 @@ dagger cloud check off [name]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -809,7 +799,6 @@ dagger cloud check on [name]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -835,7 +824,6 @@ dagger cloud check status [name]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -867,7 +855,6 @@ dagger cloud integration
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -908,7 +895,6 @@ dagger cloud integration create github
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -935,7 +921,6 @@ dagger cloud integration list [type]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -962,7 +947,6 @@ dagger cloud integration rm <id>
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -995,7 +979,6 @@ dagger cloud login [options] [org]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1021,7 +1004,6 @@ dagger cloud logout
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1071,7 +1053,6 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1103,7 +1084,6 @@ dagger cloud org [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1132,7 +1112,6 @@ dagger cloud org info [org] [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1159,7 +1138,6 @@ dagger cloud org list [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1186,7 +1164,6 @@ dagger cloud org use <org> [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1242,7 +1219,6 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1394,7 +1370,6 @@ Manage LLM provider configuration, API keys, and default models.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1438,7 +1413,6 @@ dagger llm add-key <provider>
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1464,7 +1438,6 @@ dagger llm config
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1490,7 +1463,6 @@ dagger llm remove-key <provider>
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1516,7 +1488,6 @@ dagger llm reset
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1542,7 +1513,6 @@ dagger llm set-default <provider> [model]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1568,7 +1538,6 @@ dagger llm setup
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1594,7 +1563,6 @@ dagger llm show-config
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1622,7 +1590,6 @@ Operates on the dagger-module.toml reachable from the current directory.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1648,7 +1615,6 @@ Manage this module's dependencies
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1802,7 +1768,6 @@ Manage this module's required engine version
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2057,7 +2022,6 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2144,7 +2108,6 @@ dagger sdk installed [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2177,7 +2140,6 @@ dagger sdk search [query] [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2257,7 +2219,6 @@ dagger search wolfi
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2557,7 +2518,6 @@ dagger version
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2729,7 +2689,6 @@ dagger workspace remote [flags]
 ```
   -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -19,6 +19,7 @@ dagger [options] [subcommand | file...]
   -c, --command string       Execute a dagger shell command
   -d, --debug                Enable engine and trace diagnostics
       --eager-runtime        load module runtime eagerly
+      --engine string        Use the specified engine (cloud or a runner host URI)
       --env string           Apply a named env overlay; writes target it, creating it if missing
   -m, --load-module string   Use a one-off module (local path or git ref)
       --model string         LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
@@ -116,6 +117,7 @@ dagger agent [options] [name...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -184,6 +186,7 @@ dagger api call [options] [function]...
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -266,6 +269,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -294,6 +298,7 @@ dagger api client list
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -339,6 +344,7 @@ dagger api functions [options] [function]...
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -400,6 +406,7 @@ EOF
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -460,6 +467,7 @@ dagger api with-session python main.py
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -512,6 +520,7 @@ dagger check [options] [pattern...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1069,6 +1078,7 @@ dagger generate [options] [pattern...]
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1119,6 +1129,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1141,6 +1152,7 @@ dagger installed
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1373,6 +1385,7 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1395,6 +1408,7 @@ dagger module deps list [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1423,6 +1437,7 @@ dagger module deps rm wolfi
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1457,6 +1472,7 @@ dagger module deps update wolfi@v0.20.2
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1503,6 +1519,7 @@ dagger module engine require v0.21.0
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1525,6 +1542,7 @@ dagger module engine require-current [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1547,6 +1565,7 @@ dagger module engine require-latest [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1569,6 +1588,7 @@ dagger module engine required [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1634,6 +1654,7 @@ dagger sdk install go && dagger module init go my-module
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1671,6 +1692,7 @@ dagger module sdk <subcommand> [args...] [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -1747,6 +1769,7 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1833,6 +1856,7 @@ dagger sdk uninstall [options] <name> [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1892,6 +1916,7 @@ dagger settings [module] [key] [value...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -1946,6 +1971,7 @@ dagger setup
 ```
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -1983,6 +2009,7 @@ dagger terminal [options] [pattern]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -2028,6 +2055,7 @@ dagger uninstall hello
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2066,6 +2094,7 @@ dagger up [options] [pattern...]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
@@ -2105,6 +2134,7 @@ dagger update
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2166,6 +2196,7 @@ dagger workspace
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2216,6 +2247,7 @@ dagger workspace config [key] [value] [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
       --env string         Apply a named env overlay; writes target it, creating it if missing
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
@@ -2238,6 +2270,7 @@ dagger workspace config-file [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2259,6 +2292,7 @@ dagger workspace cwd [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2299,6 +2333,7 @@ dagger workspace remotes [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
@@ -2320,6 +2355,7 @@ dagger workspace root [flags]
 
 ```
   -d, --debug              Enable engine and trace diagnostics
+      --engine string      Use the specified engine (cloud or a runner host URI)
   -i, --shell-on-error     Open a shell when a container exec fails
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -107,7 +107,7 @@ dagger agent [options] [name...]
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -176,7 +176,7 @@ dagger api call [options] [function]...
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -256,7 +256,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -285,7 +285,7 @@ dagger api client list
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -331,7 +331,7 @@ dagger api functions [options] [function]...
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -396,7 +396,7 @@ EOF
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -457,7 +457,7 @@ dagger api with-session python main.py
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -510,7 +510,7 @@ dagger check [options] [pattern...]
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -1150,7 +1150,7 @@ dagger generate [options] [pattern...]
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -1198,7 +1198,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1221,7 +1221,7 @@ dagger installed
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1454,7 +1454,7 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1477,7 +1477,7 @@ dagger module deps list [flags]
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1506,7 +1506,7 @@ dagger module deps rm wolfi
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1541,7 +1541,7 @@ dagger module deps update wolfi@v0.20.2
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1588,7 +1588,7 @@ dagger module engine require v0.21.0
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1611,7 +1611,7 @@ dagger module engine require-current [flags]
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1634,7 +1634,7 @@ dagger module engine require-latest [flags]
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1657,7 +1657,7 @@ dagger module engine required [flags]
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1723,7 +1723,7 @@ dagger sdk install go && dagger module init go my-module
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1764,7 +1764,7 @@ dagger module sdk <subcommand> [args...] [flags]
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -1837,7 +1837,7 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 ```
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1924,7 +1924,7 @@ dagger sdk uninstall [options] <name> [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -1985,7 +1985,7 @@ dagger settings [module] [key] [value...]
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2039,7 +2039,7 @@ dagger setup
   -y, --auto-apply         Automatically apply changes when an output is returned
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2081,7 +2081,7 @@ dagger terminal [options] [pattern]
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -2124,7 +2124,7 @@ dagger uninstall hello
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2166,7 +2166,7 @@ dagger up [options] [pattern...]
   -E, --no-exit            Leave the TUI running after completion
       --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -s, --silent             Do not show progress at all
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -w, --web                Open trace URL in a web browser
@@ -2203,7 +2203,7 @@ dagger update
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2265,7 +2265,7 @@ dagger workspace
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2316,7 +2316,7 @@ dagger workspace config [key] [value] [flags]
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
       --env string         Apply a named env overlay; writes target it, creating it if missing
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2338,7 +2338,7 @@ dagger workspace config-file [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2360,7 +2360,7 @@ dagger workspace cwd [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2401,7 +2401,7 @@ dagger workspace remotes [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```
@@ -2423,7 +2423,7 @@ dagger workspace root [flags]
 ```
   -d, --debug              Enable engine and trace diagnostics
       --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
-  -i, --shell-on-error     Open a shell when a container exec fails
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
   -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
   -W, --workspace string   Select the workspace location to load from (local path or git ref)
 ```

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -15,25 +15,24 @@ dagger [options] [subcommand | file...]
 ### Options
 
 ```
-      --allow-llm strings            List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-  -c, --command string               Execute a dagger shell command
-  -d, --debug                        Enable engine and trace diagnostics
-      --eager-runtime                load module runtime eagerly
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -m, --load-module string           Use a one-off module (local path or git ref)
-      --model string                 LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
-  -E, --no-exit                      Leave the TUI running after completion
-  -M, --no-load-module               Don't load any module for this command
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
+  -c, --command string       Execute a dagger shell command
+  -d, --debug                Enable engine and trace diagnostics
+      --eager-runtime        load module runtime eagerly
+      --env string           Apply a named env overlay; writes target it, creating it if missing
+  -m, --load-module string   Use a one-off module (local path or git ref)
+      --model string         LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
+  -E, --no-exit              Leave the TUI running after completion
+  -M, --no-load-module       Don't load any module for this command
+      --org string           Dagger Cloud org name for Cloud-scoped commands
+      --progress string      Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count          Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error       Open a shell when a container exec fails
+  -s, --silent               Do not show progress at all
+  -v, --verbose count        Increase verbosity (use -vv or -vvv for more)
+  -w, --web                  Open trace URL in a web browser
+  -W, --workspace string     Select the workspace location to load from (local path or git ref)
+      --x-release string     Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -76,12 +75,10 @@ dagger activity
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -122,19 +119,18 @@ dagger agent [options] [name...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -158,11 +154,9 @@ See https://docs.dagger.io/api for the full overview.
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -196,20 +190,19 @@ dagger api call [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -y, --auto-apply         Automatically apply changes when an output is returned
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -231,11 +224,9 @@ module that generates it.
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -285,15 +276,14 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -y, --auto-apply         Automatically apply changes when an output is returned
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -317,14 +307,13 @@ dagger api client list
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -365,14 +354,13 @@ dagger api functions [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -429,19 +417,18 @@ EOF
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -492,19 +479,18 @@ dagger api with-session python main.py
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -547,19 +533,18 @@ dagger check [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -573,11 +558,9 @@ Manage Dagger Cloud
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -609,11 +592,9 @@ dagger cloud billing
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -639,12 +620,10 @@ dagger cloud billing manage [org]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -662,12 +641,10 @@ dagger cloud billing plans
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -685,12 +662,10 @@ dagger cloud check
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -718,12 +693,10 @@ dagger cloud check list [version]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -741,12 +714,10 @@ dagger cloud check off [name]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -764,12 +735,10 @@ dagger cloud check on [name]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -787,12 +756,10 @@ dagger cloud check status [name]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -816,11 +783,9 @@ dagger cloud integration
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -853,12 +818,10 @@ dagger cloud integration create github
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -876,12 +839,10 @@ dagger cloud integration list [type]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -899,12 +860,10 @@ dagger cloud integration rm <id>
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -928,11 +887,9 @@ dagger cloud login [options] [org]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -950,11 +907,9 @@ dagger cloud logout
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -996,11 +951,9 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1024,11 +977,9 @@ dagger cloud org [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1049,12 +1000,10 @@ dagger cloud org info [org] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1072,12 +1021,10 @@ dagger cloud org list [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1095,12 +1042,10 @@ dagger cloud org use <org> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --json                         Print JSON output
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --json               Print JSON output
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1147,12 +1092,10 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1190,20 +1133,19 @@ dagger generate [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -y, --auto-apply         Automatically apply changes when an output is returned
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1244,14 +1186,13 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1269,14 +1210,13 @@ dagger installed
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1294,11 +1234,9 @@ Manage LLM provider configuration, API keys, and default models.
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1334,11 +1272,9 @@ dagger llm add-key <provider>
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1356,11 +1292,9 @@ dagger llm config
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1378,11 +1312,9 @@ dagger llm remove-key <provider>
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1400,11 +1332,9 @@ dagger llm reset
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1422,11 +1352,9 @@ dagger llm set-default <provider> [model]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1444,11 +1372,9 @@ dagger llm setup
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1466,11 +1392,9 @@ dagger llm show-config
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1490,11 +1414,9 @@ Operates on the dagger-module.toml reachable from the current directory.
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1512,11 +1434,9 @@ Manage this module's dependencies
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1544,14 +1464,13 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1569,14 +1488,13 @@ dagger module deps list [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1600,14 +1518,13 @@ dagger module deps rm wolfi
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1637,14 +1554,13 @@ dagger module deps update wolfi@v0.20.2
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1658,11 +1574,9 @@ Manage this module's required engine version
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1690,14 +1604,13 @@ dagger module engine require v0.21.0
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1715,14 +1628,13 @@ dagger module engine require-current [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1740,14 +1652,13 @@ dagger module engine require-latest [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1765,14 +1676,13 @@ dagger module engine required [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1832,15 +1742,14 @@ dagger sdk install go && dagger module init go my-module
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -y, --auto-apply         Automatically apply changes when an output is returned
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1873,19 +1782,18 @@ dagger module sdk <subcommand> [args...] [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1904,11 +1812,9 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1956,13 +1862,12 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -1985,12 +1890,10 @@ dagger sdk installed [flags]
 ### Options inherited from parent commands
 
 ```
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2015,11 +1918,9 @@ dagger sdk search [query] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2053,13 +1954,12 @@ dagger sdk uninstall [options] <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2089,11 +1989,9 @@ dagger search wolfi
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2119,14 +2017,13 @@ dagger settings [module] [key] [value...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2175,14 +2072,13 @@ dagger setup
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -y, --auto-apply         Automatically apply changes when an output is returned
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2216,19 +2112,18 @@ dagger terminal [options] [pattern]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2264,14 +2159,13 @@ dagger uninstall hello
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2305,19 +2199,18 @@ dagger up [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+  -E, --no-exit            Leave the TUI running after completion
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+      --progress string    Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
+  -q, --quiet count        Reduce verbosity (show progress, but clean up at the end)
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -s, --silent             Do not show progress at all
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -w, --web                Open trace URL in a web browser
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2347,14 +2240,13 @@ dagger update
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2379,11 +2271,9 @@ dagger version
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2415,14 +2305,13 @@ dagger workspace
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2468,14 +2357,13 @@ dagger workspace config [key] [value] [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-      --env string                   Apply a named env overlay; writes target it, creating it if missing
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --env string         Apply a named env overlay; writes target it, creating it if missing
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2493,13 +2381,12 @@ dagger workspace config-file [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2517,13 +2404,12 @@ dagger workspace cwd [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2541,12 +2427,10 @@ dagger workspace remote [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2564,13 +2448,12 @@ dagger workspace remotes [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO
@@ -2588,13 +2471,12 @@ dagger workspace root [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Enable engine and trace diagnostics
-  -i, --interactive                  Spawn a terminal on container exec failure
-      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-      --org string                   Dagger Cloud org name for Cloud-scoped commands
-  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -W, --workspace string             Select the workspace location to load from (local path or git ref)
-      --x-release string             Run an experimental release from a Dagger git ref
+  -d, --debug              Enable engine and trace diagnostics
+      --org string         Dagger Cloud org name for Cloud-scoped commands
+  -i, --shell-on-error     Open a shell when a container exec fails
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+      --x-release string   Run an experimental release from a Dagger git ref
 ```
 
 ### SEE ALSO

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -19,7 +19,6 @@ dagger [options] [subcommand | file...]
   -c, --command string       Execute a dagger shell command
   -d, --debug                Enable engine and trace diagnostics
       --eager-runtime        load module runtime eagerly
-      --engine string        Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (run 'dagger help engine' for details)
       --env string           Apply a named env overlay; writes target it, creating it if missing
   -m, --load-module string   Use a one-off module (local path or git ref)
       --model string         LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
@@ -27,7 +26,6 @@ dagger [options] [subcommand | file...]
   -M, --no-load-module       Don't load any module for this command
       --progress string      Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
   -q, --quiet count          Reduce verbosity (show progress, but clean up at the end)
-  -i, --shell-on-error       Open a shell when a container exec fails
   -s, --silent               Do not show progress at all
   -v, --verbose count        Increase verbosity (use -vv or -vvv for more)
   -w, --web                  Open trace URL in a web browser

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -16,7 +16,6 @@ dagger [options] [subcommand | file...]
 
 ```
       --allow-llm strings            List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -c, --command string               Execute a dagger shell command
   -d, --debug                        Show debug logs and full verbosity
       --eager-runtime                load module runtime eagerly
@@ -77,7 +76,6 @@ dagger activity
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -125,7 +123,6 @@ dagger agent [options] [name...]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -162,7 +159,6 @@ See https://docs.dagger.io/api for the full overview.
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -202,7 +198,7 @@ dagger api call [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -y, --auto-apply                   Automatically apply changes when an output is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -237,7 +233,6 @@ module that generates it.
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -293,7 +288,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -y, --auto-apply                   Automatically apply changes when an output is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -325,7 +320,6 @@ dagger api client list
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -374,7 +368,6 @@ dagger api functions [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -439,7 +432,6 @@ EOF
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -503,7 +495,6 @@ dagger api with-session python main.py
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -559,7 +550,6 @@ dagger check [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -586,7 +576,6 @@ Manage Dagger Cloud
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -624,7 +613,6 @@ dagger cloud billing
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -656,7 +644,6 @@ dagger cloud billing manage [org]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -681,7 +668,6 @@ dagger cloud billing plans
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -706,7 +692,6 @@ dagger cloud check
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -741,7 +726,6 @@ dagger cloud check list [version]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -766,7 +750,6 @@ dagger cloud check off [name]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -791,7 +774,6 @@ dagger cloud check on [name]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -816,7 +798,6 @@ dagger cloud check status [name]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -847,7 +828,6 @@ dagger cloud integration
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -886,7 +866,6 @@ dagger cloud integration create github
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -911,7 +890,6 @@ dagger cloud integration list [type]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -936,7 +914,6 @@ dagger cloud integration rm <id>
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -967,7 +944,6 @@ dagger cloud login [options] [org]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -991,7 +967,6 @@ dagger cloud logout
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1039,7 +1014,6 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1069,7 +1043,6 @@ dagger cloud org [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1096,7 +1069,6 @@ dagger cloud org info [org] [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1121,7 +1093,6 @@ dagger cloud org list [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1146,7 +1117,6 @@ dagger cloud org use <org> [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1200,7 +1170,6 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1245,7 +1214,7 @@ dagger generate [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -y, --auto-apply                   Automatically apply changes when an output is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1299,7 +1268,6 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1325,7 +1293,6 @@ dagger installed
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1351,7 +1318,6 @@ Manage LLM provider configuration, API keys, and default models.
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1393,7 +1359,6 @@ dagger llm add-key <provider>
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1417,7 +1382,6 @@ dagger llm config
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1441,7 +1405,6 @@ dagger llm remove-key <provider>
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1465,7 +1428,6 @@ dagger llm reset
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1489,7 +1451,6 @@ dagger llm set-default <provider> [model]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1513,7 +1474,6 @@ dagger llm setup
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1537,7 +1497,6 @@ dagger llm show-config
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1563,7 +1522,6 @@ Operates on the dagger-module.toml reachable from the current directory.
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1587,7 +1545,6 @@ Manage this module's dependencies
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1621,7 +1578,6 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1647,7 +1603,6 @@ dagger module deps list [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1679,7 +1634,6 @@ dagger module deps rm wolfi
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1717,7 +1671,6 @@ dagger module deps update wolfi@v0.20.2
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1739,7 +1692,6 @@ Manage this module's required engine version
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1773,7 +1725,6 @@ dagger module engine require v0.21.0
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1799,7 +1750,6 @@ dagger module engine require-current [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1825,7 +1775,6 @@ dagger module engine require-latest [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1851,7 +1800,6 @@ dagger module engine required [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1919,7 +1867,7 @@ dagger sdk install go && dagger module init go my-module
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -y, --auto-apply                   Automatically apply changes when an output is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1960,7 +1908,6 @@ dagger module sdk <subcommand> [args...] [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -1992,7 +1939,6 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2046,7 +1992,6 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2076,7 +2021,6 @@ dagger sdk installed [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2108,7 +2052,6 @@ dagger sdk search [query] [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2148,7 +2091,6 @@ dagger sdk uninstall [options] <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2185,7 +2127,6 @@ dagger search wolfi
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2217,7 +2158,6 @@ dagger settings [module] [key] [value...]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2274,7 +2214,7 @@ dagger setup
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
+  -y, --auto-apply                   Automatically apply changes when an output is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2315,7 +2255,6 @@ dagger terminal [options] [pattern]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2364,7 +2303,6 @@ dagger uninstall hello
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2406,7 +2344,6 @@ dagger up [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2449,7 +2386,6 @@ dagger update
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2482,7 +2418,6 @@ dagger version
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2520,7 +2455,6 @@ dagger workspace
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2574,7 +2508,6 @@ dagger workspace config [key] [value] [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -2600,7 +2533,6 @@ dagger workspace config-file [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2625,7 +2557,6 @@ dagger workspace cwd [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2650,7 +2581,6 @@ dagger workspace remote [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2675,7 +2605,6 @@ dagger workspace remotes [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2700,7 +2629,6 @@ dagger workspace root [flags]
 ### Options inherited from parent commands
 
 ```
-  -y, --auto-apply                   Automatically apply changes when a changeset is returned
   -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -17,7 +17,7 @@ dagger [options] [subcommand | file...]
 ```
       --allow-llm strings            List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
   -c, --command string               Execute a dagger shell command
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --eager-runtime                load module runtime eagerly
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
@@ -76,7 +76,6 @@ dagger activity
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -123,7 +122,7 @@ dagger agent [options] [name...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -159,7 +158,6 @@ See https://docs.dagger.io/api for the full overview.
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -199,7 +197,7 @@ dagger api call [options] [function]...
 
 ```
   -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -233,7 +231,6 @@ module that generates it.
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -289,7 +286,7 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
 
 ```
   -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -320,7 +317,7 @@ dagger api client list
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -368,7 +365,7 @@ dagger api functions [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -432,7 +429,7 @@ EOF
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -495,7 +492,7 @@ dagger api with-session python main.py
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -550,7 +547,7 @@ dagger check [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -576,7 +573,6 @@ Manage Dagger Cloud
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -613,7 +609,6 @@ dagger cloud billing
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -644,7 +639,6 @@ dagger cloud billing manage [org]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -668,7 +662,6 @@ dagger cloud billing plans
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -692,7 +685,6 @@ dagger cloud check
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -726,7 +718,6 @@ dagger cloud check list [version]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -750,7 +741,6 @@ dagger cloud check off [name]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -774,7 +764,6 @@ dagger cloud check on [name]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -798,7 +787,6 @@ dagger cloud check status [name]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -828,7 +816,6 @@ dagger cloud integration
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -866,7 +853,6 @@ dagger cloud integration create github
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -890,7 +876,6 @@ dagger cloud integration list [type]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -914,7 +899,6 @@ dagger cloud integration rm <id>
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -944,7 +928,6 @@ dagger cloud login [options] [org]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -967,7 +950,6 @@ dagger cloud logout
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1014,7 +996,6 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1043,7 +1024,6 @@ dagger cloud org [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1069,7 +1049,6 @@ dagger cloud org info [org] [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1093,7 +1072,6 @@ dagger cloud org list [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1117,7 +1095,6 @@ dagger cloud org use <org> [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
@@ -1170,7 +1147,6 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1215,7 +1191,7 @@ dagger generate [options] [pattern...]
 
 ```
   -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1268,7 +1244,7 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1293,7 +1269,7 @@ dagger installed
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1318,7 +1294,6 @@ Manage LLM provider configuration, API keys, and default models.
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1359,7 +1334,6 @@ dagger llm add-key <provider>
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1382,7 +1356,6 @@ dagger llm config
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1405,7 +1378,6 @@ dagger llm remove-key <provider>
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1428,7 +1400,6 @@ dagger llm reset
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1451,7 +1422,6 @@ dagger llm set-default <provider> [model]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1474,7 +1444,6 @@ dagger llm setup
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1497,7 +1466,6 @@ dagger llm show-config
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1522,7 +1490,6 @@ Operates on the dagger-module.toml reachable from the current directory.
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1545,7 +1512,6 @@ Manage this module's dependencies
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1578,7 +1544,7 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1603,7 +1569,7 @@ dagger module deps list [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1634,7 +1600,7 @@ dagger module deps rm wolfi
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1671,7 +1637,7 @@ dagger module deps update wolfi@v0.20.2
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1692,7 +1658,6 @@ Manage this module's required engine version
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1725,7 +1690,7 @@ dagger module engine require v0.21.0
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1750,7 +1715,7 @@ dagger module engine require-current [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1775,7 +1740,7 @@ dagger module engine require-latest [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1800,7 +1765,7 @@ dagger module engine required [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1868,7 +1833,7 @@ dagger sdk install go && dagger module init go my-module
 
 ```
   -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1908,7 +1873,7 @@ dagger module sdk <subcommand> [args...] [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -1939,7 +1904,6 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -1992,7 +1956,7 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2021,7 +1985,6 @@ dagger sdk installed [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2052,7 +2015,6 @@ dagger sdk search [query] [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2091,7 +2053,7 @@ dagger sdk uninstall [options] <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2127,7 +2089,6 @@ dagger search wolfi
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2158,7 +2119,7 @@ dagger settings [module] [key] [value...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2215,7 +2176,7 @@ dagger setup
 
 ```
   -y, --auto-apply                   Automatically apply changes when an output is returned
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2255,7 +2216,7 @@ dagger terminal [options] [pattern]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2303,7 +2264,7 @@ dagger uninstall hello
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2344,7 +2305,7 @@ dagger up [options] [pattern...]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2386,7 +2347,7 @@ dagger update
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2418,7 +2379,6 @@ dagger version
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2455,7 +2415,7 @@ dagger workspace
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2508,7 +2468,7 @@ dagger workspace config [key] [value] [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
@@ -2533,7 +2493,7 @@ dagger workspace config-file [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2557,7 +2517,7 @@ dagger workspace cwd [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2581,7 +2541,6 @@ dagger workspace remote [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2605,7 +2564,7 @@ dagger workspace remotes [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands
@@ -2629,7 +2588,7 @@ dagger workspace root [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug                        Show debug logs and full verbosity
+  -d, --debug                        Enable engine and trace diagnostics
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --org string                   Dagger Cloud org name for Cloud-scoped commands

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -15,21 +15,8 @@ dagger [options] [subcommand | file...]
 ### Options
 
 ```
-      --allow-llm strings    List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
-  -c, --command string       Execute a dagger shell command
-  -d, --debug                Enable engine and trace diagnostics
-      --eager-runtime        load module runtime eagerly
-      --env string           Apply a named env overlay; writes target it, creating it if missing
-  -m, --load-module string   Use a one-off module (local path or git ref)
-      --model string         LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
-  -E, --no-exit              Leave the TUI running after completion
-  -M, --no-load-module       Don't load any module for this command
-      --progress string      Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count          Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent               Do not show progress at all
-  -v, --verbose count        Increase verbosity (use -vv or -vvv for more)
-  -w, --web                  Open trace URL in a web browser
-  -W, --workspace string     Select the workspace location to load from (local path or git ref)
+  -c, --command string   Execute a dagger shell command
+  -v, --verbose count    Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -82,13 +82,8 @@ dagger activity
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -173,13 +168,8 @@ See https://docs.dagger.io/api for the full overview.
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -255,13 +245,8 @@ module that generates it.
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -318,13 +303,8 @@ dagger api client init typescript ./lib/cli .dagger/modules/api
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -355,13 +335,8 @@ dagger api client list
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -409,13 +384,8 @@ dagger api functions [options] [function]...
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -626,13 +596,8 @@ Manage Dagger Cloud
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -671,13 +636,8 @@ dagger cloud billing
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -711,13 +671,8 @@ dagger cloud billing manage [org]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -743,13 +698,8 @@ dagger cloud billing plans
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -774,13 +724,8 @@ dagger cloud check
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -815,13 +760,8 @@ dagger cloud check list [version]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -846,13 +786,8 @@ dagger cloud check off [name]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -877,13 +812,8 @@ dagger cloud check on [name]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -908,13 +838,8 @@ dagger cloud check status [name]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -945,13 +870,8 @@ dagger cloud integration
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -992,13 +912,8 @@ dagger cloud integration create github
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1024,13 +939,8 @@ dagger cloud integration list [type]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1056,13 +966,8 @@ dagger cloud integration rm <id>
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1093,13 +998,8 @@ dagger cloud login [options] [org]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1124,13 +1024,8 @@ dagger cloud logout
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1179,13 +1074,8 @@ dagger cloud logs <trace-id> [--span <id> | --check <name> | --test <name>]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1216,13 +1106,8 @@ dagger cloud org [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1251,13 +1136,8 @@ dagger cloud org info [org] [flags]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1283,13 +1163,8 @@ dagger cloud org list [flags]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1315,13 +1190,8 @@ dagger cloud org use <org> [flags]
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
       --json                         Print JSON output
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1375,13 +1245,8 @@ dagger cloud rerun [--check NAME ...] [--failed | --all]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1480,13 +1345,8 @@ dagger install github.com/shykes/daggerverse/hello@v0.3.0
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1511,13 +1371,8 @@ dagger installed
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1542,13 +1397,8 @@ Manage LLM provider configuration, API keys, and default models.
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1591,13 +1441,8 @@ dagger llm add-key <provider>
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1622,13 +1467,8 @@ dagger llm config
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1653,13 +1493,8 @@ dagger llm remove-key <provider>
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1684,13 +1519,8 @@ dagger llm reset
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1715,13 +1545,8 @@ dagger llm set-default <provider> [model]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1746,13 +1571,8 @@ dagger llm setup
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1777,13 +1597,8 @@ dagger llm show-config
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1810,13 +1625,8 @@ Operates on the dagger-module.toml reachable from the current directory.
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1841,13 +1651,8 @@ Manage this module's dependencies
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1882,13 +1687,8 @@ dagger module deps add github.com/dagger/dagger/modules/wolfi
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1913,13 +1713,8 @@ dagger module deps list [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1950,13 +1745,8 @@ dagger module deps rm wolfi
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -1993,13 +1783,8 @@ dagger module deps update wolfi@v0.20.2
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2020,13 +1805,8 @@ Manage this module's required engine version
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2061,13 +1841,8 @@ dagger module engine require v0.21.0
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2092,13 +1867,8 @@ dagger module engine require-current [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2123,13 +1893,8 @@ dagger module engine require-latest [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2154,13 +1919,8 @@ dagger module engine required [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2227,13 +1987,8 @@ dagger sdk install go && dagger module init go my-module
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2305,13 +2060,8 @@ Use an installed SDK with `dagger module init` or `dagger api client init`.
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2366,13 +2116,8 @@ dagger sdk install typescript && dagger module init typescript --help && dagger 
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2402,13 +2147,8 @@ dagger sdk installed [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2440,13 +2180,8 @@ dagger sdk search [query] [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2487,13 +2222,8 @@ dagger sdk uninstall [options] <name> [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2530,13 +2260,8 @@ dagger search wolfi
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2569,13 +2294,8 @@ dagger settings [module] [key] [value...]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2631,13 +2351,8 @@ dagger setup
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2727,13 +2442,8 @@ dagger uninstall hello
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2817,13 +2527,8 @@ dagger update
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2855,12 +2560,8 @@ dagger version
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2899,13 +2600,8 @@ dagger workspace
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2958,13 +2654,8 @@ dagger workspace config [key] [value] [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -2989,13 +2680,8 @@ dagger workspace config-file [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -3020,13 +2706,8 @@ dagger workspace cwd [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -3051,13 +2732,8 @@ dagger workspace remote [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -3082,13 +2758,8 @@ dagger workspace remotes [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```
@@ -3113,13 +2784,8 @@ dagger workspace root [flags]
       --env string                   Apply a named env overlay; writes target it, creating it if missing
   -i, --interactive                  Spawn a terminal on container exec failure
       --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
-  -E, --no-exit                      Leave the TUI running after completion
       --org string                   Dagger Cloud org name for Cloud-scoped commands
-      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
-  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
-  -s, --silent                       Do not show progress at all
   -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
-  -w, --web                          Open trace URL in a web browser
   -W, --workspace string             Select the workspace location to load from (local path or git ref)
       --x-release string             Run an experimental release from a Dagger git ref
 ```

--- a/docs/static/reference/dagger-workspace.schema.json
+++ b/docs/static/reference/dagger-workspace.schema.json
@@ -53,6 +53,10 @@
         },
         "settings": {
           "type": "object"
+        },
+        "as-sdk": {
+          "$ref": "#/$defs/ModuleAsSDK",
+          "description": "AsSDK replaces the base SDK role in this environment. A nil value inherits the base role. This lets environment-scoped authoring commands change their managed module and client lists without changing the base workspace configuration."
         }
       },
       "additionalProperties": false,

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 
 	"github.com/dagger/dagger/engine/client/imageload"
 	"github.com/dagger/dagger/internal/cloud/auth"
@@ -59,7 +60,10 @@ func register(scheme string, driver ...Driver) {
 func GetDriver(ctx context.Context, name string) (Driver, error) {
 	drivers, ok := drivers[name]
 	if !ok {
-		return nil, fmt.Errorf("no driver for scheme %q found", name)
+		// Teach the usable values here: an engine selector is often the first
+		// thing a user gets wrong, and the message is the only help they see.
+		return nil, fmt.Errorf("no driver for scheme %q found; supported schemes: %s",
+			name, strings.Join(RegisteredSchemes(), ", "))
 	}
 	for _, driver := range drivers {
 		available, err := driver.Available(ctx)

--- a/engine/client/drivers/schemes.go
+++ b/engine/client/drivers/schemes.go
@@ -1,0 +1,134 @@
+package drivers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Scheme describes one engine selector value for user-facing help. The catalog
+// below is the single source of truth for the `--engine` flag usage, the
+// `dagger help engine` topic, and shell completion. A test asserts that it
+// covers the driver registry exactly, so the three surfaces cannot drift from
+// the drivers that the CLI can actually use.
+type Scheme struct {
+	// Scheme is the key that the driver registry uses.
+	Scheme string
+	// Value is the form to write after `--engine=`.
+	Value string
+	// Note explains the value when the syntax alone is not enough.
+	Note string
+	// Group titles a set of related values in the help topic.
+	Group string
+	// Primary marks a value that the short flag usage names.
+	Primary bool
+	// Deprecated marks a value that remains for compatibility. Help and
+	// completion leave these out; the help topic still lists them.
+	Deprecated bool
+}
+
+const (
+	groupCloud     = "Dagger Cloud"
+	groupImage     = "Start from an OCI image"
+	groupContainer = "Use a running engine container"
+	groupDirect    = "Connect directly"
+	groupLegacy    = "Legacy Docker schemes"
+)
+
+var schemeCatalog = []Scheme{
+	{Scheme: "dagger-cloud", Value: "cloud", Group: groupCloud, Primary: true},
+
+	{Scheme: "image", Value: "image://IMAGE", Group: groupImage, Primary: true},
+	{Scheme: "image+docker", Value: "image+docker://IMAGE", Group: groupImage},
+	{Scheme: "image+apple", Value: "image+apple://IMAGE", Group: groupImage},
+	{Scheme: "image+podman", Value: "image+podman://IMAGE", Group: groupImage},
+	{Scheme: "image+finch", Value: "image+finch://IMAGE", Group: groupImage},
+	{Scheme: "image+nerdctl", Value: "image+nerdctl://IMAGE", Group: groupImage},
+
+	{Scheme: "container", Value: "container://NAME", Group: groupContainer, Primary: true},
+	{Scheme: "container+docker", Value: "container+docker://NAME", Group: groupContainer},
+	{Scheme: "container+apple", Value: "container+apple://NAME", Group: groupContainer},
+	{Scheme: "container+podman", Value: "container+podman://NAME", Group: groupContainer},
+	{Scheme: "container+finch", Value: "container+finch://NAME", Group: groupContainer},
+	{Scheme: "container+nerdctl", Value: "container+nerdctl://NAME", Group: groupContainer},
+
+	{Scheme: "tcp", Value: "tcp://HOST:PORT", Note: "no authentication", Group: groupDirect, Primary: true},
+	{Scheme: "tls", Value: "tls://HOST[:PORT]", Group: groupDirect, Primary: true},
+	{Scheme: "ssh", Value: "ssh://[USER@]HOST[:PORT]", Group: groupDirect, Primary: true},
+	{Scheme: "kube-pod", Value: "kube-pod://POD", Group: groupDirect, Primary: true},
+	{Scheme: "unix", Value: "unix://PATH", Group: groupDirect, Primary: true},
+
+	{Scheme: "docker-image", Value: "docker-image://IMAGE", Group: groupLegacy, Deprecated: true},
+	{Scheme: "docker-container", Value: "docker-container://NAME", Group: groupLegacy, Deprecated: true},
+}
+
+// SchemeCatalog returns the engine selector values, in help order.
+func SchemeCatalog() []Scheme {
+	return append([]Scheme(nil), schemeCatalog...)
+}
+
+// RegisteredSchemes returns the driver registry keys, sorted. Error messages
+// use it, so it reports what the client can dial, not what help documents.
+func RegisteredSchemes() []string {
+	names := make([]string, 0, len(drivers))
+	for name := range drivers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SchemePrefix returns the part of a value that a user types before the target:
+// "image://" for "image://IMAGE", and "cloud" for a value that is not a URI.
+func SchemePrefix(value string) string {
+	if prefix, _, ok := strings.Cut(value, "://"); ok {
+		return prefix + "://"
+	}
+	return value
+}
+
+// SchemeSummary names the main engine selector values on one line. The
+// `--engine` flag usage uses it.
+func SchemeSummary() string {
+	var values []string
+	for _, scheme := range schemeCatalog {
+		if scheme.Primary {
+			values = append(values, SchemePrefix(scheme.Value))
+		}
+	}
+	return strings.Join(values, ", ")
+}
+
+// SchemeCompletions returns the values to offer for shell completion of an
+// engine selector. Deprecated values are left out.
+func SchemeCompletions() []string {
+	var values []string
+	for _, scheme := range schemeCatalog {
+		if scheme.Deprecated {
+			continue
+		}
+		values = append(values, SchemePrefix(scheme.Value))
+	}
+	return values
+}
+
+// SchemeHelp renders the full catalog, grouped, for a help topic.
+func SchemeHelp() string {
+	var sb strings.Builder
+	group := ""
+	for _, scheme := range schemeCatalog {
+		if scheme.Group != group {
+			if group != "" {
+				sb.WriteString("\n")
+			}
+			group = scheme.Group
+			fmt.Fprintf(&sb, "  %s:\n", group)
+		}
+		fmt.Fprintf(&sb, "    %s", scheme.Value)
+		if scheme.Note != "" {
+			fmt.Fprintf(&sb, " (%s)", scheme.Note)
+		}
+		sb.WriteString("\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/engine/client/drivers/schemes_test.go
+++ b/engine/client/drivers/schemes_test.go
@@ -1,0 +1,63 @@
+package drivers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The catalog is what users read. The registry is what the client dials. They
+// must describe the same set, or help and completion teach a value that does
+// not work, or hide one that does.
+func TestSchemeCatalogCoversRegistry(t *testing.T) {
+	documented := map[string]bool{}
+	for _, scheme := range SchemeCatalog() {
+		require.NotEmpty(t, scheme.Value, scheme.Scheme)
+		require.NotEmpty(t, scheme.Group, scheme.Scheme)
+		require.False(t, documented[scheme.Scheme], "duplicate scheme %q", scheme.Scheme)
+		documented[scheme.Scheme] = true
+	}
+	require.ElementsMatch(t, RegisteredSchemes(), sortedKeys(documented))
+}
+
+func TestSchemeSummaryNamesPrimaryValues(t *testing.T) {
+	require.Equal(t,
+		"cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix://",
+		SchemeSummary())
+}
+
+func TestSchemeCompletionsSkipDeprecated(t *testing.T) {
+	completions := SchemeCompletions()
+	require.Contains(t, completions, "cloud")
+	require.Contains(t, completions, "image+nerdctl://")
+	require.NotContains(t, completions, "docker-image://")
+	for _, value := range completions {
+		require.False(t, strings.HasSuffix(value, "IMAGE"), value)
+	}
+}
+
+func TestSchemeHelpGroupsValues(t *testing.T) {
+	help := SchemeHelp()
+	require.Contains(t, help, "  Dagger Cloud:\n    cloud\n")
+	require.Contains(t, help, "    tcp://HOST:PORT (no authentication)\n")
+	require.Contains(t, help, "  Legacy Docker schemes:\n    docker-image://IMAGE\n")
+}
+
+// An unusable value must teach the usable ones.
+func TestGetDriverUnknownSchemeListsSchemes(t *testing.T) {
+	_, err := GetDriver(context.Background(), "")
+	require.ErrorContains(t, err, `no driver for scheme "" found`)
+	for _, name := range RegisteredSchemes() {
+		require.ErrorContains(t, err, name)
+	}
+}
+
+func sortedKeys(set map[string]bool) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -783,6 +783,9 @@ func (srv *Server) detectAndLoadWorkspaceWithRootfs(
 		return fmt.Errorf("building workspace: %w", err)
 	}
 	coreWS.SetCompatWorkspace(compatWorkspace)
+	if hasWorkspaceEnv {
+		coreWS.SetSelectedEnv(workspaceEnv)
+	}
 	if err := attachUserWorkspaceOverlay(ctx, clientMD, readFile, hostReadFile, ws, coreWS, remoteKey, isLocal); err != nil {
 		return err
 	}

--- a/future/cli-1.0.md
+++ b/future/cli-1.0.md
@@ -71,7 +71,7 @@ OPTIONS
       --env string               Apply (or write to) a named env overlay. Envs are
                                  paths under env.<name>.* in workspace config; see
                                  `dagger workspace config env`
-  -i, --interactive              Spawn a terminal on container exec failure
+  -i, --shell-on-error           Open a shell when a container exec fails
   -m, --load-module string       Use a one-off module (local path or git ref)
       --no-load-module           Don't load any module for this command
   -W, --workspace string         Select the workspace location to load from

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -83,22 +83,31 @@ one that does:
    legacy Docker schemes.
 4. An unknown scheme fails with the list of supported schemes.
 
+`DAGGER_ENGINE` is the environment form of `--engine`. It takes the same
+values, so a shell session can select an engine once for every command.
+
 Engine selection has this priority:
 
 1. `--engine`
 2. Hidden `--cloud`
-3. A future user-environment setting
-4. `DAGGER_CLOUD_ENGINE`
-5. `_EXPERIMENTAL_DAGGER_RUNNER_HOST`
-6. The built-in default
+3. `DAGGER_ENGINE`
+4. A future user-environment setting
+5. `DAGGER_CLOUD_ENGINE`
+6. `_EXPERIMENTAL_DAGGER_RUNNER_HOST`
+7. The built-in default
+
+Flags outrank the environment, and the current inputs outrank the deprecated
+ones. `--cloud` is a deprecated alias for `--engine=cloud`, so it keeps a
+flag's priority over `DAGGER_ENGINE`.
 
 `--cloud`, `DAGGER_CLOUD_ENGINE`, and `_EXPERIMENTAL_DAGGER_RUNNER_HOST` are
-all soft-deprecated: `--engine` replaces them, but they still work as a
-fallback. `--engine=cloud` replaces `--cloud` and `DAGGER_CLOUD_ENGINE`.
-`--engine=URI` replaces `_EXPERIMENTAL_DAGGER_RUNNER_HOST`. Only `--cloud`
-warns today, because pflag prints the notice for a deprecated flag. The two
-environment variables stay silent; `dagger help engine` marks them deprecated.
-A warning for them, and their removal, belong to the user-environment design.
+all soft-deprecated: `--engine` and `DAGGER_ENGINE` replace them, but they
+still work as a fallback. `--engine=cloud` replaces `--cloud` and
+`DAGGER_CLOUD_ENGINE`. `--engine=URI` replaces
+`_EXPERIMENTAL_DAGGER_RUNNER_HOST`. Only `--cloud` warns today, because pflag
+prints the notice for a deprecated flag. The two environment variables stay
+silent; `dagger help engine` marks them deprecated. A warning for them, and
+their removal, belong to the user-environment design.
 
 The root command declares no capabilities. Bare `dagger` prints usage: it calls
 no engine, selects no workspace, reads no workspace configuration, and renders

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -66,11 +66,15 @@ selects Dagger Cloud Engines. Other values use the supported engine URI
 schemes. The CLI passes these URIs through without a syntax change. The old
 `--cloud` flag is a hidden compatibility alias for `--engine=cloud`.
 
-The root command declares `MayCallEngine` locally because `dagger FILE` calls
-an engine. Thus, `dagger --engine=cloud FILE` remains valid. Dynamic commands
-stop early global flag parsing at their first schema-owned token. For example,
-the first `--engine` in `dagger --engine=cloud api call deploy --engine
-production` selects the engine. The second is an argument of `deploy`.
+The root command does not declare `MayCallEngine`. Bare `dagger` prints usage,
+so the front-door usage message stays free of the engine flags. Shell-style
+root invocations still call an engine: `dagger FILE` and `dagger -c COMMAND`
+run `dagger shell`, so the CLI checks their flags against the capabilities of
+`dagger shell`. Thus, `dagger --engine=cloud FILE` remains valid, and
+`dagger --engine=cloud` alone is an error. Dynamic commands stop early global
+flag parsing at their first schema-owned token. For example, the first
+`--engine` in `dagger --engine=cloud api call deploy --engine production`
+selects the engine. The second is an argument of `deploy`.
 
 The full list of engine URI schemes is too long for a usage message that 34
 commands print. Four surfaces teach the values, and all four read one catalog

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -73,6 +73,35 @@ example, the first `--engine` in `dagger --engine=cloud api call deploy
 --engine production` selects the engine, while the second is an argument of
 `deploy`.
 
+The full list of engine URI schemes is too long for a usage message that 34
+commands print. Four surfaces teach the values, and all four read one catalog
+in `engine/client/drivers`. A test asserts that the catalog covers the driver
+registry exactly, so no surface can name a scheme that does not work, or hide
+one that does:
+
+1. The `--engine` usage names the main values on one line: `cloud`, `image://`,
+   `container://`, `tcp://`, `tls://`, `ssh://`, `kube-pod://`, `unix://`. It
+   then points at the help topic.
+2. `dagger help engine` is a Cobra help topic. It holds the full catalog, the
+   engine selection priority, and examples. It declares no capabilities, so its
+   own usage message stays free of the global flags. `dagger --help` lists it
+   under `ADDITIONAL HELP TOPICS`, and the CLI reference documents it once.
+3. Shell completion of `--engine` offers every scheme prefix, without the
+   legacy Docker schemes.
+4. An unknown scheme fails with the list of supported schemes.
+
+Engine selection has this priority:
+
+1. `--engine`
+2. Hidden `--cloud`
+3. A future user-environment setting
+4. `DAGGER_CLOUD_ENGINE`
+5. `_EXPERIMENTAL_DAGGER_RUNNER_HOST`
+6. The built-in default
+
+The two environment variables remain silent compatibility inputs. Their
+replacement and removal plan belongs to the user-environment design.
+
 `-i`, `--shell-on-error` asks the engine to open a shell in the failed
 container state when a non-internal container exec fails. It requires
 `MayCallEngine`; it does not require `MayRenderPipeline`. The old

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -23,7 +23,7 @@ This design separates the current global flags into four groups:
 Capability scoping controls flag validation and help output. It does not have
 to prevent a flag from appearing before the subcommand. For example,
 `dagger -W ./workspace check` can remain valid when `check` declares
-`MayCallEngine`.
+`MaySelectWorkspace`.
 
 ## Command Capabilities
 
@@ -31,13 +31,15 @@ to prevent a flag from appearing before the subcommand. For example,
 |---|---|
 | `MayCallEngine` | The command can connect to and call the engine. |
 | `MaySelectWorkspace` | The command can use `-W`, `--workspace` to select or resolve a workspace. |
+| `MayReadWorkspaceConfig` | The command can use `--env` when reading workspace configuration. |
+| `MayWriteWorkspaceConfig` | The command can use `--env` when writing workspace configuration. |
 | `MayRenderPipeline` | The command can show a user-facing pipeline trace. |
 | `MayProduceOutput` | The command can produce an output that can require user review before a side effect. |
 
 The capabilities are independent. A command can declare more than one.
 
 - A normal pipeline command usually declares `MayCallEngine`,
-  `MaySelectWorkspace`, and `MayRenderPipeline`.
+  `MaySelectWorkspace`, `MayReadWorkspaceConfig`, and `MayRenderPipeline`.
 - `dagger trace` declares `MayRenderPipeline` but does not call the engine.
 - A configuration command can call the engine without rendering its internal
   trace to the user.
@@ -55,13 +57,27 @@ a trace, `--verbose` prints a final trace even if the command does not declare
 `MayRenderPipeline`. It does not enable the live TUI or make `--no-exit`,
 `--web`, or `--interactive` applicable.
 
-### Follow-up: `--env`
+### Workspace environment selection
 
-`--env` is currently scoped by `MayCallEngine` because it is passed as an
-engine connection parameter. It also selects the environment overlay that a
-workspace configuration command reads or edits. If configuration editing no
-longer requires an engine call, `--env` will need a separate capability for
-this second meaning.
+`--env` selects an `env.<name>` overlay in `dagger.toml`. For a read, the
+command uses the environment-applied configuration. For a write, the command
+targets that environment overlay. The flag is available when a command
+declares `MayReadWorkspaceConfig OR MayWriteWorkspaceConfig`.
+
+`dagger module init` and `dagger api client init` declare both capabilities.
+They resolve the SDK from the environment-applied configuration and record the
+new module or client in that environment overlay. Generated files are still
+exported to the workspace filesystem. Their dynamic SDK command registration
+also applies the selected environment.
+
+An environment SDK role replaces the base module's `as-sdk` value. An init
+command starts with the effective role, adds or replaces the requested entry,
+and writes the complete result under `env.<name>.modules.<sdk>.as-sdk`. This
+keeps the base role unchanged and gives the environment a consistent module and
+client ownership list.
+
+`dagger setup` remains base-only. It declares neither workspace configuration
+capability and does not accept `--env`.
 
 ## Workspace Configuration
 
@@ -98,7 +114,7 @@ column means that no change is proposed.
 | Move to configuration | `--cloud` | Hidden | `cloud.engines.enabled` |
 | Move to configuration | `--scale-out` | Hidden | `cloud.engines.scale-out` |
 | Scope by capability | `-W`, `--workspace` | Visible | `MaySelectWorkspace` |
-| Scope by capability | `--env` | Visible | `MayCallEngine` |
+| Scope by capability | `--env` | Visible | `MayReadWorkspaceConfig OR MayWriteWorkspaceConfig` |
 | Scope by capability | `-q`, `--quiet` | Visible | `MayRenderPipeline` |
 | Scope by capability | `-s`, `--silent` | Visible | `MayRenderPipeline` |
 | Scope by capability | `-d`, `--debug` | Visible | `MayCallEngine OR MayRenderPipeline` |
@@ -119,5 +135,6 @@ column means that no change is proposed.
 
 ## Status
 
-`MayCallEngine` and `MayRenderPipeline` capability scoping are implemented.
-The other changes are planned.
+`MayCallEngine`, `MaySelectWorkspace`, `MayReadWorkspaceConfig`,
+`MayWriteWorkspaceConfig`, and `MayRenderPipeline` capability scoping are
+implemented. The other changes are planned.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -1,0 +1,111 @@
+# Future CLI Global Flag Scoping
+
+author: shykes
+created: 2026-09-01
+status: design draft
+related: https://github.com/dagger/dagger/issues/14024
+
+## Context
+
+The Dagger CLI defines many flags as root-persistent flags. Cobra therefore
+shows them in the help for every command, including commands for which the
+flags have no useful effect.
+
+This design separates the current global flags into four groups:
+
+1. Stable workspace settings move to `dagger.toml`. A generic configuration
+   override can change these settings for one invocation.
+2. Command-specific flags are available only when a command declares the
+   required capability.
+3. Bootstrap and framework flags stay global.
+4. Development controls stay available but hidden.
+
+Capability scoping controls flag validation and help output. It does not have
+to prevent a flag from appearing before the subcommand. For example,
+`dagger -W ./workspace check` can remain valid when `check` declares
+`MayCallEngine`.
+
+## Command Capabilities
+
+| Capability | Meaning |
+|---|---|
+| `MayCallEngine` | The command can connect to and call the engine. |
+| `MayRenderPipeline` | The command can show a user-facing pipeline trace. |
+| `MayProduceOutput` | The command can produce an output that can require user review before a side effect. |
+
+The capabilities are independent. A command can declare more than one.
+
+- A normal pipeline command usually declares `MayCallEngine` and
+  `MayRenderPipeline`.
+- `dagger trace` declares `MayRenderPipeline` but does not call the engine.
+- A configuration command can call the engine without rendering its internal
+  trace to the user.
+- `dagger check` renders pass or failure status, but does not produce an
+  output. `dagger generate` and `dagger api call` can produce outputs.
+
+An output is a returned value whose disposition the CLI must decide. The CLI
+can print, export, apply, save, discard, or request approval for the output.
+The capability does not depend on the current output type.
+
+`--verbose` remains global as a diagnostic escape hatch. When a command emits
+a trace, `--verbose` prints a final trace even if the command does not declare
+`MayRenderPipeline`. It does not enable the live TUI or make `--no-exit`,
+`--web`, or `--interactive` applicable.
+
+## Workspace Configuration
+
+The proposed configuration shape is:
+
+```toml
+[cloud.traces]
+enabled = true
+org = "my-org"
+
+[cloud.engines]
+enabled = true
+scale-out = false
+```
+
+`cloud.<product>.enabled` enables client-side use for the current machine or
+workspace. It does not enable the product for the Cloud organization. The
+organization must enable and authorize the product separately.
+
+Cloud Checks configuration is not part of `dagger.toml`. It is server-side
+configuration managed through the Dagger Cloud API.
+
+`cloud.engines.scale-out` is independent of `cloud.engines.enabled`. A command
+can use a local primary engine and use Cloud Engines only for scale-out work.
+
+## Global Flag Disposition
+
+The table includes every current root-persistent flag. A dash in the `Change`
+column means that no change is proposed.
+
+| Change | Flag | Current | Capability or `dagger.toml` field |
+|---|---|---|---|
+| Move to configuration | `--org` | Visible | `cloud.traces.org` |
+| Move to configuration | `--cloud` | Hidden | `cloud.engines.enabled` |
+| Move to configuration | `--scale-out` | Hidden | `cloud.engines.scale-out` |
+| Scope by capability | `-W`, `--workspace` | Visible | `MayCallEngine` |
+| Scope by capability | `--env` | Visible | `MayCallEngine` |
+| Scope by capability | `-q`, `--quiet` | Visible | `MayRenderPipeline` |
+| Scope by capability | `-s`, `--silent` | Visible | `MayRenderPipeline` |
+| Scope by capability | `-d`, `--debug` | Visible | `MayCallEngine OR MayRenderPipeline` |
+| Scope by capability | `--progress` | Visible | `MayRenderPipeline` |
+| Scope by capability | `-i`, `--interactive` | Visible | `MayCallEngine AND MayRenderPipeline` |
+| Scope by capability | `-w`, `--web` | Visible | `MayRenderPipeline` |
+| Scope by capability | `-E`, `--no-exit` | Visible | `MayRenderPipeline` |
+| Scope by capability | `-y`, `--auto-apply` | Visible | `MayProduceOutput` |
+| Scope by capability | `--profile` | Hidden | `MayCallEngine` |
+| Scope by capability | `--dot-output` | Hidden | `MayRenderPipeline` |
+| Scope by capability | `--dot-focus-field` | Hidden | `MayRenderPipeline`; requires DOT output |
+| Scope by capability | `--dot-show-internal` | Hidden | `MayRenderPipeline`; requires DOT output |
+| Scope by capability and hide | `--interactive-command` | Visible | `MayCallEngine AND MayRenderPipeline`; only affects `--interactive` |
+| Hide | `--x-release` | Visible | Bootstrap control; prefer `DAGGER_X_RELEASE` |
+| - | `--workdir` | Hidden | Bootstrap working directory |
+| - | `-v`, `--verbose` | Visible | Global diagnostic escape hatch |
+| - | `-h`, `--help` | Hidden | Framework flag |
+
+## Status
+
+Design draft. No implementation is included.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -30,16 +30,19 @@ to prevent a flag from appearing before the subcommand. For example,
 | Capability | Meaning |
 |---|---|
 | `MayCallEngine` | The command can connect to and call the engine. |
+| `MaySelectWorkspace` | The command can use `-W`, `--workspace` to select or resolve a workspace. |
 | `MayRenderPipeline` | The command can show a user-facing pipeline trace. |
 | `MayProduceOutput` | The command can produce an output that can require user review before a side effect. |
 
 The capabilities are independent. A command can declare more than one.
 
-- A normal pipeline command usually declares `MayCallEngine` and
-  `MayRenderPipeline`.
+- A normal pipeline command usually declares `MayCallEngine`,
+  `MaySelectWorkspace`, and `MayRenderPipeline`.
 - `dagger trace` declares `MayRenderPipeline` but does not call the engine.
 - A configuration command can call the engine without rendering its internal
   trace to the user.
+- `dagger activity`, `dagger cloud rerun`, and `dagger workspace remote`
+  declare `MaySelectWorkspace` without declaring `MayCallEngine`.
 - `dagger check` renders pass or failure status, but does not produce an
   output. `dagger generate` and `dagger api call` can produce outputs.
 
@@ -51,6 +54,14 @@ The capability does not depend on the current output type.
 a trace, `--verbose` prints a final trace even if the command does not declare
 `MayRenderPipeline`. It does not enable the live TUI or make `--no-exit`,
 `--web`, or `--interactive` applicable.
+
+### Follow-up: `--env`
+
+`--env` is currently scoped by `MayCallEngine` because it is passed as an
+engine connection parameter. It also selects the environment overlay that a
+workspace configuration command reads or edits. If configuration editing no
+longer requires an engine call, `--env` will need a separate capability for
+this second meaning.
 
 ## Workspace Configuration
 
@@ -86,7 +97,7 @@ column means that no change is proposed.
 | Move to configuration | `--org` | Visible | `cloud.traces.org` |
 | Move to configuration | `--cloud` | Hidden | `cloud.engines.enabled` |
 | Move to configuration | `--scale-out` | Hidden | `cloud.engines.scale-out` |
-| Scope by capability | `-W`, `--workspace` | Visible | `MayCallEngine` |
+| Scope by capability | `-W`, `--workspace` | Visible | `MaySelectWorkspace` |
 | Scope by capability | `--env` | Visible | `MayCallEngine` |
 | Scope by capability | `-q`, `--quiet` | Visible | `MayRenderPipeline` |
 | Scope by capability | `-s`, `--silent` | Visible | `MayRenderPipeline` |
@@ -108,4 +119,5 @@ column means that no change is proposed.
 
 ## Status
 
-Design draft. No implementation is included.
+`MayCallEngine` and `MayRenderPipeline` capability scoping are implemented.
+The other changes are planned.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -57,6 +57,11 @@ a trace, `--verbose` prints a final trace even if the command does not declare
 `MayRenderPipeline`. It does not enable the live TUI or make `--no-exit`,
 `--web`, or `--interactive` applicable.
 
+`--debug` enables engine and trace diagnostics. It is available when a command
+declares `MayCallEngine OR MayRenderPipeline`. Engine commands request debug
+logs from the engine. Rendering commands expose internal trace details. No
+current command outside this capability union implements debug behavior.
+
 ### Workspace environment selection
 
 `--env` selects an `env.<name>` overlay in `dagger.toml`. For a read, the
@@ -148,4 +153,6 @@ column means that no change is proposed.
 
 `MayCallEngine`, `MaySelectWorkspace`, `MayReadWorkspaceConfig`,
 `MayWriteWorkspaceConfig`, `MayRenderPipeline`, and `MayProduceOutput`
-capability scoping are implemented. The other changes are planned.
+capability scoping are implemented. All capability-scoped flag moves are
+implemented except `--interactive` and `--interactive-command`. The
+configuration and hide changes are planned.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -76,6 +76,11 @@ flag parsing at their first schema-owned token. For example, the first
 `--engine` in `dagger --engine=cloud api call deploy --engine production`
 selects the engine. The second is an argument of `deploy`.
 
+A shell completion request (`__complete`) names the command that the user is
+completing, not the command that runs, so flag validation skips it. Completion
+hides the flags that the target command does not support, which gives the same
+result without an error.
+
 The full list of engine URI schemes is too long for a usage message that 34
 commands print. Four surfaces teach the values, and all four read one catalog
 in `engine/client/drivers`. A test asserts that the catalog covers the driver

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -62,6 +62,17 @@ declares `MayCallEngine OR MayRenderPipeline`. Engine commands request debug
 logs from the engine. Rendering commands expose internal trace details. No
 current command outside this capability union implements debug behavior.
 
+`--engine` selects the engine and requires `MayCallEngine`. The value `cloud`
+selects Dagger Cloud Engines. All other values use the existing runner-host URI
+syntax unchanged. The old `--cloud` flag is a hidden compatibility alias for
+`--engine=cloud`, and `_EXPERIMENTAL_DAGGER_RUNNER_HOST` remains a deprecated
+fallback. The root command declares the capability locally because `dagger
+FILE` calls an engine, so `dagger --engine=cloud FILE` remains valid. Dynamic
+commands stop early global flag parsing at their first schema-owned token. For
+example, the first `--engine` in `dagger --engine=cloud api call deploy
+--engine production` selects the engine, while the second is an argument of
+`deploy`.
+
 `-i`, `--shell-on-error` asks the engine to open a shell in the failed
 container state when a non-internal container exec fails. It requires
 `MayCallEngine`; it does not require `MayRenderPipeline`. The old
@@ -134,8 +145,8 @@ column means that no change is proposed.
 
 | Change | Flag | Current | Capability or `dagger.toml` field |
 |---|---|---|---|
-| Move to configuration | `--cloud` | Hidden | `cloud.engines.enabled` |
 | Move to configuration | `--scale-out` | Hidden | `cloud.engines.scale-out` |
+| Scope by capability and rename | `--cloud` | Hidden | `--engine`; `MayCallEngine`; keep `--cloud` as a hidden deprecated alias |
 | Scope by capability | `-W`, `--workspace` | Visible | `MaySelectWorkspace` |
 | Scope by capability | `--env` | Visible | `MayReadWorkspaceConfig OR MayWriteWorkspaceConfig` |
 | Scope by capability | `-q`, `--quiet` | Visible | `MayRenderPipeline` |
@@ -163,4 +174,6 @@ column means that no change is proposed.
 `MayWriteWorkspaceConfig`, `MayRenderPipeline`, and `MayProduceOutput`
 capability scoping are implemented. All capability-scoped flag moves are
 implemented. The hide changes are also implemented. The configuration changes
-are planned.
+are planned. `--engine` and its hidden `--cloud` compatibility alias are scoped
+to `MayCallEngine`. Persisted engine selection remains part of the user
+configuration design.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -137,6 +137,8 @@ configuration managed through the Dagger Cloud API.
 
 `cloud.engines.scale-out` is independent of `cloud.engines.enabled`. A command
 can use a local primary engine and use Cloud Engines only for scale-out work.
+Until persisted configuration is implemented, the hidden `--scale-out` flag is
+local to `dagger check`, which is its only consumer.
 
 ## Global Flag Disposition
 
@@ -145,7 +147,7 @@ column means that no change is proposed.
 
 | Change | Flag | Current | Capability or `dagger.toml` field |
 |---|---|---|---|
-| Move to configuration | `--scale-out` | Hidden | `cloud.engines.scale-out` |
+| Scope to command and keep hidden | `--scale-out` | Hidden | `dagger check`; persisted configuration is deferred |
 | Scope by capability and rename | `--cloud` | Hidden | `--engine`; `MayCallEngine`; keep `--cloud` as a hidden deprecated alias |
 | Scope by capability | `-W`, `--workspace` | Visible | `MaySelectWorkspace` |
 | Scope by capability | `--env` | Visible | `MayReadWorkspaceConfig OR MayWriteWorkspaceConfig` |
@@ -175,5 +177,6 @@ column means that no change is proposed.
 capability scoping are implemented. All capability-scoped flag moves are
 implemented. The hide changes are also implemented. The configuration changes
 are planned. `--engine` and its hidden `--cloud` compatibility alias are scoped
-to `MayCallEngine`. Persisted engine selection remains part of the user
-configuration design.
+to `MayCallEngine`. The hidden `--scale-out` flag is local to `dagger check`.
+Persisted engine and scale-out settings remain part of the user configuration
+design.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -66,21 +66,6 @@ selects Dagger Cloud Engines. Other values use the supported engine URI
 schemes. The CLI passes these URIs through without a syntax change. The old
 `--cloud` flag is a hidden compatibility alias for `--engine=cloud`.
 
-The root command does not declare `MayCallEngine`. Bare `dagger` prints usage,
-so the front-door usage message stays free of the engine flags. Shell-style
-root invocations still call an engine: `dagger FILE` and `dagger -c COMMAND`
-run `dagger shell`, so the CLI checks their flags against the capabilities of
-`dagger shell`. Thus, `dagger --engine=cloud FILE` remains valid, and
-`dagger --engine=cloud` alone is an error. Dynamic commands stop early global
-flag parsing at their first schema-owned token. For example, the first
-`--engine` in `dagger --engine=cloud api call deploy --engine production`
-selects the engine. The second is an argument of `deploy`.
-
-A shell completion request (`__complete`) names the command that the user is
-completing, not the command that runs, so flag validation skips it. Completion
-hides the flags that the target command does not support, which gives the same
-result without an error.
-
 The full list of engine URI schemes is too long for a usage message that 34
 commands print. Four surfaces teach the values, and all four read one catalog
 in `engine/client/drivers`. A test asserts that the catalog covers the driver
@@ -109,6 +94,31 @@ Engine selection has this priority:
 
 The two environment variables remain silent compatibility inputs. Their
 replacement and removal plan belongs to the user-environment design.
+
+The root command declares no capabilities. Bare `dagger` prints usage: it calls
+no engine, selects no workspace, reads no workspace configuration, and renders
+no pipeline, so the front-door usage message stays free of those flags. It is
+left with `-c`, `--command` and `--verbose`. Shell-style root invocations still
+do all of that:
+`dagger FILE` and `dagger -c COMMAND` run `dagger shell`, so the CLI checks
+their flags against the capabilities of `dagger shell`. Thus,
+`dagger --engine=cloud FILE` remains valid, and `dagger --engine=cloud` alone
+is an error.
+
+The module selection flags follow the same rule. `-m`, `--load-module`,
+`-M`, `--no-load-module`, `--allow-llm`, `--eager-runtime`, and `--model` are
+engine session parameters, so they require `MayCallEngine`. Every command that
+installs them declares it except the root command, which carries them only for
+the shell fallback. `-c`, `--command` stays ungated: on the root command it is
+how a user reaches the shell, so the root usage message must keep naming it. Dynamic commands stop early global
+flag parsing at their first schema-owned token. For example, the first
+`--engine` in `dagger --engine=cloud api call deploy --engine production`
+selects the engine. The second is an argument of `deploy`.
+
+A shell completion request (`__complete`) names the command that the user is
+completing, not the command that runs, so flag validation skips it. Completion
+hides the flags that the target command does not support, which gives the same
+result without an error.
 
 `-i`, `--shell-on-error` asks the engine to open a shell in the failed
 container state when a non-internal container exec fails. It requires

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -92,8 +92,13 @@ Engine selection has this priority:
 5. `_EXPERIMENTAL_DAGGER_RUNNER_HOST`
 6. The built-in default
 
-The two environment variables remain silent compatibility inputs. Their
-replacement and removal plan belongs to the user-environment design.
+`--cloud`, `DAGGER_CLOUD_ENGINE`, and `_EXPERIMENTAL_DAGGER_RUNNER_HOST` are
+all soft-deprecated: `--engine` replaces them, but they still work as a
+fallback. `--engine=cloud` replaces `--cloud` and `DAGGER_CLOUD_ENGINE`.
+`--engine=URI` replaces `_EXPERIMENTAL_DAGGER_RUNNER_HOST`. Only `--cloud`
+warns today, because pflag prints the notice for a deprecated flag. The two
+environment variables stay silent; `dagger help engine` marks them deprecated.
+A warning for them, and their removal, belong to the user-environment design.
 
 The root command declares no capabilities. Bare `dagger` prints usage: it calls
 no engine, selects no workspace, reads no workspace configuration, and renders

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -2,7 +2,7 @@
 
 author: shykes
 created: 2026-09-01
-status: design draft
+status: implemented
 related: https://github.com/dagger/dagger/issues/14024
 
 ## Context
@@ -11,12 +11,11 @@ The Dagger CLI defines many flags as root-persistent flags. Cobra therefore
 shows them in the help for every command, including commands for which the
 flags have no useful effect.
 
-This design separates the current global flags into four groups:
+This design separates the original global flags into four groups:
 
-1. Stable workspace settings move to `dagger.toml`. A generic configuration
-   override can change these settings for one invocation.
-2. Command-specific flags are available only when a command declares the
+1. Command-specific flags are available only when a command declares the
    required capability.
+2. Command-specific flags with one consumer move to that command.
 3. Bootstrap and framework flags stay global.
 4. Development controls stay available but hidden.
 
@@ -63,15 +62,15 @@ logs from the engine. Rendering commands expose internal trace details. No
 current command outside this capability union implements debug behavior.
 
 `--engine` selects the engine and requires `MayCallEngine`. The value `cloud`
-selects Dagger Cloud Engines. All other values use the existing runner-host URI
-syntax unchanged. The old `--cloud` flag is a hidden compatibility alias for
-`--engine=cloud`, and `_EXPERIMENTAL_DAGGER_RUNNER_HOST` remains a deprecated
-fallback. The root command declares the capability locally because `dagger
-FILE` calls an engine, so `dagger --engine=cloud FILE` remains valid. Dynamic
-commands stop early global flag parsing at their first schema-owned token. For
-example, the first `--engine` in `dagger --engine=cloud api call deploy
---engine production` selects the engine, while the second is an argument of
-`deploy`.
+selects Dagger Cloud Engines. Other values use the supported engine URI
+schemes. The CLI passes these URIs through without a syntax change. The old
+`--cloud` flag is a hidden compatibility alias for `--engine=cloud`.
+
+The root command declares `MayCallEngine` locally because `dagger FILE` calls
+an engine. Thus, `dagger --engine=cloud FILE` remains valid. Dynamic commands
+stop early global flag parsing at their first schema-owned token. For example,
+the first `--engine` in `dagger --engine=cloud api call deploy --engine
+production` selects the engine. The second is an argument of `deploy`.
 
 The full list of engine URI schemes is too long for a usage message that 34
 commands print. Four surfaces teach the values, and all four read one catalog
@@ -143,38 +142,22 @@ command-local flag on function-call commands. It selects a local destination
 when the output handler supports saving the result. Other output-producing
 commands do not expose it until they define how an output path affects them.
 
-## Workspace Configuration
+## Deferred Configuration
 
-The proposed configuration shape is:
+Persisted engine selection, Cloud trace settings, and scale-out settings are
+not part of this change. This change does not add them to the workspace
+`dagger.toml` schema. A separate user-environment design will define their
+configuration shape and priority.
 
-```toml
-[cloud.traces]
-enabled = true
-org = "my-org"
-
-[cloud.engines]
-enabled = true
-scale-out = false
-```
-
-`cloud.<product>.enabled` enables client-side use for the current machine or
-workspace. It does not enable the product for the Cloud organization. The
-organization must enable and authorize the product separately.
-
-Cloud Checks configuration is not part of `dagger.toml`. It is server-side
-configuration managed through the Dagger Cloud API.
-
-`cloud.engines.scale-out` is independent of `cloud.engines.enabled`. A command
-can use a local primary engine and use Cloud Engines only for scale-out work.
-Until persisted configuration is implemented, the hidden `--scale-out` flag is
-local to `dagger check`, which is its only consumer.
+The hidden `--scale-out` flag is local to `dagger check`, which is its only
+consumer.
 
 ## Global Flag Disposition
 
-The table includes every current root-persistent flag. A dash in the `Change`
-column means that no change is proposed.
+The table includes every root-persistent flag from the initial design review. A
+dash in the `Change` column means that no change was proposed.
 
-| Change | Flag | Current | Capability or `dagger.toml` field |
+| Change | Flag | Original visibility | Capability or target |
 |---|---|---|---|
 | Scope to command and keep hidden | `--scale-out` | Hidden | `dagger check`; persisted configuration is deferred |
 | Scope by capability and rename | `--cloud` | Hidden | `--engine`; `MayCallEngine`; keep `--cloud` as a hidden deprecated alias |
@@ -201,11 +184,6 @@ column means that no change is proposed.
 
 ## Status
 
-`MayCallEngine`, `MaySelectWorkspace`, `MayReadWorkspaceConfig`,
-`MayWriteWorkspaceConfig`, `MayRenderPipeline`, and `MayProduceOutput`
-capability scoping are implemented. All capability-scoped flag moves are
-implemented. The hide changes are also implemented. The configuration changes
-are planned. `--engine` and its hidden `--cloud` compatibility alias are scoped
-to `MayCallEngine`. The hidden `--scale-out` flag is local to `dagger check`.
-Persisted engine and scale-out settings remain part of the user configuration
-design.
+All changes in the table are implemented. `--engine` and its hidden `--cloud`
+compatibility alias require `MayCallEngine`. The hidden `--scale-out` flag is
+local to `dagger check`. Persisted settings remain outside this plan.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -134,7 +134,6 @@ column means that no change is proposed.
 
 | Change | Flag | Current | Capability or `dagger.toml` field |
 |---|---|---|---|
-| Move to configuration | `--org` | Visible | `cloud.traces.org` |
 | Move to configuration | `--cloud` | Hidden | `cloud.engines.enabled` |
 | Move to configuration | `--scale-out` | Hidden | `cloud.engines.scale-out` |
 | Scope by capability | `-W`, `--workspace` | Visible | `MaySelectWorkspace` |
@@ -152,6 +151,7 @@ column means that no change is proposed.
 | Scope by capability | `--dot-show-internal` | Hidden | `MayRenderPipeline`; requires DOT output |
 | Scope by capability and rename | `-i`, `--interactive` | Visible | `-i`, `--shell-on-error`; `MayCallEngine`; keep `--interactive` as a hidden deprecated alias |
 | Scope by capability, rename and hide | `--interactive-command` | Visible | `--shell-command-on-error`; `MayCallEngine`; keep `--interactive-command` as a hidden deprecated alias |
+| Hide | `--org` | Visible | Existing Cloud organization selector; replacement design is unresolved |
 | Hide | `--x-release` | Visible | Bootstrap control; prefer `DAGGER_X_RELEASE` |
 | - | `--workdir` | Hidden | Bootstrap working directory |
 | - | `-v`, `--verbose` | Visible | Global diagnostic escape hatch |
@@ -162,4 +162,5 @@ column means that no change is proposed.
 `MayCallEngine`, `MaySelectWorkspace`, `MayReadWorkspaceConfig`,
 `MayWriteWorkspaceConfig`, `MayRenderPipeline`, and `MayProduceOutput`
 capability scoping are implemented. All capability-scoped flag moves are
-implemented. The configuration and remaining hide changes are planned.
+implemented. The hide changes are also implemented. The configuration changes
+are planned.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -34,7 +34,7 @@ to prevent a flag from appearing before the subcommand. For example,
 | `MayReadWorkspaceConfig` | The command can use `--env` when reading workspace configuration. |
 | `MayWriteWorkspaceConfig` | The command can use `--env` when writing workspace configuration. |
 | `MayRenderPipeline` | The command can show a user-facing pipeline trace. |
-| `MayProduceOutput` | The command can produce an output that can require user review before a side effect. |
+| `MayProduceOutput` | The command can produce an output whose disposition can require user input, such as review before a side effect or selection of a local output path. |
 
 The capabilities are independent. A command can declare more than one.
 
@@ -78,6 +78,17 @@ client ownership list.
 
 `dagger setup` remains base-only. It declares neither workspace configuration
 capability and does not accept `--env`.
+
+### Output disposition
+
+`--auto-apply` is available on commands that declare `MayProduceOutput`. It
+applies an output without interactive review when the output handler supports
+application.
+
+`-o`, `--output` is also scoped by `MayProduceOutput`, but it remains a
+command-local flag on function-call commands. It selects a local destination
+when the output handler supports saving the result. Other output-producing
+commands do not expose it until they define how an output path affects them.
 
 ## Workspace Configuration
 
@@ -136,5 +147,5 @@ column means that no change is proposed.
 ## Status
 
 `MayCallEngine`, `MaySelectWorkspace`, `MayReadWorkspaceConfig`,
-`MayWriteWorkspaceConfig`, and `MayRenderPipeline` capability scoping are
-implemented. The other changes are planned.
+`MayWriteWorkspaceConfig`, `MayRenderPipeline`, and `MayProduceOutput`
+capability scoping are implemented. The other changes are planned.

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -55,12 +55,20 @@ The capability does not depend on the current output type.
 `--verbose` remains global as a diagnostic escape hatch. When a command emits
 a trace, `--verbose` prints a final trace even if the command does not declare
 `MayRenderPipeline`. It does not enable the live TUI or make `--no-exit`,
-`--web`, or `--interactive` applicable.
+`--web`, or other pipeline rendering flags applicable.
 
 `--debug` enables engine and trace diagnostics. It is available when a command
 declares `MayCallEngine OR MayRenderPipeline`. Engine commands request debug
 logs from the engine. Rendering commands expose internal trace details. No
 current command outside this capability union implements debug behavior.
+
+`-i`, `--shell-on-error` asks the engine to open a shell in the failed
+container state when a non-internal container exec fails. It requires
+`MayCallEngine`; it does not require `MayRenderPipeline`. The old
+`--interactive` name remains as a hidden deprecated alias.
+`--shell-command-on-error` sets the command that shell runs. It is hidden
+and also requires `MayCallEngine`; `--interactive-command` remains as a
+hidden deprecated alias.
 
 ### Workspace environment selection
 
@@ -135,7 +143,6 @@ column means that no change is proposed.
 | Scope by capability | `-s`, `--silent` | Visible | `MayRenderPipeline` |
 | Scope by capability | `-d`, `--debug` | Visible | `MayCallEngine OR MayRenderPipeline` |
 | Scope by capability | `--progress` | Visible | `MayRenderPipeline` |
-| Scope by capability | `-i`, `--interactive` | Visible | `MayCallEngine AND MayRenderPipeline` |
 | Scope by capability | `-w`, `--web` | Visible | `MayRenderPipeline` |
 | Scope by capability | `-E`, `--no-exit` | Visible | `MayRenderPipeline` |
 | Scope by capability | `-y`, `--auto-apply` | Visible | `MayProduceOutput` |
@@ -143,7 +150,8 @@ column means that no change is proposed.
 | Scope by capability | `--dot-output` | Hidden | `MayRenderPipeline` |
 | Scope by capability | `--dot-focus-field` | Hidden | `MayRenderPipeline`; requires DOT output |
 | Scope by capability | `--dot-show-internal` | Hidden | `MayRenderPipeline`; requires DOT output |
-| Scope by capability and hide | `--interactive-command` | Visible | `MayCallEngine AND MayRenderPipeline`; only affects `--interactive` |
+| Scope by capability and rename | `-i`, `--interactive` | Visible | `-i`, `--shell-on-error`; `MayCallEngine`; keep `--interactive` as a hidden deprecated alias |
+| Scope by capability, rename and hide | `--interactive-command` | Visible | `--shell-command-on-error`; `MayCallEngine`; keep `--interactive-command` as a hidden deprecated alias |
 | Hide | `--x-release` | Visible | Bootstrap control; prefer `DAGGER_X_RELEASE` |
 | - | `--workdir` | Hidden | Bootstrap working directory |
 | - | `-v`, `--verbose` | Visible | Global diagnostic escape hatch |
@@ -154,5 +162,4 @@ column means that no change is proposed.
 `MayCallEngine`, `MaySelectWorkspace`, `MayReadWorkspaceConfig`,
 `MayWriteWorkspaceConfig`, `MayRenderPipeline`, and `MayProduceOutput`
 capability scoping are implemented. All capability-scoped flag moves are
-implemented except `--interactive` and `--interactive-command`. The
-configuration and hide changes are planned.
+implemented. The configuration and remaining hide changes are planned.

--- a/hack/with-dev
+++ b/hack/with-dev
@@ -11,7 +11,7 @@ export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_BIN_ROOT/dagger
 if [[ "$(uname -s)" != "Linux" ]]; then
     export _TEST_DAGGER_CLI_LINUX_BIN=$DAGGER_BIN_ROOT/dagger-linux
 fi
-export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+export DAGGER_ENGINE=container://dagger-engine.dev
 export _DAGGER_TESTS_ENGINE_TAR=$DAGGER_BIN_ROOT/engine.tar
 export PATH=$DAGGER_BIN_ROOT:$PATH
 

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -20,6 +20,7 @@ const (
 	mayReadWorkspaceConfig  commandCapability = "MayReadWorkspaceConfig"
 	mayWriteWorkspaceConfig commandCapability = "MayWriteWorkspaceConfig"
 	mayRenderPipeline       commandCapability = "MayRenderPipeline"
+	mayProduceOutput        commandCapability = "MayProduceOutput"
 
 	commandCapabilitiesAnnotation      = "dagger.io/command-capabilities"
 	localCommandCapabilitiesAnnotation = "dagger.io/local-command-capabilities"
@@ -283,5 +284,17 @@ func init() {
 		workspaceRemoteCmd,
 	} {
 		setCommandCapabilities(cmd, maySelectWorkspace)
+	}
+
+	for _, cmd := range []*cobra.Command{
+		generateCmd,
+		apiCallCmd.Command(),
+		callModCmd.Command(),
+		callCoreCmd.Command(),
+		moduleInitCmd,
+		apiClientInitCmd,
+		setupCmd,
+	} {
+		setCommandCapabilities(cmd, mayProduceOutput)
 	}
 }

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -148,6 +148,11 @@ func resolveCommand(root *cobra.Command, args []string) (*cobra.Command, []strin
 func copyCommandFlags(cmd *cobra.Command, name string) *pflag.FlagSet {
 	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
 	flags.ParseErrorsAllowlist.UnknownFlags = true
+	if cmd.DisableFlagParsing {
+		// Dynamic commands parse their own arguments after loading a schema.
+		// Stop the early global pass at the first schema-owned token.
+		flags.SetInterspersed(false)
+	}
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		clone := *flag
 		clone.Changed = false

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -15,40 +15,48 @@ import (
 type commandCapability string
 
 const (
+	mayCallEngine     commandCapability = "MayCallEngine"
 	mayRenderPipeline commandCapability = "MayRenderPipeline"
 
-	commandCapabilitiesAnnotation = "dagger.io/command-capabilities"
-	flagCapabilitiesAnnotation    = "dagger.io/flag-capabilities"
+	commandCapabilitiesAnnotation      = "dagger.io/command-capabilities"
+	localCommandCapabilitiesAnnotation = "dagger.io/local-command-capabilities"
+	flagCapabilitiesAnnotation         = "dagger.io/flag-capabilities"
 )
 
 // setCommandCapabilities declares behavior that a command can expose. A
-// capability declared by a non-root parent applies to its subcommands. A root
-// capability applies only to the root command itself, so it does not make the
-// capability global again.
+// capability declared by a parent applies to its subcommands.
 func setCommandCapabilities(cmd *cobra.Command, capabilities ...commandCapability) {
+	addCommandCapabilities(cmd, commandCapabilitiesAnnotation, capabilities...)
+}
+
+// setLocalCommandCapabilities declares behavior for only cmd, without making
+// the capability available to its subcommands.
+func setLocalCommandCapabilities(cmd *cobra.Command, capabilities ...commandCapability) {
+	addCommandCapabilities(cmd, localCommandCapabilitiesAnnotation, capabilities...)
+}
+
+func addCommandCapabilities(cmd *cobra.Command, annotation string, capabilities ...commandCapability) {
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
 	}
 
-	declared := strings.Fields(cmd.Annotations[commandCapabilitiesAnnotation])
+	declared := strings.Fields(cmd.Annotations[annotation])
 	for _, capability := range capabilities {
 		name := string(capability)
 		if !slices.Contains(declared, name) {
 			declared = append(declared, name)
 		}
 	}
-	cmd.Annotations[commandCapabilitiesAnnotation] = strings.Join(declared, " ")
+	cmd.Annotations[annotation] = strings.Join(declared, " ")
 }
 
 func commandHasCapability(cmd *cobra.Command, capability commandCapability) bool {
-	selected := cmd
+	name := string(capability)
+	if slices.Contains(strings.Fields(cmd.Annotations[localCommandCapabilitiesAnnotation]), name) {
+		return true
+	}
 	for current := cmd; current != nil; current = current.Parent() {
-		// The root command can still run legacy shell input directly, but its
-		// capability must not be inherited by every subcommand.
-		if current != selected && current.Parent() == nil {
-			continue
-		}
-		if slices.Contains(strings.Fields(current.Annotations[commandCapabilitiesAnnotation]), string(capability)) {
+		if slices.Contains(strings.Fields(current.Annotations[commandCapabilitiesAnnotation]), name) {
 			return true
 		}
 	}
@@ -173,13 +181,14 @@ func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {
 }
 
 func init() {
+	setLocalCommandCapabilities(rootCmd, mayCallEngine, mayRenderPipeline)
+	setLocalCommandCapabilities(workspaceCmd, mayCallEngine)
+
 	for _, cmd := range []*cobra.Command{
-		rootCmd,
 		checksCmd,
 		generateCmd,
 		upCmd,
 		agentCmd,
-		traceCmd,
 		apiCallCmd.Command(),
 		callModCmd.Command(),
 		callCoreCmd.Command(),
@@ -196,6 +205,41 @@ func init() {
 		mcpCmd,
 		moduleSdkCmd,
 	} {
-		setCommandCapabilities(cmd, mayRenderPipeline)
+		setCommandCapabilities(cmd, mayCallEngine, mayRenderPipeline)
+	}
+	setCommandCapabilities(traceCmd, mayRenderPipeline)
+
+	for _, cmd := range []*cobra.Command{
+		apiFunctionsCmd,
+		functionsAliasCmd,
+		moduleDepInstallCmd,
+		moduleDepUninstallCmd,
+		moduleUpdateCmd,
+		installedCmd,
+		settingsCmd,
+		workspaceSettingsCmd,
+		workspaceRootCmd,
+		workspaceCwdCmd,
+		workspaceConfigFileCmd,
+		workspaceConfigCmd,
+		workspaceRemotesCmd,
+		moduleDepsAddCmd,
+		moduleDepsRmCmd,
+		moduleDepsUpdateCmd,
+		moduleDepsListCmd,
+		moduleEngineRequiredCmd,
+		moduleEngineRequireCmd,
+		moduleEngineRequireLatestCmd,
+		moduleEngineRequireCurrentCmd,
+		moduleInitCmd,
+		apiClientInitCmd,
+		apiClientListCmd,
+		sdkInstallCmd,
+		sdkUninstallCmd,
+		sdkModuleOptionsCmd,
+		sdkClientOptionsCmd,
+		setupCmd,
+	} {
+		setCommandCapabilities(cmd, mayCallEngine)
 	}
 }

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -178,9 +178,13 @@ func validateFlagCapabilities(root *cobra.Command, args []string) error {
 	// the flags that it can parse without changing their values.
 	_ = parsed.Parse(commandArgs)
 
+	// Bare `dagger` prints usage, but shell-style root invocations run the
+	// shell command, so they get the shell command's capabilities.
+	effective := rootShellFallbackCommand(cmd, parsed)
+
 	var unsupported []string
 	parsed.Visit(func(flag *pflag.Flag) {
-		if !FlagAvailableForCommand(cmd, flag) {
+		if !FlagAvailableForCommand(effective, flag) {
 			unsupported = append(unsupported, "--"+flag.Name)
 		}
 	})
@@ -192,6 +196,31 @@ func validateFlagCapabilities(root *cobra.Command, args []string) error {
 		return fmt.Errorf("flag %s is not supported by command %q", unsupported[0], cmd.CommandPath())
 	}
 	return fmt.Errorf("flags %s are not supported by command %q", strings.Join(unsupported, ", "), cmd.CommandPath())
+}
+
+// rootShellFallbackCommand reports the command that a root invocation runs.
+// `dagger -c ...` and `dagger file.dsh` fall back to `dagger shell`, so their
+// flags are checked against the shell command instead of the root command.
+func rootShellFallbackCommand(cmd *cobra.Command, parsed *pflag.FlagSet) *cobra.Command {
+	if cmd != rootCmd {
+		return cmd
+	}
+	if args := parsed.Args(); len(args) > 0 && isFile(args[0]) {
+		return shellCmd
+	}
+	// Only root-local flags signal a shell-style invocation. Global flags are
+	// persistent, and they do not select the shell.
+	persistent := rootCmd.PersistentFlags()
+	shellStyle := false
+	parsed.Visit(func(flag *pflag.Flag) {
+		if persistent.Lookup(flag.Name) == nil {
+			shellStyle = true
+		}
+	})
+	if shellStyle {
+		return shellCmd
+	}
+	return cmd
 }
 
 func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {
@@ -209,7 +238,11 @@ func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {
 }
 
 func init() {
-	setLocalCommandCapabilities(rootCmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig, mayRenderPipeline)
+	// The root command itself does not call the engine: bare `dagger` prints
+	// usage, and shell-style invocations (`dagger -c ...`) re-enter through
+	// `dagger shell`, which declares the capability. Keeping mayCallEngine off
+	// the root keeps engine flags out of the front-door usage message.
+	setLocalCommandCapabilities(rootCmd, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig, mayRenderPipeline)
 	setLocalCommandCapabilities(workspaceCmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
 
 	for _, cmd := range []*cobra.Command{

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -2,6 +2,7 @@ package daggercmd
 
 import (
 	"fmt"
+	"io"
 	"slices"
 	"sort"
 	"strings"
@@ -148,6 +149,10 @@ func resolveCommand(root *cobra.Command, args []string) (*cobra.Command, []strin
 func copyCommandFlags(cmd *cobra.Command, name string) *pflag.FlagSet {
 	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
 	flags.ParseErrorsAllowlist.UnknownFlags = true
+	// These are early passes over the same arguments Cobra parses later. Keep
+	// them quiet, or a deprecated flag prints its warning once per pass; the
+	// callers report their own errors.
+	flags.SetOutput(io.Discard)
 	if cmd.DisableFlagParsing {
 		// Dynamic commands parse their own arguments after loading a schema.
 		// Stop the early global pass at the first schema-owned token.

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -15,12 +15,16 @@ import (
 type commandCapability string
 
 const (
-	mayCallEngine     commandCapability = "MayCallEngine"
-	mayRenderPipeline commandCapability = "MayRenderPipeline"
+	mayCallEngine           commandCapability = "MayCallEngine"
+	maySelectWorkspace      commandCapability = "MaySelectWorkspace"
+	mayReadWorkspaceConfig  commandCapability = "MayReadWorkspaceConfig"
+	mayWriteWorkspaceConfig commandCapability = "MayWriteWorkspaceConfig"
+	mayRenderPipeline       commandCapability = "MayRenderPipeline"
 
 	commandCapabilitiesAnnotation      = "dagger.io/command-capabilities"
 	localCommandCapabilitiesAnnotation = "dagger.io/local-command-capabilities"
 	flagCapabilitiesAnnotation         = "dagger.io/flag-capabilities"
+	flagAnyCapabilitiesAnnotation      = "dagger.io/flag-any-capabilities"
 )
 
 // setCommandCapabilities declares behavior that a command can expose. A
@@ -69,16 +73,26 @@ func setFlagSetCapabilities(flags *pflag.FlagSet, capabilities ...commandCapabil
 	})
 }
 
-// setFlagCapabilities declares the capabilities a command must have for the
-// flag to be available on it.
+// setFlagCapabilities declares the capabilities a command must all have for
+// the flag to be available on it.
 func setFlagCapabilities(flag *pflag.Flag, capabilities ...commandCapability) {
+	addFlagCapabilities(flag, flagCapabilitiesAnnotation, capabilities...)
+}
+
+// setFlagAnyCapabilities declares the capabilities of which a command must
+// have at least one for the flag to be available on it.
+func setFlagAnyCapabilities(flag *pflag.Flag, capabilities ...commandCapability) {
+	addFlagCapabilities(flag, flagAnyCapabilitiesAnnotation, capabilities...)
+}
+
+func addFlagCapabilities(flag *pflag.Flag, annotation string, capabilities ...commandCapability) {
 	if flag.Annotations == nil {
 		flag.Annotations = map[string][]string{}
 	}
 	for _, capability := range capabilities {
 		value := string(capability)
-		if !slices.Contains(flag.Annotations[flagCapabilitiesAnnotation], value) {
-			flag.Annotations[flagCapabilitiesAnnotation] = append(flag.Annotations[flagCapabilitiesAnnotation], value)
+		if !slices.Contains(flag.Annotations[annotation], value) {
+			flag.Annotations[annotation] = append(flag.Annotations[annotation], value)
 		}
 	}
 }
@@ -90,6 +104,14 @@ func FlagAvailableForCommand(cmd *cobra.Command, flag *pflag.Flag) bool {
 		if !commandHasCapability(cmd, commandCapability(required)) {
 			return false
 		}
+	}
+	if any := flag.Annotations[flagAnyCapabilitiesAnnotation]; len(any) > 0 {
+		for _, required := range any {
+			if commandHasCapability(cmd, commandCapability(required)) {
+				return true
+			}
+		}
+		return false
 	}
 	return true
 }
@@ -181,8 +203,8 @@ func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {
 }
 
 func init() {
-	setLocalCommandCapabilities(rootCmd, mayCallEngine, mayRenderPipeline)
-	setLocalCommandCapabilities(workspaceCmd, mayCallEngine)
+	setLocalCommandCapabilities(rootCmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig, mayRenderPipeline)
+	setLocalCommandCapabilities(workspaceCmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
 
 	for _, cmd := range []*cobra.Command{
 		checksCmd,
@@ -205,24 +227,27 @@ func init() {
 		mcpCmd,
 		moduleSdkCmd,
 	} {
-		setCommandCapabilities(cmd, mayCallEngine, mayRenderPipeline)
+		setCommandCapabilities(cmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayRenderPipeline)
 	}
 	setCommandCapabilities(traceCmd, mayRenderPipeline)
 
 	for _, cmd := range []*cobra.Command{
-		apiFunctionsCmd,
-		functionsAliasCmd,
 		moduleDepInstallCmd,
 		moduleDepUninstallCmd,
-		moduleUpdateCmd,
-		installedCmd,
 		settingsCmd,
 		workspaceSettingsCmd,
-		workspaceRootCmd,
-		workspaceCwdCmd,
-		workspaceConfigFileCmd,
 		workspaceConfigCmd,
-		workspaceRemotesCmd,
+		moduleInitCmd,
+		apiClientInitCmd,
+	} {
+		setCommandCapabilities(cmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
+	}
+
+	for _, cmd := range []*cobra.Command{
+		apiFunctionsCmd,
+		functionsAliasCmd,
+		moduleUpdateCmd,
+		installedCmd,
 		moduleDepsAddCmd,
 		moduleDepsRmCmd,
 		moduleDepsUpdateCmd,
@@ -231,15 +256,32 @@ func init() {
 		moduleEngineRequireCmd,
 		moduleEngineRequireLatestCmd,
 		moduleEngineRequireCurrentCmd,
-		moduleInitCmd,
-		apiClientInitCmd,
 		apiClientListCmd,
-		sdkInstallCmd,
-		sdkUninstallCmd,
 		sdkModuleOptionsCmd,
 		sdkClientOptionsCmd,
+	} {
+		setCommandCapabilities(cmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig)
+	}
+	setCommandCapabilities(sdkInstalledCmd, mayReadWorkspaceConfig)
+
+	for _, cmd := range []*cobra.Command{
+		workspaceRootCmd,
+		workspaceCwdCmd,
+		workspaceConfigFileCmd,
+		workspaceRemotesCmd,
+		sdkInstallCmd,
+		sdkUninstallCmd,
 		setupCmd,
 	} {
-		setCommandCapabilities(cmd, mayCallEngine)
+		setCommandCapabilities(cmd, mayCallEngine, maySelectWorkspace)
+	}
+
+	for _, cmd := range []*cobra.Command{
+		activityCmd,
+		cloudCheckCmd,
+		cloudRerunCmd,
+		workspaceRemoteCmd,
+	} {
+		setCommandCapabilities(cmd, maySelectWorkspace)
 	}
 }

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -1,0 +1,201 @@
+package daggercmd
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/dagger/dagger/internal/cobradocs"
+)
+
+type commandCapability string
+
+const (
+	mayRenderPipeline commandCapability = "MayRenderPipeline"
+
+	commandCapabilitiesAnnotation = "dagger.io/command-capabilities"
+	flagCapabilitiesAnnotation    = "dagger.io/flag-capabilities"
+)
+
+// setCommandCapabilities declares behavior that a command can expose. A
+// capability declared by a non-root parent applies to its subcommands. A root
+// capability applies only to the root command itself, so it does not make the
+// capability global again.
+func setCommandCapabilities(cmd *cobra.Command, capabilities ...commandCapability) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+
+	declared := strings.Fields(cmd.Annotations[commandCapabilitiesAnnotation])
+	for _, capability := range capabilities {
+		name := string(capability)
+		if !slices.Contains(declared, name) {
+			declared = append(declared, name)
+		}
+	}
+	cmd.Annotations[commandCapabilitiesAnnotation] = strings.Join(declared, " ")
+}
+
+func commandHasCapability(cmd *cobra.Command, capability commandCapability) bool {
+	selected := cmd
+	for current := cmd; current != nil; current = current.Parent() {
+		// The root command can still run legacy shell input directly, but its
+		// capability must not be inherited by every subcommand.
+		if current != selected && current.Parent() == nil {
+			continue
+		}
+		if slices.Contains(strings.Fields(current.Annotations[commandCapabilitiesAnnotation]), string(capability)) {
+			return true
+		}
+	}
+	return false
+}
+
+func setFlagSetCapabilities(flags *pflag.FlagSet, capabilities ...commandCapability) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		setFlagCapabilities(flag, capabilities...)
+	})
+}
+
+// setFlagCapabilities declares the capabilities a command must have for the
+// flag to be available on it.
+func setFlagCapabilities(flag *pflag.Flag, capabilities ...commandCapability) {
+	if flag.Annotations == nil {
+		flag.Annotations = map[string][]string{}
+	}
+	for _, capability := range capabilities {
+		value := string(capability)
+		if !slices.Contains(flag.Annotations[flagCapabilitiesAnnotation], value) {
+			flag.Annotations[flagCapabilitiesAnnotation] = append(flag.Annotations[flagCapabilitiesAnnotation], value)
+		}
+	}
+}
+
+// FlagAvailableForCommand reports whether a flag's required capabilities are
+// available on cmd. It is exported for CLI reference generation.
+func FlagAvailableForCommand(cmd *cobra.Command, flag *pflag.Flag) bool {
+	for _, required := range flag.Annotations[flagCapabilitiesAnnotation] {
+		if !commandHasCapability(cmd, commandCapability(required)) {
+			return false
+		}
+	}
+	return true
+}
+
+func availableFlagsForCommand(cmd *cobra.Command, flags *pflag.FlagSet) *pflag.FlagSet {
+	available := pflag.NewFlagSet(flags.Name(), pflag.ContinueOnError)
+	available.SortFlags = flags.SortFlags
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if FlagAvailableForCommand(cmd, flag) {
+			available.AddFlag(flag)
+		}
+	})
+	return available
+}
+
+type ignoredFlagValue struct {
+	pflag.Value
+}
+
+func (ignoredFlagValue) Set(string) error {
+	return nil
+}
+
+func resolveCommand(root *cobra.Command, args []string) (*cobra.Command, []string) {
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd(args...)
+	// Cobra reports resolution errors during Execute. Policy checks use the
+	// best command match available here.
+	cmd, commandArgs, _ := root.Find(args)
+	return cmd, commandArgs
+}
+
+func copyCommandFlags(cmd *cobra.Command, name string) *pflag.FlagSet {
+	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
+	flags.ParseErrorsAllowlist.UnknownFlags = true
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		clone := *flag
+		clone.Changed = false
+		flags.AddFlag(&clone)
+	})
+	return flags
+}
+
+// validateFlagCapabilities resolves the selected command and its flags without
+// changing flag values. It must run before parseGlobalFlags, because those
+// values configure the frontend and can terminate the process.
+func validateFlagCapabilities(root *cobra.Command, args []string) error {
+	cmd, commandArgs := resolveCommand(root, args)
+	if cmd == nil {
+		return nil
+	}
+
+	parsed := copyCommandFlags(cmd, "capabilities")
+	parsed.VisitAll(func(flag *pflag.Flag) {
+		flag.Value = ignoredFlagValue{Value: flag.Value}
+	})
+	// The real parser reports syntax and value errors. This pass only records
+	// the flags that it can parse without changing their values.
+	_ = parsed.Parse(commandArgs)
+
+	var unsupported []string
+	parsed.Visit(func(flag *pflag.Flag) {
+		if !FlagAvailableForCommand(cmd, flag) {
+			unsupported = append(unsupported, "--"+flag.Name)
+		}
+	})
+	if len(unsupported) == 0 {
+		return nil
+	}
+	sort.Strings(unsupported)
+	if len(unsupported) == 1 {
+		return fmt.Errorf("flag %s is not supported by command %q", unsupported[0], cmd.CommandPath())
+	}
+	return fmt.Errorf("flags %s are not supported by command %q", strings.Join(unsupported, ", "), cmd.CommandPath())
+}
+
+func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {
+	if cmd.Name() != cobra.ShellCompRequestCmd || len(args) == 0 {
+		return nil
+	}
+
+	target, _, err := cmd.Root().Find(args[:len(args)-1])
+	if err != nil || target == nil {
+		return nil
+	}
+	return cobradocs.HideFlags(target, func(flag *pflag.Flag) bool {
+		return FlagAvailableForCommand(target, flag)
+	})
+}
+
+func init() {
+	for _, cmd := range []*cobra.Command{
+		rootCmd,
+		checksCmd,
+		generateCmd,
+		upCmd,
+		agentCmd,
+		traceCmd,
+		apiCallCmd.Command(),
+		callModCmd.Command(),
+		callCoreCmd.Command(),
+		apiQueryCmd,
+		queryCmd,
+		apiWithSessionCmd,
+		runCmd,
+		apiListenCmd,
+		listenCmd,
+		apiSessionCmd,
+		sessionAliasCmd,
+		shellCmd,
+		terminalCmd,
+		mcpCmd,
+		moduleSdkCmd,
+	} {
+		setCommandCapabilities(cmd, mayRenderPipeline)
+	}
+}

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -250,11 +250,12 @@ func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {
 }
 
 func init() {
-	// The root command itself does not call the engine: bare `dagger` prints
-	// usage, and shell-style invocations (`dagger -c ...`) re-enter through
-	// `dagger shell`, which declares the capability. Keeping mayCallEngine off
-	// the root keeps engine flags out of the front-door usage message.
-	setLocalCommandCapabilities(rootCmd, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig, mayRenderPipeline)
+	// The root command declares no capabilities. Bare `dagger` prints usage: it
+	// calls no engine, selects no workspace, reads no workspace configuration,
+	// and renders no pipeline, so its usage message stays free of those flags.
+	// Shell-style invocations (`dagger -c ...`, `dagger FILE`) do all of that,
+	// but they run `dagger shell`, which declares the capabilities;
+	// rootShellFallbackCommand routes the flag check there.
 	setLocalCommandCapabilities(workspaceCmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
 
 	for _, cmd := range []*cobra.Command{

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -165,6 +165,13 @@ func copyCommandFlags(cmd *cobra.Command, name string) *pflag.FlagSet {
 // changing flag values. It must run before parseGlobalFlags, because those
 // values configure the frontend and can terminate the process.
 func validateFlagCapabilities(root *cobra.Command, args []string) error {
+	if isShellCompletionRequest(args) {
+		// A completion request carries the flags of the command being
+		// completed, not of the command that runs. hideUnavailableCompletionFlags
+		// filters what completion offers.
+		return nil
+	}
+
 	cmd, commandArgs := resolveCommand(root, args)
 	if cmd == nil {
 		return nil
@@ -221,6 +228,11 @@ func rootShellFallbackCommand(cmd *cobra.Command, parsed *pflag.FlagSet) *cobra.
 		return shellCmd
 	}
 	return cmd
+}
+
+func isShellCompletionRequest(args []string) bool {
+	return len(args) > 0 &&
+		(args[0] == cobra.ShellCompRequestCmd || args[0] == cobra.ShellCompNoDescRequestCmd)
 }
 
 func hideUnavailableCompletionFlags(cmd *cobra.Command, args []string) func() {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandCapabilityInheritanceSkipsRoot(t *testing.T) {
+func TestCommandCapabilityInheritance(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
 	parent := &cobra.Command{Use: "parent"}
 	child := &cobra.Command{Use: "child"}
 	root.AddCommand(parent)
 	parent.AddCommand(child)
 
-	setCommandCapabilities(root, mayRenderPipeline)
+	setLocalCommandCapabilities(root, mayRenderPipeline)
 	require.True(t, commandHasCapability(root, mayRenderPipeline))
 	require.False(t, commandHasCapability(parent, mayRenderPipeline))
 	require.False(t, commandHasCapability(child, mayRenderPipeline))
@@ -27,6 +27,100 @@ func TestCommandCapabilityInheritanceSkipsRoot(t *testing.T) {
 	setCommandCapabilities(parent, mayRenderPipeline)
 	require.True(t, commandHasCapability(parent, mayRenderPipeline))
 	require.True(t, commandHasCapability(child, mayRenderPipeline))
+
+	setLocalCommandCapabilities(parent, mayCallEngine)
+	require.True(t, commandHasCapability(parent, mayCallEngine))
+	require.False(t, commandHasCapability(child, mayCallEngine))
+}
+
+func TestMayCallEngineFlags(t *testing.T) {
+	oldEnv := workspaceEnv
+	oldProfile := profileFlag
+	t.Cleanup(func() {
+		workspaceEnv = oldEnv
+		profileFlag = oldProfile
+	})
+
+	flags := pflag.NewFlagSet("engine", pflag.ContinueOnError)
+	installMayCallEngineFlags(flags)
+
+	expected := []string{"env", "profile"}
+	var count int
+	flags.VisitAll(func(*pflag.Flag) { count++ })
+	require.Equal(t, len(expected), count)
+	for _, name := range expected {
+		flag := flags.Lookup(name)
+		require.NotNil(t, flag, name)
+		require.Equal(t, []string{string(mayCallEngine)}, flag.Annotations[flagCapabilitiesAnnotation], name)
+	}
+	require.False(t, flags.Lookup("env").Hidden)
+	require.True(t, flags.Lookup("profile").Hidden)
+}
+
+func TestMayCallEngineCommands(t *testing.T) {
+	expected := []string{
+		"dagger",
+		"dagger agent",
+		"dagger api call",
+		"dagger api client init",
+		"dagger api client list",
+		"dagger api functions",
+		"dagger api listen",
+		"dagger api query",
+		"dagger api session",
+		"dagger api with-session",
+		"dagger call",
+		"dagger check",
+		"dagger core",
+		"dagger functions",
+		"dagger generate",
+		"dagger install",
+		"dagger installed",
+		"dagger listen",
+		"dagger mcp",
+		"dagger module deps add",
+		"dagger module deps list",
+		"dagger module deps rm",
+		"dagger module deps update",
+		"dagger module engine require",
+		"dagger module engine require-current",
+		"dagger module engine require-latest",
+		"dagger module engine required",
+		"dagger module init",
+		"dagger module sdk",
+		"dagger query",
+		"dagger run",
+		"dagger sdk client-options",
+		"dagger sdk install",
+		"dagger sdk module-options",
+		"dagger sdk uninstall",
+		"dagger session",
+		"dagger settings",
+		"dagger setup",
+		"dagger shell",
+		"dagger terminal",
+		"dagger uninstall",
+		"dagger up",
+		"dagger update",
+		"dagger workspace",
+		"dagger workspace config",
+		"dagger workspace config-file",
+		"dagger workspace cwd",
+		"dagger workspace remotes",
+		"dagger workspace root",
+		"dagger workspace settings",
+	}
+	require.ElementsMatch(t, expected, commandsDeclaringCapability(rootCmd, mayCallEngine))
+
+	for name, cmd := range map[string]*cobra.Command{
+		"activity":         activityCmd,
+		"cloud rerun":      cloudRerunCmd,
+		"sdk installed":    sdkInstalledCmd,
+		"trace":            traceCmd,
+		"workspace remote": workspaceRemoteCmd,
+	} {
+		require.False(t, commandHasCapability(cmd, mayCallEngine), name)
+	}
 }
 
 func TestMayRenderPipelineFlags(t *testing.T) {
@@ -99,18 +193,7 @@ func TestMayRenderPipelineCommands(t *testing.T) {
 		"dagger trace",
 		"dagger up",
 	}
-	var actual []string
-	var visit func(*cobra.Command)
-	visit = func(cmd *cobra.Command) {
-		if slices.Contains(strings.Fields(cmd.Annotations[commandCapabilitiesAnnotation]), string(mayRenderPipeline)) {
-			actual = append(actual, cmd.CommandPath())
-		}
-		for _, child := range cmd.Commands() {
-			visit(child)
-		}
-	}
-	visit(rootCmd)
-	require.ElementsMatch(t, expected, actual)
+	require.ElementsMatch(t, expected, commandsDeclaringCapability(rootCmd, mayRenderPipeline))
 
 	for name, cmd := range map[string]*cobra.Command{
 		"settings":  settingsCmd,
@@ -284,4 +367,22 @@ func commandUsage(t *testing.T, cmd *cobra.Command) string {
 	cmd.SetUsageTemplate(usageTemplate)
 	require.NoError(t, cmd.Usage())
 	return output.String()
+}
+
+func commandsDeclaringCapability(root *cobra.Command, capability commandCapability) []string {
+	var commands []string
+	var visit func(*cobra.Command)
+	visit = func(cmd *cobra.Command) {
+		name := string(capability)
+		inherited := strings.Fields(cmd.Annotations[commandCapabilitiesAnnotation])
+		local := strings.Fields(cmd.Annotations[localCommandCapabilitiesAnnotation])
+		if slices.Contains(inherited, name) || slices.Contains(local, name) {
+			commands = append(commands, cmd.CommandPath())
+		}
+		for _, child := range cmd.Commands() {
+			visit(child)
+		}
+	}
+	visit(root)
+	return commands
 }

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -95,14 +95,18 @@ func TestDebugFlags(t *testing.T) {
 
 func TestMayCallEngineFlags(t *testing.T) {
 	oldProfile := profileFlag
+	oldShellOnError := shellOnError
+	oldShellCommandOnError := shellCommandOnError
 	t.Cleanup(func() {
 		profileFlag = oldProfile
+		shellOnError = oldShellOnError
+		shellCommandOnError = oldShellCommandOnError
 	})
 
 	flags := pflag.NewFlagSet("engine", pflag.ContinueOnError)
 	installMayCallEngineFlags(flags)
 
-	expected := []string{"profile"}
+	expected := []string{"interactive", "interactive-command", "profile", "shell-command-on-error", "shell-on-error"}
 	var count int
 	flags.VisitAll(func(*pflag.Flag) { count++ })
 	require.Equal(t, len(expected), count)
@@ -111,7 +115,43 @@ func TestMayCallEngineFlags(t *testing.T) {
 		require.NotNil(t, flag, name)
 		require.Equal(t, []string{string(mayCallEngine)}, flag.Annotations[flagCapabilitiesAnnotation], name)
 	}
+	require.Equal(t, "i", flags.Lookup("shell-on-error").Shorthand)
+	require.False(t, flags.Lookup("shell-on-error").Hidden)
+	require.True(t, flags.Lookup("interactive").Hidden)
+	require.Contains(t, flags.Lookup("interactive").Deprecated, "--shell-on-error")
+	require.True(t, flags.Lookup("shell-command-on-error").Hidden)
+	require.True(t, flags.Lookup("interactive-command").Hidden)
+	require.Contains(t, flags.Lookup("interactive-command").Deprecated, "--shell-command-on-error")
 	require.True(t, flags.Lookup("profile").Hidden)
+
+	// Every deprecated alias still drives the same variables.
+	for _, name := range []string{"interactive", "shell-on-error"} {
+		shellOnError = false
+		require.NoError(t, flags.Set(name, "true"))
+		require.True(t, shellOnError, name)
+	}
+	for _, name := range []string{"interactive-command", "shell-command-on-error"} {
+		shellCommandOnError = ""
+		require.NoError(t, flags.Set(name, "/bin/bash"))
+		require.Equal(t, "/bin/bash", shellCommandOnError, name)
+	}
+
+	for _, name := range []string{"interactive", "interactive-command", "shell-command-on-error", "shell-on-error"} {
+		flag := flags.Lookup(name)
+		var visit func(*cobra.Command)
+		visit = func(cmd *cobra.Command) {
+			require.Equal(t, commandHasCapability(cmd, mayCallEngine), FlagAvailableForCommand(cmd, flag), "%s: --%s", cmd.CommandPath(), name)
+			for _, child := range cmd.Commands() {
+				visit(child)
+			}
+		}
+		visit(rootCmd)
+	}
+
+	require.True(t, FlagAvailableForCommand(settingsCmd, flags.Lookup("shell-on-error")))
+	require.False(t, FlagAvailableForCommand(traceCmd, flags.Lookup("shell-on-error")))
+	require.False(t, FlagAvailableForCommand(activityCmd, flags.Lookup("shell-on-error")))
+	require.False(t, FlagAvailableForCommand(sdkInstalledCmd, flags.Lookup("shell-on-error")))
 }
 
 func TestWorkspaceConfigFlags(t *testing.T) {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -98,19 +98,19 @@ func TestDebugFlags(t *testing.T) {
 }
 
 func TestMayCallEngineFlags(t *testing.T) {
-	oldCloud := useCloudEngine
+	oldCloud := cloudFlag
 	oldEngine := engineFlag
 	oldProfile := profileFlag
 	oldShellOnError := shellOnError
 	oldShellCommandOnError := shellCommandOnError
 	t.Cleanup(func() {
-		useCloudEngine = oldCloud
+		cloudFlag = oldCloud
 		engineFlag = oldEngine
 		profileFlag = oldProfile
 		shellOnError = oldShellOnError
 		shellCommandOnError = oldShellCommandOnError
 	})
-	useCloudEngine = false
+	cloudFlag = false
 	engineFlag = ""
 
 	flags := pflag.NewFlagSet("engine", pflag.ContinueOnError)
@@ -138,6 +138,7 @@ func TestMayCallEngineFlags(t *testing.T) {
 	require.NotContains(t, usage, "\n")
 	require.Contains(t, usage, drivers.SchemeSummary())
 	require.Contains(t, usage, "dagger help engine")
+	require.Contains(t, usage, engineEnv)
 	for _, value := range []string{"cloud", "image://", "container://", "ssh://", "unix://"} {
 		require.Contains(t, usage, value)
 	}
@@ -153,7 +154,7 @@ func TestMayCallEngineFlags(t *testing.T) {
 	require.Contains(t, flags.Lookup("interactive-command").Deprecated, "--shell-command-on-error")
 	require.True(t, flags.Lookup("profile").Hidden)
 	require.NoError(t, flags.Set("cloud", "true"))
-	require.True(t, useCloudEngine)
+	require.True(t, cloudFlag)
 	require.NoError(t, flags.Set("engine", "tcp://engine.example.com:1234"))
 	require.Equal(t, "tcp://engine.example.com:1234", engineFlag)
 

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -33,18 +33,30 @@ func TestCommandCapabilityInheritance(t *testing.T) {
 	require.False(t, commandHasCapability(child, mayCallEngine))
 }
 
+func TestMaySelectWorkspaceFlags(t *testing.T) {
+	oldWorkspace := workspaceRef
+	t.Cleanup(func() { workspaceRef = oldWorkspace })
+
+	flags := pflag.NewFlagSet("workspace", pflag.ContinueOnError)
+	installGlobalFlags(flags)
+
+	flag := flags.Lookup("workspace")
+	require.NotNil(t, flag)
+	require.Equal(t, "W", flag.Shorthand)
+	require.False(t, flag.Hidden)
+	require.Equal(t, []string{string(maySelectWorkspace)}, flag.Annotations[flagCapabilitiesAnnotation])
+}
+
 func TestMayCallEngineFlags(t *testing.T) {
-	oldEnv := workspaceEnv
 	oldProfile := profileFlag
 	t.Cleanup(func() {
-		workspaceEnv = oldEnv
 		profileFlag = oldProfile
 	})
 
 	flags := pflag.NewFlagSet("engine", pflag.ContinueOnError)
 	installMayCallEngineFlags(flags)
 
-	expected := []string{"env", "profile"}
+	expected := []string{"profile"}
 	var count int
 	flags.VisitAll(func(*pflag.Flag) { count++ })
 	require.Equal(t, len(expected), count)
@@ -53,8 +65,31 @@ func TestMayCallEngineFlags(t *testing.T) {
 		require.NotNil(t, flag, name)
 		require.Equal(t, []string{string(mayCallEngine)}, flag.Annotations[flagCapabilitiesAnnotation], name)
 	}
-	require.False(t, flags.Lookup("env").Hidden)
 	require.True(t, flags.Lookup("profile").Hidden)
+}
+
+func TestWorkspaceConfigFlags(t *testing.T) {
+	oldEnv := workspaceEnv
+	t.Cleanup(func() { workspaceEnv = oldEnv })
+
+	flags := pflag.NewFlagSet("config", pflag.ContinueOnError)
+	installGlobalFlags(flags)
+
+	flag := flags.Lookup("env")
+	require.NotNil(t, flag)
+	require.Equal(t, []string{
+		string(mayReadWorkspaceConfig),
+		string(mayWriteWorkspaceConfig),
+	}, flag.Annotations[flagAnyCapabilitiesAnnotation])
+	require.False(t, flag.Hidden)
+
+	read := &cobra.Command{Use: "read"}
+	setCommandCapabilities(read, mayReadWorkspaceConfig)
+	require.True(t, FlagAvailableForCommand(read, flag))
+	write := &cobra.Command{Use: "write"}
+	setCommandCapabilities(write, mayWriteWorkspaceConfig)
+	require.True(t, FlagAvailableForCommand(write, flag))
+	require.False(t, FlagAvailableForCommand(&cobra.Command{Use: "plain"}, flag))
 }
 
 func TestMayCallEngineCommands(t *testing.T) {
@@ -123,6 +158,46 @@ func TestMayCallEngineCommands(t *testing.T) {
 	}
 }
 
+func TestMaySelectWorkspaceCommands(t *testing.T) {
+	expected := append(commandsDeclaringCapability(rootCmd, mayCallEngine),
+		"dagger activity",
+		"dagger cloud check",
+		"dagger cloud rerun",
+		"dagger workspace remote",
+	)
+	require.ElementsMatch(t, expected, commandsDeclaringCapability(rootCmd, maySelectWorkspace))
+
+	var visit func(*cobra.Command)
+	visit = func(cmd *cobra.Command) {
+		if commandHasCapability(cmd, mayCallEngine) {
+			require.True(t, commandHasCapability(cmd, maySelectWorkspace), cmd.CommandPath())
+		}
+		for _, child := range cmd.Commands() {
+			visit(child)
+		}
+	}
+	visit(rootCmd)
+
+	for name, cmd := range map[string]*cobra.Command{
+		"activity":           activityCmd,
+		"cloud check list":   cloudCheckListCmd,
+		"cloud check status": cloudCheckStatusCmd,
+		"cloud rerun":        cloudRerunCmd,
+		"workspace remote":   workspaceRemoteCmd,
+	} {
+		require.True(t, commandHasCapability(cmd, maySelectWorkspace), name)
+		require.False(t, commandHasCapability(cmd, mayCallEngine), name)
+	}
+	for name, cmd := range map[string]*cobra.Command{
+		"cloud login":   cloudLoginCmd,
+		"sdk installed": sdkInstalledCmd,
+		"sdk search":    sdkSearchCmd,
+		"trace":         traceCmd,
+	} {
+		require.False(t, commandHasCapability(cmd, maySelectWorkspace), name)
+	}
+}
+
 func TestMayRenderPipelineFlags(t *testing.T) {
 	oldQuiet := quiet
 	oldSilent := silent
@@ -167,6 +242,92 @@ func TestMayRenderPipelineFlags(t *testing.T) {
 	for _, name := range []string{"dot-output", "dot-focus-field", "dot-show-internal"} {
 		require.True(t, flags.Lookup(name).Hidden, name)
 	}
+}
+
+func TestWorkspaceConfigCommands(t *testing.T) {
+	flags := pflag.NewFlagSet("config", pflag.ContinueOnError)
+	installGlobalFlags(flags)
+	envFlag := flags.Lookup("env")
+	require.NotNil(t, envFlag)
+	require.True(t, FlagAvailableForCommand(moduleInitCmd, envFlag))
+	require.True(t, FlagAvailableForCommand(apiClientInitCmd, envFlag))
+	require.True(t, FlagAvailableForCommand(sdkInstalledCmd, envFlag))
+	require.False(t, FlagAvailableForCommand(setupCmd, envFlag))
+	require.False(t, FlagAvailableForCommand(sdkInstallCmd, envFlag))
+	require.False(t, FlagAvailableForCommand(workspaceRootCmd, envFlag))
+
+	readers := []string{
+		"dagger",
+		"dagger agent",
+		"dagger api call",
+		"dagger api client init",
+		"dagger api client list",
+		"dagger api functions",
+		"dagger api listen",
+		"dagger api query",
+		"dagger api session",
+		"dagger api with-session",
+		"dagger call",
+		"dagger check",
+		"dagger core",
+		"dagger functions",
+		"dagger generate",
+		"dagger install",
+		"dagger installed",
+		"dagger listen",
+		"dagger mcp",
+		"dagger module deps add",
+		"dagger module deps list",
+		"dagger module deps rm",
+		"dagger module deps update",
+		"dagger module engine require",
+		"dagger module engine require-current",
+		"dagger module engine require-latest",
+		"dagger module engine required",
+		"dagger module init",
+		"dagger module sdk",
+		"dagger query",
+		"dagger run",
+		"dagger sdk client-options",
+		"dagger sdk installed",
+		"dagger sdk module-options",
+		"dagger session",
+		"dagger settings",
+		"dagger shell",
+		"dagger terminal",
+		"dagger uninstall",
+		"dagger up",
+		"dagger update",
+		"dagger workspace",
+		"dagger workspace config",
+		"dagger workspace settings",
+	}
+	require.ElementsMatch(t, readers, commandsDeclaringCapability(rootCmd, mayReadWorkspaceConfig))
+
+	writers := []string{
+		"dagger",
+		"dagger api client init",
+		"dagger install",
+		"dagger module init",
+		"dagger settings",
+		"dagger uninstall",
+		"dagger workspace",
+		"dagger workspace config",
+		"dagger workspace settings",
+	}
+	require.ElementsMatch(t, writers, commandsDeclaringCapability(rootCmd, mayWriteWorkspaceConfig))
+
+	for name, cmd := range map[string]*cobra.Command{
+		"sdk install":      sdkInstallCmd,
+		"setup":            setupCmd,
+		"workspace root":   workspaceRootCmd,
+		"workspace remote": workspaceRemoteCmd,
+	} {
+		require.False(t, commandHasCapability(cmd, mayReadWorkspaceConfig), name)
+		require.False(t, commandHasCapability(cmd, mayWriteWorkspaceConfig), name)
+	}
+	require.True(t, commandHasCapability(sdkInstalledCmd, mayReadWorkspaceConfig))
+	require.False(t, commandHasCapability(sdkInstalledCmd, mayWriteWorkspaceConfig))
 }
 
 func TestMayRenderPipelineCommands(t *testing.T) {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -1,0 +1,287 @@
+package daggercmd
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/dagger/dagger/internal/cobradocs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandCapabilityInheritanceSkipsRoot(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	parent := &cobra.Command{Use: "parent"}
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(parent)
+	parent.AddCommand(child)
+
+	setCommandCapabilities(root, mayRenderPipeline)
+	require.True(t, commandHasCapability(root, mayRenderPipeline))
+	require.False(t, commandHasCapability(parent, mayRenderPipeline))
+	require.False(t, commandHasCapability(child, mayRenderPipeline))
+
+	setCommandCapabilities(parent, mayRenderPipeline)
+	require.True(t, commandHasCapability(parent, mayRenderPipeline))
+	require.True(t, commandHasCapability(child, mayRenderPipeline))
+}
+
+func TestMayRenderPipelineFlags(t *testing.T) {
+	oldQuiet := quiet
+	oldSilent := silent
+	oldProgress := progress
+	oldWeb := web
+	oldNoExit := noExit
+	oldDotOutput := dotOutputFilePath
+	oldDotFocus := dotFocusField
+	oldDotInternal := dotShowInternal
+	t.Cleanup(func() {
+		quiet = oldQuiet
+		silent = oldSilent
+		progress = oldProgress
+		web = oldWeb
+		noExit = oldNoExit
+		dotOutputFilePath = oldDotOutput
+		dotFocusField = oldDotFocus
+		dotShowInternal = oldDotInternal
+	})
+
+	flags := pflag.NewFlagSet("render", pflag.ContinueOnError)
+	installMayRenderPipelineFlags(flags)
+
+	expected := []string{
+		"quiet",
+		"silent",
+		"progress",
+		"web",
+		"no-exit",
+		"dot-output",
+		"dot-focus-field",
+		"dot-show-internal",
+	}
+	var count int
+	flags.VisitAll(func(*pflag.Flag) { count++ })
+	require.Equal(t, len(expected), count)
+	for _, name := range expected {
+		flag := flags.Lookup(name)
+		require.NotNil(t, flag, name)
+		require.Equal(t, []string{string(mayRenderPipeline)}, flag.Annotations[flagCapabilitiesAnnotation], name)
+	}
+	for _, name := range []string{"dot-output", "dot-focus-field", "dot-show-internal"} {
+		require.True(t, flags.Lookup(name).Hidden, name)
+	}
+}
+
+func TestMayRenderPipelineCommands(t *testing.T) {
+	expected := []string{
+		"dagger",
+		"dagger agent",
+		"dagger api call",
+		"dagger api listen",
+		"dagger api query",
+		"dagger api session",
+		"dagger api with-session",
+		"dagger call",
+		"dagger check",
+		"dagger core",
+		"dagger generate",
+		"dagger listen",
+		"dagger mcp",
+		"dagger module sdk",
+		"dagger query",
+		"dagger run",
+		"dagger session",
+		"dagger shell",
+		"dagger terminal",
+		"dagger trace",
+		"dagger up",
+	}
+	var actual []string
+	var visit func(*cobra.Command)
+	visit = func(cmd *cobra.Command) {
+		if slices.Contains(strings.Fields(cmd.Annotations[commandCapabilitiesAnnotation]), string(mayRenderPipeline)) {
+			actual = append(actual, cmd.CommandPath())
+		}
+		for _, child := range cmd.Commands() {
+			visit(child)
+		}
+	}
+	visit(rootCmd)
+	require.ElementsMatch(t, expected, actual)
+
+	for name, cmd := range map[string]*cobra.Command{
+		"settings":  settingsCmd,
+		"setup":     setupCmd,
+		"installed": installedCmd,
+	} {
+		require.False(t, commandHasCapability(cmd, mayRenderPipeline), name)
+	}
+}
+
+func TestCapabilityScopedFlagHelp(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("progress", "auto", "Progress output format")
+	setFlagSetCapabilities(root.PersistentFlags(), mayRenderPipeline)
+
+	render := &cobra.Command{Use: "render"}
+	setCommandCapabilities(render, mayRenderPipeline)
+	plain := &cobra.Command{Use: "plain"}
+	root.AddCommand(render, plain)
+
+	renderHelp := commandUsage(t, render)
+	require.Contains(t, renderHelp, "--progress")
+
+	plainHelp := commandUsage(t, plain)
+	require.NotContains(t, plainHelp, "--progress")
+}
+
+func TestCapabilityScopedFlagValidation(t *testing.T) {
+	newCommand := func(render, shadow bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		root.PersistentFlags().String("progress", "auto", "Progress output format")
+		setFlagSetCapabilities(root.PersistentFlags(), mayRenderPipeline)
+		child := &cobra.Command{Use: "child", Run: func(*cobra.Command, []string) {}}
+		if shadow {
+			child.Flags().String("progress", "local", "Local progress value")
+		}
+		if render {
+			setCommandCapabilities(child, mayRenderPipeline)
+		}
+		root.AddCommand(child)
+		return root
+	}
+
+	render := newCommand(true, false)
+	require.NoError(t, validateFlagCapabilities(render, []string{"--progress=plain", "child"}))
+
+	plain := newCommand(false, false)
+	require.EqualError(t, validateFlagCapabilities(plain, []string{"--progress=plain", "child"}), `flag --progress is not supported by command "root child"`)
+
+	// Cobra resolves a command-local flag even when it appears before the
+	// subcommand. This preserves forms such as `dagger -q version`, where
+	// version has its own unrelated -q flag.
+	shadowed := newCommand(false, true)
+	require.NoError(t, validateFlagCapabilities(shadowed, []string{"--progress=local", "child"}))
+
+	local := newCommand(false, true)
+	require.NoError(t, validateFlagCapabilities(local, []string{"child", "--progress=local"}))
+
+	shortRoot := &cobra.Command{Use: "root"}
+	shortRoot.PersistentFlags().BoolP("quiet", "q", false, "Quiet pipeline output")
+	setFlagSetCapabilities(shortRoot.PersistentFlags(), mayRenderPipeline)
+	shortChild := &cobra.Command{Use: "child"}
+	shortChild.Flags().BoolP("quiet", "q", false, "Print only the result")
+	shortRoot.AddCommand(shortChild)
+	require.NoError(t, validateFlagCapabilities(shortRoot, []string{"-q", "child"}))
+
+	disabledRoot := newCommand(false, false)
+	disabledChild, _, err := disabledRoot.Find([]string{"child"})
+	require.NoError(t, err)
+	disabledChild.DisableFlagParsing = true
+	require.EqualError(t, validateFlagCapabilities(disabledRoot, []string{"child", "--progress=plain"}), `flag --progress is not supported by command "root child"`)
+	setCommandCapabilities(disabledChild, mayRenderPipeline)
+	require.NoError(t, validateFlagCapabilities(disabledRoot, []string{"child", "--progress=plain"}))
+
+	// Validation must not apply a flag value before the command is accepted.
+	var value string
+	sideEffect := &cobra.Command{Use: "root"}
+	sideEffect.PersistentFlags().StringVar(&value, "progress", "auto", "Progress output format")
+	setFlagSetCapabilities(sideEffect.PersistentFlags(), mayRenderPipeline)
+	sideEffect.AddCommand(&cobra.Command{Use: "child"})
+	require.EqualError(t, validateFlagCapabilities(sideEffect, []string{"child", "--progress=bogus"}), `flag --progress is not supported by command "root child"`)
+	require.Equal(t, "auto", value)
+}
+
+func TestGlobalFlagParsingRespectsLocalShadow(t *testing.T) {
+	oldQuiet := quiet
+	oldXRelease := xRelease
+	t.Cleanup(func() {
+		quiet = oldQuiet
+		xRelease = oldXRelease
+	})
+	quiet = 0
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().CountVarP(&quiet, "quiet", "q", "Quiet pipeline output")
+	setFlagSetCapabilities(root.PersistentFlags(), mayRenderPipeline)
+	root.PersistentFlags().StringVar(&xRelease, "x-release", "", "Experimental release")
+	child := &cobra.Command{Use: "child"}
+	var localQuiet bool
+	child.Flags().BoolVarP(&localQuiet, "quiet", "q", false, "Print only the result")
+	root.AddCommand(child)
+
+	parseGlobalFlags(root, []string{"-q", "child"})
+	require.Zero(t, quiet)
+	require.False(t, localQuiet)
+}
+
+func TestCapabilityScopedFlagCompletion(t *testing.T) {
+	complete := func(render bool) string {
+		t.Helper()
+		root := &cobra.Command{
+			Use:           "root",
+			SilenceErrors: true,
+			SilenceUsage:  true,
+			PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+				if restore := hideUnavailableCompletionFlags(cmd, args); restore != nil {
+					cobra.OnFinalize(restore)
+				}
+				return nil
+			},
+		}
+		root.PersistentFlags().String("progress", "auto", "Progress output format")
+		setFlagSetCapabilities(root.PersistentFlags(), mayRenderPipeline)
+		child := &cobra.Command{Use: "child", Run: func(*cobra.Command, []string) {}}
+		if render {
+			setCommandCapabilities(child, mayRenderPipeline)
+		}
+		root.AddCommand(child)
+
+		var output bytes.Buffer
+		root.SetOut(&output)
+		root.SetErr(&output)
+		root.SetArgs([]string{cobra.ShellCompRequestCmd, "child", "--pr"})
+		require.NoError(t, root.Execute())
+		require.False(t, root.PersistentFlags().Lookup("progress").Hidden)
+		return output.String()
+	}
+
+	require.NotContains(t, complete(false), "--progress")
+	require.Contains(t, complete(true), "--progress")
+}
+
+func TestCapabilityScopedFlagMarkdown(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("progress", "auto", "Progress output format")
+	setFlagSetCapabilities(root.PersistentFlags(), mayRenderPipeline)
+	plain := &cobra.Command{Use: "plain"}
+	render := &cobra.Command{Use: "render"}
+	setCommandCapabilities(render, mayRenderPipeline)
+	root.AddCommand(plain, render)
+
+	markdown := func(cmd *cobra.Command) string {
+		t.Helper()
+		var output bytes.Buffer
+		require.NoError(t, cobradocs.Markdown(cmd, &output, cobradocs.MarkdownOptions{
+			IncludeFlag: FlagAvailableForCommand,
+		}))
+		return output.String()
+	}
+
+	require.NotContains(t, markdown(plain), "--progress")
+	require.False(t, root.PersistentFlags().Lookup("progress").Hidden)
+	require.Contains(t, markdown(render), "--progress")
+}
+
+func commandUsage(t *testing.T, cmd *cobra.Command) string {
+	t.Helper()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetUsageTemplate(usageTemplate)
+	require.NoError(t, cmd.Usage())
+	return output.String()
+}

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -572,6 +572,7 @@ func TestCapabilityScopedFlagValidation(t *testing.T) {
 	require.NoError(t, err)
 	disabledChild.DisableFlagParsing = true
 	require.EqualError(t, validateFlagCapabilities(disabledRoot, []string{"child", "--progress=plain"}), `flag --progress is not supported by command "root child"`)
+	require.NoError(t, validateFlagCapabilities(disabledRoot, []string{"child", "function", "--progress=plain"}))
 	setCommandCapabilities(disabledChild, mayRenderPipeline)
 	require.NoError(t, validateFlagCapabilities(disabledRoot, []string{"child", "--progress=plain"}))
 
@@ -606,6 +607,23 @@ func TestGlobalFlagParsingRespectsLocalShadow(t *testing.T) {
 	parseGlobalFlags(root, []string{"-q", "child"})
 	require.Zero(t, quiet)
 	require.False(t, localQuiet)
+}
+
+func TestGlobalFlagParsingStopsAtDynamicArguments(t *testing.T) {
+	oldXRelease := xRelease
+	t.Cleanup(func() { xRelease = oldXRelease })
+
+	root := &cobra.Command{Use: "root"}
+	var cloud bool
+	root.PersistentFlags().BoolVar(&cloud, "cloud", false, "Use a Cloud Engine")
+	dynamic := &cobra.Command{Use: "dynamic", DisableFlagParsing: true}
+	root.AddCommand(dynamic)
+
+	parseGlobalFlags(root, []string{"dynamic", "function", "--cloud"})
+	require.False(t, cloud)
+
+	parseGlobalFlags(root, []string{"--cloud", "dynamic", "function"})
+	require.True(t, cloud)
 }
 
 func TestCapabilityScopedFlagCompletion(t *testing.T) {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -47,6 +47,20 @@ func TestMaySelectWorkspaceFlags(t *testing.T) {
 	require.Equal(t, []string{string(maySelectWorkspace)}, flag.Annotations[flagCapabilitiesAnnotation])
 }
 
+func TestMayProduceOutputFlags(t *testing.T) {
+	oldAutoApply := autoApply
+	t.Cleanup(func() { autoApply = oldAutoApply })
+
+	flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
+	installGlobalFlags(flags)
+
+	flag := flags.Lookup("auto-apply")
+	require.NotNil(t, flag)
+	require.Equal(t, "y", flag.Shorthand)
+	require.False(t, flag.Hidden)
+	require.Equal(t, []string{string(mayProduceOutput)}, flag.Annotations[flagCapabilitiesAnnotation])
+}
+
 func TestMayCallEngineFlags(t *testing.T) {
 	oldProfile := profileFlag
 	t.Cleanup(func() {
@@ -195,6 +209,66 @@ func TestMaySelectWorkspaceCommands(t *testing.T) {
 		"trace":         traceCmd,
 	} {
 		require.False(t, commandHasCapability(cmd, maySelectWorkspace), name)
+	}
+}
+
+func TestMayProduceOutputCommands(t *testing.T) {
+	expected := []string{
+		"dagger api call",
+		"dagger api client init",
+		"dagger call",
+		"dagger core",
+		"dagger generate",
+		"dagger module init",
+		"dagger setup",
+	}
+	require.ElementsMatch(t, expected, commandsDeclaringCapability(rootCmd, mayProduceOutput))
+
+	oldAutoApply := autoApply
+	t.Cleanup(func() { autoApply = oldAutoApply })
+	flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
+	installGlobalFlags(flags)
+	autoApplyFlag := flags.Lookup("auto-apply")
+	require.NotNil(t, autoApplyFlag)
+	for name, cmd := range map[string]*cobra.Command{
+		"api call":        apiCallCmd.Command(),
+		"api client init": apiClientInitCmd,
+		"call":            callModCmd.Command(),
+		"core":            callCoreCmd.Command(),
+		"generate":        generateCmd,
+		"module init":     moduleInitCmd,
+		"setup":           setupCmd,
+	} {
+		require.True(t, FlagAvailableForCommand(cmd, autoApplyFlag), name)
+	}
+	for name, cmd := range map[string]*cobra.Command{
+		"api functions": apiFunctionsCmd,
+		"check":         checksCmd,
+		"sdk installed": sdkInstalledCmd,
+		"trace":         traceCmd,
+	} {
+		require.False(t, commandHasCapability(cmd, mayProduceOutput), name)
+		require.False(t, FlagAvailableForCommand(cmd, autoApplyFlag), name)
+	}
+
+	for name, cmd := range map[string]*cobra.Command{
+		"api call": apiCallCmd.Command(),
+		"call":     callModCmd.Command(),
+		"core":     callCoreCmd.Command(),
+	} {
+		flag := cmd.PersistentFlags().Lookup("output")
+		require.NotNil(t, flag, name)
+		require.Equal(t, "o", flag.Shorthand, name)
+		require.Equal(t, []string{string(mayProduceOutput)}, flag.Annotations[flagCapabilitiesAnnotation], name)
+		require.True(t, FlagAvailableForCommand(cmd, flag), name)
+	}
+	for name, cmd := range map[string]*cobra.Command{
+		"api client init": apiClientInitCmd,
+		"generate":        generateCmd,
+		"module init":     moduleInitCmd,
+		"setup":           setupCmd,
+	} {
+		require.Nil(t, cmd.Flags().Lookup("output"), name)
 	}
 }
 

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -94,19 +94,25 @@ func TestDebugFlags(t *testing.T) {
 }
 
 func TestMayCallEngineFlags(t *testing.T) {
+	oldCloud := useCloudEngine
+	oldEngine := engineFlag
 	oldProfile := profileFlag
 	oldShellOnError := shellOnError
 	oldShellCommandOnError := shellCommandOnError
 	t.Cleanup(func() {
+		useCloudEngine = oldCloud
+		engineFlag = oldEngine
 		profileFlag = oldProfile
 		shellOnError = oldShellOnError
 		shellCommandOnError = oldShellCommandOnError
 	})
+	useCloudEngine = false
+	engineFlag = ""
 
 	flags := pflag.NewFlagSet("engine", pflag.ContinueOnError)
 	installMayCallEngineFlags(flags)
 
-	expected := []string{"interactive", "interactive-command", "profile", "shell-command-on-error", "shell-on-error"}
+	expected := []string{"cloud", "engine", "interactive", "interactive-command", "profile", "shell-command-on-error", "shell-on-error"}
 	var count int
 	flags.VisitAll(func(*pflag.Flag) { count++ })
 	require.Equal(t, len(expected), count)
@@ -116,6 +122,9 @@ func TestMayCallEngineFlags(t *testing.T) {
 		require.Equal(t, []string{string(mayCallEngine)}, flag.Annotations[flagCapabilitiesAnnotation], name)
 	}
 	require.Equal(t, "i", flags.Lookup("shell-on-error").Shorthand)
+	require.True(t, flags.Lookup("cloud").Hidden)
+	require.Contains(t, flags.Lookup("cloud").Deprecated, "--engine=cloud")
+	require.False(t, flags.Lookup("engine").Hidden)
 	require.False(t, flags.Lookup("shell-on-error").Hidden)
 	require.True(t, flags.Lookup("interactive").Hidden)
 	require.Contains(t, flags.Lookup("interactive").Deprecated, "--shell-on-error")
@@ -123,6 +132,10 @@ func TestMayCallEngineFlags(t *testing.T) {
 	require.True(t, flags.Lookup("interactive-command").Hidden)
 	require.Contains(t, flags.Lookup("interactive-command").Deprecated, "--shell-command-on-error")
 	require.True(t, flags.Lookup("profile").Hidden)
+	require.NoError(t, flags.Set("cloud", "true"))
+	require.True(t, useCloudEngine)
+	require.NoError(t, flags.Set("engine", "tcp://engine.example.com:1234"))
+	require.Equal(t, "tcp://engine.example.com:1234", engineFlag)
 
 	// Every deprecated alias still drives the same variables.
 	for _, name := range []string{"interactive", "shell-on-error"} {
@@ -136,7 +149,7 @@ func TestMayCallEngineFlags(t *testing.T) {
 		require.Equal(t, "/bin/bash", shellCommandOnError, name)
 	}
 
-	for _, name := range []string{"interactive", "interactive-command", "shell-command-on-error", "shell-on-error"} {
+	for _, name := range expected {
 		flag := flags.Lookup(name)
 		var visit func(*cobra.Command)
 		visit = func(cmd *cobra.Command) {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -61,6 +61,38 @@ func TestMayProduceOutputFlags(t *testing.T) {
 	require.Equal(t, []string{string(mayProduceOutput)}, flag.Annotations[flagCapabilitiesAnnotation])
 }
 
+func TestDebugFlags(t *testing.T) {
+	oldDebug := debugFlag
+	t.Cleanup(func() { debugFlag = oldDebug })
+
+	flags := pflag.NewFlagSet("debug", pflag.ContinueOnError)
+	installGlobalFlags(flags)
+
+	flag := flags.Lookup("debug")
+	require.NotNil(t, flag)
+	require.Equal(t, "d", flag.Shorthand)
+	require.False(t, flag.Hidden)
+	require.Equal(t, []string{
+		string(mayCallEngine),
+		string(mayRenderPipeline),
+	}, flag.Annotations[flagAnyCapabilitiesAnnotation])
+
+	var visit func(*cobra.Command)
+	visit = func(cmd *cobra.Command) {
+		expected := commandHasCapability(cmd, mayCallEngine) || commandHasCapability(cmd, mayRenderPipeline)
+		require.Equal(t, expected, FlagAvailableForCommand(cmd, flag), cmd.CommandPath())
+		for _, child := range cmd.Commands() {
+			visit(child)
+		}
+	}
+	visit(rootCmd)
+
+	require.True(t, FlagAvailableForCommand(settingsCmd, flag))
+	require.True(t, FlagAvailableForCommand(traceCmd, flag))
+	require.False(t, FlagAvailableForCommand(activityCmd, flag))
+	require.False(t, FlagAvailableForCommand(sdkInstalledCmd, flag))
+}
+
 func TestMayCallEngineFlags(t *testing.T) {
 	oldProfile := profileFlag
 	t.Cleanup(func() {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/dagger/dagger/engine/client/drivers"
 	"github.com/dagger/dagger/internal/cobradocs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -125,6 +127,22 @@ func TestMayCallEngineFlags(t *testing.T) {
 	require.True(t, flags.Lookup("cloud").Hidden)
 	require.Contains(t, flags.Lookup("cloud").Deprecated, "--engine=cloud")
 	require.False(t, flags.Lookup("engine").Hidden)
+	require.Equal(t, engineFlagUsage, flags.Lookup("engine").Usage)
+	require.NotContains(t, flags.Lookup("engine").Usage, "runner host")
+
+	// The usage stays on one line: it names the value space and points at the
+	// help topic that carries the full catalog.
+	usage := flags.Lookup("engine").Usage
+	require.NotContains(t, usage, "\n")
+	require.Contains(t, usage, drivers.SchemeSummary())
+	require.Contains(t, usage, "dagger help engine")
+	for _, value := range []string{"cloud", "image://", "container://", "ssh://", "unix://"} {
+		require.Contains(t, usage, value)
+	}
+	// The variants and the legacy schemes belong to the help topic only.
+	for _, value := range []string{"image+nerdctl://", "docker-image://", "kube-pod://POD"} {
+		require.NotContains(t, usage, value)
+	}
 	require.False(t, flags.Lookup("shell-on-error").Hidden)
 	require.True(t, flags.Lookup("interactive").Hidden)
 	require.Contains(t, flags.Lookup("interactive").Deprecated, "--shell-on-error")
@@ -165,6 +183,30 @@ func TestMayCallEngineFlags(t *testing.T) {
 	require.False(t, FlagAvailableForCommand(traceCmd, flags.Lookup("shell-on-error")))
 	require.False(t, FlagAvailableForCommand(activityCmd, flags.Lookup("shell-on-error")))
 	require.False(t, FlagAvailableForCommand(sdkInstalledCmd, flags.Lookup("shell-on-error")))
+}
+
+// testRootCommand returns the real root command with the global flags
+// installed. RootCommand panics if it installs the flags twice, so every test
+// in this package shares one instance.
+var testRootCommand = sync.OnceValue(RootCommand)
+
+func TestEngineFlagHelp(t *testing.T) {
+	root := testRootCommand()
+	for name, cmd := range map[string]*cobra.Command{
+		"api call": apiCallCmd.Command(),
+		"shell":    shellCmd,
+	} {
+		help := renderHelp(t, cmd)
+		require.Contains(t, help, "--engine string", name)
+		require.Contains(t, help, "dagger help engine", name)
+		// The full catalog must not repeat in every command's usage message.
+		require.NotContains(t, help, "image+nerdctl://IMAGE", name)
+		require.NotContains(t, help, "tcp://HOST:PORT (no authentication)", name)
+	}
+
+	version, _, err := root.Find([]string{"version"})
+	require.NoError(t, err)
+	require.NotContains(t, renderHelp(t, version), "--engine", "version")
 }
 
 func TestWorkspaceConfigFlags(t *testing.T) {
@@ -626,17 +668,33 @@ func TestGlobalFlagParsingStopsAtDynamicArguments(t *testing.T) {
 	oldXRelease := xRelease
 	t.Cleanup(func() { xRelease = oldXRelease })
 
-	root := &cobra.Command{Use: "root"}
-	var cloud bool
-	root.PersistentFlags().BoolVar(&cloud, "cloud", false, "Use a Cloud Engine")
-	dynamic := &cobra.Command{Use: "dynamic", DisableFlagParsing: true}
-	root.AddCommand(dynamic)
+	t.Run("string flag", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		var selectedEngine string
+		root.PersistentFlags().StringVar(&selectedEngine, "engine", "", "Select the engine")
+		dynamic := &cobra.Command{Use: "dynamic", DisableFlagParsing: true}
+		root.AddCommand(dynamic)
 
-	parseGlobalFlags(root, []string{"dynamic", "function", "--cloud"})
-	require.False(t, cloud)
+		parseGlobalFlags(root, []string{"dynamic", "function", "--engine", "production"})
+		require.Empty(t, selectedEngine)
 
-	parseGlobalFlags(root, []string{"--cloud", "dynamic", "function"})
-	require.True(t, cloud)
+		parseGlobalFlags(root, []string{"--engine=cloud", "dynamic", "function"})
+		require.Equal(t, "cloud", selectedEngine)
+	})
+
+	t.Run("boolean compatibility alias", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		var cloud bool
+		root.PersistentFlags().BoolVar(&cloud, "cloud", false, "Use a Cloud Engine")
+		dynamic := &cobra.Command{Use: "dynamic", DisableFlagParsing: true}
+		root.AddCommand(dynamic)
+
+		parseGlobalFlags(root, []string{"dynamic", "function", "--cloud"})
+		require.False(t, cloud)
+
+		parseGlobalFlags(root, []string{"--cloud", "dynamic", "function"})
+		require.True(t, cloud)
+	})
 }
 
 func TestCapabilityScopedFlagCompletion(t *testing.T) {

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -329,7 +329,6 @@ func TestRootShellFallbackKeepsEngineFlags(t *testing.T) {
 
 func TestMaySelectWorkspaceCommands(t *testing.T) {
 	expected := append(commandsDeclaringCapability(rootCmd, mayCallEngine),
-		"dagger",
 		"dagger activity",
 		"dagger cloud check",
 		"dagger cloud rerun",
@@ -359,6 +358,7 @@ func TestMaySelectWorkspaceCommands(t *testing.T) {
 		require.False(t, commandHasCapability(cmd, mayCallEngine), name)
 	}
 	for name, cmd := range map[string]*cobra.Command{
+		"root":          rootCmd,
 		"cloud login":   cloudLoginCmd,
 		"sdk installed": sdkInstalledCmd,
 		"sdk search":    sdkSearchCmd,
@@ -366,6 +366,38 @@ func TestMaySelectWorkspaceCommands(t *testing.T) {
 	} {
 		require.False(t, commandHasCapability(cmd, maySelectWorkspace), name)
 	}
+}
+
+// The module selection flags are engine session parameters, so they require
+// MayCallEngine. Every command that installs them calls the engine except the
+// root command, which only carries them for the shell fallback.
+func TestModuleFlagsRequireMayCallEngine(t *testing.T) {
+	root := testRootCommand()
+
+	gated := []string{"load-module", "mod", "no-load-module", "no-mod", "allow-llm", "eager-runtime", "model"}
+	for _, name := range gated {
+		flag := root.Flags().Lookup(name)
+		require.NotNil(t, flag, name)
+		require.Equal(t, []string{string(mayCallEngine)}, flag.Annotations[flagCapabilitiesAnnotation], name)
+		require.False(t, FlagAvailableForCommand(rootCmd, flag), name)
+		require.True(t, FlagAvailableForCommand(shellCmd, flag), name)
+		require.True(t, FlagAvailableForCommand(checksCmd, flag), name)
+	}
+
+	// -c is how a user reaches the shell from the root command, so it stays
+	// ungated and visible in the root usage message.
+	command := root.Flags().Lookup("command")
+	require.NotNil(t, command)
+	require.Empty(t, command.Annotations[flagCapabilitiesAnnotation])
+	require.True(t, FlagAvailableForCommand(rootCmd, command))
+
+	rootHelp := renderHelp(t, root)
+	for _, name := range gated {
+		require.NotContains(t, rootHelp, "--"+name, name)
+	}
+	require.Contains(t, rootHelp, "-c, --command")
+	require.Contains(t, renderHelp(t, shellCmd), "--model")
+	require.Contains(t, renderHelp(t, checksCmd), "--allow-llm")
 }
 
 func TestMayProduceOutputCommands(t *testing.T) {
@@ -482,12 +514,12 @@ func TestWorkspaceConfigCommands(t *testing.T) {
 	require.True(t, FlagAvailableForCommand(moduleInitCmd, envFlag))
 	require.True(t, FlagAvailableForCommand(apiClientInitCmd, envFlag))
 	require.True(t, FlagAvailableForCommand(sdkInstalledCmd, envFlag))
+	require.False(t, FlagAvailableForCommand(rootCmd, envFlag))
 	require.False(t, FlagAvailableForCommand(setupCmd, envFlag))
 	require.False(t, FlagAvailableForCommand(sdkInstallCmd, envFlag))
 	require.False(t, FlagAvailableForCommand(workspaceRootCmd, envFlag))
 
 	readers := []string{
-		"dagger",
 		"dagger agent",
 		"dagger api call",
 		"dagger api client init",
@@ -535,7 +567,6 @@ func TestWorkspaceConfigCommands(t *testing.T) {
 	require.ElementsMatch(t, readers, commandsDeclaringCapability(rootCmd, mayReadWorkspaceConfig))
 
 	writers := []string{
-		"dagger",
 		"dagger api client init",
 		"dagger install",
 		"dagger module init",
@@ -562,7 +593,6 @@ func TestWorkspaceConfigCommands(t *testing.T) {
 
 func TestMayRenderPipelineCommands(t *testing.T) {
 	expected := []string{
-		"dagger",
 		"dagger agent",
 		"dagger api call",
 		"dagger api listen",
@@ -587,6 +617,7 @@ func TestMayRenderPipelineCommands(t *testing.T) {
 	require.ElementsMatch(t, expected, commandsDeclaringCapability(rootCmd, mayRenderPipeline))
 
 	for name, cmd := range map[string]*cobra.Command{
+		"root":      rootCmd,
 		"settings":  settingsCmd,
 		"setup":     setupCmd,
 		"installed": installedCmd,

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -2,6 +2,8 @@ package daggercmd
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -204,6 +206,10 @@ func TestEngineFlagHelp(t *testing.T) {
 		require.NotContains(t, help, "tcp://HOST:PORT (no authentication)", name)
 	}
 
+	// The root command does not call the engine, so its usage message stays
+	// free of the engine flags.
+	require.NotContains(t, renderHelp(t, root), "--engine", "root")
+
 	version, _, err := root.Find([]string{"version"})
 	require.NoError(t, err)
 	require.NotContains(t, renderHelp(t, version), "--engine", "version")
@@ -235,7 +241,6 @@ func TestWorkspaceConfigFlags(t *testing.T) {
 
 func TestMayCallEngineCommands(t *testing.T) {
 	expected := []string{
-		"dagger",
 		"dagger agent",
 		"dagger api call",
 		"dagger api client init",
@@ -289,6 +294,7 @@ func TestMayCallEngineCommands(t *testing.T) {
 	require.ElementsMatch(t, expected, commandsDeclaringCapability(rootCmd, mayCallEngine))
 
 	for name, cmd := range map[string]*cobra.Command{
+		"root":             rootCmd,
 		"activity":         activityCmd,
 		"cloud rerun":      cloudRerunCmd,
 		"sdk installed":    sdkInstalledCmd,
@@ -299,8 +305,31 @@ func TestMayCallEngineCommands(t *testing.T) {
 	}
 }
 
+func TestRootShellFallbackKeepsEngineFlags(t *testing.T) {
+	root := testRootCommand()
+
+	// Bare `dagger` prints usage. It does not call the engine.
+	require.EqualError(t, validateFlagCapabilities(root, []string{"--engine=cloud"}),
+		`flag --engine is not supported by command "dagger"`)
+	require.EqualError(t, validateFlagCapabilities(root, []string{"--shell-on-error"}),
+		`flag --shell-on-error is not supported by command "dagger"`)
+	require.EqualError(t, validateFlagCapabilities(root, []string{"version", "--engine=cloud"}),
+		`flag --engine is not supported by command "dagger version"`)
+
+	// Shell-style root invocations run `dagger shell`, which calls the engine.
+	require.NoError(t, validateFlagCapabilities(root, []string{"--engine=cloud", "-c", "container"}))
+	require.NoError(t, validateFlagCapabilities(root, []string{"-i", "-c", "container"}))
+
+	script := filepath.Join(t.TempDir(), "main.dsh")
+	require.NoError(t, os.WriteFile(script, []byte("container\n"), 0o600))
+	require.NoError(t, validateFlagCapabilities(root, []string{"--engine=cloud", script}))
+
+	require.NoError(t, validateFlagCapabilities(root, []string{"shell", "--engine=cloud"}))
+}
+
 func TestMaySelectWorkspaceCommands(t *testing.T) {
 	expected := append(commandsDeclaringCapability(rootCmd, mayCallEngine),
+		"dagger",
 		"dagger activity",
 		"dagger cloud check",
 		"dagger cloud rerun",

--- a/internal/cmd/dagger/checks.go
+++ b/internal/cmd/dagger/checks.go
@@ -24,6 +24,7 @@ var (
 	checksNoGenerate   bool
 	checksOnlyGenerate bool
 	checksSkip         []string
+	checksScaleOut     bool
 )
 
 //go:embed checks.graphql
@@ -35,6 +36,8 @@ func init() {
 	checksCmd.Flags().BoolVar(&checksNoGenerate, "no-generate", false, "Only run annotated check functions, skip generate-as-checks")
 	checksCmd.Flags().BoolVar(&checksOnlyGenerate, "generate", false, "Only run generate-as-checks, skip annotated check functions")
 	checksCmd.Flags().StringArrayVar(&checksSkip, "skip", nil, "Skip checks matching the specified patterns")
+	checksCmd.Flags().BoolVar(&checksScaleOut, "scale-out", false, "Enable scale-out to cloud engines for each check executed")
+	checksCmd.Flags().Lookup("scale-out").Hidden = true
 	checksCmd.MarkFlagsMutuallyExclusive("no-generate", "generate")
 }
 
@@ -56,7 +59,7 @@ Examples:
 
 func runChecksCommand(cmd *cobra.Command, args []string) error {
 	params := client.Params{
-		EnableCloudScaleOut:  enableScaleOut,
+		EnableCloudScaleOut:  checksScaleOut,
 		LoadWorkspaceModules: true,
 	}
 	return withEngine(

--- a/internal/cmd/dagger/checks_test.go
+++ b/internal/cmd/dagger/checks_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestScaleOutFlagScopedToCheck(t *testing.T) {
+	flag := checksCmd.Flags().Lookup("scale-out")
+	require.NotNil(t, flag)
+	require.True(t, flag.Hidden)
+	require.Nil(t, rootCmd.PersistentFlags().Lookup("scale-out"))
+	version, _, err := rootCmd.Find([]string{"version"})
+	require.NoError(t, err)
+	require.Nil(t, version.Flags().Lookup("scale-out"))
+}
+
 func TestWriteCheckListWithGenerateChecks(t *testing.T) {
 	var out bytes.Buffer
 	err := writeCheckList(&out, []*CheckInfo{

--- a/internal/cmd/dagger/client.go
+++ b/internal/cmd/dagger/client.go
@@ -68,9 +68,6 @@ func init() {
 }
 
 func runAPIClientInitWithSDK(cmd *cobra.Command, sdkName, clientPath, moduleRef string) error {
-	if workspaceEnv != "" {
-		return fmt.Errorf("client init does not support --env; it scaffolds clients into the base workspace config")
-	}
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,

--- a/internal/cmd/dagger/cloud_test.go
+++ b/internal/cmd/dagger/cloud_test.go
@@ -44,7 +44,7 @@ func daggerCloudWithEnv(t *testing.T, env []string, args []string, testCommandFn
 
 func TestCloudEngineUnauth(t *testing.T) {
 	env := []string{}
-	args := []string{"--cloud", "api", "functions"}
+	args := []string{"--engine=cloud", "api", "functions"}
 	daggerCloudWithEnv(t, env, args, func(t *testing.T, err error, stdout *bytes.Buffer, stderr *bytes.Buffer) {
 		require.Error(t, err, fmt.Sprintf(
 			"expected '%s dagger %s' to return an error, but instead: %s",

--- a/internal/cmd/dagger/docsgen/main.go
+++ b/internal/cmd/dagger/docsgen/main.go
@@ -66,7 +66,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "create output dir: %v\n", err)
 		os.Exit(1)
 	}
-	if err := os.WriteFile(output, []byte(escapeMDXAngles(buf.String())), 0o600); err != nil {
+	generated := escapeMDXAngles(buf.String())
+	lines := strings.Split(generated, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	generated = strings.Join(lines, "\n")
+	if err := os.WriteFile(output, []byte(generated), 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "write %s: %v\n", output, err)
 		os.Exit(1)
 	}

--- a/internal/cmd/dagger/docsgen/main.go
+++ b/internal/cmd/dagger/docsgen/main.go
@@ -56,6 +56,7 @@ func main() {
 	buf := new(bytes.Buffer)
 	if err := cobradocs.Markdown(root, buf, cobradocs.MarkdownOptions{
 		Frontmatter: frontmatter,
+		IncludeFlag: daggercmd.FlagAvailableForCommand,
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "generate markdown: %v\n", err)
 		os.Exit(1)

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -185,8 +185,8 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 
 	params.WithTerminal = withTerminal
 
-	params.Interactive = interactive
-	params.InteractiveCommand = interactiveCommandParsed
+	params.Interactive = shellOnError
+	params.InteractiveCommand = shellCommandOnErrorParsed
 
 	if hasTTY {
 		params.PromptHandler = Frontend

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -27,8 +27,12 @@ import (
 const (
 	GPUSupportEnv = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
 
+	// engineEnv is the environment form of --engine. It takes the same values.
+	engineEnv = "DAGGER_ENGINE"
+
 	// cloudEngineEnv and RunnerHostEnv are soft-deprecated, like the --cloud
-	// flag: --engine replaces both, but they still work as a fallback.
+	// flag: --engine and DAGGER_ENGINE replace them, but they still work as a
+	// fallback.
 	cloudEngineEnv = "DAGGER_CLOUD_ENGINE"
 	RunnerHostEnv  = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
 
@@ -160,7 +164,7 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 		params.LogLevel = slog.LevelDebug
 	}
 
-	if engineFlag != "" || useCloudEngine || params.RunnerHost == "" {
+	if selectedEngine() != "" || params.RunnerHost == "" {
 		params.RunnerHost = configuredRunnerHost()
 	}
 
@@ -204,14 +208,42 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 	return params, nil
 }
 
-func configuredRunnerHost() string {
-	if engineFlag == "cloud" || engineFlag == "" && useCloudEngine {
-		return engine.DefaultCloudRunnerHost
-	}
+// selectedEngine returns the engine selector, or "" when nothing selects an
+// engine. Flags outrank the environment, and the current inputs outrank the
+// deprecated ones:
+//
+//  1. --engine
+//  2. --cloud            (deprecated flag)
+//  3. DAGGER_ENGINE
+//  4. DAGGER_CLOUD_ENGINE (deprecated)
+//
+// _EXPERIMENTAL_DAGGER_RUNNER_HOST is deprecated too, but it reaches the CLI
+// as RunnerHost, so configuredRunnerHost handles it below all of these.
+func selectedEngine() string {
 	if engineFlag != "" {
 		return engineFlag
 	}
-	return RunnerHost
+	if cloudFlag {
+		return "cloud"
+	}
+	if value := os.Getenv(engineEnv); value != "" {
+		return value
+	}
+	if cloudEngineEnvSet {
+		return "cloud"
+	}
+	return ""
+}
+
+func configuredRunnerHost() string {
+	switch selected := selectedEngine(); selected {
+	case "":
+		return RunnerHost
+	case "cloud":
+		return engine.DefaultCloudRunnerHost
+	default:
+		return selected
+	}
 }
 
 // withSetupSessions runs fn under a single Frontend (one live TUI) while letting

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -155,10 +155,8 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 		params.LogLevel = slog.LevelDebug
 	}
 
-	if useCloudEngine {
-		params.RunnerHost = engine.DefaultCloudRunnerHost
-	} else if params.RunnerHost == "" {
-		params.RunnerHost = RunnerHost
+	if engineFlag != "" || useCloudEngine || params.RunnerHost == "" {
+		params.RunnerHost = configuredRunnerHost()
 	}
 
 	if RunnerImageLoader != "" {
@@ -199,6 +197,16 @@ func finalizeEngineParams(ctx context.Context, params client.Params) (client.Par
 	params.CloudAuth = ca
 
 	return params, nil
+}
+
+func configuredRunnerHost() string {
+	if engineFlag == "cloud" || engineFlag == "" && useCloudEngine {
+		return engine.DefaultCloudRunnerHost
+	}
+	if engineFlag != "" {
+		return engineFlag
+	}
+	return RunnerHost
 }
 
 // withSetupSessions runs fn under a single Frontend (one live TUI) while letting

--- a/internal/cmd/dagger/engine.go
+++ b/internal/cmd/dagger/engine.go
@@ -25,8 +25,13 @@ import (
 )
 
 const (
-	GPUSupportEnv        = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
-	RunnerHostEnv        = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
+	GPUSupportEnv = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+
+	// cloudEngineEnv and RunnerHostEnv are soft-deprecated, like the --cloud
+	// flag: --engine replaces both, but they still work as a fallback.
+	cloudEngineEnv = "DAGGER_CLOUD_ENGINE"
+	RunnerHostEnv  = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
+
 	RunnerImageLoaderEnv = "_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE"
 	TraceNameEnv         = "DAGGER_TRACE_NAME"
 )

--- a/internal/cmd/dagger/engine_help.go
+++ b/internal/cmd/dagger/engine_help.go
@@ -25,12 +25,14 @@ PRIORITY
   The CLI uses the first of these that is set:
 
     1. --engine
-    2. %s (deprecated; any value selects Dagger Cloud)
-    3. %s (deprecated)
-    4. The engine that this CLI version ships with
+    2. --cloud (deprecated; the same as --engine=cloud)
+    3. %s (takes the same values as --engine)
+    4. %s (deprecated; any value selects Dagger Cloud)
+    5. %s (deprecated)
+    6. The engine that this CLI version ships with
 
-  The two environment variables are soft-deprecated, like the --cloud flag.
-  They still work as a fallback, but --engine replaces them:
+  The two deprecated variables still work as a fallback, in the same way as
+  the deprecated --cloud flag. --engine and %s replace them:
 
     --engine=cloud  instead of %s
     --engine=URI    instead of %s
@@ -45,7 +47,10 @@ EXAMPLES
 
   Run on a remote host over SSH:
     dagger call --engine=ssh://user@host build
-`, drivers.SchemeHelp(), cloudEngineEnv, RunnerHostEnv, cloudEngineEnv, RunnerHostEnv),
+
+  Select an engine for every command in a shell session:
+    export DAGGER_ENGINE=cloud
+`, drivers.SchemeHelp(), engineEnv, cloudEngineEnv, RunnerHostEnv, engineEnv, cloudEngineEnv, RunnerHostEnv),
 }
 
 func init() {

--- a/internal/cmd/dagger/engine_help.go
+++ b/internal/cmd/dagger/engine_help.go
@@ -1,0 +1,47 @@
+package daggercmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dagger/dagger/engine/client/drivers"
+)
+
+// engineHelpCmd is a help topic, not a command: it has no Run, so Cobra lists
+// it under "Additional help topics" instead of the command list. It holds the
+// full engine selector catalog that the `--engine` usage is too small to carry.
+var engineHelpCmd = &cobra.Command{
+	Use:   "engine",
+	Short: "How to select the engine that runs your workflows",
+	Long: fmt.Sprintf(`Dagger runs your workflows on an engine. Use --engine to select one.
+
+VALUES
+
+%s
+
+PRIORITY
+
+  The CLI uses the first of these that is set:
+
+    1. --engine
+    2. %s (any value selects Dagger Cloud)
+    3. %s
+    4. The engine that this CLI version ships with
+
+EXAMPLES
+
+  Run on Dagger Cloud:
+    dagger call --engine=cloud build
+
+  Run on an engine container that is already running:
+    dagger call --engine=container://dagger-engine build
+
+  Run on a remote host over SSH:
+    dagger call --engine=ssh://user@host build
+`, drivers.SchemeHelp(), "DAGGER_CLOUD_ENGINE", RunnerHostEnv),
+}
+
+func init() {
+	rootCmd.AddCommand(engineHelpCmd)
+}

--- a/internal/cmd/dagger/engine_help.go
+++ b/internal/cmd/dagger/engine_help.go
@@ -25,9 +25,15 @@ PRIORITY
   The CLI uses the first of these that is set:
 
     1. --engine
-    2. %s (any value selects Dagger Cloud)
-    3. %s
+    2. %s (deprecated; any value selects Dagger Cloud)
+    3. %s (deprecated)
     4. The engine that this CLI version ships with
+
+  The two environment variables are soft-deprecated, like the --cloud flag.
+  They still work as a fallback, but --engine replaces them:
+
+    --engine=cloud  instead of %s
+    --engine=URI    instead of %s
 
 EXAMPLES
 
@@ -39,7 +45,7 @@ EXAMPLES
 
   Run on a remote host over SSH:
     dagger call --engine=ssh://user@host build
-`, drivers.SchemeHelp(), "DAGGER_CLOUD_ENGINE", RunnerHostEnv),
+`, drivers.SchemeHelp(), cloudEngineEnv, RunnerHostEnv, cloudEngineEnv, RunnerHostEnv),
 }
 
 func init() {

--- a/internal/cmd/dagger/engine_help_test.go
+++ b/internal/cmd/dagger/engine_help_test.go
@@ -40,7 +40,12 @@ func TestEngineHelpTopic(t *testing.T) {
 	}
 	require.Contains(t, help, "tcp://HOST:PORT (no authentication)")
 	require.Contains(t, help, RunnerHostEnv)
-	require.Contains(t, help, "DAGGER_CLOUD_ENGINE")
+	require.Contains(t, help, cloudEngineEnv)
+	// Both environment variables are soft-deprecated in favour of --engine.
+	require.Contains(t, help, cloudEngineEnv+" (deprecated; any value selects Dagger Cloud)")
+	require.Contains(t, help, RunnerHostEnv+" (deprecated)")
+	require.Contains(t, help, "--engine=cloud  instead of "+cloudEngineEnv)
+	require.Contains(t, help, "--engine=URI    instead of "+RunnerHostEnv)
 	require.Contains(t, help, "dagger call --engine=cloud build")
 }
 

--- a/internal/cmd/dagger/engine_help_test.go
+++ b/internal/cmd/dagger/engine_help_test.go
@@ -59,3 +59,17 @@ func TestEngineFlagCompletion(t *testing.T) {
 	require.Contains(t, values, "container+podman://")
 	require.NotContains(t, values, "docker-container://")
 }
+
+// A completion request names the command being completed, not the command that
+// runs, so the capability gate must let it through. Completion still hides the
+// flags that the target command does not support.
+func TestShellCompletionSkipsCapabilityValidation(t *testing.T) {
+	root := testRootCommand()
+
+	for _, request := range []string{cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd} {
+		require.NoError(t, validateFlagCapabilities(root, []string{request, "check", "--engine", ""}), request)
+		require.NoError(t, validateFlagCapabilities(root, []string{request, "trace", "--engine", ""}), request)
+	}
+	require.False(t, isShellCompletionRequest(nil))
+	require.False(t, isShellCompletionRequest([]string{"check", "--engine", "cloud"}))
+}

--- a/internal/cmd/dagger/engine_help_test.go
+++ b/internal/cmd/dagger/engine_help_test.go
@@ -1,0 +1,61 @@
+package daggercmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagger/dagger/engine/client/drivers"
+)
+
+func TestEngineHelpTopic(t *testing.T) {
+	root := testRootCommand()
+
+	topic, _, err := root.Find([]string{"engine"})
+	require.NoError(t, err)
+	require.Equal(t, engineHelpCmd, topic)
+
+	// A help topic is not a command: Cobra lists it under "Additional help
+	// topics", not in the command list, and it declares no capabilities, so
+	// its usage stays free of the global flags.
+	require.False(t, topic.Hidden)
+	require.False(t, topic.Runnable())
+	require.True(t, topic.IsAdditionalHelpTopicCommand())
+	require.False(t, topic.IsAvailableCommand())
+	require.False(t, commandHasCapability(topic, mayCallEngine))
+	require.False(t, commandHasCapability(topic, mayRenderPipeline))
+
+	rootHelp := renderHelp(t, root)
+	require.Contains(t, rootHelp, "ADDITIONAL HELP TOPICS")
+	require.Contains(t, rootHelp, "dagger engine")
+	// The catalog itself must not reach the front-door usage message.
+	require.NotContains(t, rootHelp, "image+nerdctl://IMAGE")
+
+	help := renderHelp(t, topic)
+	// The topic carries the full catalog, including the variants and the
+	// legacy schemes that the flag usage leaves out.
+	for _, scheme := range drivers.SchemeCatalog() {
+		require.Contains(t, help, scheme.Value, scheme.Scheme)
+	}
+	require.Contains(t, help, "tcp://HOST:PORT (no authentication)")
+	require.Contains(t, help, RunnerHostEnv)
+	require.Contains(t, help, "DAGGER_CLOUD_ENGINE")
+	require.Contains(t, help, "dagger call --engine=cloud build")
+}
+
+func TestEngineFlagCompletion(t *testing.T) {
+	root := testRootCommand()
+
+	fn, ok := root.GetFlagCompletionFunc("engine")
+	require.True(t, ok)
+
+	values, directive := fn(root, nil, "")
+	require.Equal(t, drivers.SchemeCompletions(), values)
+	// The values end in "://", so the shell must not append a space, and a
+	// path is never a valid completion.
+	require.Equal(t, cobra.ShellCompDirectiveNoSpace|cobra.ShellCompDirectiveNoFileComp, directive)
+	require.Contains(t, values, "cloud")
+	require.Contains(t, values, "container+podman://")
+	require.NotContains(t, values, "docker-container://")
+}

--- a/internal/cmd/dagger/engine_help_test.go
+++ b/internal/cmd/dagger/engine_help_test.go
@@ -41,6 +41,8 @@ func TestEngineHelpTopic(t *testing.T) {
 	require.Contains(t, help, "tcp://HOST:PORT (no authentication)")
 	require.Contains(t, help, RunnerHostEnv)
 	require.Contains(t, help, cloudEngineEnv)
+	require.Contains(t, help, engineEnv+" (takes the same values as --engine)")
+	require.Contains(t, help, "export "+engineEnv+"=cloud")
 	// Both environment variables are soft-deprecated in favour of --engine.
 	require.Contains(t, help, cloudEngineEnv+" (deprecated; any value selects Dagger Cloud)")
 	require.Contains(t, help, RunnerHostEnv+" (deprecated)")

--- a/internal/cmd/dagger/engine_test.go
+++ b/internal/cmd/dagger/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dagger/dagger/dagql/idtui"
+	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -182,4 +183,47 @@ func TestEngineTelemetryConfigSkipsSharedExporters(t *testing.T) {
 	if cfg := engineTelemetryConfig(ctx); cfg.Detect {
 		t.Fatal("expected Detect to be disabled for an internal silent session")
 	}
+}
+
+func TestConfiguredRunnerHost(t *testing.T) {
+	oldEngine := engineFlag
+	oldCloud := useCloudEngine
+	oldRunnerHost := RunnerHost
+	t.Cleanup(func() {
+		engineFlag = oldEngine
+		useCloudEngine = oldCloud
+		RunnerHost = oldRunnerHost
+	})
+
+	RunnerHost = "image://registry.example.com/dagger-engine:latest"
+
+	t.Run("runner host fallback", func(t *testing.T) {
+		engineFlag = ""
+		useCloudEngine = false
+		require.Equal(t, RunnerHost, configuredRunnerHost())
+	})
+
+	t.Run("cloud compatibility alias", func(t *testing.T) {
+		engineFlag = ""
+		useCloudEngine = true
+		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
+	})
+
+	t.Run("cloud engine", func(t *testing.T) {
+		engineFlag = "cloud"
+		useCloudEngine = false
+		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
+	})
+
+	t.Run("runner host URI", func(t *testing.T) {
+		engineFlag = "tcp://engine.example.com:1234"
+		useCloudEngine = false
+		require.Equal(t, engineFlag, configuredRunnerHost())
+	})
+
+	t.Run("engine flag overrides cloud alias", func(t *testing.T) {
+		engineFlag = "tcp://engine.example.com:1234"
+		useCloudEngine = true
+		require.Equal(t, engineFlag, configuredRunnerHost())
+	})
 }

--- a/internal/cmd/dagger/engine_test.go
+++ b/internal/cmd/dagger/engine_test.go
@@ -187,43 +187,97 @@ func TestEngineTelemetryConfigSkipsSharedExporters(t *testing.T) {
 
 func TestConfiguredRunnerHost(t *testing.T) {
 	oldEngine := engineFlag
-	oldCloud := useCloudEngine
+	oldCloud := cloudFlag
+	oldCloudEnv := cloudEngineEnvSet
 	oldRunnerHost := RunnerHost
 	t.Cleanup(func() {
 		engineFlag = oldEngine
-		useCloudEngine = oldCloud
+		cloudFlag = oldCloud
+		cloudEngineEnvSet = oldCloudEnv
 		RunnerHost = oldRunnerHost
 	})
+	t.Setenv(engineEnv, "")
 
 	RunnerHost = "image://registry.example.com/dagger-engine:latest"
 
-	t.Run("runner host fallback", func(t *testing.T) {
+	reset := func() {
 		engineFlag = ""
-		useCloudEngine = false
+		cloudFlag = false
+		cloudEngineEnvSet = false
+	}
+
+	t.Run("runner host fallback", func(t *testing.T) {
+		reset()
 		require.Equal(t, RunnerHost, configuredRunnerHost())
 	})
 
 	t.Run("cloud compatibility alias", func(t *testing.T) {
-		engineFlag = ""
-		useCloudEngine = true
+		reset()
+		cloudFlag = true
 		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
 	})
 
 	t.Run("cloud engine", func(t *testing.T) {
+		reset()
 		engineFlag = "cloud"
-		useCloudEngine = false
 		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
 	})
 
 	t.Run("runner host URI", func(t *testing.T) {
+		reset()
 		engineFlag = "tcp://engine.example.com:1234"
-		useCloudEngine = false
 		require.Equal(t, engineFlag, configuredRunnerHost())
 	})
 
 	t.Run("engine flag overrides cloud alias", func(t *testing.T) {
+		reset()
 		engineFlag = "tcp://engine.example.com:1234"
-		useCloudEngine = true
+		cloudFlag = true
 		require.Equal(t, engineFlag, configuredRunnerHost())
+	})
+
+	t.Run("engine env var", func(t *testing.T) {
+		reset()
+		t.Setenv(engineEnv, "tcp://env.example.com:1234")
+		require.Equal(t, "tcp://env.example.com:1234", configuredRunnerHost())
+	})
+
+	t.Run("engine env var selects cloud", func(t *testing.T) {
+		reset()
+		t.Setenv(engineEnv, "cloud")
+		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
+	})
+
+	t.Run("engine flag overrides engine env var", func(t *testing.T) {
+		reset()
+		engineFlag = "tcp://flag.example.com:1234"
+		t.Setenv(engineEnv, "tcp://env.example.com:1234")
+		require.Equal(t, engineFlag, configuredRunnerHost())
+	})
+
+	// --cloud is a deprecated alias for --engine=cloud, so it keeps a flag's
+	// priority over the environment, even when DAGGER_CLOUD_ENGINE is set too.
+	t.Run("cloud flag overrides engine env var", func(t *testing.T) {
+		reset()
+		cloudFlag = true
+		t.Setenv(engineEnv, "tcp://env.example.com:1234")
+		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
+
+		cloudEngineEnvSet = true
+		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
+	})
+
+	// DAGGER_CLOUD_ENGINE is deprecated, so DAGGER_ENGINE outranks it.
+	t.Run("engine env var overrides deprecated cloud env var", func(t *testing.T) {
+		reset()
+		cloudEngineEnvSet = true
+		t.Setenv(engineEnv, "tcp://env.example.com:1234")
+		require.Equal(t, "tcp://env.example.com:1234", configuredRunnerHost())
+	})
+
+	t.Run("deprecated cloud env var without engine env var", func(t *testing.T) {
+		reset()
+		cloudEngineEnvSet = true
+		require.Equal(t, engine.DefaultCloudRunnerHost, configuredRunnerHost())
 	})
 }

--- a/internal/cmd/dagger/functions.go
+++ b/internal/cmd/dagger/functions.go
@@ -254,6 +254,7 @@ func (fc *FuncCommand) Command() *cobra.Command {
 		})
 
 		fc.cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "Save the result to a local file or directory")
+		setFlagCapabilities(fc.cmd.PersistentFlags().Lookup("output"), mayProduceOutput)
 
 		fc.cmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Present result as JSON")
 	}

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -76,7 +76,6 @@ var (
 	autoApply                 bool
 	engineFlag                string
 	_, useCloudEngine         = os.LookupEnv("DAGGER_CLOUD_ENGINE")
-	enableScaleOut            bool
 	profileFlag               bool
 
 	dotOutputFilePath string
@@ -446,10 +445,6 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 
 	installMayCallEngineFlags(flags)
 	installMayRenderPipelineFlags(flags)
-
-	// this flag enables scale-out for a few commands, e.g. checks
-	flags.BoolVar(&enableScaleOut, "scale-out", false, "Enable scale-out to cloud engines for each check executed")
-	flags.Lookup("scale-out").Hidden = true
 
 	if err := flags.MarkHidden("workdir"); err != nil {
 		fmt.Fprintln(stdout, "Error hiding flag: workdir", err)

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -221,6 +221,7 @@ func init() {
 	)
 
 	rootCmd.PersistentFlags().StringVar(&cloudOrgFlag, "org", "", "Dagger Cloud org name for Cloud-scoped commands")
+	rootCmd.PersistentFlags().Lookup("org").Hidden = true
 
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
 	cobra.AddTemplateFunc("flagUsagesWrapped", flagUsagesWrapped)
@@ -429,6 +430,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "Change the working directory before running the command")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
+	flags.Lookup("x-release").Hidden = true
 
 	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
 	setFlagCapabilities(flags.Lookup("workspace"), maySelectWorkspace)

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -60,23 +60,23 @@ var (
 	workspaceRef string
 	workspaceEnv string
 
-	silent                   = silentFromEnv()
-	verbose                  int
-	quiet, _                 = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
-	reveal                   = os.Getenv("DAGGER_REVEAL") != ""
-	expandCompleted          = os.Getenv("DAGGER_EXPAND_COMPLETED") != ""
-	debugFlag                bool
-	progress                 string
-	interactive              bool
-	interactiveCommand       string
-	interactiveCommandParsed []string
-	web                      bool
-	noExit                   bool
-	xRelease                 string
-	autoApply                bool
-	_, useCloudEngine        = os.LookupEnv("DAGGER_CLOUD_ENGINE")
-	enableScaleOut           bool
-	profileFlag              bool
+	silent                    = silentFromEnv()
+	verbose                   int
+	quiet, _                  = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
+	reveal                    = os.Getenv("DAGGER_REVEAL") != ""
+	expandCompleted           = os.Getenv("DAGGER_EXPAND_COMPLETED") != ""
+	debugFlag                 bool
+	progress                  string
+	shellOnError              bool
+	shellCommandOnError       string
+	shellCommandOnErrorParsed []string
+	web                       bool
+	noExit                    bool
+	xRelease                  string
+	autoApply                 bool
+	_, useCloudEngine         = os.LookupEnv("DAGGER_CLOUD_ENGINE")
+	enableScaleOut            bool
+	profileFlag               bool
 
 	dotOutputFilePath string
 	dotFocusField     string
@@ -428,8 +428,6 @@ func checkCloudToken(ctx context.Context, w io.Writer) error {
 func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "Change the working directory before running the command")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
-	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
-	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
 
 	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
@@ -461,8 +459,19 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	}
 }
 
+// defaultShellCommandOnError is the command --shell-on-error runs in the
+// failed container.
+const defaultShellCommandOnError = "/bin/sh"
+
 func installMayCallEngineFlags(flags *pflag.FlagSet) {
 	engineFlags := pflag.NewFlagSet(string(mayCallEngine), pflag.ContinueOnError)
+	engineFlags.BoolVarP(&shellOnError, "shell-on-error", "i", false, "Open a shell when a container exec fails")
+	engineFlags.BoolVar(&shellOnError, "interactive", false, "")
+	_ = engineFlags.MarkDeprecated("interactive", "use --shell-on-error (-i) instead")
+	engineFlags.StringVar(&shellCommandOnError, "shell-command-on-error", defaultShellCommandOnError, "Command to run when --shell-on-error opens a shell")
+	engineFlags.Lookup("shell-command-on-error").Hidden = true
+	engineFlags.StringVar(&shellCommandOnError, "interactive-command", defaultShellCommandOnError, "")
+	_ = engineFlags.MarkDeprecated("interactive-command", "use --shell-command-on-error instead")
 	engineFlags.BoolVar(&profileFlag, "profile", false, "Enable experimental engine wall-clock profiling for this session")
 	engineFlags.Lookup("profile").Hidden = true
 	setFlagSetCapabilities(engineFlags, mayCallEngine)
@@ -945,13 +954,13 @@ func Main() {
 		exitWithCode(1)
 	}
 
-	// Parse the interactive command to support shell-like syntax
-	parsedCommand, err := shlex.Split(interactiveCommand)
+	// Parse the shell command to support shell-like syntax.
+	parsedCommand, err := shlex.Split(shellCommandOnError)
 	if err != nil {
-		fmt.Fprintf(stderr, "cannot parse interactive command: %s", err)
+		fmt.Fprintf(stderr, "cannot parse --shell-command-on-error: %s", err)
 		exitWithCode(1)
 	}
-	interactiveCommandParsed = parsedCommand
+	shellCommandOnErrorParsed = parsedCommand
 
 	ctx = slog.ContextWithColorMode(ctx, termenv.EnvNoColor())
 	ctx = slog.ContextWithDebugMode(ctx, debugFlag)

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -427,13 +427,17 @@ func checkCloudToken(ctx context.Context, w io.Writer) error {
 
 func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "Change the working directory before running the command")
-	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
 	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when a changeset is returned")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
+
+	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
+	setFlagCapabilities(flags.Lookup("workspace"), maySelectWorkspace)
+	flags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
+	setFlagAnyCapabilities(flags.Lookup("env"), mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
 
 	installMayCallEngineFlags(flags)
 	installMayRenderPipelineFlags(flags)
@@ -455,7 +459,6 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 
 func installMayCallEngineFlags(flags *pflag.FlagSet) {
 	engineFlags := pflag.NewFlagSet(string(mayCallEngine), pflag.ContinueOnError)
-	engineFlags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
 	engineFlags.BoolVar(&profileFlag, "profile", false, "Enable experimental engine wall-clock profiling for this session")
 	engineFlags.Lookup("profile").Hidden = true
 	setFlagSetCapabilities(engineFlags, mayCallEngine)

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -428,7 +428,6 @@ func checkCloudToken(ctx context.Context, w io.Writer) error {
 func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "Change the working directory before running the command")
 	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
-	flags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
@@ -436,6 +435,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when a changeset is returned")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
 
+	installMayCallEngineFlags(flags)
 	installMayRenderPipelineFlags(flags)
 
 	// this flag changes the behaviour of a few commands, e.g. call, functions, core, shell, etc.
@@ -447,15 +447,19 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&enableScaleOut, "scale-out", false, "Enable scale-out to cloud engines for each check executed")
 	flags.Lookup("scale-out").Hidden = true
 
-	// experimental: enable engine wall-clock profiling (wcprof) for this
-	// session; recorded events are retrieved from the engine debug endpoint
-	flags.BoolVar(&profileFlag, "profile", false, "Enable experimental engine wall-clock profiling for this session")
-	flags.Lookup("profile").Hidden = true
-
 	if err := flags.MarkHidden("workdir"); err != nil {
 		fmt.Fprintln(stdout, "Error hiding flag: workdir", err)
 		os.Exit(1)
 	}
+}
+
+func installMayCallEngineFlags(flags *pflag.FlagSet) {
+	engineFlags := pflag.NewFlagSet(string(mayCallEngine), pflag.ContinueOnError)
+	engineFlags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
+	engineFlags.BoolVar(&profileFlag, "profile", false, "Enable experimental engine wall-clock profiling for this session")
+	engineFlags.Lookup("profile").Hidden = true
+	setFlagSetCapabilities(engineFlags, mayCallEngine)
+	flags.AddFlagSet(engineFlags)
 }
 
 func installMayRenderPipelineFlags(flags *pflag.FlagSet) {

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -224,7 +224,8 @@ func init() {
 
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
 	cobra.AddTemplateFunc("flagUsagesWrapped", flagUsagesWrapped)
-	cobra.AddTemplateFunc("hasInheritedFlags", hasInheritedFlags)
+	cobra.AddTemplateFunc("availableFlags", availableFlagsForCommand)
+	cobra.AddTemplateFunc("inheritedFlags", inheritedFlags)
 	cobra.AddTemplateFunc("toUpperBold", toUpperBold)
 	cobra.AddTemplateFunc("sortRequiredFlags", sortRequiredFlags)
 	cobra.AddTemplateFunc("groupFlags", groupFlags)
@@ -255,6 +256,9 @@ var rootCmd = &cobra.Command{
 		// if we got this far, CLI parsing worked just fine; no
 		// need to show usage for runtime errors
 		cmd.SilenceUsage = true
+		if restore := hideUnavailableCompletionFlags(cmd, args); restore != nil {
+			cobra.OnFinalize(restore)
+		}
 		applyCommandProgressDefaults(cmd)
 
 		if cpuprofile != "" {
@@ -426,20 +430,13 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
 	flags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
-	flags.CountVarP(&quiet, "quiet", "q", "Reduce verbosity (show progress, but clean up at the end)")
-	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
-	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty, dots, logs, report)")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
-	flags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")
-	flags.BoolVarP(&noExit, "no-exit", "E", false, "Leave the TUI running after completion")
 	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when a changeset is returned")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
 
-	flags.StringVar(&dotOutputFilePath, "dot-output", "", "If set, write the calls made during execution to a dot file at the given path before exiting")
-	flags.StringVar(&dotFocusField, "dot-focus-field", "", "In dot output, filter out vertices that aren't this field or descendents of this field")
-	flags.BoolVar(&dotShowInternal, "dot-show-internal", false, "In dot output, if true then include calls and spans marked as internal")
+	installMayRenderPipelineFlags(flags)
 
 	// this flag changes the behaviour of a few commands, e.g. call, functions, core, shell, etc.
 	// all those functions will run in a remote cloud engine which gets created at execution time
@@ -455,17 +452,31 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&profileFlag, "profile", false, "Enable experimental engine wall-clock profiling for this session")
 	flags.Lookup("profile").Hidden = true
 
-	for _, fl := range []string{
-		"dot-output",
-		"dot-focus-field",
-		"dot-show-internal",
-		"workdir",
-	} {
-		if err := flags.MarkHidden(fl); err != nil {
-			fmt.Fprintln(stdout, "Error hiding flag: "+fl, err)
-			os.Exit(1)
-		}
+	if err := flags.MarkHidden("workdir"); err != nil {
+		fmt.Fprintln(stdout, "Error hiding flag: workdir", err)
+		os.Exit(1)
 	}
+}
+
+func installMayRenderPipelineFlags(flags *pflag.FlagSet) {
+	renderFlags := pflag.NewFlagSet(string(mayRenderPipeline), pflag.ContinueOnError)
+	renderFlags.CountVarP(&quiet, "quiet", "q", "Reduce verbosity (show progress, but clean up at the end)")
+	renderFlags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
+	renderFlags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty, dots, logs, report)")
+	renderFlags.BoolVarP(&web, "web", "w", false, "Open trace URL in a web browser")
+	renderFlags.BoolVarP(&noExit, "no-exit", "E", false, "Leave the TUI running after completion")
+
+	hiddenFlags := pflag.NewFlagSet("hidden", pflag.ContinueOnError)
+	hiddenFlags.StringVar(&dotOutputFilePath, "dot-output", "", "If set, write the calls made during execution to a dot file at the given path before exiting")
+	hiddenFlags.StringVar(&dotFocusField, "dot-focus-field", "", "In dot output, filter out vertices that aren't this field or descendents of this field")
+	hiddenFlags.BoolVar(&dotShowInternal, "dot-show-internal", false, "In dot output, if true then include calls and spans marked as internal")
+	hiddenFlags.VisitAll(func(flag *pflag.Flag) {
+		flag.Hidden = true
+	})
+
+	renderFlags.AddFlagSet(hiddenFlags)
+	setFlagSetCapabilities(renderFlags, mayRenderPipeline)
+	flags.AddFlagSet(renderFlags)
 }
 
 // disableFlagsInUseLine disables the automatic addition of [flags]
@@ -624,16 +635,27 @@ func shouldCleanupOldEngines() bool {
 	return !leaveOldEngine
 }
 
-func parseGlobalFlags(args []string) {
-	flags := pflag.NewFlagSet("global", pflag.ContinueOnError)
+func parseGlobalFlags(root *cobra.Command, args []string) {
+	cmd, commandArgs := resolveCommand(root, args)
+	if cmd == nil {
+		return
+	}
+
+	flags := copyCommandFlags(cmd, "global")
 	flags.Usage = func() {}
-	flags.ParseErrorsAllowlist.UnknownFlags = true
-	installGlobalFlags(flags)
-	if err := flags.Parse(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		global := root.PersistentFlags().Lookup(flag.Name)
+		selected := cmd.Flags().Lookup(flag.Name)
+		if global == nil || selected != global {
+			flag.Value = ignoredFlagValue{Value: flag.Value}
+		}
+	})
+	if err := flags.Parse(commandArgs); err != nil && !errors.Is(err, pflag.ErrHelp) {
 		fmt.Fprintln(stderr, err)
 		os.Exit(1)
 	}
-	if !flags.Changed("x-release") {
+	globalXRelease := root.PersistentFlags().Lookup("x-release")
+	if globalXRelease == nil || cmd.Flags().Lookup("x-release") != globalXRelease || !flags.Changed("x-release") {
 		xRelease = os.Getenv(daggerXReleaseEnv)
 	}
 	xRelease = strings.TrimSpace(xRelease)
@@ -821,10 +843,14 @@ func applyCommandProgressDefaults(cmd *cobra.Command) {
 
 func Main() {
 	installGlobalFlags(rootCmd.PersistentFlags())
+	if err := validateFlagCapabilities(rootCmd, os.Args[1:]); err != nil {
+		fmt.Fprintln(stderr, rootCmd.ErrPrefix(), err)
+		os.Exit(1)
+	}
 
 	// Some global flags affect how the client connects, so read them before
 	// Cobra executes the command tree. Cobra still does the normal parse later.
-	parseGlobalFlags(os.Args[1:])
+	parseGlobalFlags(rootCmd, os.Args[1:])
 	resolvedWorkdir, err := NormalizeWorkdir(workdir)
 	if err != nil {
 		fmt.Fprintln(stderr, rootCmd.ErrPrefix(), err)
@@ -1005,11 +1031,11 @@ func isExperimental(cmd *cobra.Command) bool {
 	return experimental
 }
 
-func hasInheritedFlags(cmd *cobra.Command) bool {
+func inheritedFlags(cmd *cobra.Command) *pflag.FlagSet {
 	if val, ok := cmd.Annotations["help:hideInherited"]; ok && val == "true" {
-		return false
+		return pflag.NewFlagSet("inherited", pflag.ContinueOnError)
 	}
-	return cmd.HasAvailableInheritedFlags()
+	return availableFlagsForCommand(cmd, cmd.InheritedFlags())
 }
 
 // getViewWidth returns the width of the terminal, or 80 if it cannot be determined.
@@ -1374,16 +1400,18 @@ const usageTemplate = `{{ if .Runnable}}{{ "Usage" | toUpperBold }}
 {{cmdShortWrappedListByGroups .}}
 {{- end}}{{/* if .HasAvailableSubCommands */}}
 
-{{- if .HasAvailableLocalFlags}}
+{{- $localFlags := availableFlags . .LocalFlags}}
+{{- if $localFlags.HasAvailableFlags}}
 
-{{ groupFlags .LocalFlags | trimTrailingWhitespaces }}
+{{ groupFlags $localFlags | trimTrailingWhitespaces }}
 
 {{- end}}
 
-{{- if hasInheritedFlags . }}
+{{- $inheritedFlags := inheritedFlags .}}
+{{- if $inheritedFlags.HasAvailableFlags}}
 
 {{ "Inherited Options" | toUpperBold }}
-{{ flagUsagesWrapped .InheritedFlags | trimTrailingWhitespaces }}
+{{ flagUsagesWrapped $inheritedFlags | trimTrailingWhitespaces }}
 
 {{- end}}
 

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -75,8 +75,12 @@ var (
 	xRelease                  string
 	autoApply                 bool
 	engineFlag                string
-	_, useCloudEngine         = os.LookupEnv(cloudEngineEnv)
-	profileFlag               bool
+	// cloudFlag backs the deprecated --cloud flag, an alias for --engine=cloud.
+	cloudFlag bool
+	// cloudEngineEnvSet records the deprecated DAGGER_CLOUD_ENGINE variable.
+	// Any value selects Dagger Cloud.
+	_, cloudEngineEnvSet = os.LookupEnv(cloudEngineEnv)
+	profileFlag          bool
 
 	dotOutputFilePath string
 	dotFocusField     string
@@ -460,14 +464,14 @@ const defaultShellCommandOnError = "/bin/sh"
 // the help topic for the rest. The full catalog is too long to repeat in the
 // usage message of every command that can call the engine.
 var engineFlagUsage = fmt.Sprintf(
-	"Select the engine: %s (run 'dagger help engine' for details)",
-	drivers.SchemeSummary(),
+	"Select the engine: %s (or set %s; run 'dagger help engine' for details)",
+	drivers.SchemeSummary(), engineEnv,
 )
 
 func installMayCallEngineFlags(flags *pflag.FlagSet) {
 	engineFlags := pflag.NewFlagSet(string(mayCallEngine), pflag.ContinueOnError)
 	engineFlags.StringVar(&engineFlag, "engine", "", engineFlagUsage)
-	engineFlags.BoolVar(&useCloudEngine, "cloud", useCloudEngine, "")
+	engineFlags.BoolVar(&cloudFlag, "cloud", false, "")
 	_ = engineFlags.MarkDeprecated("cloud", "use --engine=cloud instead")
 	engineFlags.Lookup("cloud").Hidden = true
 	engineFlags.BoolVarP(&shellOnError, "shell-on-error", "i", false, "Open a shell when a container exec fails")
@@ -553,12 +557,12 @@ func execXRelease(ctx context.Context) error {
 	}
 
 	args := xReleaseProcessArgs(os.Args[1:])
-	env, hasRunnerHost := xReleaseProcessEnv(os.Environ())
-	if hasRunnerHost {
+	env, engineEnvs := xReleaseProcessEnv(os.Environ())
+	if len(engineEnvs) > 0 {
 		fmt.Fprintln(stderr, xReleaseLogLine(fmt.Sprintf(
 			"warning: --x-release or %s is being used with %s",
 			daggerXReleaseEnv,
-			RunnerHostEnv,
+			strings.Join(engineEnvs, " and "),
 		)))
 	}
 	execArgs := append([]string{binPath}, args...)
@@ -627,18 +631,19 @@ func xReleaseProcessArgs(args []string) []string {
 	return rewritten
 }
 
-func xReleaseProcessEnv(environ []string) ([]string, bool) {
-	env := make([]string, 0, len(environ)+1)
+// xReleaseProcessEnv returns the environment for the downloaded CLI, and the
+// names of the variables in it that select an engine. That engine may not
+// match the downloaded version, so the caller warns about them.
+func xReleaseProcessEnv(environ []string) (env []string, engineEnvs []string) {
+	env = make([]string, 0, len(environ)+1)
 	hasLeaveOldEngine := false
-	hasRunnerHost := false
 	for _, kv := range environ {
 		key, _, _ := strings.Cut(kv, "=")
 		switch key {
 		case daggerXReleaseEnv, RunnerImageLoaderEnv:
 			continue
-		}
-		if key == RunnerHostEnv {
-			hasRunnerHost = true
+		case engineEnv, RunnerHostEnv:
+			engineEnvs = append(engineEnvs, key)
 		}
 		if key == "DAGGER_LEAVE_OLD_ENGINE" {
 			hasLeaveOldEngine = true
@@ -648,7 +653,7 @@ func xReleaseProcessEnv(environ []string) ([]string, bool) {
 	if !hasLeaveOldEngine {
 		env = append(env, "DAGGER_LEAVE_OLD_ENGINE=1")
 	}
-	return env, hasRunnerHost
+	return env, engineEnvs
 }
 
 func shouldCleanupOldEngines() bool {

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -674,6 +674,15 @@ func parseGlobalFlags(root *cobra.Command, args []string) {
 	flags := copyCommandFlags(cmd, "global")
 	flags.Usage = func() {}
 	flags.VisitAll(func(flag *pflag.Flag) {
+		// Cobra owns --help. The clones share the real flag values, so applying
+		// it here would set it before Cobra runs the command. Cobra reads the
+		// value even when a command disables flag parsing, so a dynamic command
+		// such as `dagger call` would print its static usage instead of loading
+		// the module and rendering its functions.
+		if flag.Name == "help" {
+			flag.Value = ignoredFlagValue{Value: flag.Value}
+			return
+		}
 		global := root.PersistentFlags().Lookup(flag.Name)
 		selected := cmd.Flags().Lookup(flag.Name)
 		if global == nil || selected != global {

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -456,9 +456,17 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 // failed container.
 const defaultShellCommandOnError = "/bin/sh"
 
+// engineFlagUsage names the value space on one line and sends the reader to
+// the help topic for the rest. The full catalog is too long to repeat in the
+// usage message of every command that can call the engine.
+var engineFlagUsage = fmt.Sprintf(
+	"Select the engine: %s (run 'dagger help engine' for details)",
+	drivers.SchemeSummary(),
+)
+
 func installMayCallEngineFlags(flags *pflag.FlagSet) {
 	engineFlags := pflag.NewFlagSet(string(mayCallEngine), pflag.ContinueOnError)
-	engineFlags.StringVar(&engineFlag, "engine", "", "Use the specified engine (cloud or a runner host URI)")
+	engineFlags.StringVar(&engineFlag, "engine", "", engineFlagUsage)
 	engineFlags.BoolVar(&useCloudEngine, "cloud", useCloudEngine, "")
 	_ = engineFlags.MarkDeprecated("cloud", "use --engine=cloud instead")
 	engineFlags.Lookup("cloud").Hidden = true
@@ -859,7 +867,7 @@ func applyCommandProgressDefaults(cmd *cobra.Command) {
 }
 
 func Main() {
-	installGlobalFlags(rootCmd.PersistentFlags())
+	installRootGlobalFlags()
 	if err := validateFlagCapabilities(rootCmd, os.Args[1:]); err != nil {
 		fmt.Fprintln(stderr, rootCmd.ErrPrefix(), err)
 		os.Exit(1)
@@ -997,8 +1005,24 @@ func Main() {
 // documentation generation. It installs global flags so the reference includes
 // them, matching what Main does before Execute.
 func RootCommand() *cobra.Command {
-	installGlobalFlags(rootCmd.PersistentFlags())
+	installRootGlobalFlags()
 	return rootCmd
+}
+
+// installRootGlobalFlags installs the global flags on the root command and
+// registers the completions that need a command, not just a flag set.
+func installRootGlobalFlags() {
+	installGlobalFlags(rootCmd.PersistentFlags())
+	if err := rootCmd.RegisterFlagCompletionFunc("engine", completeEngineFlag); err != nil {
+		fmt.Fprintln(stderr, "Error registering completion: engine", err)
+		os.Exit(1)
+	}
+}
+
+// completeEngineFlag offers every non-deprecated engine selector prefix. The
+// values end in "://", so completion must not append a space after them.
+func completeEngineFlag(*cobra.Command, []string, string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	return drivers.SchemeCompletions(), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 }
 
 // IsExperimental reports whether cmd (or any ancestor) is marked experimental.

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -75,7 +75,7 @@ var (
 	xRelease                  string
 	autoApply                 bool
 	engineFlag                string
-	_, useCloudEngine         = os.LookupEnv("DAGGER_CLOUD_ENGINE")
+	_, useCloudEngine         = os.LookupEnv(cloudEngineEnv)
 	profileFlag               bool
 
 	dotOutputFilePath string

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -428,7 +428,6 @@ func checkCloudToken(ctx context.Context, w io.Writer) error {
 func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "Change the working directory before running the command")
 	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
-	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
@@ -440,6 +439,9 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 
 	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when an output is returned")
 	setFlagCapabilities(flags.Lookup("auto-apply"), mayProduceOutput)
+
+	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Enable engine and trace diagnostics")
+	setFlagAnyCapabilities(flags.Lookup("debug"), mayCallEngine, mayRenderPipeline)
 
 	installMayCallEngineFlags(flags)
 	installMayRenderPipelineFlags(flags)

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -86,6 +86,7 @@ var (
 	dotFocusField     string
 	dotShowInternal   bool
 
+	stdinIsTTY  = isatty.IsTerminal(os.Stdin.Fd())
 	stdoutIsTTY = isatty.IsTerminal(os.Stdout.Fd())
 	stderrIsTTY = isatty.IsTerminal(os.Stderr.Fd())
 
@@ -474,7 +475,7 @@ func installMayCallEngineFlags(flags *pflag.FlagSet) {
 	engineFlags.BoolVar(&cloudFlag, "cloud", false, "")
 	_ = engineFlags.MarkDeprecated("cloud", "use --engine=cloud instead")
 	engineFlags.Lookup("cloud").Hidden = true
-	engineFlags.BoolVarP(&shellOnError, "shell-on-error", "i", false, "Open a shell when a container exec fails")
+	engineFlags.BoolVarP(&shellOnError, "shell-on-error", "i", false, "Open a shell when a container exec fails (needs an interactive terminal)")
 	engineFlags.BoolVar(&shellOnError, "interactive", false, "")
 	_ = engineFlags.MarkDeprecated("interactive", "use --shell-on-error (-i) instead")
 	engineFlags.StringVar(&shellCommandOnError, "shell-command-on-error", defaultShellCommandOnError, "Command to run when --shell-on-error opens a shell")
@@ -880,6 +881,15 @@ func applyCommandProgressDefaults(cmd *cobra.Command) {
 	opts.Verbosity = verbosity
 }
 
+// canOpenShellOnError reports whether the CLI can hand the terminal to a shell
+// in a failed container: only the pretty TUI can run one, and it needs a
+// terminal to read keys from. The check runs before the command, so a
+// non-interactive caller -- a script, or an AI agent, which gets the report
+// frontend -- fails fast instead of hanging in a shell it cannot exit.
+func canOpenShellOnError(progress string, stdinIsTTY bool) bool {
+	return progress == "tty" && stdinIsTTY
+}
+
 func Main() {
 	installRootGlobalFlags()
 	if err := validateFlagCapabilities(rootCmd, os.Args[1:]); err != nil {
@@ -970,6 +980,12 @@ func Main() {
 		Frontend = idtui.NewReporter(stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown progress type %q\n", progress)
+		exitWithCode(1)
+	}
+
+	if shellOnError && !canOpenShellOnError(progress, stdinIsTTY) {
+		fmt.Fprintln(stderr, rootCmd.ErrPrefix(),
+			"--shell-on-error needs an interactive terminal, but none is available")
 		exitWithCode(1)
 	}
 

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -74,6 +74,7 @@ var (
 	noExit                    bool
 	xRelease                  string
 	autoApply                 bool
+	engineFlag                string
 	_, useCloudEngine         = os.LookupEnv("DAGGER_CLOUD_ENGINE")
 	enableScaleOut            bool
 	profileFlag               bool
@@ -446,11 +447,6 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	installMayCallEngineFlags(flags)
 	installMayRenderPipelineFlags(flags)
 
-	// this flag changes the behaviour of a few commands, e.g. call, functions, core, shell, etc.
-	// all those functions will run in a remote cloud engine which gets created at execution time
-	flags.BoolVar(&useCloudEngine, "cloud", useCloudEngine, "Run in a Dagger Cloud Engine")
-	flags.Lookup("cloud").Hidden = true
-
 	// this flag enables scale-out for a few commands, e.g. checks
 	flags.BoolVar(&enableScaleOut, "scale-out", false, "Enable scale-out to cloud engines for each check executed")
 	flags.Lookup("scale-out").Hidden = true
@@ -467,6 +463,10 @@ const defaultShellCommandOnError = "/bin/sh"
 
 func installMayCallEngineFlags(flags *pflag.FlagSet) {
 	engineFlags := pflag.NewFlagSet(string(mayCallEngine), pflag.ContinueOnError)
+	engineFlags.StringVar(&engineFlag, "engine", "", "Use the specified engine (cloud or a runner host URI)")
+	engineFlags.BoolVar(&useCloudEngine, "cloud", useCloudEngine, "")
+	_ = engineFlags.MarkDeprecated("cloud", "use --engine=cloud instead")
+	engineFlags.Lookup("cloud").Hidden = true
 	engineFlags.BoolVarP(&shellOnError, "shell-on-error", "i", false, "Open a shell when a container exec fails")
 	engineFlags.BoolVar(&shellOnError, "interactive", false, "")
 	_ = engineFlags.MarkDeprecated("interactive", "use --shell-on-error (-i) instead")
@@ -906,7 +906,7 @@ func Main() {
 	opts.DotOutputFilePath = dotOutputFilePath
 	opts.DotFocusField = dotFocusField
 	opts.DotShowInternal = dotShowInternal
-	opts.UsingCloudEngine = useCloudEngine || strings.HasPrefix(RunnerHost, engine.CloudRunnerHostPrefix)
+	opts.UsingCloudEngine = strings.HasPrefix(configuredRunnerHost(), engine.CloudRunnerHostPrefix)
 	if progress == "auto" {
 		if env := os.Getenv("DAGGER_PROGRESS"); env != "" {
 			progress = env

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -431,13 +431,15 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&debugFlag, "debug", "d", debugFlag, "Show debug logs and full verbosity")
 	flags.BoolVarP(&interactive, "interactive", "i", false, "Spawn a terminal on container exec failure")
 	flags.StringVar(&interactiveCommand, "interactive-command", "/bin/sh", "Change the default command for interactive mode")
-	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when a changeset is returned")
 	flags.StringVar(&xRelease, "x-release", xRelease, "Run an experimental release from a Dagger git ref")
 
 	flags.StringVarP(&workspaceRef, "workspace", "W", "", "Select the workspace location to load from (local path or git ref)")
 	setFlagCapabilities(flags.Lookup("workspace"), maySelectWorkspace)
 	flags.StringVar(&workspaceEnv, "env", "", "Apply a named env overlay; writes target it, creating it if missing")
 	setFlagAnyCapabilities(flags.Lookup("env"), mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
+
+	flags.BoolVarP(&autoApply, "auto-apply", "y", false, "Automatically apply changes when an output is returned")
+	setFlagCapabilities(flags.Lookup("auto-apply"), mayProduceOutput)
 
 	installMayCallEngineFlags(flags)
 	installMayRenderPipelineFlags(flags)

--- a/internal/cmd/dagger/main_test.go
+++ b/internal/cmd/dagger/main_test.go
@@ -42,3 +42,16 @@ func TestIsObviouslyRemoteWorkspaceRef(t *testing.T) {
 	require.False(t, isObviouslyRemoteWorkspaceRef("common/.dagger/mymod"))
 	require.False(t, isObviouslyRemoteWorkspaceRef("my.dir"))
 }
+
+func TestCanOpenShellOnError(t *testing.T) {
+	// Only the pretty TUI can run the shell, and it needs a terminal to read
+	// keys from.
+	require.True(t, canOpenShellOnError("tty", true))
+
+	require.False(t, canOpenShellOnError("tty", false))
+	// The report frontend is what an AI agent gets.
+	require.False(t, canOpenShellOnError("report", true))
+	require.False(t, canOpenShellOnError("plain", true))
+	require.False(t, canOpenShellOnError("dots", true))
+	require.False(t, canOpenShellOnError("logs", true))
+}

--- a/internal/cmd/dagger/main_test.go
+++ b/internal/cmd/dagger/main_test.go
@@ -20,6 +20,12 @@ func TestCommandProgressDefault(t *testing.T) {
 	require.Empty(t, commandProgressDefault(nil))
 }
 
+func TestCloudOrgFlagHidden(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("org")
+	require.NotNil(t, flag)
+	require.True(t, flag.Hidden)
+}
+
 func TestIsObviouslyRemoteWorkspaceRef(t *testing.T) {
 	require.True(t, isObviouslyRemoteWorkspaceRef("github.com/acme/mono"))
 	require.True(t, isObviouslyRemoteWorkspaceRef("git@github.com:acme/mono"))

--- a/internal/cmd/dagger/module.go
+++ b/internal/cmd/dagger/module.go
@@ -36,29 +36,40 @@ func addWorkspaceInstallFlags(cmd *cobra.Command) {
 
 // moduleAddFlags adds common module-loading flags to a command.
 // If optional is true, it also adds the --no-load-module flag and marks --load-module and --no-load-module as mutually exclusive.
+// moduleAddFlags installs the module selection flags. Every consumer but the
+// root command calls the engine: loading a module, allowing an LLM, and eager
+// runtime loading are all engine session parameters. They therefore require
+// MayCallEngine, which keeps them out of the root command's usage message.
 func moduleAddFlags(cmd *cobra.Command, flags *pflag.FlagSet, optional bool) {
-	flags.StringVarP(&moduleURL, "load-module", "m", "", "Use a one-off module (local path or git ref)")
+	moduleFlags := pflag.NewFlagSet("Module", pflag.ContinueOnError)
+	moduleFlags.StringVarP(&moduleURL, "load-module", "m", "", "Use a one-off module (local path or git ref)")
 	// --mod is the pre-1.0 name for --load-module; keep it as a deprecated
 	// alias so existing scripts and shebangs don't break.
-	flags.StringVar(&moduleURL, "mod", "", "")
-	_ = flags.MarkDeprecated("mod", "use --load-module (-m) instead")
+	moduleFlags.StringVar(&moduleURL, "mod", "", "")
+	_ = moduleFlags.MarkDeprecated("mod", "use --load-module (-m) instead")
 	if optional {
-		flags.BoolVarP(&moduleNoURL, "no-load-module", "M", false, "Don't load any module for this command")
-		cmd.MarkFlagsMutuallyExclusive("load-module", "no-load-module")
+		moduleFlags.BoolVarP(&moduleNoURL, "no-load-module", "M", false, "Don't load any module for this command")
 		// --no-mod is the pre-1.0 name for --no-load-module; keep it as a
 		// deprecated alias so existing scripts and shebangs don't break.
-		flags.BoolVar(&moduleNoURL, "no-mod", false, "")
-		_ = flags.MarkDeprecated("no-mod", "use --no-load-module (-M) instead")
+		moduleFlags.BoolVar(&moduleNoURL, "no-mod", false, "")
+		_ = moduleFlags.MarkDeprecated("no-mod", "use --no-load-module (-M) instead")
 	}
 
 	var defaultAllowLLM []string
 	if allowLLMEnv := os.Getenv("DAGGER_ALLOW_LLM"); allowLLMEnv != "" {
 		defaultAllowLLM = strings.Split(allowLLMEnv, ",")
 	}
-	flags.StringSliceVar(&allowedLLMModules, "allow-llm", defaultAllowLLM, "List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session")
+	moduleFlags.StringSliceVar(&allowedLLMModules, "allow-llm", defaultAllowLLM, "List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session")
 
 	// Add the eager module loading flag to disable lazy load on runtime.
-	flags.BoolVar(&eagerRuntime, "eager-runtime", false, "load module runtime eagerly")
+	moduleFlags.BoolVar(&eagerRuntime, "eager-runtime", false, "load module runtime eagerly")
+
+	setFlagSetCapabilities(moduleFlags, mayCallEngine)
+	flags.AddFlagSet(moduleFlags)
+
+	if optional {
+		cmd.MarkFlagsMutuallyExclusive("load-module", "no-load-module")
+	}
 }
 
 func init() {

--- a/internal/cmd/dagger/module_init.go
+++ b/internal/cmd/dagger/module_init.go
@@ -169,9 +169,6 @@ func init() {
 }
 
 func runModuleInitWithSDK(cmd *cobra.Command, sdkName, name string) error {
-	if workspaceEnv != "" {
-		return fmt.Errorf("module init does not support --env; it scaffolds modules into the base workspace config")
-	}
 	return withEngine(cmd.Context(), client.Params{
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,

--- a/internal/cmd/dagger/module_init_test.go
+++ b/internal/cmd/dagger/module_init_test.go
@@ -302,6 +302,36 @@ source = "github.com/acme/custom-sdk"
 	require.NotContains(t, out, "\tM\tC")
 }
 
+func TestRunSDKListUsesSelectedEnv(t *testing.T) {
+	oldEnv := workspaceEnv
+	workspaceEnv = "dev"
+	t.Cleanup(func() { workspaceEnv = oldEnv })
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, workspace.ConfigFileName), []byte(`
+[modules.custom-sdk]
+source = "github.com/acme/custom-sdk"
+
+[modules.custom-sdk.as-sdk]
+name = "base"
+
+[env.dev.modules.custom-sdk]
+source = "./sdk/dev"
+
+[env.dev.modules.custom-sdk.as-sdk]
+name = "dev"
+`), 0o600))
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	require.NoError(t, runSDKList(cmd, nil))
+	require.Contains(t, buf.String(), "dev")
+	require.Contains(t, buf.String(), "./sdk/dev")
+	require.NotContains(t, buf.String(), "base")
+}
+
 // Conventional SDK short-name derivation is now in core/workspace as
 // ConventionalSDKShortName (shared with the engine's migration code). Tests
 // for it live there.

--- a/internal/cmd/dagger/module_sdk.go
+++ b/internal/cmd/dagger/module_sdk.go
@@ -165,6 +165,12 @@ func currentModuleSDKName() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse workspace config %q: %w", wsConfigPath, err)
 	}
+	if workspaceEnv != "" {
+		wsCfg, err = workspace.ApplyEnvOverlay(wsCfg, workspaceEnv)
+		if err != nil {
+			return "", err
+		}
+	}
 
 	for installedName, installed := range wsCfg.Modules {
 		if installed.AsSDK == nil {

--- a/internal/cmd/dagger/module_sdk_test.go
+++ b/internal/cmd/dagger/module_sdk_test.go
@@ -85,6 +85,32 @@ func TestCurrentModuleSDKName(t *testing.T) {
 	}
 }
 
+func TestCurrentModuleSDKNameUsesSelectedEnv(t *testing.T) {
+	oldEnv := workspaceEnv
+	workspaceEnv = "dev"
+	t.Cleanup(func() { workspaceEnv = oldEnv })
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, workspace.ConfigFileName), []byte(`
+[modules.my-sdk]
+source = "github.com/dagger/my-sdk"
+
+[[modules.my-sdk.as-sdk.modules]]
+path = ".dagger/modules/base"
+
+[[env.dev.modules.my-sdk.as-sdk.modules]]
+path = ".dagger/modules/foo"
+`), 0o644))
+	moduleDir := filepath.Join(root, ".dagger", "modules", "foo")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, modules.Filename), []byte("name = \"foo\"\n"), 0o644))
+
+	t.Chdir(moduleDir)
+	name, err := currentModuleSDKName()
+	require.NoError(t, err)
+	require.Equal(t, "my-sdk", name)
+}
+
 // A dagger.toml in a subdirectory of the repo is where the two spellings stop
 // coinciding: a config-relative entry is measured from the config, a
 // root-anchored one from the repository root above it.

--- a/internal/cmd/dagger/sdk.go
+++ b/internal/cmd/dagger/sdk.go
@@ -574,6 +574,12 @@ func readLocalWorkspaceConfig() (*workspace.Config, string, error) {
 			if err != nil {
 				return nil, "", fmt.Errorf("parse workspace config %q: %w", cfgPath, err)
 			}
+			if workspaceEnv != "" {
+				cfg, err = workspace.ApplyEnvOverlay(cfg, workspaceEnv)
+				if err != nil {
+					return nil, "", err
+				}
+			}
 			return cfg, cfgPath, nil
 		}
 		parent := filepath.Dir(dir)

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -38,6 +38,18 @@ func registerInstalledSDKInitCommands(ctx context.Context, args []string) error 
 	if err != nil {
 		return err
 	}
+	if cfg != nil && workspaceEnv != "" {
+		applied, err := workspace.ApplyEnvOverlay(cfg, workspaceEnv)
+		var undefined *workspace.UndefinedEnvError
+		if errors.As(err, &undefined) {
+			workspace.EnsureEnv(cfg, workspaceEnv)
+			applied, err = workspace.ApplyEnvOverlay(cfg, workspaceEnv)
+		}
+		if err != nil {
+			return err
+		}
+		cfg = applied
+	}
 	if cfg == nil {
 		clearDynamicSDKInitCommands(moduleInitCmd)
 		clearDynamicSDKInitCommands(apiClientInitCmd)
@@ -59,6 +71,17 @@ func registerInstalledSDKInitCommands(ctx context.Context, args []string) error 
 		SkipWorkspaceModules:           true,
 		SuppressCompatWorkspaceWarning: true,
 	}, func(ctx context.Context, ec *client.Client) error {
+		if workspaceEnv != "" {
+			raw, readErr := callWorkspaceConfigRead(ctx, ec.Dagger())
+			if readErr == nil {
+				cfg, err = workspace.ParseConfig([]byte(raw))
+				if err != nil {
+					return err
+				}
+			} else if !isUndefinedEnvError(readErr, workspaceEnv) {
+				return readErr
+			}
+		}
 		return registerSDKInitCommandsFromConfigForKind(ctx, ec.Dagger(), moduleInitCmd, apiClientInitCmd, cfg, cfgDir, kind, args)
 	})
 }

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -442,6 +442,7 @@ func sdkInitGlobalFlagTakesValue(name string) bool {
 		"env",
 		"progress",
 		"lock",
+		"shell-command-on-error",
 		"interactive-command",
 		"x-release",
 		"dot-output",

--- a/internal/cmd/dagger/sdk_init_dynamic.go
+++ b/internal/cmd/dagger/sdk_init_dynamic.go
@@ -439,6 +439,7 @@ func sdkInitGlobalFlagTakesValue(name string) bool {
 	switch name {
 	case "workdir",
 		"workspace",
+		"engine",
 		"env",
 		"progress",
 		"lock",

--- a/internal/cmd/dagger/sdk_init_dynamic_test.go
+++ b/internal/cmd/dagger/sdk_init_dynamic_test.go
@@ -233,6 +233,11 @@ func TestShouldRegisterSDKInitCommands(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "global shell on error flag",
+			args: []string{"--shell-on-error", "module", "init", "go", "myapp"},
+			want: true,
+		},
+		{
 			name: "unrelated command",
 			args: []string{"sdk", "list"},
 			want: false,

--- a/internal/cmd/dagger/sdk_init_dynamic_test.go
+++ b/internal/cmd/dagger/sdk_init_dynamic_test.go
@@ -238,6 +238,11 @@ func TestShouldRegisterSDKInitCommands(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "global engine flag with a separate value",
+			args: []string{"--engine", "cloud", "module", "init", "go", "myapp"},
+			want: true,
+		},
+		{
 			name: "unrelated command",
 			args: []string{"sdk", "list"},
 			want: false,
@@ -303,4 +308,17 @@ func sdkInitArgNames(args []*modFunctionArg) []string {
 		names[i] = arg.Name
 	}
 	return names
+}
+
+func TestSDKInitInvocationSDKName(t *testing.T) {
+	name, ok := sdkInitInvocationSDKName([]string{"--engine", "cloud", "module", "init", "go", "myapp"})
+	require.True(t, ok)
+	require.Equal(t, "go", name)
+
+	name, ok = sdkInitInvocationSDKName([]string{"--engine=cloud", "api", "client", "init", "python", "./client", "."})
+	require.True(t, ok)
+	require.Equal(t, "python", name)
+
+	_, ok = sdkInitInvocationSDKName([]string{"sdk", "list"})
+	require.False(t, ok)
 }

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"dagger.io/dagger"
+	"github.com/charmbracelet/x/ansi"
 	workspacepkg "github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/engine/client"
-	"github.com/juju/ansiterm/tabwriter"
 	"github.com/spf13/cobra"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
@@ -321,26 +321,116 @@ func workspaceEnvSettingConfigKey(envName, moduleName, settingName string) strin
 }
 
 func writeWorkspaceSettingsTable(out io.Writer, settings []workspaceSetting) error {
+	return writeWorkspaceSettingsTableAtWidth(out, settings, getViewWidth())
+}
+
+const (
+	workspaceSettingsColumnPadding = 2
+	workspaceSettingsModuleMax     = 20
+	workspaceSettingsKeyMax        = 24
+	workspaceSettingsValueMax      = 32
+	workspaceSettingsValueReserve  = 18
+	workspaceSettingsDescReserve   = 24
+)
+
+var workspaceSettingsHeaders = []string{"MODULE", "KEY", "VALUE", "DESCRIPTION"}
+
+func writeWorkspaceSettingsTableAtWidth(out io.Writer, settings []workspaceSetting, viewWidth int) error {
 	if len(settings) == 0 {
 		_, err := fmt.Fprintln(out, "(no settings)")
 		return err
 	}
 
-	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "MODULE\tKEY\tVALUE\tDESCRIPTION"); err != nil {
-		return err
-	}
+	rows := make([][]string, 0, len(settings)+1)
+	rows = append(rows, workspaceSettingsHeaders)
 	for _, setting := range settings {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-			setting.Module,
-			setting.Key,
-			setting.Value,
-			workspaceSettingShortDescription(setting.Description),
-		); err != nil {
+		rows = append(rows, []string{
+			workspaceSettingSingleLine(setting.Module),
+			workspaceSettingSingleLine(setting.Key),
+			workspaceSettingSingleLine(setting.Value),
+			workspaceSettingSingleLine(workspaceSettingShortDescription(setting.Description)),
+		})
+	}
+
+	widths := workspaceSettingsColumnWidths(rows, viewWidth)
+	for _, row := range rows {
+		var line strings.Builder
+		for column, cell := range row {
+			cell = ansi.Truncate(cell, widths[column], "…")
+			line.WriteString(cell)
+			if column < len(row)-1 {
+				padding := widths[column] - ansi.StringWidth(cell) + workspaceSettingsColumnPadding
+				line.WriteString(strings.Repeat(" ", padding))
+			}
+		}
+		if _, err := fmt.Fprintln(out, line.String()); err != nil {
 			return err
 		}
 	}
-	return tw.Flush()
+	return nil
+}
+
+func workspaceSettingsColumnWidths(rows [][]string, viewWidth int) []int {
+	minimums := make([]int, len(workspaceSettingsHeaders))
+	desired := make([]int, len(workspaceSettingsHeaders))
+	for column, header := range workspaceSettingsHeaders {
+		minimums[column] = ansi.StringWidth(header)
+		desired[column] = minimums[column]
+	}
+	for _, row := range rows[1:] {
+		for column, cell := range row {
+			desired[column] = max(desired[column], ansi.StringWidth(cell))
+		}
+	}
+	desired[0] = min(desired[0], workspaceSettingsModuleMax)
+	desired[1] = min(desired[1], workspaceSettingsKeyMax)
+	desired[2] = min(desired[2], workspaceSettingsValueMax)
+
+	paddingWidth := workspaceSettingsColumnPadding * (len(workspaceSettingsHeaders) - 1)
+	minimumContentWidth := 0
+	for _, width := range minimums {
+		minimumContentWidth += width
+	}
+	contentWidth := max(viewWidth-paddingWidth, minimumContentWidth)
+
+	valueAndDescriptionReserve := min(desired[2], workspaceSettingsValueReserve) +
+		min(desired[3], workspaceSettingsDescReserve)
+	moduleAndKeyMinimum := minimums[0] + minimums[1]
+	moduleAndKeyWidth := max(contentWidth-valueAndDescriptionReserve, moduleAndKeyMinimum)
+	moduleWidth, keyWidth := workspaceSettingsFitColumns(
+		desired[0], desired[1], minimums[0], minimums[1], moduleAndKeyWidth,
+	)
+	valueAndDescriptionWidth := contentWidth - moduleWidth - keyWidth
+	valueWidth, descriptionWidth := workspaceSettingsFitColumns(
+		desired[2], desired[3], minimums[2], minimums[3], valueAndDescriptionWidth,
+	)
+
+	return []int{moduleWidth, keyWidth, valueWidth, descriptionWidth}
+}
+
+// workspaceSettingsFitColumns reduces two columns fairly until they fit the
+// available width. Each column always remains wide enough for its header.
+func workspaceSettingsFitColumns(first, second, firstMinimum, secondMinimum, available int) (int, int) {
+	if first+second <= available {
+		return first, second
+	}
+
+	extra := available - firstMinimum - secondMinimum
+	firstExtra := min(first-firstMinimum, (extra+1)/2)
+	secondExtra := min(second-secondMinimum, extra-firstExtra)
+	extra -= firstExtra + secondExtra
+
+	secondExtraMore := min(second-secondMinimum-secondExtra, extra)
+	secondExtra += secondExtraMore
+	extra -= secondExtraMore
+	firstExtra += min(first-firstMinimum-firstExtra, extra)
+
+	return firstMinimum + firstExtra, secondMinimum + secondExtra
+}
+
+func workspaceSettingSingleLine(value string) string {
+	replacer := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ", "\t", " ")
+	return replacer.Replace(value)
 }
 
 func workspaceSettingShortDescription(description string) string {

--- a/internal/cmd/dagger/settings_test.go
+++ b/internal/cmd/dagger/settings_test.go
@@ -1,9 +1,13 @@
 package daggercmd
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
@@ -67,4 +71,55 @@ func TestIsUndefinedEnvError(t *testing.T) {
 	require.True(t, isUndefinedEnvError(plain, "dev"))
 	require.False(t, isUndefinedEnvError(plain, "prod"))
 	require.False(t, isUndefinedEnvError(nil, "dev"))
+}
+
+func TestWriteWorkspaceSettingsTableFitsViewWidth(t *testing.T) {
+	settings := []workspaceSetting{
+		{
+			Module:      "module-with-a-name-that-is-too-long",
+			Key:         "setting-with-a-key-that-is-too-long",
+			Value:       strings.Repeat("value", 20),
+			Description: strings.Repeat("A long description. ", 10),
+		},
+		{
+			Module:      "short",
+			Key:         "multiline",
+			Value:       "first\nsecond\tthird",
+			Description: "First description line.\nSecond description line.",
+		},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, writeWorkspaceSettingsTableAtWidth(&out, settings, 60))
+
+	lines := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	require.Len(t, lines, len(settings)+1)
+	for _, line := range lines {
+		require.LessOrEqual(t, ansi.StringWidth(line), 60, line)
+	}
+	require.Contains(t, out.String(), "…")
+	require.NotContains(t, out.String(), settings[0].Value)
+	require.Contains(t, out.String(), "first second third")
+	require.Contains(t, out.String(), "First description line.")
+	require.NotContains(t, out.String(), "Second description line.")
+}
+
+func TestWriteWorkspaceSettingsTableMeasuresUnicodeWidth(t *testing.T) {
+	settings := []workspaceSetting{
+		{
+			Module:      "unicode",
+			Key:         "emoji",
+			Value:       strings.Repeat("界", 30),
+			Description: strings.Repeat("Configuration 🚀 ", 10),
+		},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, writeWorkspaceSettingsTableAtWidth(&out, settings, 48))
+
+	for _, line := range strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n") {
+		require.LessOrEqual(t, ansi.StringWidth(line), 48, line)
+		require.True(t, utf8.ValidString(line))
+	}
+	require.Contains(t, out.String(), "…")
 }

--- a/internal/cmd/dagger/shell.go
+++ b/internal/cmd/dagger/shell.go
@@ -37,8 +37,13 @@ var (
 )
 
 func shellAddFlags(cmd *cobra.Command) {
+	// -c stays ungated: on the root command it is how a user reaches the shell
+	// at all, so the root usage message must keep naming it.
 	cmd.Flags().StringVarP(&shellCode, "command", "c", "", "Execute a dagger shell command")
+
+	// The model is an engine session parameter.
 	cmd.Flags().StringVar(&llmModel, "model", "", "LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')")
+	setFlagCapabilities(cmd.Flags().Lookup("model"), mayCallEngine)
 }
 
 var shellCmd = &cobra.Command{

--- a/internal/cmd/dagger/terminal.go
+++ b/internal/cmd/dagger/terminal.go
@@ -26,7 +26,10 @@ func init() {
 var terminalCmd = &cobra.Command{
 	Use:     "terminal [options] [pattern]",
 	Aliases: []string{"tty"},
-	Short:   "Open a terminal for a container or directory in your project",
+	Annotations: map[string]string{
+		visibleAliasesAnnotation: "tty",
+	},
+	Short: "Open a terminal for a container or directory in your project",
 	Long: `Open a terminal for a container or directory in your project.
 
 Examples:

--- a/internal/cmd/dagger/version.go
+++ b/internal/cmd/dagger/version.go
@@ -79,7 +79,7 @@ func versionHuman() string {
 		commit,
 		dirty,
 		platforms.DefaultString(),
-		RunnerHost,
+		configuredRunnerHost(),
 	)
 }
 

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -415,6 +415,40 @@ func TestParseGlobalFlagsAfterDynamicCommand(t *testing.T) {
 	require.Equal(t, "./ws", workspaceRef)
 }
 
+// Cobra owns --help. The early global pass shares the real flag values, so it
+// must not apply --help: Cobra reads that value even for a command that
+// disables flag parsing, and a dynamic command such as `dagger call` would
+// then print its static usage instead of loading the module and listing its
+// functions.
+func TestParseGlobalFlagsLeavesHelpToCobra(t *testing.T) {
+	oldWorkdir := workdir
+	t.Cleanup(func() { workdir = oldWorkdir })
+	workdir = "."
+
+	root := &cobra.Command{Use: "root"}
+	call := &cobra.Command{Use: "call", DisableFlagParsing: true}
+	root.AddCommand(call)
+	installGlobalFlags(root.PersistentFlags())
+	root.PersistentFlags().BoolP("help", "h", false, "Print usage")
+
+	for _, args := range [][]string{
+		{"call", "--help"},
+		{"call", "-h"},
+		{"--help", "call"},
+		{"call", "build", "--help"},
+	} {
+		require.NoError(t, root.PersistentFlags().Set("help", "false"))
+		parseGlobalFlags(root, args)
+		help, err := root.PersistentFlags().GetBool("help")
+		require.NoError(t, err, args)
+		require.False(t, help, args)
+	}
+
+	// The other global flags still apply.
+	parseGlobalFlags(root, []string{"call", "--workdir", "/work/help"})
+	require.Equal(t, "/work/help", workdir)
+}
+
 func TestWorkspaceFlagPolicy(t *testing.T) {
 	oldWorkspaceRef := workspaceRef
 	oldWorkspaceEnv := workspaceEnv

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -371,7 +371,7 @@ func commandIndex(names []string, name string) int {
 	return -1
 }
 
-func TestInstallGlobalFlagsWorkspaceSelection(t *testing.T) {
+func TestInstallGlobalFlags(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	installGlobalFlags(flags)
 
@@ -388,6 +388,10 @@ func TestInstallGlobalFlagsWorkspaceSelection(t *testing.T) {
 	webFlag := flags.Lookup("web")
 	require.NotNil(t, webFlag)
 	require.Equal(t, "w", webFlag.Shorthand)
+
+	xReleaseFlag := flags.Lookup("x-release")
+	require.NotNil(t, xReleaseFlag)
+	require.True(t, xReleaseFlag.Hidden)
 }
 
 func TestParseGlobalFlagsAfterDynamicCommand(t *testing.T) {

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -401,7 +401,11 @@ func TestParseGlobalFlagsAfterDynamicCommand(t *testing.T) {
 	workdir = "."
 	workspaceRef = ""
 
-	parseGlobalFlags([]string{"call", "--workdir", "/work/shell", "-W", "./ws", "identify"})
+	root := &cobra.Command{Use: "root"}
+	call := &cobra.Command{Use: "call"}
+	root.AddCommand(call)
+	installGlobalFlags(root.PersistentFlags())
+	parseGlobalFlags(root, []string{"call", "--workdir", "/work/shell", "-W", "./ws", "identify"})
 
 	require.Equal(t, "/work/shell", workdir)
 	require.Equal(t, "./ws", workspaceRef)

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -207,6 +207,7 @@ func TestRootHelpShowsImplicitCommandGrouping(t *testing.T) {
 	require.NotContains(t, help, "function, fn")
 	require.NotContains(t, help, "module, mod")
 	require.Contains(t, help, "workspace, ws")
+	require.Contains(t, help, "terminal, tty")
 	require.NotContains(t, help, "exec, run")
 
 	names := rootHelpCommandNames(help)

--- a/internal/cmd/dagger/xrelease_test.go
+++ b/internal/cmd/dagger/xrelease_test.go
@@ -53,26 +53,28 @@ func TestXReleaseReleaseRef(t *testing.T) {
 	}
 }
 
-func TestXReleaseProcessEnvPreservesRunnerHost(t *testing.T) {
-	env, hasRunnerHost := xReleaseProcessEnv([]string{
+func TestXReleaseProcessEnvPreservesEngineSelection(t *testing.T) {
+	env, engineEnvs := xReleaseProcessEnv([]string{
 		daggerXReleaseEnv + "=v0.20.8",
+		engineEnv + "=container://dagger-engine.dev",
 		RunnerHostEnv + "=docker-container://dagger-engine.dev",
 		RunnerImageLoaderEnv + "=docker",
 		"KEEP=1",
 	})
 
-	require.True(t, hasRunnerHost)
+	require.Equal(t, []string{engineEnv, RunnerHostEnv}, engineEnvs)
 	require.Equal(t, []string{
+		engineEnv + "=container://dagger-engine.dev",
 		RunnerHostEnv + "=docker-container://dagger-engine.dev",
 		"KEEP=1",
 		"DAGGER_LEAVE_OLD_ENGINE=1",
 	}, env)
 }
 
-func TestXReleaseProcessEnvWithoutRunnerHost(t *testing.T) {
-	env, hasRunnerHost := xReleaseProcessEnv([]string{"KEEP=1"})
+func TestXReleaseProcessEnvWithoutEngineSelection(t *testing.T) {
+	env, engineEnvs := xReleaseProcessEnv([]string{"KEEP=1"})
 
-	require.False(t, hasRunnerHost)
+	require.Empty(t, engineEnvs)
 	require.Equal(t, []string{
 		"KEEP=1",
 		"DAGGER_LEAVE_OLD_ENGINE=1",

--- a/internal/cobradocs/markdown.go
+++ b/internal/cobradocs/markdown.go
@@ -51,7 +51,12 @@ func markdown(cmd *cobra.Command, w io.Writer, opts MarkdownOptions) error {
 	}
 
 	for _, c := range cmd.Commands() {
-		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
+		if c.Hidden || len(c.Deprecated) > 0 {
+			continue
+		}
+		// Help topics have no Run, so Cobra does not call them available.
+		// They are reference content, so the generated docs include them.
+		if !c.IsAvailableCommand() && !c.IsAdditionalHelpTopicCommand() {
 			continue
 		}
 		if err := markdown(c, w, opts); err != nil {

--- a/internal/cobradocs/markdown.go
+++ b/internal/cobradocs/markdown.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	"github.com/spf13/pflag"
 )
 
 type MarkdownOptions struct {
 	// Frontmatter is prepended verbatim to the output, before any command docs.
 	Frontmatter string
+	// IncludeFlag controls whether a flag is included in a command's reference.
+	// A nil function includes all flags.
+	IncludeFlag func(*cobra.Command, *pflag.Flag) bool
 }
 
 // Markdown writes reference documentation for root and all of its subcommands.
@@ -26,7 +30,7 @@ func Markdown(root *cobra.Command, w io.Writer, opts MarkdownOptions) error {
 		}
 	}
 
-	return markdown(root, w)
+	return markdown(root, w, opts)
 }
 
 // HideCommands hides every command in the tree for which condition reports true,
@@ -41,8 +45,8 @@ func HideCommands(cmd *cobra.Command, condition func(*cobra.Command) bool) {
 	}
 }
 
-func markdown(cmd *cobra.Command, w io.Writer) error {
-	if err := doc.GenMarkdownCustom(cmd, w, linkHandler); err != nil {
+func markdown(cmd *cobra.Command, w io.Writer, opts MarkdownOptions) error {
+	if err := generateCommandMarkdown(cmd, w, opts.IncludeFlag); err != nil {
 		return err
 	}
 
@@ -50,12 +54,38 @@ func markdown(cmd *cobra.Command, w io.Writer) error {
 		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
 			continue
 		}
-		if err := markdown(c, w); err != nil {
+		if err := markdown(c, w, opts); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func generateCommandMarkdown(cmd *cobra.Command, w io.Writer, includeFlag func(*cobra.Command, *pflag.Flag) bool) error {
+	if includeFlag != nil {
+		defer HideFlags(cmd, func(flag *pflag.Flag) bool { return includeFlag(cmd, flag) })()
+	}
+	return doc.GenMarkdownCustom(cmd, w, linkHandler)
+}
+
+// HideFlags hides every visible flag of cmd for which keep reports false, and
+// returns the function that shows them again.
+func HideFlags(cmd *cobra.Command, keep func(*pflag.Flag) bool) (restore func()) {
+	var hidden []*pflag.Flag
+	for _, flags := range []*pflag.FlagSet{cmd.InheritedFlags(), cmd.NonInheritedFlags()} {
+		flags.VisitAll(func(flag *pflag.Flag) {
+			if !flag.Hidden && !keep(flag) {
+				flag.Hidden = true
+				hidden = append(hidden, flag)
+			}
+		})
+	}
+	return func() {
+		for _, flag := range hidden {
+			flag.Hidden = false
+		}
+	}
 }
 
 // linkHandler links to other commands in the same document via a fragment.


### PR DESCRIPTION
Closes #14024

## Problem

The CLI has too many global flags that pollute every help output even when they are not relevant.

```console
$ dagger --help
A tool to run composable workflows in containers

USAGE
  dagger [options] [subcommand | file...]

AVAILABLE COMMANDS
  setup           Ensure Dagger is properly set up and operational in the workspace

  activity        Show recent activity (runs, traces, etc.) for this workspace
  agent           Compose your installed agent modules and drop into an interactive prompt.
  check           Verify your project — tests, linters, type checks, security scans, etc.
  generate        Generate derived files for your project — code, SDKs, types, docs, etc.
  up              Run your project's services for local development — databases, APIs, dev servers, etc.

  install         Install a module into your workspace
  installed       List installed modules
  search          Search for modules you can install
  settings        Get, set, or unset module settings (use --env for an env overlay)
  uninstall       Uninstall a module from your workspace
  update          Refresh installed-module state

  api             Interact with the Dagger API (advanced)
  cloud           Manage Dagger Cloud
  module          Author a module: edit dependencies, engine version, etc.
  sdk             Install and manage SDKs (the modules that author other modules)
  workspace, ws   Inspect or configure your workspace (cwd, remotes, config, etc.)

  help            Help about any command
  version         Print dagger version

  llm             Manage LLM configuration

OPTIONS
      --allow-llm strings            List of URLs of remote modules allowed to access LLM APIs, or 'all' to bypass restrictions for the entire session
  -y, --auto-apply                   Automatically apply changes when a changeset is returned
  -c, --command string               Execute a dagger shell command
  -d, --debug                        Show debug logs and full verbosity
      --eager-runtime                load module runtime eagerly
      --env string                   Apply a named env overlay; writes target it, creating it if missing
  -i, --interactive                  Spawn a terminal on container exec failure
      --interactive-command string   Change the default command for interactive mode (default "/bin/sh")
  -m, --load-module string           Use a one-off module (local path or git ref)
      --model string                 LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')
  -E, --no-exit                      Leave the TUI running after completion
  -M, --no-load-module               Don't load any module for this command
      --org string                   Dagger Cloud org name for Cloud-scoped commands
      --progress string              Progress output format (auto, plain, tty, dots, logs, report) (default "auto")
  -q, --quiet count                  Reduce verbosity (show progress, but clean up at the end)
  -s, --silent                       Do not show progress at all
  -v, --verbose count                Increase verbosity (use -vv or -vvv for more)
  -w, --web                          Open trace URL in a web browser
  -W, --workspace string             Select the workspace location to load from (local path or git ref)
      --x-release string             Run an experimental release from a Dagger git ref

Use "dagger [command] --help" for more information about a command.
```

## Side quest: stabilizing remote engine configuration

This could be done in a separate PR, but easier to combine.

- Deprecate `--cloud`
- Deprecate `_EXPERIMENTAL_DAGGER_RUNNER_HOST`
- Introduce `--engine` which accepts `cloud` and all other values allowed by `EXPERIMENTAL_DAGGER_RUNNER_HOST`
- It's a soft deprecation: old flags and env vars are still allowed as fallback
- New help topic to learn about possible values directly from the CLI

Related: (FIXME issue about stabilizing experimental APIs before 1.0)


## Solution

Only show flags relevant to the current command. Flags are grouped by capability, and different commands get different capabilities.

### Rendering a pipeline

These flags are relevant to rendering a pipeline on the terminal:

- `-q, --quiet`
- `-s, --silent`
- `--progress`
- `-w, --web`
- `-E, --no-exit`
- `-d, --debug` (also relevant when calling an engine - one flag two meanings)
--dot-output
--dot-focus-field
--dot-show-internal 

Note: some commands render a pipeline without calling the engine. Example: `dagger trace`.

### Calling the engine

These flags are relevant to calling the Dagger Engine API.

- `--engine` (new, see side quest)
- `--cloud` (deprecated by `--engine`, now hidden alias to `--engine-cloud`)
- `--profile`
- `-i, --interactive` -> renamed to `--tty-on-error`
- `--interactive-command` -> hidden, deal with it later
- `-d, --debug` (also relevant when rendering a pipeline - one flag two meanings)
- `-m, --load-module`
- `-M, --no-load-module`
- `--allow-llm`
- `--eager-runtime`
- `--model`


Note: some commands call the engine without rendering a pipeline. Example: `dagger settings`

### Selecting a workspace

These flags are relevant to selecting a workspace. Note: some commands select a workspace without calling an engine (`ws remote`, `activity`..)

- `-W, --workspace`

### Reading Workspace config

These flags are relevant to reading the workspace configuration.

- `--env`

### Writing Workspace configuration

These flags are relevant to writing the workspace configuration.

- `--env`

### Producing an output

These flags are relevant to receiving and processing a Dagger value as output.

- `-y, --auto-apply`
- `-o, --output`

### Other

These flags were handled individually:

- `--scale-out`: moved to `dagger check` only
- `--org`: hidden and left global until we figure out a final design for exposing Dagger Cloud orgs
- `--x-release`: stays global, hidden

### Side quest: table alignment

We fix the output of `dagger settings` to keep it within the terminal width.

### Side quest: env-aware config writes

`dagger module init` and `dagger api client init` now honor `--env`

### Side quest: fix argument conflicts in `api call`

LLM says:

> Preserves schema-owned flags after a dynamic function name, including a function argument named `--engine`.
