### PR TITLE
patchpreview: budget actual diffstat width

### DIFF
--- a/util/patchpreview/patch.go
+++ b/util/patchpreview/patch.go
@@ -43,7 +43,13 @@ func Summarize(out *termenv.Output, entries []Entry, maxWidth int) {
 		return strings.Compare(a.Path, b.Path)
 	})
 
-	maxFilenameLen := max(maxWidth-20, 10)
+	maxDiffstatLen := 0
+	for _, e := range entries {
+		if l := diffstatLen(e); l > maxDiffstatLen {
+			maxDiffstatLen = l
+		}
+	}
+	maxFilenameLen := max(maxWidth-maxDiffstatLen, 10)
 	longestFilenameLen := 0
 	for _, e := range entries {
 		if l := len(entryLabel(e)); l > longestFilenameLen {
@@ -99,6 +105,19 @@ func Summarize(out *termenv.Output, entries []Entry, maxWidth int) {
 		}
 		out.WriteString(" lines")
 	}
+}
+
+// diffstatLen measures the width of the " +N -M" suffix rendered after an
+// entry's filename, so filenames are only truncated as much as necessary.
+func diffstatLen(e Entry) int {
+	length := 0
+	if e.Added > 0 {
+		length += len(fmt.Sprintf(" +%d", e.Added))
+	}
+	if e.Removed > 0 {
+		length += len(fmt.Sprintf(" -%d", e.Removed))
+	}
+	return length
 }
 
 func entryLabel(e Entry) string {

--- a/util/patchpreview/patch_test.go
+++ b/util/patchpreview/patch_test.go
@@ -68,6 +68,24 @@ func TestTruncateLabelRenameAware(t *testing.T) {
 	require.LessOrEqual(t, len(got), 40)
 }
 
+func TestSummarizeUsesActualDiffstatWidth(t *testing.T) {
+	var buf strings.Builder
+	out := termenv.NewOutput(&buf, termenv.WithProfile(termenv.Ascii))
+	Summarize(out, []Entry{
+		{Path: "commit-file-name.go", Kind: KindModified, Added: 46},
+		{Path: "another-file-name.go", Kind: KindModified, Added: 1, Removed: 2},
+	}, 26) // The narrowest Changes bubble has 26 columns for content.
+
+	// The widest diffstat suffix (" +1 -2") is 6 columns, so 20 columns
+	// remain for filenames — enough to show both without truncation.
+	require.Equal(t, strings.Join([]string{
+		"another-file-name.go +1 -2",
+		"commit-file-name.go  +46",
+		"",
+		"2 files changed, +47 -2 lines",
+	}, "\n"), buf.String())
+}
+
 func TestSummarizeEmpty(t *testing.T) {
 	var buf strings.Builder
 	out := termenv.NewOutput(&buf, termenv.WithProfile(termenv.Ascii))


### PR DESCRIPTION
## Problem

`util/patchpreview` budgets filename width with a fixed `maxWidth-20`, assuming 20 columns for the `+N/-M` diffstat suffix. Since the real suffix is usually much narrower (e.g. ` +1 -2` is 6 columns), filenames get truncated more than necessary — and could overflow when the suffix is wider than assumed.

## Fix

Measure the widest diffstat suffix actually rendered (new `diffstatLen` helper) and budget filename width against that, so filenames are only truncated as much as the real columns require.

## Tests

Added `TestSummarizeUsesActualDiffstatWidth`, asserting that at a narrow 26-column width two 19/20-char filenames render untruncated. `go test ./util/patchpreview/ -count=1` passes.

---

Extracted from the agent dev-env branch (#13838), source commit bfd836acc5.