### PR TITLE
feat(vault): full path to secret in vault:// scheme

### DIFF
--- a/.changes/unreleased/Breaking-20260820-165248.yaml
+++ b/.changes/unreleased/Breaking-20260820-165248.yaml
@@ -1,0 +1,13 @@
+kind: Breaking
+body: |
+    The `vault://` scheme now accepts the full path to secrets,
+    including the kv v2 mount name. The resulting URI format is:
+    `vault://<mount>/<path>.<field>`. The `VAULT_PATH_PREFIX` variable
+    is still prepended to the path for backward compatibility,
+    but in any case, the default behavior (if your `VAULT_PATH_PREFIX`
+    variable is not set and you were relying on the default mount
+    name `secret`) no longer works.
+time: 2026-08-20T16:52:48.098363+03:00
+custom:
+    Author: nilune
+    PR: "13941"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Use your local dev environment to iterate until you're ready for review.
 To run an interactive playground with all Dagger components built and integrated:
 
 ```shell
-dagger call engine-dev playground terminal
+dagger api call engine-dev playground terminal
 ```
 
 This will:
@@ -75,25 +75,25 @@ This will:
 
 #### Integration testing
 
-- Run all core tests: `dagger checks test-split:*`
-- Run available core tests: `dagger call engine-dev tests`
-- Run a specific core test (eg. `TestNamespacing` in the `TestModule` suite): `dagger call engine-dev test --pkg="./core/integration" --run="^TestModule/TestNamespacing$"`
+- Run all core tests: `dagger check test-split:*`
+- Run available core tests: `dagger api call engine-dev tests`
+- Run a specific core test (eg. `TestNamespacing` in the `TestModule` suite): `dagger api call engine-dev test --pkg="./core/integration" --run="^TestModule/TestNamespacing$"`
 - Run SDK tests: `dagger check *sdk:*test*`
 
 #### Linting
 
-To run all linters: `dagger checks *:lint`
+To run all linters: `dagger check *:lint`
 
 #### Local docs server
 
-To run a local docs server: `dagger call docs server up`
+To run a local docs server: `dagger api call docs server up`
 
 ### 4. Prepare your pull request
 
 Before submitting your pull request, follow this checklist.
 
 - Generate API docs, client bindings, and other generated files with `dagger generate`, and include the output in your git commit.
-- Call all linters: `dagger checks *:lint`
+- Call all linters: `dagger check *:lint`
 - If your change is user-facing, add a release note: run `changie new` then follow instructions. Add produced files to your commit.
 - Understand the license. All contributions are made under the Apache License 2.0 (Apache-2.0). Make sure you are willing and able to honor the terms of the license.
 - Make sure all your commits are accompanied by a [Developer Certificate of Origin (DCO)](https://developercertificate.org). You can do this with `git commit -s`. The `Signed-off-by` line must match the author's real name.

--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -275,14 +275,7 @@ func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 
 	// Create a secret with a client
 	secretValue := "secret" + identity.NewID()
-	_, err = vaultImage.
-		WithEnvVariable("VAULT_ADDR", "http://vault:8200").
-		WithServiceBinding("vault", vaultServer).
-		WithEnvVariable("VAULT_SKIP_VERIFY", "1").
-		WithEnvVariable("VAULT_TOKEN", "myroot").
-		WithEnvVariable("NOCACHE", time.Now().String()).
-		WithExec([]string{"vault", "kv", "put", "/secret/testsecret", "foo=" + secretValue}).
-		Sync(ctx)
+	seedVaultSecret(ctx, t, vaultImage, vaultServer, "secret/testsecret", "foo", secretValue)
 	require.NoError(t, err)
 
 	// Test Vault provider with token auth
@@ -297,7 +290,7 @@ func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 	out, err := fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.foo",
+		"vault://secret/testsecret.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
@@ -306,15 +299,15 @@ func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 	_, err = fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.bar",
+		"vault://secret/testsecret.bar",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
-	requireErrOut(t, err, `secret "bar" not found in path "testsecret"`)
+	requireErrOut(t, err, `secret "bar" not found in path "secret/testsecret"`)
 
 	_, err = fetchSecret(
 		ctx,
 		ctr,
-		"vault://nosecret.baz",
+		"vault://secret/nosecret.baz",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, `secret not found`)
@@ -324,7 +317,7 @@ func (SecretProvider) TestVaultOIDCFallbackError(ctx context.Context, t *testctx
 	c := connect(ctx, t)
 
 	vaultImage, vaultServer := startVaultDevServer(ctx, t, c, nil)
-	seedVaultSecret(ctx, t, vaultImage, vaultServer, "testsecret", "foo", "secret"+identity.NewID())
+	seedVaultSecret(ctx, t, vaultImage, vaultServer, "secret/testsecret", "foo", "secret"+identity.NewID())
 
 	ctr := newVaultQueryContainer(c, t, vaultServer).
 		WithEnvVariable("VAULT_OIDC_SKIP_BROWSER", "1")
@@ -332,7 +325,7 @@ func (SecretProvider) TestVaultOIDCFallbackError(ctx context.Context, t *testctx
 	_, err := fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.foo",
+		"vault://secret/testsecret.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrRegexp(t, err, `(?i)vault oidc login failed`)
@@ -349,7 +342,7 @@ func (SecretProvider) TestVaultOIDCMissingVaultAddr(ctx context.Context, t *test
 	_, err := fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.foo",
+		"vault://secret/testsecret.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "VAULT_ADDR must be set when using Vault OIDC fallback auth")
@@ -360,7 +353,7 @@ func (SecretProvider) TestVaultOIDCTokenPriority(ctx context.Context, t *testctx
 
 	vaultImage, vaultServer := startVaultDevServer(ctx, t, c, nil)
 	secretValue := "secret" + identity.NewID()
-	seedVaultSecret(ctx, t, vaultImage, vaultServer, "testsecret", "foo", secretValue)
+	seedVaultSecret(ctx, t, vaultImage, vaultServer, "secret/testsecret", "foo", secretValue)
 
 	ctr := newVaultQueryContainer(c, t, vaultServer).
 		WithEnvVariable("VAULT_TOKEN", "myroot").
@@ -370,7 +363,7 @@ func (SecretProvider) TestVaultOIDCTokenPriority(ctx context.Context, t *testctx
 	out, err := fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.foo",
+		"vault://secret/testsecret.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
@@ -382,7 +375,7 @@ func (SecretProvider) TestVaultOIDCCachedToken(ctx context.Context, t *testctx.T
 
 	vaultImage, vaultServer := startVaultDevServer(ctx, t, c, nil)
 	secretValue := "secret" + identity.NewID()
-	seedVaultSecret(ctx, t, vaultImage, vaultServer, "testsecret", "foo", secretValue)
+	seedVaultSecret(ctx, t, vaultImage, vaultServer, "secret/testsecret", "foo", secretValue)
 
 	ctr := newVaultQueryContainer(c, t, vaultServer).
 		WithEnvVariable("VAULT_OIDC_SKIP_BROWSER", "1")
@@ -391,7 +384,7 @@ func (SecretProvider) TestVaultOIDCCachedToken(ctx context.Context, t *testctx.T
 	out, err := fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.foo",
+		"vault://secret/testsecret.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
@@ -402,7 +395,7 @@ func (SecretProvider) TestVaultOIDCExpiredCachedToken(ctx context.Context, t *te
 	c := connect(ctx, t)
 
 	vaultImage, vaultServer := startVaultDevServer(ctx, t, c, nil)
-	seedVaultSecret(ctx, t, vaultImage, vaultServer, "testsecret", "foo", "secret"+identity.NewID())
+	seedVaultSecret(ctx, t, vaultImage, vaultServer, "secret/testsecret", "foo", "secret"+identity.NewID())
 
 	ctr := newVaultQueryContainer(c, t, vaultServer).
 		WithEnvVariable("VAULT_OIDC_SKIP_BROWSER", "1")
@@ -411,7 +404,7 @@ func (SecretProvider) TestVaultOIDCExpiredCachedToken(ctx context.Context, t *te
 	_, err := fetchSecret(
 		ctx,
 		ctr,
-		"vault://testsecret.foo",
+		"vault://secret/testsecret.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrRegexp(t, err, `(?i)vault oidc login failed`)
@@ -445,7 +438,7 @@ func (SecretProvider) TestVaultOIDCEndToEnd(ctx context.Context, t *testctx.T) {
 	out, err := querySecretWithOIDCBrowserSimulation(
 		queryCtx,
 		ctr,
-		"vault://oidctest.foo",
+		"vault://secret/oidctest.foo",
 		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
@@ -477,12 +470,12 @@ func (SecretProvider) TestVaultTTL(ctx context.Context, t *testctx.T) {
 	}{
 		{
 			name:                    "without-ttl",
-			secret:                  "vault://without-ttl.password",
+			secret:                  "vault://secret/without-ttl.password",
 			expectedUpdatedPassword: "original-password",
 		},
 		{
 			name:                    "with-ttl",
-			secret:                  "vault://with-ttl.password?ttl=2s",
+			secret:                  "vault://secret/with-ttl.password?ttl=2s",
 			expectedUpdatedPassword: "updated-password",
 		},
 	}
@@ -797,7 +790,7 @@ func seedVaultSecret(ctx context.Context, t *testctx.T, vaultImage *dagger.Conta
 		WithEnvVariable("VAULT_SKIP_VERIFY", "1").
 		WithEnvVariable("VAULT_TOKEN", "myroot").
 		WithEnvVariable("NOCACHE", time.Now().String()).
-		WithExec([]string{"vault", "kv", "put", "/secret/" + path, field + "=" + value}).
+		WithExec([]string{"vault", "kv", "put", path, field + "=" + value}).
 		Sync(ctx)
 	require.NoError(t, err)
 }

--- a/docs/current_docs/config/secrets.mdx
+++ b/docs/current_docs/config/secrets.mdx
@@ -1,0 +1,132 @@
+---
+title: "Secrets"
+slug: /config/secrets
+description: "Configure secret providers for your Dagger workflows"
+---
+
+# Secrets
+
+Dagger has built-in support for secrets — passwords, API keys, tokens — sourced from multiple providers. Secrets are never exposed in logs, written to container filesystems, or inserted into the cache.
+
+## Passing secrets
+
+Secrets are passed to functions via provider URIs:
+
+```shell
+# From environment variables
+dagger api call deploy --token=env:DEPLOY_TOKEN
+
+# From files
+dagger api call deploy --token=file:./secrets/token.txt
+
+# From command output
+dagger api call deploy --token=cmd:"aws sts get-session-token --query Token"
+```
+
+## Providers
+
+### Environment variables
+
+```shell
+dagger api call my-function --secret=env:MY_SECRET
+```
+
+Reads the value of `MY_SECRET` from the host environment.
+
+### Files
+
+```shell
+dagger api call my-function --secret=file:/path/to/secret
+```
+
+Reads the secret from a file on the host.
+
+### Command output
+
+```shell
+dagger api call my-function --secret=cmd:"command to run"
+```
+
+Runs the command on the host and uses its stdout as the secret value.
+
+### HashiCorp Vault
+
+Dagger can resolve secrets directly from Vault using the `vault://` scheme. Only KVv2 mounts are supported.
+
+​```shell
+dagger api call my-function --secret=vault://secret/foo/bar.token
+​```
+
+Reads the `token` field of the KVv2 secret `foo/bar` from the `secret` mount.
+
+**URI format:** `vault://<mount>/<path>.<field>` — the mount is the first path segment, the field is everything after the last dot.
+
+**Caching:** by default, ttl is infinite. Add `?ttl=1h` to cache the resolved value client-side for the given duration.
+
+**Authentication:** requires the Dagger CLI to be authenticated with Vault via `VAULT_ADDR`, plus auth-method-specific variables:
+
+- `VAULT_TOKEN` — token authentication
+- `VAULT_APPROLE_MOUNT_PATH`, `VAULT_APPROLE_ROLE_ID`, `VAULT_APPROLE_SECRET_ID` — AppRole authentication
+- `VAULT_OIDC_MOUNT_PATH`, `VAULT_OIDC_CALLBACK_PORT`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_SKIP_BROWSER` - OIDC authentication
+
+### 1Password
+
+```shell
+dagger api call my-function --secret=op://vault-name/item-name/field
+```
+
+Reads from 1Password. Requires authentication via `op signin`.
+
+### AWS Secrets Manager
+
+```shell
+dagger api call my-function --secret=aws+sm://prod/my-secret
+```
+
+For JSON secrets, extract a specific field:
+
+```shell
+dagger api call my-function --secret=aws+sm://prod/database?field=password
+```
+
+Options: `?region=us-west-2`, `?version=<id>`, `?stage=AWSPREVIOUS`.
+
+### AWS Parameter Store
+
+```shell
+dagger api call my-function --secret=aws+ps://prod/api-key
+```
+
+Reads the parameter `/prod/api-key` (the leading slash is added for you). SecureString parameters are automatically decrypted.
+
+### AWS authentication
+
+Both AWS providers use the [default credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html): environment variables, shared credentials file (`~/.aws/credentials`), or IAM role (EC2, ECS, Lambda).
+
+Set the region with `AWS_REGION` or the `?region=` query parameter.
+
+### Google Cloud Secret Manager
+
+```shell
+dagger api call my-function --secret=gcp://my-secret
+```
+
+A bare name reads the secret from the project set by `GCP_PROJECT_ID`, `GOOGLE_CLOUD_PROJECT`, or `GCLOUD_PROJECT`. Use `gcp://projects/PROJECT_ID/secrets/SECRET_NAME/versions/VERSION` to specify the project and version explicitly. Authentication uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials).
+
+### libsecret (GNOME Keyring)
+
+```shell
+dagger api call my-function --secret=libsecret://login/my-secret
+```
+
+Reads from the host's freedesktop.org Secret Service (e.g. GNOME Keyring) on Linux.
+
+## Safeguards
+
+Dagger ensures secrets never leak:
+
+- **Logs**: Secret values are redacted from all output
+- **Filesystem**: Secrets are never written to container layers
+- **Cache**: Operations using secrets are excluded from cache keys
+
+If a workflow crashes, secrets remain protected.

--- a/docs/versioned_docs/version-1.0-beta/config/secrets.mdx
+++ b/docs/versioned_docs/version-1.0-beta/config/secrets.mdx
@@ -1,0 +1,132 @@
+---
+title: "Secrets"
+slug: /config/secrets
+description: "Configure secret providers for your Dagger workflows"
+---
+
+# Secrets
+
+Dagger has built-in support for secrets — passwords, API keys, tokens — sourced from multiple providers. Secrets are never exposed in logs, written to container filesystems, or inserted into the cache.
+
+## Passing secrets
+
+Secrets are passed to functions via provider URIs:
+
+```shell
+# From environment variables
+dagger api call deploy --token=env:DEPLOY_TOKEN
+
+# From files
+dagger api call deploy --token=file:./secrets/token.txt
+
+# From command output
+dagger api call deploy --token=cmd:"aws sts get-session-token --query Token"
+```
+
+## Providers
+
+### Environment variables
+
+```shell
+dagger api call my-function --secret=env:MY_SECRET
+```
+
+Reads the value of `MY_SECRET` from the host environment.
+
+### Files
+
+```shell
+dagger api call my-function --secret=file:/path/to/secret
+```
+
+Reads the secret from a file on the host.
+
+### Command output
+
+```shell
+dagger api call my-function --secret=cmd:"command to run"
+```
+
+Runs the command on the host and uses its stdout as the secret value.
+
+### HashiCorp Vault
+
+Dagger can resolve secrets directly from Vault using the `vault://` scheme. Only KVv2 mounts are supported.
+
+​```shell
+dagger api call my-function --secret=vault://secret/foo/bar.token
+​```
+
+Reads the `token` field of the KVv2 secret `foo/bar` from the `secret` mount.
+
+**URI format:** `vault://<mount>/<path>.<field>` — the mount is the first path segment, the field is everything after the last dot.
+
+**Caching:** by default, ttl is infinite. Add `?ttl=1h` to cache the resolved value client-side for the given duration.
+
+**Authentication:** requires the Dagger CLI to be authenticated with Vault via `VAULT_ADDR`, plus auth-method-specific variables:
+
+- `VAULT_TOKEN` — token authentication
+- `VAULT_APPROLE_MOUNT_PATH`, `VAULT_APPROLE_ROLE_ID`, `VAULT_APPROLE_SECRET_ID` — AppRole authentication
+- `VAULT_OIDC_MOUNT_PATH`, `VAULT_OIDC_CALLBACK_PORT`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_SKIP_BROWSER` - OIDC authentication
+
+### 1Password
+
+```shell
+dagger api call my-function --secret=op://vault-name/item-name/field
+```
+
+Reads from 1Password. Requires authentication via `op signin`.
+
+### AWS Secrets Manager
+
+```shell
+dagger api call my-function --secret=aws+sm://prod/my-secret
+```
+
+For JSON secrets, extract a specific field:
+
+```shell
+dagger api call my-function --secret=aws+sm://prod/database?field=password
+```
+
+Options: `?region=us-west-2`, `?version=<id>`, `?stage=AWSPREVIOUS`.
+
+### AWS Parameter Store
+
+```shell
+dagger api call my-function --secret=aws+ps://prod/api-key
+```
+
+Reads the parameter `/prod/api-key` (the leading slash is added for you). SecureString parameters are automatically decrypted.
+
+### AWS authentication
+
+Both AWS providers use the [default credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html): environment variables, shared credentials file (`~/.aws/credentials`), or IAM role (EC2, ECS, Lambda).
+
+Set the region with `AWS_REGION` or the `?region=` query parameter.
+
+### Google Cloud Secret Manager
+
+```shell
+dagger api call my-function --secret=gcp://my-secret
+```
+
+A bare name reads the secret from the project set by `GCP_PROJECT_ID`, `GOOGLE_CLOUD_PROJECT`, or `GCLOUD_PROJECT`. Use `gcp://projects/PROJECT_ID/secrets/SECRET_NAME/versions/VERSION` to specify the project and version explicitly. Authentication uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials).
+
+### libsecret (GNOME Keyring)
+
+```shell
+dagger api call my-function --secret=libsecret://login/my-secret
+```
+
+Reads from the host's freedesktop.org Secret Service (e.g. GNOME Keyring) on Linux.
+
+## Safeguards
+
+Dagger ensures secrets never leak:
+
+- **Logs**: Secret values are redacted from all output
+- **Filesystem**: Secrets are never written to container layers
+- **Cache**: Operations using secrets are excluded from cache keys
+
+If a workflow crashes, secrets remain protected.

--- a/docs/versioned_docs/version-1.0-beta/sdks/dang.mdx
+++ b/docs/versioned_docs/version-1.0-beta/sdks/dang.mdx
@@ -453,7 +453,7 @@ dagger api call deploy --token=env:DEPLOY_TOKEN        # environment variable
 dagger api call deploy --token=file:./token.txt        # file
 dagger api call deploy --token=cmd:"gh auth token"     # command output
 dagger api call deploy --token=op://vault/item/field   # 1Password
-dagger api call deploy --token=vault://path/to/secret  # HashiCorp Vault
+dagger api call deploy --token=vault://mount/path.field  # HashiCorp Vault
 dagger api call deploy --token=gcp://secret-name       # Google Cloud Secret Manager
 ```
 

--- a/engine/client/secretprovider/vault.go
+++ b/engine/client/secretprovider/vault.go
@@ -24,6 +24,21 @@ var (
 	vaultCache  = make(map[string]dataWithTTL)
 )
 
+func splitVaultPath(path string) (mount, secretPath, secretField string, err error) {
+	mount, rest, found := strings.Cut(path, "/")
+	if !found {
+		return "", "", "", fmt.Errorf("missing \"/\" separator")
+	}
+	if mount == "" {
+		return "", "", "", fmt.Errorf("missing mount")
+	}
+	n := strings.LastIndex(rest, ".")
+	if n < 0 {
+		return "", "", "", fmt.Errorf("missing field name after \".\"")
+	}
+	return mount, rest[:n], rest[n+1:], nil
+}
+
 // HashiCorp Vault provider for SecretProvider
 func vaultProvider(ctx context.Context, pathWithQuery string) ([]byte, error) {
 	mutex.Lock()
@@ -34,33 +49,36 @@ func vaultProvider(ctx context.Context, pathWithQuery string) ([]byte, error) {
 		return nil, err
 	}
 
-	// this is just path part without the query params such as ttl
-	key := parsed.Path
+	// Vault path, excluding query params such as ttl
+	path := parsed.Path
 
+	// Deprecated: Legacy VAULT_PATH_PREFIX variable. It will be removed in a future release. Use the full path in the secret path instead.
+	pathPrefix := os.Getenv("VAULT_PATH_PREFIX")
+	if pathPrefix != "" {
+		path = strings.TrimRight(pathPrefix, "/") + "/" + path
+	}
+
+	// Get the mount, secret path and secret field from the path
+	mount, secretPath, secretField, err := splitVaultPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path %q: %w", path, err)
+	}
+
+	// Get the TTL from the query parameters, if provided
 	var ttl time.Duration
 	ttlStr := strings.TrimSpace(parsed.Query().Get("ttl"))
 	if ttlStr != "" {
 		ttl, err = time.ParseDuration(ttlStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ttl %q provided for secret %q: %w", ttlStr, key, err)
+			return nil, fmt.Errorf("invalid ttl %q provided for secret %q: %w", ttlStr, path, err)
 		}
 	}
 
-	// KVv2 mount path. Default "secret"
-	mount := os.Getenv("VAULT_PATH_PREFIX")
-	if mount == "" {
-		mount = "secret"
-	}
+	// Cache for the whole secret path, not just the field, since Vault returns all fields in a secret at once
+	cacheKey := mount + "/" + secretPath
 
-	// split key into path and field, e.g. "path/to/secret.field"
-	keyParts := strings.Split(key, ".")
-	if len(keyParts) != 2 {
-		return nil, fmt.Errorf("invalid key format: %s", key)
-	}
-	secretPath := keyParts[0]
-	secretField := keyParts[1]
-
-	if existing, ok := vaultCache[key]; !ok || hasExpired(existing) {
+	// If the secret is not in the cache or has expired, fetch it from Vault
+	if existing, ok := vaultCache[cacheKey]; !ok || hasExpired(existing) {
 		// check if client is initialized
 		if vaultClient == nil {
 			err := vaultConfigureClient(ctx)
@@ -69,10 +87,10 @@ func vaultProvider(ctx context.Context, pathWithQuery string) ([]byte, error) {
 			}
 		}
 
-		// read the secret
+		// Read the secret
 		s, err := vaultClient.KVv2(mount).Get(ctx, secretPath)
 		if err != nil {
-			return nil, fmt.Errorf("path %q: %w", secretPath, err)
+			return nil, fmt.Errorf("mount path %q: %w", secretPath, err)
 		}
 		data := dataWithTTL{
 			data: s.Data,
@@ -82,17 +100,16 @@ func vaultProvider(ctx context.Context, pathWithQuery string) ([]byte, error) {
 			data.expiresAt = time.Now().Add(ttl)
 		}
 
-		// cache response
-		vaultCache[key] = data
+		vaultCache[cacheKey] = data
 	}
 
-	secretDataAny := vaultCache[key].data[secretField]
+	secretDataAny := vaultCache[cacheKey].data[secretField]
 	if secretDataAny == nil {
-		return nil, fmt.Errorf("secret %q not found in path %q", secretField, secretPath)
+		return nil, fmt.Errorf("secret %q not found in path \"%s/%s\"", secretField, mount, secretPath)
 	}
 	secretData, ok := secretDataAny.(string)
 	if !ok {
-		return nil, fmt.Errorf("secret %q in path %q is not a string", secretField, secretPath)
+		return nil, fmt.Errorf("secret %q in path \"%s/%s\" is not a string", secretField, mount, secretPath)
 	}
 	return []byte(secretData), nil
 }

--- a/engine/client/secretprovider/vault_test.go
+++ b/engine/client/secretprovider/vault_test.go
@@ -1,0 +1,138 @@
+package secretprovider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSplitVaultPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantMount  string
+		wantSecret string
+		wantField  string
+		wantErr    bool
+	}{
+		{
+			name:       "simple path",
+			path:       "my-app/token",
+			wantMount:  "my-app",
+			wantSecret: "token",
+			wantField:  "",
+			wantErr:    true,
+		},
+		{
+			name:       "mount with field",
+			path:       "my-app/secret.token",
+			wantMount:  "my-app",
+			wantSecret: "secret",
+			wantField:  "token",
+		},
+		{
+			name:       "nested secret path with field",
+			path:       "kv/path/to/secret.credential",
+			wantMount:  "kv",
+			wantSecret: "path/to/secret",
+			wantField:  "credential",
+		},
+		{
+			name:    "field with dot in path (last dot splits)",
+			path:    "foo.bar.baz.qux",
+			wantErr: true,
+		},
+		{
+			name:    "no separator slash",
+			path:    "single",
+			wantErr: true,
+		},
+		{
+			name:    "starts with slash (empty mount)",
+			path:    "/.token",
+			wantErr: true,
+		},
+		{
+			name:       "empty mount after slash",
+			path:       "/secret.field",
+			wantMount:  "",
+			wantSecret: "secret",
+			wantField:  "field",
+			wantErr:    true,
+		},
+		{
+			name:    "empty string",
+			path:    "",
+			wantErr: true,
+		},
+		{
+			name:    "slash but no dot",
+			path:    "mount/secret",
+			wantErr: true,
+		},
+		{
+			name:       "secret path with dot in name",
+			path:       "kv/data/config.v2.api_key",
+			wantMount:  "kv",
+			wantSecret: "data/config.v2",
+			wantField:  "api_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mount, secretPath, secretField, err := splitVaultPath(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("splitVaultPath(%q) expected error, got nil", tt.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("splitVaultPath(%q) unexpected error: %v", tt.path, err)
+				return
+			}
+			if mount != tt.wantMount {
+				t.Errorf("splitVaultPath(%q) mount = %q, want %q", tt.path, mount, tt.wantMount)
+			}
+			if secretPath != tt.wantSecret {
+				t.Errorf("splitVaultPath(%q) secretPath = %q, want %q", tt.path, secretPath, tt.wantSecret)
+			}
+			if secretField != tt.wantField {
+				t.Errorf("splitVaultPath(%q) secretField = %q, want %q", tt.path, secretField, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestHasExpired(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    dataWithTTL
+		wantBool bool
+	}{
+		{
+			name:     "no ttl set (zero time)",
+			input:    dataWithTTL{},
+			wantBool: false,
+		},
+		{
+			name:     "not expired",
+			input:    dataWithTTL{expiresAt: time.Now().Add(time.Hour)},
+			wantBool: false,
+		},
+		{
+			name:     "expired",
+			input:    dataWithTTL{expiresAt: time.Now().Add(-time.Hour)},
+			wantBool: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasExpired(tt.input)
+			if got != tt.wantBool {
+				t.Errorf("hasExpired() = %v, want %v", got, tt.wantBool)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- The `vault://` scheme now accepts the full path to secrets, including the kv v2 mount name. The resulting URI format is: `vault://<mount>/<path>.<field>`. The `VAULT_PATH_PREFIX` variable is still prepended to the path for backward compatibility, but in any case, the default behavior (if your `VAULT_PATH_PREFIX` variable is not set and you were relying on the default mount name `secret`) no longer works. 
Resolves #12756
- Secret caching for vault now ignores the `field` part of the secret path. This will optimize the number of requests made to Vault for the same secret.
- Updated the documentation on working with the vault scheme, adding notes on TTL and authentication methods.
- Fixed the CHANGELOG documentation to match the current v1.0.0 version.

original PR: #13941

P.S. The failed tests are not related to the PR itself ⚠️