### PR TITLE
core: add SemVer version constraints

### DIFF
--- a/.changes/unreleased/Added-20260908-235319.yaml
+++ b/.changes/unreleased/Added-20260908-235319.yaml
@@ -1,0 +1,32 @@
+kind: Added
+body: |
+  Dagger now supports SemVer version constraints for Git repositories, OCI
+  images, and module sources. Use the new `version` argument on
+  `GitRepository.latest`, `Container.from`, or `Query.moduleSource`. You can
+  also use a module reference such as `github.com/acme/tool@v1.2`.
+
+  A constraint with a missing component selects the greatest matching stable
+  release. For example, `v1` selects the latest `v1.x.x` release, and `v1.2`
+  selects the latest `v1.2.x` release. A prerelease suffix, such as
+  `v1.2-beta`, selects the latest matching prerelease. The `v` prefix is
+  optional.
+
+  Git resolution checks matching tags first and then matching branches. OCI
+  resolution checks matching tags. The workspace lockfile records the
+  selected Git ref and commit, or the selected OCI tag and digest. `dagger
+  update` resolves the constraint again and updates the lock.
+
+  The `version` argument cannot be combined with a tagged or digested OCI
+  address. It also cannot be combined with a version suffix in `refString`.
+
+  This feature changes how module refs without a `v` prefix resolve for
+  modules that opt in through their engine version. For example,
+  `github.com/acme/tool@1.2.3` is now a SemVer query instead of an exact Git ref
+  name. Use `@refs/heads/1.2.3` or `@refs/tags/1.2.3` to select an exact Git
+  ref. Generated PHP methods place `version` before existing optional
+  arguments. PHP calls that pass those optional arguments by position must use
+  named arguments or add the new argument.
+time: 2026-09-08T23:53:19Z
+custom:
+  Author: tiborvass
+  PR: 14034

--- a/core/container_latest.go
+++ b/core/container_latest.go
@@ -9,6 +9,14 @@ import (
 // numeric components. If tags contains no eligible release, it returns
 // "latest".
 func SelectLatestContainerTag(tags []string) (string, error) {
+	return SelectContainerTag(tags, "")
+}
+
+// SelectContainerTag returns the greatest release tag that matches
+// versionQuery. An empty query selects the latest stable release and falls
+// back to "latest" when no release exists. A non-empty query returns an error
+// when no tag matches.
+func SelectContainerTag(tags []string, versionQuery string) (string, error) {
 	candidates := make([]releaseTagCandidate, 0, len(tags))
 	for _, tag := range tags {
 		candidates = append(candidates, releaseTagCandidate{
@@ -16,11 +24,14 @@ func SelectLatestContainerTag(tags []string) (string, error) {
 			Version: tag,
 		})
 	}
-	selected, found, err := selectLatestReleaseTag(candidates)
+	selected, found, err := selectReleaseTag(candidates, versionQuery)
 	if err != nil {
 		return "", err
 	}
 	if !found {
+		if versionQuery != "" {
+			return "", fmt.Errorf("no image tag matches version query %q", versionQuery)
+		}
 		return "latest", nil
 	}
 	return selected.Name, nil
@@ -28,15 +39,30 @@ func SelectLatestContainerTag(tags []string) (string, error) {
 
 // ValidateContainerLatestTag validates a tag selected by oci-latest.
 func ValidateContainerLatestTag(tag string) error {
+	return ValidateContainerTag(tag, "")
+}
+
+// ValidateContainerTag validates a tag selected for versionQuery.
+func ValidateContainerTag(tag string, versionQuery string) error {
 	if tag == "latest" {
-		return nil
+		if versionQuery == "" {
+			return nil
+		}
+		return fmt.Errorf("tag %q does not match version query %q", tag, versionQuery)
 	}
 	parsed, ok := parseReleaseTag(releaseTagCandidate{Name: tag, Version: tag})
 	if !ok {
 		return fmt.Errorf("tag %q is not a semantic version", tag)
 	}
-	if parsed.Semver.Prerelease != "" {
+	query, err := parseReleaseVersionQuery(versionQuery)
+	if err != nil {
+		return err
+	}
+	if versionQuery == "" && parsed.Semver.Prerelease != "" {
 		return fmt.Errorf("tag %q is not a stable semantic version", tag)
+	}
+	if !query.matches(parsed) {
+		return fmt.Errorf("tag %q does not match version query %q", tag, versionQuery)
 	}
 	return nil
 }

--- a/core/container_latest_test.go
+++ b/core/container_latest_test.go
@@ -115,3 +115,37 @@ func TestValidateContainerLatestTag(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectContainerTagWithVersionQuery(t *testing.T) {
+	t.Parallel()
+
+	tags := []string{
+		"1.2.3",
+		"1.2.4-beta.1",
+		"1.2.4-beta.2",
+		"1.2.4-rc.1",
+		"1.3.0",
+		"2.0.0",
+	}
+
+	selected, err := SelectContainerTag(tags, "1.2")
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", selected)
+
+	selected, err = SelectContainerTag(tags, "v1.2-beta")
+	require.NoError(t, err)
+	require.Equal(t, "1.2.4-beta.2", selected)
+
+	_, err = SelectContainerTag(tags, "v3")
+	require.ErrorContains(t, err, `no image tag matches version query "v3"`)
+}
+
+func TestValidateContainerTagWithVersionQuery(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateContainerTag("1.2.4-beta.2", "v1.2-beta"))
+	require.ErrorContains(t,
+		ValidateContainerTag("1.2.4-rc.1", "v1.2-beta"),
+		`does not match version query "v1.2-beta"`,
+	)
+}

--- a/core/git.go
+++ b/core/git.go
@@ -86,7 +86,7 @@ type GitRefBackend interface {
 // normalizing optional v prefixes, incomplete versions, and zero-padded numeric
 // components. It falls back to HEAD when no eligible release tag exists.
 func SelectLatestGitRef(remote *gitutil.Remote) (*gitutil.Ref, error) {
-	return SelectLatestGitRefWithTagPrefix(remote, "")
+	return SelectGitRefWithVersionQuery(remote, "", "")
 }
 
 // SelectLatestGitRefWithTagPrefix selects the greatest normalized stable
@@ -96,8 +96,19 @@ func SelectLatestGitRefWithTagPrefix(
 	remote *gitutil.Remote,
 	tagPrefix string,
 ) (*gitutil.Ref, error) {
+	return SelectGitRefWithVersionQuery(remote, tagPrefix, "")
+}
+
+// SelectGitRefWithVersionQuery selects the greatest release ref that matches
+// versionQuery. Tags take priority over branches. An empty query selects the
+// latest stable tag and falls back to HEAD when no release exists.
+func SelectGitRefWithVersionQuery(
+	remote *gitutil.Remote,
+	tagPrefix string,
+	versionQuery string,
+) (*gitutil.Ref, error) {
 	if remote == nil {
-		return nil, fmt.Errorf("select latest git ref: nil remote")
+		return nil, fmt.Errorf("select git ref: nil remote")
 	}
 
 	tagPrefix = strings.Trim(tagPrefix, "/")
@@ -105,18 +116,33 @@ func SelectLatestGitRefWithTagPrefix(
 		tagPrefix += "/"
 	}
 
-	bestRef, err := selectLatestGitRelease(remote, tagPrefix)
+	bestRef, err := selectGitRelease(remote.Tags(), tagPrefix, versionQuery)
 	if err != nil {
 		return nil, err
 	}
 	if bestRef == "" && tagPrefix != "" {
-		bestRef, err = selectLatestGitRelease(remote, "")
+		bestRef, err = selectGitRelease(remote.Tags(), "", versionQuery)
 		if err != nil {
 			return nil, err
 		}
 	}
+	if bestRef == "" && versionQuery != "" {
+		bestRef, err = selectGitRelease(remote.Branches(), tagPrefix, versionQuery)
+		if err != nil {
+			return nil, err
+		}
+		if bestRef == "" && tagPrefix != "" {
+			bestRef, err = selectGitRelease(remote.Branches(), "", versionQuery)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if bestRef == "" {
+		if versionQuery != "" {
+			return nil, fmt.Errorf("no Git ref matches version query %q", versionQuery)
+		}
 		ref, err := remote.Lookup("HEAD")
 		if err != nil {
 			return nil, fmt.Errorf("resolve git remote HEAD: %w", err)
@@ -131,13 +157,14 @@ func SelectLatestGitRefWithTagPrefix(
 	return ref, nil
 }
 
-func selectLatestGitRelease(
+func selectGitRelease(
 	remote *gitutil.Remote,
 	tagPrefix string,
+	versionQuery string,
 ) (string, error) {
-	candidates := make([]releaseTagCandidate, 0, len(remote.Tags().Refs))
+	candidates := make([]releaseTagCandidate, 0, len(remote.Refs))
 	refs := map[string]string{}
-	for _, ref := range remote.Tags().Refs {
+	for _, ref := range remote.Refs {
 		version := ref.ShortName()
 		if tagPrefix != "" {
 			var ok bool
@@ -154,7 +181,7 @@ func selectLatestGitRelease(
 		})
 		refs[original] = ref.Name
 	}
-	selected, found, err := selectLatestReleaseTag(candidates)
+	selected, found, err := selectReleaseTag(candidates, versionQuery)
 	if err != nil {
 		return "", err
 	}
@@ -166,29 +193,45 @@ func selectLatestGitRelease(
 
 // ValidateGitLatestRef validates a ref selected by git-latest.
 func ValidateGitLatestRef(refName string, tagPrefix string) error {
+	return ValidateGitVersionRef(refName, tagPrefix, "")
+}
+
+// ValidateGitVersionRef validates a ref selected for versionQuery.
+func ValidateGitVersionRef(refName string, tagPrefix string, versionQuery string) error {
 	if tag, ok := strings.CutPrefix(refName, "refs/tags/"); ok {
-		version := tag
-		tagPrefix = strings.Trim(tagPrefix, "/")
-		if tagPrefix != "" {
-			version, _ = strings.CutPrefix(version, tagPrefix+"/")
-		}
-		parsed, ok := parseReleaseTag(releaseTagCandidate{
-			Name:    tag,
-			Version: version,
-		})
-		if !ok {
-			return fmt.Errorf("invalid git-latest tag %q: not a semantic version", tag)
-		}
-		if parsed.Semver.Prerelease != "" {
-			return fmt.Errorf("invalid git-latest tag %q: prerelease tags are not supported", tag)
-		}
-		return nil
+		return validateGitVersionName("tag", tag, tagPrefix, versionQuery)
 	}
 
 	if branch, ok := strings.CutPrefix(refName, "refs/heads/"); ok && branch != "" {
-		return nil
+		if versionQuery == "" {
+			return nil
+		}
+		return validateGitVersionName("branch", branch, tagPrefix, versionQuery)
 	}
 	return fmt.Errorf("invalid git-latest ref %q", refName)
+}
+
+func validateGitVersionName(kind, name, tagPrefix, versionQuery string) error {
+	version := name
+	tagPrefix = strings.Trim(tagPrefix, "/")
+	if tagPrefix != "" {
+		version, _ = strings.CutPrefix(version, tagPrefix+"/")
+	}
+	parsed, ok := parseReleaseTag(releaseTagCandidate{Name: name, Version: version})
+	if !ok {
+		return fmt.Errorf("invalid git-latest %s %q: not a semantic version", kind, name)
+	}
+	query, err := parseReleaseVersionQuery(versionQuery)
+	if err != nil {
+		return err
+	}
+	if versionQuery == "" && parsed.Semver.Prerelease != "" {
+		return fmt.Errorf("invalid git-latest %s %q: prerelease tags are not supported", kind, name)
+	}
+	if !query.matches(parsed) {
+		return fmt.Errorf("invalid git-latest %s %q: does not match version query %q", kind, name, versionQuery)
+	}
+	return nil
 }
 
 var _ dagql.PersistedObject = (*GitRepository)(nil)

--- a/core/git_latest_test.go
+++ b/core/git_latest_test.go
@@ -201,6 +201,55 @@ func TestSelectLatestGitRefAcceptsCalver(t *testing.T) {
 	require.Equal(t, latestCommit, ref.SHA)
 }
 
+func TestSelectGitRefWithVersionQuery(t *testing.T) {
+	t.Parallel()
+
+	remote := &gitutil.Remote{Refs: []*gitutil.Ref{
+		{Name: "refs/tags/v1.2.3", SHA: "1111111111111111111111111111111111111111"},
+		{Name: "refs/tags/v1.2.4-beta.1", SHA: "2222222222222222222222222222222222222222"},
+		{Name: "refs/tags/v1.2.4-beta.2", SHA: "3333333333333333333333333333333333333333"},
+		{Name: "refs/tags/v1.3.0", SHA: "4444444444444444444444444444444444444444"},
+		{Name: "refs/tags/v2.0.0", SHA: "5555555555555555555555555555555555555555"},
+	}}
+
+	ref, err := SelectGitRefWithVersionQuery(remote, "", "v1.2")
+	require.NoError(t, err)
+	require.Equal(t, "refs/tags/v1.2.3", ref.Name)
+
+	ref, err = SelectGitRefWithVersionQuery(remote, "", "v1.2-beta")
+	require.NoError(t, err)
+	require.Equal(t, "refs/tags/v1.2.4-beta.2", ref.Name)
+
+	_, err = SelectGitRefWithVersionQuery(remote, "", "v3")
+	require.ErrorContains(t, err, `no Git ref matches version query "v3"`)
+}
+
+func TestSelectGitRefWithVersionQueryFallsBackToBranch(t *testing.T) {
+	t.Parallel()
+
+	remote := &gitutil.Remote{Refs: []*gitutil.Ref{
+		{Name: "refs/heads/v1.2.4", SHA: "1111111111111111111111111111111111111111"},
+		{Name: "refs/heads/v1.2.5", SHA: "2222222222222222222222222222222222222222"},
+	}}
+
+	ref, err := SelectGitRefWithVersionQuery(remote, "", "v1.2")
+	require.NoError(t, err)
+	require.Equal(t, "refs/heads/v1.2.5", ref.Name)
+}
+
+func TestSelectGitRefWithVersionQueryPrefersTags(t *testing.T) {
+	t.Parallel()
+
+	remote := &gitutil.Remote{Refs: []*gitutil.Ref{
+		{Name: "refs/tags/v1.2.3", SHA: "1111111111111111111111111111111111111111"},
+		{Name: "refs/heads/v1.2.4", SHA: "2222222222222222222222222222222222222222"},
+	}}
+
+	ref, err := SelectGitRefWithVersionQuery(remote, "", "v1.2")
+	require.NoError(t, err)
+	require.Equal(t, "refs/tags/v1.2.3", ref.Name)
+}
+
 func TestValidateGitLatestRef(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -936,6 +936,22 @@ func (LockfileSuite) TestOCIVersionQueryCreatesPin(ctx context.Context, t *testc
 	require.NotEmpty(t, requireOCISHALockValue(t, lockBytes, "docker.io/library/alpine:"+selectedTag))
 }
 
+func (LockfileSuite) TestOCIVersionQueryRejectsTaggedAddress(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeQueryDoc(t, workdir, "oci-version-tag.graphql", `{
+  container {
+    from(address: "alpine:3.20", version: "3.20") {
+      imageRef
+    }
+  }
+}`)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.ErrorContains(t, err, `version query "3.20" cannot be used with image address "alpine:3.20" because it contains a tag or digest`)
+}
+
 func writeOCILatestLock(
 	t *testctx.T,
 	workdir,

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -548,6 +548,43 @@ func (LockfileSuite) TestGitLatestCreatesPin(ctx context.Context, t *testctx.T) 
 	assertGitLatestLockEntry(t, lockBytes)
 }
 
+func (LockfileSuite) TestGitLatestVersionQueryCreatesPin(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeQueryDoc(t, workdir, "git-version.graphql", `{
+  git(url: "`+lockTestGitRepoURL+`") {
+    latest(version: "v0.18") {
+      ref
+      commit
+    }
+  }
+}`)
+
+	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(filepath.Join(workdir, workspace.LockFileName))
+	require.NoError(t, err)
+	parsed, err := lockfile.Parse(lockBytes)
+	require.NoError(t, err)
+
+	var selectedRef string
+	for _, entry := range parsed.Entries() {
+		if entry.Namespace != "" || entry.Operation != workspace.LockOperationGitLatest {
+			continue
+		}
+		require.Equal(t, workspace.LookupInputs(
+			[]any{lockTestGitRepoURL},
+			workspace.LookupOption{Name: "version", Value: "v0.18"},
+		), entry.Inputs)
+		selectedRef = entry.Value
+	}
+	require.True(t, strings.HasPrefix(selectedRef, "refs/tags/v0.18."), selectedRef)
+	require.Contains(t, string(out), selectedRef)
+	assertGitLockEntry(t, lockBytes, []any{lockTestGitRepoURL, selectedRef})
+}
+
 func (LockfileSuite) TestGitLatestUsesPin(ctx context.Context, t *testctx.T) {
 	workdir := t.TempDir()
 	hostGitInit(t, workdir)
@@ -862,6 +899,41 @@ func (LockfileSuite) TestOCILatestLockLifecycle(ctx context.Context, t *testctx.
 		staleLatestDigest,
 		requireOCISHALockValue(t, updatedLockBytes, "docker.io/library/alpine:latest"),
 	)
+}
+
+func (LockfileSuite) TestOCIVersionQueryCreatesPin(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+	queryPath := writeQueryDoc(t, workdir, "oci-version.graphql", `{
+  container {
+    from(address: "alpine", version: "3.20") {
+      imageRef
+    }
+  }
+}`)
+
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	lockBytes, err := os.ReadFile(filepath.Join(workdir, workspace.LockFileName))
+	require.NoError(t, err)
+	parsed, err := lockfile.Parse(lockBytes)
+	require.NoError(t, err)
+
+	var selectedTag string
+	for _, entry := range parsed.Entries() {
+		if entry.Namespace != "" || entry.Operation != workspace.LockOperationOCILatest {
+			continue
+		}
+		require.Equal(t, workspace.LookupInputs(
+			[]any{"docker.io/library/alpine"},
+			workspace.LookupOption{Name: "version", Value: "3.20"},
+		), entry.Inputs)
+		selectedTag = entry.Value
+	}
+	require.True(t, strings.HasPrefix(selectedTag, "3.20."), selectedTag)
+	require.NotEmpty(t, requireOCISHALockValue(t, lockBytes, "docker.io/library/alpine:"+selectedTag))
 }
 
 func writeOCILatestLock(

--- a/core/integration/module_helpers_test.go
+++ b/core/integration/module_helpers_test.go
@@ -71,6 +71,19 @@ func daggerCallAt(modPath string, args ...string) dagger.WithContainerFunc {
 	}
 }
 
+func daggerCallFail(args ...string) dagger.WithContainerFunc {
+	return func(c *dagger.Container) *dagger.Container {
+		return c.WithExec(
+			append([]string{"dagger", "--progress=report", "call"}, args...),
+			dagger.ContainerWithExecOpts{
+				UseEntrypoint:                 true,
+				ExperimentalPrivilegedNesting: true,
+				Expect:                        dagger.ReturnTypeFailure,
+			},
+		)
+	}
+}
+
 func daggerFunctions(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "api", "functions"}, args...), dagger.ContainerWithExecOpts{

--- a/core/integration/module_path_inputs_test.go
+++ b/core/integration/module_path_inputs_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1563,6 +1564,8 @@ func (ModuleSuite) TestContextGitRemoteDep(ctx context.Context, t *testctx.T) {
 			fullref, err := g.Name(ctx)
 			require.NoError(t, err)
 			require.Contains(t, fullref, version)
+			resolvedCommit, err := g.CommitSHA(ctx)
+			require.NoError(t, err)
 
 			fixture := map[string]string{
 				"":            "go/path-context-git-remote-dep-default",
@@ -1574,6 +1577,24 @@ func (ModuleSuite) TestContextGitRemoteDep(ctx context.Context, t *testctx.T) {
 				WithWorkdir("/work").
 				With(withModuleFixture(t, c, "/work", fixture)).
 				WithExec([]string{"sh", "-c", `git init && git add . && git commit -m "initial commit"`})
+
+			if version == "v1.2.3" {
+				out, err := modGen.
+					With(daggerCallFail("test-ref-local")).
+					CombinedOutput(ctx)
+				require.NoError(t, err)
+				require.Contains(t, out, fmt.Sprintf(
+					"version query %q resolved to Git ref %q at commit %q",
+					version,
+					fullref,
+					resolvedCommit,
+				))
+				require.Contains(t, out, fmt.Sprintf(
+					"but the requested pin is %q",
+					commit,
+				))
+				return
+			}
 
 			t.Run("repo local", func(ctx context.Context, t *testctx.T) {
 				out, err := modGen.With(daggerCall("test-repo-local")).Stdout(ctx)

--- a/core/lockfile_update.go
+++ b/core/lockfile_update.go
@@ -164,6 +164,9 @@ func selectedSHAEntry(
 		}
 		var shaOptions []workspace.LookupOption
 		for name, optionValue := range options {
+			if name == "version" {
+				continue
+			}
 			shaOptions = append(shaOptions, workspace.LookupOption{
 				Name:  name,
 				Value: optionValue,
@@ -245,6 +248,7 @@ func updateVanityURLLockEntry(ctx context.Context, entry workspace.LookupEntry) 
 
 type ociLockInputs struct {
 	ref               string
+	version           string
 	registryTransport serverresolver.RegistryTransport
 }
 
@@ -281,6 +285,15 @@ func parseOCILockInputs(
 
 	for name, value := range options {
 		switch name {
+		case "version":
+			version, ok := value.(string)
+			if !ok || version == "" || !latest {
+				return parsed, fmt.Errorf("invalid %s version %v", operation, value)
+			}
+			if _, err := parseReleaseVersionQuery(version); err != nil {
+				return parsed, fmt.Errorf("invalid %s version %v: %w", operation, value, err)
+			}
+			parsed.version = version
 		case "protocol":
 			protocol, ok := value.(string)
 			if !ok {
@@ -343,7 +356,7 @@ func updateOCILatestLockEntry(
 	if err != nil {
 		return "", fmt.Errorf("list image tags for %q: %w", refName.String(), err)
 	}
-	selectedTag, err := SelectLatestContainerTag(tags)
+	selectedTag, err := SelectContainerTag(tags, inputs.version)
 	if err != nil {
 		return "", fmt.Errorf("select latest image tag for %q: %w", refName.String(), err)
 	}
@@ -488,6 +501,7 @@ func updateGitLatestLockEntry(ctx context.Context, entry workspace.LookupEntry) 
 		)
 	}
 	var tagPrefix string
+	var version string
 	for name, value := range options {
 		switch name {
 		case "tagPrefix":
@@ -499,6 +513,19 @@ func updateGitLatestLockEntry(ctx context.Context, entry workspace.LookupEntry) 
 					workspace.LockOperationGitLatest,
 					value,
 				)
+			}
+		case "version":
+			var ok bool
+			version, ok = value.(string)
+			if !ok || version == "" {
+				return "", fmt.Errorf(
+					"invalid %s version %v",
+					workspace.LockOperationGitLatest,
+					value,
+				)
+			}
+			if _, err := parseReleaseVersionQuery(version); err != nil {
+				return "", fmt.Errorf("invalid %s version %v: %w", workspace.LockOperationGitLatest, value, err)
 			}
 		default:
 			return "", unsupportedLockOptionError(
@@ -517,6 +544,12 @@ func updateGitLatestLockEntry(ctx context.Context, entry workspace.LookupEntry) 
 	}
 
 	var latestInputs []dagql.NamedInput
+	if version != "" {
+		latestInputs = append(latestInputs, dagql.NamedInput{
+			Name:  "version",
+			Value: dagql.String(version),
+		})
+	}
 	if tagPrefix != "" {
 		latestInputs = append(latestInputs, dagql.NamedInput{
 			Name:  "tagPrefix",

--- a/core/lockfile_update_test.go
+++ b/core/lockfile_update_test.go
@@ -155,6 +155,7 @@ func TestSelectedSHAEntry(t *testing.T) {
 				Inputs: workspace.LookupInputs(
 					[]any{"https://example.com/repo.git"},
 					workspace.LookupOption{Name: "tagPrefix", Value: "sdk/go"},
+					workspace.LookupOption{Name: "version", Value: "v1.2"},
 				),
 			},
 			"refs/tags/sdk/go/v1.2.3",
@@ -176,6 +177,7 @@ func TestSelectedSHAEntry(t *testing.T) {
 				Inputs: workspace.LookupInputs(
 					[]any{"registry.example/acme/image"},
 					workspace.LookupOption{Name: "protocol", Value: "http"},
+					workspace.LookupOption{Name: "version", Value: "2"},
 				),
 			},
 			"2.0.0",
@@ -215,6 +217,14 @@ func TestUpdateGitLatestLockEntryValidatesInputs(t *testing.T) {
 				workspace.LookupOption{Name: "tagPrefix", Value: ""},
 			),
 			wantErr: "invalid git-latest tagPrefix",
+		},
+		{
+			name: "invalid version query",
+			inputs: workspace.LookupInputs(
+				[]any{"https://example.com/repo.git"},
+				workspace.LookupOption{Name: "version", Value: "v1.x"},
+			),
+			wantErr: `invalid git-latest version v1.x: invalid version query "v1.x"`,
 		},
 		{
 			name: "unknown option",
@@ -353,6 +363,7 @@ func TestParseOCILatestLockInputs(t *testing.T) {
 		[]any{"docker.io/library/alpine"},
 		workspace.LookupOption{Name: "protocol", Value: "https"},
 		workspace.LookupOption{Name: "insecureSkipTLSVerify", Value: true},
+		workspace.LookupOption{Name: "version", Value: "v3.20"},
 	)
 	got, err := parseOCILockInputs(workspace.LockOperationOCILatest, inputs, true)
 	require.NoError(t, err)
@@ -360,6 +371,7 @@ func TestParseOCILatestLockInputs(t *testing.T) {
 		Protocol:              serverresolver.RegistryProtocolHTTPS,
 		InsecureSkipTLSVerify: true,
 	}, got.registryTransport)
+	require.Equal(t, "v3.20", got.version)
 
 	_, err = parseOCILockInputs(
 		workspace.LockOperationOCILatest,

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/mod/semver"
-
 	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
@@ -134,6 +132,19 @@ func ParseGitRefString(ctx context.Context, refString string) (ParsedGitRefStrin
 	return ParsedGitRefString{parsed}, err
 }
 
+// SetVersion sets a separate version query on a parsed Git module reference.
+func (p *ParsedGitRefString) SetVersion(version string) error {
+	if version == "" {
+		return nil
+	}
+	if _, err := parseReleaseVersionQuery(version); err != nil {
+		return err
+	}
+	p.ModVersion = version
+	p.HasVersion = true
+	return nil
+}
+
 func (p *ParsedGitRefString) GitRef(
 	ctx context.Context,
 	dag *dagql.Server,
@@ -148,34 +159,11 @@ func (p *ParsedGitRefString) GitRef(
 		return selector
 	}
 
-	var modTag string
-	if p.HasVersion && semver.IsValid(p.ModVersion) {
-		var tags dagql.Array[dagql.String]
-		err := dag.Select(ctx, dag.Root(), &tags,
-			dagql.Selector{
-				Field: "git",
-				Args: []dagql.NamedInput{
-					{Name: "url", Value: dagql.String(p.CloneRef)},
-				},
-			},
-			dagql.Selector{
-				Field: "tags",
-			},
-		)
-		if err != nil {
-			return inst, fmt.Errorf("failed to resolve git tags: %w", err)
+	versionQuery := ""
+	if p.HasVersion && Supports(ctx, workspace.VersionQueriesVersion) {
+		if IsReleaseVersionQuery(p.ModVersion) {
+			versionQuery = p.ModVersion
 		}
-
-		allTags := make([]string, len(tags))
-		for i, tag := range tags {
-			allTags[i] = tag.String()
-		}
-
-		matched, err := matchVersion(allTags, p.ModVersion, p.RepoRootSubdir)
-		if err != nil {
-			return inst, fmt.Errorf("matching version to tags: %w", err)
-		}
-		modTag = matched
 	}
 
 	repoSelector := dagql.Selector{
@@ -188,11 +176,26 @@ func (p *ParsedGitRefString) GitRef(
 
 	refSelector := moduleGitDefaultRefSelector(ctx, p)
 	switch {
-	case modTag != "":
+	case versionQuery != "" && !pinIsSHA:
+		args := []dagql.NamedInput{
+			{Name: "version", Value: dagql.String(versionQuery)},
+		}
+		if p.RepoRootSubdir != "/" {
+			args = append(args, dagql.NamedInput{
+				Name:  "tagPrefix",
+				Value: dagql.String(strings.Trim(p.RepoRootSubdir, "/")),
+			})
+		}
+		refSelector = dagql.Selector{Field: "latest", Args: args}
+	case pinIsSHA:
+		// A module config pin is authoritative over both the declared version
+		// query and the consuming workspace's git-sha lock entries. Use HEAD as
+		// a neutral ref name so a partial query such as v1.2 is not looked up as
+		// a literal tag or branch before the pinned commit is applied.
 		refSelector = withCommitArg(dagql.Selector{
-			Field: "tag",
+			Field: "ref",
 			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String(modTag)},
+				{Name: "name", Value: dagql.String("HEAD")},
 			},
 		})
 	case p.HasVersion:
@@ -209,16 +212,6 @@ func (p *ParsedGitRefString) GitRef(
 				{Name: "name", Value: dagql.String(pinCommitRef)},
 			},
 		}
-	case pinIsSHA:
-		// A module config pin is authoritative over the consuming workspace's
-		// git-sha lock entries. Pass it through ref's internal commit argument so
-		// ref resolution cannot replay a stale HEAD lock entry.
-		refSelector = withCommitArg(dagql.Selector{
-			Field: "ref",
-			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String("HEAD")},
-			},
-		})
 	}
 
 	var gitRef dagql.ObjectResult[*GitRef]

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -183,7 +183,7 @@ func (p *ParsedGitRefString) GitRef(
 
 	refSelector := moduleGitDefaultRefSelector(ctx, p)
 	switch {
-	case versionQuery != "" && !pinIsSHA:
+	case versionQuery != "":
 		args := []dagql.NamedInput{
 			{Name: "version", Value: dagql.String(versionQuery)},
 		}
@@ -194,17 +194,6 @@ func (p *ParsedGitRefString) GitRef(
 			})
 		}
 		refSelector = dagql.Selector{Field: "latest", Args: args}
-	case pinIsSHA:
-		// A module config pin is authoritative over both the declared version
-		// query and the consuming workspace's git-sha lock entries. Use HEAD as
-		// a neutral ref name so a partial query such as v1.2 is not looked up as
-		// a literal tag or branch before the pinned commit is applied.
-		refSelector = withCommitArg(dagql.Selector{
-			Field: "ref",
-			Args: []dagql.NamedInput{
-				{Name: "name", Value: dagql.String("HEAD")},
-			},
-		})
 	case p.HasVersion:
 		refSelector = withCommitArg(dagql.Selector{
 			Field: "ref",
@@ -219,12 +208,32 @@ func (p *ParsedGitRefString) GitRef(
 				{Name: "name", Value: dagql.String(pinCommitRef)},
 			},
 		}
+	case pinIsSHA:
+		refSelector = withCommitArg(dagql.Selector{
+			Field: "ref",
+			Args: []dagql.NamedInput{
+				{Name: "name", Value: dagql.String("HEAD")},
+			},
+		})
 	}
 
 	var gitRef dagql.ObjectResult[*GitRef]
 	err := dag.Select(ctx, dag.Root(), &gitRef, repoSelector, refSelector)
 	if err != nil {
 		return inst, fmt.Errorf("failed to resolve git src: %w", err)
+	}
+	if versionQuery != "" && pinIsSHA && gitRef.Self().Ref.SHA != pinCommitRef {
+		// A normal load must satisfy both the version resolution and the module
+		// pin. It cannot rewrite either value. In contrast, dagger update is an
+		// explicit request to refresh the lock, so it accepts a moved tag after
+		// it warns the user.
+		return inst, fmt.Errorf(
+			"version query %q resolved to Git ref %q at commit %q, but the requested pin is %q",
+			versionQuery,
+			gitRef.Self().Ref.Name,
+			gitRef.Self().Ref.SHA,
+			pinCommitRef,
+		)
 	}
 
 	return gitRef, nil

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -137,6 +137,13 @@ func (p *ParsedGitRefString) SetVersion(version string) error {
 	if version == "" {
 		return nil
 	}
+	if p.HasVersion {
+		return fmt.Errorf(
+			"version query %q cannot be used because the module source ref already has version %q",
+			version,
+			p.ModVersion,
+		)
+	}
 	if _, err := parseReleaseVersionQuery(version); err != nil {
 		return err
 	}

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -52,6 +52,11 @@ func TestParsedGitRefStringSetVersion(t *testing.T) {
 	require.True(t, parsed.HasVersion)
 	require.Equal(t, "v1.2-beta", parsed.ModVersion)
 
+	require.EqualError(t,
+		parsed.SetVersion("v2"),
+		`version query "v2" cannot be used because the module source ref already has version "v1.2-beta"`,
+	)
+
 	invalid := &ParsedGitRefString{}
 	require.ErrorContains(t, invalid.SetVersion("main"), `invalid version query "main"`)
 }

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -44,6 +44,18 @@ func TestModuleGitDefaultRefSelector(t *testing.T) {
 	}
 }
 
+func TestParsedGitRefStringSetVersion(t *testing.T) {
+	t.Parallel()
+
+	parsed := &ParsedGitRefString{}
+	require.NoError(t, parsed.SetVersion("v1.2-beta"))
+	require.True(t, parsed.HasVersion)
+	require.Equal(t, "v1.2-beta", parsed.ModVersion)
+
+	invalid := &ParsedGitRefString{}
+	require.ErrorContains(t, invalid.SetVersion("main"), `invalid version query "main"`)
+}
+
 func TestMatchVersion(t *testing.T) {
 	vers := []string{"v1.0.0", "v1.0.1", "v2.0.0", "path/v1.0.1", "path/v2.0.1"}
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -442,6 +442,7 @@ type persistedGitModuleSourcePayload struct {
 	HTMLURL      string `json:"htmlURL,omitempty"`
 	RepoRootPath string `json:"repoRootPath,omitempty"`
 	Version      string `json:"version,omitempty"`
+	VersionQuery string `json:"versionQuery,omitempty"`
 	Commit       string `json:"commit,omitempty"`
 	Ref          string `json:"ref,omitempty"`
 }
@@ -885,6 +886,7 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 			HTMLURL:      src.Git.HTMLURL,
 			RepoRootPath: src.Git.RepoRootPath,
 			Version:      src.Git.Version,
+			VersionQuery: src.Git.VersionQuery,
 			Commit:       src.Git.Commit,
 			Ref:          src.Git.Ref,
 		}
@@ -980,6 +982,7 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 			HTMLURL:      persisted.Git.HTMLURL,
 			RepoRootPath: persisted.Git.RepoRootPath,
 			Version:      persisted.Git.Version,
+			VersionQuery: persisted.Git.VersionQuery,
 			Commit:       persisted.Git.Commit,
 			Ref:          persisted.Git.Ref,
 		}
@@ -1022,7 +1025,11 @@ func (src *ModuleSource) AsString() string {
 		return filepath.Join(src.Local.ContextDirectoryPath, src.SourceRootSubpath)
 
 	case ModuleSourceKindGit:
-		return GitRefString(src.Git.CloneRef, src.SourceRootSubpath, src.Git.Version)
+		version := src.Git.VersionQuery
+		if version == "" {
+			version = src.Git.Version
+		}
+		return GitRefString(src.Git.CloneRef, src.SourceRootSubpath, version)
 
 	default:
 		return ""
@@ -2037,6 +2044,9 @@ type GitModuleSource struct {
 
 	// The version of the source; may be a branch, tag, or commit hash
 	Version string
+
+	// The version query used to select Version.
+	VersionQuery string
 
 	// The resolved commit hash of the source
 	Commit string

--- a/core/modulesource_test.go
+++ b/core/modulesource_test.go
@@ -124,10 +124,11 @@ func TestModuleSourcePersistenceRetainsSelfCallsCapability(t *testing.T) {
 
 func TestGitModuleSourceSymbolic(t *testing.T) {
 	testCases := []struct {
-		name        string
-		cloneRef    string
-		rootSubpath string
-		expected    string
+		name         string
+		cloneRef     string
+		rootSubpath  string
+		versionQuery string
+		expected     string
 	}{
 		{
 			name:        "Go-style URL",
@@ -147,6 +148,13 @@ func TestGitModuleSourceSymbolic(t *testing.T) {
 			rootSubpath: "",
 			expected:    "git@github.com:user/repo.git",
 		},
+		{
+			name:         "version query",
+			cloneRef:     "https://github.com/user/repo.git",
+			rootSubpath:  "subdir",
+			versionQuery: "v1.2",
+			expected:     "https://github.com/user/repo.git/subdir@v1.2",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -154,7 +162,8 @@ func TestGitModuleSourceSymbolic(t *testing.T) {
 			src := &ModuleSource{
 				Kind: ModuleSourceKindGit,
 				Git: &GitModuleSource{
-					CloneRef: tc.cloneRef,
+					CloneRef:     tc.cloneRef,
+					VersionQuery: tc.versionQuery,
 				},
 				SourceRootSubpath: tc.rootSubpath,
 			}

--- a/core/release_version.go
+++ b/core/release_version.go
@@ -38,6 +38,71 @@ type parsedReleaseTag struct {
 	Semver semvery.Version
 }
 
+// releaseVersionQuery is a SemVer prefix query. Missing numeric components
+// match every value for that component. A prerelease suffix selects only that
+// prerelease channel.
+type releaseVersionQuery struct {
+	parts      []string
+	prerelease string
+}
+
+func parseReleaseVersionQuery(query string) (releaseVersionQuery, error) {
+	if query == "" {
+		return releaseVersionQuery{}, nil
+	}
+	parsed, ok := semvery.Parse(query)
+	if !ok || parsed.Build != "" {
+		return releaseVersionQuery{}, fmt.Errorf("invalid version query %q", query)
+	}
+	parts := make([]string, len(parsed.RawParts))
+	for i, part := range parsed.RawParts {
+		part = strings.TrimLeft(part, "0")
+		if part == "" {
+			part = "0"
+		}
+		parts[i] = part
+	}
+	return releaseVersionQuery{
+		parts:      parts,
+		prerelease: strings.TrimPrefix(parsed.Prerelease, "-"),
+	}, nil
+}
+
+// IsReleaseVersionQuery reports whether query uses the release query syntax.
+func IsReleaseVersionQuery(query string) bool {
+	if query == "" {
+		return false
+	}
+	_, err := parseReleaseVersionQuery(query)
+	return err == nil
+}
+
+func (query releaseVersionQuery) matches(candidate parsedReleaseTag) bool {
+	parts := candidate.Semver.RawParts
+	for i, want := range query.parts {
+		if i >= len(parts) {
+			// Missing candidate components are concrete zeroes.
+			if want != "0" {
+				return false
+			}
+			continue
+		}
+		got := strings.TrimLeft(parts[i], "0")
+		if got == "" {
+			got = "0"
+		}
+		if got != want {
+			return false
+		}
+	}
+
+	prerelease := strings.TrimPrefix(candidate.Semver.Prerelease, "-")
+	if query.prerelease == "" {
+		return prerelease == ""
+	}
+	return prerelease == query.prerelease || strings.HasPrefix(prerelease, query.prerelease+".")
+}
+
 func parseReleaseTag(candidate releaseTagCandidate) (parsedReleaseTag, bool) {
 	version, ok := semvery.Parse(candidate.Version)
 	if !ok {
@@ -52,7 +117,18 @@ func parseReleaseTag(candidate releaseTagCandidate) (parsedReleaseTag, bool) {
 func selectLatestReleaseTag(
 	candidates []releaseTagCandidate,
 ) (releaseTagCandidate, bool, error) {
-	winners := highestStableReleaseTags(candidates)
+	return selectReleaseTag(candidates, "")
+}
+
+func selectReleaseTag(
+	candidates []releaseTagCandidate,
+	versionQuery string,
+) (releaseTagCandidate, bool, error) {
+	query, err := parseReleaseVersionQuery(versionQuery)
+	if err != nil {
+		return releaseTagCandidate{}, false, err
+	}
+	winners := highestReleaseTags(candidates, query)
 	winners = preferCompleteReleaseAliases(winners)
 
 	switch len(winners) {
@@ -68,15 +144,16 @@ func selectLatestReleaseTag(
 	return preferCanonicalGitReleaseTag(winners).releaseTagCandidate, true, nil
 }
 
-func highestStableReleaseTags(
+func highestReleaseTags(
 	candidates []releaseTagCandidate,
+	query releaseVersionQuery,
 ) []parsedReleaseTag {
 	var winners []parsedReleaseTag
 	var best semvery.Version
 	found := false
 	for _, candidate := range candidates {
 		parsed, ok := parseReleaseTag(candidate)
-		if !ok || parsed.Semver.Prerelease != "" {
+		if !ok || !query.matches(parsed) {
 			continue
 		}
 

--- a/core/release_version_test.go
+++ b/core/release_version_test.go
@@ -29,6 +29,47 @@ func TestSelectLatestReleaseTagReportsOriginalTags(t *testing.T) {
 	require.ErrorContains(t, err, `equivalent tags ["24.04" "v24.4.0"]`)
 }
 
+func TestSelectReleaseTagWithVersionQuery(t *testing.T) {
+	t.Parallel()
+
+	candidates := []releaseTagCandidate{
+		{Name: "v1.2", Version: "v1.2"},
+		{Name: "v1.2.3", Version: "v1.2.3"},
+		{Name: "v1.2.4-beta.1", Version: "v1.2.4-beta.1"},
+		{Name: "v1.2.4-beta.2", Version: "v1.2.4-beta.2"},
+		{Name: "v1.2.4-rc.1", Version: "v1.2.4-rc.1"},
+		{Name: "v1.3.0", Version: "v1.3.0"},
+		{Name: "v2.0.0", Version: "v2.0.0"},
+	}
+
+	for _, tc := range []struct {
+		query string
+		want  string
+	}{
+		{query: "v1", want: "v1.3.0"},
+		{query: "1.2", want: "v1.2.3"},
+		{query: "v1.2.3", want: "v1.2.3"},
+		{query: "v1.2-beta", want: "v1.2.4-beta.2"},
+		{query: "v1.2.4-beta", want: "v1.2.4-beta.2"},
+		{query: "v1.2.4-rc", want: "v1.2.4-rc.1"},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			selected, found, err := selectReleaseTag(candidates, tc.query)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, tc.want, selected.Name)
+		})
+	}
+}
+
+func TestSelectReleaseTagRejectsInvalidVersionQuery(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := selectReleaseTag(nil, "v1.x")
+	require.ErrorContains(t, err, `invalid version query "v1.x"`)
+}
+
 func TestParseReleaseTagPreservesPrefixedName(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1136,6 +1136,13 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 	if err != nil {
 		return inst, fmt.Errorf("failed to parse image address %s: %w", args.Address, err)
 	}
+	if args.Version != "" && !reference.IsNameOnly(refName) {
+		return inst, fmt.Errorf(
+			"version query %q cannot be used with image address %q because it contains a tag or digest",
+			args.Version,
+			args.Address,
+		)
+	}
 	latestRelease := args.Version != "" || shouldSelectLatestImageRelease(ctx, refName)
 	if latestRelease {
 		refName = reference.TrimNamed(refName)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -72,6 +72,9 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 					`Address of the container image to download, in standard OCI ref format. Example: "registry.dagger.io/engine:latest".`,
 					`An address without a tag or digest selects the greatest stable release tag, falling back to the literal "latest" tag when no eligible release exists.`,
 				),
+				dagql.Arg("version").
+					Doc(`Version query used to select an image tag. The address must not contain a tag or digest.`).
+					View(AfterVersion(workspace.VersionQueriesVersion)),
 				dagql.Arg("registryService").Doc(
 					`Service to use as the registry endpoint for the image address.`,
 					`The service will be started only for this pull.`).
@@ -1029,6 +1032,7 @@ func (s *containerSchema) container(ctx context.Context, parent *core.Query, arg
 
 type containerFromArgs struct {
 	Address               string
+	Version               string `default:""`
 	RegistryService       dagql.Optional[core.ServiceID]
 	Protocol              dagql.Optional[core.RegistryProtocol]
 	InsecureSkipTLSVerify bool `name:"insecureSkipTLSVerify" default:"false"`
@@ -1132,7 +1136,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 	if err != nil {
 		return inst, fmt.Errorf("failed to parse image address %s: %w", args.Address, err)
 	}
-	latestRelease := shouldSelectLatestImageRelease(ctx, refName)
+	latestRelease := args.Version != "" || shouldSelectLatestImageRelease(ctx, refName)
 	if latestRelease {
 		refName = reference.TrimNamed(refName)
 	} else {
@@ -1270,6 +1274,12 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 
 	if latestRelease {
 		latestOptions := registryLockOptions()
+		if args.Version != "" {
+			latestOptions = append(latestOptions, workspace.LookupOption{
+				Name:  "version",
+				Value: args.Version,
+			})
+		}
 		latestInputs := workspace.LookupInputs(
 			[]any{refName.String()},
 			latestOptions...,
@@ -1283,7 +1293,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 		var selectedTag string
 		if latestResolution.Pin != "" {
 			selectedTag = latestResolution.Pin
-			if err := core.ValidateContainerLatestTag(selectedTag); err != nil {
+			if err := core.ValidateContainerTag(selectedTag, args.Version); err != nil {
 				return inst, fmt.Errorf("%s lock value: %w", workspace.LockOperationOCILatest, err)
 			}
 		} else {
@@ -1311,7 +1321,7 @@ func (s *containerSchema) from(ctx context.Context, parent dagql.ObjectResult[*c
 			if err != nil {
 				return inst, fmt.Errorf("failed to list image tags for %q: %w", refName.String(), err)
 			}
-			selectedTag, err = core.SelectLatestContainerTag(tags)
+			selectedTag, err = core.SelectContainerTag(tags, args.Version)
 			if err != nil {
 				return inst, fmt.Errorf("select latest image tag for %q: %w", refName.String(), err)
 			}

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -116,6 +116,9 @@ func (s *gitSchema) Install(srv *dagql.Server) {
 				`Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.`,
 			).
 			Args(
+				dagql.Arg("version").
+					Doc(`Version query used to select the greatest matching release ref.`).
+					View(AfterVersion(workspace.VersionQueriesVersion)),
 				dagql.Arg("tagPrefix").
 					Doc(`Restrict release tags to a monorepo subpath.`).
 					Internal(),
@@ -2294,6 +2297,7 @@ func (s *gitSchema) log(
 }
 
 type latestArgs struct {
+	Version   string `default:""`
 	TagPrefix string `name:"tagPrefix" default:""`
 }
 
@@ -2309,9 +2313,10 @@ func (s *gitSchema) latest(
 		if err != nil {
 			return inst, err
 		}
-		ref, err := core.SelectLatestGitRefWithTagPrefix(
+		ref, err := core.SelectGitRefWithVersionQuery(
 			remote,
 			args.TagPrefix,
+			args.Version,
 		)
 		if err != nil {
 			return inst, err
@@ -2324,6 +2329,12 @@ func (s *gitSchema) latest(
 		lockOptions = append(lockOptions, workspace.LookupOption{
 			Name:  "tagPrefix",
 			Value: args.TagPrefix,
+		})
+	}
+	if args.Version != "" {
+		lockOptions = append(lockOptions, workspace.LookupOption{
+			Name:  "version",
+			Value: args.Version,
 		})
 	}
 	lockInputs := workspace.LookupInputs(
@@ -2348,9 +2359,10 @@ func (s *gitSchema) latest(
 	var selectedRef string
 	if lockResolution.Pin != "" {
 		selectedRef = lockResolution.Pin
-		if err := core.ValidateGitLatestRef(
+		if err := core.ValidateGitVersionRef(
 			selectedRef,
 			args.TagPrefix,
+			args.Version,
 		); err != nil {
 			return inst, fmt.Errorf("%s lock value: %w", workspace.LockOperationGitLatest, err)
 		}
@@ -2359,9 +2371,10 @@ func (s *gitSchema) latest(
 		if err != nil {
 			return inst, err
 		}
-		ref, err := core.SelectLatestGitRefWithTagPrefix(
+		ref, err := core.SelectGitRefWithVersionQuery(
 			remote,
 			args.TagPrefix,
+			args.Version,
 		)
 		if err != nil {
 			return inst, err

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -66,6 +66,9 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 			Doc(`Create a new module source instance from a source ref string`).
 			Args(
 				dagql.Arg("refString").Doc(`The string ref representation of the module source`),
+				dagql.Arg("version").
+					Doc(`Version query for a Git module source.`).
+					View(AfterVersion(workspace.VersionQueriesVersion)),
 				dagql.Arg("refPin").Doc(`The pinned version of the module source`),
 				dagql.Arg("disableFindUp").Doc(`If true, do not attempt to find a module config file in a parent directory of the provided path. Only relevant for local module sources.`),
 				dagql.Arg("allowNotExists").Doc(`If true, do not error out if the provided ref string is a local path and does not exist yet. Useful when initializing new modules in directories that don't exist yet.`),
@@ -325,6 +328,7 @@ func (s *moduleSourceSchema) Install(dag *dagql.Server) {
 type moduleSourceArgs struct {
 	// avoiding name "ref" due to that being a reserved word in some SDKs (e.g. Rust)
 	RefString      string
+	Version        string `default:""`
 	RefPin         string `default:""`
 	DisableFindUp  bool   `default:"false"`
 	AllowNotExists bool   `default:"false"`
@@ -343,6 +347,14 @@ func (s *moduleSourceSchema) moduleSource(
 	parsedRef, err := core.ParseRefString(ctx, core.NewCallerStatFS(bk), args.RefString, args.RefPin)
 	if err != nil {
 		return inst, err
+	}
+	if args.Version != "" {
+		if parsedRef.Kind != core.ModuleSourceKindGit {
+			return inst, errors.New("version query requires a Git module source")
+		}
+		if err := parsedRef.Git.SetVersion(args.Version); err != nil {
+			return inst, err
+		}
 	}
 
 	if args.RequireKind.Valid && parsedRef.Kind != args.RequireKind.Value {
@@ -766,6 +778,10 @@ func (s *moduleSourceSchema) gitModuleSource(
 	if err != nil {
 		return inst, fmt.Errorf("failed to resolve git src: %w", err)
 	}
+	versionQuery := ""
+	if core.Supports(ctx, workspace.VersionQueriesVersion) && core.IsReleaseVersionQuery(parsed.ModVersion) {
+		versionQuery = parsed.ModVersion
+	}
 
 	gitSrc := &core.ModuleSource{
 		ConfigExists:   true, // we can't load uninitialized git modules, we'll error out later if it's not there
@@ -775,6 +791,7 @@ func (s *moduleSourceSchema) gitModuleSource(
 			HTMLRepoURL:  parsed.RepoRoot.Repo,
 			RepoRootPath: parsed.RepoRoot.Root,
 			Version:      cmp.Or(gitRef.Self().Ref.ShortName(), gitRef.Self().Ref.SHA),
+			VersionQuery: versionQuery,
 			Commit:       gitRef.Self().Ref.SHA,
 			Ref:          gitRef.Self().Ref.Name,
 			CloneRef:     parsed.SourceCloneRef,
@@ -2036,8 +2053,7 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 			}
 			depCfg.Source = rel
 		case core.ModuleSourceKindGit:
-			depCfg.Source = moduleSourceDeclaredRef(relatedSrc)
-			depCfg.Pin = relatedSrc.Git.Commit
+			setModuleConfigDependencyGitSource(depCfg, relatedSrc)
 		default:
 			return nil, fmt.Errorf("unhandled module source kind: %s", relatedSrc.Kind.HumanString())
 		}
@@ -2055,8 +2071,7 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 				}
 				depCfg.Source = rel
 			} else {
-				depCfg.Source = moduleSourceDeclaredRef(relatedSrc)
-				depCfg.Pin = relatedSrc.Git.Commit
+				setModuleConfigDependencyGitSource(depCfg, relatedSrc)
 			}
 		default:
 			return nil, fmt.Errorf("unhandled module source kind: %s", relatedSrc.Kind.HumanString())
@@ -2072,8 +2087,7 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 			}
 			depCfg.Source = rel
 		case core.ModuleSourceKindGit:
-			depCfg.Source = moduleSourceDeclaredRef(relatedSrc)
-			depCfg.Pin = relatedSrc.Git.Commit
+			setModuleConfigDependencyGitSource(depCfg, relatedSrc)
 		default:
 			return nil, fmt.Errorf(
 				"parent module source kind %s cannot reference module source kind %s",
@@ -2086,6 +2100,14 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 	}
 
 	return depCfg, nil
+}
+
+func setModuleConfigDependencyGitSource(depCfg *modules.ModuleConfigDependency, src *core.ModuleSource) {
+	depCfg.Source = moduleSourceDeclaredRef(src)
+	if src.Git.VersionQuery != "" {
+		depCfg.Source = replaceModuleRefVersion(depCfg.Source, src.Git.VersionQuery)
+	}
+	depCfg.Pin = src.Git.Commit
 }
 
 func moduleSourceDeclaredRef(src *core.ModuleSource) string {

--- a/core/schema/modulesource_test.go
+++ b/core/schema/modulesource_test.go
@@ -143,9 +143,10 @@ func TestLoadCurrentModuleSourceConfigPreservesGitDependencySourceAndPin(t *test
 		OriginalRefString: "https://github.com/acme/dep/sdk",
 		SourceRootSubpath: "sdk",
 		Git: &core.GitModuleSource{
-			CloneRef: "https://github.com/acme/dep",
-			Version:  "v1.2.3",
-			Commit:   "1234567890abcdef",
+			CloneRef:     "https://github.com/acme/dep",
+			Version:      "v1.2.3",
+			VersionQuery: "v1.2",
+			Commit:       "1234567890abcdef",
 		},
 	}
 	parent := &core.ModuleSource{
@@ -172,8 +173,9 @@ func TestLoadCurrentModuleSourceConfigPreservesGitDependencySourceAndPin(t *test
 	require.Contains(t, string(out), `name = "parent"`)
 	require.Contains(t, string(out), `engineVersion = "`+engine.Version+`"`)
 	require.Contains(t, string(out), `name = "dep"`)
-	require.Contains(t, string(out), `source = "https://github.com/acme/dep/sdk"`)
+	require.Contains(t, string(out), `source = "https://github.com/acme/dep/sdk@v1.2"`)
 	require.Contains(t, string(out), `pin = "1234567890abcdef"`)
+	require.NotContains(t, string(out), `version =`)
 }
 
 func moduleSourceObjectResult(t *testing.T, dag *dagql.Server, op string, self *core.ModuleSource) dagql.ObjectResult[*core.ModuleSource] {

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -23,7 +23,8 @@ const (
 	LockOperationGitSHA    = "git-sha"
 	LockOperationVanityURL = "vanity-url"
 
-	LatestReleaseVersion = "v1.0.0-beta.11"
+	LatestReleaseVersion  = "v1.0.0-beta.11"
+	VersionQueriesVersion = "v1.0.0-beta.12"
 )
 
 // CanonicalLockFilePath maps the legacy .dagger/lock path to its dagger.lock

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -634,6 +634,11 @@ type Container implements Exportable & Node & Syncer {
     address: String!
 
     """
+    Version query used to select an image tag. The address must not contain a tag or digest.
+    """
+    version: String = ""
+
+    """
     Service to use as the registry endpoint for the image address.
 
     The service will be started only for this pull.
@@ -3401,7 +3406,10 @@ type GitRepository implements Node {
   Release selection accepts an optional "v" prefix, incomplete versions, and
   zero-padded numeric components. This operation is pinned.
   """
-  latest: GitRef!
+  latest(
+    """Version query used to select the greatest matching release ref."""
+    version: String = ""
+  ): GitRef!
 
   """Returns details of a ref."""
   ref(
@@ -4969,6 +4977,9 @@ type Query implements Node {
   moduleSource(
     """The string ref representation of the module source"""
     refString: String!
+
+    """Version query for a Git module source."""
+    version: String = ""
 
     """The pinned version of the module source"""
     refPin: String = ""

--- a/docs/static/reference/php/Dagger/Client.html
+++ b/docs/static/reference/php/Dagger/Client.html
@@ -482,7 +482,7 @@
                     <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_moduleSource">moduleSource</a>(string $refString, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
+                    <a href="#method_moduleSource">moduleSource</a>(string $refString, string|null $version = &#039;&#039;, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
         
                                             <p><p>Create a new module source instance from a source ref string</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -2047,7 +2047,7 @@
                     <h3 id="method_moduleSource">
         <div class="location">at line 393</div>
         <code>                    <a href="../Dagger/ModuleSource.html"><abbr title="Dagger\ModuleSource">ModuleSource</abbr></a>
-    <strong>moduleSource</strong>(string $refString, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
+    <strong>moduleSource</strong>(string $refString, string|null $version = &#039;&#039;, string|null $refPin = &#039;&#039;, bool|null $disableFindUp = false, bool|null $allowNotExists = false, <abbr title="Dagger\Dagger\ModuleSourceKind">ModuleSourceKind</abbr>|null $requireKind = null)
         </code>
     </h3>
     <div class="details">    
@@ -2064,6 +2064,11 @@
                     <tr>
                 <td>string</td>
                 <td>$refString</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$version</td>
                 <td></td>
             </tr>
                     <tr>
@@ -2107,7 +2112,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_node">
-        <div class="location">at line 420</div>
+        <div class="location">at line 424</div>
         <code>                    <abbr title="Dagger\Dagger\Node">Node</abbr>|null
     <strong>node</strong>(<a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a> $id)
         </code>
@@ -2149,7 +2154,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_schema">
-        <div class="location">at line 435</div>
+        <div class="location">at line 439</div>
         <code>                    <a href="../Dagger/Schema.html"><abbr title="Dagger\Schema">Schema</abbr></a>
     <strong>schema</strong>(<a href="../Dagger/Json.html"><abbr title="Dagger\Json">Json</abbr></a> $json)
         </code>
@@ -2191,7 +2196,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_secret">
-        <div class="location">at line 445</div>
+        <div class="location">at line 449</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>secret</strong>(string $uri, string|null $cacheKey = null)
         </code>
@@ -2238,7 +2243,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_setSecret">
-        <div class="location">at line 460</div>
+        <div class="location">at line 464</div>
         <code>                    <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a>
     <strong>setSecret</strong>(string $name, string $plaintext)
         </code>
@@ -2285,7 +2290,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceDir">
-        <div class="location">at line 468</div>
+        <div class="location">at line 472</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>sourceDir</strong>()
         </code>
@@ -2318,7 +2323,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sourceMap">
-        <div class="location">at line 477</div>
+        <div class="location">at line 481</div>
         <code>                    <a href="../Dagger/SourceMap.html"><abbr title="Dagger\SourceMap">SourceMap</abbr></a>
     <strong>sourceMap</strong>(string $filename, int $line, int $column)
         </code>
@@ -2370,7 +2375,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sshfsVolume">
-        <div class="location">at line 489</div>
+        <div class="location">at line 493</div>
         <code>                    <a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a>
     <strong>sshfsVolume</strong>(string $endpoint, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $privateKey, <abbr title="Dagger\Dagger\Secret">Secret</abbr>|null $knownHosts = null, string|null $cacheKey = null, bool|null $insecureSkipHostKeyCheck = false, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $experimentalServiceHost = null)
         </code>
@@ -2437,7 +2442,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_typeDef">
-        <div class="location">at line 518</div>
+        <div class="location">at line 522</div>
         <code>                    <a href="../Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a>
     <strong>typeDef</strong>()
         </code>
@@ -2469,7 +2474,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_version">
-        <div class="location">at line 527</div>
+        <div class="location">at line 531</div>
         <code>                    string
     <strong>version</strong>()
         </code>
@@ -2501,7 +2506,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_with">
-        <div class="location">at line 536</div>
+        <div class="location">at line 540</div>
         <code>                    <a href="../Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a>
     <strong>with</strong>(<abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $sdkSourceDir = null)
         </code>

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -316,7 +316,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_from">from</a>(string $address, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
+                    <a href="#method_from">from</a>(string $address, string|null $version = &#039;&#039;, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         
                                             <p><p>Download a container image, and apply it to the container state. All previous state will be lost.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1811,7 +1811,7 @@
                     <h3 id="method_from">
         <div class="location">at line 291</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>from</strong>(string $address, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
+    <strong>from</strong>(string $address, string|null $version = &#039;&#039;, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         </code>
     </h3>
     <div class="details">    
@@ -1828,6 +1828,11 @@
                     <tr>
                 <td>string</td>
                 <td>$address</td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td>string|null</td>
+                <td>$version</td>
                 <td></td>
             </tr>
                     <tr>
@@ -1866,7 +1871,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_id">
-        <div class="location">at line 314</div>
+        <div class="location">at line 318</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -1898,7 +1903,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_imageRef">
-        <div class="location">at line 323</div>
+        <div class="location">at line 327</div>
         <code>                    string
     <strong>imageRef</strong>()
         </code>
@@ -1930,7 +1935,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_import">
-        <div class="location">at line 332</div>
+        <div class="location">at line 336</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>import</strong>(<a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $tag = &#039;&#039;)
         </code>
@@ -1977,7 +1982,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_label">
-        <div class="location">at line 345</div>
+        <div class="location">at line 349</div>
         <code>                    string
     <strong>label</strong>(string $name)
         </code>
@@ -2019,7 +2024,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_labels">
-        <div class="location">at line 355</div>
+        <div class="location">at line 359</div>
         <code>                    array
     <strong>labels</strong>()
         </code>
@@ -2051,7 +2056,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_layer">
-        <div class="location">at line 364</div>
+        <div class="location">at line 368</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>layer</strong>(string $id, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2103,7 +2108,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_manifest">
-        <div class="location">at line 383</div>
+        <div class="location">at line 387</div>
         <code>                    <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a>
     <strong>manifest</strong>(<abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null)
         </code>
@@ -2150,7 +2155,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_mounts">
-        <div class="location">at line 400</div>
+        <div class="location">at line 404</div>
         <code>                    array
     <strong>mounts</strong>()
         </code>
@@ -2182,7 +2187,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_platform">
-        <div class="location">at line 409</div>
+        <div class="location">at line 413</div>
         <code>                    <a href="../Dagger/Platform.html"><abbr title="Dagger\Platform">Platform</abbr></a>
     <strong>platform</strong>()
         </code>
@@ -2214,7 +2219,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_publish">
-        <div class="location">at line 420</div>
+        <div class="location">at line 424</div>
         <code>                    string
     <strong>publish</strong>(string $address, array|null $platformVariants = null, <abbr title="Dagger\Dagger\ImageLayerCompression">ImageLayerCompression</abbr>|null $forcedCompression = null, <abbr title="Dagger\Dagger\ImageMediaTypes">ImageMediaTypes</abbr>|null $mediaTypes = null, <abbr title="Dagger\Dagger\Service">Service</abbr>|null $registryService = null, <abbr title="Dagger\Dagger\RegistryProtocol">RegistryProtocol</abbr>|null $protocol = null, bool|null $insecureSkipTLSVerify = false)
         </code>
@@ -2286,7 +2291,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_rootfs">
-        <div class="location">at line 455</div>
+        <div class="location">at line 459</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
     <strong>rootfs</strong>()
         </code>
@@ -2318,7 +2323,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stat">
-        <div class="location">at line 464</div>
+        <div class="location">at line 468</div>
         <code>                    <abbr title="Dagger\Dagger\Stat">Stat</abbr>|null
     <strong>stat</strong>(string $path, bool|null $doNotFollowSymlinks = false)
         </code>
@@ -2365,7 +2370,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stderr">
-        <div class="location">at line 484</div>
+        <div class="location">at line 488</div>
         <code>                    string
     <strong>stderr</strong>()
         </code>
@@ -2397,7 +2402,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_stdout">
-        <div class="location">at line 495</div>
+        <div class="location">at line 499</div>
         <code>                    string
     <strong>stdout</strong>()
         </code>
@@ -2429,7 +2434,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_sync">
-        <div class="location">at line 506</div>
+        <div class="location">at line 510</div>
         <code>                    <a href="../Dagger/Syncer.html"><abbr title="Dagger\Syncer">Syncer</abbr></a>
     <strong>sync</strong>()
         </code>
@@ -2461,7 +2466,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_terminal">
-        <div class="location">at line 516</div>
+        <div class="location">at line 520</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>terminal</strong>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2513,7 +2518,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_up">
-        <div class="location">at line 539</div>
+        <div class="location">at line 543</div>
         <code>                    void
     <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -2590,7 +2595,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_user">
-        <div class="location">at line 580</div>
+        <div class="location">at line 584</div>
         <code>                    string
     <strong>user</strong>()
         </code>
@@ -2622,7 +2627,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withAnnotation">
-        <div class="location">at line 589</div>
+        <div class="location">at line 593</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withAnnotation</strong>(string $name, string $value)
         </code>
@@ -2669,7 +2674,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultArgs">
-        <div class="location">at line 600</div>
+        <div class="location">at line 604</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultArgs</strong>(array $args)
         </code>
@@ -2711,7 +2716,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDefaultTerminalCmd">
-        <div class="location">at line 610</div>
+        <div class="location">at line 614</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
@@ -2763,7 +2768,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDirectory">
-        <div class="location">at line 629</div>
+        <div class="location">at line 633</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, array|null $exclude = [], array|null $include = [], bool|null $gitignore = false, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false, int|null $permissions = null)
         </code>
@@ -2845,7 +2850,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withDockerHealthcheck">
-        <div class="location">at line 670</div>
+        <div class="location">at line 674</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withDockerHealthcheck</strong>(array $args, bool|null $shell = null, string|null $interval = null, string|null $timeout = null, string|null $startPeriod = null, string|null $startInterval = null, int|null $retries = null)
         </code>
@@ -2917,7 +2922,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEntrypoint">
-        <div class="location">at line 705</div>
+        <div class="location">at line 709</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEntrypoint</strong>(array $args, bool|null $keepDefaultArgs = false)
         </code>
@@ -2964,7 +2969,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvFileVariables">
-        <div class="location">at line 718</div>
+        <div class="location">at line 722</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvFileVariables</strong>(<a href="../Dagger/EnvFile.html"><abbr title="Dagger\EnvFile">EnvFile</abbr></a> $source)
         </code>
@@ -3006,7 +3011,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withEnvVariable">
-        <div class="location">at line 728</div>
+        <div class="location">at line 732</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withEnvVariable</strong>(string $name, string $value, bool|null $expand = false)
         </code>
@@ -3058,7 +3063,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withError">
-        <div class="location">at line 742</div>
+        <div class="location">at line 746</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withError</strong>(string $err)
         </code>
@@ -3100,7 +3105,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExec">
-        <div class="location">at line 752</div>
+        <div class="location">at line 756</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
@@ -3192,7 +3197,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withExposedPort">
-        <div class="location">at line 809</div>
+        <div class="location">at line 813</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null, string|null $description = null, bool|null $experimentalSkipHealthcheck = false)
         </code>
@@ -3257,7 +3262,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFile">
-        <div class="location">at line 832</div>
+        <div class="location">at line 836</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3324,7 +3329,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withFiles">
-        <div class="location">at line 861</div>
+        <div class="location">at line 865</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withFiles</strong>(string $path, array $sources, int|null $permissions = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3391,7 +3396,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withLabel">
-        <div class="location">at line 890</div>
+        <div class="location">at line 894</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withLabel</strong>(string $name, string $value)
         </code>
@@ -3438,7 +3443,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedCache">
-        <div class="location">at line 901</div>
+        <div class="location">at line 905</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedCache</strong>(string $path, <a href="../Dagger/CacheVolume.html"><abbr title="Dagger\CacheVolume">CacheVolume</abbr></a> $cache, <abbr title="Dagger\Dagger\Directory">Directory</abbr>|null $source = null, <abbr title="Dagger\Dagger\CacheSharingMode">CacheSharingMode</abbr>|null $sharing = null, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3510,7 +3515,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedDirectory">
-        <div class="location">at line 934</div>
+        <div class="location">at line 938</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedDirectory</strong>(string $path, <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3577,7 +3582,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedFile">
-        <div class="location">at line 963</div>
+        <div class="location">at line 967</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedFile</strong>(string $path, <a href="../Dagger/File.html"><abbr title="Dagger\File">File</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3639,7 +3644,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedSecret">
-        <div class="location">at line 988</div>
+        <div class="location">at line 992</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedSecret</strong>(string $path, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, int|null $mode = 256, bool|null $expand = false)
         </code>
@@ -3706,7 +3711,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedTemp">
-        <div class="location">at line 1017</div>
+        <div class="location">at line 1021</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedTemp</strong>(string $path, int|null $size = null, bool|null $expand = false)
         </code>
@@ -3758,7 +3763,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withMountedVolume">
-        <div class="location">at line 1033</div>
+        <div class="location">at line 1037</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withMountedVolume</strong>(string $path, <a href="../Dagger/Volume.html"><abbr title="Dagger\Volume">Volume</abbr></a> $volume, bool|null $readOnly = false, bool|null $expand = false)
         </code>
@@ -3815,7 +3820,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withNewFile">
-        <div class="location">at line 1054</div>
+        <div class="location">at line 1058</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withNewFile</strong>(string $path, string $contents, int|null $permissions = 420, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -3882,7 +3887,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRegistryAuth">
-        <div class="location">at line 1083</div>
+        <div class="location">at line 1087</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRegistryAuth</strong>(string $address, string $username, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -3934,7 +3939,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withRootfs">
-        <div class="location">at line 1095</div>
+        <div class="location">at line 1099</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withRootfs</strong>(<a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a> $directory)
         </code>
@@ -3976,7 +3981,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSecretVariable">
-        <div class="location">at line 1105</div>
+        <div class="location">at line 1109</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSecretVariable</strong>(string $name, <a href="../Dagger/Secret.html"><abbr title="Dagger\Secret">Secret</abbr></a> $secret)
         </code>
@@ -4023,7 +4028,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withServiceBinding">
-        <div class="location">at line 1122</div>
+        <div class="location">at line 1126</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withServiceBinding</strong>(string $alias, <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a> $service)
         </code>
@@ -4072,7 +4077,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withSymlink">
-        <div class="location">at line 1133</div>
+        <div class="location">at line 1137</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withSymlink</strong>(string $target, string $linkName, bool|null $expand = false)
         </code>
@@ -4124,7 +4129,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUnixSocket">
-        <div class="location">at line 1147</div>
+        <div class="location">at line 1151</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUnixSocket</strong>(string $path, <a href="../Dagger/Socket.html"><abbr title="Dagger\Socket">Socket</abbr></a> $source, string|null $owner = &#039;&#039;, bool|null $inheritOwner = false, bool|null $expand = false)
         </code>
@@ -4186,7 +4191,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withUser">
-        <div class="location">at line 1172</div>
+        <div class="location">at line 1176</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withUser</strong>(string $name)
         </code>
@@ -4228,7 +4233,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withVolatileVariable">
-        <div class="location">at line 1184</div>
+        <div class="location">at line 1188</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withVolatileVariable</strong>(string $name, string $value)
         </code>
@@ -4275,7 +4280,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withWorkdir">
-        <div class="location">at line 1195</div>
+        <div class="location">at line 1199</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withWorkdir</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4322,7 +4327,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutAnnotation">
-        <div class="location">at line 1208</div>
+        <div class="location">at line 1212</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutAnnotation</strong>(string $name)
         </code>
@@ -4364,7 +4369,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDefaultArgs">
-        <div class="location">at line 1218</div>
+        <div class="location">at line 1222</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDefaultArgs</strong>()
         </code>
@@ -4396,7 +4401,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDirectory">
-        <div class="location">at line 1227</div>
+        <div class="location">at line 1231</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDirectory</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4443,7 +4448,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutDockerHealthcheck">
-        <div class="location">at line 1240</div>
+        <div class="location">at line 1244</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutDockerHealthcheck</strong>()
         </code>
@@ -4475,7 +4480,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEntrypoint">
-        <div class="location">at line 1249</div>
+        <div class="location">at line 1253</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEntrypoint</strong>(bool|null $keepDefaultArgs = false)
         </code>
@@ -4517,7 +4522,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutEnvVariable">
-        <div class="location">at line 1261</div>
+        <div class="location">at line 1265</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutEnvVariable</strong>(string $name)
         </code>
@@ -4559,7 +4564,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutExposedPort">
-        <div class="location">at line 1271</div>
+        <div class="location">at line 1275</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutExposedPort</strong>(int $port, <abbr title="Dagger\Dagger\NetworkProtocol">NetworkProtocol</abbr>|null $protocol = null)
         </code>
@@ -4606,7 +4611,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFile">
-        <div class="location">at line 1284</div>
+        <div class="location">at line 1288</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFile</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4653,7 +4658,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutFiles">
-        <div class="location">at line 1297</div>
+        <div class="location">at line 1301</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutFiles</strong>(array $paths, bool|null $expand = false)
         </code>
@@ -4700,7 +4705,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutLabel">
-        <div class="location">at line 1310</div>
+        <div class="location">at line 1314</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutLabel</strong>(string $name)
         </code>
@@ -4742,7 +4747,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutMount">
-        <div class="location">at line 1320</div>
+        <div class="location">at line 1324</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutMount</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4789,7 +4794,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutRegistryAuth">
-        <div class="location">at line 1333</div>
+        <div class="location">at line 1337</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutRegistryAuth</strong>(string $address)
         </code>
@@ -4831,7 +4836,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutSecretVariable">
-        <div class="location">at line 1343</div>
+        <div class="location">at line 1347</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutSecretVariable</strong>(string $name)
         </code>
@@ -4873,7 +4878,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUnixSocket">
-        <div class="location">at line 1353</div>
+        <div class="location">at line 1357</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUnixSocket</strong>(string $path, bool|null $expand = false)
         </code>
@@ -4920,7 +4925,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutUser">
-        <div class="location">at line 1368</div>
+        <div class="location">at line 1372</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutUser</strong>()
         </code>
@@ -4952,7 +4957,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutVolatileVariable">
-        <div class="location">at line 1377</div>
+        <div class="location">at line 1381</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutVolatileVariable</strong>(string $name)
         </code>
@@ -4994,7 +4999,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withoutWorkdir">
-        <div class="location">at line 1389</div>
+        <div class="location">at line 1393</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
     <strong>withoutWorkdir</strong>()
         </code>
@@ -5026,7 +5031,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_workdir">
-        <div class="location">at line 1398</div>
+        <div class="location">at line 1402</div>
         <code>                    string
     <strong>workdir</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/GitRepository.html
+++ b/docs/static/reference/php/Dagger/GitRepository.html
@@ -216,7 +216,7 @@
                     <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_latest">latest</a>()
+                    <a href="#method_latest">latest</a>(string|null $version = &#039;&#039;)
         
                                             <p><p>Return the latest stable release tag, falling back to HEAD when no release exists.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -659,7 +659,7 @@
                     <h3 id="method_latest">
         <div class="location">at line 96</div>
         <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
-    <strong>latest</strong>()
+    <strong>latest</strong>(string|null $version = &#039;&#039;)
         </code>
     </h3>
     <div class="details">    
@@ -670,6 +670,16 @@
                             <p><p>Return the latest stable release tag, falling back to HEAD when no release exists.</p></p>                <p><p>Release selection accepts an optional &quot;v&quot; prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.</p></p>        
         </div>
         <div class="tags">
+                            <h4>Parameters</h4>
+
+                    <table class="table table-condensed">
+                    <tr>
+                <td>string|null</td>
+                <td>$version</td>
+                <td></td>
+            </tr>
+            </table>
+
             
                             <h4>Return Value</h4>
 
@@ -689,7 +699,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_ref">
-        <div class="location">at line 105</div>
+        <div class="location">at line 108</div>
         <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
     <strong>ref</strong>(string $name)
         </code>
@@ -731,7 +741,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tag">
-        <div class="location">at line 115</div>
+        <div class="location">at line 118</div>
         <code>                    <a href="../Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a>
     <strong>tag</strong>(string $name)
         </code>
@@ -773,7 +783,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_tags">
-        <div class="location">at line 125</div>
+        <div class="location">at line 128</div>
         <code>                    array
     <strong>tags</strong>(array|null $patterns = null)
         </code>
@@ -815,7 +825,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_uncommitted">
-        <div class="location">at line 137</div>
+        <div class="location">at line 140</div>
         <code>                    <a href="../Dagger/Changeset.html"><abbr title="Dagger\Changeset">Changeset</abbr></a>
     <strong>uncommitted</strong>()
         </code>
@@ -847,7 +857,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_url">
-        <div class="location">at line 146</div>
+        <div class="location">at line 149</div>
         <code>                    string
     <strong>url</strong>()
         </code>
@@ -879,7 +889,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_withBundle">
-        <div class="location">at line 155</div>
+        <div class="location">at line 158</div>
         <code>                    <a href="../Dagger/GitRepository.html"><abbr title="Dagger\GitRepository">GitRepository</abbr></a>
     <strong>withBundle</strong>(<a href="../Dagger/GitBundle.html"><abbr title="Dagger\GitBundle">GitBundle</abbr></a> $bundle, string|null $prerequisiteRef = &#039;&#039;)
         </code>

--- a/hack/designs/lockfile.md
+++ b/hack/designs/lockfile.md
@@ -234,9 +234,9 @@ Current core operation keys:
 
 | Operation | Required inputs | Optional inputs | Result |
 | --- | --- | --- | --- |
-| `oci-latest` | image name | registry transport | tag |
+| `oci-latest` | image name | registry transport, `version` | tag |
 | `oci-sha` | tagged image reference | registry transport | OCI digest |
-| `git-latest` | remote URL | `tagPrefix` | tag ref or canonical remote HEAD branch ref |
+| `git-latest` | remote URL | `tagPrefix`, `version` | tag ref or canonical remote HEAD branch ref |
 | `git-sha` | remote URL, ref | none | commit SHA |
 
 Notes:

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -518,6 +518,7 @@ defmodule Dagger.Client do
   Create a new module source instance from a source ref string
   """
   @spec module_source(t(), String.t(), [
+          {:version, String.t() | nil},
           {:ref_pin, String.t() | nil},
           {:disable_find_up, boolean() | nil},
           {:allow_not_exists, boolean() | nil},
@@ -528,6 +529,7 @@ defmodule Dagger.Client do
       client.query_builder
       |> QB.select("moduleSource")
       |> QB.put_arg("refString", ref_string)
+      |> QB.maybe_put_arg("version", optional_args[:version])
       |> QB.maybe_put_arg("refPin", optional_args[:ref_pin])
       |> QB.maybe_put_arg("disableFindUp", optional_args[:disable_find_up])
       |> QB.maybe_put_arg("allowNotExists", optional_args[:allow_not_exists])

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -370,6 +370,7 @@ defmodule Dagger.Container do
   Download a container image, and apply it to the container state. All previous state will be lost.
   """
   @spec from(t(), String.t(), [
+          {:version, String.t() | nil},
           {:registry_service, Dagger.Service.t() | nil},
           {:protocol, Dagger.RegistryProtocol.t() | nil},
           {:insecure_skip_tls_verify, boolean() | nil}
@@ -379,6 +380,7 @@ defmodule Dagger.Container do
       container.query_builder
       |> QB.select("from")
       |> QB.put_arg("address", address)
+      |> QB.maybe_put_arg("version", optional_args[:version])
       |> QB.maybe_put_arg(
         "registryService",
         if(optional_args[:registry_service],

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -122,10 +122,12 @@ defmodule Dagger.GitRepository do
 
   Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.
   """
-  @spec latest(t()) :: Dagger.GitRef.t()
-  def latest(%__MODULE__{} = git_repository) do
+  @spec latest(t(), [{:version, String.t() | nil}]) :: Dagger.GitRef.t()
+  def latest(%__MODULE__{} = git_repository, optional_args \\ []) do
     query_builder =
-      git_repository.query_builder |> QB.select("latest")
+      git_repository.query_builder
+      |> QB.select("latest")
+      |> QB.maybe_put_arg("version", optional_args[:version])
 
     %Dagger.GitRef{
       query_builder: query_builder,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1954,6 +1954,8 @@ func (r *Container) File(path string, opts ...ContainerFileOpts) *File {
 
 // ContainerFromOpts contains options for Container.From
 type ContainerFromOpts struct {
+	// Version query used to select an image tag. The address must not contain a tag or digest.
+	Version string
 	// Service to use as the registry endpoint for the image address.
 	//
 	// The service will be started only for this pull.
@@ -1970,6 +1972,10 @@ type ContainerFromOpts struct {
 func (r *Container) From(address string, opts ...ContainerFromOpts) *Container {
 	q := r.query.Select("from")
 	for i := len(opts) - 1; i >= 0; i-- {
+		// `version` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Version) {
+			q = q.Arg("version", opts[i].Version)
+		}
 		// `registryService` optional argument
 		if !querybuilder.IsZeroValue(opts[i].RegistryService) {
 			q = q.Arg("registryService", opts[i].RegistryService)
@@ -9451,11 +9457,23 @@ func (r *GitRepository) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
+// GitRepositoryLatestOpts contains options for GitRepository.Latest
+type GitRepositoryLatestOpts struct {
+	// Version query used to select the greatest matching release ref.
+	Version string
+}
+
 // Return the latest stable release tag, falling back to HEAD when no release exists.
 //
 // Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.
-func (r *GitRepository) Latest() *GitRef {
+func (r *GitRepository) Latest(opts ...GitRepositoryLatestOpts) *GitRef {
 	q := r.query.Select("latest")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `version` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Version) {
+			q = q.Arg("version", opts[i].Version)
+		}
+	}
 
 	return &GitRef{
 		query: q,
@@ -14036,6 +14054,8 @@ func (r *Query) Module() *Module {
 
 // ModuleSourceOpts contains options for Query.ModuleSource
 type ModuleSourceOpts struct {
+	// Version query for a Git module source.
+	Version string
 	// The pinned version of the module source
 	RefPin string
 	// If true, do not attempt to find a module config file in a parent directory of the provided path. Only relevant for local module sources.
@@ -14050,6 +14070,10 @@ type ModuleSourceOpts struct {
 func (r *Query) ModuleSource(refString string, opts ...ModuleSourceOpts) *ModuleSource {
 	q := r.query.Select("moduleSource")
 	for i := len(opts) - 1; i >= 0; i-- {
+		// `version` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Version) {
+			q = q.Arg("version", opts[i].Version)
+		}
 		// `refPin` optional argument
 		if !querybuilder.IsZeroValue(opts[i].RefPin) {
 			q = q.Arg("refPin", opts[i].RefPin)

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -392,6 +392,7 @@ class Client extends Client\AbstractClient implements Client\IdAble, Node
      */
     public function moduleSource(
         string $refString,
+        ?string $version = '',
         ?string $refPin = '',
         ?bool $disableFindUp = false,
         ?bool $allowNotExists = false,
@@ -399,6 +400,9 @@ class Client extends Client\AbstractClient implements Client\IdAble, Node
     ): ModuleSource {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('moduleSource');
         $innerQueryBuilder->setArgument('refString', $refString);
+        if (null !== $version) {
+        $innerQueryBuilder->setArgument('version', $version);
+        }
         if (null !== $refPin) {
         $innerQueryBuilder->setArgument('refPin', $refPin);
         }

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -290,12 +290,16 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
      */
     public function from(
         string $address,
+        ?string $version = '',
         ?Service $registryService = null,
         ?RegistryProtocol $protocol = null,
         ?bool $insecureSkipTLSVerify = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('from');
         $innerQueryBuilder->setArgument('address', $address);
+        if (null !== $version) {
+        $innerQueryBuilder->setArgument('version', $version);
+        }
         if (null !== $registryService) {
         $innerQueryBuilder->setArgument('registryService', $registryService);
         }

--- a/sdk/php/generated/GitRepository.php
+++ b/sdk/php/generated/GitRepository.php
@@ -93,9 +93,12 @@ class GitRepository extends Client\AbstractObject implements Client\IdAble, Node
      *
      * Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.
      */
-    public function latest(): GitRef
+    public function latest(?string $version = ''): GitRef
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('latest');
+        if (null !== $version) {
+        $innerQueryBuilder->setArgument('version', $version);
+        }
         return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1997,6 +1997,7 @@ class Container(Type):
         self,
         address: str,
         *,
+        version: str | None = "",
         registry_service: "Service | None" = None,
         protocol: RegistryProtocol | None = None,
         insecure_skip_tls_verify: bool | None = False,
@@ -2012,6 +2013,9 @@ class Container(Type):
             An address without a tag or digest selects the greatest stable
             release tag, falling back to the literal "latest" tag when no
             eligible release exists.
+        version:
+            Version query used to select an image tag. The address must not
+            contain a tag or digest.
         registry_service:
             Service to use as the registry endpoint for the image address.
             The service will be started only for this pull.
@@ -2024,6 +2028,7 @@ class Container(Type):
         """
         _args = [
             Arg("address", address),
+            Arg("version", version, ""),
             Arg("registryService", registry_service, None),
             Arg("protocol", protocol, None),
             Arg("insecureSkipTLSVerify", insecure_skip_tls_verify, False),
@@ -9030,14 +9035,21 @@ class GitRepository(Type):
         _ctx = self._select("id", _args)
         return await _ctx.execute(str)
 
-    def latest(self) -> GitRef:
+    def latest(self, *, version: str | None = "") -> GitRef:
         """Return the latest stable release tag, falling back to HEAD when no
         release exists.
 
         Release selection accepts an optional "v" prefix, incomplete versions,
         and zero-padded numeric components. This operation is pinned.
+
+        Parameters
+        ----------
+        version:
+            Version query used to select the greatest matching release ref.
         """
-        _args: list[Arg] = []
+        _args = [
+            Arg("version", version, ""),
+        ]
         _ctx = self._select("latest", _args)
         return GitRef(_ctx)
 
@@ -13335,6 +13347,7 @@ class Query(Root):
         self,
         ref_string: str,
         *,
+        version: str | None = "",
         ref_pin: str | None = "",
         disable_find_up: bool | None = False,
         allow_not_exists: bool | None = False,
@@ -13346,6 +13359,8 @@ class Query(Root):
         ----------
         ref_string:
             The string ref representation of the module source
+        version:
+            Version query for a Git module source.
         ref_pin:
             The pinned version of the module source
         disable_find_up:
@@ -13362,6 +13377,7 @@ class Query(Root):
         """
         _args = [
             Arg("refString", ref_string),
+            Arg("version", version, ""),
             Arg("refPin", ref_pin, ""),
             Arg("disableFindUp", disable_find_up, False),
             Arg("allowNotExists", allow_not_exists, False),

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1399,7 +1399,7 @@ pub struct ContainerFileOpts {
     pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct ContainerFromOpts {
+pub struct ContainerFromOpts<'a> {
     /// Allow HTTPS registry communication without verifying the server certificate.
     #[builder(setter(into, strip_option), default)]
     pub insecure_skip_tls_verify: Option<bool>,
@@ -1411,6 +1411,9 @@ pub struct ContainerFromOpts {
     /// The service will be started only for this pull.
     #[builder(setter(into, strip_option), default)]
     pub registry_service: Option<Id>,
+    /// Version query used to select an image tag. The address must not contain a tag or digest.
+    #[builder(setter(into, strip_option), default)]
+    pub version: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerImportOpts<'a> {
@@ -2269,9 +2272,16 @@ impl Container {
     ///
     /// An address without a tag or digest selects the greatest stable release tag, falling back to the literal "latest" tag when no eligible release exists.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn from_opts(&self, address: impl Into<String>, opts: ContainerFromOpts) -> Container {
+    pub fn from_opts<'a>(
+        &self,
+        address: impl Into<String>,
+        opts: ContainerFromOpts<'a>,
+    ) -> Container {
         let mut query = self.selection.select("from");
         query = query.arg("address", address.into());
+        if let Some(version) = opts.version {
+            query = query.arg("version", version);
+        }
         if let Some(registry_service) = opts.registry_service {
             query = query.arg("registryService", registry_service);
         }
@@ -9226,6 +9236,12 @@ pub struct GitRepositoryBundleOpts {
     pub base: Option<Id>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct GitRepositoryLatestOpts<'a> {
+    /// Version query used to select the greatest matching release ref.
+    #[builder(setter(into, strip_option), default)]
+    pub version: Option<&'a str>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct GitRepositoryTagsOpts<'a> {
     /// Glob patterns (e.g., "refs/tags/v*").
     #[builder(setter(into, strip_option), default)]
@@ -9401,8 +9417,29 @@ impl GitRepository {
     }
     /// Return the latest stable release tag, falling back to HEAD when no release exists.
     /// Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn latest(&self) -> GitRef {
         let query = self.selection.select("latest");
+        GitRef {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+    /// Return the latest stable release tag, falling back to HEAD when no release exists.
+    /// Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn latest_opts<'a>(&self, opts: GitRepositoryLatestOpts<'a>) -> GitRef {
+        let mut query = self.selection.select("latest");
+        if let Some(version) = opts.version {
+            query = query.arg("version", version);
+        }
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -12820,6 +12857,9 @@ pub struct QueryModuleSourceOpts<'a> {
     /// If set, error out if the ref string is not of the provided requireKind.
     #[builder(setter(into, strip_option), default)]
     pub require_kind: Option<ModuleSourceKind>,
+    /// Version query for a Git module source.
+    #[builder(setter(into, strip_option), default)]
+    pub version: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QuerySecretOpts<'a> {
@@ -13474,6 +13514,9 @@ impl Query {
     ) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
         query = query.arg("refString", ref_string.into());
+        if let Some(version) = opts.version {
+            query = query.arg("version", version);
+        }
         if let Some(ref_pin) = opts.ref_pin {
             query = query.arg("refPin", ref_pin);
         }

--- a/sdk/rust/crates/dagger-sdk/src/lib.rs
+++ b/sdk/rust/crates/dagger-sdk/src/lib.rs
@@ -67,6 +67,7 @@ mod tests {
             insecure_skip_tls_verify: Some(true),
             protocol: Some(RegistryProtocol::Https),
             registry_service: None,
+            version: None,
         };
         let publish_opts = ContainerPublishOpts {
             forced_compression: None,

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -394,6 +394,11 @@ export type ContainerFileOpts = {
 
 export type ContainerFromOpts = {
   /**
+   * Version query used to select an image tag. The address must not contain a tag or digest.
+   */
+  version?: string
+
+  /**
    * Service to use as the registry endpoint for the image address.
    *
    * The service will be started only for this pull.
@@ -1860,6 +1865,13 @@ export type GitRepositoryBundleOpts = {
   base?: GitRef
 }
 
+export type GitRepositoryLatestOpts = {
+  /**
+   * Version query used to select the greatest matching release ref.
+   */
+  version?: string
+}
+
 export type GitRepositoryTagsOpts = {
   /**
    * Glob patterns (e.g., "refs/tags/v*").
@@ -2653,6 +2665,11 @@ export type ClientLLMOpts = {
 }
 
 export type ClientModuleSourceOpts = {
+  /**
+   * Version query for a Git module source.
+   */
+  version?: string
+
   /**
    * The pinned version of the module source
    */
@@ -4712,6 +4729,7 @@ export class Container extends BaseClient {
    * @param address Address of the container image to download, in standard OCI ref format. Example: "registry.dagger.io/engine:latest".
    *
    * An address without a tag or digest selects the greatest stable release tag, falling back to the literal "latest" tag when no eligible release exists.
+   * @param opts.version Version query used to select an image tag. The address must not contain a tag or digest.
    * @param opts.registryService Service to use as the registry endpoint for the image address.
    *
    * The service will be started only for this pull.
@@ -10041,9 +10059,10 @@ export class GitRepository extends BaseClient {
    * Return the latest stable release tag, falling back to HEAD when no release exists.
    *
    * Release selection accepts an optional "v" prefix, incomplete versions, and zero-padded numeric components. This operation is pinned.
+   * @param opts.version Version query used to select the greatest matching release ref.
    */
-  latest = (): GitRef => {
-    const ctx = this._ctx.select("latest")
+  latest = (opts?: GitRepositoryLatestOpts): GitRef => {
+    const ctx = this._ctx.select("latest", { ...opts })
     return new GitRef(ctx)
   }
 
@@ -13586,6 +13605,7 @@ export class Client extends BaseClient {
   /**
    * Create a new module source instance from a source ref string
    * @param refString The string ref representation of the module source
+   * @param opts.version Version query for a Git module source.
    * @param opts.refPin The pinned version of the module source
    * @param opts.disableFindUp If true, do not attempt to find a module config file in a parent directory of the provided path. Only relevant for local module sources.
    * @param opts.allowNotExists If true, do not error out if the provided ref string is a local path and does not exist yet. Useful when initializing new modules in directories that don't exist yet.


### PR DESCRIPTION
Closes #14023.

## Summary

- Add an optional `version` query to `Container.from`, `GitRepository.latest`, and `Query.moduleSource`.
- Select the greatest matching stable release by default. Select a requested prerelease channel when the query contains one.
- For Git, check matching tags first. If no tag matches, check matching branches.
- Store the selected Git ref, Git commit, OCI tag, and OCI digest in `dagger.lock`.
- Keep module dependency configuration unchanged. Combined references such as `github.com/acme/tool@v1.2` continue to store the constraint in the source string.
- Keep exact non-SemVer module refs such as `@main` unchanged.
- Regenerate the API schema, SDK clients, and PHP reference in a separate `chore: regenerate` commit.

## API examples

```graphql
container {
  from(address: "alpine", version: "3.20") {
    imageRef
  }
}

git(url: "https://github.com/acme/tool") {
  latest(version: "v1.2") {
    ref
    commit
  }
}

moduleSource(
  refString: "github.com/acme/tool"
  version: "v1.2"
) {
  version
  commit
}
```

## Conflicting selectors

`Container.from` returns an error when `version` is set and `address` already contains a tag or digest.

```graphql
container {
  from(address: "alpine:3.20", version: "3.20") {
    imageRef
  }
}
```

`Query.moduleSource` returns an error when `version` is set and `refString` already contains an `@version` suffix.

```graphql
moduleSource(
  refString: "github.com/acme/tool@v1.2.3"
  version: "v1.2"
) {
  commit
}
```

`GitRepository.latest` does not have this conflict. Its repository URL and selected ref are separate API values.

## Compatibility notes

The existing `container.from(address: "alpine:3.20")` API does not change. The new `version` argument requires an address without a tag or digest.

The generated PHP methods put `version` before existing optional parameters. This breaks calls that pass those optional parameters by position. Supported PHP versions have named arguments, and callers can use them to select later optional parameters.

This PR does not add a `version` key to `dagger-module.toml` or `dagger.toml`. A separate module configuration field is deferred to the dependency-management work.

## Tests

- `dagger generate -y`
- `go test ./core ./core/modules ./core/workspace ./core/schema`
- `(cd sdk/go && go test ./...)`
- `python3 -m compileall -q sdk/python/src/dagger/client/gen.py`
- `dagger api call engine-dev test --pkg ./core/integration --run="TestLockfile/Test(GitLatestVersionQueryCreatesPin|OCIVersionQueryCreatesPin|OCIVersionQueryRejectsTaggedAddress)"`
