### PR TITLE
feat(core): https redirect mechanism for module refs (dagger-get)

### DIFF
--- a/.changes/unreleased/Added-20260901-190000.yaml
+++ b/.changes/unreleased/Added-20260901-190000.yaml
@@ -1,0 +1,15 @@
+kind: Added
+body: |
+  Module refs now support an https redirect mechanism: when resolving an https
+  (or schemeless) module ref, the engine probes `<ref>?dagger-get=1` and, if the
+  host answers with a single 3xx redirect to an absolute https `Location`,
+  resolution continues at that destination. Any `@version`/`@sha` suffix is
+  stripped before the probe and re-appended to the destination. This lets vanity
+  domains point `dagger install` (and all module-source resolution) at the real
+  repository, independent of git-protocol redirects. Redirect resolution runs
+  only when session infrastructure is available and its result is cached per
+  session.
+time: 2026-09-01T19:00:00Z
+custom:
+  Author: marcosnils
+  PR: ""

--- a/.changes/unreleased/Added-20260901-190000.yaml
+++ b/.changes/unreleased/Added-20260901-190000.yaml
@@ -1,15 +1,24 @@
 kind: Added
 body: |
-  Module refs now support an https redirect mechanism: when resolving an https
-  (or schemeless) module ref, the engine probes `<ref>?dagger-get=1` and, if the
-  host answers with a single 3xx redirect to an absolute https `Location`,
-  resolution continues at that destination. Any `@version`/`@sha` suffix is
-  stripped before the probe and re-appended to the destination. This lets vanity
-  domains point `dagger install` (and all module-source resolution) at the real
-  repository, independent of git-protocol redirects. Redirect resolution runs
-  only when session infrastructure is available and its result is cached per
-  session.
+  Module and workspace refs now support an https vanity-URL redirect mechanism:
+  when resolving an https (or schemeless) ref, the engine probes
+  `<ref>?dagger-get=1` and, if the host answers with a single 3xx redirect to an
+  absolute https `Location` that echoes the `dagger-get=1` marker, resolution
+  continues at that destination (with only the `dagger-get` param stripped).
+  Any `@version`/`@sha` suffix is stripped before the probe and re-applied to
+  the destination; a version supplied by the redirect acts as a default that an
+  explicit caller version overrides. Redirects that do not echo the marker
+  (e.g. auth walls) or that merely canonicalize the same repository URL
+  (e.g. `repo.git` -> `repo`) are ignored.
+
+  Successful resolutions are recorded as `vanity-url` entries in the workspace
+  lockfile (keyed by the https source URL, shared by schemeless and explicit
+  refs) and are re-used from the lock thereafter; a server-side redirect change
+  takes effect on `dagger update`, which refreshes the entries and fails if a
+  locked vanity URL no longer returns a valid redirect. Without a lock entry,
+  results are cached per session. Resolution runs only when session
+  infrastructure is available; git-protocol, ssh, and http refs are untouched.
 time: 2026-09-01T19:00:00Z
 custom:
-  Author: marcosnils
+  Author: marcosnils tiborvass
   PR: ""

--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -226,6 +226,19 @@ func isSCPLike(ref string) bool {
 	return strings.Contains(ref, ":") && !strings.Contains(ref, "//")
 }
 
+// Scheme classifies the transport scheme of a ref string, including SCP-like
+// ("git@host:path") refs. It is a pure, network-free helper so callers can
+// decide eligibility (e.g. for the https-only dagger-get redirect probe)
+// without importing the engine.
+func Scheme(refString string) SchemeType {
+	refString = strings.Replace(refString, "#", "@", 1)
+	scheme, schemeless := parseScheme(refString)
+	if scheme == NoScheme && isSCPLike(schemeless) {
+		return SchemeSCPLike
+	}
+	return scheme
+}
+
 func parseScheme(refString string) (SchemeType, string) {
 	schemes := []SchemeType{
 		SchemeHTTP,

--- a/core/lockfile_update.go
+++ b/core/lockfile_update.go
@@ -171,18 +171,43 @@ func selectedSHAEntry(
 }
 
 func updateWorkspaceLockEntry(ctx context.Context, query *Query, entry workspace.LookupEntry) (string, error) {
-	switch {
-	case entry.Namespace == workspace.CoreLockNamespace && entry.Operation == workspace.LockOperationOCILatest:
+	if entry.Namespace != workspace.CoreLockNamespace {
+		return "", fmt.Errorf("unsupported lock entry %q %q", entry.Namespace, entry.Operation)
+	}
+
+	switch entry.Operation {
+	case workspace.LockOperationOCILatest:
 		return updateOCILatestLockEntry(ctx, query, entry)
-	case entry.Namespace == workspace.CoreLockNamespace && entry.Operation == workspace.LockOperationOCISHA:
+	case workspace.LockOperationOCISHA:
 		return updateOCISHALockEntry(ctx, query, entry)
-	case entry.Namespace == workspace.CoreLockNamespace && entry.Operation == workspace.LockOperationGitLatest:
+	case workspace.LockOperationGitLatest:
 		return updateGitLatestLockEntry(ctx, entry)
-	case entry.Namespace == workspace.CoreLockNamespace && entry.Operation == workspace.LockOperationGitSHA:
+	case workspace.LockOperationGitSHA:
 		return updateGitSHALockEntry(ctx, entry)
+	case workspace.LockOperationVanityURL:
+		return updateVanityURLLockEntry(ctx, entry)
 	default:
 		return "", fmt.Errorf("unsupported lock entry %q %q", entry.Namespace, entry.Operation)
 	}
+}
+
+func updateVanityURLLockEntry(ctx context.Context, entry workspace.LookupEntry) (string, error) {
+	required, options, err := workspace.ParseLookupInputs(entry.Inputs)
+	if err != nil {
+		return "", fmt.Errorf("invalid %s inputs %v: %w", entry.Operation, entry.Inputs, err)
+	}
+	if len(required) != 1 || len(options) != 0 {
+		return "", fmt.Errorf("invalid %s inputs %v", entry.Operation, entry.Inputs)
+	}
+	sourceURL, ok := required[0].(string)
+	if !ok || sourceURL == "" {
+		return "", fmt.Errorf("invalid %s source URL %v", entry.Operation, required[0])
+	}
+	resolved := daggerGetProbe(ctx, sourceURL)
+	if resolved == sourceURL {
+		return "", fmt.Errorf("refresh vanity-url %q: no valid redirect received", sourceURL)
+	}
+	return resolved, nil
 }
 
 type ociLockInputs struct {

--- a/core/lockfile_update_test.go
+++ b/core/lockfile_update_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dagger/dagger/core/workspace"
@@ -18,6 +20,101 @@ func TestUpdateWorkspaceLockEntry(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `unsupported lock entry "acme" "resolve"`)
+}
+
+func TestUpdateVanityURLLockEntry(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://github.com/dagger/dagger?dagger-get=1", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	sourceURL := "https://" + srv.Listener.Addr().String() + "/go"
+	lock := workspace.NewLock()
+	require.NoError(t, lock.SetLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationVanityURL,
+		[]any{sourceURL},
+		"https://github.com/old/repository",
+	))
+
+	require.NoError(t, UpdateWorkspaceLock(t.Context(), nil, lock))
+	resolved, ok := lock.GetLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationVanityURL,
+		[]any{sourceURL},
+	)
+	require.True(t, ok)
+	require.Equal(t, "https://github.com/dagger/dagger", resolved)
+}
+
+func TestUpdateVanityURLLockEntryValidatesInputs(t *testing.T) {
+	for _, inputs := range [][]any{
+		nil,
+		{42},
+		{""},
+		{"https://example.com/source", "extra"},
+		workspace.LookupInputs(
+			[]any{"https://example.com/source"},
+			workspace.LookupOption{Name: "other", Value: true},
+		),
+	} {
+		_, err := updateVanityURLLockEntry(t.Context(), workspace.LookupEntry{
+			Operation: workspace.LockOperationVanityURL,
+			Inputs:    inputs,
+		})
+		require.Error(t, err)
+	}
+}
+
+func TestUpdateVanityURLLockEntryPreservesMappingOnFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		status   int
+		location string
+		cancel   bool
+	}{
+		{name: "server error", status: http.StatusInternalServerError},
+		{name: "not a redirect", status: http.StatusOK},
+		{name: "missing location", status: http.StatusTemporaryRedirect},
+		{name: "invalid location", status: http.StatusTemporaryRedirect, location: "http://example.com/repo?dagger-get=1"},
+		{name: "cancelled request", status: http.StatusTemporaryRedirect, cancel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", tc.location)
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+			oldClient := daggerGetClient
+			daggerGetClient = srv.Client()
+			daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+			defer func() { daggerGetClient = oldClient }()
+
+			lock := workspace.NewLock()
+			inputs := []any{srv.URL + "/go"}
+			previous := "https://github.com/dagger/dagger@v1.2.3"
+			require.NoError(t, lock.SetLookup(workspace.CoreLockNamespace, workspace.LockOperationVanityURL, inputs, previous))
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
+			err := UpdateWorkspaceLock(ctx, nil, lock)
+			require.ErrorContains(t, err, "no valid redirect received")
+			actual, ok := lock.GetLookup(workspace.CoreLockNamespace, workspace.LockOperationVanityURL, inputs)
+			require.True(t, ok)
+			require.Equal(t, previous, actual)
+		})
+	}
 }
 
 func TestSelectedSHAEntry(t *testing.T) {

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -68,7 +68,7 @@ func ParseRefString(
 			},
 		}, nil
 	case ModuleSourceKindGit:
-		refString = resolveDaggerGetRedirect(ctx, refString)
+		refString = ResolveDaggerGetRedirect(ctx, refString)
 		parsedGitRef, err := ParseGitRefString(ctx, refString)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse git ref string: %w", err)
@@ -92,7 +92,7 @@ func ParseRefString(
 	}
 
 	// Parse scheme and attempt to parse as git endpoint
-	refString = resolveDaggerGetRedirect(ctx, refString)
+	refString = ResolveDaggerGetRedirect(ctx, refString)
 	parsedGitRef, err := ParseGitRefString(ctx, refString)
 	switch {
 	case err == nil:

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -68,7 +68,10 @@ func ParseRefString(
 			},
 		}, nil
 	case ModuleSourceKindGit:
-		refString = ResolveDaggerGetRedirect(ctx, refString)
+		refString, err := ResolveDaggerGetRedirect(ctx, refString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve module ref string: %w", err)
+		}
 		parsedGitRef, err := ParseGitRefString(ctx, refString)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse git ref string: %w", err)
@@ -92,7 +95,10 @@ func ParseRefString(
 	}
 
 	// Parse scheme and attempt to parse as git endpoint
-	refString = ResolveDaggerGetRedirect(ctx, refString)
+	refString, err := ResolveDaggerGetRedirect(ctx, refString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve module ref string: %w", err)
+	}
 	parsedGitRef, err := ParseGitRefString(ctx, refString)
 	switch {
 	case err == nil:

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -68,6 +68,7 @@ func ParseRefString(
 			},
 		}, nil
 	case ModuleSourceKindGit:
+		refString = resolveDaggerGetRedirect(ctx, refString)
 		parsedGitRef, err := ParseGitRefString(ctx, refString)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse git ref string: %w", err)
@@ -91,6 +92,7 @@ func ParseRefString(
 	}
 
 	// Parse scheme and attempt to parse as git endpoint
+	refString = resolveDaggerGetRedirect(ctx, refString)
 	parsedGitRef, err := ParseGitRefString(ctx, refString)
 	switch {
 	case err == nil:

--- a/core/modulerefs_redirect.go
+++ b/core/modulerefs_redirect.go
@@ -53,7 +53,7 @@ func ResolveDaggerGetRedirect(ctx context.Context, refString string) (string, er
 
 	sourceURL, version, err := splitSourceURLVersion(refString)
 	if err != nil {
-		return refString, nil
+		return refString, nil //nolint:nilerr // deliberate: unparseable refs fall back to the original ref
 	}
 
 	lock, lockOverridden := ctx.Value(vanityURLLookupLockKey{}).(*workspace.Lock)
@@ -97,7 +97,7 @@ func ResolveDaggerGetRedirect(ctx context.Context, refString string) (string, er
 	cache, cacheErr := dagql.EngineCache(ctx)
 	clientMetadata, mdErr := engine.ClientMetadataFromContext(ctx)
 	if cacheErr != nil || mdErr != nil {
-		return refString, nil
+		return refString, nil //nolint:nilerr // deliberate: no session infrastructure means no probe, keep parsing network-free
 	}
 
 	res, err := cache.GetOrInitArbitrary(

--- a/core/modulerefs_redirect.go
+++ b/core/modulerefs_redirect.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/dagger/dagger/core/gitref"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/slog"
@@ -33,29 +35,69 @@ var daggerGetClient = &http.Client{
 	},
 }
 
-// ResolveDaggerGetRedirect implements the module redirect mechanism: for https
-// (or schemeless, attempted over https) module refs, it fetches
-// "<ref>?dagger-get=1" and, if the host answers with a single 3xx pointing at
-// an absolute https Location, continues resolution with that destination. Any
-// "@version"/"@sha" suffix is stripped before the probe and re-appended to the
-// destination. Git-protocol, http, and ssh refs are left untouched.
-//
-// On any non-redirect outcome (non-3xx status, missing/invalid Location,
-// timeout, or transport error) it falls back to the original ref. The result is
-// cached per session so a ref is probed at most once per session.
-//
-// Redirect resolution requires session infrastructure (engine cache + client
-// metadata). When either is unavailable the ref is returned untouched and no
-// network probe is issued, so standalone/offline ref parsing stays network-free.
-func ResolveDaggerGetRedirect(ctx context.Context, refString string) string {
+type vanityURLLookupLockKey struct{}
+
+// ContextWithVanityURLLookupLock makes an explicitly loaded workspace lock
+// available while resolving module sources for a workspace overlay.
+func ContextWithVanityURLLookupLock(ctx context.Context, lock *workspace.Lock) context.Context {
+	return context.WithValue(ctx, vanityURLLookupLockKey{}, lock)
+}
+
+// ResolveDaggerGetRedirect resolves a dagger-get vanity URL for any Git-backed
+// source consumer, including both modules and workspaces. It first consults the
+// workspace lockfile, then falls back to the session-cached HTTP probe.
+func ResolveDaggerGetRedirect(ctx context.Context, refString string) (string, error) {
 	if !daggerGetEligible(refString) {
-		return refString
+		return refString, nil
+	}
+
+	sourceURL, version, err := splitSourceURLVersion(refString)
+	if err != nil {
+		return refString, nil
+	}
+
+	lock, lockOverridden := ctx.Value(vanityURLLookupLockKey{}).(*workspace.Lock)
+	var setLookup func(string, string, []any, string) error
+	query, queryErr := CurrentQuery(ctx)
+	if lockOverridden {
+		setLookup = lock.SetLookup
+	} else if queryErr == nil {
+		var ok bool
+		lock, ok, err = query.CurrentWorkspaceLock(ctx, false)
+		if err != nil {
+			return "", fmt.Errorf("vanity-url lockfile: %w", err)
+		}
+		if !ok {
+			lock = nil
+		}
+	}
+
+	lockInputs := []any{sourceURL}
+	if lock != nil {
+		if resolvedURL, ok := lock.GetLookup(
+			workspace.CoreLockNamespace,
+			workspace.LockOperationVanityURL,
+			lockInputs,
+		); ok {
+			return sourceURLWithVersion(resolvedURL, version), nil
+		}
+		if !lockOverridden && queryErr == nil {
+			_, lockWritable, err := query.CurrentWorkspaceLock(ctx, true)
+			if err != nil {
+				return "", fmt.Errorf("vanity-url lockfile: %w", err)
+			}
+			if lockWritable {
+				setLookup = func(namespace, operation string, inputs []any, value string) error {
+					return query.SetCurrentWorkspaceLookup(ctx, namespace, operation, inputs, value)
+				}
+			}
+		}
 	}
 
 	cache, cacheErr := dagql.EngineCache(ctx)
 	clientMetadata, mdErr := engine.ClientMetadataFromContext(ctx)
 	if cacheErr != nil || mdErr != nil {
-		return refString
+		return refString, nil
 	}
 
 	res, err := cache.GetOrInitArbitrary(
@@ -64,19 +106,82 @@ func ResolveDaggerGetRedirect(ctx context.Context, refString string) string {
 		// Scope the cached value to the session: GetOrInitArbitrary looks entries
 		// up by call key alone (the session ID only tracks ownership), so the
 		// session ID must be part of the key to keep results session-private.
-		"module-dagger-get-redirect:"+clientMetadata.SessionID+":"+refString,
+		"module-dagger-get-redirect:"+clientMetadata.SessionID+":"+sourceURL,
 		func(ctx context.Context) (any, error) {
-			return daggerGetProbe(ctx, refString), nil
+			return daggerGetProbe(ctx, sourceURL), nil
 		},
 	)
+	var resolvedRef string
 	if err != nil {
 		slog.Debug("dagger-get redirect cache error; probing directly", "ref", refString, "error", err)
-		return daggerGetProbe(ctx, refString)
+		resolvedRef = daggerGetProbe(ctx, sourceURL)
+	} else if resolved, ok := res.Value().(string); ok && resolved != "" {
+		resolvedRef = resolved
+	} else {
+		resolvedRef = sourceURL
 	}
-	if resolved, ok := res.Value().(string); ok && resolved != "" {
-		return resolved
+
+	if resolvedRef == sourceURL {
+		return refString, nil
 	}
-	return refString
+	if setLookup == nil {
+		return sourceURLWithVersion(resolvedRef, version), nil
+	}
+	// Store the destination before applying the caller's version. A version in
+	// the redirect is its default and must survive later lookups and refreshes.
+	if err := setLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationVanityURL,
+		lockInputs,
+		resolvedRef,
+	); err != nil {
+		return "", fmt.Errorf("set vanity-url lock entry: %w", err)
+	}
+	return sourceURLWithVersion(resolvedRef, version), nil
+}
+
+func splitSourceURLVersion(refString string) (string, string, error) {
+	normalized := strings.Replace(refString, "#", "@", 1)
+	if !strings.HasPrefix(normalized, gitref.SchemeHTTPS.Prefix()) {
+		normalized = gitref.SchemeHTTPS.Prefix() + normalized
+	}
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return "", "", err
+	}
+	version := ""
+	if i := strings.Index(u.Path, "@"); i >= 0 {
+		version = u.Path[i+1:]
+		u.Path = u.Path[:i]
+	}
+	// Keep the scheme so schemeless and HTTPS refs share one lockfile key.
+	return u.String(), version, nil
+}
+
+func sourceURLWithVersion(sourceURL, version string) string {
+	if version == "" {
+		return sourceURL
+	}
+	schemeless := !strings.HasPrefix(sourceURL, gitref.SchemeHTTPS.Prefix())
+	parsedURL := sourceURL
+	if schemeless {
+		parsedURL = gitref.SchemeHTTPS.Prefix() + parsedURL
+	}
+	u, err := url.Parse(parsedURL)
+	if err != nil {
+		return sourceURL + "@" + version
+	}
+	// An explicit caller version overrides a default supplied by the redirect.
+	u.Fragment = ""
+	if i := strings.Index(u.Path, "@"); i >= 0 {
+		u.Path = u.Path[:i]
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/") + "@" + version
+	resolved := u.String()
+	if schemeless {
+		resolved = strings.TrimPrefix(resolved, gitref.SchemeHTTPS.Prefix())
+	}
+	return resolved
 }
 
 // daggerGetEligible reports whether the redirect probe applies to refString.
@@ -187,17 +292,7 @@ func daggerGetProbe(ctx context.Context, refString string) string {
 	q.Del(daggerGetQueryParam)
 	locURL.RawQuery = q.Encode()
 
-	// Re-append the version into the destination path (before any query) so the
-	// downstream git-ref parser reads it as a version, not a query value.
-	if version != "" {
-		base := strings.TrimSuffix(locURL.Path, "/")
-		if base == "" {
-			base = "/"
-		}
-		locURL.Path = base + "@" + version
-	}
-
-	resolved := locURL.String()
+	resolved := sourceURLWithVersion(locURL.String(), version)
 	slog.Debug("dagger-get redirect resolved", "from", refString, "to", resolved)
 	return resolved
 }

--- a/core/modulerefs_redirect.go
+++ b/core/modulerefs_redirect.go
@@ -1,0 +1,216 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/dagger/dagger/core/gitref"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/slog"
+)
+
+const (
+	// daggerGetQueryParam is the query flag appended to a module ref to probe
+	// for a redirect that points at the real module source.
+	daggerGetQueryParam = "dagger-get"
+
+	// daggerGetProbeTimeout bounds the redirect probe so a slow or hanging host
+	// cannot block module resolution.
+	daggerGetProbeTimeout = 5 * time.Second
+)
+
+// daggerGetClient issues the redirect probe. It never follows redirects itself:
+// we must read the Location header and rewrite it (stripping dagger-get,
+// re-appending any version) before continuing resolution.
+var daggerGetClient = &http.Client{
+	Timeout: daggerGetProbeTimeout,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// resolveDaggerGetRedirect implements the module redirect mechanism: for https
+// (or schemeless, attempted over https) module refs, it fetches
+// "<ref>?dagger-get=1" and, if the host answers with a single 3xx pointing at
+// an absolute https Location, continues resolution with that destination. Any
+// "@version"/"@sha" suffix is stripped before the probe and re-appended to the
+// destination. Git-protocol, http, and ssh refs are left untouched.
+//
+// On any non-redirect outcome (non-3xx status, missing/invalid Location,
+// timeout, or transport error) it falls back to the original ref. The result is
+// cached per session so a ref is probed at most once per session.
+//
+// Redirect resolution requires session infrastructure (engine cache + client
+// metadata). When either is unavailable the ref is returned untouched and no
+// network probe is issued, so standalone/offline ref parsing stays network-free.
+func resolveDaggerGetRedirect(ctx context.Context, refString string) string {
+	if !daggerGetEligible(refString) {
+		return refString
+	}
+
+	cache, cacheErr := dagql.EngineCache(ctx)
+	clientMetadata, mdErr := engine.ClientMetadataFromContext(ctx)
+	if cacheErr != nil || mdErr != nil {
+		return refString
+	}
+
+	res, err := cache.GetOrInitArbitrary(
+		ctx,
+		clientMetadata.SessionID,
+		// Scope the cached value to the session: GetOrInitArbitrary looks entries
+		// up by call key alone (the session ID only tracks ownership), so the
+		// session ID must be part of the key to keep results session-private.
+		"module-dagger-get-redirect:"+clientMetadata.SessionID+":"+refString,
+		func(ctx context.Context) (any, error) {
+			return daggerGetProbe(ctx, refString), nil
+		},
+	)
+	if err != nil {
+		slog.Debug("dagger-get redirect cache error; probing directly", "ref", refString, "error", err)
+		return daggerGetProbe(ctx, refString)
+	}
+	if resolved, ok := res.Value().(string); ok && resolved != "" {
+		return resolved
+	}
+	return refString
+}
+
+// daggerGetEligible reports whether the redirect probe applies to refString.
+// Only https and schemeless refs qualify; local paths, SCP-like refs, and
+// explicit non-https schemes (http, ssh, git) are excluded.
+func daggerGetEligible(refString string) bool {
+	if refString == "" || refString[0] == '/' || refString[0] == '.' {
+		return false
+	}
+	if strings.Contains(refString, "://") && !strings.HasPrefix(refString, gitref.SchemeHTTPS.Prefix()) {
+		return false
+	}
+	switch gitref.Scheme(refString) {
+	case gitref.SchemeHTTPS:
+		return true
+	case gitref.NoScheme:
+		// Schemeless refs are attempted over https; require a hostname with a
+		// dot so we don't probe obvious non-URLs.
+		host := refString
+		if i := strings.IndexAny(host, "/@:"); i >= 0 {
+			host = host[:i]
+		}
+		return strings.Contains(host, ".")
+	default:
+		return false
+	}
+}
+
+// daggerGetProbe performs the actual single-hop redirect probe and returns the
+// resolved ref, or the original ref on any non-redirect outcome.
+func daggerGetProbe(ctx context.Context, refString string) string {
+	// Module refs spell versions with "@" (and historically "#"); normalize so
+	// url.Parse doesn't treat a version as a URL fragment.
+	normalized := strings.Replace(refString, "#", "@", 1)
+	if !strings.HasPrefix(normalized, gitref.SchemeHTTPS.Prefix()) {
+		normalized = gitref.SchemeHTTPS.Prefix() + normalized
+	}
+
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return refString
+	}
+
+	// Strip a path-level "@version"; userinfo "@" stays in u.User, not u.Path.
+	version := ""
+	if i := strings.Index(u.Path, "@"); i >= 0 {
+		version = u.Path[i+1:]
+		u.Path = u.Path[:i]
+	}
+
+	probe := *u
+	probe.RawQuery = daggerGetQueryParam + "=1"
+	probe.Fragment = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probe.String(), nil)
+	if err != nil {
+		return refString
+	}
+	resp, err := daggerGetClient.Do(req)
+	if err != nil {
+		slog.Debug("dagger-get probe failed; using original ref", "url", probe.String(), "error", err)
+		return refString
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusMultipleChoices || resp.StatusCode >= http.StatusBadRequest {
+		// Not a 3xx: no redirect configured for this ref.
+		return refString
+	}
+
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return refString
+	}
+	locURL, err := url.Parse(loc)
+	if err != nil || locURL.Scheme != "https" || locURL.Host == "" {
+		slog.Debug("dagger-get redirect ignored: Location is not an absolute https URL",
+			"ref", refString, "location", loc)
+		return refString
+	}
+
+	// Hosts also emit incidental 3xx responses that are not dagger-get
+	// opt-ins: auth walls (e.g. GitLab 302s unauthenticated repo paths to
+	// /users/sign_in, dropping the query string) and same-repo URL
+	// canonicalization. Require the Location to echo the dagger-get marker as
+	// proof of intent: a host opting in preserves the query (standard
+	// path+query passthrough redirects do), while auth-wall redirects drop it.
+	if locURL.Query().Get(daggerGetQueryParam) != "1" {
+		slog.Debug("dagger-get redirect ignored: Location does not echo the dagger-get marker",
+			"ref", refString, "location", loc)
+		return refString
+	}
+
+	// Canonicalization redirects (e.g. GitHub 301s "repo.git" -> "repo",
+	// "www." -> apex, trailing-slash and case fixups) echo the query string,
+	// so they pass the marker check above. Treating them as redirects would
+	// silently rewrite the user's ref and change the module's clone
+	// ref/identity. Only honor redirects that point somewhere genuinely
+	// different.
+	if canonicalRepoKey(u) == canonicalRepoKey(locURL) {
+		slog.Debug("dagger-get redirect ignored: same-repo canonicalization",
+			"ref", refString, "location", loc)
+		return refString
+	}
+
+	// Drop only the dagger-get param the server may have echoed back.
+	q := locURL.Query()
+	q.Del(daggerGetQueryParam)
+	locURL.RawQuery = q.Encode()
+
+	// Re-append the version into the destination path (before any query) so the
+	// downstream git-ref parser reads it as a version, not a query value.
+	if version != "" {
+		base := strings.TrimSuffix(locURL.Path, "/")
+		if base == "" {
+			base = "/"
+		}
+		locURL.Path = base + "@" + version
+	}
+
+	resolved := locURL.String()
+	slog.Debug("dagger-get redirect resolved", "from", refString, "to", resolved)
+	return resolved
+}
+
+// canonicalRepoKey reduces a URL to a host+path key that is stable across the
+// common canonicalization redirects hosts emit for the same repository:
+// case-only differences, a leading "www.", a ".git" suffix, and trailing
+// slashes.
+func canonicalRepoKey(u *url.URL) string {
+	host := strings.ToLower(u.Host)
+	host = strings.TrimPrefix(host, "www.")
+	path := strings.ToLower(u.Path)
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	return host + path
+}

--- a/core/modulerefs_redirect.go
+++ b/core/modulerefs_redirect.go
@@ -33,7 +33,7 @@ var daggerGetClient = &http.Client{
 	},
 }
 
-// resolveDaggerGetRedirect implements the module redirect mechanism: for https
+// ResolveDaggerGetRedirect implements the module redirect mechanism: for https
 // (or schemeless, attempted over https) module refs, it fetches
 // "<ref>?dagger-get=1" and, if the host answers with a single 3xx pointing at
 // an absolute https Location, continues resolution with that destination. Any
@@ -47,7 +47,7 @@ var daggerGetClient = &http.Client{
 // Redirect resolution requires session infrastructure (engine cache + client
 // metadata). When either is unavailable the ref is returned untouched and no
 // network probe is issued, so standalone/offline ref parsing stays network-free.
-func resolveDaggerGetRedirect(ctx context.Context, refString string) string {
+func ResolveDaggerGetRedirect(ctx context.Context, refString string) string {
 	if !daggerGetEligible(refString) {
 		return refString
 	}

--- a/core/modulerefs_redirect_test.go
+++ b/core/modulerefs_redirect_test.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
@@ -183,11 +185,17 @@ func TestResolveDaggerGetRedirectCachesPerSession(t *testing.T) {
 	ctxA := ctxForSession("session-a")
 	ctxB := ctxForSession("session-b")
 
-	require.Equal(t, "https://github.com/dagger/dagger", ResolveDaggerGetRedirect(ctxA, ref))
-	require.Equal(t, "https://github.com/dagger/dagger", ResolveDaggerGetRedirect(ctxA, ref))
+	resolved, err := ResolveDaggerGetRedirect(ctxA, ref)
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/dagger/dagger", resolved)
+	resolved, err = ResolveDaggerGetRedirect(ctxA, ref)
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/dagger/dagger", resolved)
 	require.EqualValues(t, 1, requests.Load(), "same-session lookup should hit the cache")
 
-	require.Equal(t, "https://github.com/dagger/dagger", ResolveDaggerGetRedirect(ctxB, ref))
+	resolved, err = ResolveDaggerGetRedirect(ctxB, ref)
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/dagger/dagger", resolved)
 	require.EqualValues(t, 2, requests.Load(), "different sessions should not share redirect results")
 }
 
@@ -218,8 +226,168 @@ func TestResolveDaggerGetRedirectRequiresSessionInfrastructure(t *testing.T) {
 		}),
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, ref, ResolveDaggerGetRedirect(ctx, ref))
+			resolved, err := ResolveDaggerGetRedirect(ctx, ref)
+			require.NoError(t, err)
+			require.Equal(t, ref, resolved)
 		})
 	}
 	require.Zero(t, requests.Load())
+}
+
+func TestResolveDaggerGetRedirectUsesWorkspaceLock(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Redirect(w, r, "https://github.com/dagger/dagger?dagger-get=1", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	lock := workspace.NewLock()
+	ref := "https://127.0.0.1/go"
+	require.NoError(t, lock.SetLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationVanityURL,
+		[]any{ref},
+		"https://github.com/dagger/dagger",
+	))
+	ctx := ContextWithQuery(t.Context(), &Query{Server: &mockServer{workspaceLock: lock}})
+
+	for _, input := range []string{ref + "@main", strings.TrimPrefix(ref, "https://") + "@main"} {
+		resolved, err := ResolveDaggerGetRedirect(ctx, input)
+		require.NoError(t, err)
+		require.Equal(t, "https://github.com/dagger/dagger@main", resolved)
+	}
+	require.Zero(t, requests.Load(), "lock hit should avoid the HTTP probe")
+}
+
+func TestResolveDaggerGetRedirectWritesWorkspaceLock(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Redirect(w, r, "https://github.com/dagger/dagger?dagger-get=1", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	// Use a port-free vanity URL; schemeless host:port refs are SSH-like.
+	daggerGetClient.Transport.(*http.Transport).DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, srv.Listener.Addr().String())
+	}
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	lock := workspace.NewLock()
+	cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+	require.NoError(t, err)
+	ctx := ContextWithQuery(t.Context(), &Query{Server: &mockServer{workspaceLock: lock, lockWritable: true}})
+	ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{SessionID: "session-a"})
+	ctx = dagql.ContextWithCache(ctx, cache)
+	ref := "https://127.0.0.1/go"
+
+	resolved, err := ResolveDaggerGetRedirect(ctx, strings.TrimPrefix(ref, "https://")+"@main")
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/dagger/dagger@main", resolved)
+	require.EqualValues(t, 1, requests.Load())
+	locked, ok := lock.GetLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationVanityURL,
+		[]any{ref},
+	)
+	require.True(t, ok)
+	require.Equal(t, "https://github.com/dagger/dagger", locked)
+	_, ok = lock.GetLookup(
+		workspace.CoreLockNamespace,
+		workspace.LockOperationVanityURL,
+		[]any{strings.TrimPrefix(ref, "https://")},
+	)
+	require.False(t, ok, "must not write a schemeless lockfile key")
+
+	// A different spelling and version must reuse the lock, not the session cache.
+	resolved, err = ResolveDaggerGetRedirect(ctx, ref+"@other")
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/dagger/dagger@other", resolved)
+	require.EqualValues(t, 1, requests.Load(), "HTTPS lookup should reuse the schemeless lookup's lock entry")
+}
+
+func TestSourceURLWithVersionOverridesDestinationVersion(t *testing.T) {
+	for _, destination := range []string{
+		"https://github.com/dagger/dagger@v1.2.3?other=1",
+		"https://github.com/dagger/dagger?other=1#v1.2.3",
+	} {
+		require.Equal(t, destination, sourceURLWithVersion(destination, ""))
+		require.Equal(t, "https://github.com/dagger/dagger@main?other=1", sourceURLWithVersion(destination, "main"))
+	}
+}
+
+func TestResolveDaggerGetRedirectPreservesDestinationVersion(t *testing.T) {
+	for _, destinationSuffix := range []string{"", "@v1.2.3", "#v1.2.3"} {
+		for _, inputSuffix := range []string{"", "@main"} {
+			t.Run(destinationSuffix+"/input="+inputSuffix, func(t *testing.T) {
+				const repo = "https://github.com/dagger/dagger"
+				destination := repo + destinationSuffix
+				var requests atomic.Int32
+				srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requests.Add(1)
+					require.Equal(t, "/go", r.URL.Path)
+					location := repo + "?dagger-get=1"
+					if strings.HasPrefix(destinationSuffix, "#") {
+						location += destinationSuffix
+					} else {
+						location = destination + "?dagger-get=1"
+					}
+					http.Redirect(w, r, location, http.StatusTemporaryRedirect)
+				}))
+				defer srv.Close()
+				oldClient := daggerGetClient
+				daggerGetClient = srv.Client()
+				daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				}
+				defer func() { daggerGetClient = oldClient }()
+
+				lock := workspace.NewLock()
+				ctx := ContextWithVanityURLLookupLock(t.Context(), lock)
+				cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+				require.NoError(t, err)
+				probeCtx := dagql.ContextWithCache(ctx, cache)
+				probeCtx = engine.ContextWithClientMetadata(probeCtx, &engine.ClientMetadata{SessionID: "first"})
+				ref := srv.URL + "/go"
+				resolved, err := ResolveDaggerGetRedirect(probeCtx, ref+inputSuffix)
+				require.NoError(t, err)
+				want := destination
+				if inputSuffix != "" {
+					want = repo + inputSuffix
+				}
+				require.Equal(t, want, resolved)
+				locked, ok := lock.GetLookup(workspace.CoreLockNamespace, workspace.LockOperationVanityURL, []any{ref})
+				require.True(t, ok)
+				require.Equal(t, destination, locked)
+
+				// Replay without session infrastructure: only the lock can resolve it.
+				resolved, err = ResolveDaggerGetRedirect(ctx, ref)
+				require.NoError(t, err)
+				require.Equal(t, destination, resolved)
+				resolved, err = ResolveDaggerGetRedirect(ctx, ref+"@other")
+				require.NoError(t, err)
+				require.Equal(t, repo+"@other", resolved)
+				require.EqualValues(t, 1, requests.Load())
+
+				require.NoError(t, UpdateWorkspaceLock(ctx, nil, lock))
+				locked, ok = lock.GetLookup(workspace.CoreLockNamespace, workspace.LockOperationVanityURL, []any{ref})
+				require.True(t, ok)
+				require.Equal(t, destination, locked, "refresh must use the same destination format as creation")
+				require.EqualValues(t, 2, requests.Load())
+			})
+		}
+	}
 }

--- a/core/modulerefs_redirect_test.go
+++ b/core/modulerefs_redirect_test.go
@@ -183,11 +183,11 @@ func TestResolveDaggerGetRedirectCachesPerSession(t *testing.T) {
 	ctxA := ctxForSession("session-a")
 	ctxB := ctxForSession("session-b")
 
-	require.Equal(t, "https://github.com/dagger/dagger", resolveDaggerGetRedirect(ctxA, ref))
-	require.Equal(t, "https://github.com/dagger/dagger", resolveDaggerGetRedirect(ctxA, ref))
+	require.Equal(t, "https://github.com/dagger/dagger", ResolveDaggerGetRedirect(ctxA, ref))
+	require.Equal(t, "https://github.com/dagger/dagger", ResolveDaggerGetRedirect(ctxA, ref))
 	require.EqualValues(t, 1, requests.Load(), "same-session lookup should hit the cache")
 
-	require.Equal(t, "https://github.com/dagger/dagger", resolveDaggerGetRedirect(ctxB, ref))
+	require.Equal(t, "https://github.com/dagger/dagger", ResolveDaggerGetRedirect(ctxB, ref))
 	require.EqualValues(t, 2, requests.Load(), "different sessions should not share redirect results")
 }
 
@@ -218,7 +218,7 @@ func TestResolveDaggerGetRedirectRequiresSessionInfrastructure(t *testing.T) {
 		}),
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, ref, resolveDaggerGetRedirect(ctx, ref))
+			require.Equal(t, ref, ResolveDaggerGetRedirect(ctx, ref))
 		})
 	}
 	require.Zero(t, requests.Load())

--- a/core/modulerefs_redirect_test.go
+++ b/core/modulerefs_redirect_test.go
@@ -1,0 +1,225 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDaggerGetEligible(t *testing.T) {
+	for _, tc := range []struct {
+		ref  string
+		want bool
+	}{
+		{"www.marcosnils.com/go", true},
+		{"https://www.marcosnils.com/go", true},
+		{"github.com/dagger/dagger", true},
+		{"www.marcosnils.com/go@v1.2.3", true},
+		{"http://example.com/mod", false},
+		{"ssh://git@github.com/foo/bar", false},
+		{"git://example.com/foo", false},
+		{"git@github.com:foo/bar", false},
+		{"./local/path", false},
+		{"/abs/path", false},
+		{"nodot/path", false},
+		{"", false},
+	} {
+		t.Run(tc.ref, func(t *testing.T) {
+			require.Equal(t, tc.want, daggerGetEligible(tc.ref))
+		})
+	}
+}
+
+func TestDaggerGetProbe(t *testing.T) {
+	// Server redirects only the exact dagger-get probe and echoes the flag back
+	// in Location to verify it gets stripped.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get(daggerGetQueryParam) == "1" && r.URL.Path == "/go" {
+			http.Redirect(w, r, "https://github.com/dagger/dagger?dagger-get=1", http.StatusTemporaryRedirect)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	host := srv.Listener.Addr().String()
+
+	t.Run("redirect strips dagger-get and preserves version", func(t *testing.T) {
+		got := daggerGetProbe(t.Context(), "https://"+host+"/go@v1.2.3")
+		require.Equal(t, "https://github.com/dagger/dagger@v1.2.3", got)
+	})
+
+	t.Run("redirect without version", func(t *testing.T) {
+		got := daggerGetProbe(t.Context(), "https://"+host+"/go")
+		require.Equal(t, "https://github.com/dagger/dagger", got)
+	})
+
+	t.Run("no redirect falls back to original", func(t *testing.T) {
+		ref := "https://" + host + "/other"
+		require.Equal(t, ref, daggerGetProbe(t.Context(), ref))
+	})
+}
+
+func TestDaggerGetProbeRejectsNonHTTPSLocation(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://github.com/dagger/dagger", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	ref := "https://" + srv.Listener.Addr().String() + "/go"
+	require.Equal(t, ref, daggerGetProbe(t.Context(), ref))
+}
+
+func TestDaggerGetProbeIgnoresCanonicalizationRedirects(t *testing.T) {
+	// GitHub (and other hosts) 301 "repo.git" -> "repo", "www." -> apex, etc.
+	// for the same repository. These must not be treated as dagger-get
+	// redirects: the user's ref must stay untouched.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := r.Host
+		switch {
+		case strings.HasSuffix(r.URL.Path, ".git"):
+			http.Redirect(w, r,
+				"https://"+host+strings.TrimSuffix(r.URL.Path, ".git")+"?"+r.URL.RawQuery,
+				http.StatusMovedPermanently)
+		case strings.HasSuffix(r.URL.Path, "/slash/"):
+			http.Redirect(w, r, "https://"+host+strings.TrimSuffix(r.URL.Path, "/"), http.StatusMovedPermanently)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	host := srv.Listener.Addr().String()
+
+	t.Run("dot-git canonicalization is ignored", func(t *testing.T) {
+		ref := "https://" + host + "/dagger/dagger.git"
+		require.Equal(t, ref, daggerGetProbe(t.Context(), ref))
+	})
+
+	t.Run("dot-git canonicalization with version is ignored", func(t *testing.T) {
+		ref := "https://" + host + "/dagger/dagger.git@v0.16.2"
+		require.Equal(t, ref, daggerGetProbe(t.Context(), ref))
+	})
+
+	t.Run("trailing-slash canonicalization is ignored", func(t *testing.T) {
+		ref := "https://" + host + "/foo/slash/"
+		require.Equal(t, ref, daggerGetProbe(t.Context(), ref))
+	})
+}
+
+func TestDaggerGetProbeIgnoresAuthWallRedirects(t *testing.T) {
+	// GitLab 302s unauthenticated repo paths to /users/sign_in and drops the
+	// query string. Without the dagger-get marker in Location, the redirect
+	// must be ignored.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://"+r.Host+"/users/sign_in", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	host := srv.Listener.Addr().String()
+	ref := "https://" + host + "/dagger-modules/test/more/dagger-test-modules-public/top-level@d730fb3af8757e1ca293e01aa4fcfd510a6e40e5"
+	require.Equal(t, ref, daggerGetProbe(t.Context(), ref))
+}
+
+func TestResolveDaggerGetRedirectCachesPerSession(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Redirect(w, r, "https://github.com/dagger/dagger?dagger-get=1", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+	require.NoError(t, err)
+
+	ctxForSession := func(sessionID string) context.Context {
+		ctx := engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{SessionID: sessionID})
+		return dagql.ContextWithCache(ctx, cache)
+	}
+
+	ref := "https://" + srv.Listener.Addr().String() + "/go"
+	ctxA := ctxForSession("session-a")
+	ctxB := ctxForSession("session-b")
+
+	require.Equal(t, "https://github.com/dagger/dagger", resolveDaggerGetRedirect(ctxA, ref))
+	require.Equal(t, "https://github.com/dagger/dagger", resolveDaggerGetRedirect(ctxA, ref))
+	require.EqualValues(t, 1, requests.Load(), "same-session lookup should hit the cache")
+
+	require.Equal(t, "https://github.com/dagger/dagger", resolveDaggerGetRedirect(ctxB, ref))
+	require.EqualValues(t, 2, requests.Load(), "different sessions should not share redirect results")
+}
+
+func TestResolveDaggerGetRedirectRequiresSessionInfrastructure(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Redirect(w, r, "https://github.com/dagger/dagger", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	oldClient := daggerGetClient
+	daggerGetClient = srv.Client()
+	daggerGetClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { daggerGetClient = oldClient }()
+
+	cache, err := dagql.NewCache(t.Context(), "", nil, nil)
+	require.NoError(t, err)
+
+	ref := "https://" + srv.Listener.Addr().String() + "/go"
+	for name, ctx := range map[string]context.Context{
+		"no session infrastructure": t.Context(),
+		"cache without metadata":    dagql.ContextWithCache(t.Context(), cache),
+		"metadata without cache": engine.ContextWithClientMetadata(t.Context(), &engine.ClientMetadata{
+			SessionID: "session-a",
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, ref, resolveDaggerGetRedirect(ctx, ref))
+		})
+	}
+	require.Zero(t, requests.Load())
+}

--- a/core/schema/lockfile.go
+++ b/core/schema/lockfile.go
@@ -44,6 +44,7 @@ func workspaceLookupLockRefresh(ctx context.Context) bool {
 
 func withWorkspaceLookupLockOverride(ctx context.Context, lock *workspace.Lock) context.Context {
 	ctx = context.WithValue(ctx, workspaceLookupLockOverrideKey{}, lock)
+	ctx = core.ContextWithVanityURLLookupLock(ctx, lock)
 	return dagql.WithPerClientCacheScope(ctx)
 }
 

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -46,6 +46,8 @@ type mockServer struct {
 	functionCall   *FunctionCall
 	clientMetadata *engine.ClientMetadata
 	attachables    map[string]*grpc.ClientConn
+	workspaceLock  *workspacepkg.Lock
+	lockWritable   bool
 }
 
 func (ms *mockServer) ServeHTTPToNestedClient(http.ResponseWriter, *http.Request, *engine.ClientMetadata, string, bool, dagql.AnyObjectResult, dagql.Typed) {
@@ -132,12 +134,18 @@ func (ms *mockServer) SpecificClientAttachableConn(_ context.Context, clientID s
 	return conn, conn != nil, nil
 }
 
-func (ms *mockServer) CurrentWorkspaceLock(context.Context, bool) (*workspacepkg.Lock, bool, error) {
-	return nil, false, nil
+func (ms *mockServer) CurrentWorkspaceLock(_ context.Context, requireWritable bool) (*workspacepkg.Lock, bool, error) {
+	if requireWritable && !ms.lockWritable {
+		return nil, false, nil
+	}
+	return ms.workspaceLock, ms.workspaceLock != nil, nil
 }
 
-func (ms *mockServer) SetCurrentWorkspaceLookup(context.Context, string, string, []any, string) error {
-	return nil
+func (ms *mockServer) SetCurrentWorkspaceLookup(_ context.Context, namespace, operation string, inputs []any, value string) error {
+	if ms.workspaceLock == nil {
+		return nil
+	}
+	return ms.workspaceLock.SetLookup(namespace, operation, inputs, value)
 }
 
 func (ms *mockServer) NonModuleParentClientMetadata(context.Context) (*engine.ClientMetadata, error) {

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -20,6 +20,7 @@ const (
 	LockOperationOCISHA    = "oci-sha"
 	LockOperationGitLatest = "git-latest"
 	LockOperationGitSHA    = "git-sha"
+	LockOperationVanityURL = "vanity-url"
 
 	LatestReleaseVersion = "v1.0.0-beta.11"
 )

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -2102,6 +2102,40 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		require.Equal(t, "main", ref.version)
 		require.Equal(t, ".", ref.workspaceSubdir)
 	})
+
+	t.Run("resolves legacy vanity ref", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := parseWorkspaceRemoteRefWithResolver(
+			context.Background(),
+			"dagger.io/go@main",
+			func(_ context.Context, got string) string {
+				require.Equal(t, "dagger.io/go@main", got)
+				return "https://github.com/dagger/dagger/sdk/go@main"
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
+		require.Equal(t, "main", ref.version)
+		require.Equal(t, "sdk/go", ref.workspaceSubdir)
+	})
+
+	t.Run("resolves fragment vanity ref and preserves subdir", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := parseWorkspaceRemoteRefWithResolver(
+			context.Background(),
+			"https://dagger.io/go#main:docs",
+			func(_ context.Context, got string) string {
+				require.Equal(t, "https://dagger.io/go", got)
+				return "https://github.com/dagger/dagger/sdk/go"
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
+		require.Equal(t, "main", ref.version)
+		require.Equal(t, "sdk/go/docs", ref.workspaceSubdir)
+	})
 }
 
 func TestGatherModuleLoadRequests(t *testing.T) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -2109,9 +2109,9 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		ref, err := parseWorkspaceRemoteRefWithResolver(
 			context.Background(),
 			"dagger.io/go@main",
-			func(_ context.Context, got string) string {
+			func(_ context.Context, got string) (string, error) {
 				require.Equal(t, "dagger.io/go@main", got)
-				return "https://github.com/dagger/dagger/sdk/go@main"
+				return "https://github.com/dagger/dagger/sdk/go@main", nil
 			},
 		)
 		require.NoError(t, err)
@@ -2126,9 +2126,9 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		ref, err := parseWorkspaceRemoteRefWithResolver(
 			context.Background(),
 			"https://dagger.io/go#main:docs",
-			func(_ context.Context, got string) string {
+			func(_ context.Context, got string) (string, error) {
 				require.Equal(t, "https://dagger.io/go", got)
-				return "https://github.com/dagger/dagger/sdk/go"
+				return "https://github.com/dagger/dagger/sdk/go", nil
 			},
 		)
 		require.NoError(t, err)

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -308,7 +308,7 @@ func parseWorkspaceRemoteRef(ctx context.Context, remoteRef string) (workspaceRe
 func parseWorkspaceRemoteRefWithResolver(
 	ctx context.Context,
 	remoteRef string,
-	resolve func(context.Context, string) string,
+	resolve func(context.Context, string) (string, error),
 ) (workspaceRemoteRef, error) {
 	// Fragment refs are parsed via the same git URL parser used by Address.*.
 	if strings.Contains(remoteRef, "#") {
@@ -327,7 +327,10 @@ func parseWorkspaceRemoteRefWithResolver(
 			return workspaceRemoteRef{}, fmt.Errorf("invalid git subdir in workspace ref %q: %w", remoteRef, err)
 		}
 		cloneRef := gitURL.Remote()
-		resolvedRef := resolve(ctx, cloneRef)
+		resolvedRef, err := resolve(ctx, cloneRef)
+		if err != nil {
+			return workspaceRemoteRef{}, err
+		}
 		if resolvedRef != cloneRef {
 			parsedRef, err := core.ParseGitRefString(ctx, resolvedRef)
 			if err != nil {
@@ -351,7 +354,10 @@ func parseWorkspaceRemoteRefWithResolver(
 	}
 
 	// Preserve legacy @ref parsing semantics for existing workspace refs.
-	remoteRef = resolve(ctx, remoteRef)
+	remoteRef, err := resolve(ctx, remoteRef)
+	if err != nil {
+		return workspaceRemoteRef{}, err
+	}
 	parsedRef, err := core.ParseGitRefString(ctx, remoteRef)
 	if err != nil {
 		return workspaceRemoteRef{}, err

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -302,6 +302,14 @@ type workspaceRemoteRef struct {
 }
 
 func parseWorkspaceRemoteRef(ctx context.Context, remoteRef string) (workspaceRemoteRef, error) {
+	return parseWorkspaceRemoteRefWithResolver(ctx, remoteRef, core.ResolveDaggerGetRedirect)
+}
+
+func parseWorkspaceRemoteRefWithResolver(
+	ctx context.Context,
+	remoteRef string,
+	resolve func(context.Context, string) string,
+) (workspaceRemoteRef, error) {
 	// Fragment refs are parsed via the same git URL parser used by Address.*.
 	if strings.Contains(remoteRef, "#") {
 		gitURL, err := gitutil.ParseURL(remoteRef)
@@ -318,14 +326,32 @@ func parseWorkspaceRemoteRef(ctx context.Context, remoteRef string) (workspaceRe
 		if err != nil {
 			return workspaceRemoteRef{}, fmt.Errorf("invalid git subdir in workspace ref %q: %w", remoteRef, err)
 		}
+		cloneRef := gitURL.Remote()
+		resolvedRef := resolve(ctx, cloneRef)
+		if resolvedRef != cloneRef {
+			parsedRef, err := core.ParseGitRefString(ctx, resolvedRef)
+			if err != nil {
+				return workspaceRemoteRef{}, err
+			}
+			cloneRef = parsedRef.SourceCloneRef
+			resolvedSubdir := parsedRef.RepoRootSubdir
+			if resolvedSubdir == "/" {
+				resolvedSubdir = "."
+			}
+			workspaceSubdir, err = normalizeWorkspaceRemoteSubdir(filepath.Join(resolvedSubdir, workspaceSubdir))
+			if err != nil {
+				return workspaceRemoteRef{}, err
+			}
+		}
 		return workspaceRemoteRef{
-			cloneRef:        gitURL.Remote(),
+			cloneRef:        cloneRef,
 			version:         version,
 			workspaceSubdir: workspaceSubdir,
 		}, nil
 	}
 
 	// Preserve legacy @ref parsing semantics for existing workspace refs.
+	remoteRef = resolve(ctx, remoteRef)
 	parsedRef, err := core.ParseGitRefString(ctx, remoteRef)
 	if err != nil {
 		return workspaceRemoteRef{}, err


### PR DESCRIPTION
## Summary

Adds an https **vanity-URL redirect mechanism** for module and workspace refs so custom domains can transparently point `dagger install` (and all module-source and remote-workspace resolution) at the real repository.

When resolving an https (or schemeless, attempted over https) ref, the engine probes the ref with a `?dagger-get=1` query. If the host answers with a **single 3xx** to an **absolute https** `Location` that **echoes the `dagger-get=1` marker**, resolution continues at that destination. Successful resolutions are pinned as `vanity-url` entries in the workspace lockfile.

## Motivation

Ref resolution and git-source fetching use two different mechanisms:

- `dagger core git --url <...>` → git **smart-HTTP**, which already honours HTTP redirects via git's default `http.followRedirects=initial`.
- `dagger install <ref>` → Go-style **vanity import discovery** (`?go-get=1` + `<meta name="go-import">`), which does **not** use git redirects.

A URL like `https://www.marcosnils.com/go` redirecting to `github.com/dagger/dagger` worked for the raw `git` command but failed `dagger install` with `does not point to an initialized module`. Rather than force users to serve `go-import` meta tags, this introduces a dagger-native redirect contract.

## Server-side contract

```
GET https://www.marcosnils.com/go?dagger-get=1
→ 307 Location: https://github.com/dagger/dagger?dagger-get=1
```

- The `Location` must be **absolute https** and must **echo `dagger-get=1`** (proof of intent). Standard path+query passthrough redirects (e.g. Vercel `:path*`) do this by default.
- Only the `dagger-get` param is stripped from the destination; other query params are preserved.
- A version in the destination path acts as a **default**; an explicit caller version overrides it.

`dagger install www.marcosnils.com/go@v1.2.3` then resolves to `https://github.com/dagger/dagger@v1.2.3`.

## How it works

Hooked into `ParseRefString` (modules) and `parseWorkspaceRemoteRef` (workspaces), **before** the existing `?go-get=1` dynamic discovery.

1. **Eligibility** — only `https://` and schemeless refs. `http://`, `ssh://`, `git://`, scp-like, and local paths are skipped.
2. **Version split** — a path-level `@version`/`@sha` (or `#`) is stripped before probing and re-applied to the destination.
3. **Lock-first resolution** — the workspace lockfile is consulted first: a `vanity-url` entry (keyed by the https source URL, shared by schemeless/explicit refs) short-circuits the probe for reproducible builds.
4. **Probe** — `GET <ref>?dagger-get=1` with a dedicated **non-following** client and a **5s timeout**; single hop.
5. **Rejected redirects** — missing marker echo (e.g. **auth walls**: GitLab 302s unauthenticated repo paths to `/users/sign_in`, dropping the query) and **same-repo canonicalization** (GitHub 301s `repo.git` → `repo`, `www.` → apex, trailing slash, case) are ignored: they are not opt-ins and must not rewrite the ref.
6. **Fallback** — non-3xx, invalid Location, timeout, or transport error → original ref, unchanged.
7. **Persistence** — successful resolutions are written to the lockfile; the session cache is the fallback when no lock is available. `dagger update` refreshes `vanity-url` entries and **fails if a locked vanity URL no longer returns a valid redirect** (go-get-like: an update with a broken dependency fails as a whole).
8. **Workspaces** — fragment refs (`#ref:subdir`) resolve the remote and compose the destination subdir with the fragment subdir; legacy `@` refs resolve the full ref.

## Design decisions

| Decision | Choice |
|---|---|
| Schemeless refs | Eligible; attempted over https |
| Persistence | Resolved destination flows into parsing; mapping pinned in lockfile, refreshed by `dagger update` |
| Scope | Universal — modules and remote workspaces |
| Redirect depth | Single hop |
| Timeout / failure | 5s; fall back to original ref |
| `Location` | Absolute https; must echo `dagger-get=1`; only that param stripped |
| Incidental 3xx | Auth-wall and canonicalization redirects ignored |
| Caching | Lock-first, then per-session cache |
| Update failures | `dagger update` fails hard if a locked vanity URL stops redirecting (intentional, go-get-like) |
| Git protocol | Out of scope (handled by git's own `followRedirects=initial`) |

## Changes

- `core/gitref/gitref.go` — pure `Scheme()` classifier.
- `core/modulerefs_redirect.go` — resolver: eligibility, probe, marker/canonicalization guards, lock-first lookup + write-back, session cache.
- `core/modulerefs.go` — hook into `ParseRefString`.
- `engine/server/session_workspaces.go` — hook into workspace remote refs (injectable resolver).
- `core/lockfile_update.go`, `core/workspace/lock.go`, `core/schema/lockfile.go` — `vanity-url` lock operation + `dagger update` refresh.
- Unit tests throughout (hermetic; no live network in `TestParseRefString`).

## Testing

- Unit: eligibility matrix, redirect with/without version, marker/auth-wall/canonicalization guards, lock read/write, version override/preserve, update refresh, workspace ref shapes.
- Integration: full `TestCall` suite passes against a dev engine (including the GitHub `.git` 301 and GitLab sign-in 302 regressions it caught).
- Live-verified: GitHub `.git@vX` refs, GitLab deep paths, and Bitbucket refs pass the probe untouched.
