### PR TITLE
fix(up): lead with service rows in the TUI

### DIFF
--- a/.dagger/modules/docs-dev/dagger.gen.go
+++ b/.dagger/modules/docs-dev/dagger.gen.go
@@ -389,9 +389,9 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							dag.TypeDef().WithKind(dagger.TypeDefKindStringKind)).
 							WithDescription("Deploys a current build of the docs.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 285, 1)).
-							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 287, 2)}).
-							WithArg("netlifyToken", dag.TypeDef().WithObject("Secret"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 288, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 287, 1)).
+							WithArg("message", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 289, 2)}).
+							WithArg("netlifyToken", dag.TypeDef().WithObject("Secret"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 290, 2)})).
 					WithFunction(
 						dag.Function("GenerateVersion",
 							dag.TypeDef().WithObject("Changeset")).
@@ -406,18 +406,18 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							dag.TypeDef().WithKind(dagger.TypeDefKindVoidKind).WithOptional(true)).
 							WithDescription("Publish a previous deployment to production - defaults to the latest deployment on the main branch.").
 							WithCachePolicy(dagger.FunctionCachePolicyPerSession).
-							WithSourceMap(dag.SourceMap("main.go", 314, 1)).
-							WithArg("netlifyToken", dag.TypeDef().WithObject("Secret"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 316, 2)}).
-							WithArg("deployment", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 318, 2)}).
-							WithArg("apiURL", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 320, 2)})).
+							WithSourceMap(dag.SourceMap("main.go", 316, 1)).
+							WithArg("netlifyToken", dag.TypeDef().WithObject("Secret"), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 318, 2)}).
+							WithArg("deployment", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 320, 2)}).
+							WithArg("apiURL", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{SourceMap: dag.SourceMap("main.go", 322, 2)})).
 					WithFunction(
 						dag.Function("References",
 							dag.TypeDef().WithObject("Changeset")).
 							WithDescription("Regenerate the API schema and CLI reference docs").
-							WithSourceMap(dag.SourceMap("main.go", 230, 1)).
+							WithSourceMap(dag.SourceMap("main.go", 232, 1)).
 							WithGenerator().
-							WithArg("version", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{Description: "Dagger version to generate API docs for", SourceMap: dag.SourceMap("main.go", 233, 2)}).
-							WithArg("ws", dag.TypeDef().WithObject("Workspace").WithOptional(true), dagger.FunctionWithArgOpts{Description: "Workspace forwarded to engine-dev for VCS stamping (References is the\nonly docs-dev method that builds). Auto-injected on a direct call;\ndependencies don't inherit it.", SourceMap: dag.SourceMap("main.go", 239, 2)})).
+							WithArg("version", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind).WithOptional(true), dagger.FunctionWithArgOpts{Description: "Dagger version to generate API docs for", SourceMap: dag.SourceMap("main.go", 235, 2)}).
+							WithArg("ws", dag.TypeDef().WithObject("Workspace").WithOptional(true), dagger.FunctionWithArgOpts{Description: "Workspace forwarded to engine-dev for VCS stamping (References is the\nonly docs-dev method that builds). Auto-injected on a direct call;\ndependencies don't inherit it.", SourceMap: dag.SourceMap("main.go", 241, 2)})).
 					WithFunction(
 						dag.Function("RenameVersion",
 							dag.TypeDef().WithObject("Changeset")).
@@ -427,9 +427,10 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 							WithArg("to", dag.TypeDef().WithKind(dagger.TypeDefKindStringKind), dagger.FunctionWithArgOpts{Description: "New docs version.", SourceMap: dag.SourceMap("main.go", 156, 2)})).
 					WithFunction(
 						dag.Function("Server",
-							dag.TypeDef().WithObject("Container")).
+							dag.TypeDef().WithObject("Service")).
 							WithDescription("Build the docs server").
-							WithSourceMap(dag.SourceMap("main.go", 217, 1))).
+							WithSourceMap(dag.SourceMap("main.go", 218, 1)).
+							WithUp()).
 					WithFunction(
 						dag.Function("Site",
 							dag.TypeDef().WithObject("Directory")).

--- a/.dagger/modules/docs-dev/internal/dagger/docs-dev.gen.go
+++ b/.dagger/modules/docs-dev/internal/dagger/docs-dev.gen.go
@@ -211,10 +211,10 @@ func (r *DocsDev) RenameVersion(from string, to string) *Changeset {
 }
 
 // Build the docs server
-func (r *DocsDev) Server() *Container {
+func (r *DocsDev) Server() *Service {
 	q := r.query.Select("server")
 
-	return &Container{
+	return &Service{
 		query: q,
 	}
 }

--- a/.dagger/modules/docs-dev/main.go
+++ b/.dagger/modules/docs-dev/main.go
@@ -214,7 +214,8 @@ func (d DocsDev) Check(ctx context.Context) error {
 }
 
 // Build the docs server
-func (d DocsDev) Server() *dagger.Container {
+// +up
+func (d DocsDev) Server() *dagger.Service {
 	return dag.
 		Container().
 		From("nginx").
@@ -222,7 +223,8 @@ func (d DocsDev) Server() *dagger.Container {
 		WithFile("/etc/nginx/conf.d/default.conf", d.NginxConfig).
 		WithDefaultArgs([]string{"nginx", "-g", "daemon off;"}).
 		WithDirectory("/var/www", d.Site()).
-		WithExposedPort(8000)
+		WithExposedPort(8000).
+		AsService()
 }
 
 // Regenerate the API schema and CLI reference docs

--- a/.dagger/modules/release/internal/dagger/docs-dev.gen.go
+++ b/.dagger/modules/release/internal/dagger/docs-dev.gen.go
@@ -35,7 +35,7 @@ func (r *DocsDev) Check(ctx context.Context) error { // docs-dev (../../../../..
 }
 
 // Deploys a current build of the docs.
-func (r *DocsDev) Deploy(ctx context.Context, message string, netlifyToken *Secret) (string, error) { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:285:1)
+func (r *DocsDev) Deploy(ctx context.Context, message string, netlifyToken *Secret) (string, error) { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:287:1)
 	assertNotNil("netlifyToken", netlifyToken)
 	if r.deploy != nil {
 		return *r.deploy, nil
@@ -149,13 +149,13 @@ func (r *DocsDev) UnmarshalJSON(bs []byte) error {
 
 // DocsDevPublishOpts contains options for DocsDev.Publish
 type DocsDevPublishOpts struct {
-	Deployment string // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:318:2)
+	Deployment string // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:320:2)
 
-	APIURL string // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:320:2)
+	APIURL string // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:322:2)
 }
 
 // Publish a previous deployment to production - defaults to the latest deployment on the main branch.
-func (r *DocsDev) Publish(ctx context.Context, netlifyToken *Secret, opts ...DocsDevPublishOpts) error { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:314:1)
+func (r *DocsDev) Publish(ctx context.Context, netlifyToken *Secret, opts ...DocsDevPublishOpts) error { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:316:1)
 	assertNotNil("netlifyToken", netlifyToken)
 	if r.publish != nil {
 		return nil
@@ -181,17 +181,17 @@ type DocsDevReferencesOpts struct {
 	//
 	// Dagger version to generate API docs for
 	//
-	Version string // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:233:2)
+	Version string // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:235:2)
 	//
 	// Workspace forwarded to engine-dev for VCS stamping (References is the
 	// only docs-dev method that builds). Auto-injected on a direct call;
 	// dependencies don't inherit it.
 	//
-	Ws *Workspace // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:239:2)
+	Ws *Workspace // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:241:2)
 }
 
 // Regenerate the API schema and CLI reference docs
-func (r *DocsDev) References(opts ...DocsDevReferencesOpts) *Changeset { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:230:1)
+func (r *DocsDev) References(opts ...DocsDevReferencesOpts) *Changeset { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:232:1)
 	q := r.query.Select("references")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `version` optional argument
@@ -221,10 +221,10 @@ func (r *DocsDev) RenameVersion(from string, to string) *Changeset { // docs-dev
 }
 
 // Build the docs server
-func (r *DocsDev) Server() *Container { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:217:1)
+func (r *DocsDev) Server() *Service { // docs-dev (../../../../../.dagger/modules/docs-dev/main.go:218:1)
 	q := r.query.Select("server")
 
-	return &Container{
+	return &Service{
 		query: q,
 	}
 }

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -119,6 +119,23 @@ func (UpSuite) TestUpEnvServices(ctx context.Context, t *testctx.T) {
 	require.Contains(t, out, "infra:database")
 }
 
+func (UpSuite) TestUpNoServices(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen, err := upTestEnv(t, c)
+	require.NoError(t, err)
+
+	// An empty workspace must report the problem rather than wait for Ctrl+C.
+	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	out, err := modGen.
+		WithWorkdir("/empty").
+		WithNewFile("dagger.toml", "").
+		With(daggerExecFail("up")).
+		CombinedOutput(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "no services found")
+}
+
 func (UpSuite) TestUpPortCollision(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 	modGen, err := upTestEnv(t, c)

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -317,64 +317,120 @@ func (node *ModTreeNode) tryRunCheckScaleOut(ctx context.Context) (_ bool, rerr 
 // callers.
 const ServiceNameAttr = telemetryattrs.ServiceNameAttr
 
-// RunUp starts the service and returns a result that must be cleaned up.
-// It does NOT block — the caller (UpGroup.Run) handles the blocking wait.
-func (node *ModTreeNode) RunUp(ctx context.Context, include, exclude []string, portMappings []PortForward) (*runUpStartResult, error) {
-	var result *runUpStartResult
-	err := node.Run(ctx,
-		func(n *ModTreeNode) bool { return n.IsUp },
-		func(ctx context.Context, n *ModTreeNode, clientMD *engine.ClientMetadata) (rerr error) {
-			ctx, span := Tracer(ctx).Start(ctx, n.PathString(),
-				trace.WithAttributes(
-					attribute.Bool(telemetry.UIRollUpLogsAttr, true),
-					attribute.String(ServiceNameAttr, n.PathString()),
-				),
-			)
-			defer func() {
-				telemetry.EndWithCause(span, &rerr)
-			}()
-			var err error
-			result, err = n.runUpLocally(ctx, span, portMappings)
-			return err
-		},
-		include, exclude)
-	return result, err
-}
+// PrepareUp opens the service's display span and evaluates the +up function
+// beneath it, returning the prepared service without starting anything. The
+// caller decides when (and whether) to Start it — UpGroup.Run evaluates every
+// service first and refuses to start any of them on a host-port collision.
+//
+// The evaluation deliberately happens beneath the display span: the API spans
+// it creates are where dagui routes the service's stdio, so this is what puts
+// the service's log stream under its own row in `dagger up`. The display span
+// stays open until Start or Abort ends it.
+func (node *ModTreeNode) PrepareUp(ctx context.Context, portMappings []PortForward) (_ *preparedUp, rerr error) {
+	if !node.IsUp {
+		return nil, fmt.Errorf("%s is not a service function", node.PathString())
+	}
+	ctx, span := Tracer(ctx).Start(ctx, node.PathString(),
+		trace.WithAttributes(
+			attribute.Bool(telemetry.UIRollUpLogsAttr, true),
+			attribute.String(ServiceNameAttr, node.PathString()),
+		),
+	)
+	defer func() {
+		if rerr != nil {
+			telemetry.EndWithCause(span, &rerr)
+		}
+	}()
 
-// runUpStartResult is the result of starting a single service in runUpLocally.
-// It contains everything needed to display status and clean up after ctx cancellation.
-type runUpStartResult struct {
-	ReadySpan trace.Span
-}
-
-// runUpLocally evaluates the +up function, creates a host tunnel, starts the
-// service, and returns immediately. It does NOT block — the caller is
-// responsible for blocking on ctx.Done() after all services have started.
-// This two-phase design ensures that if one service fails to start, sibling
-// goroutines are not left hanging on <-ctx.Done() forever.
-func (node *ModTreeNode) runUpLocally(ctx context.Context, parentSpan trace.Span, portMappings []PortForward) (*runUpStartResult, error) {
 	// Evaluate the +up function to get the Service
 	var svcResult dagql.ObjectResult[*Service]
 	if err := node.DagqlValue(ctx, &svcResult); err != nil {
 		return nil, err
 	}
 
-	// Update parent span name with port info.
-	var portStrs []string
+	// Collect the service's host ports: the explicit mappings' host side, or
+	// the container's exposed ports tunneled 1:1.
+	var hostPorts []upHostPort
 	if len(portMappings) > 0 {
-		portStrs = make([]string, 0, len(portMappings))
+		hostPorts = make([]upHostPort, 0, len(portMappings))
 		for _, pf := range portMappings {
-			portStrs = append(portStrs, fmt.Sprintf(":%d→%d", pf.FrontendOrBackendPort(), pf.Backend))
+			hostPorts = append(hostPorts, upHostPort{
+				port:     pf.FrontendOrBackendPort(),
+				protocol: pf.Protocol,
+			})
 		}
 	} else if svc := svcResult.Self(); svc != nil && svc.Container.Self() != nil {
-		portStrs = make([]string, 0, len(svc.Container.Self().Ports))
+		hostPorts = make([]upHostPort, 0, len(svc.Container.Self().Ports))
 		for _, p := range svc.Container.Self().Ports {
-			portStrs = append(portStrs, fmt.Sprintf(":%d", p.Port))
+			hostPorts = append(hostPorts, upHostPort{
+				port:     p.Port,
+				protocol: p.Protocol,
+			})
 		}
 	}
-	if len(portStrs) > 0 {
-		parentSpan.SetName(fmt.Sprintf("%s %s", node.PathString(), strings.Join(portStrs, ", ")))
+
+	// Update the display span name with port info.
+	if len(hostPorts) > 0 {
+		portStrs := make([]string, 0, len(hostPorts))
+		if len(portMappings) > 0 {
+			for _, pf := range portMappings {
+				portStrs = append(portStrs, fmt.Sprintf(":%d→%d", pf.FrontendOrBackendPort(), pf.Backend))
+			}
+		} else {
+			for _, p := range hostPorts {
+				portStrs = append(portStrs, fmt.Sprintf(":%d", p.port))
+			}
+		}
+		span.SetName(fmt.Sprintf("%s %s", node.PathString(), strings.Join(portStrs, ", ")))
 	}
+
+	return &preparedUp{
+		node:         node,
+		span:         span,
+		svc:          svcResult,
+		portMappings: portMappings,
+		hostPorts:    hostPorts,
+	}, nil
+}
+
+// preparedUp is a service that has been evaluated beneath its own display
+// span and is ready to start: PrepareUp's output, Start's receiver. Its
+// display span stays open until exactly one of Start or Abort runs.
+type preparedUp struct {
+	node         *ModTreeNode
+	span         trace.Span
+	svc          dagql.ObjectResult[*Service]
+	portMappings []PortForward
+	hostPorts    []upHostPort
+}
+
+func (p *preparedUp) Name() string {
+	return p.node.PathString()
+}
+
+// Abort ends the display span without starting the service — the group's
+// answer when a sibling failed to evaluate or the port-collision verdict
+// refused the whole group.
+func (p *preparedUp) Abort(err error) {
+	telemetry.EndWithCause(p.span, &err)
+}
+
+// runUpStartResult is the result of starting a single service.
+// It contains everything needed to display status and clean up after ctx cancellation.
+type runUpStartResult struct {
+	ReadySpan trace.Span
+}
+
+// Start creates the host tunnel, starts the service, and returns immediately
+// once it is healthy — the caller is responsible for blocking on ctx.Done()
+// afterwards. It runs beneath the display span PrepareUp opened and ends it on
+// return; the returned ReadySpan (the `ready <url>` marker) stays open until
+// the caller ends it at shutdown, keeping the display row visibly live.
+func (p *preparedUp) Start(ctx context.Context) (_ *runUpStartResult, rerr error) {
+	ctx = trace.ContextWithSpan(ctx, p.span)
+	defer func() {
+		telemetry.EndWithCause(p.span, &rerr)
+	}()
 
 	// Set up the host tunnel
 	srv, err := CurrentDagqlServer(ctx)
@@ -383,17 +439,17 @@ func (node *ModTreeNode) runUpLocally(ctx context.Context, parentSpan trace.Span
 	}
 
 	var hostSvc dagql.Result[*Service]
-	svcID, err := svcResult.ID()
+	svcID, err := p.svc.ID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service ID: %w", err)
 	}
 	tunnelArgs := []dagql.NamedInput{
 		{Name: "service", Value: dagql.NewID[*Service](svcID)},
 	}
-	if len(portMappings) > 0 {
+	if len(p.portMappings) > 0 {
 		// Use explicit port mappings instead of native 1:1 tunneling.
-		portInputs := make([]dagql.InputObject[PortForward], len(portMappings))
-		for i, pf := range portMappings {
+		portInputs := make([]dagql.InputObject[PortForward], len(p.portMappings))
+		for i, pf := range p.portMappings {
 			inputMap := map[string]any{
 				"backend": pf.Backend,
 			}
@@ -420,7 +476,14 @@ func (node *ModTreeNode) runUpLocally(ctx context.Context, parentSpan trace.Span
 	} else {
 		tunnelArgs = append(tunnelArgs, dagql.NamedInput{Name: "native", Value: dagql.Boolean(true)})
 	}
-	err = srv.Select(ctx, srv.Root(), &hostSvc,
+	// Select non-internal: dagui routes the service's stdio to the most
+	// recent creator span for its call digest, and the service ID load
+	// inside host.tunnel presents exactly such a span. Server.Select would
+	// mark the tunnel span internal (it's an engine-side call), and internal
+	// spans block the log roll-up walk — which would strand the service's
+	// stdio beneath machinery instead of rolling it up into the service's
+	// display row (the span PrepareUp opened, see above).
+	err = srv.Select(dagql.WithNonInternalTelemetry(ctx), srv.Root(), &hostSvc,
 		dagql.Selector{Field: "host"},
 		dagql.Selector{
 			Field: "tunnel",
@@ -458,14 +521,20 @@ func (node *ModTreeNode) runUpLocally(ctx context.Context, parentSpan trace.Span
 		urls = append(urls, fmt.Sprintf("%s://localhost:%d", scheme, port.Port))
 	}
 
-	// Create a "ready" child span visible in the TUI.
+	// Stamp the URLs on the display span itself: it ends right below, and the
+	// end export delivers them, so the TUI can show where to point a browser
+	// on the service's own collapsed row (see idtui's renderStepTitle).
+	p.span.SetAttributes(attribute.StringSlice(telemetryattrs.ServiceURLsAttr, urls))
+
+	// Create a "ready" child span visible in the TUI. It stays open while the
+	// service runs, which also keeps the display row's rolled-up logs live.
 	readyName := "ready"
 	if len(urls) > 0 {
 		readyName = "ready " + strings.Join(urls, " ")
 	}
 	_, readySpan := Tracer(ctx).Start(ctx, readyName,
 		trace.WithAttributes(
-			attribute.StringSlice("service.urls", urls),
+			attribute.StringSlice(telemetryattrs.ServiceURLsAttr, urls),
 		),
 	)
 

--- a/core/up.go
+++ b/core/up.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -61,13 +62,19 @@ func (ug *UpGroup) List() []*Up {
 	return ug.Ups
 }
 
-// Run starts all service functions in the group.
-// Before starting, it evaluates all services to detect port collisions.
+// Run starts all service functions in the group and blocks until ctx is
+// cancelled (e.g. Ctrl+C).
 //
-// Uses a two-phase approach: phase 1 starts all services in parallel and
-// returns immediately once each is healthy; phase 2 blocks on ctx.Done().
-// This ensures that if one service fails to start, the error is surfaced
-// immediately without leaving sibling goroutines hanging forever.
+// It runs in two phases. Phase 1 evaluates every service in parallel, each
+// beneath its own display span (see ModTreeNode.PrepareUp) — evaluating
+// there matters beyond ordering: the evaluation's API spans are what the
+// service's log stream is routed to (dagui routes a service's stdio to the
+// span that created its value), so this is what makes `dagger up` show each
+// service's logs under its own row rather than under a separate preflight
+// subtree. Nothing starts until every service has evaluated and the group's
+// host ports are collision-free. Phase 2 then starts them all in parallel,
+// returning from each as soon as it is healthy, so a service that fails to
+// start surfaces immediately without leaving sibling goroutines hanging.
 func (ug *UpGroup) Run(ctx context.Context) (*UpGroup, error) {
 	ug = ug.Clone()
 
@@ -79,21 +86,54 @@ func (ug *UpGroup) Run(ctx context.Context) (*UpGroup, error) {
 		ctx = WorkspaceToContext(ctx, ug.BoundWorkspace)
 	}
 
-	if err := ug.checkPortCollisions(ctx); err != nil {
+	// Phase 1: evaluate every service beneath its own display span, in
+	// parallel, collecting the host ports each wants. The jobs themselves are
+	// untraced: each service's display span is its row, and a wrapper job
+	// span would only duplicate it.
+	preps := make([]*preparedUp, len(ug.Ups))
+	jobs := parallel.New().WithTracing(false)
+	for i, up := range ug.Ups {
+		jobs = jobs.WithJob(up.Name(), func(ctx context.Context) error {
+			prep, err := up.Node.PrepareUp(ctx, up.PortMappings)
+			if err != nil {
+				return err
+			}
+			preps[i] = prep
+			return nil
+		})
+	}
+	// abort ends every prepared service's display span without starting it —
+	// the group never partially starts when it's known to be doomed.
+	abort := func(cause error) {
+		for _, prep := range preps {
+			if prep != nil {
+				prep.Abort(cause)
+			}
+		}
+	}
+	if err := jobs.Run(ctx); err != nil {
+		abort(errors.New("not started: another service in the group failed"))
 		return nil, err
 	}
 
-	// Phase 1: start all services in parallel. Each RunUp evaluates the
-	// module function, creates the host tunnel, and waits for the health
-	// check — then returns immediately (no blocking).
+	// Verdict: refuse to start anything when two services claim the same
+	// host port.
+	if err := checkPortCollisions(preps); err != nil {
+		abort(err)
+		return nil, err
+	}
+
+	// Phase 2: start all services in parallel. Each Start creates the host
+	// tunnel and waits for the health check — then returns immediately (no
+	// blocking).
 	var (
 		mu      sync.Mutex
 		results []*runUpStartResult
 	)
-	jobs := parallel.New().WithContextualTracer(true)
-	for _, up := range ug.Ups {
-		jobs = jobs.WithJob(up.Name(), func(ctx context.Context) error {
-			result, err := up.Node.RunUp(ctx, nil, nil, up.PortMappings)
+	jobs = parallel.New().WithTracing(false)
+	for _, prep := range preps {
+		jobs = jobs.WithJob(prep.Name(), func(ctx context.Context) error {
+			result, err := prep.Start(ctx)
 			if err != nil {
 				return err
 			}
@@ -111,8 +151,8 @@ func (ug *UpGroup) Run(ctx context.Context) (*UpGroup, error) {
 		return nil, err
 	}
 
-	// Phase 2: all services started successfully. Block until context
-	// cancellation (e.g. Ctrl+C).
+	// All services started successfully. Block until context cancellation
+	// (e.g. Ctrl+C).
 	<-ctx.Done()
 	for _, r := range results {
 		r.ReadySpan.End()
@@ -120,88 +160,33 @@ func (ug *UpGroup) Run(ctx context.Context) (*UpGroup, error) {
 	return ug, nil
 }
 
-// checkPortCollisions evaluates all service functions to collect their exposed
-// ports and fails fast if two services expose the same host port.
-func (ug *UpGroup) checkPortCollisions(ctx context.Context) error {
-	type portKey struct {
-		port     int
-		protocol NetworkProtocol
-	}
-
-	// Evaluate all services in parallel to collect ports.
-	// NOTE: the same DagqlValue() call happens again in runUpLocally during
-	// Run(). This is safe because dagql caches Select results by content
-	// address, so the second evaluation is a cache hit with no re-execution.
-	type servicePort struct {
-		name string
-		port portKey
-	}
-	var (
-		mu       = new(sync.Mutex)
-		allPorts []servicePort
-	)
-
-	jobs := parallel.New().WithContextualTracer(true)
-	for _, up := range ug.Ups {
-		jobs = jobs.WithJob(up.Name()+":preflight", func(ctx context.Context) error {
-			// If port mappings are configured, use the frontend (host) ports
-			// for collision detection instead of the container ports.
-			if len(up.PortMappings) > 0 {
-				mu.Lock()
-				defer mu.Unlock()
-				for _, pf := range up.PortMappings {
-					hostPort := pf.Backend
-					if pf.Frontend != nil {
-						hostPort = *pf.Frontend
-					}
-					allPorts = append(allPorts, servicePort{
-						name: up.Name(),
-						port: portKey{port: hostPort, protocol: pf.Protocol},
-					})
-				}
-				return nil
-			}
-
-			var svcResult dagql.ObjectResult[*Service]
-			if err := up.Node.DagqlValue(ctx, &svcResult); err != nil {
-				return err
-			}
-			svc := svcResult.Self()
-			if svc == nil || svc.Container.Self() == nil {
-				return nil
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			for _, p := range svc.Container.Self().Ports {
-				allPorts = append(allPorts, servicePort{
-					name: up.Name(),
-					port: portKey{port: p.Port, protocol: p.Protocol},
-				})
-			}
-			return nil
-		})
-	}
-	if err := jobs.Run(ctx); err != nil {
-		return err
-	}
-
-	// Check for duplicates.
-	seen := make(map[portKey]string) // port → first service name
+// checkPortCollisions reports an error when two prepared services claim the
+// same host port. preps follows the group's declaration order, so the
+// output is deterministic.
+func checkPortCollisions(preps []*preparedUp) error {
+	seen := make(map[upHostPort]string) // port → first service name
 	var conflicts []string
-	for _, sp := range allPorts {
-		if first, ok := seen[sp.port]; ok {
-			conflicts = append(conflicts, fmt.Sprintf(
-				"port %d/%s is exposed by both %q and %q",
-				sp.port.port, strings.ToLower(string(sp.port.protocol)), first, sp.name,
-			))
-		} else {
-			seen[sp.port] = sp.name
+	for _, prep := range preps {
+		for _, port := range prep.hostPorts {
+			if first, ok := seen[port]; ok {
+				conflicts = append(conflicts, fmt.Sprintf(
+					"port %d/%s is exposed by both %q and %q",
+					port.port, strings.ToLower(string(port.protocol)), first, prep.Name(),
+				))
+			} else {
+				seen[port] = prep.Name()
+			}
 		}
 	}
 	if len(conflicts) > 0 {
 		return fmt.Errorf("port collision detected:\n  %s", strings.Join(conflicts, "\n  "))
 	}
 	return nil
+}
+
+type upHostPort struct {
+	port     int
+	protocol NetworkProtocol
 }
 
 func (ug *UpGroup) Clone() *UpGroup {
@@ -248,7 +233,11 @@ func (u *Up) Clone() *Up {
 // Run starts the service returned by this up function and blocks until ctx is cancelled.
 func (u *Up) Run(ctx context.Context) (*Up, error) {
 	u = u.Clone()
-	result, err := u.Node.RunUp(ctx, nil, nil, u.PortMappings)
+	prep, err := u.Node.PrepareUp(ctx, u.PortMappings)
+	if err != nil {
+		return u, err
+	}
+	result, err := prep.Start(ctx)
 	if err != nil {
 		return u, err
 	}

--- a/core/up.go
+++ b/core/up.go
@@ -76,6 +76,9 @@ func (ug *UpGroup) List() []*Up {
 // returning from each as soon as it is healthy, so a service that fails to
 // start surfaces immediately without leaving sibling goroutines hanging.
 func (ug *UpGroup) Run(ctx context.Context) (*UpGroup, error) {
+	if len(ug.Ups) == 0 {
+		return nil, errors.New("no services found")
+	}
 	ug = ug.Clone()
 
 	// Run the services against the workspace this group was rolled up from, so

--- a/dagql/dagui/db.go
+++ b/dagql/dagui/db.go
@@ -204,6 +204,11 @@ type DB struct {
 	surfacedServicesRoot SpanID
 	surfacedServicesInit bool
 
+	serviceDisplays     []*Span
+	serviceDisplaysAt   uint64
+	serviceDisplaysRoot SpanID
+	serviceDisplaysInit bool
+
 	testIndex *TestIndex
 }
 
@@ -1002,6 +1007,10 @@ func (db *DB) integrateSpan(span *Span) { //nolint: gocyclo
 		db.resolvePendingLogs(span.Output, span.TraceID)
 	}
 
+	if span.Service {
+		db.resolvePendingServiceLogs(span)
+	}
+
 	db.maybeResumeOutput(span)
 
 	// finally, install the span if we don't already have it
@@ -1110,6 +1119,44 @@ func (db *DB) resolvePendingLogs(output string, traceID TraceID) {
 	}
 }
 
+// resolvePendingServiceLogs claims parked digest-routed log records whose own
+// span is this service's exec span. A service's stdio names the call that
+// created it (DagDigestAttr, see routeLog), but the records can arrive before
+// the exec span's snapshot does: routeLog then finds neither a creator span
+// nor a known Service span and parks the record under its digest. On a warm,
+// fully-cached trace the creator's span is never emitted, so nothing else
+// will ever claim them — do it here, when the exec span shows up. Records
+// from other spans sharing the digest stay parked for the creator path.
+func (db *DB) resolvePendingServiceLogs(span *Span) {
+	for key, records := range db.pendingLogsByOutput {
+		if key.TraceID != span.TraceID {
+			continue
+		}
+		var kept []sdklog.Record
+		var claimed bool
+		for _, record := range records {
+			if (SpanID{SpanID: record.SpanID()}) != span.ID {
+				kept = append(kept, record)
+				continue
+			}
+			claimed = true
+			if span.ID == db.PrimarySpan {
+				db.PrimaryLogs[span.ID] = append(db.PrimaryLogs[span.ID], record)
+			}
+			db.resolvedLogsBySpan[span.ID] = append(db.resolvedLogsBySpan[span.ID], record)
+		}
+		if !claimed {
+			continue
+		}
+		span.HasLogs = true
+		if len(kept) == 0 {
+			delete(db.pendingLogsByOutput, key)
+		} else {
+			db.pendingLogsByOutput[key] = kept
+		}
+	}
+}
+
 func (db *DB) DrainResolvedLogs(spanID SpanID) []sdklog.Record {
 	logs := db.resolvedLogsBySpan[spanID]
 	delete(db.resolvedLogsBySpan, spanID)
@@ -1134,6 +1181,20 @@ func (db *DB) routeLog(record sdklog.Record) (SpanID, *resumeOutputKey) {
 
 	if creator := db.creatorSpanForDigestInTrace(targetDig, record.TraceID()); creator != nil {
 		return creator.ID, nil
+	}
+
+	// A service's stdio names the call that created the service (the engine
+	// stamps DagDigestAttr with e.g. the asService call digest) so the stream
+	// renders beneath the API call that installed it. On a warm, fully-cached
+	// trace that call's span is never emitted, so no creator will ever arrive
+	// to claim parked lines. The record's own span is the service's
+	// long-lived exec span: attach the stream there, keeping it beneath the
+	// service instance — and, via log roll-up, in whatever row displays it,
+	// e.g. `dagger up`'s per-service display span — instead of parking it
+	// forever. (On a cold trace a record can win a race against the creator
+	// span's arrival and land here too; it stays in the same subtree.)
+	if span, ok := db.Spans.Map[fallback]; ok && span.Service {
+		return fallback, nil
 	}
 
 	key := resumeOutputKey{

--- a/dagql/dagui/opts.go
+++ b/dagql/dagui/opts.go
@@ -57,6 +57,12 @@ type FrontendOpts struct {
 	// Whether the span has been expanded by the user.
 	SpanExpanded map[SpanID]bool
 
+	// RootFilter selects the top-level spans for a command at the primary zoom.
+	// Returning no spans keeps the normal startup tree. Explicit zooms use the
+	// regular subtree, so navigation and search share the same RowsView.
+	// The callback must not mutate the DB or its spans.
+	RootFilter func(*DB, *Span) []*Span
+
 	// Filter is applied while constructing the tree.
 	Filter func(*Span) WalkDecision
 

--- a/dagql/dagui/services.go
+++ b/dagql/dagui/services.go
@@ -122,3 +122,42 @@ func (db *DB) buildSurfacedServices(root *Span) []*ServiceNode {
 	sortNodes(roots)
 	return roots
 }
+
+// ServiceDisplaySpans returns the per-service display spans beneath root, in
+// start order: the spans core's ModTreeNode.PrepareUp opens for each `dagger
+// up` service, recognizable by a service name (ServiceNameAttr) WITHOUT the
+// engine's service-instance mark (ServiceAttr). Each carries the service's
+// port-suffixed name, its rolled-up evaluation/health-check/service logs, its
+// readiness URLs (ServiceURLs, stamped once the health check passes), and the
+// `ready <url>` child span.
+//
+// Used as dagger up's RootFilter, so the regular trace UI leads with these
+// spans from the moment evaluation begins, including build logs and readiness
+// URLs. The same zoom-relative containment as other surfaced kinds applies.
+// The result is cached per DB mutation and per root; callers must treat the
+// returned slice as read-only.
+func (db *DB) ServiceDisplaySpans(root *Span) []*Span {
+	r := db.surfaceRoot(root)
+	key := surfaceRootID(r)
+	if db.serviceDisplaysInit && db.serviceDisplaysAt == db.mutations && db.serviceDisplaysRoot == key {
+		return db.serviceDisplays
+	}
+	var displays []*Span
+	for span := range db.Spans.Iter() {
+		if span.ServiceName == "" || span.Service || span.Internal || !span.Received {
+			continue
+		}
+		if !spanMayRollUp(span, r, nil) {
+			continue
+		}
+		displays = append(displays, span)
+	}
+	sort.SliceStable(displays, func(i, j int) bool {
+		return displays[i].Before(displays[j])
+	})
+	db.serviceDisplays = displays
+	db.serviceDisplaysAt = db.mutations
+	db.serviceDisplaysRoot = key
+	db.serviceDisplaysInit = true
+	return displays
+}

--- a/dagql/dagui/services_test.go
+++ b/dagql/dagui/services_test.go
@@ -103,3 +103,49 @@ func TestSurfacedServicesName(t *testing.T) {
 		t.Fatalf("bare.Name() = %q, want span-name fallback", bare.Name())
 	}
 }
+
+// TestServiceDisplaySpans covers the live-dashboard anchor for `dagger up`:
+// per-service display spans (a service name WITHOUT the engine's
+// service-instance mark) surface in start order from the moment they exist,
+// wherever they sit beneath the root; instance and boundary-contained spans
+// stay out.
+func TestServiceDisplaySpans(t *testing.T) {
+	const (
+		rootID byte = iota + 1
+		runID
+		displayAID
+		displayBID
+		execAID
+		boundaryID
+		hiddenID
+	)
+	markDisplay := func(snap SpanSnapshot, name string) SpanSnapshot {
+		snap.ServiceName = name
+		return snap
+	}
+	db := NewDB()
+	boundary := serviceTestSnapshot(boundaryID, "fixture", spanID(rootID))
+	boundary.Boundary = true
+	// Import the later-starting display span first to prove the sort.
+	db.ImportSnapshots([]SpanSnapshot{
+		serviceTestSnapshot(rootID, "root", SpanID{}),
+		// the call machinery the display spans live under
+		serviceTestSnapshot(runID, "UpGroup.run", spanID(rootID)),
+		markDisplay(serviceTestSnapshot(displayBID, "b :81", spanID(runID)), "b"),
+		markDisplay(serviceTestSnapshot(displayAID, "a :80", spanID(runID)), "a"),
+		// the engine's service-instance span is NOT a display span
+		markService(serviceTestSnapshot(execAID, "exec a", spanID(displayAID)), "a.dagger.local"),
+		boundary,
+		// a display span contained behind a boundary (a test fixture) stays out
+		markDisplay(serviceTestSnapshot(hiddenID, "hidden :99", spanID(boundaryID)), "hidden"),
+	})
+
+	displays := db.ServiceDisplaySpans(db.RootSpan)
+	names := make([]string, len(displays))
+	for i, span := range displays {
+		names[i] = span.Name
+	}
+	if len(displays) != 2 || names[0] != "a :80" || names[1] != "b :81" {
+		t.Fatalf("displays = %v, want [a :80 b :81]", names)
+	}
+}

--- a/dagql/dagui/spans.go
+++ b/dagql/dagui/spans.go
@@ -297,6 +297,13 @@ type SpanSnapshot struct {
 	// Service name
 	ServiceName string `json:",omitempty"`
 
+	// ServiceURLs marks a service-readiness marker span: the local URLs at
+	// which a just-started service is reachable (`dagger up`'s `ready <url>`
+	// span). Also stamped on the service's display span itself, so its
+	// collapsed row can show where to point a browser (see idtui's
+	// renderServiceURLs).
+	ServiceURLs []string `json:",omitempty"`
+
 	ActorEmoji  string `json:",omitempty"`
 	Message     string `json:",omitempty"`
 	ContentType string `json:",omitempty"`
@@ -462,6 +469,9 @@ func (snapshot *SpanSnapshot) ProcessAttribute(name string, val any) { //nolint:
 
 	case telemetryattrs.ServiceNameAttr:
 		snapshot.ServiceName = val.(string)
+
+	case telemetryattrs.ServiceURLsAttr:
+		snapshot.ServiceURLs = sliceOf[string](val)
 
 	case telemetry.LLMRoleAttr:
 		snapshot.LLMRole = val.(string)

--- a/dagql/dagui/spans_test.go
+++ b/dagql/dagui/spans_test.go
@@ -270,6 +270,143 @@ func TestLogTargetSpanIDWaitsForMatchingTraceCreator(t *testing.T) {
 	}
 }
 
+// TestLogTargetSpanIDFallsBackToServiceSpan covers the warm-trace routing
+// gap: a running service's stdio names the call that created it (its
+// DagDigestAttr), but a fully cached trace never emits that call's span, so
+// no creator would ever arrive to claim parked lines. When the record's own
+// span is the service's long-lived exec span, the stream attaches there
+// instead of parking forever; a non-service span still parks awaiting its
+// creator.
+func TestLogTargetSpanIDFallsBackToServiceSpan(t *testing.T) {
+	db := NewDB()
+
+	traceID := trace.TraceID{2}
+	execID := trace.SpanID{9}
+	plainID := trace.SpanID{10}
+	db.ImportSnapshots([]SpanSnapshot{
+		{
+			ID:          SpanID{SpanID: execID},
+			TraceID:     TraceID{TraceID: traceID},
+			Name:        "exec nginx",
+			Service:     true,
+			ServiceName: "web.dagger.local",
+			Passthrough: true,
+			StartTime:   time.Unix(1, 0),
+		},
+		{
+			ID:        SpanID{SpanID: plainID},
+			TraceID:   TraceID{TraceID: traceID},
+			Name:      "exec build",
+			StartTime: time.Unix(1, 0),
+		},
+	})
+
+	record := newTestLogRecord(
+		traceID,
+		execID,
+		"nginx: ready",
+		otellog.String(telemetry.DagDigestAttr, "xxh3:never-created"),
+	)
+	if got := db.LogTargetSpanID(record); got != (SpanID{SpanID: execID}) {
+		t.Fatalf("expected the service exec span fallback, got %s", got)
+	}
+
+	other := newTestLogRecord(
+		traceID,
+		plainID,
+		"hello",
+		otellog.String(telemetry.DagDigestAttr, "xxh3:never-created"),
+	)
+	if got := db.LogTargetSpanID(other); got.IsValid() {
+		t.Fatalf("expected unresolved target for non-service span, got %s", got)
+	}
+}
+
+// TestPendingDigestLogsResolveWhenServiceSpanArrives covers the other half
+// of the warm-trace routing gap: the service's stdio can arrive BEFORE its
+// exec span snapshot does. routeLog then finds neither a creator span nor a
+// known Service span, so the record parks under its digest — and on a fully
+// cached trace no creator will ever arrive to claim it. When the exec span
+// shows up flagged as a Service, it must claim its own parked records.
+func TestPendingDigestLogsResolveWhenServiceSpanArrives(t *testing.T) {
+	db := NewDB()
+
+	traceID := trace.TraceID{2}
+	execID := SpanID{SpanID: trace.SpanID{9}}
+	otherID := trace.SpanID{10}
+	outputDig := "xxh3:never-created"
+
+	record := newTestLogRecord(
+		traceID,
+		execID.SpanID,
+		"nginx: ready",
+		otellog.String(telemetry.DagDigestAttr, outputDig),
+	)
+	// a record from a different span sharing the digest must stay parked
+	other := newTestLogRecord(
+		traceID,
+		otherID,
+		"unrelated",
+		otellog.String(telemetry.DagDigestAttr, outputDig),
+	)
+
+	if err := db.LogExporter().Export(context.Background(), []sdklog.Record{record, other}); err != nil {
+		t.Fatalf("export logs: %v", err)
+	}
+
+	if got := db.DrainResolvedLogs(execID); len(got) != 0 {
+		t.Fatalf("expected no resolved logs before exec span, got %d", len(got))
+	}
+
+	db.ImportSnapshots([]SpanSnapshot{
+		{
+			ID:          execID,
+			TraceID:     TraceID{TraceID: traceID},
+			Name:        "exec nginx",
+			Service:     true,
+			ServiceName: "web.dagger.local",
+			Passthrough: true,
+			StartTime:   time.Unix(1, 0),
+		},
+	})
+
+	resolved := db.DrainResolvedLogs(execID)
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 resolved log, got %d", len(resolved))
+	}
+	if resolved[0].Body().AsString() != "nginx: ready" {
+		t.Fatalf("expected resolved log body %q, got %q", "nginx: ready", resolved[0].Body().AsString())
+	}
+
+	exec := db.Spans.Map[execID]
+	if exec == nil {
+		t.Fatal("expected exec span")
+	}
+	if !exec.HasLogs {
+		t.Fatal("expected exec span to have logs")
+	}
+
+	// the other span's record still awaits its creator
+	creatorID := SpanID{SpanID: trace.SpanID{3}}
+	db.ImportSnapshots([]SpanSnapshot{
+		{
+			ID:         creatorID,
+			TraceID:    TraceID{TraceID: traceID},
+			StartTime:  time.Unix(3, 0),
+			EndTime:    time.Unix(4, 0),
+			CallDigest: "xxh3:live-call",
+			Output:     outputDig,
+		},
+	})
+	remaining := db.DrainResolvedLogs(creatorID)
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 log resolved to creator, got %d", len(remaining))
+	}
+	if remaining[0].Body().AsString() != "unrelated" {
+		t.Fatalf("expected creator-resolved log body %q, got %q", "unrelated", remaining[0].Body().AsString())
+	}
+}
+
 func TestPendingDigestLogsResolveWhenCreatorArrives(t *testing.T) {
 	db := NewDB()
 

--- a/dagql/dagui/types.go
+++ b/dagql/dagui/types.go
@@ -2,6 +2,7 @@ package dagui
 
 import (
 	"iter"
+	"slices"
 	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -146,6 +147,12 @@ func (db *DB) RowsView(opts FrontendOpts) *RowsView {
 	} else {
 		spans = db.AllSpans()
 	}
+	if opts.RootFilter != nil && (!opts.ZoomedSpan.IsValid() || opts.ZoomedSpan == db.PrimarySpan) {
+		if roots := opts.RootFilter(db, view.Zoomed); len(roots) > 0 {
+			spans = slices.Values(roots)
+		}
+	}
+
 	db.WalkSpans(opts, spans, func(tree *TraceTree) {
 		if tree.Parent != nil {
 			tree.Parent.Children = append(tree.Parent.Children, tree)

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -901,6 +901,26 @@ func (r renderer) renderToolResultTokens(out TermOutput, span *dagui.Span) {
 	fmt.Fprint(out, badge)
 }
 
+// renderServiceURLs shows, inline on a service's display row, the local URLs
+// where the service is reachable (ServiceURLs, stamped by core's PrepareUp
+// once the health check passes). The chip makes a collapsed service row
+// self-sufficient: no need to expand it to find where to point a browser.
+// Only display rows chip — the engine's service-instance span carries no
+// URLs, and the `ready <url>` marker (no service name) already says its URL
+// in its own name.
+func (r renderer) renderServiceURLs(out TermOutput, span *dagui.Span) {
+	if span == nil || span.ServiceName == "" || span.Service || len(span.ServiceURLs) == 0 {
+		return
+	}
+	fmt.Fprint(out, out.String(" "+Diamond+" ").Faint())
+	for i, url := range span.ServiceURLs {
+		if i > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, out.String(url).Foreground(termenv.ANSICyan))
+	}
+}
+
 // tokenSizeColor grades a token count so a context-bloating tool result reads as
 // a warning: small results stay faint, a few thousand tokens turn yellow, and
 // tens of thousands turn red.

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -2745,11 +2745,12 @@ func (fe *frontendPretty) Render(ctx tuist.Context) {
 	var chrome []string
 	if len(logsLines) > 0 {
 		chrome = append(chrome, logsLines...)
-		chrome = append(chrome, "") // trailing gap
 	}
 	if len(globalTestLines) > 0 {
+		if len(chrome) > 0 {
+			chrome = append(chrome, "")
+		}
 		chrome = append(chrome, globalTestLines...)
-		chrome = append(chrome, "") // trailing gap
 	}
 	chromeReserve := 0
 	if h := ctx.ScreenHeight(); h > 0 && len(chrome) > 0 {
@@ -2762,8 +2763,12 @@ func (fe *frontendPretty) Render(ctx tuist.Context) {
 	var body []string
 	if len(progressLines) > 0 {
 		body = append(body, progressLines...)
-		body = append(body, "") // gap line after progress
+		if len(chrome) > 0 {
+			body = append(body, "") // separate tree from logs/tests
+		}
 	}
+	// The keymap supplies its own leading gap; content sections only need
+	// separators between them, not a trailing blank line.
 	body = append(body, chrome...)
 
 	// Crop the bottom to the rows available for the body: the screen minus the

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -2274,6 +2274,13 @@ func (fe *frontendPretty) updateSpanTreesForLogs(spanID dagui.SpanID) {
 				if sr, ok := fe.spanTrees[id]; ok {
 					sr.Update()
 				}
+				// The rolled-up lines land in the roll-up span's own Vterm, so
+				// its memoized LogsView must be invalidated too — an *expanded*
+				// roll-up row (a promoted `dagger up` service) renders through
+				// it and would otherwise freeze at its first-paint content.
+				if lv, ok := fe.logsViews[id]; ok {
+					lv.Update()
+				}
 				break
 			}
 			if !span.ParentID.IsValid() {
@@ -2846,7 +2853,11 @@ func (fe *frontendPretty) renderFinalReport(ctx tuist.Context, r *renderer) {
 	// passing ones. Fall back to the progress tree when there are no surfaced
 	// checks (e.g. a plain trace, or one whose only checks are test fixtures).
 	var renderedRows bool
-	if checkLines := fe.checksReport(ctx, r, zoomed); len(checkLines) > 0 {
+	if fe.RootFilter != nil && !zoomed {
+		lines := fe.renderProgressLines(r, ctx, 0)
+		ctx.Lines(lines...)
+		renderedRows = len(lines) > 0
+	} else if checkLines := fe.checksReport(ctx, r, zoomed); len(checkLines) > 0 {
 		ctx.Lines(checkLines...)
 		renderedRows = true
 	} else if genRows := fe.generatorsReport(ctx, r, zoomed); len(genRows) > 0 {
@@ -3457,7 +3468,7 @@ func (fe *frontendPretty) formHeight() int {
 //nolint:gocyclo // sequential view-rebuild steps; splitting obscures the order dependencies
 func (fe *frontendPretty) recalculateViewLocked() {
 	fe.viewDirty = false // clear in case called directly from event handlers
-	if !fe.reportScopedSubtree {
+	if !fe.reportScopedSubtree && fe.RootFilter == nil {
 		// Promotion reshapes the trace around what the whole run was about: it
 		// hangs the surfaced checks/conversation/generators off the zoomed span
 		// as revealed spans and marks it passthrough, so RowsView iterates
@@ -6268,6 +6279,9 @@ func (fe *frontendPretty) renderStepTitle(ctx tuist.Context, out TermOutput, r *
 		// Flag how many tokens a tool call's result added to the model's
 		// context, so an outsized one stands out at a glance.
 		r.renderToolResultTokens(out, span)
+
+		// Show where a ready service is reachable, right on its own row.
+		r.renderServiceURLs(out, span)
 
 		// Render RollUp dots after status/duration for collapsed RollUp spans
 		if span.RollUpSpans {

--- a/dagql/idtui/frontend_span_list.go
+++ b/dagql/idtui/frontend_span_list.go
@@ -79,6 +79,11 @@ func (v *SpanListView) sync() bool {
 		return v.clear()
 	}
 
+	ids := []dagui.SpanID(nil)
+	if v.include != nil {
+		ids = v.include()
+	}
+
 	opts := v.fe.FrontendOpts
 	opts.ZoomedSpan = rootID
 	rowsView := v.fe.db.RowsView(opts)
@@ -89,10 +94,6 @@ func (v *SpanListView) sync() bool {
 	v.scope.rows = rowsView.Rows(opts)
 	v.scope.opts = opts
 
-	ids := []dagui.SpanID(nil)
-	if v.include != nil {
-		ids = v.include()
-	}
 	children := make([]tuist.Component, 0, len(rowsView.Body))
 	if v.include == nil {
 		ids = make([]dagui.SpanID, 0, len(rowsView.Body))

--- a/dagql/idtui/services_report_test.go
+++ b/dagql/idtui/services_report_test.go
@@ -114,3 +114,147 @@ func TestServicesReportSurfacesInstances(t *testing.T) {
 		t.Fatalf("failed service line = %q, want ERROR", line)
 	}
 }
+
+// TestServiceRootFilterUsesTraceUI covers startup fallback, service headers,
+// and navigation through the regular trace frontend rather than a command view.
+func TestServiceRootFilterUsesTraceUI(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	rootID := prettyTestSpanID(1)
+	servicesID := prettyTestSpanID(2)
+	loadID := prettyTestSpanID(3)
+	runID := prettyTestSpanID(4)
+	displayID := prettyTestSpanID(5)
+	starterID := prettyTestSpanID(6)
+	execID := prettyTestSpanID(7)
+	readyID := prettyTestSpanID(8)
+	start := time.Unix(100, 0)
+	at := func(n int) time.Time { return start.Add(time.Duration(n) * time.Second) }
+	base := []dagui.SpanSnapshot{
+		// the CLI root; still running (an ended root would cancel the
+		// running service on import)
+		{ID: rootID, TraceID: prettyTestTraceID(), Name: "dagger up web", StartTime: start},
+		// the CLI's `services` zoom span: passthrough, set primary --
+		// exactly what internal/cmd/dagger/up.go's runServices creates
+		{ID: servicesID, TraceID: prettyTestTraceID(), ParentID: rootID, Name: "services", Passthrough: true, StartTime: at(1)},
+		// setup machinery the service rows must not drown in
+		{ID: loadID, TraceID: prettyTestTraceID(), ParentID: servicesID, Name: "Workspace.services", StartTime: at(1)},
+		// the call span the display spans actually live under: NOT
+		// passthrough, so leading with the services requires hoisting
+		{ID: runID, TraceID: prettyTestTraceID(), ParentID: servicesID, Name: "UpGroup.run", StartTime: at(2)},
+	}
+	service := []dagui.SpanSnapshot{
+		// the per-service display span PrepareUp opens, with the ready URL
+		// stamped on it once the health check passed
+		{ID: displayID, TraceID: prettyTestTraceID(), ParentID: runID, Name: "hello:web :80", ServiceName: "hello:web", RollUpLogs: true, ServiceURLs: []string{"http://localhost:80"}, StartTime: at(3)},
+		{ID: starterID, TraceID: prettyTestTraceID(), ParentID: displayID, Name: "service.start", Passthrough: true, StartTime: at(4)},
+		{ID: execID, TraceID: prettyTestTraceID(), ParentID: starterID, Name: "exec nginx", Service: true, ServiceName: "web.dagger.local", Passthrough: true, StartTime: at(4)},
+		{ID: readyID, TraceID: prettyTestTraceID(), ParentID: displayID, Name: "ready http://localhost:80", ServiceURLs: []string{"http://localhost:80"}, StartTime: at(5)},
+	}
+
+	install := func(db *dagui.DB) (*frontendPretty, string) {
+		db.SetPrimarySpan(servicesID)
+		fe := newWithTerminal(io.Discard, db, tuist.NewHeadlessTerminal(120, 40))
+		fe.FrontendOpts.RootFilter = (*dagui.DB).ServiceDisplaySpans
+		fe.FrontendOpts.ZoomedSpan = servicesID
+		fe.FrontendOpts.Verbosity = dagui.ShowCompletedVerbosity
+		fe.setupTUI()
+		fe.recalculateViewLocked()
+		rendered := strings.Join(fe.tui.RenderLines(), "\n")
+		return fe, rendered
+	}
+
+	// Before any display span exists: fall back to root's children, so the
+	// screen shows setup progress instead of nothing.
+	db := dagui.NewDB()
+	db.ImportSnapshots(base)
+	_, rendered := install(db)
+	if !strings.Contains(rendered, "Workspace.services") {
+		t.Fatalf("pre-service render lost setup progress:\n%s", rendered)
+	}
+
+	// With a display span: lead with it, hoisted past UpGroup.run, and drop
+	// the setup noise.
+	db = dagui.NewDB()
+	db.ImportSnapshots(append(append([]dagui.SpanSnapshot{}, base...), service...))
+	fe, rendered := install(db)
+	displayLine := ""
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "hello:web :80") {
+			displayLine = line
+			break
+		}
+	}
+	if displayLine == "" {
+		t.Fatalf("display span was not rendered:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "Workspace.services") || strings.Contains(rendered, "UpGroup.run") {
+		t.Fatalf("setup noise rendered alongside the services:\n%s", rendered)
+	}
+	// The display span rolls up its logs (RollUpLogs), so its row stays
+	// collapsed -- the ready URL must be legible on the row itself.
+	if !strings.Contains(displayLine, "http://localhost:80") {
+		t.Fatalf("display row = %q, want the ready URL chip", displayLine)
+	}
+	if len(fe.rows.Order) != 1 || fe.rows.Order[0].Span.ID != displayID {
+		t.Fatalf("regular trace rows = %+v, want the service display row", fe.rows.Order)
+	}
+	if fe.commandView != nil {
+		t.Fatal("services installed a custom command view")
+	}
+	press := func(keys ...string) {
+		t.Helper()
+		for _, k := range keys {
+			fe.tui.Inject(tuist.ParseKey(k))
+			fe.tui.Step()
+		}
+	}
+
+	// Search must use the displayed tree and reveal a collapsed descendant.
+	press("/")
+	if !fe.searchActive {
+		t.Fatal("/ did not open search")
+	}
+	fe.confirmSearch("ready")
+	fe.tui.RenderLines()
+	if len(fe.searchMatches) != 1 || fe.FocusedSpan != readyID {
+		t.Fatalf("search matches = %+v, focus = %s, want ready span", fe.searchMatches, fe.FocusedSpan)
+	}
+	press("esc", "home", "space")
+	if !fe.autoFocus || fe.FocusedSpan != readyID {
+		t.Fatalf("space: follow = %v, focus = %s, want ready span", fe.autoFocus, fe.FocusedSpan)
+	}
+	newID := prettyTestSpanID(9)
+	db.ImportSnapshots([]dagui.SpanSnapshot{
+		{ID: newID, TraceID: prettyTestTraceID(), ParentID: displayID, Name: "new output", StartTime: at(6)},
+	})
+	fe.recalculateViewLocked()
+	fe.Update()
+	fe.tui.RenderLines()
+	if fe.FocusedSpan != newID {
+		t.Fatalf("follow after telemetry update = %s, want %s", fe.FocusedSpan, newID)
+	}
+
+	// Enter zooms; Escape restores the selected service roots.
+	press("home", "enter")
+	if fe.ZoomedSpan != displayID || fe.rows.BySpan[readyID] == nil || fe.rows.BySpan[displayID] != nil {
+		t.Fatalf("zoom did not show the service's ordinary subtree: zoom = %s", fe.ZoomedSpan)
+	}
+	press("esc")
+	if fe.ZoomedSpan != servicesID || fe.rows.BySpan[displayID] == nil {
+		t.Fatal("Escape did not restore the service roots")
+	}
+
+	var final strings.Builder
+	if err := fe.FinalRender(&final); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(final.String(), "hello:web :80") || !strings.Contains(final.String(), "http://localhost:80") {
+		t.Fatalf("final output lost service header: %s", final.String())
+	}
+
+	// Selecting roots must not reshape the shared DB for another frontend.
+	ordinary := db.RowsView(dagui.FrontendOpts{ZoomedSpan: servicesID})
+	if ordinary.BySpan[runID] == nil || ordinary.BySpan[loadID] == nil {
+		t.Fatal("service root filter changed the underlying trace")
+	}
+}

--- a/engine/telemetryattrs/attrs.go
+++ b/engine/telemetryattrs/attrs.go
@@ -58,6 +58,15 @@ const (
 	// cannot modify. (string)
 	ServiceNameAttr = "dagger.io/service.name"
 
+	// ServiceURLsAttr marks a service-readiness marker span, carrying the
+	// local URLs at which a just-started service is reachable. `dagger up`
+	// stamps it on the `ready <url>` span it starts beneath a service's
+	// display span once the health check passes (core/modtree.go); the TUI
+	// uses it to surface readiness alongside the service when a run leads
+	// with its services. Predates the dagger.io/ attribute prefix
+	// convention. (string slice)
+	ServiceURLsAttr = "service.urls"
+
 	// Streaming progress over OTel logs.
 	//
 	// A log record carrying ProgressItemAttr is progress data, not log text:

--- a/internal/cmd/dagger/up.go
+++ b/internal/cmd/dagger/up.go
@@ -37,6 +37,11 @@ Examples:
 		showFinalProgressKey: "true",
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !upListMode {
+			previous := opts.RootFilter
+			opts.RootFilter = (*dagui.DB).ServiceDisplaySpans
+			defer func() { opts.RootFilter = previous }()
+		}
 		return withEngine(
 			cmd.Context(),
 			client.Params{


### PR DESCRIPTION
`dagger up` now leads with each service's build output, logs, and forwarded URLs. It selects service display spans as roots in the regular trace UI, preserving the existing search, bottom-follow, zoom, and log navigation.

Service evaluation, health checks, and stdout/stderr stream into those rows on cold and fully cached runs. Startup evaluates all services and checks port collisions before starting tunnels. Empty service groups return `no services found`, and the TUI leaves a single blank line above the keymap. The `docs-dev` module also gains `+up` support.

Validation included 115 dagui tests, focused service UI and keymap/viewport tests, and an empty-workspace CLI integration test through `engine-dev test`. Live `docs:server` checks covered search, follow, zoom, the log pager, resizing, and clean shutdown; the tree-to-keymap spacing was also verified live. Earlier development covered the full `TestUp` suite, targeted service goldens, and cold, warm, multi-service, and port-mapping runs.

Fixes #14001
Supersedes #14016
