### PR TITLE
core: normalize diff --git header prefixes in Changeset.asPatch

### DIFF
--- a/core/changeset.go
+++ b/core/changeset.go
@@ -754,45 +754,11 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 					return nil
 				}
 
-				// --no-renames: with --no-prefix, git strips the a/ b/ mount dirs
-				// from the ---/+++ lines but not from rename from/to lines, so a
-				// rename entry makes the patch unapplyable ("inconsistent old
-				// filename"). Emitting renames as delete+add avoids the mismatch;
-				// with --binary the result is identical.
-				args := []string{"diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b"}
-				if len(pathSpecs) > 0 {
-					// -- so a path starting with - isn't parsed as a flag, and
-					// GIT_LITERAL_PATHSPECS below so one starting with : isn't
-					// parsed as pathspec magic. Either would otherwise fail the
-					// diff or silently drop the path from the patch.
-					args = append(args, "--")
-					args = append(args, pathSpecs...)
-				}
 				return enginetel.Task(ctx, "git diff", func(ctx context.Context) error {
 					stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary, log.Bool(telemetry.LogsVerboseAttr, true))
 					defer stdio.Close()
-					// The span is named for the command rather than the whole
-					// argv, which the pathspecs make unbounded; log those.
-					fmt.Fprintln(stdio.Stdout, "running git", strings.Join(args, " "))
-					cmd := exec.CommandContext(ctx, "git", args...)
-					cmd.Dir = root
-					cmd.Env = append(os.Environ(), "GIT_LITERAL_PATHSPECS=1")
-					cmd.Stdout = io.MultiWriter(patchFile, stdio.Stdout)
-					cmd.Stderr = stdio.Stderr
-					if err := cmd.Run(); err != nil {
-						var exitErr *exec.ExitError
-						// Exit code 1 just means the trees differ, which is the
-						// whole point; returning it would end the span in error
-						// for every patch that isn't empty.
-						if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-							return nil
-						}
-						// NB: we could technically populate an ExecError here, but that
-						// feels like it leaks implementation details; "exit status 128" isn't
-						// exactly clear
-						return fmt.Errorf("failed to generate patch: %w", err)
-					}
-					return nil
+					return writeGitDiffPatch(ctx, root, pathSpecs,
+						io.MultiWriter(patchFile, stdio.Stdout), stdio.Stdout, stdio.Stderr)
 				})
 			})
 		}, mountRefAsReadOnly)
@@ -812,6 +778,147 @@ func (ch *Changeset) AsPatch(ctx context.Context) (*File, error) {
 	file.File.setValue(ChangesetPatchFilename)
 	file.Snapshot.setValue(snap)
 	return file, nil
+}
+
+// writeGitDiffPatch runs `git diff` between the a/ and b/ mount dirs beneath
+// root and writes the resulting unified diff to out, normalizing the
+// `diff --git` header lines along the way (see diffGitHeaderRewriter).
+//
+// logOut/logErr receive the command's own diagnostics; logOut also gets the
+// argv, which the span name can't carry.
+func writeGitDiffPatch(ctx context.Context, root string, pathSpecs []string, out, logOut, logErr io.Writer) error {
+	// --no-renames: with --no-prefix, git strips the a/ b/ mount dirs
+	// from the ---/+++ lines but not from rename from/to lines, so a
+	// rename entry makes the patch unapplyable ("inconsistent old
+	// filename"). Emitting renames as delete+add avoids the mismatch;
+	// with --binary the result is identical.
+	args := []string{"diff", "--binary", "--no-prefix", "--no-renames", "--no-index", "a", "b"}
+	if len(pathSpecs) > 0 {
+		// -- so a path starting with - isn't parsed as a flag, and
+		// GIT_LITERAL_PATHSPECS below so one starting with : isn't
+		// parsed as pathspec magic. Either would otherwise fail the
+		// diff or silently drop the path from the patch.
+		args = append(args, "--")
+		args = append(args, pathSpecs...)
+	}
+	// The span is named for the command rather than the whole argv, which the
+	// pathspecs make unbounded; log those.
+	fmt.Fprintln(logOut, "running git", strings.Join(args, " "))
+
+	rewriter := &diffGitHeaderRewriter{w: out}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GIT_LITERAL_PATHSPECS=1")
+	cmd.Stdout = rewriter
+	cmd.Stderr = logErr
+	runErr := cmd.Run()
+	if flushErr := rewriter.Flush(); flushErr != nil && runErr == nil {
+		return flushErr
+	}
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		// Exit code 1 just means the trees differ, which is the
+		// whole point; returning it would end the span in error
+		// for every patch that isn't empty.
+		if errors.As(runErr, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		// NB: we could technically populate an ExecError here, but that
+		// feels like it leaks implementation details; "exit status 128" isn't
+		// exactly clear
+		return fmt.Errorf("failed to generate patch: %w", runErr)
+	}
+	return nil
+}
+
+// diffGitHeaderRewriter is an io.Writer that passes a unified diff through
+// unchanged apart from its `diff --git` header lines, which it rewrites via
+// fixDiffGitHeader. Data is buffered until a newline, so callers must Flush
+// once the source is exhausted.
+type diffGitHeaderRewriter struct {
+	w   io.Writer
+	buf []byte
+}
+
+func (r *diffGitHeaderRewriter) Write(p []byte) (int, error) {
+	r.buf = append(r.buf, p...)
+	for {
+		i := bytes.IndexByte(r.buf, '\n')
+		if i < 0 {
+			return len(p), nil
+		}
+		line := string(r.buf[:i])
+		r.buf = r.buf[i+1:]
+		if _, err := io.WriteString(r.w, fixDiffGitHeader(line)+"\n"); err != nil {
+			return 0, err
+		}
+	}
+}
+
+// Flush writes any trailing data not terminated by a newline.
+func (r *diffGitHeaderRewriter) Flush() error {
+	if len(r.buf) == 0 {
+		return nil
+	}
+	line := string(r.buf)
+	r.buf = nil
+	_, err := io.WriteString(r.w, fixDiffGitHeader(line))
+	return err
+}
+
+// fixDiffGitHeader normalizes the path prefixes on a `diff --git` header line.
+//
+// AsPatch diffs two bind mounts literally named a/ and b/ with --no-prefix, so
+// the header line carries whichever mount dir the file exists in on both
+// sides: an added file yields "diff --git b/f b/f" and a deleted one
+// "diff --git a/f a/f". Real git always writes "diff --git a/<path> b/<path>"
+// regardless of the change kind (only the ---/+++ lines use /dev/null), and
+// `git apply` — plus anything else consuming these patches — expects that, so
+// rewrite the prefixes to a/ and b/.
+//
+// Lines that aren't headers, or that don't parse as a header, are returned
+// unchanged. Diff payload lines can never be mistaken for a header: text hunk
+// lines always start with ' ', '+', '-' or '\', and --binary payload lines are
+// base85, which has no space or '-'.
+func fixDiffGitHeader(line string) string {
+	const marker = "diff --git "
+	rest, ok := strings.CutPrefix(line, marker)
+	if !ok {
+		return line
+	}
+	// The two paths only differ in their leading mount dir (--no-renames means
+	// git never emits a rename header here), so they have equal length and the
+	// separating space sits exactly in the middle. Splitting there — rather
+	// than on the first space — keeps paths containing spaces intact.
+	var left, right string
+	if mid := len(rest) / 2; len(rest)%2 == 1 && rest[mid] == ' ' {
+		left, right = rest[:mid], rest[mid+1:]
+	} else if fields := strings.Split(rest, " "); len(fields) == 2 {
+		left, right = fields[0], fields[1]
+	} else {
+		return line
+	}
+	newLeft, leftOK := retagDiffPath(left, 'a')
+	newRight, rightOK := retagDiffPath(right, 'b')
+	if !leftOK || !rightOK {
+		return line
+	}
+	return marker + newLeft + " " + newRight
+}
+
+// retagDiffPath replaces the leading a/ or b/ prefix of a path as it appears on
+// a `diff --git` line with the given tag, accounting for git's C-style quoting
+// of paths with unusual characters. It reports false if the path doesn't have
+// such a prefix, in which case the caller leaves the line alone.
+func retagDiffPath(p string, tag byte) (string, bool) {
+	i := 0
+	if strings.HasPrefix(p, `"`) {
+		i = 1
+	}
+	if len(p) < i+2 || (p[i] != 'a' && p[i] != 'b') || p[i+1] != '/' {
+		return "", false
+	}
+	return p[:i] + string(tag) + p[i+1:], true
 }
 
 func (ch *Changeset) Export(ctx context.Context, destPath string) (rerr error) {

--- a/core/changeset_patch_test.go
+++ b/core/changeset_patch_test.go
@@ -1,0 +1,193 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixDiffGitHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "added file (both sides b/)",
+			in:   "diff --git b/add.txt b/add.txt",
+			want: "diff --git a/add.txt b/add.txt",
+		},
+		{
+			name: "deleted file (both sides a/)",
+			in:   "diff --git a/gone.txt a/gone.txt",
+			want: "diff --git a/gone.txt b/gone.txt",
+		},
+		{
+			name: "modified file is left alone",
+			in:   "diff --git a/mod.txt b/mod.txt",
+			want: "diff --git a/mod.txt b/mod.txt",
+		},
+		{
+			name: "nested path",
+			in:   "diff --git b/sub/dir/new.txt b/sub/dir/new.txt",
+			want: "diff --git a/sub/dir/new.txt b/sub/dir/new.txt",
+		},
+		{
+			name: "path containing spaces",
+			in:   "diff --git b/with space.txt b/with space.txt",
+			want: "diff --git a/with space.txt b/with space.txt",
+		},
+		{
+			name: "quoted path",
+			in:   `diff --git "b/caf\303\251.txt" "b/caf\303\251.txt"`,
+			want: `diff --git "a/caf\303\251.txt" "b/caf\303\251.txt"`,
+		},
+		{
+			name: "rename header keeps distinct paths",
+			in:   "diff --git a/old-name.txt b/renamed.txt",
+			want: "diff --git a/old-name.txt b/renamed.txt",
+		},
+		{
+			name: "non-header line untouched",
+			in:   "+diff --git b/x b/x",
+			want: "+diff --git b/x b/x",
+		},
+		{
+			name: "unparseable header untouched",
+			in:   "diff --git nonsense",
+			want: "diff --git nonsense",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, fixDiffGitHeader(tc.in))
+		})
+	}
+}
+
+func TestDiffGitHeaderRewriter(t *testing.T) {
+	in := "diff --git b/add.txt b/add.txt\nnew file mode 100644\n--- /dev/null\n+++ b/add.txt\n@@ -0,0 +1 @@\n+hi\ntrailing-no-newline"
+	var out bytes.Buffer
+	rw := &diffGitHeaderRewriter{w: &out}
+	// Write in awkward chunks to exercise the line buffering.
+	for i := 0; i < len(in); i += 7 {
+		end := min(i+7, len(in))
+		n, err := rw.Write([]byte(in[i:end]))
+		require.NoError(t, err)
+		require.Equal(t, end-i, n)
+	}
+	require.NoError(t, rw.Flush())
+	require.Equal(t,
+		"diff --git a/add.txt b/add.txt\nnew file mode 100644\n--- /dev/null\n+++ b/add.txt\n@@ -0,0 +1 @@\n+hi\ntrailing-no-newline",
+		out.String())
+}
+
+// TestWriteGitDiffPatch_Integration generates a real patch the way AsPatch
+// does, asserts the `diff --git` header of every change kind (added, deleted,
+// modified, renamed) uses git's a/ ... b/ convention, and - most importantly -
+// asserts the patch actually applies (and reverse-applies) with `git apply`.
+func TestWriteGitDiffPatch_Integration(t *testing.T) {
+	ctx := context.Background()
+
+	root := t.TempDir()
+	before := filepath.Join(root, "a")
+	after := filepath.Join(root, "b")
+
+	writeFile := func(dir, path, contents string) {
+		full := filepath.Join(dir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(contents), 0o644))
+	}
+
+	// before/
+	writeFile(before, "keep.txt", "unchanged\n")
+	writeFile(before, "mod.txt", "original\n")
+	writeFile(before, "gone.txt", "will be removed\n")
+	writeFile(before, "old-name.txt", "same content across the rename\n")
+
+	// after/
+	writeFile(after, "keep.txt", "unchanged\n")
+	writeFile(after, "mod.txt", "modified\n")
+	writeFile(after, "add.txt", "newly added\n")
+	writeFile(after, "new-name.txt", "same content across the rename\n")
+
+	var patch bytes.Buffer
+	require.NoError(t, writeGitDiffPatch(ctx, root, nil, &patch, io.Discard, io.Discard))
+
+	patchText := patch.String()
+	require.NotEmpty(t, patchText)
+
+	var headers []string
+	for _, line := range strings.Split(patchText, "\n") {
+		if strings.HasPrefix(line, "diff --git ") {
+			headers = append(headers, line)
+		}
+	}
+
+	// Renames are emitted as delete+add (--no-renames), but every kind must
+	// still use a/ on the left and b/ on the right.
+	require.ElementsMatch(t, []string{
+		"diff --git a/add.txt b/add.txt",           // added
+		"diff --git a/gone.txt b/gone.txt",         // deleted
+		"diff --git a/mod.txt b/mod.txt",           // modified
+		"diff --git a/new-name.txt b/new-name.txt", // renamed (add side)
+		"diff --git a/old-name.txt b/old-name.txt", // renamed (delete side)
+	}, headers)
+
+	// Now prove the patch is actually consumable by git apply.
+	repo := t.TempDir()
+	writeFile(repo, "keep.txt", "unchanged\n")
+	writeFile(repo, "mod.txt", "original\n")
+	writeFile(repo, "gone.txt", "will be removed\n")
+	writeFile(repo, "old-name.txt", "same content across the rename\n")
+
+	git := func(t *testing.T, args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
+		return string(out)
+	}
+
+	git(t, "init", "-q")
+	git(t, "add", ".")
+	git(t, "commit", "-qm", "base")
+
+	patchPath := filepath.Join(t.TempDir(), "changes.patch")
+	require.NoError(t, os.WriteFile(patchPath, patch.Bytes(), 0o644))
+
+	git(t, "apply", "--check", patchPath)
+	git(t, "apply", patchPath)
+
+	readRepoFile := func(path string) string {
+		contents, err := os.ReadFile(filepath.Join(repo, path))
+		require.NoError(t, err)
+		return string(contents)
+	}
+	require.Equal(t, "unchanged\n", readRepoFile("keep.txt"))
+	require.Equal(t, "modified\n", readRepoFile("mod.txt"))
+	require.Equal(t, "newly added\n", readRepoFile("add.txt"))
+	require.Equal(t, "same content across the rename\n", readRepoFile("new-name.txt"))
+	require.NoFileExists(t, filepath.Join(repo, "gone.txt"))
+	require.NoFileExists(t, filepath.Join(repo, "old-name.txt"))
+
+	// And that it reverse-applies cleanly, which the undo/redo use case needs.
+	git(t, "apply", "-R", "--check", patchPath)
+	git(t, "apply", "-R", patchPath)
+	require.Equal(t, "original\n", readRepoFile("mod.txt"))
+	require.Equal(t, "will be removed\n", readRepoFile("gone.txt"))
+	require.Equal(t, "same content across the rename\n", readRepoFile("old-name.txt"))
+	require.NoFileExists(t, filepath.Join(repo, "add.txt"))
+	require.NoFileExists(t, filepath.Join(repo, "new-name.txt"))
+}

--- a/core/changeset_patch_test.go
+++ b/core/changeset_patch_test.go
@@ -147,7 +147,7 @@ func TestWriteGitDiffPatch_Integration(t *testing.T) {
 	writeFile(repo, "gone.txt", "will be removed\n")
 	writeFile(repo, "old-name.txt", "same content across the rename\n")
 
-	git := func(t *testing.T, args ...string) string {
+	git := func(t *testing.T, args ...string) {
 		t.Helper()
 		cmd := exec.CommandContext(ctx, "git", args...)
 		cmd.Dir = repo
@@ -157,7 +157,6 @@ func TestWriteGitDiffPatch_Integration(t *testing.T) {
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
-		return string(out)
 	}
 
 	git(t, "init", "-q")


### PR DESCRIPTION
## Problem

`Changeset.asPatch` diffs two bind mounts literally named `a/` and `b/` with `--no-prefix`, so the `diff --git` header line carries whichever mount dir the file exists in **on both sides**:

- an added file yields `diff --git b/f b/f`
- a deleted file yields `diff --git a/f a/f`
- a modified file yields `diff --git a/f b/f`, correct only because it exists under both mounts

Real git always writes `diff --git a/<path> b/<path>` regardless of change kind; only the `---`/`+++` lines use `/dev/null`, and those were already right.

This is a conformance fix, not a functional one. `git apply` strips one leading path component per side under the default `-p1` without caring what it's called, so the old headers apply and reverse-apply fine in every mode (`--check`, plain, `-R`, `--index`, `--cached`, `--3way`), and `Directory.withPatch`/`withPatchFile` go through `git apply`, so dagger's own round trip was never affected. The value is in everything else that reads these patches: tools that match the conventional `a/… b/…` header shape, humans and LLMs reading a patch where a deleted file's header claims `a/f a/f`, and exported patches that should look like git produced them.

## Fix

The `git diff` invocation is extracted into `writeGitDiffPatch`, which streams the output through a small line-buffered rewriter (`diffGitHeaderRewriter`) that normalizes each `diff --git` header: the left path is retagged to `a/` and the right to `b/`, handling git's C-style quoted paths and paths containing spaces (under `--no-renames` the two sides only differ in their leading mount dir, so the separating space sits exactly in the middle of the header). Non-header lines and unparseable headers pass through untouched; diff payload lines can never be mistaken for a header (text hunk lines start with ` `, `+`, `-` or `\`, and `--binary` payload is base85).

The rewritten output is byte-for-byte what `git diff` emits with its default prefixes, including quoted non-ASCII paths and the trailing tab after a `+++` path containing spaces. Only the `diff --git` lines of added and deleted files change.

## Regression coverage

New `core/changeset_patch_test.go`:

- `TestFixDiffGitHeader` — table-driven cases for added/deleted/modified headers, nested paths, paths with spaces, quoted paths, rename-shaped headers, non-header lines, and unparseable headers.
- `TestDiffGitHeaderRewriter` — chunked writes exercising the line buffering + `Flush` of a trailing unterminated line.
- `TestWriteGitDiffPatch_Integration` — generates a real patch the way `AsPatch` does across every change kind and asserts all headers use `a/ … b/`. It also applies and reverse-applies the patch with `git apply`; that part passes against the old output too and is there to guard against the rewriter ever breaking applicability.

## Validation

- `go build ./core/...` — ok
- `go test ./core/ -run 'TestFixDiffGitHeader|TestDiffGitHeaderRewriter|TestWriteGitDiffPatch_Integration' -count=1 -v` — all pass
- `go test ./core/ -count=1` — full core package unit tests pass

## Provenance

Extracted from the agent dev-env branch (#13838), source commit caf3365431.
