### PR TITLE
test: stop passing render flags to commands that render no pipeline

### DIFF
--- a/core/integration/command_hints_test.go
+++ b/core/integration/command_hints_test.go
@@ -22,7 +22,8 @@ func TestCommandHints(t *testing.T) {
 
 // TestEmptySetupHint verifies that `dagger setup` on a greenfield workspace
 // (nothing to migrate, no config) prints the get-started hint, writes no
-// dagger.toml, and that --silent suppresses the hint.
+// dagger.toml, and that DAGGER_SILENT suppresses the hint (`dagger setup`
+// renders no pipeline, so it does not take --silent).
 func (CommandHintsSuite) TestEmptySetupHint(ctx context.Context, t *testctx.T) {
 	workdir := t.TempDir()
 	initGitRepo(ctx, t, workdir)
@@ -39,7 +40,9 @@ func (CommandHintsSuite) TestEmptySetupHint(ctx context.Context, t *testctx.T) {
 	_, statErr := os.Stat(filepath.Join(workdir, "dagger.toml"))
 	require.True(t, os.IsNotExist(statErr), "setup should not create dagger.toml on an empty workspace")
 
-	silentOut, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "setup", "--auto-apply")
+	silentCmd := hostDaggerCommandRaw(ctx, t, workdir, "setup", "--auto-apply")
+	silentCmd.Env = append(silentCmd.Env, "DAGGER_SILENT=true")
+	silentOut, err := silentCmd.CombinedOutput()
 	require.NoError(t, err, "%s", string(silentOut))
 	require.NotContains(t, string(silentOut), "To get started")
 }
@@ -61,7 +64,7 @@ func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t
 	require.Contains(t, got, "dagger module init go")
 	require.Contains(t, got, "dagger api client init go")
 
-	_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+	_, err = hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "module", "init", "go", "myapp")
 	require.NoError(t, err)
 
 	clientOut, err := hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "api", "client", "init", "go", "./myclient", ".dagger/modules/myapp")

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -1535,7 +1535,7 @@ func (GeneratorsSuite) TestWorkspaceCallNarrowsToRequestedModule(ctx context.Con
 
 	t.Run("listing the healthy module's functions skips the broken module", func(ctx context.Context, t *testctx.T) {
 		out, err := base.
-			With(daggerExec("api", "functions", "good", "--progress=plain")).
+			With(daggerExec("api", "functions", "good")).
 			CombinedOutput(ctx)
 		require.NoError(t, err)
 		require.NotContains(t, out, "intentionally invalid")
@@ -1588,7 +1588,7 @@ func (GeneratorsSuite) TestWorkspaceCallNarrowsByCliNameAndEntrypoint(ctx contex
 
 	t.Run("kebab-case functions listing skips the broken module", func(ctx context.Context, t *testctx.T) {
 		out, err := base.
-			With(daggerExec("api", "functions", "good-mod", "--progress=plain")).
+			With(daggerExec("api", "functions", "good-mod")).
 			CombinedOutput(ctx)
 		require.NoError(t, err)
 		require.NotContains(t, out, "intentionally invalid")

--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -119,7 +119,7 @@ func (LockfileSuite) TestUpdateCreatesNewFile(ctx context.Context, t *testctx.T)
 	writeEmptyWorkspaceConfig(t, workdir)
 	lockPath := filepath.Join(workdir, workspace.LockFileName)
 
-	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "update")
+	_, err := hostDaggerExec(ctx, t, workdir, "update")
 	require.NoError(t, err)
 
 	lockBytes, err := os.ReadFile(lockPath)
@@ -133,7 +133,7 @@ func (LockfileSuite) TestUpdateRefreshesExistingEntry(ctx context.Context, t *te
 	writeEmptyWorkspaceConfig(t, workdir)
 	lockPath, originalLock := writeOCISHALock(t, workdir, "sha256:"+strings.Repeat("0", 64))
 
-	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "update")
+	_, err := hostDaggerExec(ctx, t, workdir, "update")
 	require.NoError(t, err)
 
 	lockBytes, err := os.ReadFile(lockPath)
@@ -148,7 +148,7 @@ func (LockfileSuite) TestUpdateRefreshesExistingGitEntry(ctx context.Context, t 
 	writeEmptyWorkspaceConfig(t, workdir)
 	lockPath, originalLock := writeGitRefLock(t, workdir, "git.branch", lockTestGitBranchName, lockTestGitBranchCommit)
 
-	out, err := hostDaggerExec(ctx, t, workdir, "--silent", "update")
+	out, err := hostDaggerExec(ctx, t, workdir, "update")
 	require.NoError(t, err)
 	require.Equal(t, "Updated dagger.lock", strings.TrimSpace(string(out)))
 
@@ -601,7 +601,7 @@ func (LockfileSuite) TestUpdateRefreshesPrivateGitLatestEntry(ctx context.Contex
 	gitConfigPath := filepath.Join(workdir, ".gitconfig")
 	require.NoError(t, os.WriteFile(gitConfigPath, []byte(makeGitCredentials("github.com", "x-token-auth", token)), 0o600))
 
-	cmd := hostDaggerCommandRaw(ctx, t, workdir, "--silent", "update")
+	cmd := hostDaggerCommandRaw(ctx, t, workdir, "update")
 	cmd.Env = append(cmd.Env,
 		"GIT_CONFIG_GLOBAL="+gitConfigPath,
 		"GIT_CONFIG_SYSTEM=/dev/null",
@@ -628,8 +628,12 @@ func (LockfileSuite) TestUpdateRefreshesExistingGitLatestEntry(ctx context.Conte
 		"refs/tags/"+lockTestGitTagName+"@"+staleCommit,
 	)
 
-	out, err := hostDaggerExec(ctx, t, workdir, "--progress=plain", "update")
-	require.NoError(t, err)
+	// `dagger update` renders no pipeline, so the engine warning it emits is only
+	// visible through the plain frontend, selected via DAGGER_PROGRESS.
+	updateCmd := hostDaggerCommand(ctx, t, workdir, "update")
+	updateCmd.Env = append(updateCmd.Env, "DAGGER_PROGRESS=plain")
+	out, err := updateCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
 	require.Contains(t, string(out), "git tag points to a different commit")
 	require.Contains(t, string(out), "Updated dagger.lock")
 
@@ -755,7 +759,7 @@ func (LockfileSuite) TestOCILatestLockLifecycle(ctx context.Context, t *testctx.
 	staleLatestDigest := "sha256:" + strings.Repeat("1", 64)
 	writeOCILatestLock(t, workdir, stalePin, staleLatestDigest)
 
-	_, err = hostDaggerExec(ctx, t, workdir, "--silent", "update")
+	_, err = hostDaggerExec(ctx, t, workdir, "update")
 	require.NoError(t, err)
 
 	updatedLockBytes, err := os.ReadFile(lockPath)

--- a/core/integration/module_loading_test.go
+++ b/core/integration/module_loading_test.go
@@ -34,7 +34,7 @@ func TestModuleLoading(t *testing.T) {
 
 func moduleLoadingDaggerExecFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
+		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 			Expect:                        dagger.ReturnTypeFailure,
 		})
@@ -62,7 +62,7 @@ func moduleLoadingDaggerCallFail(args ...string) dagger.WithContainerFunc {
 
 func moduleLoadingDaggerFunctions(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "--progress=report", "api", "functions"}, args...), dagger.ContainerWithExecOpts{
+		return c.WithExec(append([]string{"dagger", "api", "functions"}, args...), dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 		})
 	}

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -44,7 +44,7 @@ func TestWorkspaceCompat(t *testing.T) {
 
 func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
+		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 		})
 	}
@@ -52,7 +52,7 @@ func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 
 func compatDaggerExecFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
+		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 			Expect:                        dagger.ReturnTypeFailure,
 		})
@@ -547,7 +547,7 @@ func (WorkspaceCompatSuite) TestCompatRequiresWorkspaceRoot(ctx context.Context,
 	// With no detected workspace root this cannot become an ambient compat
 	// workspace. Load it explicitly to verify legacy workspace fields are still
 	// rejected as generic module fields.
-	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "api", "functions", "-m", ".")
+	_, err := hostDaggerExec(ctx, t, workdir, "api", "functions", "-m", ".")
 	requireErrOut(t, err, "This module's dagger.json uses toolchains or blueprints, which have moved to workspaces.")
 }
 
@@ -569,7 +569,7 @@ func (WorkspaceCompatSuite) TestWorkspaceCompatMutationGuards(ctx context.Contex
 		copyTestdataFixture(ctx, t, depDir, "modules", "go", "minimal-dep")
 		copyTestdataFixture(ctx, t, workdir, "modules", "go", "minimal-app")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "./dep")
 		require.Error(t, err)
 		requireErrOut(t, err, "workspace is using legacy dagger.json config; run dagger setup first")
 
@@ -596,8 +596,14 @@ func (WorkspaceCompatSuite) TestLegacyWorkspaceDirectLoadErrors(ctx context.Cont
   ]
 }`), 0o644))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "api", "functions", "-m", ".")
+		// The assertion matches the raw error text, which the plain frontend
+		// prints as-is; `api functions` renders no pipeline and takes no
+		// --silent, so select the plain frontend through DAGGER_SILENT.
+		cmd := hostDaggerCommand(ctx, t, workdir, "api", "functions", "-m", ".")
+		cmd.Env = append(cmd.Env, "DAGGER_SILENT=true")
+		out, err := cmd.CombinedOutput()
 		require.Error(t, err)
+		err = fmt.Errorf("%s: %w", string(out), err)
 		requireErrOut(t, err, "This module's dagger.json uses toolchains or blueprints, which have moved to workspaces.\n\nTry: dagger -W .\n\nTo learn more: https://docs.dagger.io/reference/upgrade-to-workspaces")
 	})
 

--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -90,7 +90,7 @@ source = "github.com/dagger/dagger/modules/wolfi"
 `)
 
 	t.Run("full config", func(ctx context.Context, t *testctx.T) {
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config")
 		require.NoError(t, err)
 		require.Contains(t, string(out), `source = "modules/greeter"`)
 		require.Contains(t, string(out), "entrypoint = true")
@@ -98,20 +98,20 @@ source = "github.com/dagger/dagger/modules/wolfi"
 	})
 
 	t.Run("scalar value", func(ctx context.Context, t *testctx.T) {
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.source")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.source")
 		require.NoError(t, err)
 		require.Equal(t, "modules/greeter", strings.TrimSpace(string(out)))
 	})
 
 	t.Run("table value", func(ctx context.Context, t *testctx.T) {
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter")
 		require.NoError(t, err)
 		require.Contains(t, string(out), `source = "modules/greeter"`)
 		require.Contains(t, string(out), "entrypoint = true")
 	})
 
 	t.Run("missing key", func(ctx context.Context, t *testctx.T) {
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.missing.source")
+		_, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.missing.source")
 		require.Error(t, err)
 		requireErrOut(t, err, `key "modules.missing.source" is not set`)
 	})
@@ -124,16 +124,16 @@ source = "modules/greeter"
 entrypoint = true
 `)
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.source", "github.com/acme/greeter")
+		_, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.source", "github.com/acme/greeter")
 		require.NoError(t, err)
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.entrypoint", "false")
+		_, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.entrypoint", "false")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.source")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.source")
 		require.NoError(t, err)
 		require.Equal(t, "github.com/acme/greeter", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.entrypoint")
+		out, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.entrypoint")
 		require.NoError(t, err)
 		require.Equal(t, "false", strings.TrimSpace(string(out)))
 	})
@@ -144,7 +144,7 @@ source = "modules/greeter"
 entrypoint = true
 `)
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.settings.tags", "main, develop")
+		_, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.settings.tags", "main, develop")
 		require.NoError(t, err)
 
 		configContents, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
@@ -160,7 +160,7 @@ source = "modules/greeter"
 entrypoint = true
 `)
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.greeter.badfield", "value")
+		_, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.greeter.badfield", "value")
 		require.Error(t, err)
 		requireErrOut(t, err, "unknown config key")
 	})
@@ -274,7 +274,7 @@ func (WorkspaceSuite) TestWorkspaceConfigReadWithoutNativeConfig(ctx context.Con
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config")
 		require.NoError(t, err)
 		require.Empty(t, string(out))
 	})
@@ -285,7 +285,7 @@ func (WorkspaceSuite) TestWorkspaceConfigReadWithoutNativeConfig(ctx context.Con
 		require.NoError(t, os.WriteFile(filepath.Join(workdir, workspace.ModuleConfigFileName), []byte(`name = "app"
 `), 0o644))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config")
 		require.NoError(t, err)
 		require.Empty(t, string(out))
 	})
@@ -294,7 +294,7 @@ func (WorkspaceSuite) TestWorkspaceConfigReadWithoutNativeConfig(ctx context.Con
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.missing.source")
+		_, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.missing.source")
 		require.Error(t, err)
 		requireErrOut(t, err, `key "modules.missing.source" is not set`)
 	})
@@ -595,11 +595,11 @@ source = "modules/inner"
 `)
 		require.NoError(t, os.MkdirAll(nestedDir, 0o755))
 
-		out, err := hostDaggerExec(ctx, t, nestedDir, "--silent", "workspace", "config", "modules.inner.source")
+		out, err := hostDaggerExec(ctx, t, nestedDir, "workspace", "config", "modules.inner.source")
 		require.NoError(t, err)
 		require.Equal(t, "modules/inner", strings.TrimSpace(string(out)))
 
-		_, err = hostDaggerExec(ctx, t, nestedDir, "--silent", "workspace", "config", "modules.outer.source")
+		_, err = hostDaggerExec(ctx, t, nestedDir, "workspace", "config", "modules.outer.source")
 		require.Error(t, err)
 		requireErrOut(t, err, `key "modules.outer.source" is not set`)
 	})

--- a/core/integration/workspace_env_management_test.go
+++ b/core/integration/workspace_env_management_test.go
@@ -46,7 +46,7 @@ region = "us-east-1"
 func hostDaggerEnvExec(ctx context.Context, t *testctx.T, workdir string, args ...string) ([]byte, error) {
 	t.Helper()
 
-	cmd := hostDaggerCommandRaw(ctx, t, workdir, append([]string{"--progress=report"}, args...)...)
+	cmd := hostDaggerCommandRaw(ctx, t, workdir, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -453,7 +453,7 @@ func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *test
 		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
 `)
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "./dep")
 		require.NoError(t, err)
 		outStr := string(out)
 		require.Contains(t, outStr, `Created env "dev"`)
@@ -464,7 +464,7 @@ func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *test
 		require.Equal(t, "dep", cfg.Env["dev"].Modules["dep"].Source)
 
 		// Reinstalling into the now-existing env is a no-op without the notice.
-		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "./dep")
 		require.NoError(t, err)
 		require.NotContains(t, string(out), "Created env")
 		require.Contains(t, string(out), `Module "dep" is already installed in env "dev"`)
@@ -473,7 +473,7 @@ func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *test
 	t.Run("env install with no dagger.toml creates config and env", func(ctx context.Context, t *testctx.T) {
 		workdir := newEnvInstallWorkdir(ctx, t, "")
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "./dep")
 		require.NoError(t, err)
 		outStr := string(out)
 		require.Contains(t, outStr, "Created workspace config in")
@@ -494,7 +494,7 @@ func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *test
 		subdir := filepath.Join(workdir, "sub")
 		require.NoError(t, os.MkdirAll(subdir, 0o755))
 
-		out, err := hostDaggerExecRaw(ctx, t, subdir, "--silent", "--env=dev", "install", "../dep", "--here")
+		out, err := hostDaggerExecRaw(ctx, t, subdir, "--env=dev", "install", "../dep", "--here")
 		require.NoError(t, err)
 		outStr := string(out)
 		require.Contains(t, outStr, `Created env "dev"`)
@@ -512,18 +512,18 @@ func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *test
 		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "./dep")
 		require.NoError(t, err)
 
 		// minimal-dep has no constructor args, so exercise the raw config path:
 		// the point is that the env-scoped unset accepts a module the env itself
 		// added, which only exists in the overlay.
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "workspace", "config", "env.dev.modules.dep.settings.foo", "bar")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "workspace", "config", "env.dev.modules.dep.settings.foo", "bar")
 		require.NoError(t, err)
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.Equal(t, "bar", cfg.Env["dev"].Modules["dep"].Settings["foo"])
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "workspace", "config", "--unset", "modules.dep.settings.foo")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "workspace", "config", "--unset", "modules.dep.settings.foo")
 		require.NoError(t, err)
 		cfg = readInstalledWorkspaceConfig(t, workdir)
 		require.NotContains(t, cfg.Env["dev"].Modules["dep"].Settings, "foo")
@@ -534,14 +534,14 @@ func (WorkspaceSuite) TestWorkspaceEnvModuleInstall(ctx context.Context, t *test
 		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "./dep")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "installed")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "installed")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "dep")
 
-		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "installed")
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "installed")
 		require.NoError(t, err)
 		require.NotContains(t, string(out), "dep")
 
@@ -559,7 +559,7 @@ source = "dep"
 source = "dep"
 `)
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "other")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "uninstall", "other")
 		require.NoError(t, err)
 		require.Contains(t, string(out), `Uninstalled module "other" from env "dev"`)
 
@@ -568,12 +568,12 @@ source = "dep"
 		require.NotContains(t, cfg.Env["dev"].Modules, "other")
 
 		// A module only in base is not removable through an env selection.
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "dep")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "uninstall", "dep")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "dep" is not installed in env "dev"`)
 
 		// And a missing env stays a strict error for uninstall.
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=missing", "uninstall", "dep")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--env=missing", "uninstall", "dep")
 		require.Error(t, err)
 		requireErrOut(t, err, `workspace env "missing" is not defined`)
 	})
@@ -583,12 +583,12 @@ source = "dep"
 source = "dep"
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "./dep")
 		require.NoError(t, err)
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "workspace", "config", "modules.dep.settings.foo", "bar")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "workspace", "config", "modules.dep.settings.foo", "bar")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "dep")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "uninstall", "dep")
 		require.NoError(t, err)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
@@ -598,7 +598,7 @@ source = "dep"
 		require.Equal(t, "bar", cfg.Env["dev"].Modules["dep"].Settings["foo"])
 
 		// The settings-only leftover is not an install, so uninstall refuses it.
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "uninstall", "dep")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "uninstall", "dep")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "dep" is not installed in env "dev"`)
 	})
@@ -611,7 +611,7 @@ source = "dep"
 		require.NoError(t, os.MkdirAll(forkDir, 0o755))
 		copyTestdataFixture(ctx, t, forkDir, "modules", "go", "minimal-dep")
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "--name=dep", "./fork")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "--name=dep", "./fork")
 		require.NoError(t, err)
 		outStr := string(out)
 		require.Contains(t, outStr, `Installed module "dep" into env "dev"`)
@@ -625,7 +625,7 @@ source = "dep"
 		otherDir := filepath.Join(workdir, "other")
 		require.NoError(t, os.MkdirAll(otherDir, 0o755))
 		copyTestdataFixture(ctx, t, otherDir, "modules", "go", "minimal-dep")
-		out, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "install", "--name=other", "./other")
+		out, err = hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "install", "--name=other", "./other")
 		require.NoError(t, err)
 		require.NotContains(t, string(out), "overrides source")
 	})
@@ -634,9 +634,9 @@ source = "dep"
 		workdir := newEnvInstallWorkdir(ctx, t, `[modules]
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "sdk", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "sdk", "install", "./dep")
 		require.Error(t, err)
-		requireErrOut(t, err, `SDKs cannot be installed in env "dev"`)
+		requireErrOut(t, err, `flag --env is not supported by command "dagger sdk install"`)
 	})
 
 	t.Run("SDK uninstall rejects an env selection", func(ctx context.Context, t *testctx.T) {
@@ -648,17 +648,17 @@ source = "dep"
 [env.dev]
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "sdk", "uninstall", "dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "sdk", "uninstall", "dep")
 		require.Error(t, err)
-		requireErrOut(t, err, "SDKs are not env-scoped")
+		requireErrOut(t, err, `flag --env is not supported by command "dagger sdk uninstall"`)
 	})
 
 	t.Run("setup rejects an env selection", func(ctx context.Context, t *testctx.T) {
 		workdir := newEnvInstallWorkdir(ctx, t, `[env.dev]
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "--env=dev", "setup")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "--env=dev", "setup")
 		require.Error(t, err)
-		requireErrOut(t, err, "setup does not support --env")
+		requireErrOut(t, err, `flag --env is not supported by command "dagger setup"`)
 	})
 }

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -39,10 +39,10 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "dang")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "sdk", "install", "dang")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "dang", "editor", "--path", "editor")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "module", "init", "dang", "editor", "--path", "editor")
 		require.NoError(t, err)
 
 		info, err := os.Stat(filepath.Join(workdir, "editor"))
@@ -135,7 +135,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *
 
 		copyTestdataFixture(ctx, t, depDir, "modules", "go", "minimal-dep")
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./dep")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "install", "./dep")
 		require.NoError(t, err)
 		outStr := strings.TrimSpace(string(out))
 		require.Contains(t, outStr, "Created workspace config in "+workdir)
@@ -154,7 +154,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *
 		initGitRepo(ctx, t, workdir)
 		copyTestdataFixture(ctx, t, depDir, "modules", "go", "defaults", "superconstructor")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "./dep")
 		require.NoError(t, err)
 
 		configBytes, err := os.ReadFile(filepath.Join(workdir, workspacecfg.ConfigFileName))
@@ -167,7 +167,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *
 		initGitRepo(ctx, t, workdir)
 
 		ref := "github.com/dagger/dagger/modules/wolfi@v0.20.2"
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", ref)
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "install", ref)
 		require.NoError(t, err)
 		require.Equal(t,
 			"Created workspace config in "+workdir+"\n"+
@@ -220,7 +220,7 @@ entrypoint = true
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "--load-module=.", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "--load-module=.", "./dep")
 		require.Error(t, err)
 		requireErrOut(t, err, "unknown flag: --load-module")
 	})
@@ -236,7 +236,7 @@ entrypoint = true
 		// (not) corrupt.
 		writeWorkspaceConfigFile(t, workdir, "[modules]\n")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./empty")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "./empty")
 		require.Error(t, err)
 		requireErrOut(t, err, `ref "./empty" does not point to an initialized module`)
 
@@ -261,11 +261,11 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 		initGitRepo(ctx, t, workdir)
 		copyTestdataFixture(ctx, t, depDir, "modules", "go", "minimal-dep")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "./dep")
 		require.NoError(t, err)
 		require.Contains(t, readInstalledWorkspaceConfig(t, workdir).Modules, "dep")
 
-		out, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "dep")
+		out, err := hostDaggerExecRaw(ctx, t, workdir, "uninstall", "dep")
 		require.NoError(t, err)
 		require.Contains(t, strings.TrimSpace(string(out)),
 			`Uninstalled module "dep" from `+filepath.Join(workdir, workspacecfg.ConfigFileName))
@@ -281,11 +281,11 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 		initGitRepo(ctx, t, workdir)
 		copyTestdataFixture(ctx, t, depDir, "modules", "go", "minimal-dep")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "./dep")
 		require.NoError(t, err)
 		require.Contains(t, readInstalledWorkspaceConfig(t, workdir).Modules, "dep")
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "dep")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "uninstall", "dep")
 		require.NoError(t, err)
 		require.NotContains(t, readInstalledWorkspaceConfig(t, workdir).Modules, "dep")
 	})
@@ -294,10 +294,10 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "go")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "sdk", "install", "go")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "module", "init", "go", "myapp")
 		require.NoError(t, err)
 
 		moduleDir := filepath.Join(workdir, ".dagger", "modules", "myapp")
@@ -311,7 +311,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 		require.NotNil(t, goSDK.AsSDK)
 		require.Equal(t, []workspacecfg.SDKManagedModule{{Path: ".dagger/modules/myapp"}}, goSDK.AsSDK.Modules)
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "myapp")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "uninstall", "myapp")
 		require.NoError(t, err)
 
 		cfg = readInstalledWorkspaceConfig(t, workdir)
@@ -331,7 +331,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 		// workspace config directly so uninstall has a workspace to look in.
 		writeWorkspaceConfigFile(t, workdir, "[modules]\n")
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "uninstall", "ghost")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "uninstall", "ghost")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "ghost" is not installed in the workspace`)
 	})
@@ -344,10 +344,10 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleGenerate(ctx context.Context, t 
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "go")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "sdk", "install", "go")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+		_, err = hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "module", "init", "go", "myapp")
 		require.NoError(t, err)
 
 		moduleDir := filepath.Join(workdir, ".dagger", "modules", "myapp")
@@ -389,7 +389,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleMutation(ctx context.Context, t 
 source = "existing"
 `)
 
-		_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "install", "--name=dep", "./dep")
+		_, err := hostDaggerExecRaw(ctx, t, workdir, "install", "--name=dep", "./dep")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "dep" already exists in workspace config with source "existing" (new source "dep")`)
 
@@ -556,10 +556,10 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleInitConcurrent(ctx context.Conte
 			workdir := t.TempDir()
 			initGitRepo(ctx, t, workdir)
 
-			_, err := hostDaggerExecRaw(ctx, t, workdir, "--silent", "sdk", "install", "go")
+			_, err := hostDaggerExecRaw(ctx, t, workdir, "sdk", "install", "go")
 			require.NoError(t, err)
 
-			_, err = hostDaggerExecRaw(ctx, t, workdir, "--silent", "--auto-apply", "module", "init", "go", "myapp")
+			_, err = hostDaggerExecRaw(ctx, t, workdir, "--auto-apply", "module", "init", "go", "myapp")
 			require.NoError(t, err)
 
 			_, err = os.Stat(filepath.Join(workdir, ".dagger", "modules", "myapp", "dagger-module.toml"))

--- a/core/integration/workspace_selection_test.go
+++ b/core/integration/workspace_selection_test.go
@@ -33,7 +33,7 @@ func TestWorkspaceSelection(t *testing.T) {
 
 func workspaceSelectionDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
+		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 		})
 	}

--- a/core/integration/workspace_settings_test.go
+++ b/core/integration/workspace_settings_test.go
@@ -36,13 +36,13 @@ entrypoint = true
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "aws")
 		require.Contains(t, string(out), "region")
 		require.Contains(t, string(out), "us-west-2")
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws")
+		out, err = hostDaggerExec(ctx, t, workdir, "settings", "aws")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "MODULE")
 		require.Contains(t, string(out), "KEY")
@@ -50,18 +50,18 @@ region = "us-west-2"
 		require.Contains(t, string(out), "DESCRIPTION")
 		require.Contains(t, string(out), "region")
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		out, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "eu-central-1")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "region", "eu-central-1")
 		require.NoError(t, err)
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		out, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "eu-central-1", "extra")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "region", "eu-central-1", "extra")
 		require.Error(t, err)
 		requireErrOut(t, err, `setting "region" of module "aws" is not a list and accepts a single value`)
 	})
@@ -75,7 +75,7 @@ entrypoint = true
 greeting = "hello"
 `, workspaceSettingsGreeterModule("modules/greeter", "greeter"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "greeting")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "greeting")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "greeting" is not installed in the workspace`)
 	})
@@ -88,11 +88,11 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "prod-aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "prod-aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "aws" is not installed in the workspace`)
 	})
@@ -109,7 +109,7 @@ source = "modules/vitest"
 source = "modules/aws"
 `, workspaceSettingsAWSModule("modules/aws", "aws"), workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings")
 		require.NoError(t, err)
 
 		output := string(out)
@@ -134,7 +134,7 @@ region = "us-west-2"
 secretKey = "op://vault/aws"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "aws")
 		require.NoError(t, err)
 
 		output := string(out)
@@ -162,7 +162,7 @@ name = "demo"
 secret = "env://TOKEN"
 `, workspaceSettingsResourcesModule("modules/resources", "resources"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "resources")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "resources")
 		require.NoError(t, err)
 
 		output := string(out)
@@ -175,11 +175,11 @@ secret = "env://TOKEN"
 		require.NotContains(t, output, "workspace")
 		require.NotContains(t, output, "cache")
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "resources", "workspace")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "resources", "workspace")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "resources" has no setting "workspace"`)
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "resources", "cache")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "resources", "cache")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "resources" has no setting "cache"`)
 	})
@@ -196,7 +196,7 @@ region = "us-west-2"
 region = "us-east-1"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws")
+		out, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws")
 		require.NoError(t, err)
 
 		output := string(out)
@@ -212,7 +212,7 @@ region = "us-east-1"
 source = "modules/aws"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "missing")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "missing")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "missing" is not installed in the workspace`)
 	})
@@ -230,7 +230,7 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
 	})
@@ -247,11 +247,11 @@ region = "us-west-2"
 region = "us-east-1"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "format")
+		out, err = hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "format")
 		require.NoError(t, err)
 		require.Equal(t, "json", strings.TrimSpace(string(out)))
 	})
@@ -264,7 +264,7 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
+		_, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region")
 		require.Error(t, err)
 		requireErrOut(t, err, `workspace env "ci" is not defined`)
 	})
@@ -277,11 +277,11 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "missing")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "missing")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "aws" has no setting "missing"`)
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "source")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "source")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "aws" has no setting "source"`)
 	})
@@ -298,14 +298,14 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "eu-central-1")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region", "eu-central-1")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
+		out, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 
@@ -323,18 +323,18 @@ region = "us-west-2"
 [env.ci]
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region", "us-east-1")
+		_, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region", "us-east-1")
 		require.NoError(t, err)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
 		require.Equal(t, "us-east-1", cfg.Env["ci"].Modules["aws"].Settings["region"])
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
+		out, err = hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
 	})
@@ -345,21 +345,21 @@ region = "us-west-2"
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, `[modules]
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "install", "./modules/aws")
+		_, err := hostDaggerExec(ctx, t, workdir, "--env=dev", "install", "./modules/aws")
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "settings", "aws", "region", "us-east-1")
+		_, err = hostDaggerExec(ctx, t, workdir, "--env=dev", "settings", "aws", "region", "us-east-1")
 		require.NoError(t, err)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.NotContains(t, cfg.Modules, "aws")
 		require.Equal(t, "us-east-1", cfg.Env["dev"].Modules["aws"].Settings["region"])
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "--env=dev", "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=dev", "settings", "--unset", "aws", "region")
+		_, err = hostDaggerExec(ctx, t, workdir, "--env=dev", "settings", "--unset", "aws", "region")
 		require.NoError(t, err)
 
 		cfg = readInstalledWorkspaceConfig(t, workdir)
@@ -375,7 +375,7 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=staging", "settings", "aws", "region", "us-east-1")
+		out, err := hostDaggerExec(ctx, t, workdir, "--env=staging", "settings", "aws", "region", "us-east-1")
 		require.NoError(t, err)
 		require.Contains(t, string(out), `Created env "staging"`)
 
@@ -383,18 +383,18 @@ region = "us-west-2"
 		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
 		require.Equal(t, "us-east-1", cfg.Env["staging"].Modules["aws"].Settings["region"])
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=staging", "settings", "aws", "region")
+		out, err = hostDaggerExec(ctx, t, workdir, "--env=staging", "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-east-1", strings.TrimSpace(string(out)))
 
 		// Writing again into the now-existing env doesn't repeat the notice.
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=staging", "settings", "aws", "region", "eu-west-3")
+		out, err = hostDaggerExec(ctx, t, workdir, "--env=staging", "settings", "aws", "region", "eu-west-3")
 		require.NoError(t, err)
 		require.NotContains(t, string(out), "Created env")
 
 		// Typed writes still validate the setting exists, even for a new env,
 		// and a rejected write doesn't create the env as a side effect.
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "--env=another", "settings", "aws", "nope", "x")
+		_, err = hostDaggerExec(ctx, t, workdir, "--env=another", "settings", "aws", "nope", "x")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "aws" has no setting "nope"`)
 		cfg = readInstalledWorkspaceConfig(t, workdir)
@@ -406,22 +406,22 @@ region = "us-west-2"
 source = "modules/vitest"
 `, workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "failFast", "true")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "vitest", "failFast", "true")
 		require.NoError(t, err)
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "retries", "3")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "vitest", "retries", "3")
 		require.NoError(t, err)
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke, regression")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "vitest", "tags", "smoke, regression")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.failFast")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.vitest.settings.failFast")
 		require.NoError(t, err)
 		require.Equal(t, "true", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.retries")
+		out, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.vitest.settings.retries")
 		require.NoError(t, err)
 		require.Equal(t, "3", strings.TrimSpace(string(out)))
 
-		out, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.tags")
+		out, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.vitest.settings.tags")
 		require.NoError(t, err)
 		require.Equal(t, "[smoke, regression]", strings.TrimSpace(string(out)))
 	})
@@ -445,7 +445,7 @@ region = "us-west-2"
 		}
 
 		for _, tt := range tests {
-			_, err := hostDaggerExec(ctx, t, workdir, append([]string{"--silent", "settings"}, tt.args...)...)
+			_, err := hostDaggerExec(ctx, t, workdir, append([]string{"settings"}, tt.args...)...)
 			require.Error(t, err)
 			requireErrOut(t, err, tt.err)
 		}
@@ -465,18 +465,18 @@ format = "json"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "--unset")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region", "--unset")
 		require.NoError(t, err)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.NotContains(t, cfg.Modules["aws"].Settings, "region")
 		require.Equal(t, "json", cfg.Modules["aws"].Settings["format"])
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
+		_, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.aws.settings.region")
 		require.Error(t, err)
 		requireErrOut(t, err, `key "modules.aws.settings.region" is not set`)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Empty(t, strings.TrimSpace(string(out)))
 	})
@@ -492,7 +492,7 @@ region = "us-west-2"
 region = "us-east-1"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region", "--unset")
+		_, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region", "--unset")
 		require.NoError(t, err)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
@@ -500,7 +500,7 @@ region = "us-east-1"
 		require.Contains(t, cfg.Env, "ci")
 		require.NotContains(t, cfg.Env["ci"].Modules, "aws")
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
+		out, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region")
 		require.NoError(t, err)
 		require.Equal(t, "us-west-2", strings.TrimSpace(string(out)))
 	})
@@ -513,11 +513,11 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "--unset")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "--unset")
 		require.Error(t, err)
 		requireErrOut(t, err, "--unset requires MODULE and KEY arguments")
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "value", "--unset")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "region", "value", "--unset")
 		require.Error(t, err)
 		requireErrOut(t, err, "--unset requires MODULE and KEY arguments")
 	})
@@ -530,11 +530,11 @@ source = "modules/aws"
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "missing", "--unset")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "missing", "--unset")
 		require.Error(t, err)
 		requireErrOut(t, err, `module "aws" has no setting "missing"`)
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "format", "--unset")
+		_, err = hostDaggerExec(ctx, t, workdir, "settings", "aws", "format", "--unset")
 		require.Error(t, err)
 		requireErrOut(t, err, `key "modules.aws.settings.format" is not set`)
 	})
@@ -548,14 +548,14 @@ region = "us-west-2"
 stale = "left over"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.stale", "-u")
+		_, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.aws.settings.stale", "-u")
 		require.NoError(t, err)
 
 		cfg := readInstalledWorkspaceConfig(t, workdir)
 		require.NotContains(t, cfg.Modules["aws"].Settings, "stale")
 		require.Equal(t, "us-west-2", cfg.Modules["aws"].Settings["region"])
 
-		_, err = hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "--unset")
+		_, err = hostDaggerExec(ctx, t, workdir, "workspace", "config", "--unset")
 		require.Error(t, err)
 		requireErrOut(t, err, "--unset requires a KEY argument")
 	})
@@ -576,15 +576,15 @@ region = "us-west-2"
 region = "us-east-1"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		settingsBase, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region")
+		settingsBase, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region")
 		require.NoError(t, err)
-		configBase, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
+		configBase, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(string(configBase)), strings.TrimSpace(string(settingsBase)))
 
-		settingsEnv, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "settings", "aws", "region")
+		settingsEnv, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "settings", "aws", "region")
 		require.NoError(t, err)
-		configEnv, err := hostDaggerExec(ctx, t, workdir, "--silent", "--env=ci", "workspace", "config", "modules.aws.settings.region")
+		configEnv, err := hostDaggerExec(ctx, t, workdir, "--env=ci", "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(string(configEnv)), strings.TrimSpace(string(settingsEnv)))
 	})
@@ -598,10 +598,10 @@ entrypoint = true
 region = "us-west-2"
 `, workspaceSettingsAWSModule("modules/aws", "aws"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "aws", "region", "eu-central-1")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "aws", "region", "eu-central-1")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.aws.settings.region")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.aws.settings.region")
 		require.NoError(t, err)
 		require.Equal(t, "eu-central-1", strings.TrimSpace(string(out)))
 
@@ -646,10 +646,10 @@ retries = 0
 	t.Run("variadic writes round-trip through settings to the constructor", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke", "regression")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "vitest", "tags", "smoke", "regression")
 		require.NoError(t, err)
 
-		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "workspace", "config", "modules.vitest.settings.tags")
+		out, err := hostDaggerExec(ctx, t, workdir, "workspace", "config", "modules.vitest.settings.tags")
 		require.NoError(t, err)
 		require.Equal(t, "[smoke, regression]", strings.TrimSpace(string(out)))
 
@@ -661,7 +661,7 @@ retries = 0
 	t.Run("variadic values keep commas and JSON-looking elements verbatim", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke,regression", `["docs"]`)
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "vitest", "tags", "smoke,regression", `["docs"]`)
 		require.NoError(t, err)
 
 		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "tags", "--json")
@@ -672,7 +672,7 @@ retries = 0
 	t.Run("a single trailing value for a list setting keeps comma-splitting behavior", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "tags", "smoke,regression")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "vitest", "tags", "smoke,regression")
 		require.NoError(t, err)
 
 		out, err := hostDaggerExec(ctx, t, workdir, "--silent", "call", "tags", "--json")
@@ -683,7 +683,7 @@ retries = 0
 	t.Run("multiple values for a scalar setting fail clearly", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceSettingsWorkdir(ctx, t, vitestConfig, workspaceSettingsVitestModule("modules/vitest", "vitest"))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "--silent", "settings", "vitest", "retries", "1", "2")
+		_, err := hostDaggerExec(ctx, t, workdir, "settings", "vitest", "retries", "1", "2")
 		require.Error(t, err)
 		requireErrOut(t, err, `setting "retries" of module "vitest" is not a list and accepts a single value`)
 	})

--- a/core/integration/workspace_user_config_test.go
+++ b/core/integration/workspace_user_config_test.go
@@ -57,7 +57,7 @@ func newUserConfigWorkdir(ctx context.Context, t *testctx.T, originURL, userConf
 func hostDaggerUserConfigExec(ctx context.Context, t *testctx.T, workdir, userConfigPath string, args ...string) ([]byte, error) {
 	t.Helper()
 
-	cmd := hostDaggerCommandRaw(ctx, t, workdir, append([]string{"--progress=report"}, args...)...)
+	cmd := hostDaggerCommandRaw(ctx, t, workdir, args...)
 	cmd.Env = append(cmd.Env, "DAGGER_CONFIG="+userConfigPath)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -104,11 +104,11 @@ profile = "alice-dev"
 source = "github.com/acme/personal"
 `)
 
-		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--silent", "installed")
+		out, err := hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "installed")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "personal")
 
-		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--silent", "--env=staging", "installed")
+		out, err = hostDaggerUserConfigExec(ctx, t, workdir, userConfigPath, "--env=staging", "installed")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "personal")
 	})
@@ -392,7 +392,7 @@ region = "us-east-1"
 	remoteRef := workspaceSelectionRemoteRef(ctx, t, c, c.Host().Directory(hostDir))
 
 	userConfigDaggerExec := func(ctr *dagger.Container, args ...string) *dagger.Container {
-		return ctr.WithExec(append([]string{"dagger", "--progress=report"}, args...), dagger.ContainerWithExecOpts{
+		return ctr.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
 			UseEntrypoint:                 true,
 			ExperimentalPrivilegedNesting: true,
 		})


### PR DESCRIPTION
## What

Fixes the `test-split:test-base`, `test-modules` and `test-workspaces` failures on `main` since #14027.

The global flag scoping made `--silent`, `--progress` and the other pipeline rendering flags available only on commands that declare `MayRenderPipeline`. Configuration commands (`install`, `uninstall`, `installed`, `sdk install/uninstall`, `module init`, `setup`, `settings`, `workspace config`, `api functions`, `update`) intentionally do not declare it, so the CLI now rejects those flags at validation time:

```
Error: flag --silent is not supported by command "dagger install"
```

The integration tests still passed them, and failed before reaching the engine.

## Changes (test code only)

- Drop `--silent` / `--progress=...` from invocations of non-rendering commands, and drop the `--progress=report` prefix from the generic exec wrappers that prepended it to every command. Without a TTY the report frontend is already the default, so nothing changes for the rendering commands routed through the same wrappers.
- Three tests expected a command's own `--env` rejection message; `setup` and `sdk install/uninstall` now reject `--env` at flag validation, so they expect that message instead.
- Three tests depended on the flag's *effect* rather than its acceptance and now use the environment forms:
  - setup hint suppression via `DAGGER_SILENT`
  - lockfile `update` selects the plain frontend via `DAGGER_PROGRESS` to see the engine's "tag moved" warning
  - compat direct-load error matching via `DAGGER_SILENT` (raw error text instead of the report rendering)

## Verification

Ran `TestWorkspace`, `TestWorkspaceModules`, `TestWorkspaceSelection`, `TestWorkspaceCompat`, `TestLockfile`, `TestCommandHints`, `TestModuleLoading` and `TestGenerators/TestWorkspaceCallNarrowsByCliNameAndEntrypoint` through `engine-dev test`: 463 passed. The only remaining failures are a pre-existing `sdk install go` capability-probe issue that reproduces identically on pristine `main` and is unrelated to this change.

## Follow-up worth noting

The runtime half of the scoping design isn't there yet: frontend selection ignores capabilities, so a non-rendering command like `dagger install` still launches the full TUI in a terminal and there is no longer a flag to quiet it (only `DAGGER_SILENT` / `DAGGER_PROGRESS`). That's why three tests fall back to the environment variables here. cc @shykes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqoCfFSewDPG3noK5X4Z1P
