### PR TITLE
core: entrypoint module refs in workspace wiring, short and long form

### DIFF
--- a/.changes/unreleased/Fixed-20260908-160000.yaml
+++ b/.changes/unreleased/Fixed-20260908-160000.yaml
@@ -1,6 +1,0 @@
-kind: Fixed
-body: Workspace module settings can now reference functions of the workspace entrypoint module, as `<module>:<function>` or the short `<function>` form; `dagger settings` accepts both and stores the long form.
-time: 2026-09-08T16:00:00.000000Z
-custom:
-    Author: kpenfound
-    PR: "14059"

--- a/.changes/unreleased/Fixed-20260908-160000.yaml
+++ b/.changes/unreleased/Fixed-20260908-160000.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Workspace module settings can now reference functions of the workspace entrypoint module, as `<module>:<function>` or the short `<function>` form; `dagger settings` accepts both and stores the long form.
+time: 2026-09-08T16:00:00.000000Z
+custom:
+    Author: kpenfound
+    PR: "14059"

--- a/core/integration/testdata/services/service-ref-consumer/main.go
+++ b/core/integration/testdata/services/service-ref-consumer/main.go
@@ -16,6 +16,9 @@ type ServiceRefConsumer struct {
 	Directory       *dagger.Directory
 	File            *dagger.File
 	WorkspaceMarker *dagger.File
+	// A plain string setting, used to check that settings normalization only
+	// rewrites object-typed values.
+	Label string
 }
 
 func New(
@@ -29,6 +32,8 @@ func New(
 	file *dagger.File,
 	// +optional
 	sourceWorkspace *dagger.Workspace,
+	// +optional
+	label string,
 ) *ServiceRefConsumer {
 	var workspaceMarker *dagger.File
 	if sourceWorkspace != nil {
@@ -37,6 +42,7 @@ func New(
 	return &ServiceRefConsumer{
 		App: app, Base: base, Directory: directory, File: file,
 		WorkspaceMarker: workspaceMarker,
+		Label:           label,
 	}
 }
 

--- a/core/integration/testdata/services/service-ref-consumer/main.go
+++ b/core/integration/testdata/services/service-ref-consumer/main.go
@@ -16,9 +16,7 @@ type ServiceRefConsumer struct {
 	Directory       *dagger.Directory
 	File            *dagger.File
 	WorkspaceMarker *dagger.File
-	// A plain string setting, used to check that settings normalization only
-	// rewrites object-typed values.
-	Label string
+	Label           string
 }
 
 func New(

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -312,6 +312,75 @@ settings.app = "hello-with-services:web"
 		require.Contains(t, out, "check-service")
 	})
 
+	t.Run("short-form entrypoint ref via settings", func(ctx context.Context, t *testctx.T) {
+		// The entrypoint's functions are hoisted onto the root, so a bare
+		// "<function>" is the same call as "<entrypoint>:<function>" and is
+		// accepted as a short form (a hand-edited dagger.toml may carry it).
+		ctr := modGen.
+			WithWorkdir("app").
+			WithNewFile("dagger.toml", `[modules.container-provider]
+source = "../container-provider"
+entrypoint = true
+
+[modules.service-ref-consumer]
+source = "../service-ref-consumer"
+settings.base = "image"
+settings.file = "marker.txt"
+`)
+		out, err := ctr.
+			With(daggerExec("call", "service-ref-consumer", "container-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "container-provider")
+
+		// A bare value that names no entrypoint function keeps its ordinary
+		// address meaning: "marker.txt" is the local file, not a module ref,
+		// even though the entrypoint defines a "file" function.
+		out, err = ctr.
+			With(daggerExec("call", "service-ref-consumer", "file-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "ambient", strings.TrimSpace(out))
+	})
+
+	t.Run("settings stores entrypoint refs in long form", func(ctx context.Context, t *testctx.T) {
+		// `dagger settings` accepts the short form for an address-typed
+		// setting but always writes the long form, so dagger.toml stays
+		// explicit about which module a value comes from. A plain string
+		// setting is never rewritten, even when its value matches an
+		// entrypoint function name.
+		ctr := modGen.
+			WithWorkdir("app").
+			WithNewFile("dagger.toml", `[modules.container-provider]
+source = "../container-provider"
+entrypoint = true
+
+[modules.service-ref-consumer]
+source = "../service-ref-consumer"
+`).
+			With(daggerExec("settings", "service-ref-consumer", "base", "image")).
+			With(daggerExec("settings", "service-ref-consumer", "label", "image"))
+
+		cfg, err := ctr.File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, cfg, `base = "container-provider:image"`)
+		require.Contains(t, cfg, `label = "image"`)
+		require.NotContains(t, cfg, `label = "container-provider:image"`)
+
+		out, err := ctr.
+			With(daggerExec("call", "service-ref-consumer", "container-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "container-provider")
+
+		// The long form is accepted on the command line too and stored as is.
+		cfg, err = ctr.
+			With(daggerExec("settings", "service-ref-consumer", "base", "container-provider:image")).
+			File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, cfg, `base = "container-provider:image"`)
+	})
+
 	t.Run("artifact refs via settings", func(ctx context.Context, t *testctx.T) {
 		ctr := modGen.
 			WithWorkdir("app").

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -313,9 +313,7 @@ settings.app = "hello-with-services:web"
 	})
 
 	t.Run("short-form entrypoint ref via settings", func(ctx context.Context, t *testctx.T) {
-		// The entrypoint's functions are hoisted onto the root, so a bare
-		// "<function>" is the same call as "<entrypoint>:<function>" and is
-		// accepted as a short form (a hand-edited dagger.toml may carry it).
+		// A bare "<function>" names a function of the entrypoint module.
 		ctr := modGen.
 			WithWorkdir("app").
 			WithNewFile("dagger.toml", `[modules.container-provider]
@@ -333,9 +331,8 @@ settings.file = "marker.txt"
 		require.NoError(t, err)
 		require.Contains(t, out, "container-provider")
 
-		// A bare value that names no entrypoint function keeps its ordinary
-		// address meaning: "marker.txt" is the local file, not a module ref,
-		// even though the entrypoint defines a "file" function.
+		// A bare value that names no entrypoint function keeps its address
+		// meaning, even though the entrypoint defines a "file" function.
 		out, err = ctr.
 			With(daggerExec("call", "service-ref-consumer", "file-provided-by")).
 			Stdout(ctx)
@@ -344,11 +341,8 @@ settings.file = "marker.txt"
 	})
 
 	t.Run("settings stores entrypoint refs in long form", func(ctx context.Context, t *testctx.T) {
-		// `dagger settings` accepts the short form for an address-typed
-		// setting but always writes the long form, so dagger.toml stays
-		// explicit about which module a value comes from. A plain string
-		// setting is never rewritten, even when its value matches an
-		// entrypoint function name.
+		// The short form is accepted but the long form is written; a string
+		// setting is never rewritten.
 		ctr := modGen.
 			WithWorkdir("app").
 			WithNewFile("dagger.toml", `[modules.container-provider]
@@ -373,7 +367,6 @@ source = "../service-ref-consumer"
 		require.NoError(t, err)
 		require.Contains(t, out, "container-provider")
 
-		// The long form is accepted on the command line too and stored as is.
 		cfg, err = ctr.
 			With(daggerExec("settings", "service-ref-consumer", "base", "container-provider:image")).
 			File("dagger.toml").Contents(ctx)

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -353,7 +353,6 @@ source = "../service-ref-consumer"
 		require.NoError(t, err)
 		require.Contains(t, cfg, `base = "container-provider:image"`)
 		require.Contains(t, cfg, `label = "image"`)
-		require.NotContains(t, cfg, `label = "container-provider:image"`)
 
 		out, err := ctr.
 			With(daggerExec("call", "service-ref-consumer", "container-provided-by")).

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -272,13 +272,7 @@ settings.base = "container-provider:image"
 	})
 
 	t.Run("entrypoint module ref via settings", func(ctx context.Context, t *testctx.T) {
-		// The referenced module is the workspace entrypoint. Its functions are
-		// hoisted onto the sugared Query root and its constructor field is only
-		// installed on the canonical server, so the resolver must look the
-		// module up there (see resolveModuleRef in core/schema/address.go).
-		// Regression: this used to fail with "module is the workspace
-		// entrypoint; its functions are hoisted to the root and cannot be
-		// referenced" (github.com/dagger/dagger/issues/14058).
+		// The referenced module is the workspace entrypoint.
 		out, err := modGen.
 			WithWorkdir("app").
 			WithNewFile("dagger.toml", `[modules.container-provider]

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -271,6 +271,47 @@ settings.base = "container-provider:image"
 		require.Contains(t, out, "container-provider")
 	})
 
+	t.Run("entrypoint module ref via settings", func(ctx context.Context, t *testctx.T) {
+		// The referenced module is the workspace entrypoint. Its functions are
+		// hoisted onto the sugared Query root and its constructor field is only
+		// installed on the canonical server, so the resolver must look the
+		// module up there (see resolveModuleRef in core/schema/address.go).
+		// Regression: this used to fail with "module is the workspace
+		// entrypoint; its functions are hoisted to the root and cannot be
+		// referenced" (github.com/dagger/dagger/issues/14058).
+		out, err := modGen.
+			WithWorkdir("app").
+			WithNewFile("dagger.toml", `[modules.container-provider]
+source = "../container-provider"
+entrypoint = true
+
+[modules.service-ref-consumer]
+source = "../service-ref-consumer"
+settings.base = "container-provider:image"
+`).
+			With(daggerExec("call", "service-ref-consumer", "container-provided-by")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "container-provider")
+
+		// Filtered check: only the consumer loads up front, so the entrypoint
+		// module must be demand-loaded when the wiring resolves.
+		out, err = modGen.
+			WithWorkdir("app").
+			WithNewFile("dagger.toml", `[modules.hello-with-services]
+source = "../hello-with-services"
+entrypoint = true
+
+[modules.service-ref-consumer]
+source = "../service-ref-consumer"
+settings.app = "hello-with-services:web"
+`).
+			With(daggerExec("check", "service-ref-consumer:check-service")).
+			CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "check-service")
+	})
+
 	t.Run("artifact refs via settings", func(ctx context.Context, t *testctx.T) {
 		ctr := modGen.
 			WithWorkdir("app").

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -24,23 +24,17 @@ type moduleRefCycleKey struct{}
 
 // resolveModuleRef detects and resolves a module function reference, wiring
 // one module's function output into another object-typed value. Two spellings
-// are accepted:
-//   - the long form "<module>:<function>" (e.g. "docusaurus:serve");
-//   - the short form "<function>" (e.g. "serve"), which names a function of
-//     the workspace entrypoint module. The entrypoint's functions are hoisted
-//     onto the Query root, so the short form is the same call a user makes on
-//     the command line. It is only considered when the workspace installs an
-//     entrypoint.
+// are accepted: the long form "<module>:<function>" (e.g. "docusaurus:serve")
+// and the short form "<function>", which names a function of the workspace
+// entrypoint module (whose functions are hoisted onto the Query root).
 //
 // Detection & precedence (commit-on-match, no silent fallback):
 //   - A long-form candidate contains EXACTLY one ":" with non-empty parts on
 //     both sides. Strings containing "://" (URL-ish, e.g. "tcp://...") are
 //     never module refs.
 //   - A short-form candidate is a bare name (no ":" or "/", not a relative
-//     path). It is committed as a ref only if the entrypoint module has a
-//     function of that name; otherwise it keeps its ordinary address meaning
-//     (an image name, a file name), so "alpine" is only shadowed by an
-//     entrypoint that defines an "alpine" function.
+//     path). It is committed only if the entrypoint has that function;
+//     otherwise it keeps its ordinary address meaning (image name, file name).
 //   - The first segment is normalized to a gql field name and looked up on the
 //     CANONICAL Query root's object type. Only if a field of that name EXISTS
 //     — AND carries module provenance (FieldSpec.Module != nil), which
@@ -72,9 +66,7 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 	shortForm := false
 	switch {
 	case !ok:
-		// Short form: resolve a bare "<function>" against the workspace
-		// entrypoint as "<entrypoint>:<function>". Commit only once the
-		// entrypoint is known to have the function (checked below).
+		// Short form: resolve "<function>" as "<entrypoint>:<function>".
 		if !workspace.IsBareModuleFunctionRef(addr) {
 			return false, nil
 		}
@@ -84,7 +76,6 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 		}
 		module, rest, shortForm = entrypoint, addr, true
 	case module == "" || rest == "":
-		// A long-form candidate has non-empty parts on both sides.
 		return false, nil
 	}
 
@@ -149,9 +140,8 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 	}
 	functionField := strcase.ToLowerCamel(rest)
 
-	// Look the function up on the module's object type. For the long form an
-	// unknown function is a hard error, reported by the typed Select below.
-	// For the short form it means the bare string is not a module ref at all.
+	// An unknown function is a hard error for the long form (reported by the
+	// typed Select below) but means "not a module ref" for the short form.
 	var fnSpec dagql.FieldSpec
 	fnExists := false
 	if objType, ok := srv.ObjectType(spec.Type.Type().Name()); ok {
@@ -268,10 +258,8 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 }
 
 // currentWorkspaceConfig returns the workspace config visible to the current
-// query, or ok=false when there is none. The lookups deliberately discard
-// their errors: any failure to see the workspace from address resolution means
-// the string cannot be a module ref, and the caller's normal address decoding
-// should run.
+// query, or ok=false when there is none. Errors are deliberately discarded: no
+// visible workspace means the string cannot be a module ref.
 func currentWorkspaceConfig(ctx context.Context) (cfg *workspace.Config, ws *core.Workspace, ok bool) {
 	q, _ := core.CurrentQuery(ctx)
 	if q == nil {
@@ -289,7 +277,7 @@ func currentWorkspaceConfig(ctx context.Context) (cfg *workspace.Config, ws *cor
 }
 
 // workspaceEntrypointModuleName returns the install name of the workspace
-// entrypoint module, the target of short-form "<function>" references.
+// entrypoint module, the target of short-form references.
 func workspaceEntrypointModuleName(ctx context.Context) (string, bool) {
 	cfg, _, ok := currentWorkspaceConfig(ctx)
 	if !ok {

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -30,11 +30,16 @@ type moduleRefCycleKey struct{}
 //     parts on both sides. Strings containing "://" (URL-ish, e.g. "tcp://...")
 //     are never module refs.
 //   - The first segment is normalized to a gql field name and looked up on the
-//     (non-canonical) current Query root's object type. Only if a field of that
-//     name EXISTS — AND carries module provenance (FieldSpec.Module != nil),
-//     which distinguishes a module entrypoint from a reserved core
-//     field like "git" or "secret" that shares the root namespace — is the
-//     string committed as a module ref.
+//     CANONICAL Query root's object type. Only if a field of that name EXISTS
+//     — AND carries module provenance (FieldSpec.Module != nil), which
+//     distinguishes a module constructor from a reserved core field like
+//     "git" or "secret" that shares the root namespace — is the string
+//     committed as a module ref. The canonical server is used because the
+//     workspace entrypoint's constructor is only installed there: the sugared
+//     (client-facing) server hoists its functions onto the root as proxies
+//     and never installs the module field itself, so resolving against the
+//     sugared root would make an entrypoint module unreferenceable (see
+//     hack/designs/entrypoint-proxy.md).
 //   - Once committed, any subsequent failure (unknown function, type mismatch,
 //     cycle) is a HARD error and does NOT fall through to image/URL handling.
 //
@@ -57,12 +62,15 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 		return false, nil
 	}
 
-	// Use the non-canonical current server: module fields live on the
-	// outer Query root, not the canonical core schema.
+	// Resolve against the canonical server: every module's constructor
+	// lives there, including the workspace entrypoint's, whose field is
+	// skipped on the sugared server in favor of hoisted function proxies.
+	// For servers without an entrypoint Canonical() returns the receiver.
 	srv := dagql.CurrentDagqlServer(ctx)
 	if srv == nil {
 		return false, nil
 	}
+	srv = srv.Canonical()
 	root := srv.Root()
 	moduleField := strcase.ToLowerCamel(module)
 	// Detect whether the module is actually installed by checking the Query
@@ -87,7 +95,7 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 			// a module ref and the load failure is the real error.
 			return true, fmt.Errorf("resolve module reference %q: load module %q: %w", addr, module, loadErr)
 		}
-		srv = refreshed
+		srv = refreshed.Canonical()
 		root = srv.Root()
 		spec, exists = root.ObjectType().FieldSpec(moduleField, srv.View)
 		if !exists {
@@ -200,23 +208,14 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 		return nil, false, nil
 	}
 	want := strcase.ToKebab(name)
-	isEntrypoint := false
-	for installedName, entry := range cfg.Modules {
+	for installedName := range cfg.Modules {
 		if strcase.ToKebab(installedName) == want {
 			installed = true
-			isEntrypoint = entry.Entrypoint
 			break
 		}
 	}
 	if !installed {
 		return nil, false, nil
-	}
-	// An entrypoint module's functions are hoisted onto the Query root and no
-	// module field is served for it, so a <module>:<function> reference can
-	// never resolve. Committed: report that directly instead of loading the
-	// module only to miss the retry and fall back to the generic address error.
-	if isEntrypoint {
-		return nil, true, fmt.Errorf("module %q is the workspace entrypoint; its functions are hoisted to the root and cannot be referenced as %q", name, name+":<function>")
 	}
 	// Strict (non-best-effort) load: the consumer's constructor requires this
 	// module, so a load failure is that resolution's real error. This does not

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iancoleman/strcase"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/util/gitutil"
@@ -21,14 +22,25 @@ import (
 // module-reference strings, used to detect reference cycles.
 type moduleRefCycleKey struct{}
 
-// resolveModuleRef detects and resolves a module function reference of the
-// bare form "<module>:<function>" (e.g. "docusaurus:serve"), wiring one
-// module's function output into another object-typed value.
+// resolveModuleRef detects and resolves a module function reference, wiring
+// one module's function output into another object-typed value. Two spellings
+// are accepted:
+//   - the long form "<module>:<function>" (e.g. "docusaurus:serve");
+//   - the short form "<function>" (e.g. "serve"), which names a function of
+//     the workspace entrypoint module. The entrypoint's functions are hoisted
+//     onto the Query root, so the short form is the same call a user makes on
+//     the command line. It is only considered when the workspace installs an
+//     entrypoint.
 //
 // Detection & precedence (commit-on-match, no silent fallback):
-//   - The candidate must be a string containing EXACTLY one ":" with non-empty
-//     parts on both sides. Strings containing "://" (URL-ish, e.g. "tcp://...")
-//     are never module refs.
+//   - A long-form candidate contains EXACTLY one ":" with non-empty parts on
+//     both sides. Strings containing "://" (URL-ish, e.g. "tcp://...") are
+//     never module refs.
+//   - A short-form candidate is a bare name (no ":" or "/", not a relative
+//     path). It is committed as a ref only if the entrypoint module has a
+//     function of that name; otherwise it keeps its ordinary address meaning
+//     (an image name, a file name), so "alpine" is only shadowed by an
+//     entrypoint that defines an "alpine" function.
 //   - The first segment is normalized to a gql field name and looked up on the
 //     CANONICAL Query root's object type. Only if a field of that name EXISTS
 //     — AND carries module provenance (FieldSpec.Module != nil), which
@@ -56,9 +68,23 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 	if strings.Contains(addr, "://") {
 		return false, nil
 	}
-	// A module ref candidate has exactly one ":" with non-empty parts.
 	module, rest, ok := strings.Cut(addr, ":")
-	if !ok || module == "" || rest == "" {
+	shortForm := false
+	switch {
+	case !ok:
+		// Short form: resolve a bare "<function>" against the workspace
+		// entrypoint as "<entrypoint>:<function>". Commit only once the
+		// entrypoint is known to have the function (checked below).
+		if !workspace.IsBareModuleFunctionRef(addr) {
+			return false, nil
+		}
+		entrypoint, found := workspaceEntrypointModuleName(ctx)
+		if !found {
+			return false, nil
+		}
+		module, rest, shortForm = entrypoint, addr, true
+	case module == "" || rest == "":
+		// A long-form candidate has non-empty parts on both sides.
 		return false, nil
 	}
 
@@ -123,6 +149,18 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 	}
 	functionField := strcase.ToLowerCamel(rest)
 
+	// Look the function up on the module's object type. For the long form an
+	// unknown function is a hard error, reported by the typed Select below.
+	// For the short form it means the bare string is not a module ref at all.
+	var fnSpec dagql.FieldSpec
+	fnExists := false
+	if objType, ok := srv.ObjectType(spec.Type.Type().Name()); ok {
+		fnSpec, fnExists = objType.FieldSpec(functionField, srv.View)
+	}
+	if shortForm && !fnExists {
+		return false, nil
+	}
+
 	// Cycle guard: track the chain of in-flight module refs on the context
 	// and refuse to descend into one already present. Context values propagate
 	// through dagql Select into nested module construction, so re-entry of an
@@ -160,10 +198,8 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 	// the context, else the session's current one.
 	ctorArgs := core.WithBoundWorkspaceArgs(ctx, srv, spec.Args.Inputs(srv.View), nil)
 	var fnArgs []dagql.NamedInput
-	if objType, ok := srv.ObjectType(spec.Type.Type().Name()); ok {
-		if fnSpec, ok := objType.FieldSpec(functionField, srv.View); ok {
-			fnArgs = core.WithBoundWorkspaceArgs(ctx, srv, fnSpec.Args.Inputs(srv.View), nil)
-		}
+	if fnExists {
+		fnArgs = core.WithBoundWorkspaceArgs(ctx, srv, fnSpec.Args.Inputs(srv.View), nil)
 	}
 	selectors := []dagql.Selector{
 		{Field: moduleField, Args: ctorArgs},
@@ -184,15 +220,8 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 // err reports the load outcome and srv is the refreshed schema served to the
 // current client (which now carries the module as a root field).
 func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Server, installed bool, err error) {
-	// The lookups below deliberately discard their errors: any failure to see
-	// the workspace from here means the string cannot be a demand-loadable
-	// module ref, and the caller's normal address decoding should run.
-	q, _ := core.CurrentQuery(ctx)
-	if q == nil {
-		return nil, false, nil
-	}
-	ws, _ := q.Server.CurrentWorkspace(ctx)
-	if ws == nil {
+	cfg, ws, ok := currentWorkspaceConfig(ctx)
+	if !ok {
 		return nil, false, nil
 	}
 	// Only the workspace-owning client may trigger module loads from address
@@ -201,10 +230,6 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 	// and this gate keeps a bare string from becoming a capability grant.
 	md, _ := engine.ClientMetadataFromContext(ctx)
 	if md == nil || md.ClientID != ws.ClientID {
-		return nil, false, nil
-	}
-	cfg, _ := workspaceConfigWithCompatFallback(ctx, ws)
-	if cfg == nil {
 		return nil, false, nil
 	}
 	want := strcase.ToKebab(name)
@@ -224,6 +249,10 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 	// the recorded error here without reloading, and ModTree runs nodes
 	// without fail-fast — so only the node that genuinely needs the broken
 	// module fails, and repair generators keep running.
+	q, err := core.CurrentQuery(ctx)
+	if err != nil {
+		return nil, true, err
+	}
 	if _, err := q.Server.EnsureWorkspaceModules(ctx, []string{name}, false); err != nil {
 		return nil, true, err
 	}
@@ -236,6 +265,42 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 		return nil, true, err
 	}
 	return srv, true, nil
+}
+
+// currentWorkspaceConfig returns the workspace config visible to the current
+// query, or ok=false when there is none. The lookups deliberately discard
+// their errors: any failure to see the workspace from address resolution means
+// the string cannot be a module ref, and the caller's normal address decoding
+// should run.
+func currentWorkspaceConfig(ctx context.Context) (cfg *workspace.Config, ws *core.Workspace, ok bool) {
+	q, _ := core.CurrentQuery(ctx)
+	if q == nil {
+		return nil, nil, false
+	}
+	ws, _ = q.Server.CurrentWorkspace(ctx)
+	if ws == nil {
+		return nil, nil, false
+	}
+	cfg, _ = workspaceConfigWithCompatFallback(ctx, ws)
+	if cfg == nil {
+		return nil, nil, false
+	}
+	return cfg, ws, true
+}
+
+// workspaceEntrypointModuleName returns the install name of the workspace
+// entrypoint module, the target of short-form "<function>" references.
+func workspaceEntrypointModuleName(ctx context.Context) (string, bool) {
+	cfg, _, ok := currentWorkspaceConfig(ctx)
+	if !ok {
+		return "", false
+	}
+	for name, entry := range cfg.Modules {
+		if entry.Entrypoint {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // isBareRefShaped reports whether addr looks like it was intended as a bare

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -23,29 +23,21 @@ import (
 type moduleRefCycleKey struct{}
 
 // resolveModuleRef detects and resolves a module function reference, wiring
-// one module's function output into another object-typed value. Two spellings
-// are accepted: the long form "<module>:<function>" (e.g. "docusaurus:serve")
-// and the short form "<function>", which names a function of the workspace
-// entrypoint module (whose functions are hoisted onto the Query root).
+// one module's function output into another object-typed value: the long form
+// "<module>:<function>" or the short form "<function>" (a workspace entrypoint function).
 //
 // Detection & precedence (commit-on-match, no silent fallback):
 //   - A long-form candidate contains EXACTLY one ":" with non-empty parts on
 //     both sides. Strings containing "://" (URL-ish, e.g. "tcp://...") are
 //     never module refs.
-//   - A short-form candidate is a bare name (no ":" or "/", not a relative
-//     path). It is committed only if the entrypoint has that function;
-//     otherwise it keeps its ordinary address meaning (image name, file name).
+//   - A short-form candidate is a bare name, committed only if the entrypoint
+//     has that function; otherwise it keeps its ordinary address meaning.
 //   - The first segment is normalized to a gql field name and looked up on the
-//     CANONICAL Query root's object type. Only if a field of that name EXISTS
-//     — AND carries module provenance (FieldSpec.Module != nil), which
-//     distinguishes a module constructor from a reserved core field like
-//     "git" or "secret" that shares the root namespace — is the string
-//     committed as a module ref. The canonical server is used because the
-//     workspace entrypoint's constructor is only installed there: the sugared
-//     (client-facing) server hoists its functions onto the root as proxies
-//     and never installs the module field itself, so resolving against the
-//     sugared root would make an entrypoint module unreferenceable (see
-//     hack/designs/entrypoint-proxy.md).
+//     canonical Query root's object type (the sugared root omits the
+//     entrypoint's constructor). Only if a field of that name EXISTS — AND
+//     carries module provenance (FieldSpec.Module != nil), which distinguishes
+//     a module constructor from a reserved core field like "git" or "secret"
+//     that shares the root namespace — is the string committed as a module ref.
 //   - Once committed, any subsequent failure (unknown function, type mismatch,
 //     cycle) is a HARD error and does NOT fall through to image/URL handling.
 //
@@ -79,10 +71,7 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 		return false, nil
 	}
 
-	// Resolve against the canonical server: every module's constructor
-	// lives there, including the workspace entrypoint's, whose field is
-	// skipped on the sugared server in favor of hoisted function proxies.
-	// For servers without an entrypoint Canonical() returns the receiver.
+	// The entrypoint's constructor only exists on the canonical server.
 	srv := dagql.CurrentDagqlServer(ctx)
 	if srv == nil {
 		return false, nil
@@ -258,8 +247,7 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 }
 
 // currentWorkspaceConfig returns the workspace config visible to the current
-// query, or ok=false when there is none. Errors are deliberately discarded: no
-// visible workspace means the string cannot be a module ref.
+// query, or ok=false when there is none (errors are deliberately discarded).
 func currentWorkspaceConfig(ctx context.Context) (cfg *workspace.Config, ws *core.Workspace, ok bool) {
 	q, _ := core.CurrentQuery(ctx)
 	if q == nil {
@@ -276,8 +264,7 @@ func currentWorkspaceConfig(ctx context.Context) (cfg *workspace.Config, ws *cor
 	return cfg, ws, true
 }
 
-// workspaceEntrypointModuleName returns the install name of the workspace
-// entrypoint module, the target of short-form references.
+// workspaceEntrypointModuleName returns the install name of the entrypoint module.
 func workspaceEntrypointModuleName(ctx context.Context) (string, bool) {
 	cfg, _, ok := currentWorkspaceConfig(ctx)
 	if !ok {

--- a/core/schema/address.go
+++ b/core/schema/address.go
@@ -30,7 +30,8 @@ type moduleRefCycleKey struct{}
 //   - A long-form candidate contains EXACTLY one ":" with non-empty parts on
 //     both sides. Strings containing "://" (URL-ish, e.g. "tcp://...") are
 //     never module refs.
-//   - A short-form candidate is a bare name, committed only if the entrypoint
+//   - A short-form candidate has no ":" or "/" and no leading "." (see
+//     workspace.IsShortFormModuleRef). It is committed only if the entrypoint
 //     has that function; otherwise it keeps its ordinary address meaning.
 //   - The first segment is normalized to a gql field name and looked up on the
 //     canonical Query root's object type (the sugared root omits the
@@ -59,7 +60,7 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 	switch {
 	case !ok:
 		// Short form: resolve "<function>" as "<entrypoint>:<function>".
-		if !workspace.IsBareModuleFunctionRef(addr) {
+		if !workspace.IsShortFormModuleRef(addr) {
 			return false, nil
 		}
 		entrypoint, found := workspaceEntrypointModuleName(ctx)
@@ -199,7 +200,7 @@ func resolveModuleRef(ctx context.Context, addr string, dest any) (matched bool,
 // err reports the load outcome and srv is the refreshed schema served to the
 // current client (which now carries the module as a root field).
 func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Server, installed bool, err error) {
-	cfg, ws, ok := currentWorkspaceConfig(ctx)
+	q, ws, cfg, ok := currentWorkspaceConfig(ctx)
 	if !ok {
 		return nil, false, nil
 	}
@@ -228,10 +229,6 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 	// the recorded error here without reloading, and ModTree runs nodes
 	// without fail-fast — so only the node that genuinely needs the broken
 	// module fails, and repair generators keep running.
-	q, err := core.CurrentQuery(ctx)
-	if err != nil {
-		return nil, true, err
-	}
 	if _, err := q.Server.EnsureWorkspaceModules(ctx, []string{name}, false); err != nil {
 		return nil, true, err
 	}
@@ -246,27 +243,27 @@ func demandLoadInstalledModule(ctx context.Context, name string) (srv *dagql.Ser
 	return srv, true, nil
 }
 
-// currentWorkspaceConfig returns the workspace config visible to the current
-// query, or ok=false when there is none (errors are deliberately discarded).
-func currentWorkspaceConfig(ctx context.Context) (cfg *workspace.Config, ws *core.Workspace, ok bool) {
-	q, _ := core.CurrentQuery(ctx)
+// currentWorkspaceConfig returns the current query with its workspace and
+// config, or ok=false when there is none (errors are deliberately discarded).
+func currentWorkspaceConfig(ctx context.Context) (q *core.Query, ws *core.Workspace, cfg *workspace.Config, ok bool) {
+	q, _ = core.CurrentQuery(ctx)
 	if q == nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	ws, _ = q.Server.CurrentWorkspace(ctx)
 	if ws == nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	cfg, _ = workspaceConfigWithCompatFallback(ctx, ws)
 	if cfg == nil {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return cfg, ws, true
+	return q, ws, cfg, true
 }
 
 // workspaceEntrypointModuleName returns the install name of the entrypoint module.
 func workspaceEntrypointModuleName(ctx context.Context) (string, bool) {
-	cfg, _, ok := currentWorkspaceConfig(ctx)
+	_, _, cfg, ok := currentWorkspaceConfig(ctx)
 	if !ok {
 		return "", false
 	}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -464,6 +464,9 @@ func (s *workspaceSchema) Install(srv *dagql.Server) {
 		dagql.NodeFunc("settings", s.moduleSettings).
 			DoNotCache("Reads live config and module metadata from the workspace").
 			Doc("List constructor-backed settings for this module."),
+		dagql.NodeFunc("functions", s.moduleFunctions).
+			DoNotCache("Reads live config and module metadata from the workspace").
+			Doc("List the functions of this module's main object, in GraphQL field form."),
 	}.Install(srv)
 	dagql.Fields[*core.WorkspaceModuleSetting]{}.Install(srv)
 	dagql.Fields[*core.WorkspaceSDK]{}.Install(srv)

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -170,45 +170,61 @@ func (s *workspaceSchema) workspaceModule(
 	}, nil
 }
 
-func (s *workspaceSchema) moduleSettings(
+// workspaceModuleEntry resolves the config entry behind a WorkspaceModule
+// result, along with the owning workspace, the effective (overlay-merged)
+// config it came from, and the config directory. The entry lookup is
+// effective so modules an overlay itself adds resolve too.
+func (s *workspaceSchema) workspaceModuleEntry(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.WorkspaceModule],
-	_ struct{},
-) ([]*core.WorkspaceModuleSetting, error) {
+) (ws *core.Workspace, effectiveCfg *workspace.Config, entry workspace.ModuleEntry, configDir string, err error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, entry, "", err
 	}
 
 	// modules creates WorkspaceModule results from Workspace.__workspaceModule,
 	// so the DagQL receiver is the workspace that owns this module entry.
 	receiver, err := parent.Receiver(ctx, srv)
 	if err != nil {
-		return nil, err
+		return nil, nil, entry, "", err
 	}
-	ws, ok := receiver.(dagql.ObjectResult[*core.Workspace])
+	wsResult, ok := receiver.(dagql.ObjectResult[*core.Workspace])
 	if !ok {
-		return nil, fmt.Errorf("workspace module %q has unexpected receiver %T", parent.Self().Name, receiver)
+		return nil, nil, entry, "", fmt.Errorf("workspace module %q has unexpected receiver %T", parent.Self().Name, receiver)
 	}
-	cfg, err := readWorkspaceConfig(ctx, ws.Self())
+	ws = wsResult.Self()
+	cfg, err := readWorkspaceConfig(ctx, ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, entry, "", err
 	}
 
 	// Values come from the user-level overlay and the selected env overlay,
 	// merged in the same order as module loading. The entry lookup is also
 	// effective so modules an overlay itself adds resolve their settings.
-	effectiveCfg, err := effectiveWorkspaceConfig(ctx, ws.Self(), cfg)
+	effectiveCfg, err = effectiveWorkspaceConfig(ctx, ws, cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, entry, "", err
 	}
 
-	entry, ok := effectiveCfg.Modules[parent.Self().Name]
+	entry, ok = effectiveCfg.Modules[parent.Self().Name]
 	if !ok {
-		return nil, fmt.Errorf("module %q is not installed in the workspace", parent.Self().Name)
+		return nil, nil, entry, "", fmt.Errorf("module %q is not installed in the workspace", parent.Self().Name)
 	}
 
-	configDir, err := workspaceConfigDirectory(ws.Self())
+	configDir, err = workspaceConfigDirectory(ws)
+	if err != nil {
+		return nil, nil, entry, "", err
+	}
+	return ws, effectiveCfg, entry, configDir, nil
+}
+
+func (s *workspaceSchema) moduleSettings(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.WorkspaceModule],
+	_ struct{},
+) ([]*core.WorkspaceModuleSetting, error) {
+	ws, effectiveCfg, entry, configDir, err := s.workspaceModuleEntry(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
@@ -216,15 +232,16 @@ func (s *workspaceSchema) moduleSettings(
 		return nil, nil
 	}
 
-	ctx, srv, err = workspaceSettingsHintIntrospectionContext(ctx, ws.Self())
+	ctx, srv, err := workspaceSettingsHintIntrospectionContext(ctx, ws)
 	if err != nil {
 		return nil, err
 	}
 
-	hints, err := introspectWorkspaceModuleSettings(ctx, srv, ws.Self(), configDir, entry.Source)
+	mod, err := introspectWorkspaceModule(ctx, srv, ws, configDir, entry.Source)
 	if err != nil {
 		return nil, fmt.Errorf("discover settings for module %q: %w", parent.Self().Name, err)
 	}
+	hints := constructorHintsFromModule(mod)
 
 	settings := make([]*core.WorkspaceModuleSetting, 0, len(hints))
 	effectiveConfigBytes := workspace.SerializeConfig(effectiveCfg)
@@ -241,32 +258,68 @@ func (s *workspaceSchema) moduleSettings(
 			Value:       value,
 			Description: hint.Description,
 			IsList:      hint.IsList,
+			IsObject:    hint.IsObject,
 		})
 	}
 
 	return settings, nil
 }
 
-func introspectWorkspaceModuleSettings(
+// moduleFunctions lists the functions of the module's main object, in GraphQL
+// field form. `dagger settings` uses it to recognize a short-form reference to
+// an entrypoint function and store the long form.
+func (s *workspaceSchema) moduleFunctions(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.WorkspaceModule],
+	_ struct{},
+) (dagql.Array[dagql.String], error) {
+	ws, _, entry, configDir, err := s.workspaceModuleEntry(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
+	if entry.Source == "" {
+		return dagql.Array[dagql.String]{}, nil
+	}
+
+	ctx, srv, err := workspaceSettingsHintIntrospectionContext(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+
+	mod, err := introspectWorkspaceModule(ctx, srv, ws, configDir, entry.Source)
+	if err != nil {
+		return nil, fmt.Errorf("discover functions for module %q: %w", parent.Self().Name, err)
+	}
+	names := mainObjectFunctionNames(mod)
+	result := make(dagql.Array[dagql.String], 0, len(names))
+	for _, name := range names {
+		result = append(result, dagql.String(name))
+	}
+	return result, nil
+}
+
+// introspectWorkspaceModule loads the module behind a workspace config entry's
+// source, resolving local sources against the workspace.
+func introspectWorkspaceModule(
 	ctx context.Context,
 	srv *dagql.Server,
 	ws *core.Workspace,
 	configDir string,
 	source string,
-) ([]constructorArgHint, error) {
+) (*core.Module, error) {
 	if core.FastModuleSourceKindCheck(source, "") != core.ModuleSourceKindLocal {
-		return introspectConstructorArgs(ctx, srv, source)
+		return introspectModule(ctx, srv, source)
 	}
 
 	resolvedSource := workspace.ResolveModuleEntrySource(configDir, source)
 	if filepath.IsAbs(resolvedSource) {
-		return introspectConstructorArgs(ctx, srv, resolvedSource)
+		return introspectModule(ctx, srv, resolvedSource)
 	}
 	if rootfs, ok := ws.SourceDirectory(); ok && rootfs.Self() != nil {
-		return introspectConstructorArgsFromDirectory(ctx, srv, rootfs, resolvedSource)
+		return introspectModuleFromDirectory(ctx, srv, rootfs, resolvedSource)
 	}
 	if ws.HostPath() != "" {
-		return introspectConstructorArgs(ctx, srv, filepath.Join(ws.HostPath(), resolvedSource))
+		return introspectModule(ctx, srv, filepath.Join(ws.HostPath(), resolvedSource))
 	}
 	return nil, fmt.Errorf("workspace project root is required for local module source %q", source)
 }

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -170,10 +170,8 @@ func (s *workspaceSchema) workspaceModule(
 	}, nil
 }
 
-// workspaceModuleEntry resolves the config entry behind a WorkspaceModule
-// result, along with the owning workspace, the effective (overlay-merged)
-// config it came from, and the config directory. The entry lookup is
-// effective so modules an overlay itself adds resolve too.
+// workspaceModuleEntry resolves the effective (overlay-merged) config entry
+// behind a WorkspaceModule result, with its owning workspace and config directory.
 func (s *workspaceSchema) workspaceModuleEntry(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.WorkspaceModule],
@@ -199,9 +197,6 @@ func (s *workspaceSchema) workspaceModuleEntry(
 		return nil, nil, entry, "", err
 	}
 
-	// Values come from the user-level overlay and the selected env overlay,
-	// merged in the same order as module loading. The entry lookup is also
-	// effective so modules an overlay itself adds resolve their settings.
 	effectiveCfg, err = effectiveWorkspaceConfig(ctx, ws, cfg)
 	if err != nil {
 		return nil, nil, entry, "", err
@@ -265,9 +260,7 @@ func (s *workspaceSchema) moduleSettings(
 	return settings, nil
 }
 
-// moduleFunctions lists the functions of the module's main object, in GraphQL
-// field form. `dagger settings` uses it to recognize a short-form reference to
-// an entrypoint function and store the long form.
+// moduleFunctions lists the main object's functions in GraphQL field form.
 func (s *workspaceSchema) moduleFunctions(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.WorkspaceModule],
@@ -298,8 +291,7 @@ func (s *workspaceSchema) moduleFunctions(
 	return result, nil
 }
 
-// introspectWorkspaceModule loads the module behind a workspace config entry's
-// source, resolving local sources against the workspace.
+// introspectWorkspaceModule loads the module behind a config entry's source.
 func introspectWorkspaceModule(
 	ctx context.Context,
 	srv *dagql.Server,

--- a/core/schema/workspace_module.go
+++ b/core/schema/workspace_module.go
@@ -170,48 +170,63 @@ func (s *workspaceSchema) workspaceModule(
 	}, nil
 }
 
-// workspaceModuleEntry resolves the effective (overlay-merged) config entry
-// behind a WorkspaceModule result, with its owning workspace and config directory.
-func (s *workspaceSchema) workspaceModuleEntry(
+// loadWorkspaceModule loads the module behind a WorkspaceModule
+// result, with the effective (overlay-merged) workspace config. mod is nil
+// when the config entry has no source.
+func (s *workspaceSchema) loadWorkspaceModule(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.WorkspaceModule],
-) (ws *core.Workspace, effectiveCfg *workspace.Config, entry workspace.ModuleEntry, configDir string, err error) {
+) (mod *core.Module, effectiveCfg *workspace.Config, err error) {
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, nil, entry, "", err
+		return nil, nil, err
 	}
 
 	// modules creates WorkspaceModule results from Workspace.__workspaceModule,
 	// so the DagQL receiver is the workspace that owns this module entry.
 	receiver, err := parent.Receiver(ctx, srv)
 	if err != nil {
-		return nil, nil, entry, "", err
+		return nil, nil, err
 	}
 	wsResult, ok := receiver.(dagql.ObjectResult[*core.Workspace])
 	if !ok {
-		return nil, nil, entry, "", fmt.Errorf("workspace module %q has unexpected receiver %T", parent.Self().Name, receiver)
+		return nil, nil, fmt.Errorf("workspace module %q has unexpected receiver %T", parent.Self().Name, receiver)
 	}
-	ws = wsResult.Self()
+	ws := wsResult.Self()
 	cfg, err := readWorkspaceConfig(ctx, ws)
 	if err != nil {
-		return nil, nil, entry, "", err
+		return nil, nil, err
 	}
 
+	// Values come from the user-level overlay and the selected env overlay,
+	// merged in the same order as module loading. The entry lookup is also
+	// effective so modules an overlay itself adds resolve their settings.
 	effectiveCfg, err = effectiveWorkspaceConfig(ctx, ws, cfg)
 	if err != nil {
-		return nil, nil, entry, "", err
+		return nil, nil, err
 	}
 
-	entry, ok = effectiveCfg.Modules[parent.Self().Name]
+	entry, ok := effectiveCfg.Modules[parent.Self().Name]
 	if !ok {
-		return nil, nil, entry, "", fmt.Errorf("module %q is not installed in the workspace", parent.Self().Name)
+		return nil, nil, fmt.Errorf("module %q is not installed in the workspace", parent.Self().Name)
+	}
+	if entry.Source == "" {
+		return nil, effectiveCfg, nil
 	}
 
-	configDir, err = workspaceConfigDirectory(ws)
+	configDir, err := workspaceConfigDirectory(ws)
 	if err != nil {
-		return nil, nil, entry, "", err
+		return nil, nil, err
 	}
-	return ws, effectiveCfg, entry, configDir, nil
+	ctx, srv, err = workspaceSettingsHintIntrospectionContext(ctx, ws)
+	if err != nil {
+		return nil, nil, err
+	}
+	mod, err = introspectWorkspaceModule(ctx, srv, ws, configDir, entry.Source)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspect module %q: %w", parent.Self().Name, err)
+	}
+	return mod, effectiveCfg, nil
 }
 
 func (s *workspaceSchema) moduleSettings(
@@ -219,22 +234,12 @@ func (s *workspaceSchema) moduleSettings(
 	parent dagql.ObjectResult[*core.WorkspaceModule],
 	_ struct{},
 ) ([]*core.WorkspaceModuleSetting, error) {
-	ws, effectiveCfg, entry, configDir, err := s.workspaceModuleEntry(ctx, parent)
+	mod, effectiveCfg, err := s.loadWorkspaceModule(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
-	if entry.Source == "" {
+	if mod == nil {
 		return nil, nil
-	}
-
-	ctx, srv, err := workspaceSettingsHintIntrospectionContext(ctx, ws)
-	if err != nil {
-		return nil, err
-	}
-
-	mod, err := introspectWorkspaceModule(ctx, srv, ws, configDir, entry.Source)
-	if err != nil {
-		return nil, fmt.Errorf("discover settings for module %q: %w", parent.Self().Name, err)
 	}
 	hints := constructorHintsFromModule(mod)
 
@@ -266,29 +271,11 @@ func (s *workspaceSchema) moduleFunctions(
 	parent dagql.ObjectResult[*core.WorkspaceModule],
 	_ struct{},
 ) (dagql.Array[dagql.String], error) {
-	ws, _, entry, configDir, err := s.workspaceModuleEntry(ctx, parent)
+	mod, _, err := s.loadWorkspaceModule(ctx, parent)
 	if err != nil {
 		return nil, err
 	}
-	if entry.Source == "" {
-		return dagql.Array[dagql.String]{}, nil
-	}
-
-	ctx, srv, err := workspaceSettingsHintIntrospectionContext(ctx, ws)
-	if err != nil {
-		return nil, err
-	}
-
-	mod, err := introspectWorkspaceModule(ctx, srv, ws, configDir, entry.Source)
-	if err != nil {
-		return nil, fmt.Errorf("discover functions for module %q: %w", parent.Self().Name, err)
-	}
-	names := mainObjectFunctionNames(mod)
-	result := make(dagql.Array[dagql.String], 0, len(names))
-	for _, name := range names {
-		result = append(result, dagql.String(name))
-	}
-	return result, nil
+	return dagql.NewStringArray(mainObjectFunctionNames(mod)...), nil
 }
 
 // introspectWorkspaceModule loads the module behind a config entry's source.

--- a/core/schema/workspace_settings_hints.go
+++ b/core/schema/workspace_settings_hints.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/dagger/dagger/core"
@@ -16,6 +17,7 @@ type constructorArgHint struct {
 	Name         string
 	TypeLabel    string
 	IsList       bool
+	IsObject     bool
 	Description  string
 	ExampleValue string
 }
@@ -37,11 +39,11 @@ func workspaceSettingsHintIntrospectionContext(
 	return ctx, srv, nil
 }
 
-func introspectConstructorArgs(
+func introspectModule(
 	ctx context.Context,
 	srv *dagql.Server,
 	ref string,
-) ([]constructorArgHint, error) {
+) (*core.Module, error) {
 	var mod dagql.ObjectResult[*core.Module]
 	if err := srv.Select(ctx, srv.Root(), &mod,
 		dagql.Selector{
@@ -55,16 +57,15 @@ func introspectConstructorArgs(
 	); err != nil {
 		return nil, fmt.Errorf("loading module: %w", err)
 	}
-
-	return constructorHintsFromModule(mod.Self()), nil
+	return mod.Self(), nil
 }
 
-func introspectConstructorArgsFromDirectory(
+func introspectModuleFromDirectory(
 	ctx context.Context,
 	srv *dagql.Server,
 	dir dagql.ObjectResult[*core.Directory],
 	sourceRootPath string,
-) ([]constructorArgHint, error) {
+) (*core.Module, error) {
 	sourceRootPath = path.Clean(filepath.ToSlash(sourceRootPath))
 	if sourceRootPath == "" {
 		sourceRootPath = "."
@@ -79,8 +80,28 @@ func introspectConstructorArgsFromDirectory(
 	}); err != nil {
 		return nil, fmt.Errorf("loading module from directory: %w", err)
 	}
+	return mod.Self(), nil
+}
 
-	return constructorHintsFromModule(mod.Self()), nil
+// mainObjectFunctionNames lists the functions of the module's main object in
+// GraphQL field form, sorted.
+func mainObjectFunctionNames(mod *core.Module) []string {
+	if mod == nil {
+		return nil
+	}
+	mainObj, ok := mod.MainObject()
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(mainObj.Functions))
+	for _, fn := range mainObj.Functions {
+		if fn.Self() == nil {
+			continue
+		}
+		names = append(names, fn.Self().Name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func constructorHintsFromModule(mod *core.Module) []constructorArgHint {
@@ -139,6 +160,7 @@ func buildHintFromArg(arg *core.FunctionArg) (constructorArgHint, bool) {
 		Name:         arg.Name,
 		TypeLabel:    typeLabel,
 		IsList:       arg.TypeDef.Self().Kind == core.TypeDefKindList,
+		IsObject:     arg.TypeDef.Self().Kind == core.TypeDefKindObject,
 		Description:  arg.Description,
 		ExampleValue: exampleValue,
 	}, true

--- a/core/schema/workspace_settings_hints.go
+++ b/core/schema/workspace_settings_hints.go
@@ -94,9 +94,6 @@ func mainObjectFunctionNames(mod *core.Module) []string {
 	}
 	names := make([]string, 0, len(mainObj.Functions))
 	for _, fn := range mainObj.Functions {
-		if fn.Self() == nil {
-			continue
-		}
 		names = append(names, fn.Self().Name)
 	}
 	sort.Strings(names)

--- a/core/schema/workspace_settings_hints.go
+++ b/core/schema/workspace_settings_hints.go
@@ -83,8 +83,7 @@ func introspectModuleFromDirectory(
 	return mod.Self(), nil
 }
 
-// mainObjectFunctionNames lists the functions of the module's main object in
-// GraphQL field form, sorted.
+// mainObjectFunctionNames lists the main object's functions in GraphQL field form, sorted.
 func mainObjectFunctionNames(mod *core.Module) []string {
 	if mod == nil {
 		return nil

--- a/core/workspace/moduleref.go
+++ b/core/workspace/moduleref.go
@@ -2,16 +2,9 @@ package workspace
 
 import "strings"
 
-// IsBareModuleFunctionRef reports whether a settings value has the shape of a
-// short-form module reference: a bare "<function>" naming a function of the
-// workspace entrypoint module, as opposed to the long form
-// "<module>:<function>". It is a shape check only. Whether the entrypoint
-// actually has such a function is decided by whoever resolves or rewrites the
-// value.
-//
-// A bare name has no ":" (that would be the long form, an image tag, or a
-// URL), no "/" (a path or a registry ref), and does not start with "." (a
-// relative path).
+// IsBareModuleFunctionRef reports whether value has the shape of a short-form
+// entrypoint function reference ("<function>" rather than "<module>:<function>"):
+// no ":" or "/", and not a relative path. Shape only; callers check the function exists.
 func IsBareModuleFunctionRef(value string) bool {
 	return value != "" &&
 		!strings.ContainsAny(value, ":/") &&

--- a/core/workspace/moduleref.go
+++ b/core/workspace/moduleref.go
@@ -2,10 +2,10 @@ package workspace
 
 import "strings"
 
-// IsBareModuleFunctionRef reports whether value has the shape of a short-form
+// IsShortFormModuleRef reports whether value has the shape of a short-form
 // entrypoint function reference ("<function>" rather than "<module>:<function>"):
 // no ":" or "/", and not a relative path. Shape only; callers check the function exists.
-func IsBareModuleFunctionRef(value string) bool {
+func IsShortFormModuleRef(value string) bool {
 	return value != "" &&
 		!strings.ContainsAny(value, ":/") &&
 		!strings.HasPrefix(value, ".")

--- a/core/workspace/moduleref.go
+++ b/core/workspace/moduleref.go
@@ -1,0 +1,19 @@
+package workspace
+
+import "strings"
+
+// IsBareModuleFunctionRef reports whether a settings value has the shape of a
+// short-form module reference: a bare "<function>" naming a function of the
+// workspace entrypoint module, as opposed to the long form
+// "<module>:<function>". It is a shape check only. Whether the entrypoint
+// actually has such a function is decided by whoever resolves or rewrites the
+// value.
+//
+// A bare name has no ":" (that would be the long form, an image tag, or a
+// URL), no "/" (a path or a registry ref), and does not start with "." (a
+// relative path).
+func IsBareModuleFunctionRef(value string) bool {
+	return value != "" &&
+		!strings.ContainsAny(value, ":/") &&
+		!strings.HasPrefix(value, ".")
+}

--- a/core/workspace_module.go
+++ b/core/workspace_module.go
@@ -56,6 +56,7 @@ type WorkspaceModuleSetting struct {
 	Value       string `field:"true" doc:"The configured value after applying the selected workspace environment, or empty when unset."`
 	Description string `field:"true" doc:"The constructor argument description."`
 	IsList      bool   `field:"true" doc:"Whether the setting accepts a list of values."`
+	IsObject    bool   `field:"true" doc:"Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference."`
 }
 
 var _ dagql.PersistedObject = (*WorkspaceModuleSetting)(nil)

--- a/docs/current_docs/config/module-wiring.mdx
+++ b/docs/current_docs/config/module-wiring.mdx
@@ -62,9 +62,14 @@ source = "source-prep:workspace"
 
 ## Reference the workspace entrypoint
 
-The entrypoint module's functions are hoisted onto the root of the workspace,
-so `dagger call serve` and `dagger call myapp:serve` are the same call. A
-reference to an entrypoint function accepts the same two spellings:
+The entrypoint module's functions are hoisted onto the workspace root, so a
+reference to one can drop the module name:
+
+```shell
+dagger settings playwright service serve
+```
+
+The config always stores the long form:
 
 ```toml
 [modules.myapp]
@@ -72,16 +77,11 @@ source = "./ci/myapp"
 entrypoint = true
 
 [modules.playwright.settings]
-service = "myapp:serve"   # long form, always written by `dagger settings`
-service = "serve"         # short form, accepted when hand-editing
+service = "myapp:serve"
 ```
 
-`dagger settings playwright service serve` accepts the short form and stores
-the long form, so `dagger.toml` stays explicit about which module the value
-comes from. A bare name is only treated as a reference when the entrypoint
-actually has a function of that name; otherwise it keeps its ordinary address
-meaning, so an image name like `alpine` is unaffected unless your entrypoint
-defines an `alpine` function.
+A bare name is only treated as a reference when the entrypoint has a function
+of that name; otherwise it keeps its ordinary address meaning.
 
 ## Use a reference on the command line
 

--- a/docs/current_docs/config/module-wiring.mdx
+++ b/docs/current_docs/config/module-wiring.mdx
@@ -60,6 +60,29 @@ assets = "frontend:assets"
 source = "source-prep:workspace"
 ```
 
+## Reference the workspace entrypoint
+
+The entrypoint module's functions are hoisted onto the root of the workspace,
+so `dagger call serve` and `dagger call myapp:serve` are the same call. A
+reference to an entrypoint function accepts the same two spellings:
+
+```toml
+[modules.myapp]
+source = "./ci/myapp"
+entrypoint = true
+
+[modules.playwright.settings]
+service = "myapp:serve"   # long form, always written by `dagger settings`
+service = "serve"         # short form, accepted when hand-editing
+```
+
+`dagger settings playwright service serve` accepts the short form and stores
+the long form, so `dagger.toml` stays explicit about which module the value
+comes from. A bare name is only treated as a reference when the entrypoint
+actually has a function of that name; otherwise it keeps its ordinary address
+meaning, so an image name like `alpine` is unaffected unless your entrypoint
+defines an `alpine` function.
+
 ## Use a reference on the command line
 
 A module reference is an ordinary address string, so it also works as a CLI
@@ -73,7 +96,8 @@ dagger api call playwright --service=myapp:serve test
 
 - The leading segment is a module's install name, the `[modules.X]` key in
   this `dagger.toml`. The second segment is a zero-arg function on it whose
-  return type matches the argument.
+  return type matches the argument. A bare `<function>` with no module segment
+  refers to the workspace entrypoint module.
 - If the first segment names an installed module, the string *is* a module
   reference. A missing function or mismatched type is then a hard error, never
   a silent fallback to an image or URL. If no install name matches, the string

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -6357,6 +6357,11 @@ type WorkspaceModule implements Node {
   """
   entrypoint: Boolean!
 
+  """
+  List the functions of this module's main object, in GraphQL field form.
+  """
+  functions: [String!]!
+
   """A unique identifier for this WorkspaceModule."""
   id: ID!
 
@@ -6380,6 +6385,13 @@ type WorkspaceModuleSetting implements Node {
 
   """Whether the setting accepts a list of values."""
   isList: Boolean!
+
+  """
+  Whether the setting is an object type resolved from an address string
+  (Container, Directory, File, Secret, Service, ...), which may be a module
+  reference.
+  """
+  isObject: Boolean!
 
   """The setting key."""
   key: String!

--- a/docs/static/reference/php/Dagger/WorkspaceModule.html
+++ b/docs/static/reference/php/Dagger/WorkspaceModule.html
@@ -153,6 +153,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    array
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_functions">functions</a>()
+        
+                                            <p><p>List the functions of this module's main object, in GraphQL field form.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
                 </div>
                 <div class="col-md-8">
@@ -319,8 +329,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_id">
+                    <h3 id="method_functions">
         <div class="location">at line 28</div>
+        <code>                    array
+    <strong>functions</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>List the functions of this module's main object, in GraphQL field form.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>array</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_id">
+        <div class="location">at line 37</div>
         <code>                    <a href="../Dagger/Id.html"><abbr title="Dagger\Id">Id</abbr></a>
     <strong>id</strong>()
         </code>
@@ -352,7 +394,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_name">
-        <div class="location">at line 37</div>
+        <div class="location">at line 46</div>
         <code>                    string
     <strong>name</strong>()
         </code>
@@ -384,7 +426,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_settings">
-        <div class="location">at line 46</div>
+        <div class="location">at line 55</div>
         <code>                    array
     <strong>settings</strong>()
         </code>
@@ -416,7 +458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_source">
-        <div class="location">at line 55</div>
+        <div class="location">at line 64</div>
         <code>                    string
     <strong>source</strong>()
         </code>

--- a/docs/static/reference/php/Dagger/WorkspaceModuleSetting.html
+++ b/docs/static/reference/php/Dagger/WorkspaceModuleSetting.html
@@ -173,6 +173,16 @@
             </div>
                     <div class="row">
                 <div class="col-md-2 type">
+                    bool
+                </div>
+                <div class="col-md-8">
+                    <a href="#method_isObject">isObject</a>()
+        
+                                            <p><p>Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.</p></p>                </div>
+                <div class="col-md-2"></div>
+            </div>
+                    <div class="row">
+                <div class="col-md-2 type">
                     string
                 </div>
                 <div class="col-md-8">
@@ -383,8 +393,40 @@
 
             </div>
                     <div class="method-item">
-                    <h3 id="method_key">
+                    <h3 id="method_isObject">
         <div class="location">at line 46</div>
+        <code>                    bool
+    <strong>isObject</strong>()
+        </code>
+    </h3>
+    <div class="details">    
+    
+            
+
+        <div class="method-description">
+                            <p><p>Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.</p></p>                        
+        </div>
+        <div class="tags">
+            
+                            <h4>Return Value</h4>
+
+                    <table class="table table-condensed">
+        <tr>
+            <td>bool</td>
+            <td></td>
+        </tr>
+    </table>
+
+            
+            
+            
+                    </div>
+    </div>
+
+            </div>
+                    <div class="method-item">
+                    <h3 id="method_key">
+        <div class="location">at line 55</div>
         <code>                    string
     <strong>key</strong>()
         </code>
@@ -416,7 +458,7 @@
             </div>
                     <div class="method-item">
                     <h3 id="method_value">
-        <div class="location">at line 55</div>
+        <div class="location">at line 64</div>
         <code>                    string
     <strong>value</strong>()
         </code>

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -752,7 +752,9 @@
 <abbr title="Dagger\Workspace">Workspace</abbr>::findRoots</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
                     <dd><p>Find project roots marked by any of the given filenames, starting from a path relative to the workspace cwd.</p></dd><dt><a href="Dagger/Workspace.html#method_findUp">
 <abbr title="Dagger\Workspace">Workspace</abbr>::findUp</a>() &mdash; <em>Method in class <a href="Dagger/Workspace.html"><abbr title="Dagger\Workspace">Workspace</abbr></a></em></dt>
-                    <dd><p>Search for a file or directory by walking up from the start path within the workspace.</p></dd>        </dl><h2 id="letterG">G</h2>
+                    <dd><p>Search for a file or directory by walking up from the start path within the workspace.</p></dd><dt><a href="Dagger/WorkspaceModule.html#method_functions">
+<abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr>::functions</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a></em></dt>
+                    <dd><p>List the functions of this module's main object, in GraphQL field form.</p></dd>        </dl><h2 id="letterG">G</h2>
         <dl id="indexG"><dt><a href="Dagger/Address.html#method_gitRef">
 <abbr title="Dagger\Address">Address</abbr>::gitRef</a>() &mdash; <em>Method in class <a href="Dagger/Address.html"><abbr title="Dagger\Address">Address</abbr></a></em></dt>
                     <dd><p>Load a git ref (branch, tag or commit) from the address.</p></dd><dt><a href="Dagger/Address.html#method_gitRepository">
@@ -1063,7 +1065,9 @@
 <abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
                     <dd><p>A unique identifier for this WorkspaceModuleSetting.</p></dd><dt><a href="Dagger/WorkspaceModuleSetting.html#method_isList">
 <abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::isList</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
-                    <dd><p>Whether the setting accepts a list of values.</p></dd><dt><a href="Dagger/WorkspaceSDK.html#method_id">
+                    <dd><p>Whether the setting accepts a list of values.</p></dd><dt><a href="Dagger/WorkspaceModuleSetting.html#method_isObject">
+<abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr>::isObject</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModuleSetting.html"><abbr title="Dagger\WorkspaceModuleSetting">WorkspaceModuleSetting</abbr></a></em></dt>
+                    <dd><p>Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.</p></dd><dt><a href="Dagger/WorkspaceSDK.html#method_id">
 <abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr>::id</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceSDK.html"><abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr></a></em></dt>
                     <dd><p>A unique identifier for this WorkspaceSDK.</p></dd>        </dl><h2 id="letterJ">J</h2>
         <dl id="indexJ"><dt><a href="Dagger/Client.html#method_json">

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -7840,6 +7840,12 @@
 		},
 		{
 			"t": "M",
+			"n": "Dagger\\WorkspaceModule::functions",
+			"p": "Dagger/WorkspaceModule.html#method_functions",
+			"d": "<p>List the functions of this module's main object, in GraphQL field form.</p>"
+		},
+		{
+			"t": "M",
 			"n": "Dagger\\WorkspaceModule::id",
 			"p": "Dagger/WorkspaceModule.html#method_id",
 			"d": "<p>A unique identifier for this WorkspaceModule.</p>"
@@ -7879,6 +7885,12 @@
 			"n": "Dagger\\WorkspaceModuleSetting::isList",
 			"p": "Dagger/WorkspaceModuleSetting.html#method_isList",
 			"d": "<p>Whether the setting accepts a list of values.</p>"
+		},
+		{
+			"t": "M",
+			"n": "Dagger\\WorkspaceModuleSetting::isObject",
+			"p": "Dagger/WorkspaceModuleSetting.html#method_isObject",
+			"d": "<p>Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.</p>"
 		},
 		{
 			"t": "M",

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -45,10 +45,11 @@ query WorkspaceModuleSettings($module: String!) {
 }
 `
 
-// workspaceModuleSettingsQueryWithIsList additionally requests isList, which
-// older engines don't expose. Only multi-value writes need it, so other flows
-// use the queries above and keep working against those engines.
-const workspaceModuleSettingsQueryWithIsList = `
+// workspaceModuleSettingsQueryForWrite additionally requests the setting
+// shape a write needs: isList (multi-value writes) and isObject (module
+// reference normalization). Older engines don't expose these fields, so writes
+// fall back to the query above against them and skip what the fields enable.
+const workspaceModuleSettingsQueryForWrite = `
 query WorkspaceModuleSettings($module: String!) {
   currentWorkspace {
     module(name: $module) {
@@ -58,7 +59,29 @@ query WorkspaceModuleSettings($module: String!) {
         value
         description
         isList
+        isObject
       }
+    }
+  }
+}
+`
+
+const workspaceEntrypointQuery = `
+query WorkspaceEntrypoint {
+  currentWorkspace {
+    modules {
+      name
+      entrypoint
+    }
+  }
+}
+`
+
+const workspaceModuleFunctionsQuery = `
+query WorkspaceModuleFunctions($module: String!) {
+  currentWorkspace {
+    module(name: $module) {
+      functions
     }
   }
 }
@@ -139,7 +162,7 @@ func runWorkspaceSettingsSession(cmd *cobra.Command, args []string, envWrite, su
 			moduleName = args[0]
 		}
 
-		state, err := loadWorkspaceSettingsState(ctx, engineClient.Dagger(), moduleName, len(args) > 3)
+		state, err := loadWorkspaceSettingsState(ctx, engineClient.Dagger(), moduleName, len(args) > 2)
 		if err != nil {
 			return err
 		}
@@ -175,6 +198,12 @@ func runWorkspaceSettingsSession(cmd *cobra.Command, args []string, envWrite, su
 			value, values, err := workspaceSettingWriteValue(setting, args[2:])
 			if err != nil {
 				return err
+			}
+			if values == nil {
+				value, err = normalizeEntrypointFunctionRef(ctx, engineClient.Dagger(), setting, value)
+				if err != nil {
+					return err
+				}
 			}
 			if workspaceSettingsGlobal {
 				// User-level writes happen client-side; --env composes there
@@ -216,6 +245,73 @@ type workspaceSetting struct {
 	Value       string
 	Description string
 	IsList      bool
+	IsObject    bool
+}
+
+// normalizeEntrypointFunctionRef rewrites a short-form reference to a function
+// of the workspace entrypoint module ("image") into the long form the config
+// always stores ("container-provider:image"). Both forms resolve identically at
+// runtime; storing the long form keeps dagger.toml explicit about which module
+// a value comes from. Only address-typed (object) settings are candidates, so a
+// string setting whose value happens to match a function name is left alone.
+// Anything else, including values on engines that predate the fields this
+// relies on, passes through unchanged.
+func normalizeEntrypointFunctionRef(ctx context.Context, dag *dagger.Client, setting workspaceSetting, value string) (string, error) {
+	if !setting.IsObject || !workspacepkg.IsBareModuleFunctionRef(value) {
+		return value, nil
+	}
+
+	var modules struct {
+		CurrentWorkspace struct {
+			Modules []struct {
+				Name       string
+				Entrypoint bool
+			}
+		}
+	}
+	if err := dag.Do(ctx, &dagger.Request{Query: workspaceEntrypointQuery}, &dagger.Response{Data: &modules}); err != nil {
+		return "", err
+	}
+	entrypoint := ""
+	for _, module := range modules.CurrentWorkspace.Modules {
+		if module.Entrypoint {
+			entrypoint = module.Name
+			break
+		}
+	}
+	if entrypoint == "" {
+		return value, nil
+	}
+
+	var functions struct {
+		CurrentWorkspace struct {
+			Module struct {
+				Functions []string
+			}
+		}
+	}
+	if err := dag.Do(ctx, &dagger.Request{
+		Query:     workspaceModuleFunctionsQuery,
+		Variables: map[string]any{"module": entrypoint},
+	}, &dagger.Response{Data: &functions}); err != nil {
+		if isUnknownGraphQLFieldError(err) {
+			return value, nil
+		}
+		return "", err
+	}
+	want := gqlFieldName(value)
+	for _, fn := range functions.CurrentWorkspace.Module.Functions {
+		if fn == want {
+			return entrypoint + ":" + value, nil
+		}
+	}
+	return value, nil
+}
+
+// isUnknownGraphQLFieldError reports whether err is the engine rejecting a
+// field the CLI asked for, i.e. the engine predates that field.
+func isUnknownGraphQLFieldError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Cannot query field")
 }
 
 // workspaceSettingWriteValue maps trailing CLI args onto WithConfigValue's
@@ -239,7 +335,7 @@ type workspaceSettingsState struct {
 	Settings  []workspaceSetting
 }
 
-func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleName string, withIsList bool) (*workspaceSettingsState, error) {
+func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleName string, forWrite bool) (*workspaceSettingsState, error) {
 	type settingsModule struct {
 		Name     string
 		Settings []workspaceSetting
@@ -257,18 +353,26 @@ func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleN
 		modules = res.CurrentWorkspace.Modules
 	} else {
 		query := workspaceModuleSettingsQuery
-		if withIsList {
-			query = workspaceModuleSettingsQueryWithIsList
+		if forWrite {
+			query = workspaceModuleSettingsQueryForWrite
 		}
 		var res struct {
 			CurrentWorkspace struct {
 				Module settingsModule
 			}
 		}
-		if err := dag.Do(ctx, &dagger.Request{
+		err := dag.Do(ctx, &dagger.Request{
 			Query:     query,
 			Variables: map[string]any{"module": moduleName},
-		}, &dagger.Response{Data: &res}); err != nil {
+		}, &dagger.Response{Data: &res})
+		if err != nil && forWrite && isUnknownGraphQLFieldError(err) {
+			// Older engine: retry without the write-only fields.
+			err = dag.Do(ctx, &dagger.Request{
+				Query:     workspaceModuleSettingsQuery,
+				Variables: map[string]any{"module": moduleName},
+			}, &dagger.Response{Data: &res})
+		}
+		if err != nil {
 			return nil, err
 		}
 		modules = []settingsModule{res.CurrentWorkspace.Module}

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -45,10 +45,8 @@ query WorkspaceModuleSettings($module: String!) {
 }
 `
 
-// workspaceModuleSettingsQueryForWrite additionally requests the setting
-// shape a write needs: isList (multi-value writes) and isObject (module
-// reference normalization). Older engines don't expose these fields, so writes
-// fall back to the query above against them and skip what the fields enable.
+// workspaceModuleSettingsQueryForWrite adds isList and isObject, which older
+// engines don't expose; writes fall back to the query above against them.
 const workspaceModuleSettingsQueryForWrite = `
 query WorkspaceModuleSettings($module: String!) {
   currentWorkspace {
@@ -248,14 +246,10 @@ type workspaceSetting struct {
 	IsObject    bool
 }
 
-// normalizeEntrypointFunctionRef rewrites a short-form reference to a function
-// of the workspace entrypoint module ("image") into the long form the config
-// always stores ("container-provider:image"). Both forms resolve identically at
-// runtime; storing the long form keeps dagger.toml explicit about which module
-// a value comes from. Only address-typed (object) settings are candidates, so a
-// string setting whose value happens to match a function name is left alone.
-// Anything else, including values on engines that predate the fields this
-// relies on, passes through unchanged.
+// normalizeEntrypointFunctionRef rewrites a short-form entrypoint function
+// reference ("image") to the long form the config stores ("provider:image").
+// Only object-typed settings are candidates, so a string setting whose value
+// matches a function name is left alone.
 func normalizeEntrypointFunctionRef(ctx context.Context, dag *dagger.Client, setting workspaceSetting, value string) (string, error) {
 	if !setting.IsObject || !workspacepkg.IsBareModuleFunctionRef(value) {
 		return value, nil
@@ -308,8 +302,7 @@ func normalizeEntrypointFunctionRef(ctx context.Context, dag *dagger.Client, set
 	return value, nil
 }
 
-// isUnknownGraphQLFieldError reports whether err is the engine rejecting a
-// field the CLI asked for, i.e. the engine predates that field.
+// isUnknownGraphQLFieldError reports whether the engine predates a requested field.
 func isUnknownGraphQLFieldError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "Cannot query field")
 }
@@ -366,7 +359,6 @@ func loadWorkspaceSettingsState(ctx context.Context, dag *dagger.Client, moduleN
 			Variables: map[string]any{"module": moduleName},
 		}, &dagger.Response{Data: &res})
 		if err != nil && forWrite && isUnknownGraphQLFieldError(err) {
-			// Older engine: retry without the write-only fields.
 			err = dag.Do(ctx, &dagger.Request{
 				Query:     workspaceModuleSettingsQuery,
 				Variables: map[string]any{"module": moduleName},

--- a/internal/cmd/dagger/settings.go
+++ b/internal/cmd/dagger/settings.go
@@ -251,7 +251,7 @@ type workspaceSetting struct {
 // Only object-typed settings are candidates, so a string setting whose value
 // matches a function name is left alone.
 func normalizeEntrypointFunctionRef(ctx context.Context, dag *dagger.Client, setting workspaceSetting, value string) (string, error) {
-	if !setting.IsObject || !workspacepkg.IsBareModuleFunctionRef(value) {
+	if !setting.IsObject || !workspacepkg.IsShortFormModuleRef(value) {
 		return value, nil
 	}
 
@@ -288,9 +288,6 @@ func normalizeEntrypointFunctionRef(ctx context.Context, dag *dagger.Client, set
 		Query:     workspaceModuleFunctionsQuery,
 		Variables: map[string]any{"module": entrypoint},
 	}, &dagger.Response{Data: &functions}); err != nil {
-		if isUnknownGraphQLFieldError(err) {
-			return value, nil
-		}
 		return "", err
 	}
 	want := gqlFieldName(value)

--- a/sdk/elixir/lib/dagger/gen/workspace_module.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace_module.ex
@@ -27,6 +27,17 @@ defmodule Dagger.WorkspaceModule do
   end
 
   @doc """
+  List the functions of this module's main object, in GraphQL field form.
+  """
+  @spec functions(t()) :: {:ok, [String.t()]} | {:error, term()}
+  def functions(%__MODULE__{} = workspace_module) do
+    query_builder =
+      workspace_module.query_builder |> QB.select("functions")
+
+    Client.execute(workspace_module.client, query_builder)
+  end
+
+  @doc """
   A unique identifier for this WorkspaceModule.
   """
   @spec id(t()) :: {:ok, String.t()} | {:error, term()}

--- a/sdk/elixir/lib/dagger/gen/workspace_module_setting.ex
+++ b/sdk/elixir/lib/dagger/gen/workspace_module_setting.ex
@@ -49,6 +49,17 @@ defmodule Dagger.WorkspaceModuleSetting do
   end
 
   @doc """
+  Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.
+  """
+  @spec object?(t()) :: {:ok, boolean()} | {:error, term()}
+  def object?(%__MODULE__{} = workspace_module_setting) do
+    query_builder =
+      workspace_module_setting.query_builder |> QB.select("isObject")
+
+    Client.execute(workspace_module_setting.client, query_builder)
+  end
+
+  @doc """
   The setting key.
   """
   @spec key(t()) :: {:ok, String.t()} | {:error, term()}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -17847,6 +17847,16 @@ func (r *WorkspaceModule) Entrypoint(ctx context.Context) (bool, error) {
 	return response, q.Execute(ctx)
 }
 
+// List the functions of this module's main object, in GraphQL field form.
+func (r *WorkspaceModule) Functions(ctx context.Context) ([]string, error) {
+	q := r.query.Select("functions")
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // A unique identifier for this WorkspaceModule.
 func (r *WorkspaceModule) ID(ctx context.Context) (ID, error) {
 	if r.id != nil {
@@ -17961,6 +17971,7 @@ type WorkspaceModuleSetting struct {
 	description *string
 	id          *ID
 	isList      *bool
+	isObject    *bool
 	key         *string
 	value       *string
 }
@@ -18030,6 +18041,19 @@ func (r *WorkspaceModuleSetting) IsList(ctx context.Context) (bool, error) {
 		return *r.isList, nil
 	}
 	q := r.query.Select("isList")
+
+	var response bool
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
+// Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.
+func (r *WorkspaceModuleSetting) IsObject(ctx context.Context) (bool, error) {
+	if r.isObject != nil {
+		return *r.isObject, nil
+	}
+	q := r.query.Select("isObject")
 
 	var response bool
 

--- a/sdk/php/generated/WorkspaceModule.php
+++ b/sdk/php/generated/WorkspaceModule.php
@@ -23,6 +23,15 @@ class WorkspaceModule extends Client\AbstractObject implements Client\IdAble, No
     }
 
     /**
+     * List the functions of this module's main object, in GraphQL field form.
+     */
+    public function functions(): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('functions');
+        return (array)$this->queryLeaf($leafQueryBuilder, 'functions');
+    }
+
+    /**
      * A unique identifier for this WorkspaceModule.
      */
     public function id(): Id

--- a/sdk/php/generated/WorkspaceModuleSetting.php
+++ b/sdk/php/generated/WorkspaceModuleSetting.php
@@ -41,6 +41,15 @@ class WorkspaceModuleSetting extends Client\AbstractObject implements Client\IdA
     }
 
     /**
+     * Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.
+     */
+    public function isObject(): bool
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('isObject');
+        return (bool)$this->queryLeaf($leafQueryBuilder, 'isObject');
+    }
+
+    /**
      * The setting key.
      */
     public function key(): string

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -16693,6 +16693,28 @@ class WorkspaceModule(Type):
         _ctx = self._select("entrypoint", _args)
         return await _ctx.execute(bool)
 
+    async def functions(self) -> list[str]:
+        """List the functions of this module's main object, in GraphQL field
+        form.
+
+        Returns
+        -------
+        list[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("functions", _args)
+        return await _ctx.execute(list[str])
+
     async def id(self) -> str:
         """A unique identifier for this WorkspaceModule.
 
@@ -16840,6 +16862,27 @@ class WorkspaceModuleSetting(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("isList", _args)
+        return await _ctx.execute(bool)
+
+    async def is_object(self) -> bool:
+        """Whether the setting is an object type resolved from an address string
+        (Container, Directory, File, Secret, Service, ...), which may be a
+        module reference.
+
+        Returns
+        -------
+        bool
+            The `Boolean` scalar type represents `true` or `false`.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("isObject", _args)
         return await _ctx.execute(bool)
 
     async def key(self) -> str:

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -17305,6 +17305,11 @@ impl WorkspaceModule {
         let query = self.selection.select("entrypoint");
         query.execute(self.graphql_client.clone()).await
     }
+    /// List the functions of this module's main object, in GraphQL field form.
+    pub async fn functions(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("functions");
+        query.execute(self.graphql_client.clone()).await
+    }
     /// A unique identifier for this WorkspaceModule.
     pub async fn id(&self) -> Result<Id, DaggerError> {
         let query = self.selection.select("id");
@@ -17388,6 +17393,11 @@ impl WorkspaceModuleSetting {
     /// Whether the setting accepts a list of values.
     pub async fn is_list(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("isList");
+        query.execute(self.graphql_client.clone()).await
+    }
+    /// Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.
+    pub async fn is_object(&self) -> Result<bool, DaggerError> {
+        let query = self.selection.select("isObject");
         query.execute(self.graphql_client.clone()).await
     }
     /// The setting key.

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -16262,6 +16262,17 @@ export class WorkspaceModule extends BaseClient {
   }
 
   /**
+   * List the functions of this module's main object, in GraphQL field form.
+   */
+  functions = async (): Promise<string[]> => {
+    const ctx = this._ctx.select("functions")
+
+    const response: Awaited<string[]> = await ctx.execute()
+
+    return response
+  }
+
+  /**
    * The module name.
    */
   name = async (): Promise<string> => {
@@ -16319,6 +16330,7 @@ export class WorkspaceModuleSetting extends BaseClient {
   private readonly _id?: ID = undefined
   private readonly _description?: string = undefined
   private readonly _isList?: boolean = undefined
+  private readonly _isObject?: boolean = undefined
   private readonly _key?: string = undefined
   private readonly _value?: string = undefined
 
@@ -16330,6 +16342,7 @@ export class WorkspaceModuleSetting extends BaseClient {
     _id?: ID,
     _description?: string,
     _isList?: boolean,
+    _isObject?: boolean,
     _key?: string,
     _value?: string,
   ) {
@@ -16338,6 +16351,7 @@ export class WorkspaceModuleSetting extends BaseClient {
     this._id = _id
     this._description = _description
     this._isList = _isList
+    this._isObject = _isObject
     this._key = _key
     this._value = _value
   }
@@ -16381,6 +16395,21 @@ export class WorkspaceModuleSetting extends BaseClient {
     }
 
     const ctx = this._ctx.select("isList")
+
+    const response: Awaited<boolean> = await ctx.execute()
+
+    return response
+  }
+
+  /**
+   * Whether the setting is an object type resolved from an address string (Container, Directory, File, Secret, Service, ...), which may be a module reference.
+   */
+  isObject = async (): Promise<boolean> => {
+    if (this._isObject) {
+      return this._isObject
+    }
+
+    const ctx = this._ctx.select("isObject")
 
     const response: Awaited<boolean> = await ctx.execute()
 


### PR DESCRIPTION
Fixes #14058

## Problem

A settings-wired module reference (`settings.arg = "module:function"`) could not name the workspace entrypoint module. Both `demo:worker-bundle-as-container` and demand-loading under selector verbs failed with:

```
module "demo" is the workspace entrypoint; its functions are hoisted to the root and cannot be referenced as "demo:<function>"
```

The bare form `worker-bundle-as-container`, the same call a user makes on the command line for an entrypoint, was not recognized at all.

## Root cause

`resolveModuleRef` (core/schema/address.go) looked the module field up on the **sugared** (client-facing) Query root. When a module is the entrypoint, `SchemaBuilder` builds two servers (see `hack/designs/entrypoint-proxy.md`):

- the **canonical** server installs the module normally, including its constructor field (`demo`);
- the **sugared** server skips the constructor and installs only per-function proxies on the root.

So the lookup missed on the sugared root, and `demandLoadInstalledModule` then rejected entrypoints outright on the premise that the module field "can never match". That premise only holds for the sugared server. The entrypoint proxies themselves already resolve through `dag.Canonical()`.

## Changes

**Long form resolves (commit 1).** Module refs resolve against `srv.Canonical()` (a no-op for servers without an entrypoint), also after a demand-load, and the entrypoint rejection is dropped. Commit-on-match semantics are unchanged: the canonical root still carries module provenance on constructor fields and has no proxies that could shadow core fields.

**Short form resolves (commit 2).** A bare `<function>` (no `:` or `/`, not a relative path) is treated as `<entrypoint>:<function>` when the workspace installs an entrypoint, and is committed as a module ref only if that module actually has the function. Otherwise the string keeps its ordinary address meaning, so an image name is only shadowed by an entrypoint that defines a function of that name. Both spellings are accepted from `dagger.toml`, since a hand edit can write either.

**`dagger settings` stores the long form.** The CLI accepts the short form for an address-typed setting and always writes `<entrypoint>:<function>`, keeping stored config explicit about which module a value comes from. The rewrite is type-aware: a plain string setting whose value happens to match a function name is never touched. To support that, `WorkspaceModuleSetting` gains `isObject` and `WorkspaceModule` gains `functions`; writes fall back to the previous query shape against engines that predate them. The shared shape check lives in `core/workspace.IsBareModuleFunctionRef`, so engine and CLI agree on what a short-form candidate looks like.

Docs: `config/module-wiring.mdx` documents both spellings. SDK bindings and docs references regenerated for the two new fields.

## Tests

`TestUpModuleWiring` gains:

- `entrypoint module ref via settings`: long form via `call`, and the filtered `check` path that demand-loads the entrypoint.
- `short-form entrypoint ref via settings`: `settings.base = "image"` resolves; `settings.file = "marker.txt"` stays a file even though the entrypoint defines a `file` function.
- `settings stores entrypoint refs in long form`: `dagger settings consumer base image` writes `base = "container-provider:image"`, while `dagger settings consumer label image` on a string setting stays `label = "image"`.

Verified locally via `engine-dev test`: the wiring suite, the workspace settings and user-config suites, and the entrypoint-related module, generator, selection, and compat tests all pass. The original long-form case fails on main with the error above and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFAJBxyFv7ZoBKmQyjiSmb
