### PR TITLE
fix(workspace): preserve module source backing

### DIFF
--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -1205,10 +1205,19 @@ func (WorkspaceAPISuite) TestModuleSourceResolvesWorkspacePaths(ctx context.Cont
 		WithNewFile("sub/dagger-module.toml", `name = "submod"
 engineVersion = "latest"
 `).
+		WithNewFile("dep-a/dagger-module.toml", `name = "dep-a"
+engineVersion = "latest"
+`).
+		WithNewFile("dep-b/dagger-module.toml", `name = "dep-b"
+engineVersion = "latest"
+`).
 		WithNewFile("nested/marker", "x")
 
 	t.Run("relative path resolves from the workspace root cwd", func(ctx context.Context, t *testctx.T) {
 		src := base.AsWorkspace().ModuleSource("sub")
+		kind, err := src.Kind(ctx)
+		require.NoError(t, err)
+		require.Equal(t, dagger.ModuleSourceKindDirSource, kind)
 		exists, err := src.ConfigExists(ctx)
 		require.NoError(t, err)
 		require.True(t, exists)
@@ -1242,6 +1251,103 @@ engineVersion = "latest"
 		require.Error(t, err)
 		require.ErrorContains(t, err, "escapes workspace root")
 	})
+
+	t.Run("directory sources preserve distinct dependencies", func(ctx context.Context, t *testctx.T) {
+		ws := base.AsWorkspace()
+		withDeps := ws.ModuleSource("sub").WithDependencies([]*dagger.ModuleSource{
+			ws.ModuleSource("dep-a"),
+			ws.ModuleSource("dep-b"),
+		})
+		deps, err := withDeps.Dependencies(ctx)
+		require.NoError(t, err)
+		require.Len(t, deps, 2)
+
+		remaining, err := withDeps.WithoutDependencies([]string{"../dep-a"}).Dependencies(ctx)
+		require.NoError(t, err)
+		require.Len(t, remaining, 1)
+		name, err := remaining[0].ModuleOriginalName(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "dep-b", name)
+	})
+}
+
+func (WorkspaceAPISuite) TestModuleSourcePreservesWorkspaceBacking(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+	for path, contents := range map[string]string{
+		"modules/parent/dagger-module.toml": `name = "parent"
+engineVersion = "latest"
+
+[[dependencies]]
+name = "dep-a"
+source = "../dep-a"
+`,
+		"modules/dep-a/dagger-module.toml": `name = "dep-a"
+engineVersion = "latest"
+`,
+		"modules/dep-b/dagger-module.toml": `name = "dep-b"
+engineVersion = "latest"
+`,
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(workdir, path)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, path), []byte(contents), 0o600))
+	}
+	c := connect(ctx, t, dagger.WithWorkdir(workdir))
+	ws := c.CurrentWorkspace()
+
+	parent := ws.ModuleSource("modules/parent")
+	kind, err := parent.Kind(ctx)
+	require.NoError(t, err)
+	require.Equal(t, dagger.ModuleSourceKindLocalSource, kind)
+	configuredDeps, err := parent.Dependencies(ctx)
+	require.NoError(t, err)
+	require.Len(t, configuredDeps, 1)
+	configuredDepKind, err := configuredDeps[0].Kind(ctx)
+	require.NoError(t, err)
+	require.Equal(t, dagger.ModuleSourceKindLocalSource, configuredDepKind)
+
+	staged := ws.WithNewFile("modules/parent/dagger-module.toml", `name = "staged-parent"
+engineVersion = "latest"
+`).ModuleSource("modules/parent")
+	stagedKind, err := staged.Kind(ctx)
+	require.NoError(t, err)
+	require.Equal(t, dagger.ModuleSourceKindLocalSource, stagedKind)
+	stagedName, err := staged.ModuleOriginalName(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "staged-parent", stagedName)
+
+	withDeps := parent.WithDependencies([]*dagger.ModuleSource{
+		ws.ModuleSource("modules/dep-a"),
+		ws.ModuleSource("modules/dep-b"),
+	})
+	deps, err := withDeps.Dependencies(ctx)
+	require.NoError(t, err)
+	require.Len(t, deps, 2)
+
+	withoutA := withDeps.WithoutDependencies([]string{"../dep-a"})
+	remaining, err := withoutA.Dependencies(ctx)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	name, err := remaining[0].ModuleOriginalName(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "dep-b", name)
+}
+
+func (WorkspaceAPISuite) TestGitWorkspaceModuleSourcePreservesKind(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	source := c.Directory().WithNewFile("module/dagger-module.toml", `name = "git-module"
+engineVersion = "latest"
+`)
+	gitDaemon, repoURL := gitService(ctx, t, c, source)
+	ws := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).Head().AsWorkspace()
+
+	src := ws.ModuleSource("module")
+	kind, err := src.Kind(ctx)
+	require.NoError(t, err)
+	require.Equal(t, dagger.ModuleSourceKindGitSource, kind)
+	name, err := src.ModuleOriginalName(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "git-module", name)
 }
 
 func (WorkspaceAPISuite) TestSyntheticWorkspaceGitModuleStagesConfigAndLock(ctx context.Context, t *testctx.T) {

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -1350,6 +1350,120 @@ engineVersion = "latest"
 	require.Equal(t, "git-module", name)
 }
 
+func (WorkspaceAPISuite) TestGitWorkspaceModuleSourcePreservesGitContext(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	moduleDir := c.Directory().
+		WithNewFile("module/dagger-module.toml", `name = "git-module"
+engineVersion = "latest"
+source = "."
+
+[runtime]
+source = "go"
+`).
+		WithNewFile("module/main.go", `package main
+
+import (
+	"context"
+	"fmt"
+
+	"dagger/git-module/internal/dagger"
+)
+
+type GitModule struct{}
+
+func (m *GitModule) ContextCommits(
+	ctx context.Context,
+	// +defaultPath="/"
+	repoRoot *dagger.GitRepository,
+	// +defaultPath="."
+	repoDot *dagger.GitRepository,
+	// +defaultPath="./.git"
+	repoDotGit *dagger.GitRepository,
+	// +defaultPath=".git"
+	repoGit *dagger.GitRepository,
+	// +defaultPath="/"
+	refRoot *dagger.GitRef,
+	// +defaultPath="."
+	refDot *dagger.GitRef,
+	// +defaultPath="./.git"
+	refDotGit *dagger.GitRef,
+	// +defaultPath=".git"
+	refGit *dagger.GitRef,
+) ([]string, error) {
+	refs := map[string]*dagger.GitRef{
+		"repo /":       head(repoRoot),
+		"repo .":       head(repoDot),
+		"repo ./.git":  head(repoDotGit),
+		"repo .git":    head(repoGit),
+		"ref /":        refRoot,
+		"ref .":        refDot,
+		"ref ./.git":   refDotGit,
+		"ref .git":     refGit,
+	}
+	commits := make([]string, 0, len(refs))
+	for name, ref := range refs {
+		if ref == nil {
+			return nil, fmt.Errorf("%s context is nil", name)
+		}
+		commit, err := ref.Commit(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("%s commit: %w", name, err)
+		}
+		commits = append(commits, commit)
+	}
+	return commits, nil
+}
+
+func head(repo *dagger.GitRepository) *dagger.GitRef {
+	if repo == nil {
+		return nil
+	}
+	return repo.Head()
+}
+`)
+	moduleDir = moduleDir.WithDirectory("module", moduleDir.Directory("module").
+		AsModuleSource().GeneratedContextDirectory())
+	source := c.Directory().WithDirectory("module", moduleDir.Directory("module"))
+	repoCtr := c.Container().From(alpineImage).
+		WithExec([]string{"apk", "add", "git"}).
+		WithDirectory("/repo", source).
+		WithWorkdir("/repo").
+		WithExec([]string{"git", "init", "-b", "main"}).
+		WithExec([]string{"git", "config", "user.email", "root@localhost"}).
+		WithExec([]string{"git", "config", "user.name", "Test User"}).
+		WithExec([]string{"git", "add", "-A"}).
+		WithExec([]string{"git", "commit", "-m", "module"}).
+		WithExec([]string{"git", "branch", "workspace-ref"}).
+		WithNewFile("/repo/main-only.txt", "not in the workspace ref").
+		WithExec([]string{"git", "add", "-A"}).
+		WithExec([]string{"git", "commit", "-m", "advance default branch"})
+	wantCommit, err := repoCtr.WithExec([]string{"git", "rev-parse", "workspace-ref"}).Stdout(ctx)
+	require.NoError(t, err)
+	wantCommit = strings.TrimSpace(wantCommit)
+	defaultCommit, err := repoCtr.WithExec([]string{"git", "rev-parse", "main"}).Stdout(ctx)
+	require.NoError(t, err)
+	defaultCommit = strings.TrimSpace(defaultCommit)
+	require.NotEqual(t, defaultCommit, wantCommit)
+
+	source = repoCtr.Directory("/repo")
+	gitDaemon, repoURL := gitService(ctx, t, c, source)
+	repo := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon})
+	ref := repo.Branch("workspace-ref")
+
+	src := ref.AsWorkspace().ModuleSource("module")
+	require.NoError(t, src.AsModule().Serve(ctx))
+	got, err := testutil.QueryWithClient[struct {
+		GitModule struct {
+			ContextCommits []string
+		}
+	}](c, t, `{gitModule{contextCommits}}`, nil)
+	require.NoError(t, err)
+	require.Len(t, got.GitModule.ContextCommits, 8)
+	for _, commit := range got.GitModule.ContextCommits {
+		require.Equal(t, wantCommit, commit)
+	}
+}
+
 func (WorkspaceAPISuite) TestSyntheticWorkspaceGitModuleStagesConfigAndLock(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	workspaceID, err := c.Directory().AsWorkspace().ID(ctx)

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -1909,7 +1909,30 @@ func (src *ModuleSource) LoadContextGit(
 	ctx context.Context,
 	dag *dagql.Server,
 ) (inst dagql.ObjectResult[*GitRepository], err error) {
-	if src.Kind == ModuleSourceKindGit && src.Workspace.Self() == nil {
+	if src.Kind == ModuleSourceKindGit && src.Workspace.Self() != nil {
+		ref, ok := src.Workspace.Self().SourceGitRef()
+		if !ok || ref.Self().Repo.Self() == nil {
+			return inst, fmt.Errorf("git workspace module source has no backing repository")
+		}
+		// A Git workspace deliberately keeps its checkout tree free of .git and
+		// retains the selected GitRef as separate source provenance. Derive a
+		// repository from that exact ref so contextual GitRepository/GitRef
+		// arguments keep the original credentials and service bindings while HEAD
+		// remains pinned to the workspace ref.
+		refID, err := ref.ID()
+		if err != nil {
+			return inst, fmt.Errorf("git workspace source ref ID: %w", err)
+		}
+		if err := dag.Select(ctx, ref.Self().Repo, &inst, dagql.Selector{
+			Field: "__withHead",
+			Args:  []dagql.NamedInput{{Name: "ref", Value: dagql.NewID[*GitRef](refID)}},
+		}); err != nil {
+			return inst, fmt.Errorf("pin git workspace source repository: %w", err)
+		}
+		return inst, nil
+	}
+
+	if src.Kind == ModuleSourceKindGit {
 		// easy, we're running a git repo
 		err := dag.Select(ctx, dag.Root(), &inst,
 			dagql.Selector{

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -1492,25 +1492,7 @@ func (src *ModuleSource) LoadContextDir(
 	path string,
 	filter CopyFilter,
 ) (inst dagql.ObjectResult[*Directory], err error) {
-	filterInputs := []dagql.NamedInput{}
-	if len(filter.Include) > 0 {
-		filterInputs = append(filterInputs, dagql.NamedInput{
-			Name:  "include",
-			Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(filter.Include...)),
-		})
-	}
-	if len(filter.Exclude) > 0 {
-		filterInputs = append(filterInputs, dagql.NamedInput{
-			Name:  "exclude",
-			Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(filter.Exclude...)),
-		})
-	}
-	if filter.Gitignore {
-		filterInputs = append(filterInputs, dagql.NamedInput{
-			Name:  "gitignore",
-			Value: dagql.NewBoolean(true),
-		})
-	}
+	filterInputs := copyFilterInputs(filter)
 
 	// Determine the context for defaultPath arguments, in priority order:
 	//
@@ -1523,10 +1505,8 @@ func (src *ModuleSource) LoadContextDir(
 	// Git, or a Directory.
 	if ws, ok := WorkspaceFromContext(ctx); ok {
 		inst, err = src.loadContextFromWorkspace(ctx, dag, ws, path, filterInputs)
-	} else if src.Workspace.Self() != nil {
-		inst, err = src.loadContextFromWorkspace(ctx, dag, src.Workspace, path, filterInputs)
 	} else {
-		inst, err = src.loadContextFromSource(ctx, dag, path, filterInputs)
+		inst, err = NewModuleSourceFS(nil, src).directory(ctx, dag, path, filterInputs)
 	}
 	if err != nil {
 		return inst, err
@@ -1559,6 +1539,29 @@ func (src *ModuleSource) LoadContextDir(
 	}
 
 	return inst, nil
+}
+
+func copyFilterInputs(filter CopyFilter) []dagql.NamedInput {
+	var inputs []dagql.NamedInput
+	if len(filter.Include) > 0 {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "include",
+			Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(filter.Include...)),
+		})
+	}
+	if len(filter.Exclude) > 0 {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "exclude",
+			Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(filter.Exclude...)),
+		})
+	}
+	if filter.Gitignore {
+		inputs = append(inputs, dagql.NamedInput{
+			Name:  "gitignore",
+			Value: dagql.NewBoolean(true),
+		})
+	}
+	return inputs
 }
 
 func (src *ModuleSource) loadContextFromWorkspace(
@@ -2099,7 +2102,7 @@ func ResolveDepToSource(
 
 	parsedDepRef, err := ParseRefString(
 		ctx,
-		ModuleSourceStatFS{bk, parentSrc},
+		NewModuleSourceFS(bk, parentSrc),
 		depSrcRef,
 		depPin,
 	)
@@ -2352,9 +2355,40 @@ func (csfs CallerStatFS) Exists(ctx context.Context, path string) (string, bool,
 	}
 }
 
-type ModuleSourceStatFS struct {
+// ModuleSourceFS provides filesystem access through a ModuleSource's backing
+// source, including a retained Workspace when present.
+type ModuleSourceFS struct {
 	bk  *engineutil.Client
 	src *ModuleSource
+}
+
+func NewModuleSourceFS(bk *engineutil.Client, src *ModuleSource) *ModuleSourceFS {
+	return &ModuleSourceFS{bk: bk, src: src}
+}
+
+// ContextDirectory loads the source's context root. Filter patterns are
+// context-root-relative, matching ModuleSource.ContextDirectory semantics.
+func (fs ModuleSourceFS) ContextDirectory(ctx context.Context, filter CopyFilter) (dagql.ObjectResult[*Directory], error) {
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*Directory]{}, err
+	}
+	return fs.directory(ctx, dag, "/", copyFilterInputs(filter))
+}
+
+func (fs ModuleSourceFS) directory(
+	ctx context.Context,
+	dag *dagql.Server,
+	path string,
+	filterInputs []dagql.NamedInput,
+) (dagql.ObjectResult[*Directory], error) {
+	if fs.src == nil {
+		return dagql.ObjectResult[*Directory]{}, os.ErrNotExist
+	}
+	if fs.src.Workspace.Self() != nil {
+		return fs.src.loadContextFromWorkspace(ctx, dag, fs.src.Workspace, path, filterInputs)
+	}
+	return fs.src.loadContextFromSource(ctx, dag, path, filterInputs)
 }
 
 func CallDirExists(ctx context.Context, dir dagql.ObjectResult[*Directory], path string) (string, bool, error) {
@@ -2429,15 +2463,16 @@ func DirectoryReadFile(ctx context.Context, dir dagql.ObjectResult[*Directory], 
 	return []byte(contents), nil
 }
 
-func (fs ModuleSourceStatFS) Stat(ctx context.Context, path string) (string, *Stat, error) {
+func (fs ModuleSourceFS) Stat(ctx context.Context, path string) (string, *Stat, error) {
 	if fs.src == nil {
 		return "", nil, os.ErrNotExist
 	}
 	if fs.src.Workspace.Self() != nil {
-		return WorkspaceStatFS{
-			Workspace: fs.src.Workspace,
-			Root:      fs.src.SourceRootSubpath,
-		}.Stat(ctx, path)
+		dir, basename, err := fs.workspaceEntry(ctx, path)
+		if err != nil {
+			return "", nil, err
+		}
+		return CallDirStat(ctx, dir, basename)
 	}
 
 	switch fs.src.Kind {
@@ -2455,15 +2490,19 @@ func (fs ModuleSourceStatFS) Stat(ctx context.Context, path string) (string, *St
 	}
 }
 
-func (fs ModuleSourceStatFS) Exists(ctx context.Context, path string) (string, bool, error) {
+func (fs ModuleSourceFS) Exists(ctx context.Context, path string) (string, bool, error) {
 	if fs.src == nil {
 		return "", false, nil
 	}
 	if fs.src.Workspace.Self() != nil {
-		return WorkspaceStatFS{
-			Workspace: fs.src.Workspace,
-			Root:      fs.src.SourceRootSubpath,
-		}.Exists(ctx, path)
+		dir, basename, err := fs.workspaceEntry(ctx, path)
+		if errors.Is(err, os.ErrNotExist) || status.Code(err) == codes.NotFound {
+			return filepath.Dir(path), false, nil
+		}
+		if err != nil {
+			return "", false, err
+		}
+		return CallDirExists(ctx, dir, basename)
 	}
 
 	switch fs.src.Kind {
@@ -2481,74 +2520,38 @@ func (fs ModuleSourceStatFS) Exists(ctx context.Context, path string) (string, b
 	}
 }
 
-// WorkspaceStatFS implements StatFS against a workspace without first
-// converting its complete tree to a Directory. Root is workspace-relative;
-// callers may use it to scope paths to a module within the workspace.
-type WorkspaceStatFS struct {
-	Workspace dagql.ObjectResult[*Workspace]
-	Root      string
-}
-
-func (fs WorkspaceStatFS) Stat(ctx context.Context, p string) (string, *Stat, error) {
+func (fs ModuleSourceFS) workspaceEntry(ctx context.Context, path string) (dagql.ObjectResult[*Directory], string, error) {
+	var dir dagql.ObjectResult[*Directory]
 	dag, err := CurrentDagqlServer(ctx)
 	if err != nil {
-		return "", nil, err
+		return dir, "", err
 	}
-	workspacePath := filepath.Join("/", fs.Root, p)
+	workspacePath := filepath.Join("/", fs.src.SourceRootSubpath, path)
 	parentPath := filepath.Dir(workspacePath)
 	basename := filepath.Base(workspacePath)
-	var dir dagql.ObjectResult[*Directory]
-	if err := dag.Select(ctx, fs.Workspace, &dir, dagql.Selector{
+	if err := dag.Select(ctx, fs.src.Workspace, &dir, dagql.Selector{
 		Field: "directory",
 		Args: []dagql.NamedInput{
 			{Name: "path", Value: dagql.String(parentPath)},
 			{Name: "include", Value: dagql.ArrayInput[dagql.String]{dagql.String(basename)}},
 		},
 	}); err != nil {
-		return "", nil, err
+		return dir, "", err
 	}
-	return CallDirStat(ctx, dir, basename)
+	return dir, basename, nil
 }
 
-func (fs WorkspaceStatFS) Exists(ctx context.Context, p string) (string, bool, error) {
-	dag, err := CurrentDagqlServer(ctx)
-	if err != nil {
-		return "", false, err
-	}
-	workspacePath := filepath.Join("/", fs.Root, p)
-	parentPath := filepath.Dir(workspacePath)
-	basename := filepath.Base(workspacePath)
-	var dir dagql.ObjectResult[*Directory]
-	if err := dag.Select(ctx, fs.Workspace, &dir, dagql.Selector{
-		Field: "directory",
-		Args: []dagql.NamedInput{
-			{Name: "path", Value: dagql.String(parentPath)},
-			{Name: "include", Value: dagql.ArrayInput[dagql.String]{dagql.String(basename)}},
-		},
-	}); err != nil {
-		if errors.Is(err, os.ErrNotExist) || status.Code(err) == codes.NotFound {
-			return filepath.Dir(p), false, nil
-		}
-		return "", false, err
-	}
-	return CallDirExists(ctx, dir, basename)
-}
-
-// WorkspaceReadFile reads one workspace file without materializing the
-// workspace's complete tree.
-func WorkspaceReadFile(ctx context.Context, workspace dagql.ObjectResult[*Workspace], p string) ([]byte, error) {
+func (fs ModuleSourceFS) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	dag, err := CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, err
 	}
+	file, err := fs.src.LoadContextFile(ctx, dag, path)
+	if err != nil {
+		return nil, err
+	}
 	var contents dagql.String
-	if err := dag.Select(ctx, workspace, &contents,
-		dagql.Selector{
-			Field: "file",
-			Args:  []dagql.NamedInput{{Name: "path", Value: dagql.String(filepath.Join("/", p))}},
-		},
-		dagql.Selector{Field: "contents"},
-	); err != nil {
+	if err := dag.Select(ctx, file, &contents, dagql.Selector{Field: "contents"}); err != nil {
 		return nil, err
 	}
 	return []byte(contents), nil

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -227,6 +227,12 @@ type ModuleSource struct {
 
 	ContextDirectory dagql.ObjectResult[*Directory] `field:"true" name:"contextDirectory" doc:"The full directory loaded for the module source, including the source code as a subdirectory."`
 
+	// Workspace is the originating workspace for sources loaded through
+	// Workspace.moduleSource. It preserves the workspace's backing source,
+	// pending overlay, and owner route without flattening the workspace into a
+	// Directory. SourceRootSubpath remains workspace-root-relative.
+	Workspace dagql.ObjectResult[*Workspace] `json:"-"`
+
 	Kind   ModuleSourceKind `field:"true" name:"kind" doc:"The kind of module source (currently local, git or dir)."`
 	Local  *LocalModuleSource
 	Git    *GitModuleSource
@@ -319,7 +325,20 @@ func (src *ModuleSource) AttachDependencyResults(
 		return nil, nil
 	}
 
-	owned := make([]dagql.AnyResult, 0, 4+len(src.Dependencies)+len(src.Toolchains))
+	owned := make([]dagql.AnyResult, 0, 5+len(src.Dependencies)+len(src.Toolchains))
+
+	if src.Workspace.Self() != nil {
+		attached, err := attach(src.Workspace)
+		if err != nil {
+			return nil, fmt.Errorf("attach module source workspace: %w", err)
+		}
+		typed, ok := attached.(dagql.ObjectResult[*Workspace])
+		if !ok {
+			return nil, fmt.Errorf("attach module source workspace: unexpected result %T", attached)
+		}
+		src.Workspace = typed
+		owned = append(owned, typed)
+	}
 
 	if src.ContextDirectory.Self() != nil {
 		attached, err := attach(src.ContextDirectory)
@@ -467,6 +486,7 @@ type persistedModuleSourcePayload struct {
 	SourceSubpath                   string                                `json:"sourceSubpath,omitempty"`
 	OriginalSubpath                 string                                `json:"originalSubpath,omitempty"`
 	ContextDirectoryResultID        uint64                                `json:"contextDirectoryResultID,omitempty"`
+	WorkspaceResultID               uint64                                `json:"workspaceResultID,omitempty"`
 	Kind                            ModuleSourceKind                      `json:"kind"`
 	Local                           *LocalModuleSource                    `json:"local,omitempty"`
 	Git                             *persistedGitModuleSourcePayload      `json:"git,omitempty"`
@@ -821,6 +841,13 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 		}
 		payload.ContextDirectoryResultID = contextDirID
 	}
+	if src.Workspace.Self() != nil {
+		workspaceID, err := encodePersistedObjectRef(cache, src.Workspace, "module source workspace")
+		if err != nil {
+			return dagql.PersistedObjectEncoding{}, err
+		}
+		payload.WorkspaceResultID = workspaceID
+	}
 	payload.DependencyResultIDs = make([]uint64, 0, len(src.Dependencies))
 	for _, dep := range src.Dependencies {
 		if dep.Self() == nil {
@@ -893,6 +920,10 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 	if err != nil {
 		return nil, err
 	}
+	workspace, err := loadPersistedObjectResultByResultID[*Workspace](ctx, dag, persisted.WorkspaceResultID, "module source workspace")
+	if err != nil {
+		return nil, err
+	}
 	dependencies := make([]dagql.ObjectResult[*ModuleSource], 0, len(persisted.DependencyResultIDs))
 	for _, depID := range persisted.DependencyResultIDs {
 		depRes, err := loadPersistedObjectResultByResultID[*ModuleSource](ctx, dag, depID, "module source dependency")
@@ -937,6 +968,7 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 		SourceSubpath:                 persisted.SourceSubpath,
 		OriginalSubpath:               persisted.OriginalSubpath,
 		ContextDirectory:              contextDirectory,
+		Workspace:                     workspace,
 		Kind:                          persisted.Kind,
 		Local:                         persisted.Local,
 	}
@@ -1102,6 +1134,27 @@ func (src *ModuleSource) innerEnvFile(ctx context.Context) (*EnvFile, string, er
 	dag, err := CurrentDagqlServer(ctx)
 	if err != nil {
 		return nil, "", err
+	}
+	if src.Workspace.Self() != nil {
+		envFilePath := path.Join("/", src.SourceRootSubpath, ".env")
+		var envFile *EnvFile
+		if err := dag.Select(ctx, src.Workspace, &envFile,
+			dagql.Selector{
+				Field: "file",
+				Args:  []dagql.NamedInput{{Name: "path", Value: dagql.String(envFilePath)}},
+			},
+			dagql.Selector{
+				Field: "asEnvFile",
+				Args: []dagql.NamedInput{
+					{Name: "expand", Value: dagql.Opt(dagql.NewBoolean(true))},
+				},
+			},
+		); status.Code(err) == codes.NotFound || errors.Is(err, os.ErrNotExist) {
+			return nil, "", nil
+		} else if err != nil {
+			return nil, "", fmt.Errorf("failed to load inner env file in %s: %w", envFilePath, err)
+		}
+		return envFile, envFilePath, nil
 	}
 
 	// FIXME: .env must be at the root of the module directory
@@ -1470,6 +1523,8 @@ func (src *ModuleSource) LoadContextDir(
 	// Git, or a Directory.
 	if ws, ok := WorkspaceFromContext(ctx); ok {
 		inst, err = src.loadContextFromWorkspace(ctx, dag, ws, path, filterInputs)
+	} else if src.Workspace.Self() != nil {
+		inst, err = src.loadContextFromWorkspace(ctx, dag, src.Workspace, path, filterInputs)
 	} else {
 		inst, err = src.loadContextFromSource(ctx, dag, path, filterInputs)
 	}
@@ -1735,6 +1790,17 @@ func (src *ModuleSource) LoadContextFile(
 	dag *dagql.Server,
 	path string,
 ) (inst dagql.ObjectResult[*File], err error) {
+	if src.Workspace.Self() != nil {
+		workspacePath := workspaceContextDirPath(src.SourceRootSubpath, path)
+		if err := dag.Select(ctx, src.Workspace, &inst, dagql.Selector{
+			Field: "file",
+			Args:  []dagql.NamedInput{{Name: "path", Value: dagql.String(workspacePath)}},
+		}); err != nil {
+			return inst, fmt.Errorf("failed to select workspace file: %w", err)
+		}
+		return inst, nil
+	}
+
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return inst, err
@@ -1840,7 +1906,7 @@ func (src *ModuleSource) LoadContextGit(
 	ctx context.Context,
 	dag *dagql.Server,
 ) (inst dagql.ObjectResult[*GitRepository], err error) {
-	if src.Kind == ModuleSourceKindGit {
+	if src.Kind == ModuleSourceKindGit && src.Workspace.Self() == nil {
 		// easy, we're running a git repo
 		err := dag.Select(ctx, dag.Root(), &inst,
 			dagql.Selector{
@@ -2051,6 +2117,33 @@ func ResolveDepToSource(
 		if filepath.IsAbs(depSrcRef) {
 			// they need to be relative to the parent module's source root
 			return inst, fmt.Errorf("local module dep source path %q is absolute", depSrcRef)
+		}
+		if parentSrc.Workspace.Self() != nil {
+			depPath := filepath.Join(parentSrc.SourceRootSubpath, depSrcRef)
+			if !filepath.IsLocal(depPath) {
+				return inst, fmt.Errorf("local module dep source path %q escapes workspace", depSrcRef)
+			}
+			selectors := []dagql.Selector{{
+				Field: "moduleSource",
+				Args: []dagql.NamedInput{
+					{Name: "path", Value: dagql.String(filepath.ToSlash(depPath))},
+				},
+			}}
+			if depName != "" {
+				selectors = append(selectors, dagql.Selector{
+					Field: "withName",
+					Args: []dagql.NamedInput{
+						{Name: "name", Value: dagql.String(depName)},
+					},
+				})
+			}
+			if err := dag.Select(ctx, parentSrc.Workspace, &inst, selectors...); err != nil {
+				if errors.Is(err, dagql.ErrCacheRecursiveCall) {
+					return inst, fmt.Errorf("module %q has a circular dependency on itself through dependency %q", parentSrc.ModuleName, depName)
+				}
+				return inst, err
+			}
+			return inst, nil
 		}
 
 		switch parentSrc.Kind {
@@ -2340,6 +2433,12 @@ func (fs ModuleSourceStatFS) Stat(ctx context.Context, path string) (string, *St
 	if fs.src == nil {
 		return "", nil, os.ErrNotExist
 	}
+	if fs.src.Workspace.Self() != nil {
+		return WorkspaceStatFS{
+			Workspace: fs.src.Workspace,
+			Root:      fs.src.SourceRootSubpath,
+		}.Stat(ctx, path)
+	}
 
 	switch fs.src.Kind {
 	case ModuleSourceKindLocal:
@@ -2360,6 +2459,12 @@ func (fs ModuleSourceStatFS) Exists(ctx context.Context, path string) (string, b
 	if fs.src == nil {
 		return "", false, nil
 	}
+	if fs.src.Workspace.Self() != nil {
+		return WorkspaceStatFS{
+			Workspace: fs.src.Workspace,
+			Root:      fs.src.SourceRootSubpath,
+		}.Exists(ctx, path)
+	}
 
 	switch fs.src.Kind {
 	case ModuleSourceKindLocal:
@@ -2374,6 +2479,79 @@ func (fs ModuleSourceStatFS) Exists(ctx context.Context, path string) (string, b
 	default:
 		return "", false, fmt.Errorf("unsupported module source kind: %s", fs.src.Kind)
 	}
+}
+
+// WorkspaceStatFS implements StatFS against a workspace without first
+// converting its complete tree to a Directory. Root is workspace-relative;
+// callers may use it to scope paths to a module within the workspace.
+type WorkspaceStatFS struct {
+	Workspace dagql.ObjectResult[*Workspace]
+	Root      string
+}
+
+func (fs WorkspaceStatFS) Stat(ctx context.Context, p string) (string, *Stat, error) {
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	workspacePath := filepath.Join("/", fs.Root, p)
+	parentPath := filepath.Dir(workspacePath)
+	basename := filepath.Base(workspacePath)
+	var dir dagql.ObjectResult[*Directory]
+	if err := dag.Select(ctx, fs.Workspace, &dir, dagql.Selector{
+		Field: "directory",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(parentPath)},
+			{Name: "include", Value: dagql.ArrayInput[dagql.String]{dagql.String(basename)}},
+		},
+	}); err != nil {
+		return "", nil, err
+	}
+	return CallDirStat(ctx, dir, basename)
+}
+
+func (fs WorkspaceStatFS) Exists(ctx context.Context, p string) (string, bool, error) {
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	workspacePath := filepath.Join("/", fs.Root, p)
+	parentPath := filepath.Dir(workspacePath)
+	basename := filepath.Base(workspacePath)
+	var dir dagql.ObjectResult[*Directory]
+	if err := dag.Select(ctx, fs.Workspace, &dir, dagql.Selector{
+		Field: "directory",
+		Args: []dagql.NamedInput{
+			{Name: "path", Value: dagql.String(parentPath)},
+			{Name: "include", Value: dagql.ArrayInput[dagql.String]{dagql.String(basename)}},
+		},
+	}); err != nil {
+		if errors.Is(err, os.ErrNotExist) || status.Code(err) == codes.NotFound {
+			return filepath.Dir(p), false, nil
+		}
+		return "", false, err
+	}
+	return CallDirExists(ctx, dir, basename)
+}
+
+// WorkspaceReadFile reads one workspace file without materializing the
+// workspace's complete tree.
+func WorkspaceReadFile(ctx context.Context, workspace dagql.ObjectResult[*Workspace], p string) ([]byte, error) {
+	dag, err := CurrentDagqlServer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var contents dagql.String
+	if err := dag.Select(ctx, workspace, &contents,
+		dagql.Selector{
+			Field: "file",
+			Args:  []dagql.NamedInput{{Name: "path", Value: dagql.String(filepath.Join("/", p))}},
+		},
+		dagql.Selector{Field: "contents"},
+	); err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
 }
 
 type ModuleSourceExperimentalFeature string

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -167,6 +167,12 @@ func (s *gitSchema) Install(srv *dagql.Server) {
 		dagql.NodeFunc("__cleaned", s.cleaned).
 			IsPersistable().
 			Doc(`(Internal-only) Cleans the git repository by removing untracked files and resetting modifications.`),
+		dagql.NodeFunc("__withHead", s.withHead).
+			IsPersistable().
+			Doc(`(Internal-only) Return this repository with HEAD pinned to a selected ref.`).
+			Args(
+				dagql.Arg("ref"),
+			),
 		dagql.NodeFunc("uncommitted", s.uncommitted).
 			Doc("Returns the changeset of uncommitted changes in the git repository."),
 		dagql.NodeFunc("asWorkspace", s.asWorkspace).
@@ -1567,6 +1573,33 @@ func (s *gitSchema) gitRefAsWorkspace(ctx context.Context, parent dagql.ObjectRe
 
 type withAuthTokenArgs struct {
 	Token core.SecretID
+}
+
+type withHeadArgs struct {
+	Ref core.GitRefID
+}
+
+func (s *gitSchema) withHead(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.GitRepository],
+	args withHeadArgs,
+) (dagql.ObjectResult[*core.GitRepository], error) {
+	srv, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return dagql.ObjectResult[*core.GitRepository]{}, err
+	}
+	ref, err := args.Ref.Load(ctx, srv)
+	if err != nil {
+		return dagql.ObjectResult[*core.GitRepository]{}, fmt.Errorf("load git HEAD ref: %w", err)
+	}
+	if ref.Self().Ref == nil {
+		return dagql.ObjectResult[*core.GitRepository]{}, fmt.Errorf("git HEAD ref is unresolved")
+	}
+
+	repo := parent.Self().CloneWithBackend(parent.Self().Backend)
+	pinnedRef := *ref.Self().Ref
+	repo.Remote.Head = &pinnedRef
+	return dagql.NewObjectResultForCurrentCall(ctx, srv, repo)
 }
 
 func (s *gitSchema) withAuthToken(ctx context.Context, parent *core.GitRepository, args withAuthTokenArgs) (*core.GitRepository, error) {

--- a/core/schema/module_as_sdk.go
+++ b/core/schema/module_as_sdk.go
@@ -215,5 +215,5 @@ func (s *moduleSchema) currentModuleAsSDKClientModuleSource(
 		}
 	}
 
-	return wsSchema.resolveClientTargetModule(workspaceCtx, ws, moduleLoadRef, client.Pin)
+	return wsSchema.resolveClientTargetModule(workspaceCtx, client.BoundWorkspace, moduleLoadRef, client.Pin)
 }

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -677,53 +676,14 @@ func (s *moduleSourceSchema) localModuleSource(
 		if err != nil {
 			return inst, err
 		}
-	} else {
-		// we found a module config, load the module source using its values
-		configPath := filepath.Join(sourceRootPath, configFilename)
-		contents, err := bk.ReadCallerHostFile(ctx, configPath)
-		if err != nil {
-			return inst, fmt.Errorf("failed to read module config file: %w", err)
-		}
-		if err := s.initFromModConfig(contents, localSrc); err != nil {
-			return inst, err
-		}
-
-		// load this module source's context directory, ignore patterns, sdk and deps in parallel
-		var eg errgroup.Group
-		eg.Go(func() error {
-			if err := s.loadModuleSourceContext(ctx, localSrc); err != nil {
-				return fmt.Errorf("failed to load local module source context: %w", err)
-			}
-
-			if localSrc.SDK != nil {
-				localSrc.SDKImpl, err = sdk.NewLoader().SDKForModule(ctx, query.Self(), localSrc.SDK, localSrc)
-				if err != nil {
-					return fmt.Errorf("failed to load sdk for local module source: %w", err)
-				}
-			}
-
-			return nil
-		})
-
-		localSrc.Dependencies = make([]dagql.ObjectResult[*core.ModuleSource], len(localSrc.ConfigDependencies))
-		for i, depCfg := range localSrc.ConfigDependencies {
-			eg.Go(func() error {
-				var err error
-				localSrc.Dependencies[i], err = core.ResolveDepToSource(ctx, bk, dag, localSrc, depCfg.Source, depCfg.Pin, depCfg.Name)
-				if err != nil {
-					return fmt.Errorf("failed to resolve dep to source: %w", err)
-				}
-				return nil
-			})
-		}
-
-		if err := eg.Wait(); err != nil {
-			return inst, err
-		}
+	} else if err := s.loadConfiguredModuleSource(ctx, localSrc); err != nil {
+		return inst, fmt.Errorf("load local module source: %w", err)
 	}
 
-	if err := localSrc.LoadUserDefaults(ctx); err != nil {
-		return inst, fmt.Errorf("load user defaults: %w", err)
+	if !daggerCfgFound {
+		if err := localSrc.LoadUserDefaults(ctx); err != nil {
+			return inst, fmt.Errorf("load user defaults: %w", err)
+		}
 	}
 
 	return dagql.NewResultForCurrentCall(ctx, localSrc)
@@ -821,11 +781,6 @@ func (s *moduleSourceSchema) gitModuleSource(
 		},
 	}
 
-	bk, err := query.Self().Engine(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get engine client: %w", err)
-	}
-
 	// TODO:(sipsma) support sparse loading of git repos similar to how local dirs are loaded.
 	// Related: https://github.com/dagger/dagger/issues/6292
 	err = dag.Select(ctx, gitRef, &gitSrc.ContextDirectory,
@@ -839,7 +794,7 @@ func (s *moduleSourceSchema) gitModuleSource(
 	gitSrc.SourceRootSubpath = strings.TrimPrefix(parsed.RepoRootSubdir, "/")
 	gitSrc.OriginalSubpath = gitSrc.SourceRootSubpath
 
-	configPath, configFound, err := s.findGitModuleConfig(ctx, gitSrc, doFindUp, allowNotExists)
+	_, configFound, err := s.findGitModuleConfig(ctx, gitSrc, doFindUp, allowNotExists)
 	if err != nil {
 		return inst, err
 	}
@@ -872,60 +827,8 @@ func (s *moduleSourceSchema) gitModuleSource(
 		return inst, nil
 	}
 
-	var configContents string
-	err = dag.Select(ctx, gitSrc.ContextDirectory, &configContents,
-		dagql.Selector{
-			Field: "file",
-			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.String(configPath)},
-			},
-		},
-		dagql.Selector{Field: "contents"},
-	)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return inst, fmt.Errorf("git module source %q does not contain a dagger config file", gitSrc.AsString())
-		}
-		return inst, fmt.Errorf("failed to load git module dagger config: %w", err)
-	}
-	if err := s.initFromModConfig([]byte(configContents), gitSrc); err != nil {
-		return inst, err
-	}
-
-	// load this module source's context directory and deps in parallel
-	var eg errgroup.Group
-	eg.Go(func() error {
-		if err := s.loadModuleSourceContext(ctx, gitSrc); err != nil {
-			return fmt.Errorf("failed to load git module source context: %w", err)
-		}
-
-		if gitSrc.SDK != nil {
-			gitSrc.SDKImpl, err = sdk.NewLoader().SDKForModule(ctx, query.Self(), gitSrc.SDK, gitSrc)
-			if err != nil {
-				return fmt.Errorf("failed to load sdk for git module source: %w", err)
-			}
-		}
-
-		return nil
-	})
-
-	gitSrc.Dependencies = make([]dagql.ObjectResult[*core.ModuleSource], len(gitSrc.ConfigDependencies))
-	for i, depCfg := range gitSrc.ConfigDependencies {
-		eg.Go(func() error {
-			var err error
-			gitSrc.Dependencies[i], err = core.ResolveDepToSource(ctx, bk, dag, gitSrc, depCfg.Source, depCfg.Pin, depCfg.Name)
-			if err != nil {
-				return fmt.Errorf("failed to resolve dep to source: %w", err)
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return inst, err
-	}
-
-	if err := gitSrc.LoadUserDefaults(ctx); err != nil {
-		return inst, fmt.Errorf("load user defaults: %w", err)
+	if err := s.loadConfiguredModuleSource(ctx, gitSrc); err != nil {
+		return inst, fmt.Errorf("load Git module source: %w", err)
 	}
 
 	inst, err = dagql.NewResultForCurrentCall(ctx, gitSrc)
@@ -969,15 +872,6 @@ func (s *moduleSourceSchema) directoryAsModuleSource(
 	contextDir dagql.ObjectResult[*core.Directory],
 	args directoryAsModuleArgs,
 ) (inst dagql.Result[*core.ModuleSource], err error) {
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
-	}
-	dag, err := query.Server.Server(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get dag server: %w", err)
-	}
-
 	sourceRootSubpath := args.SourceRootPath
 	if sourceRootSubpath == "" {
 		sourceRootSubpath = "."
@@ -1006,61 +900,8 @@ func (s *moduleSourceSchema) directoryAsModuleSource(
 		return inst, fmt.Errorf("dir module source does not contain a dagger config file")
 	}
 	dirSrc.ConfigFilename = configFilename
-	configPath := filepath.Join(dirSrc.SourceRootSubpath, configFilename)
-	var configContents string
-	err = dag.Select(ctx, contextDir, &configContents,
-		dagql.Selector{
-			Field: "file",
-			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.String(configPath)},
-			},
-		},
-		dagql.Selector{Field: "contents"},
-	)
-	if err != nil {
-		return inst, fmt.Errorf("failed to load dir module dagger config: %w", err)
-	}
-	if err := s.initFromModConfig([]byte(configContents), dirSrc); err != nil {
-		return inst, err
-	}
-
-	// load this module source's deps in parallel
-	bk, err := query.Engine(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("failed to get engine client: %w", err)
-	}
-
-	var eg errgroup.Group
-
-	if dirSrc.SDK != nil {
-		eg.Go(func() error {
-			if err := s.loadModuleSourceContext(ctx, dirSrc); err != nil {
-				return err
-			}
-
-			var err error
-			dirSrc.SDKImpl, err = sdk.NewLoader().SDKForModule(ctx, query, dirSrc.SDK, dirSrc)
-			if err != nil {
-				return fmt.Errorf("failed to load sdk for dir module source: %w", err)
-			}
-
-			return nil
-		})
-	}
-
-	dirSrc.Dependencies = make([]dagql.ObjectResult[*core.ModuleSource], len(dirSrc.ConfigDependencies))
-	for i, depCfg := range dirSrc.ConfigDependencies {
-		eg.Go(func() error {
-			var err error
-			dirSrc.Dependencies[i], err = core.ResolveDepToSource(ctx, bk, dag, dirSrc, depCfg.Source, depCfg.Pin, depCfg.Name)
-			if err != nil {
-				return fmt.Errorf("failed to resolve dep to source: %w", err)
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return inst, err
+	if err := s.loadConfiguredModuleSource(ctx, dirSrc); err != nil {
+		return inst, fmt.Errorf("load directory module source: %w", err)
 	}
 
 	inst, err = dagql.NewResultForCurrentCall(ctx, dirSrc)
@@ -1068,9 +909,6 @@ func (s *moduleSourceSchema) directoryAsModuleSource(
 		return inst, fmt.Errorf("failed to create instance: %w", err)
 	}
 
-	if err := dirSrc.LoadUserDefaults(ctx); err != nil {
-		return inst, fmt.Errorf("load user defaults: %w", err)
-	}
 	return inst, nil
 }
 
@@ -1130,9 +968,7 @@ func (s *moduleSourceSchema) workspaceModuleSource(
 		return inst, fmt.Errorf("workspace module source: unsupported workspace backing %T", base)
 	}
 
-	configFilename, found, err := moduleConfigInDir(ctx, core.WorkspaceStatFS{
-		Workspace: workspaceResult,
-	}, filepath.Join("/", sourceRootPath))
+	configFilename, found, err := moduleConfigInDir(ctx, core.NewModuleSourceFS(nil, src), ".")
 	if err != nil {
 		return inst, fmt.Errorf("workspace module source %q: find module config: %w", sourceRootPath, err)
 	}
@@ -1140,58 +976,12 @@ func (s *moduleSourceSchema) workspaceModuleSource(
 		return inst, fmt.Errorf("workspace module source %q does not contain a dagger config file", sourceRootPath)
 	}
 	src.ConfigFilename = configFilename
-	configContents, err := core.WorkspaceReadFile(ctx, workspaceResult, filepath.Join(sourceRootPath, configFilename))
-	if err != nil {
-		return inst, fmt.Errorf("workspace module source %q: read module config: %w", sourceRootPath, err)
-	}
-	if err := s.initFromModConfig(configContents, src); err != nil {
-		return inst, err
-	}
-
-	query, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return inst, err
+	if err := s.loadConfiguredModuleSource(ctx, src); err != nil {
+		return inst, fmt.Errorf("load workspace module source: %w", err)
 	}
 	dag, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return inst, err
-	}
-	bk, err := query.Engine(ctx)
-	if err != nil {
-		return inst, fmt.Errorf("workspace module source: engine client: %w", err)
-	}
-
-	var eg errgroup.Group
-	eg.Go(func() error {
-		if err := s.loadModuleSourceContext(ctx, src); err != nil {
-			return fmt.Errorf("load workspace module source context: %w", err)
-		}
-		if src.SDK != nil {
-			loaded, err := sdk.NewLoader().SDKForModule(ctx, query, src.SDK, src)
-			if err != nil {
-				return fmt.Errorf("load SDK for workspace module source: %w", err)
-			}
-			src.SDKImpl = loaded
-		}
-		return nil
-	})
-
-	src.Dependencies = make([]dagql.ObjectResult[*core.ModuleSource], len(src.ConfigDependencies))
-	for i, depCfg := range src.ConfigDependencies {
-		eg.Go(func() error {
-			dep, err := core.ResolveDepToSource(ctx, bk, dag, src, depCfg.Source, depCfg.Pin, depCfg.Name)
-			if err != nil {
-				return fmt.Errorf("resolve workspace module dependency: %w", err)
-			}
-			src.Dependencies[i] = dep
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return inst, err
-	}
-	if err := src.LoadUserDefaults(ctx); err != nil {
-		return inst, fmt.Errorf("load workspace module user defaults: %w", err)
 	}
 	return dagql.NewObjectResultForCurrentCall(ctx, dag, src)
 }
@@ -1313,16 +1103,73 @@ func moduleSourceConfigFilename(src *core.ModuleSource) string {
 	return modules.Filename
 }
 
+// loadConfiguredModuleSource performs the source-independent half of module
+// loading after the source kind, root, and config filename have been resolved.
+// All filesystem access goes through ModuleSourceFS, so callers do not need to
+// know whether the source is backed by the host, Git, a Directory, or a
+// Workspace.
+func (s *moduleSourceSchema) loadConfiguredModuleSource(ctx context.Context, src *core.ModuleSource) error {
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return err
+	}
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return err
+	}
+	bk, err := query.Engine(ctx)
+	if err != nil {
+		return fmt.Errorf("module source engine client: %w", err)
+	}
+
+	configContents, err := core.NewModuleSourceFS(bk, src).ReadFile(ctx, moduleSourceConfigFilename(src))
+	if err != nil {
+		return fmt.Errorf("read module config: %w", err)
+	}
+	if err := s.initFromModConfig(configContents, src); err != nil {
+		return err
+	}
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		if err := s.loadModuleSourceContext(ctx, src); err != nil {
+			return fmt.Errorf("load module source context: %w", err)
+		}
+		if src.SDK != nil {
+			loaded, err := sdk.NewLoader().SDKForModule(ctx, query, src.SDK, src)
+			if err != nil {
+				return fmt.Errorf("load module source SDK: %w", err)
+			}
+			src.SDKImpl = loaded
+		}
+		return nil
+	})
+
+	src.Dependencies = make([]dagql.ObjectResult[*core.ModuleSource], len(src.ConfigDependencies))
+	for i, depCfg := range src.ConfigDependencies {
+		eg.Go(func() error {
+			dep, err := core.ResolveDepToSource(ctx, bk, dag, src, depCfg.Source, depCfg.Pin, depCfg.Name)
+			if err != nil {
+				return fmt.Errorf("resolve module dependency: %w", err)
+			}
+			src.Dependencies[i] = dep
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	if err := src.LoadUserDefaults(ctx); err != nil {
+		return fmt.Errorf("load module source user defaults: %w", err)
+	}
+	return nil
+}
+
 // load (or re-load) the context directory for the given module source
 func (s *moduleSourceSchema) loadModuleSourceContext(
 	ctx context.Context,
 	src *core.ModuleSource,
 ) error {
-	dag, err := core.CurrentDagqlServer(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get dag server: %w", err)
-	}
-
 	// we load the includes specified by the user in the module config (if any) plus a few
 	// prepended paths that are always loaded
 	fullIncludePaths := []string{
@@ -1342,69 +1189,20 @@ func (s *moduleSourceSchema) loadModuleSourceContext(
 		fullIncludePaths = append(fullIncludePaths, src.SourceRootSubpath)
 	}
 
-	if src.Workspace.Self() != nil {
-		fullIncludePaths = append(fullIncludePaths, src.RebasedIncludePaths...)
-		return dag.Select(ctx, src.Workspace, &src.ContextDirectory, dagql.Selector{
-			Field: "directory",
-			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.String("/")},
-				{Name: "include", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(fullIncludePaths...))},
-				{Name: "gitignore", Value: dagql.NewBoolean(true)},
-			},
-		})
+	if src.Kind == core.ModuleSourceKindDir && src.Workspace.Self() == nil {
+		// Directory sources already carry their complete in-engine context.
+		return nil
 	}
 
-	switch src.Kind {
-	case core.ModuleSourceKindLocal:
-		fullIncludePaths = append(fullIncludePaths, src.RebasedIncludePaths...)
-
-		err = dag.Select(ctx, dag.Root(), &src.ContextDirectory,
-			dagql.Selector{Field: "host"},
-			dagql.Selector{
-				Field: "directory",
-				Args: []dagql.NamedInput{
-					{Name: "path", Value: dagql.String(src.Local.ContextDirectoryPath)},
-					{Name: "include", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(fullIncludePaths...))},
-					{Name: "gitignore", Value: dagql.NewBoolean(true)},
-				},
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		// A worktree/submodule checkout has a dangling .git pointer file at
-		// the context root; the engine never interprets it (git-ness comes
-		// canonically via MaterializeHostGitCheckout), so drop it before it
-		// poisons git discovery near the synced tree.
-		src.ContextDirectory, err = core.DropRootGitPointerFile(ctx, dag, src.ContextDirectory)
-		if err != nil {
-			return err
-		}
-
-	case core.ModuleSourceKindGit:
-		fullIncludePaths = append(fullIncludePaths, src.RebasedIncludePaths...)
-		unfilteredContextDirID, err := src.Git.UnfilteredContextDir.ID()
-		if err != nil {
-			return fmt.Errorf("failed to get git unfiltered context directory ID: %w", err)
-		}
-
-		err = dag.Select(ctx, dag.Root(), &src.ContextDirectory,
-			dagql.Selector{Field: "directory"},
-			dagql.Selector{
-				Field: "withDirectory",
-				Args: []dagql.NamedInput{
-					{Name: "path", Value: dagql.String("/")},
-					{Name: "source", Value: dagql.NewID[*core.Directory](unfilteredContextDirID)},
-					{Name: "include", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(fullIncludePaths...))},
-				},
-			},
-		)
-		if err != nil {
-			return err
-		}
+	fullIncludePaths = append(fullIncludePaths, src.RebasedIncludePaths...)
+	contextDir, err := core.NewModuleSourceFS(nil, src).ContextDirectory(ctx, core.CopyFilter{
+		Include:   fullIncludePaths,
+		Gitignore: src.Workspace.Self() != nil || src.Kind == core.ModuleSourceKindLocal,
+	})
+	if err != nil {
+		return err
 	}
-
+	src.ContextDirectory = contextDir
 	return nil
 }
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1074,6 +1074,128 @@ func (s *moduleSourceSchema) directoryAsModuleSource(
 	return inst, nil
 }
 
+// workspaceModuleSource loads a module without flattening its workspace into a
+// Directory. Local and Git workspaces retain their native source kind while
+// filesystem reads continue through the workspace, preserving staged changes
+// and the workspace owner's host route.
+func (s *moduleSourceSchema) workspaceModuleSource(
+	ctx context.Context,
+	workspaceResult dagql.ObjectResult[*core.Workspace],
+	sourceRootPath string,
+) (inst dagql.ObjectResult[*core.ModuleSource], err error) {
+	ws := workspaceResult.Self()
+	if ws == nil {
+		return inst, fmt.Errorf("workspace module source: workspace is required")
+	}
+
+	sourceRootPath = filepath.Clean(sourceRootPath)
+	if sourceRootPath == "" {
+		sourceRootPath = "."
+	}
+	src := &core.ModuleSource{
+		ConfigExists:      true,
+		ConfigFilename:    modules.Filename,
+		SourceRootSubpath: sourceRootPath,
+		OriginalSubpath:   sourceRootPath,
+		Workspace:         workspaceResult,
+	}
+
+	switch base := ws.BaseSource().(type) {
+	case *core.WorkspaceSourceClientLocal:
+		src.Kind = core.ModuleSourceKindLocal
+		src.Local = &core.LocalModuleSource{ContextDirectoryPath: base.HostPath}
+	case *core.WorkspaceSourceGitRef:
+		ref := base.Ref.Self()
+		if ref == nil || ref.Repo.Self() == nil || !ref.Repo.Self().URL.Valid {
+			return inst, fmt.Errorf("workspace module source: Git workspace has no repository URL")
+		}
+		cloneRef := ref.Repo.Self().URL.Value.String()
+		src.Kind = core.ModuleSourceKindGit
+		src.Git = &core.GitModuleSource{
+			CloneRef:    cloneRef,
+			HTMLRepoURL: cloneRef,
+			Version:     cmp.Or(ref.Ref.ShortName(), ref.Ref.SHA),
+			Commit:      ref.Ref.SHA,
+			Ref:         ref.Ref.Name,
+		}
+		src.Git.Symbolic = cloneRef
+		if sourceRootPath != "." {
+			src.Git.Symbolic += "/" + filepath.ToSlash(sourceRootPath)
+		}
+		src.Git.HTMLURL, err = src.Git.Link(sourceRootPath, -1, -1)
+		if err != nil {
+			return inst, fmt.Errorf("workspace module source URL: %w", err)
+		}
+	default:
+		return inst, fmt.Errorf("workspace module source: unsupported workspace backing %T", base)
+	}
+
+	configFilename, found, err := moduleConfigInDir(ctx, core.WorkspaceStatFS{
+		Workspace: workspaceResult,
+	}, filepath.Join("/", sourceRootPath))
+	if err != nil {
+		return inst, fmt.Errorf("workspace module source %q: find module config: %w", sourceRootPath, err)
+	}
+	if !found {
+		return inst, fmt.Errorf("workspace module source %q does not contain a dagger config file", sourceRootPath)
+	}
+	src.ConfigFilename = configFilename
+	configContents, err := core.WorkspaceReadFile(ctx, workspaceResult, filepath.Join(sourceRootPath, configFilename))
+	if err != nil {
+		return inst, fmt.Errorf("workspace module source %q: read module config: %w", sourceRootPath, err)
+	}
+	if err := s.initFromModConfig(configContents, src); err != nil {
+		return inst, err
+	}
+
+	query, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return inst, err
+	}
+	dag, err := core.CurrentDagqlServer(ctx)
+	if err != nil {
+		return inst, err
+	}
+	bk, err := query.Engine(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("workspace module source: engine client: %w", err)
+	}
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		if err := s.loadModuleSourceContext(ctx, src); err != nil {
+			return fmt.Errorf("load workspace module source context: %w", err)
+		}
+		if src.SDK != nil {
+			loaded, err := sdk.NewLoader().SDKForModule(ctx, query, src.SDK, src)
+			if err != nil {
+				return fmt.Errorf("load SDK for workspace module source: %w", err)
+			}
+			src.SDKImpl = loaded
+		}
+		return nil
+	})
+
+	src.Dependencies = make([]dagql.ObjectResult[*core.ModuleSource], len(src.ConfigDependencies))
+	for i, depCfg := range src.ConfigDependencies {
+		eg.Go(func() error {
+			dep, err := core.ResolveDepToSource(ctx, bk, dag, src, depCfg.Source, depCfg.Pin, depCfg.Name)
+			if err != nil {
+				return fmt.Errorf("resolve workspace module dependency: %w", err)
+			}
+			src.Dependencies[i] = dep
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return inst, err
+	}
+	if err := src.LoadUserDefaults(ctx); err != nil {
+		return inst, fmt.Errorf("load workspace module user defaults: %w", err)
+	}
+	return dagql.NewObjectResultForCurrentCall(ctx, dag, src)
+}
+
 // set values in the given src using values read from the module config file provided as bytes
 func (s *moduleSourceSchema) initFromModConfig(configBytes []byte, src *core.ModuleSource) error {
 	// sanity checks
@@ -1218,6 +1340,18 @@ func (s *moduleSourceSchema) loadModuleSourceContext(
 		// otherwise load the source root; this supports use cases like an sdk-less module w/ a pyproject.toml
 		// that's now going to be upgraded to using the python sdk and needs pyproject.toml to be loaded
 		fullIncludePaths = append(fullIncludePaths, src.SourceRootSubpath)
+	}
+
+	if src.Workspace.Self() != nil {
+		fullIncludePaths = append(fullIncludePaths, src.RebasedIncludePaths...)
+		return dag.Select(ctx, src.Workspace, &src.ContextDirectory, dagql.Selector{
+			Field: "directory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String("/")},
+				{Name: "include", Value: dagql.ArrayInput[dagql.String](dagql.NewStringArray(fullIncludePaths...))},
+				{Name: "gitignore", Value: dagql.NewBoolean(true)},
+			},
+		})
 	}
 
 	switch src.Kind {
@@ -1702,6 +1836,14 @@ func (s *moduleSourceSchema) validateAndCollectRelatedModules(
 				return nil, fmt.Errorf("unhandled module source kind: %s", newRelatedModule.Self().Kind)
 			}
 
+		case core.ModuleSourceKindDir:
+			switch newRelatedModule.Self().Kind {
+			case core.ModuleSourceKindDir, core.ModuleSourceKindGit:
+				allRelatedModules = append(allRelatedModules, newRelatedModule)
+			default:
+				return nil, fmt.Errorf("unhandled module source kind: %s", newRelatedModule.Self().Kind)
+			}
+
 		default:
 			return nil, fmt.Errorf("unhandled module source kind: %s", parentSrc.Kind)
 		}
@@ -1737,6 +1879,19 @@ func (s *moduleSourceSchema) deduplicateAndSortItems(
 					symbolicItemStr += "@" + item.Self().Git.Commit
 				}
 			}
+		case core.ModuleSourceKindDir:
+			if item.Self().DirSrc == nil || item.Self().DirSrc.OriginalContextDir.Self() == nil {
+				return nil, fmt.Errorf("directory module source %q has no original context", item.Self().ModuleName)
+			}
+			contextID, err := item.Self().DirSrc.OriginalContextDir.ID()
+			if err != nil {
+				return nil, fmt.Errorf("directory module source %q context ID: %w", item.Self().ModuleName, err)
+			}
+			encodedContextID, err := contextID.Encode()
+			if err != nil {
+				return nil, fmt.Errorf("encode directory module source %q context ID: %w", item.Self().ModuleName, err)
+			}
+			symbolicItemStr = encodedContextID + "\x00" + filepath.Clean(item.Self().SourceRootSubpath)
 		}
 
 		if _, isDuplicateSymbolic := symbolicItems[symbolicItemStr]; isDuplicateSymbolic {
@@ -1949,6 +2104,18 @@ func (s *moduleSourceSchema) moduleSourceRemoveItems(
 				existingSymbolic += "/" + strings.TrimPrefix(existingItem.Self().SourceRootSubpath, "/")
 			}
 			existingVersion = existingItem.Self().Git.Version
+
+		case core.ModuleSourceKindDir:
+			if parentSrc.Kind != core.ModuleSourceKindDir {
+				return nil, fmt.Errorf("cannot remove directory %s from module source kind %s", accessor.typ, parentSrc.Kind)
+			}
+			parentSrcRoot := filepath.Join("/", parentSrc.SourceRootSubpath)
+			itemSrcRoot := filepath.Join("/", existingItem.Self().SourceRootSubpath)
+			var err error
+			existingSymbolic, err = pathutil.LexicalRelativePath(parentSrcRoot, itemSrcRoot)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get relative path: %w", err)
+			}
 
 		default:
 			return nil, fmt.Errorf("unhandled %s kind: %s", accessor.typ, existingItem.Self().Kind)

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -66,7 +66,7 @@ func (s *workspaceSchema) initClientChanges(
 			return res, scope, fmt.Errorf("workspace client context: %w", err)
 		}
 	}
-	targetModule, err := s.resolveClientTargetModule(workspaceCtx, ws, moduleLoadRef, "")
+	targetModule, err := s.resolveClientTargetModule(workspaceCtx, parent, moduleLoadRef, "")
 	if err != nil {
 		return res, scope, err
 	}
@@ -158,7 +158,7 @@ func (s *workspaceSchema) initClientChanges(
 
 func (s *workspaceSchema) resolveClientTargetModule(
 	ctx context.Context,
-	ws *core.Workspace,
+	workspaceResult dagql.ObjectResult[*core.Workspace],
 	ref string,
 	pin string,
 ) (dagql.ObjectResult[*core.ModuleSource], error) {
@@ -168,14 +168,10 @@ func (s *workspaceSchema) resolveClientTargetModule(
 		return src, fmt.Errorf("dagql server: %w", err)
 	}
 	if workspace.IsLocalRef(ref, "") {
-		root, err := s.workspaceOverlayRootfs(ctx, ws)
-		if err != nil {
-			return src, err
-		}
-		if err := srv.Select(ctx, root, &src, dagql.Selector{
-			Field: "asModuleSource",
+		if err := srv.Select(ctx, workspaceResult, &src, dagql.Selector{
+			Field: "moduleSource",
 			Args: []dagql.NamedInput{
-				{Name: "sourceRootPath", Value: dagql.String(filepath.ToSlash(ref))},
+				{Name: "path", Value: dagql.String(filepath.ToSlash(ref))},
 			},
 		}); err != nil {
 			return src, fmt.Errorf("load module source: %w", err)

--- a/core/schema/workspace_client.go
+++ b/core/schema/workspace_client.go
@@ -168,10 +168,13 @@ func (s *workspaceSchema) resolveClientTargetModule(
 		return src, fmt.Errorf("dagql server: %w", err)
 	}
 	if workspace.IsLocalRef(ref, "") {
+		// Local client refs have already been normalized to workspace-root
+		// coordinates. Anchor them so Workspace.moduleSource does not resolve
+		// them against a non-root workspace cwd a second time.
 		if err := srv.Select(ctx, workspaceResult, &src, dagql.Selector{
 			Field: "moduleSource",
 			Args: []dagql.NamedInput{
-				{Name: "path", Value: dagql.String(filepath.ToSlash(ref))},
+				{Name: "path", Value: dagql.String(filepath.ToSlash(filepath.Join("/", ref)))},
 			},
 		}); err != nil {
 			return src, fmt.Errorf("load module source: %w", err)

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -121,11 +121,9 @@ type workspaceModuleSourceArgs struct {
 
 // moduleSource loads a module source from a path within the workspace, applying
 // the standard workspace path rules (absolute from the workspace root, relative
-// from the workspace cwd). The whole workspace tree is materialized so the
-// module's dagger.json and dependency include paths resolve; asModuleSource then
-// scopes to sourceRootPath. Host reads route to the workspace owner via
-// workspaceOverlayRootfs, so this works both from the session that owns the
-// workspace and from a module that received the workspace as an argument.
+// from the workspace cwd). Local and Git workspaces retain their backing source
+// and pending overlay; a genuinely Directory-backed workspace remains a
+// DIR_SOURCE.
 func (s *workspaceSchema) moduleSource(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
@@ -135,6 +133,11 @@ func (s *workspaceSchema) moduleSource(
 	resolvedPath, err := resolveWorkspacePath(args.Path, ws.Cwd)
 	if err != nil {
 		return inst, err
+	}
+
+	switch ws.BaseSource().(type) {
+	case *core.WorkspaceSourceClientLocal, *core.WorkspaceSourceGitRef:
+		return (&moduleSourceSchema{}).workspaceModuleSource(ctx, parent, filepath.ToSlash(resolvedPath))
 	}
 
 	root, err := s.workspaceOverlayRootfs(ctx, ws)


### PR DESCRIPTION
## Summary

- preserve `LOCAL_SOURCE` and `GIT_SOURCE` backing when loading a module with `Workspace.moduleSource`, while genuine directory workspaces remain `DIR_SOURCE`
- route module config, filtered context, local dependencies, files, and `.env` reads through the originating workspace so staged changes and the workspace owner's host route survive
- introduce a common `ModuleSourceFS` boundary and shared configured-source initializer for local, Git, Directory, and Workspace-backed sources
- resolve SDK client targets through the canonical `Workspace.moduleSource` path and support dependency authoring for directory-backed module sources without collapsing distinct sources

## Test plan

- `go test ./core ./core/schema`
- `dagger api call engine-dev test --pkg ./core/integration --run='TestWorkspaceAPI/(TestModuleSourceResolvesWorkspacePaths|TestModuleSourcePreservesWorkspaceBacking|TestGitWorkspaceModuleSourcePreservesKind)'`
- `dagger api call engine-dev test --pkg ./core/integration --run='Test(ModuleLoading|WorkspaceCompat|Agents|ContextualWorkspace|Generators)/(TestModuleSourceResolution|TestOuterEnvFile|TestModuleWithDash|TestOverlayModuleSource(IsResolvedThroughOverlay|Edit)|TestContextualWorkspaceModuleSourceLocalDeps|TestCurrentModuleAsSDKClientModuleSourceField)'`
- `dagger api call engine-dev test --pkg ./core/integration --run='TestGenerators/(TestAPIClientInitDottedModulePath|TestInitFromSubdirectoryCwd|TestInitFromSubdirectoryWorkspace)'`

Closes #14040
