### PR TITLE
core: unify module and workspace Git reference parsing

### DIFF
--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -10,6 +10,7 @@ package gitref
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -43,6 +44,19 @@ const (
 	SchemeSCPLike
 )
 
+// SelectorType describes how a ref selects a revision and source subpath.
+type SelectorType int
+
+const (
+	NoSelector SelectorType = iota
+	// ModuleVersionSelector is the Go-like import path form: path/to/module@ref.
+	// SemVer-shaped refs in this form may be resolved as version queries.
+	ModuleVersionSelector
+	// GitRefSelector is the Git URL form: protocol://repo#ref:subpath. Its ref
+	// is always resolved literally, even when it looks like a SemVer query.
+	GitRefSelector
+)
+
 func (s SchemeType) Prefix() string {
 	switch s {
 	case SchemeHTTP:
@@ -72,6 +86,13 @@ func RefString(cloneRef, sourceRootSubpath, version string) string {
 		refPath += "@" + version
 	}
 	return refPath
+}
+
+// GitURLRefString builds the explicit Git URL form protocol://repo#ref:subpath.
+func GitURLRefString(cloneRef, sourceRootSubpath, version string) string {
+	subpath := filepath.ToSlash(filepath.Clean(sourceRootSubpath))
+	subpath = strings.TrimPrefix(subpath, "/")
+	return cloneRef + "#" + version + ":" + subpath
 }
 
 // FastKindCheck performs a quick heuristic check to determine whether a module
@@ -107,6 +128,7 @@ type Parsed struct {
 
 	ModVersion string
 	HasVersion bool
+	Selector   SelectorType
 
 	RepoRoot       *vcs.RepoRoot
 	RepoRootSubdir string
@@ -129,10 +151,14 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 	_, span := tracer.Start(ctx, fmt.Sprintf("parseGitRefString: %s", refString), telemetry.Internal())
 	defer telemetry.EndWithCause(span, &rerr)
 
-	// Module refs historically use "@" for versions, while other Git-backed
-	// resource addresses use "#". Accept both spellings at this boundary.
-	refString = strings.Replace(refString, "#", "@", 1)
 	scheme, schemelessRef := parseScheme(refString)
+	fragmentRef, fragmentSubdir, hasFragment, err := parseGitFragmentSelector(scheme, schemelessRef)
+	if err != nil {
+		return Parsed{}, err
+	}
+	if hasFragment {
+		schemelessRef, _, _ = strings.Cut(schemelessRef, "#")
+	}
 
 	if scheme == NoScheme && isSCPLike(schemelessRef) {
 		scheme = SchemeSCPLike
@@ -157,11 +183,18 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 		Scheme:  scheme,
 	}
 
-	parts := strings.SplitN(endpoint.Path, "@", 2)
-	if len(parts) == 2 {
-		gitParsed.ModPath = endpoint.Host + parts[0]
-		gitParsed.ModVersion = parts[1]
+	if modulePath, version, ok := strings.Cut(endpoint.Path, "@"); ok {
+		if version == "" || strings.Contains(version, ":") {
+			return Parsed{}, fmt.Errorf("invalid module version selector %q", version)
+		}
+		gitParsed.ModPath = endpoint.Host + modulePath
+		gitParsed.ModVersion = version
 		gitParsed.HasVersion = true
+		gitParsed.Selector = ModuleVersionSelector
+	} else if hasFragment {
+		gitParsed.ModVersion = fragmentRef
+		gitParsed.HasVersion = true
+		gitParsed.Selector = GitRefSelector
 	}
 
 	// Try to isolate the root of the git repo
@@ -179,9 +212,20 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 	}
 
 	gitParsed.RepoRoot = repoRoot
+	if hasFragment && gitParsed.ModPath != repoRoot.Root {
+		return Parsed{}, fmt.Errorf(
+			"git URL selector requires a repository URL before #: got %q, repository root is %q",
+			gitParsed.ModPath,
+			repoRoot.Root,
+		)
+	}
 
 	// the extra "/" trim is important as subpath traversal such as /../ are being cleaned by filePath.Clean
-	gitParsed.RepoRootSubdir = strings.TrimPrefix(strings.TrimPrefix(gitParsed.ModPath, repoRoot.Root), "/")
+	if hasFragment {
+		gitParsed.RepoRootSubdir = fragmentSubdir
+	} else {
+		gitParsed.RepoRootSubdir = strings.TrimPrefix(strings.TrimPrefix(gitParsed.ModPath, repoRoot.Root), "/")
+	}
 	if gitParsed.RepoRootSubdir == "" {
 		gitParsed.RepoRootSubdir = "/"
 	}
@@ -223,7 +267,30 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 }
 
 func isSCPLike(ref string) bool {
-	return strings.Contains(ref, ":") && !strings.Contains(ref, "//")
+	colon := strings.IndexByte(ref, ':')
+	if colon < 0 || strings.Contains(ref, "//") {
+		return false
+	}
+	slash := strings.IndexByte(ref, '/')
+	return slash < 0 || colon < slash
+}
+
+func parseGitFragmentSelector(scheme SchemeType, ref string) (gitRef, subdir string, ok bool, err error) {
+	_, fragment, ok := strings.Cut(ref, "#")
+	if !ok {
+		return "", "", false, nil
+	}
+	if scheme == NoScheme {
+		return "", "", false, errors.New("git URL selector requires an explicit protocol")
+	}
+	if strings.Contains(fragment, "#") {
+		return "", "", false, errors.New("git URL selector contains multiple # delimiters")
+	}
+	gitRef, subdir, ok = strings.Cut(fragment, ":")
+	if !ok || gitRef == "" || subdir == "" {
+		return "", "", false, errors.New("git URL selector must have the form #ref:subpath")
+	}
+	return gitRef, subdir, true, nil
 }
 
 // Scheme classifies the transport scheme of a ref string, including SCP-like
@@ -231,7 +298,6 @@ func isSCPLike(ref string) bool {
 // decide eligibility (e.g. for the https-only dagger-get redirect probe)
 // without importing the engine.
 func Scheme(refString string) SchemeType {
-	refString = strings.Replace(refString, "#", "@", 1)
 	scheme, schemeless := parseScheme(refString)
 	if scheme == NoScheme && isSCPLike(schemeless) {
 		return SchemeSCPLike

--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -40,6 +40,7 @@ const (
 	NoScheme SchemeType = iota
 	SchemeHTTP
 	SchemeHTTPS
+	SchemeGit
 	SchemeSSH
 	SchemeSCPLike
 )
@@ -63,6 +64,8 @@ func (s SchemeType) Prefix() string {
 		return "http://"
 	case SchemeHTTPS:
 		return "https://"
+	case SchemeGit:
+		return "git://"
 	case SchemeSSH:
 		return "ssh://"
 	default:
@@ -109,6 +112,8 @@ func FastKindCheck(refString, refPin string) Kind {
 	case strings.HasPrefix(refString, SchemeHTTP.Prefix()):
 		return KindGit
 	case strings.HasPrefix(refString, SchemeHTTPS.Prefix()):
+		return KindGit
+	case strings.HasPrefix(refString, SchemeGit.Prefix()):
 		return KindGit
 	case strings.HasPrefix(refString, SchemeSSH.Prefix()):
 		return KindGit
@@ -197,12 +202,27 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 		gitParsed.Selector = GitRefSelector
 	}
 
-	// Try to isolate the root of the git repo
-	// RepoRootForImportPath does not support SCP-like ref style. In parseGitEndpoint, we made sure that all refs
-	// would be compatible with this function to benefit from the repo URL and root splitting
-	repoRoot, err := vcs.RepoRootForImportPath(gitParsed.ModPath, false)
-	if err != nil {
-		return Parsed{}, EndpointError{fmt.Errorf("failed to get repo root for import path: %w", err)}
+	// Go-like module refs use import-path discovery to split the repository from
+	// its module subpath. The explicit #ref:subpath form already provides that
+	// boundary, so it can accept any Git URL without go-import metadata.
+	var repoRoot *vcs.RepoRoot
+	if hasFragment {
+		repoRoot = explicitGitRepoRoot(gitParsed.ModPath, scheme, endpoint)
+		if knownRoot, staticErr := vcs.RepoRootForImportPathStatic(gitParsed.ModPath, ""); staticErr == nil {
+			if knownRoot.Root != gitParsed.ModPath {
+				return Parsed{}, fmt.Errorf(
+					"git URL selector requires a repository URL before #: got %q, repository root is %q",
+					gitParsed.ModPath,
+					knownRoot.Root,
+				)
+			}
+			repoRoot = knownRoot
+		}
+	} else {
+		repoRoot, err = vcs.RepoRootForImportPath(gitParsed.ModPath, false)
+		if err != nil {
+			return Parsed{}, EndpointError{fmt.Errorf("failed to get repo root for import path: %w", err)}
+		}
 	}
 	if repoRoot == nil || repoRoot.VCS == nil {
 		return Parsed{}, fmt.Errorf("invalid repo root for import path: %s", gitParsed.ModPath)
@@ -212,13 +232,6 @@ func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 	}
 
 	gitParsed.RepoRoot = repoRoot
-	if hasFragment && gitParsed.ModPath != repoRoot.Root {
-		return Parsed{}, fmt.Errorf(
-			"git URL selector requires a repository URL before #: got %q, repository root is %q",
-			gitParsed.ModPath,
-			repoRoot.Root,
-		)
-	}
 
 	// the extra "/" trim is important as subpath traversal such as /../ are being cleaned by filePath.Clean
 	if hasFragment {
@@ -293,6 +306,22 @@ func parseGitFragmentSelector(scheme SchemeType, ref string) (gitRef, subdir str
 	return gitRef, subdir, true, nil
 }
 
+func explicitGitRepoRoot(modPath string, scheme SchemeType, endpoint *transport.Endpoint) *vcs.RepoRoot {
+	webScheme := scheme
+	if webScheme != SchemeHTTP && webScheme != SchemeHTTPS {
+		webScheme = SchemeHTTPS
+	}
+	host := endpoint.Host
+	if endpoint.Port > 0 && (scheme == SchemeHTTP || scheme == SchemeHTTPS) {
+		host = fmt.Sprintf("%s:%d", host, endpoint.Port)
+	}
+	return &vcs.RepoRoot{
+		VCS:  vcs.ByCmd("git"),
+		Root: modPath,
+		Repo: webScheme.Prefix() + host + strings.TrimSuffix(endpoint.Path, ".git"),
+	}
+}
+
 // Scheme classifies the transport scheme of a ref string, including SCP-like
 // ("git@host:path") refs. It is a pure, network-free helper so callers can
 // decide eligibility (e.g. for the https-only dagger-get redirect probe)
@@ -309,6 +338,7 @@ func parseScheme(refString string) (SchemeType, string) {
 	schemes := []SchemeType{
 		SchemeHTTP,
 		SchemeHTTPS,
+		SchemeGit,
 		SchemeSSH,
 	}
 

--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -53,7 +53,7 @@ const (
 	// ModuleVersionSelector is the Go-like import path form: path/to/module@ref.
 	// SemVer-shaped refs in this form may be resolved as version queries.
 	ModuleVersionSelector
-	// GitRefSelector is the Git URL form: protocol://repo#ref:subpath. Its ref
+	// GitRefSelector is the Git URL form: protocol://repo#ref[:subpath]. Its ref
 	// is always resolved literally, even when it looks like a SemVer query.
 	GitRefSelector
 )
@@ -91,10 +91,13 @@ func RefString(cloneRef, sourceRootSubpath, version string) string {
 	return refPath
 }
 
-// GitURLRefString builds the explicit Git URL form protocol://repo#ref:subpath.
+// GitURLRefString builds the explicit Git URL form protocol://repo#ref[:subpath].
 func GitURLRefString(cloneRef, sourceRootSubpath, version string) string {
 	subpath := filepath.ToSlash(filepath.Clean(sourceRootSubpath))
 	subpath = strings.TrimPrefix(subpath, "/")
+	if subpath == "" || subpath == "." {
+		return cloneRef + "#" + version
+	}
 	return cloneRef + "#" + version + ":" + subpath
 }
 
@@ -299,9 +302,12 @@ func parseGitFragmentSelector(scheme SchemeType, ref string) (gitRef, subdir str
 	if strings.Contains(fragment, "#") {
 		return "", "", false, errors.New("git URL selector contains multiple # delimiters")
 	}
-	gitRef, subdir, ok = strings.Cut(fragment, ":")
-	if !ok || gitRef == "" || subdir == "" {
-		return "", "", false, errors.New("git URL selector must have the form #ref:subpath")
+	gitRef, subdir, hasSubdir := strings.Cut(fragment, ":")
+	if gitRef == "" {
+		return "", "", false, errors.New("git URL selector requires a ref after #")
+	}
+	if hasSubdir && subdir == "" {
+		return "", "", false, errors.New("git URL selector has an empty subpath after colon")
 	}
 	return gitRef, subdir, true, nil
 }

--- a/core/gitref/gitref_test.go
+++ b/core/gitref/gitref_test.go
@@ -54,6 +54,18 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			urlStr: "https://github.com/dagger/python#v1.2:ruff",
+			want: Parsed{
+				ModPath:        "github.com/dagger/python",
+				ModVersion:     "v1.2",
+				HasVersion:     true,
+				Selector:       GitRefSelector,
+				RepoRoot:       &vcs.RepoRoot{Root: "github.com/dagger/python", Repo: "https://github.com/dagger/python"},
+				RepoRootSubdir: "ruff",
+				Scheme:         SchemeHTTPS,
+			},
+		},
+		{
 			urlStr: "http://github.com/shykes/daggerverse.git/ci",
 			want: Parsed{
 				ModPath:        "github.com/shykes/daggerverse.git/ci",
@@ -112,6 +124,8 @@ func TestParse(t *testing.T) {
 				Scheme:         SchemeSSH,
 				SourceUser:     "user",
 				ModVersion:     "version",
+				HasVersion:     true,
+				Selector:       ModuleVersionSelector,
 			},
 		},
 		{
@@ -123,6 +137,8 @@ func TestParse(t *testing.T) {
 				Scheme:         SchemeSSH,
 				SourceUser:     "",
 				ModVersion:     "version",
+				HasVersion:     true,
+				Selector:       ModuleVersionSelector,
 			},
 		},
 
@@ -212,6 +228,7 @@ func TestParse(t *testing.T) {
 				RepoRootSubdir: "ci",
 				HasVersion:     true,
 				ModVersion:     "version",
+				Selector:       ModuleVersionSelector,
 			},
 		},
 		{
@@ -223,6 +240,7 @@ func TestParse(t *testing.T) {
 				RepoRootSubdir: "ci",
 				HasVersion:     true,
 				ModVersion:     "version",
+				Selector:       ModuleVersionSelector,
 			},
 		},
 		// Azure ref parsing
@@ -278,6 +296,9 @@ func TestParse(t *testing.T) {
 			require.Equal(t, tc.want.RepoRootSubdir, parsed.RepoRootSubdir)
 			require.Equal(t, tc.want.Scheme, parsed.Scheme)
 			require.Equal(t, tc.want.SourceUser, parsed.SourceUser)
+			require.Equal(t, tc.want.ModVersion, parsed.ModVersion)
+			require.Equal(t, tc.want.HasVersion, parsed.HasVersion)
+			require.Equal(t, tc.want.Selector, parsed.Selector)
 
 			if tc.want.SourceCloneRef != "" {
 				require.Equal(t, tc.want.SourceCloneRef, parsed.SourceCloneRef)

--- a/core/gitref/gitref_test.go
+++ b/core/gitref/gitref_test.go
@@ -66,6 +66,38 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			urlStr: "https://github.com/dagger/python#v1.2",
+			want: Parsed{
+				ModPath:        "github.com/dagger/python",
+				ModVersion:     "v1.2",
+				HasVersion:     true,
+				Selector:       GitRefSelector,
+				RepoRoot:       &vcs.RepoRoot{Root: "github.com/dagger/python", Repo: "https://github.com/dagger/python"},
+				RepoRootSubdir: "/",
+				Scheme:         SchemeHTTPS,
+			},
+		},
+		{
+			urlStr: "https://github.com/dagger/python#v1.2:.",
+			want: Parsed{
+				ModPath:        "github.com/dagger/python",
+				ModVersion:     "v1.2",
+				HasVersion:     true,
+				Selector:       GitRefSelector,
+				RepoRoot:       &vcs.RepoRoot{Root: "github.com/dagger/python", Repo: "https://github.com/dagger/python"},
+				RepoRootSubdir: ".",
+				Scheme:         SchemeHTTPS,
+			},
+		},
+		{
+			urlStr:          "https://github.com/dagger/python#",
+			wantErrContains: "requires a ref after #",
+		},
+		{
+			urlStr:          "https://github.com/dagger/python#main:",
+			wantErrContains: "empty subpath",
+		},
+		{
 			urlStr: "https://git.example.com/team/repo#main:src",
 			want: Parsed{
 				ModPath:        "git.example.com/team/repo",

--- a/core/gitref/gitref_test.go
+++ b/core/gitref/gitref_test.go
@@ -66,6 +66,34 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			urlStr: "https://git.example.com/team/repo#main:src",
+			want: Parsed{
+				ModPath:        "git.example.com/team/repo",
+				ModVersion:     "main",
+				HasVersion:     true,
+				Selector:       GitRefSelector,
+				RepoRoot:       &vcs.RepoRoot{Root: "git.example.com/team/repo", Repo: "https://git.example.com/team/repo"},
+				RepoRootSubdir: "src",
+				Scheme:         SchemeHTTPS,
+			},
+		},
+		{
+			urlStr: "git://git.example.com/team/repo#main:src",
+			want: Parsed{
+				ModPath:        "git.example.com/team/repo",
+				ModVersion:     "main",
+				HasVersion:     true,
+				Selector:       GitRefSelector,
+				RepoRoot:       &vcs.RepoRoot{Root: "git.example.com/team/repo", Repo: "https://git.example.com/team/repo"},
+				RepoRootSubdir: "src",
+				Scheme:         SchemeGit,
+			},
+		},
+		{
+			urlStr:          "https://github.com/dagger/python/ruff#main:docs",
+			wantErrContains: "repository root is \"github.com/dagger/python\"",
+		},
+		{
 			urlStr: "http://github.com/shykes/daggerverse.git/ci",
 			want: Parsed{
 				ModPath:        "github.com/shykes/daggerverse.git/ci",

--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -178,9 +178,9 @@ func newWorkspaceModuleSettingsCtr(t *testctx.T, c *dagger.Client, configTOML st
 func (WorkspaceSuite) TestWorkspaceModuleSettingsRuntime(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	t.Run("git refs accept the same separators in sources and settings", func(ctx context.Context, t *testctx.T) {
+	t.Run("git refs accept at separators in sources and settings", func(ctx context.Context, t *testctx.T) {
 		ctr := newWorkspaceModuleSettingsCtr(t, c, `[modules.wolfi]
-source = "https://github.com/dagger/dagger/modules/wolfi#v0.20.2"
+source = "https://github.com/dagger/dagger/modules/wolfi@v0.20.2"
 
 [modules.superconstructor]
 source = "defaults/superconstructor"

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -149,6 +149,7 @@ func (p *ParsedGitRefString) SetVersion(version string) error {
 	}
 	p.ModVersion = version
 	p.HasVersion = true
+	p.Selector = gitref.ModuleVersionSelector
 	return nil
 }
 
@@ -166,12 +167,7 @@ func (p *ParsedGitRefString) GitRef(
 		return selector
 	}
 
-	versionQuery := ""
-	if p.HasVersion && Supports(ctx, workspace.VersionQueriesVersion) {
-		if IsReleaseVersionQuery(p.ModVersion) {
-			versionQuery = p.ModVersion
-		}
-	}
+	versionQuery := p.versionQuery(ctx)
 
 	repoSelector := dagql.Selector{
 		Field: "git",
@@ -237,6 +233,15 @@ func (p *ParsedGitRefString) GitRef(
 	}
 
 	return gitRef, nil
+}
+
+func (p *ParsedGitRefString) versionQuery(ctx context.Context) string {
+	if p.Selector == gitref.ModuleVersionSelector &&
+		Supports(ctx, workspace.VersionQueriesVersion) &&
+		IsReleaseVersionQuery(p.ModVersion) {
+		return p.ModVersion
+	}
+	return ""
 }
 
 func moduleGitDefaultRefSelector(

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -51,6 +51,7 @@ func TestParsedGitRefStringSetVersion(t *testing.T) {
 	require.NoError(t, parsed.SetVersion("v1.2-beta"))
 	require.True(t, parsed.HasVersion)
 	require.Equal(t, "v1.2-beta", parsed.ModVersion)
+	require.Equal(t, gitref.ModuleVersionSelector, parsed.Selector)
 
 	require.EqualError(t,
 		parsed.SetVersion("v2"),
@@ -59,6 +60,32 @@ func TestParsedGitRefStringSetVersion(t *testing.T) {
 
 	invalid := &ParsedGitRefString{}
 	require.ErrorContains(t, invalid.SetVersion("main"), `invalid version query "main"`)
+}
+
+func TestParsedGitRefStringVersionQuerySemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := dagql.ContextWithCall(t.Context(), &dagql.ResultCall{
+		View: call.View(workspace.VersionQueriesVersion),
+	})
+	for _, tc := range []struct {
+		name     string
+		selector gitref.SelectorType
+		want     string
+	}{
+		{name: "at selector uses semver query", selector: gitref.ModuleVersionSelector, want: "v1.2"},
+		{name: "fragment selector stays literal", selector: gitref.GitRefSelector, want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parsed := &ParsedGitRefString{Parsed: gitref.Parsed{
+				ModVersion: "v1.2",
+				HasVersion: true,
+				Selector:   tc.selector,
+			}}
+			require.Equal(t, tc.want, parsed.versionQuery(ctx))
+		})
+	}
 }
 
 func TestMatchVersion(t *testing.T) {
@@ -95,6 +122,7 @@ func TestParseRefString(t *testing.T) {
 		wantCloneRef    string
 		wantSubdir      string
 		wantVersion     string
+		wantSelector    gitref.SelectorType
 		wantErrContains string
 	}{
 		{
@@ -109,13 +137,59 @@ func TestParseRefString(t *testing.T) {
 			wantCloneRef: "ssh://github.com/shykes/daggerverse",
 			wantSubdir:   "ci",
 			wantVersion:  "version",
+			wantSelector: gitref.ModuleVersionSelector,
 		},
 		{
-			urlStr:       "https://github.com/shykes/daggerverse/ci#version",
+			urlStr:       "https://github.com/shykes/daggerverse#version:ci",
 			wantKind:     ModuleSourceKindGit,
 			wantCloneRef: "https://github.com/shykes/daggerverse",
 			wantSubdir:   "ci",
 			wantVersion:  "version",
+			wantSelector: gitref.GitRefSelector,
+		},
+		{
+			urlStr:       "github.com/dagger/python/ruff@main",
+			wantKind:     ModuleSourceKindGit,
+			wantCloneRef: "github.com/dagger/python",
+			wantSubdir:   "ruff",
+			wantVersion:  "main",
+			wantSelector: gitref.ModuleVersionSelector,
+		},
+		{
+			urlStr:       "https://github.com/dagger/python/ruff@main",
+			wantKind:     ModuleSourceKindGit,
+			wantCloneRef: "https://github.com/dagger/python",
+			wantSubdir:   "ruff",
+			wantVersion:  "main",
+			wantSelector: gitref.ModuleVersionSelector,
+		},
+		{
+			urlStr:       "https://github.com/dagger/python#main:ruff",
+			wantKind:     ModuleSourceKindGit,
+			wantCloneRef: "https://github.com/dagger/python",
+			wantSubdir:   "ruff",
+			wantVersion:  "main",
+			wantSelector: gitref.GitRefSelector,
+		},
+		{
+			urlStr:          "github.com/dagger/python/ruff#main",
+			wantErrContains: "requires an explicit protocol",
+		},
+		{
+			urlStr:          "https://github.com/dagger/python/ruff#main",
+			wantErrContains: "must have the form #ref:subpath",
+		},
+		{
+			urlStr:          "github.com/dagger/python@main:ruff",
+			wantErrContains: "invalid module version selector",
+		},
+		{
+			urlStr:          "https://github.com/dagger/python@main:ruff",
+			wantErrContains: "invalid module version selector",
+		},
+		{
+			urlStr:          "github.com/dagger/python#main:ruff",
+			wantErrContains: "requires an explicit protocol",
 		},
 		{
 			// no dot in the ref string: treated as a local path
@@ -145,6 +219,7 @@ func TestParseRefString(t *testing.T) {
 				require.Equal(t, tc.wantCloneRef, parsed.Git.SourceCloneRef)
 				require.Equal(t, tc.wantSubdir, parsed.Git.RepoRootSubdir)
 				require.Equal(t, tc.wantVersion, parsed.Git.ModVersion)
+				require.Equal(t, tc.wantSelector, parsed.Git.Selector)
 			case ModuleSourceKindLocal:
 				require.NotNil(t, parsed.Local)
 				require.Equal(t, tc.urlStr, parsed.Local.ModPath)

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -172,12 +172,20 @@ func TestParseRefString(t *testing.T) {
 			wantSelector: gitref.GitRefSelector,
 		},
 		{
+			urlStr:       "https://github.com/dagger/python#main",
+			wantKind:     ModuleSourceKindGit,
+			wantCloneRef: "https://github.com/dagger/python",
+			wantSubdir:   "/",
+			wantVersion:  "main",
+			wantSelector: gitref.GitRefSelector,
+		},
+		{
 			urlStr:          "github.com/dagger/python/ruff#main",
 			wantErrContains: "requires an explicit protocol",
 		},
 		{
 			urlStr:          "https://github.com/dagger/python/ruff#main",
-			wantErrContains: "must have the form #ref:subpath",
+			wantErrContains: "repository root is \"github.com/dagger/python\"",
 		},
 		{
 			urlStr:          "github.com/dagger/python@main:ruff",

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
@@ -436,15 +437,16 @@ func (src *ModuleSource) AttachDependencyResults(
 }
 
 type persistedGitModuleSourcePayload struct {
-	CloneRef     string `json:"cloneRef,omitempty"`
-	Symbolic     string `json:"symbolic,omitempty"`
-	HTMLRepoURL  string `json:"htmlRepoURL,omitempty"`
-	HTMLURL      string `json:"htmlURL,omitempty"`
-	RepoRootPath string `json:"repoRootPath,omitempty"`
-	Version      string `json:"version,omitempty"`
-	VersionQuery string `json:"versionQuery,omitempty"`
-	Commit       string `json:"commit,omitempty"`
-	Ref          string `json:"ref,omitempty"`
+	CloneRef     string              `json:"cloneRef,omitempty"`
+	Symbolic     string              `json:"symbolic,omitempty"`
+	HTMLRepoURL  string              `json:"htmlRepoURL,omitempty"`
+	HTMLURL      string              `json:"htmlURL,omitempty"`
+	RepoRootPath string              `json:"repoRootPath,omitempty"`
+	Version      string              `json:"version,omitempty"`
+	VersionQuery string              `json:"versionQuery,omitempty"`
+	Selector     gitref.SelectorType `json:"selector,omitempty"`
+	Commit       string              `json:"commit,omitempty"`
+	Ref          string              `json:"ref,omitempty"`
 }
 
 type persistedDirModuleSourcePayload struct {
@@ -887,6 +889,7 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 			RepoRootPath: src.Git.RepoRootPath,
 			Version:      src.Git.Version,
 			VersionQuery: src.Git.VersionQuery,
+			Selector:     src.Git.Selector,
 			Commit:       src.Git.Commit,
 			Ref:          src.Git.Ref,
 		}
@@ -983,6 +986,7 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 			RepoRootPath: persisted.Git.RepoRootPath,
 			Version:      persisted.Git.Version,
 			VersionQuery: persisted.Git.VersionQuery,
+			Selector:     persisted.Git.Selector,
 			Commit:       persisted.Git.Commit,
 			Ref:          persisted.Git.Ref,
 		}
@@ -1028,6 +1032,9 @@ func (src *ModuleSource) AsString() string {
 		version := src.Git.VersionQuery
 		if version == "" {
 			version = src.Git.Version
+		}
+		if src.Git.Selector == gitref.GitRefSelector {
+			return gitref.GitURLRefString(src.Git.CloneRef, src.SourceRootSubpath, version)
 		}
 		return GitRefString(src.Git.CloneRef, src.SourceRootSubpath, version)
 
@@ -2047,6 +2054,10 @@ type GitModuleSource struct {
 
 	// The version query used to select Version.
 	VersionQuery string
+
+	// Selector preserves whether the source used @ version-query semantics or
+	// literal #ref:subpath Git URL semantics.
+	Selector gitref.SelectorType
 
 	// The resolved commit hash of the source
 	Commit string

--- a/core/modulesource_test.go
+++ b/core/modulesource_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dagger/dagger/core/gitref"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/dagger/dagger/dagql"
@@ -128,6 +130,8 @@ func TestGitModuleSourceSymbolic(t *testing.T) {
 		cloneRef     string
 		rootSubpath  string
 		versionQuery string
+		version      string
+		selector     gitref.SelectorType
 		expected     string
 	}{
 		{
@@ -155,6 +159,14 @@ func TestGitModuleSourceSymbolic(t *testing.T) {
 			versionQuery: "v1.2",
 			expected:     "https://github.com/user/repo.git/subdir@v1.2",
 		},
+		{
+			name:        "literal Git ref",
+			cloneRef:    "https://github.com/user/repo.git",
+			rootSubpath: "subdir",
+			version:     "v1.2",
+			selector:    gitref.GitRefSelector,
+			expected:    "https://github.com/user/repo.git#v1.2:subdir",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -164,6 +176,8 @@ func TestGitModuleSourceSymbolic(t *testing.T) {
 				Git: &GitModuleSource{
 					CloneRef:     tc.cloneRef,
 					VersionQuery: tc.versionQuery,
+					Version:      tc.version,
+					Selector:     tc.selector,
 				},
 				SourceRootSubpath: tc.rootSubpath,
 			}

--- a/core/modulesource_test.go
+++ b/core/modulesource_test.go
@@ -167,6 +167,21 @@ func TestGitModuleSourceSymbolic(t *testing.T) {
 			selector:    gitref.GitRefSelector,
 			expected:    "https://github.com/user/repo.git#v1.2:subdir",
 		},
+		{
+			name:     "literal Git ref at repository root",
+			cloneRef: "https://github.com/user/repo.git",
+			version:  "v1.2",
+			selector: gitref.GitRefSelector,
+			expected: "https://github.com/user/repo.git#v1.2",
+		},
+		{
+			name:        "literal Git ref with explicit dot subpath",
+			cloneRef:    "https://github.com/user/repo.git",
+			rootSubpath: ".",
+			version:     "v1.2",
+			selector:    gitref.GitRefSelector,
+			expected:    "https://github.com/user/repo.git#v1.2",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/sdk"
 	"github.com/dagger/dagger/core/workspace"
@@ -782,7 +783,7 @@ func (s *moduleSourceSchema) gitModuleSource(
 		return inst, fmt.Errorf("failed to resolve git src: %w", err)
 	}
 	versionQuery := ""
-	if core.Supports(ctx, workspace.VersionQueriesVersion) && core.IsReleaseVersionQuery(parsed.ModVersion) {
+	if parsed.Selector == gitref.ModuleVersionSelector && core.Supports(ctx, workspace.VersionQueriesVersion) && core.IsReleaseVersionQuery(parsed.ModVersion) {
 		versionQuery = parsed.ModVersion
 	}
 
@@ -795,6 +796,7 @@ func (s *moduleSourceSchema) gitModuleSource(
 			RepoRootPath: parsed.RepoRoot.Root,
 			Version:      cmp.Or(gitRef.Self().Ref.ShortName(), gitRef.Self().Ref.SHA),
 			VersionQuery: versionQuery,
+			Selector:     parsed.Selector,
 			Commit:       gitRef.Self().Ref.SHA,
 			Ref:          gitRef.Self().Ref.Name,
 			CloneRef:     parsed.SourceCloneRef,

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -302,8 +302,11 @@ func parseCallerCalleeRefs(ctx context.Context, q *Query, frame *dagql.ResultCal
 		callerRef.functionName = fc.Name
 		callerRef.typeName = fc.ParentName
 		if ms.Git != nil {
-			idx := strings.LastIndex(ms.AsString(), "@")
-			callerRef.ref, callerRef.version = ms.AsString()[:idx], ms.AsString()[idx+1:]
+			callerRef.ref = GitRefString(ms.Git.CloneRef, ms.SourceRootSubpath, "")
+			callerRef.version = ms.Git.VersionQuery
+			if callerRef.version == "" {
+				callerRef.version = ms.Git.Version
+			}
 		} else if gremote, ok := cm.Labels["dagger.io/git.remote"]; ok {
 			callerRef.ref = path.Join(gremote, ms.SourceRootSubpath)
 			if gref, ok := cm.Labels["dagger.io/git.ref"]; ok {

--- a/core/telemetry_test.go
+++ b/core/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/dagger/dagger/auth"
+	"github.com/dagger/dagger/core/gitref"
 	workspacepkg "github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/engine"
@@ -242,6 +243,18 @@ func TestParseCallerCalleeRefs(t *testing.T) {
 	require.Equal(t, "github.com/dagger/dagger-test-modules/versioned", calleeRef.ref)
 	require.Equal(t, "0cabe03cc0a9079e738c92b2c589d81fd560011f", calleeRef.version)
 	require.Equal(t, "VersionedGitSSH.hello", calleeRef.functionName)
+
+	// Literal Git URL selectors serialize with #ref:subpath rather than @ref.
+	// Telemetry reads the structured source fields so both forms are safe.
+	mockSrv.moduleSource.SourceRootSubpath = "ruff"
+	mockSrv.moduleSource.Git.CloneRef = "https://github.com/dagger/python"
+	mockSrv.moduleSource.Git.Selector = gitref.GitRefSelector
+	mockSrv.moduleSource.Git.Version = "v1.2"
+
+	callerRef, _ = parseCallerCalleeRefs(t.Context(), &Query{Server: mockSrv}, call)
+	require.NotNil(t, callerRef)
+	require.Equal(t, "https://github.com/dagger/python/ruff", callerRef.ref)
+	require.Equal(t, "v1.2", callerRef.version)
 }
 
 func TestAroundFuncMarksIntrospectionRootAsSkipped(t *testing.T) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/clientdb"
 	"github.com/dagger/dagger/engine/engineutil"
@@ -2065,14 +2067,11 @@ func TestRemoteWorkspaceAddress(t *testing.T) {
 func TestParseWorkspaceRemoteRef(t *testing.T) {
 	t.Parallel()
 
-	t.Run("supports address fragment ref", func(t *testing.T) {
+	t.Run("rejects fragment without subpath", func(t *testing.T) {
 		t.Parallel()
 
-		ref, err := parseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger#main")
-		require.NoError(t, err)
-		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
-		require.Equal(t, "main", ref.version)
-		require.Equal(t, ".", ref.workspaceSubdir)
+		_, err := parseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger#main")
+		require.ErrorContains(t, err, "must have the form #ref:subpath")
 	})
 
 	t.Run("supports address fragment ref and subdir", func(t *testing.T) {
@@ -2083,6 +2082,7 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
 		require.Equal(t, "main", ref.version)
 		require.Equal(t, "toolchains/changelog", ref.workspaceSubdir)
+		require.Equal(t, gitref.GitRefSelector, ref.selector)
 	})
 
 	t.Run("supports legacy at-ref syntax", func(t *testing.T) {
@@ -2092,6 +2092,7 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "main", ref.version)
 		require.Equal(t, "toolchains/changelog", ref.workspaceSubdir)
+		require.Equal(t, gitref.ModuleVersionSelector, ref.selector)
 	})
 
 	t.Run("preserves legacy https at-ref syntax", func(t *testing.T) {
@@ -2101,6 +2102,7 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "main", ref.version)
 		require.Equal(t, ".", ref.workspaceSubdir)
+		require.Equal(t, gitref.ModuleVersionSelector, ref.selector)
 	})
 
 	t.Run("resolves legacy vanity ref", func(t *testing.T) {
@@ -2120,14 +2122,14 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		require.Equal(t, "sdk/go", ref.workspaceSubdir)
 	})
 
-	t.Run("resolves fragment vanity ref and preserves subdir", func(t *testing.T) {
+	t.Run("resolves fragment clone ref and preserves subdir", func(t *testing.T) {
 		t.Parallel()
 
 		ref, err := parseWorkspaceRemoteRefWithResolver(
 			context.Background(),
-			"https://dagger.io/go#main:docs",
+			"https://github.com/dagger/python#main:docs",
 			func(_ context.Context, got string) (string, error) {
-				require.Equal(t, "https://dagger.io/go", got)
+				require.Equal(t, "https://github.com/dagger/python", got)
 				return "https://github.com/dagger/dagger/sdk/go", nil
 			},
 		)
@@ -2135,7 +2137,52 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 		require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
 		require.Equal(t, "main", ref.version)
 		require.Equal(t, "sdk/go/docs", ref.workspaceSubdir)
+		require.Equal(t, gitref.GitRefSelector, ref.selector)
 	})
+
+	for _, invalid := range []string{
+		"github.com/dagger/python/ruff#main",
+		"https://github.com/dagger/python/ruff#main",
+		"github.com/dagger/python@main:ruff",
+		"https://github.com/dagger/python@main:ruff",
+		"github.com/dagger/python#main:ruff",
+	} {
+		t.Run("rejects "+invalid, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseWorkspaceRemoteRef(context.Background(), invalid)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestWorkspaceGitRefSelectorSemverSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := dagql.ContextWithCall(t.Context(), &dagql.ResultCall{
+		View: call.View(workspace.VersionQueriesVersion),
+	})
+	for _, tc := range []struct {
+		name      string
+		selector  gitref.SelectorType
+		wantField string
+	}{
+		{name: "at selector uses semver query", selector: gitref.ModuleVersionSelector, wantField: "latest"},
+		{name: "fragment selector uses literal git ref", selector: gitref.GitRefSelector, wantField: "ref"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			selector := workspaceGitRefSelector(ctx, workspaceRemoteRef{
+				version:         "v1.2",
+				workspaceSubdir: "ruff",
+				selector:        tc.selector,
+			})
+			require.Equal(t, tc.wantField, selector.Field)
+			if tc.wantField == "latest" {
+				require.Equal(t, "version", selector.Args[0].Name)
+				require.Equal(t, "tagPrefix", selector.Args[1].Name)
+			}
+		})
+	}
 }
 
 func TestGatherModuleLoadRequests(t *testing.T) {

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -2066,11 +2066,20 @@ func TestRemoteWorkspaceAddress(t *testing.T) {
 func TestParseWorkspaceRemoteRef(t *testing.T) {
 	t.Parallel()
 
-	t.Run("rejects fragment without subpath", func(t *testing.T) {
+	t.Run("supports address fragment ref at repository root", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := parseWorkspaceRemoteRef(context.Background(), "https://github.com/dagger/dagger#main")
-		require.ErrorContains(t, err, "must have the form #ref:subpath")
+		for _, address := range []string{
+			"https://github.com/dagger/dagger#main",
+			"https://github.com/dagger/dagger#main:.",
+		} {
+			ref, err := parseWorkspaceRemoteRef(context.Background(), address)
+			require.NoError(t, err)
+			require.Equal(t, "https://github.com/dagger/dagger", ref.cloneRef)
+			require.Equal(t, "main", ref.version)
+			require.Equal(t, ".", ref.workspaceSubdir)
+			require.Equal(t, gitref.GitRefSelector, ref.selector)
+		}
 	})
 
 	t.Run("supports address fragment ref and subdir", func(t *testing.T) {
@@ -2142,6 +2151,7 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 	for _, invalid := range []string{
 		"github.com/dagger/python/ruff#main",
 		"https://github.com/dagger/python/ruff#main",
+		"https://github.com/dagger/python#main:",
 		"github.com/dagger/python@main:ruff",
 		"https://github.com/dagger/python@main:ruff",
 		"github.com/dagger/python#main:ruff",

--- a/engine/server/session_test.go
+++ b/engine/server/session_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/workspace"
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/clientdb"
 	"github.com/dagger/dagger/engine/engineutil"
@@ -2158,24 +2157,23 @@ func TestParseWorkspaceRemoteRef(t *testing.T) {
 func TestWorkspaceGitRefSelectorSemverSemantics(t *testing.T) {
 	t.Parallel()
 
-	ctx := dagql.ContextWithCall(t.Context(), &dagql.ResultCall{
-		View: call.View(workspace.VersionQueriesVersion),
-	})
 	for _, tc := range []struct {
-		name      string
-		selector  gitref.SelectorType
-		wantField string
+		name                   string
+		selector               gitref.SelectorType
+		supportsVersionQueries bool
+		wantField              string
 	}{
-		{name: "at selector uses semver query", selector: gitref.ModuleVersionSelector, wantField: "latest"},
-		{name: "fragment selector uses literal git ref", selector: gitref.GitRefSelector, wantField: "ref"},
+		{name: "at selector uses semver query", selector: gitref.ModuleVersionSelector, supportsVersionQueries: true, wantField: "latest"},
+		{name: "old client uses literal git ref", selector: gitref.ModuleVersionSelector, supportsVersionQueries: false, wantField: "ref"},
+		{name: "fragment selector uses literal git ref", selector: gitref.GitRefSelector, supportsVersionQueries: true, wantField: "ref"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			selector := workspaceGitRefSelector(ctx, workspaceRemoteRef{
+			selector := workspaceGitRefSelector(workspaceRemoteRef{
 				version:         "v1.2",
 				workspaceSubdir: "ruff",
 				selector:        tc.selector,
-			})
+			}, tc.supportsVersionQueries)
 			require.Equal(t, tc.wantField, selector.Field)
 			if tc.wantField == "latest" {
 				require.Equal(t, "version", selector.Args[0].Name)

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/gitref"
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/core/schema"
 	coresdk "github.com/dagger/dagger/core/sdk"
@@ -299,6 +300,7 @@ type workspaceRemoteRef struct {
 	cloneRef        string
 	version         string
 	workspaceSubdir string
+	selector        gitref.SelectorType
 }
 
 func parseWorkspaceRemoteRef(ctx context.Context, remoteRef string) (workspaceRemoteRef, error) {
@@ -310,23 +312,17 @@ func parseWorkspaceRemoteRefWithResolver(
 	remoteRef string,
 	resolve func(context.Context, string) (string, error),
 ) (workspaceRemoteRef, error) {
-	// Fragment refs are parsed via the same git URL parser used by Address.*.
+	// A # selector is the explicit Git URL form: protocol://repo#ref:subpath.
 	if strings.Contains(remoteRef, "#") {
-		gitURL, err := gitutil.ParseURL(remoteRef)
+		parsedRef, err := core.ParseGitRefString(ctx, remoteRef)
 		if err != nil {
 			return workspaceRemoteRef{}, err
 		}
-		version := ""
-		subdir := "."
-		if gitURL.Fragment != nil {
-			version = gitURL.Fragment.Ref
-			subdir = gitURL.Fragment.Subdir
-		}
-		workspaceSubdir, err := normalizeWorkspaceRemoteSubdir(subdir)
+		workspaceSubdir, err := normalizeWorkspaceRemoteSubdir(parsedRef.RepoRootSubdir)
 		if err != nil {
 			return workspaceRemoteRef{}, fmt.Errorf("invalid git subdir in workspace ref %q: %w", remoteRef, err)
 		}
-		cloneRef := gitURL.Remote()
+		cloneRef := parsedRef.SourceCloneRef
 		resolvedRef, err := resolve(ctx, cloneRef)
 		if err != nil {
 			return workspaceRemoteRef{}, err
@@ -348,12 +344,14 @@ func parseWorkspaceRemoteRefWithResolver(
 		}
 		return workspaceRemoteRef{
 			cloneRef:        cloneRef,
-			version:         version,
+			version:         parsedRef.ModVersion,
 			workspaceSubdir: workspaceSubdir,
+			selector:        parsedRef.Selector,
 		}, nil
 	}
 
-	// Preserve legacy @ref parsing semantics for existing workspace refs.
+	// The @ selector uses Go-like import path semantics, with any path after the
+	// repository root identifying the workspace subdirectory.
 	remoteRef, err := resolve(ctx, remoteRef)
 	if err != nil {
 		return workspaceRemoteRef{}, err
@@ -370,6 +368,7 @@ func parseWorkspaceRemoteRefWithResolver(
 		cloneRef:        parsedRef.SourceCloneRef,
 		version:         parsedRef.ModVersion,
 		workspaceSubdir: workspaceSubdir,
+		selector:        parsedRef.Selector,
 	}, nil
 }
 
@@ -395,7 +394,7 @@ func (srv *Server) loadWorkspaceFromRemote(ctx context.Context, client *daggerCl
 		return fmt.Errorf("remote workspace %q: parsing git ref: %w", remoteRef, err)
 	}
 
-	tree, gitRef, err := srv.cloneGitTree(ctx, client.dag, parsedRef.cloneRef, parsedRef.version)
+	tree, gitRef, err := srv.cloneGitTree(ctx, client.dag, parsedRef)
 	if err != nil {
 		return fmt.Errorf("remote workspace %q: %w", remoteRef, err)
 	}
@@ -1109,22 +1108,15 @@ func remoteWorkspaceAddress(cloneRef, workspaceCwd, version string) string {
 }
 
 // cloneGitTree clones a git repository and returns its selected ref and tree.
-func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef, version string) (dagql.ObjectResult[*core.Directory], dagql.ObjectResult[*core.GitRef], error) {
-	// Build the ref selector — use "head" if no version specified.
-	refSelector := dagql.Selector{Field: "head"}
-	if version != "" {
-		refSelector = dagql.Selector{
-			Field: "ref",
-			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(version)}},
-		}
-	}
+func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, remote workspaceRemoteRef) (dagql.ObjectResult[*core.Directory], dagql.ObjectResult[*core.GitRef], error) {
+	refSelector := workspaceGitRefSelector(ctx, remote)
 
 	var gitRef dagql.ObjectResult[*core.GitRef]
 	err := dag.Select(ctx, dag.Root(), &gitRef,
 		dagql.Selector{
 			Field: "git",
 			Args: []dagql.NamedInput{
-				{Name: "url", Value: dagql.String(cloneRef)},
+				{Name: "url", Value: dagql.String(remote.cloneRef)},
 			},
 		},
 		refSelector,
@@ -1146,6 +1138,36 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, cloneRef
 		return tree, gitRef, fmt.Errorf("cloning repo: %w", err)
 	}
 	return tree, gitRef, nil
+}
+
+func workspaceGitRefSelector(ctx context.Context, remote workspaceRemoteRef) dagql.Selector {
+	// Use HEAD without a selector and literal ref resolution unless an @
+	// selector contains a SemVer query supported by this API version.
+	refSelector := dagql.Selector{Field: "head"}
+	if remote.version != "" {
+		refSelector = dagql.Selector{
+			Field: "ref",
+			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(remote.version)}},
+		}
+		if remote.selector == gitref.ModuleVersionSelector &&
+			core.Supports(ctx, workspace.VersionQueriesVersion) &&
+			core.IsReleaseVersionQuery(remote.version) {
+			refSelector = dagql.Selector{
+				Field: "latest",
+				Args: []dagql.NamedInput{{
+					Name:  "version",
+					Value: dagql.String(remote.version),
+				}},
+			}
+			if remote.workspaceSubdir != "." {
+				refSelector.Args = append(refSelector.Args, dagql.NamedInput{
+					Name:  "tagPrefix",
+					Value: dagql.String(remote.workspaceSubdir),
+				})
+			}
+		}
+	}
+	return refSelector
 }
 
 // ensureModulesLoaded loads pending modules (workspace, compat, and -m) on

--- a/engine/server/session_workspaces.go
+++ b/engine/server/session_workspaces.go
@@ -1109,7 +1109,8 @@ func remoteWorkspaceAddress(cloneRef, workspaceCwd, version string) string {
 
 // cloneGitTree clones a git repository and returns its selected ref and tree.
 func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, remote workspaceRemoteRef) (dagql.ObjectResult[*core.Directory], dagql.ObjectResult[*core.GitRef], error) {
-	refSelector := workspaceGitRefSelector(ctx, remote)
+	supportsVersionQueries := core.AfterVersion(workspace.VersionQueriesVersion).Contains(dag.View)
+	refSelector := workspaceGitRefSelector(remote, supportsVersionQueries)
 
 	var gitRef dagql.ObjectResult[*core.GitRef]
 	err := dag.Select(ctx, dag.Root(), &gitRef,
@@ -1140,7 +1141,7 @@ func (srv *Server) cloneGitTree(ctx context.Context, dag *dagql.Server, remote w
 	return tree, gitRef, nil
 }
 
-func workspaceGitRefSelector(ctx context.Context, remote workspaceRemoteRef) dagql.Selector {
+func workspaceGitRefSelector(remote workspaceRemoteRef, supportsVersionQueries bool) dagql.Selector {
 	// Use HEAD without a selector and literal ref resolution unless an @
 	// selector contains a SemVer query supported by this API version.
 	refSelector := dagql.Selector{Field: "head"}
@@ -1150,7 +1151,7 @@ func workspaceGitRefSelector(ctx context.Context, remote workspaceRemoteRef) dag
 			Args:  []dagql.NamedInput{{Name: "name", Value: dagql.String(remote.version)}},
 		}
 		if remote.selector == gitref.ModuleVersionSelector &&
-			core.Supports(ctx, workspace.VersionQueriesVersion) &&
+			supportsVersionQueries &&
 			core.IsReleaseVersionQuery(remote.version) {
 			refSelector = dagql.Selector{
 				Field: "latest",


### PR DESCRIPTION
Closes #14045.

Module and workspace references parsed `@` and `#` inconsistently, so the same source could resolve differently depending on whether it was passed through `-m` or `-W`. This change gives both paths the same three version-bearing forms for the `ruff` subdirectory:

- `github.com/dagger/python/ruff@main`
- `https://github.com/dagger/python/ruff@main`
- `https://github.com/dagger/python#main:ruff`

The `@ref` forms use Go-like import-path semantics. When `ref` is a SemVer constraint, Dagger selects the greatest matching release using the version-query support merged in #14034. The `#ref[:subpath]` form requires an explicit protocol and repository URL; omitting the subpath selects the repository root, and its ref is always passed to Git literally, including when it looks like SemVer.

The parser retains the selector form in persisted module sources so a literal `#v1.2:subpath` ref cannot later be serialized as `@v1.2` and gain SemVer behavior. Workspace cloning uses the same selector distinction, and the other forms reported in #14045 are rejected consistently.

Validation:

- `go test ./core/gitref ./core ./core/schema ./engine/server -count=1`
- `dagger api call engine-dev test --pkg ./core/integration --run='TestWorkspace/TestWorkspaceModuleSettingsRuntime/git_refs_accept_at_separators_in_sources_and_settings'` (9 passed)
