### PR TITLE
fix(core/workspace): preserve overlay writes at gitignored paths during gitignore reads

### DIFF
--- a/core/integration/workspace_write_directory_test.go
+++ b/core/integration/workspace_write_directory_test.go
@@ -362,3 +362,44 @@ func (WorkspaceSuite) TestWorkspaceWithDirectoryDoesNotPinHostContent(ctx contex
 		require.NotContains(t, modified, "target/keep.txt")
 	})
 }
+
+// TestWorkspaceOverlayAtGitignoredPathPreservedUnderGitignoreRead verifies that
+// an overlay edit made at a gitignored path (via withNewFile / withDirectory)
+// is retained when reading the workspace with gitignore: true, even if the
+// host already holds a byte-identical copy of that ignored file (dagger/dagger#14053).
+func (WorkspaceSuite) TestWorkspaceOverlayAtGitignoredPathPreservedUnderGitignoreRead(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	initGitRepo(ctx, t, workdir)
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, ".gitignore"), []byte("build/\n*.ignored\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(workdir, "build"), 0o755))
+	cssPath := filepath.Join(workdir, "build", "style.css")
+	require.NoError(t, os.WriteFile(cssPath, []byte("body { color: red; }\n"), 0o644))
+
+	c := connect(ctx, t, dagger.WithWorkdir(workdir))
+	ws := c.CurrentWorkspace()
+
+	t.Run("withNewFile byte-identical to host ignored file", func(ctx context.Context, t *testctx.T) {
+		written := ws.WithNewFile("build/style.css", "body { color: red; }\n")
+		entries, err := written.Directory("/", dagger.WorkspaceDirectoryOpts{Gitignore: true}).Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, entries, "build")
+
+		content, err := written.File("build/style.css").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "body { color: red; }\n", content)
+
+		buildEntries, err := written.Directory("build", dagger.WorkspaceDirectoryOpts{Gitignore: true}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"style.css"}, buildEntries)
+	})
+
+	t.Run("withDirectory byte-identical to host ignored file", func(ctx context.Context, t *testctx.T) {
+		cssDir := c.Directory().WithNewFile("style.css", "body { color: red; }\n")
+		written := ws.WithDirectory("build", cssDir)
+
+		buildEntries, err := written.Directory("build", dagger.WorkspaceDirectoryOpts{Gitignore: true}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"style.css"}, buildEntries)
+	})
+}
+

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -987,7 +987,29 @@ func (s *workspaceSchema) resolveHostOverlayRootfs(
 		return inst, fmt.Errorf("workspace directory %q: %w", resolvedPath, err)
 	}
 
-	changesID, err := changes.ID()
+	activeChanges := changes
+	if gitignore {
+		if deltaRoot, ok := ws.OverlayDeltaRoot(); ok {
+			sparseBase, err := s.sparseHostBaseWithGitignore(ctx, ws, ws.OverlayTouchedPaths(), true)
+			if err != nil {
+				return inst, err
+			}
+			sparseBaseID, err := sparseBase.ID()
+			if err != nil {
+				return inst, err
+			}
+			var gitignoreChanges dagql.ObjectResult[*core.Changeset]
+			if err := srv.Select(ctx, deltaRoot, &gitignoreChanges, dagql.Selector{
+				Field: "changes",
+				Args:  []dagql.NamedInput{{Name: "from", Value: dagql.NewID[*core.Directory](sparseBaseID)}},
+			}); err != nil {
+				return inst, fmt.Errorf("workspace directory %q (overlay gitignore diff): %w", resolvedPath, err)
+			}
+			activeChanges = gitignoreChanges
+		}
+	}
+
+	changesID, err := activeChanges.ID()
 	if err != nil {
 		return inst, err
 	}
@@ -2491,6 +2513,15 @@ func (s *workspaceSchema) sparseHostBase(
 	ws *core.Workspace,
 	touched []string,
 ) (dagql.ObjectResult[*core.Directory], error) {
+	return s.sparseHostBaseWithGitignore(ctx, ws, touched, false)
+}
+
+func (s *workspaceSchema) sparseHostBaseWithGitignore(
+	ctx context.Context,
+	ws *core.Workspace,
+	touched []string,
+	gitignore bool,
+) (dagql.ObjectResult[*core.Directory], error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
 		return dagql.ObjectResult[*core.Directory]{}, err
@@ -2513,13 +2544,20 @@ func (s *workspaceSchema) sparseHostBase(
 	if err != nil {
 		return dagql.ObjectResult[*core.Directory]{}, err
 	}
+	args := []dagql.NamedInput{
+		{Name: "path", Value: dagql.NewString(absPath)},
+		{Name: "include", Value: includes},
+	}
+	if gitignore {
+		args = append(args,
+			dagql.NamedInput{Name: "gitignore", Value: dagql.NewBoolean(true)},
+			dagql.NamedInput{Name: "gitIgnoreRoot", Value: dagql.NewString(ws.HostPath())},
+		)
+	}
 	var out dagql.ObjectResult[*core.Directory]
 	if err := srv.Select(ctx, srv.Root(), &out,
 		dagql.Selector{Field: "host"},
-		dagql.Selector{Field: "directory", Args: []dagql.NamedInput{
-			{Name: "path", Value: dagql.NewString(absPath)},
-			{Name: "include", Value: includes},
-		}},
+		dagql.Selector{Field: "directory", Args: args},
 	); err != nil {
 		return dagql.ObjectResult[*core.Directory]{}, fmt.Errorf("sparse host base: %w", err)
 	}


### PR DESCRIPTION
### Summary

Fixes #14053.

When creating or modifying files in a workspace overlay at a path covered by `.gitignore` (e.g. via `ws.WithNewFile("build/style.css", ...)` or `ws.WithDirectory("build", ...)`), reading the workspace with `gitignore: true` previously dropped the overlay edits if the host directory already contained a byte-identical copy of that ignored file.

### Root Cause
1. `resolveHostOverlayRootfs` resolved the base directory with `gitignore: true` on the host, excluding gitignored paths from `base`.
2. The overlay changeset was computed against `sparseHostBase`, which was queried with `gitignore: false`.
3. When the overlay file matched the byte content of the existing host file, `deltaRoot.changes(from: sparseBase)` saw identical bytes and emitted no diff entry for that path.
4. When `base.withChanges(changes)` was evaluated under `gitignore: true`, `base` lacked the file (filtered by gitignore) and `changes` lacked the file (no diff against un-gitignored base), causing the overlay write to silently disappear.

### Fix
- In `resolveHostOverlayRootfs`, when `gitignore: true` and an overlay delta is present, diff `deltaRoot.changes` against `sparseHostBaseWithGitignore(..., gitignore: true)`.
- Because the gitignored path is absent from the gitignored sparse base, the overlay write is properly detected as an added file in `activeChanges`, ensuring it is preserved when applied on `base`.
- Added regression tests in `core/integration/workspace_write_directory_test.go` covering both `withNewFile` and `withDirectory` writes at gitignored paths.