### PR TITLE
workspace: keep reloaded out of its call chain

### DIFF
--- a/.changes/unreleased/Fixed-20260907-210000.yaml
+++ b/.changes/unreleased/Fixed-20260907-210000.yaml
@@ -1,0 +1,12 @@
+kind: Fixed
+body: |
+  `Workspace.reloaded` no longer appears in the call chain of the workspace it
+  returns. It invalidates cached host reads as a side effect and re-runs on
+  every call, so the workspace it minted carried a per-call nonce that every
+  workspace derived from it inherited for the rest of the session — a chain
+  nothing could be served from cache against. An agent that reloaded its own
+  tools once would re-declare every workspace module on every subsequent edit.
+time: 2026-09-07T21:00:00Z
+custom:
+  Author: vito
+  PR: ""

--- a/core/integration/workspace_reloaded_test.go
+++ b/core/integration/workspace_reloaded_test.go
@@ -1,0 +1,83 @@
+package core
+
+// Coverage for Workspace.reloaded, whose whole job is a side effect: bumping
+// the owning client's host-read epoch. The value it returns must therefore be
+// the workspace it was called on, unchanged and — crucially — with an
+// unchanged call chain.
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkspaceReloadedKeepsCallChain locks in that reloaded does not appear in
+// the call chain of its own result.
+//
+// The field carries dagql.PerCallInput so that it re-runs — and re-bumps the
+// read epoch — on every call. Minting a result for the current call would
+// therefore stamp a random nonce into the returned workspace's ID, and every
+// workspace derived from it afterwards would carry that nonce for the rest of
+// the session: a permanently novel chain nothing can be served from cache
+// against, module loads included. An agent that reloads its own tools once
+// would re-declare every module on every subsequent edit.
+func (WorkspaceSuite) TestWorkspaceReloadedKeepsCallChain(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	base := c.Directory().WithNewFile("a.txt", "a\n").AsWorkspace()
+
+	edited := workspaceRecipeFields(ctx, t, c, base.Reloaded().WithNewFile("b.txt", "b\n"))
+	require.True(t, edited["asWorkspace"], "sanity: the workspace recipe was reached")
+	require.True(t, edited["withNewFile"], "sanity: the edit is in the chain")
+	require.False(t, edited["reloaded"],
+		"an edit made after reloaded must not carry a reloaded segment: "+
+			"reloaded must return its parent's own result, not a new one minted for the current call")
+
+	// Not even the reload itself records one.
+	reloaded := workspaceRecipeFields(ctx, t, c, base.Reloaded())
+	require.False(t, reloaded["reloaded"])
+}
+
+// workspaceRecipeFields returns every field name in a workspace's recipe-form
+// call chain.
+//
+// Workspace.id is an engine-local runtime handle, which says nothing about how
+// the workspace was derived. LLM.portableID is the one place a client can see
+// the recipe: it embeds the bound workspace's recipe ID as the argument of
+// withWorkspace, and collectIDFieldNames walks into nested ID literals.
+func workspaceRecipeFields(
+	ctx context.Context,
+	t *testctx.T,
+	c *dagger.Client,
+	ws *dagger.Workspace,
+) map[string]bool {
+	t.Helper()
+	portable, err := c.LLM().WithWorkspace(ws).PortableID(ctx)
+	require.NoError(t, err)
+	id := new(call.ID)
+	require.NoError(t, id.Decode(string(portable)))
+	fields := map[string]bool{}
+	collectIDFieldNames(id, fields)
+	return fields
+}
+
+// TestWorkspaceReloadedPreservesContent guards the other half of the contract:
+// returning the parent must not lose the workspace's pending overlay.
+func (WorkspaceSuite) TestWorkspaceReloadedPreservesContent(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	ws := c.Directory().WithNewFile("a.txt", "a\n").AsWorkspace().
+		WithNewFile("b.txt", "b\n").
+		Reloaded()
+
+	contents, err := ws.File("b.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "b\n", contents)
+
+	empty, err := ws.Changes().IsEmpty(ctx)
+	require.NoError(t, err)
+	require.False(t, empty, "the pending overlay must survive a reload")
+}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -2208,15 +2208,22 @@ func (s *workspaceSchema) export(
 // discards its pending overlay to re-sync with whatever the host now holds
 // (the CLI's ctrl+u), and any other caller that knows its cached reads are
 // stale.
+//
+// The invalidation is entirely a side effect on the owning client's read epoch,
+// so the result is the PARENT's own object result rather than a new one minted
+// for this call. That is load-bearing: the field carries dagql.PerCallInput (it
+// must re-run, and re-bump, on every call), so a result minted for the current
+// call would carry a random nonce in its ID — and every workspace the caller
+// derives afterwards would chain off that ID for the rest of the session,
+// permanently novel and unmatchable in the cache. Module loads pay that price
+// worst: an agent that reloads once would re-declare its own modules on every
+// subsequent edit. Returning parent keeps the epoch bump and leaves the
+// caller's call chain exactly where it was.
 func (s *workspaceSchema) reloaded(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
 	_ struct{},
 ) (dagql.ObjectResult[*core.Workspace], error) {
-	srv, err := core.CurrentDagqlServer(ctx)
-	if err != nil {
-		return dagql.ObjectResult[*core.Workspace]{}, err
-	}
 	// Bump under the workspace's owning client, the context
 	// withWorkspaceHostReadContext reads the epoch from — a
 	// bump under the caller's own client would be a silent no-op whenever the
@@ -2235,7 +2242,7 @@ func (s *workspaceSchema) reloaded(
 			slog.Warn("could not bump workspace read epoch", "error", err)
 		}
 	}
-	return dagql.NewObjectResultForCurrentCall(ctx, srv, parent.Self().Clone())
+	return parent, nil
 }
 
 func (s *workspaceSchema) overlayWorkspaceWithMutation(


### PR DESCRIPTION
## Problem

`Workspace.reloaded` exists purely for a side effect: it bumps the owning client's host-read epoch so cached `host.directory` reads get re-issued. Because it must re-run (and re-bump) on every call, the field carries `dagql.PerCallInput`, which stamps a random nonce into every invocation.

The resolver returned `dagql.NewObjectResultForCurrentCall` with a clone — binding the returned workspace's ID to that nonce-bearing `reloaded` call. Every workspace derived from it afterwards chained off that ID for the rest of the session: a permanently novel recipe that nothing can be served from cache against, module loads included. Worst case in practice: an agent that reloads its workspace once re-declares every workspace module on every subsequent edit for the rest of the session.

## Fix

Return the parent's own object result instead of minting one for the current call. The epoch bump is the entire useful effect of the field, and it still happens on every call (`PerCallInput` guarantees re-execution); the caller's call chain stays exactly where it was.

## Regression coverage

New `core/integration/workspace_reloaded_test.go`:

- **`TestWorkspaceReloadedKeepsCallChain`** — decodes the workspace's recipe-form ID (via `LLM.portableID`, the one place a client can see the recipe) and asserts no `reloaded` segment appears in the chain of `base.Reloaded().WithNewFile(...)` nor of `base.Reloaded()` itself. Before the fix this fails deterministically: `NewObjectResultForCurrentCall` binds the result's ID to the current (`reloaded`) call, so the segment — nonce included — is present in every derived recipe.
- **`TestWorkspaceReloadedPreservesContent`** — guards the other half of the contract: returning the parent must not drop the pending overlay (a file added before `Reloaded()` is still readable, and `changes` is still non-empty).

## Validation

- `go build ./core/...` and `go vet` clean.
- Both tests pass against a dev engine rebuilt from this branch (`TestWorkspace/TestWorkspaceReloaded` in `./core/integration`).

## Provenance

Extracted from the agent dev-env branch (#13838), source commit acd462100a.