### PR TITLE
fix(workspace): search paths under mounts

### DIFF
--- a/.changes/unreleased/Fixed-20260907-201921.yaml
+++ b/.changes/unreleased/Fixed-20260907-201921.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Workspace searches scoped to mounted files, directories, or their parent directories now include mounted content without failing on paths absent from the source tree.
+time: 2026-09-07T20:19:21.411421Z
+custom:
+    Author: vito

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -783,6 +783,77 @@ func (WorkspaceAPISuite) TestWorkspaceMountsSearchGlobFindUp(ctx context.Context
 		require.Equal(t, []string{"shadowed/mounted.txt"}, paths)
 	})
 
+	t.Run("value workspace search scoped to a path existing only through a mount", func(ctx context.Context, t *testctx.T) {
+		// Regression test: .refs/deps exists in no source tree, only in the
+		// mounts tree. Passing it to ripgrep as a path operand against the
+		// source rootfs hard-errored the whole search.
+		c := connect(ctx, t)
+		results, err := valueWorkspace(c).Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+			Literal: true,
+			Paths:   []string{".refs/deps"},
+		})
+		require.NoError(t, err)
+		paths := searchFilePaths(ctx, t, results)
+		require.Equal(t, []string{".refs/deps/vendored.txt"}, paths)
+	})
+
+	t.Run("value workspace search scoped to source and mount paths", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		results, err := valueWorkspace(c).Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+			Literal: true,
+			Paths:   []string{"src", ".refs/deps"},
+		})
+		require.NoError(t, err)
+		paths := searchFilePaths(ctx, t, results)
+		require.Equal(t, []string{".refs/deps/vendored.txt", "src/hay.txt"}, paths)
+	})
+
+	t.Run("value workspace search scoped to a mount point ancestor", func(ctx context.Context, t *testctx.T) {
+		// .refs exists in the workspace view only because the mount at
+		// .refs/deps materializes its parents; scoping to it must not error.
+		c := connect(ctx, t)
+		results, err := valueWorkspace(c).Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+			Literal: true,
+			Paths:   []string{".refs"},
+		})
+		require.NoError(t, err)
+		paths := searchFilePaths(ctx, t, results)
+		require.Equal(t, []string{".refs/deps/vendored.txt"}, paths)
+	})
+
+	t.Run("value workspace search keeps source content under a mount ancestor", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		results, err := valueWorkspace(c).
+			WithNewFile(".refs/local.txt", "needle in source\n").
+			Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+				Literal: true,
+				Paths:   []string{".refs"},
+			})
+		require.NoError(t, err)
+		require.Equal(t, []string{".refs/deps/vendored.txt", ".refs/local.txt"}, searchFilePaths(ctx, t, results))
+	})
+
+	t.Run("value workspace search scoped to a mounted file", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		results, err := c.Directory().AsWorkspace().
+			WithMountedFile("refs/note.txt", c.Directory().WithNewFile("note.txt", "needle in mount\n").File("note.txt")).
+			Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+				Literal: true,
+				Paths:   []string{"refs/note.txt"},
+			})
+		require.NoError(t, err)
+		require.Equal(t, []string{"refs/note.txt"}, searchFilePaths(ctx, t, results))
+	})
+
+	t.Run("value workspace search still rejects nonexistent paths", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		_, err := valueWorkspace(c).Search(ctx, "needle", dagger.WorkspaceSearchOpts{
+			Literal: true,
+			Paths:   []string{"no/such/dir"},
+		})
+		require.Error(t, err, "a path missing from both the source and the mounts must still error")
+	})
+
 	t.Run("value workspace glob", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		matches, err := valueWorkspace(c).Glob(ctx, "**/*.txt")
@@ -869,6 +940,36 @@ func (WorkspaceAPISuite) TestWorkspaceMountsSearchGlobFindUp(ctx context.Context
 			require.Contains(t, paths, ".refs/deps/vendored.txt")
 			require.Contains(t, paths, "shadowed/mounted.txt")
 			require.NotContains(t, paths, "shadowed/real.txt")
+		})
+
+		t.Run("search scoped to a path existing only through a mount", func(ctx context.Context, t *testctx.T) {
+			// Regression test: .refs/deps exists only in the mounts tree, never
+			// on the host. Passing it to the client-side ripgrep as a path
+			// operand hard-errored the whole search.
+			got := mountedQuery(t, `search(pattern: "needle", literal: true, paths: [".refs/deps"]) { filePath }`)
+			paths := []string{}
+			for _, raw := range got["search"].([]any) {
+				paths = append(paths, raw.(map[string]any)["filePath"].(string))
+			}
+			require.Equal(t, []string{".refs/deps/vendored.txt"}, paths)
+		})
+
+		t.Run("search scoped to a mount point ancestor", func(ctx context.Context, t *testctx.T) {
+			got := mountedQuery(t, `search(pattern: "needle", literal: true, paths: [".refs"]) { filePath }`)
+			paths := []string{}
+			for _, raw := range got["search"].([]any) {
+				paths = append(paths, raw.(map[string]any)["filePath"].(string))
+			}
+			require.Equal(t, []string{".refs/deps/vendored.txt"}, paths)
+		})
+
+		t.Run("search scoped to host and mount paths", func(ctx context.Context, t *testctx.T) {
+			got := mountedQuery(t, `search(pattern: "needle", literal: true, paths: ["hay.txt", ".refs/deps"]) { filePath }`)
+			paths := []string{}
+			for _, raw := range got["search"].([]any) {
+				paths = append(paths, raw.(map[string]any)["filePath"].(string))
+			}
+			require.Equal(t, []string{".refs/deps/vendored.txt", "hay.txt"}, paths)
 		})
 
 		t.Run("glob sees mounts and shadows the host", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1206,8 +1206,25 @@ func (s *workspaceSchema) search(
 ) (dagql.Array[*core.SearchResult], error) {
 	ws := parent.Self()
 
+	// Mounted content lives in the mounts tree, never in the source rootfs or
+	// on the host, and ripgrep hard-errors on path operands that don't exist.
+	// So explicit paths that resolve to mounted content are withheld from the
+	// source-side searches — the mounts-side search below covers them via
+	// post-filter — and when every requested path is mount-covered the source
+	// side is skipped entirely.
+	sourcePaths, searchSource, err := s.searchSourcePaths(ctx, ws, args.Paths)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	sourceArgs := args
+	sourceArgs.Paths = sourcePaths
+
 	var results []*core.SearchResult
-	if ws.HostPath() == "" {
+	switch {
+	case !searchSource:
+		// Every requested path is covered by mounts: results come solely from
+		// the mounts tree below.
+	case ws.HostPath() == "":
 		// No host boundary: search the workspace's in-engine root filesystem.
 		// Overlay edits are already visible here: value/git overlays surface
 		// the changeset's after-tree as the source directory.
@@ -1215,13 +1232,12 @@ func (s *workspaceSchema) search(
 		if err != nil {
 			return nil, err
 		}
-		results, err = rootfs.Self().Search(ctx, rootfs, args.SearchOpts, false, args.Paths, args.Globs)
+		results, err = rootfs.Self().Search(ctx, rootfs, sourceArgs.SearchOpts, false, sourceArgs.Paths, sourceArgs.Globs)
 		if err != nil {
 			return nil, fmt.Errorf("search: %w", err)
 		}
-	} else {
-		var err error
-		results, err = s.searchHost(ctx, ws, args)
+	default:
+		results, err = s.searchHost(ctx, ws, sourceArgs)
 		if err != nil {
 			return nil, fmt.Errorf("search: %w", err)
 		}
@@ -1237,7 +1253,9 @@ func (s *workspaceSchema) search(
 
 	// Mounted content is readable through the normal workspace file tools, so
 	// it is searchable too: the mounts tree's results win at and under mount
-	// points, mirroring resolveReadRootfs's shadowing.
+	// points, mirroring resolveReadRootfs's shadowing, and explicit search
+	// paths under mounts — withheld from the source side above — are honored
+	// here via searchDirectoryTree's post-filter.
 	if mounts, ok := ws.MountsDir(); ok {
 		mountResults, err := searchDirectoryTree(ctx, mounts, args)
 		if err != nil {
@@ -1248,6 +1266,49 @@ func (s *workspaceSchema) search(
 
 	emitSearchResults(ctx, results, args.FilesOnly)
 	return dagql.Array[*core.SearchResult](results), nil
+}
+
+// searchSourcePaths filters explicit search paths down to the operands the
+// source-side search (rootfs or host) can safely receive. Mounted content
+// exists only in the mounts tree, and ripgrep hard-errors on missing path
+// operands, so:
+//
+//   - a path at or under a mount point is always dropped: the mounts-side
+//     search covers it via searchDirectoryTree's post-filter;
+//   - a path that is a strict ancestor of a mount point is dropped when the
+//     source doesn't have it — mounts materialize their own parents, so the
+//     path can exist in the workspace view through the mount alone.
+//
+// Paths uninvolved with mounts pass through untouched, so a genuinely
+// nonexistent path still errors like today. The boolean reports whether the
+// source-side search should run at all: false when the caller scoped the
+// search entirely to mounted content.
+func (s *workspaceSchema) searchSourcePaths(
+	ctx context.Context,
+	ws *core.Workspace,
+	paths []string,
+) ([]string, bool, error) {
+	if len(paths) == 0 {
+		return nil, true, nil
+	}
+	sourcePaths := make([]string, 0, len(paths))
+	for _, p := range paths {
+		scope := cleanSearchScope(p)
+		if ws.MountedPath(scope) {
+			continue
+		}
+		if ws.HasMountsUnder(scope) {
+			exists, err := s.workspaceReadPathExists(ctx, ws, scope)
+			if err != nil {
+				return nil, false, err
+			}
+			if !exists {
+				continue
+			}
+		}
+		sourcePaths = append(sourcePaths, p)
+	}
+	return sourcePaths, len(sourcePaths) > 0, nil
 }
 
 // searchHost runs the search client-side against the workspace's host path
@@ -1384,13 +1445,19 @@ func mergeSearchResults(
 	return merged
 }
 
+// cleanSearchScope normalizes a caller-supplied search path to the
+// workspace-root-relative form used for scope comparisons.
+func cleanSearchScope(scope string) string {
+	return path.Clean(strings.TrimPrefix(filepath.ToSlash(scope), "/"))
+}
+
 // searchPathInScopes reports whether a result path falls under any of the
 // requested search paths (matching a file itself or anything beneath a
 // directory).
 func searchPathInScopes(filePath string, scopes []string) bool {
 	fp := path.Clean(filepath.ToSlash(filePath))
 	for _, scope := range scopes {
-		sc := path.Clean(strings.TrimPrefix(filepath.ToSlash(scope), "/"))
+		sc := cleanSearchScope(scope)
 		if sc == "." || fp == sc || strings.HasPrefix(fp, sc+"/") {
 			return true
 		}

--- a/core/schema/workspace_overlay_search_test.go
+++ b/core/schema/workspace_overlay_search_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dagger/dagger/core"
@@ -92,6 +93,54 @@ func TestSearchPathInScopes(t *testing.T) {
 	require.True(t, searchPathInScopes("docs/new.md", []string{"src", "docs"}))
 	require.False(t, searchPathInScopes("docs/new.md", []string{"src"}))
 	require.False(t, searchPathInScopes("docs-extra/new.md", []string{"docs"}))
+}
+
+func TestSearchSourcePaths(t *testing.T) {
+	ctx := context.Background()
+	s := &workspaceSchema{}
+	ws := (&core.Workspace{}).WithMounted(dagql.ObjectResult[*core.Directory]{}, "deps/vendored")
+
+	t.Run("no explicit paths pass through", func(t *testing.T) {
+		paths, searchSource, err := s.searchSourcePaths(ctx, ws, nil)
+		require.NoError(t, err)
+		require.True(t, searchSource)
+		require.Empty(t, paths)
+	})
+
+	t.Run("mount-covered paths are dropped from source operands", func(t *testing.T) {
+		paths, searchSource, err := s.searchSourcePaths(ctx, ws,
+			[]string{"src", "deps/vendored", "/deps/vendored/sub"})
+		require.NoError(t, err)
+		require.True(t, searchSource)
+		require.Equal(t, []string{"src"}, paths)
+	})
+
+	t.Run("all paths mount-covered skips the source side", func(t *testing.T) {
+		paths, searchSource, err := s.searchSourcePaths(ctx, ws,
+			[]string{"deps/vendored", "deps/vendored/sub"})
+		require.NoError(t, err)
+		require.False(t, searchSource)
+		require.Empty(t, paths)
+	})
+
+	t.Run("mount ancestor absent from the source is dropped", func(t *testing.T) {
+		// "deps" exists in the workspace view only because the mount at
+		// deps/vendored materializes its parents; this synthetic workspace has
+		// no source content, so the ancestor must not reach ripgrep.
+		paths, searchSource, err := s.searchSourcePaths(ctx, ws, []string{"deps"})
+		require.NoError(t, err)
+		require.False(t, searchSource)
+		require.Empty(t, paths)
+	})
+
+	t.Run("paths uninvolved with mounts are kept verbatim", func(t *testing.T) {
+		// A genuinely nonexistent path outside any mount still reaches the
+		// source-side search, preserving today's error behavior.
+		paths, searchSource, err := s.searchSourcePaths(ctx, ws, []string{"no/such/dir"})
+		require.NoError(t, err)
+		require.True(t, searchSource)
+		require.Equal(t, []string{"no/such/dir"}, paths)
+	})
 }
 
 func TestMergeGlobMatches(t *testing.T) {


### PR DESCRIPTION
Workspace.search fails with a ripgrep missing-path error when an explicit path exists only through a mount, such as `.refs/deps`. Partition source search operands from mount-covered paths, and search mount-only ancestors without losing source files when the ancestor exists in both trees.

Includes regression coverage for host and value workspaces, mounted files, mixed scopes, ancestor paths, shadowing, and missing paths outside mounts. No public schema changes.

Validation through `dagger api call engine-dev test`:

- Before the fix, seven integration regression cases fail on upstream main with missing-path errors ([trace](https://dagger.cloud/dagger/traces/6dbd5201075fe9fa48dcfebe21ffe716)).
- `./core/schema`: `TestSearchSourcePaths`, `TestSearchPathInScopes`, and `TestMergeSearchResults` pass ([trace](https://dagger.cloud/dagger/traces/e89804ab96a3346631220dfe7be66366)).
- `./core/integration`: `TestWorkspaceAPI/TestWorkspaceMountsSearchGlobFindUp` passes all 16 leaf cases ([trace](https://dagger.cloud/dagger/traces/487d83b4809048920bda32867055db95)).
