### PR TITLE
feat(workspace): load modules from values

### DIFF
--- a/.changes/unreleased/Added-20260908-160000.yaml
+++ b/.changes/unreleased/Added-20260908-160000.yaml
@@ -1,0 +1,9 @@
+kind: Added
+body: |
+  Load checks, generators, services, terminals, and agents from modules in
+  `Directory.asWorkspace` and `GitRef.asWorkspace` values. Legacy toolchains
+  resolve default paths from the workspace tree, including pending edits.
+time: 2026-09-08T16:00:00Z
+custom:
+  Author: vito
+  PR: ""

--- a/core/integration/testdata/modules/go/legacy-default-path-reader/main.go
+++ b/core/integration/testdata/modules/go/legacy-default-path-reader/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"dagger/reader/internal/dagger"
 )
@@ -19,4 +21,19 @@ func New(
 
 func (m *Reader) Read(ctx context.Context) (string, error) {
 	return m.Source.File("workspace-marker.txt").Contents(ctx)
+}
+
+// CheckMarker asserts the +defaultPath context resolved from the consuming
+// workspace root ("from workspace root", the marker the legacy-default-path
+// tests write there) rather than this module's own source directory.
+// +check
+func (m *Reader) CheckMarker(ctx context.Context) error {
+	contents, err := m.Source.File("workspace-marker.txt").Contents(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(contents) != "from workspace root" {
+		return fmt.Errorf("unexpected marker: %q", contents)
+	}
+	return nil
 }

--- a/core/integration/workspace_legacy_default_path_test.go
+++ b/core/integration/workspace_legacy_default_path_test.go
@@ -113,6 +113,63 @@ legacy-default-path = true
 	require.NotContains(t, out, toolMarker)
 }
 
+// Value workspaces load legacy toolchains with their own root as the
+// +defaultPath context, including pending edits.
+func (WorkspaceLegacyDefaultPathSuite) TestToolchainDefaultPathResolvesFromValueWorkspace(ctx context.Context, t *testctx.T) {
+	const (
+		workspaceMarker = "from workspace root"
+		toolMarker      = "from tool module source"
+	)
+
+	c := connect(ctx, t)
+
+	readerFixture := c.Host().Directory(testDataPath(t, "modules", "go/legacy-default-path-reader"))
+	source := c.Directory().
+		WithNewFile("dagger.toml", `[modules.reader]
+source = "tool"
+legacy-default-path = true
+`).
+		WithNewFile("workspace-marker.txt", workspaceMarker).
+		WithDirectory("tool", readerFixture).
+		WithNewFile("tool/workspace-marker.txt", toolMarker)
+	daemon, url := gitService(ctx, t, c, source)
+	for _, tc := range []struct {
+		name string
+		ws   *dagger.Workspace
+	}{
+		{"directory", source.AsWorkspace()},
+		{"git", c.Git(url, dagger.GitOpts{ExperimentalServiceHost: daemon}).Branch("main").AsWorkspace()},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			ws := tc.ws
+			checks, err := ws.Checks().List(ctx)
+			require.NoError(t, err)
+			require.Len(t, checks, 1)
+			name, err := checks[0].Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "reader:check-marker", name)
+
+			passed, err := checks[0].Run().Passed(ctx)
+			require.NoError(t, err)
+			require.True(t, passed)
+
+			// The module code is unchanged, so only the context tree differs.
+			// Its content must distinguish module instances in the cache.
+			edited := ws.WithNewFile("workspace-marker.txt", "wrong marker")
+			editedChecks, err := edited.Checks().List(ctx)
+			require.NoError(t, err)
+			require.Len(t, editedChecks, 1)
+			passed, err = editedChecks[0].Run().Passed(ctx)
+			require.NoError(t, err)
+			require.False(t, passed)
+
+			passed, err = checks[0].Run().Passed(ctx)
+			require.NoError(t, err)
+			require.True(t, passed)
+		})
+	}
+}
+
 func legacyDefaultPathFixture(t testing.TB, c *dagger.Client, workspaceMarker, toolMarker string) *dagger.Container {
 	t.Helper()
 

--- a/core/integration/workspace_synthetic_test.go
+++ b/core/integration/workspace_synthetic_test.go
@@ -147,6 +147,139 @@ func (WorkspaceSuite) TestGitRefBackedSyntheticWorkspaceUsesSelectedRef(ctx cont
 	require.True(t, empty)
 }
 
+func (WorkspaceSuite) TestValueBackedWorkspaceLoadsModulesFromTree(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	const gitAgentDoc = "Agent loaded from the GitRef workspace tree."
+	source := c.Directory().
+		WithNewFile("dagger.toml", "[modules.git-agent]\nsource = \"./modules/git-agent\"\n").
+		WithNewFile("modules/git-agent/dagger.json", `{"name":"git-agent","engineVersion":"v1.0.0","sdk":"dang"}`).
+		WithNewFile("modules/git-agent/main.dang", `type GitAgent {
+  agent(base: LLM!): LLM! @agent {
+    base.withTools(currentNode)
+  }
+
+  """`+gitAgentDoc+`"""
+  fromGit(): String! {
+    "git"
+  }
+
+  verify: Void @check {
+    null
+  }
+
+  generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "generated").changes(workdir)
+  }
+
+  web: Service! @up {
+    container.from("nginx:alpine").asService
+  }
+
+  sandbox: Container! {
+    container.from("alpine")
+  }
+}
+`)
+	gitDaemon, repoURL := gitService(ctx, t, c, source)
+	for _, tc := range []struct {
+		name string
+		ws   *dagger.Workspace
+	}{
+		{"directory", source.AsWorkspace()},
+		{"git", c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).Head().AsWorkspace()},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			ws := tc.ws
+			modules, err := ws.Modules(ctx)
+			require.NoError(t, err)
+			require.Len(t, modules, 1)
+			name, err := modules[0].Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "git-agent", name)
+
+			tools, err := ws.Agents().Compose().Tools(ctx)
+			require.NoError(t, err)
+			require.Contains(t, tools, "## fromGit")
+			require.Contains(t, tools, gitAgentDoc)
+
+			checks, err := ws.Checks(dagger.WorkspaceChecksOpts{NoGenerate: true}).List(ctx)
+			require.NoError(t, err)
+			require.Len(t, checks, 1)
+			checkName, err := checks[0].Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "git-agent:verify", checkName)
+
+			generators, err := ws.Generators().List(ctx)
+			require.NoError(t, err)
+			require.Len(t, generators, 1)
+			generatorName, err := generators[0].Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "git-agent:generate", generatorName)
+
+			services, err := ws.Services().List(ctx)
+			require.NoError(t, err)
+			require.Len(t, services, 1)
+			serviceName, err := services[0].Name(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "git-agent:web", serviceName)
+
+			terminals, err := ws.Terminals().List(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, terminals)
+
+			passed, err := checks[0].Run().Passed(ctx)
+			require.NoError(t, err)
+			require.True(t, passed)
+		})
+	}
+}
+
+func (WorkspaceSuite) TestGitRefBackedSyntheticWorkspaceGeneratorLoadingIsBestEffort(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	source := c.Directory().
+		WithNewFile("dagger.toml", `[modules.good]
+source = "./modules/good"
+
+[modules.bad]
+source = "./modules/bad"
+`).
+		WithNewFile("modules/good/dagger.json", `{"name":"good","engineVersion":"v1.0.0","sdk":"dang"}`).
+		WithNewFile("modules/good/main.dang", `type Good {
+  generate(workdir: Directory! @defaultPath(path: ".")): Changeset! @generate {
+    workdir.withNewFile("generated.txt", "generated").changes(workdir)
+  }
+}
+`).
+		WithNewFile("modules/bad/dagger.json", `{"name":"bad","engineVersion":"v1.0.0","sdk":"dang"}`).
+		WithNewFile("modules/bad/main.dang", "this is not valid Dang")
+	gitDaemon, repoURL := gitService(ctx, t, c, source)
+	ws := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
+		Head().
+		AsWorkspace()
+
+	group := ws.Generators()
+	generators, err := group.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, generators, 1)
+	name, err := generators[0].Name(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "good:generate", name)
+
+	loadFailures, err := group.LoadFailures(ctx)
+	require.NoError(t, err)
+	require.Len(t, loadFailures, 1)
+	require.Contains(t, loadFailures[0], `module "bad"`)
+
+	_, err = ws.Checks().List(ctx)
+	require.ErrorContains(t, err, `module "bad"`)
+
+	selected, err := ws.Generators(dagger.WorkspaceGeneratorsOpts{Include: []string{"good"}}).List(ctx)
+	require.NoError(t, err)
+	require.Len(t, selected, 1)
+}
+
 // TestGitRefBackedSyntheticWorkspaceRoundTripsFromID asserts the simplest ID
 // contract for GitRef.asWorkspace: a workspace returned from a Git ref can be
 // saved as an ID, loaded again, and still reads files from that Git ref.

--- a/core/llm.go
+++ b/core/llm.go
@@ -1128,7 +1128,7 @@ func (q *Query) NewLLM(ctx context.Context, model, provider string) (*LLM, error
 	// binds currentWorkspace at session start, agent composition seeds the base
 	// from the workspace the group was rolled up from, and a module function
 	// returning an LLM threads a Workspace it was handed. An unbound LLM is
-	// valid — MCP.Server falls back to the current client's served deps —
+	// valid — MCP.baseServer falls back to the current client's served deps —
 	// so nothing here depends on the calling context's ambient workspace.
 	_ = ctx
 	return &LLM{

--- a/core/llm_object_tools.go
+++ b/core/llm_object_tools.go
@@ -394,7 +394,7 @@ func namespacedTypes(toolsets []bindingToolset) map[string]bool {
 // the report lets callers surface the renaming when composing several agents'
 // toolsets onto one LLM (hack/designs/workspace-agents.md §3).
 func (m *MCP) ToolNameCollisions(ctx context.Context) (map[string][]string, error) {
-	srv, err := m.Server(ctx)
+	srv, err := m.baseServer(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/core/llm_skills.go
+++ b/core/llm_skills.go
@@ -232,7 +232,7 @@ type directorySkillSource struct {
 }
 
 func (s directorySkillSource) enumerate(ctx context.Context) (map[string]discoveredSkill, error) {
-	srv, err := s.m.Server(ctx)
+	srv, err := s.m.baseServer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (s directorySkillSource) read(ctx context.Context, name, rel string) (strin
 		return "", errSkillNotFound
 	}
 	rel = skillFilePath(rel)
-	srv, err := s.m.Server(ctx)
+	srv, err := s.m.baseServer(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -279,7 +279,7 @@ func (s workspaceSkillSource) enumerate(ctx context.Context) (map[string]discove
 	if s.m.workspace.Self() == nil {
 		return nil, nil
 	}
-	srv, err := s.m.Server(ctx)
+	srv, err := s.m.baseServer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (s workspaceSkillSource) read(ctx context.Context, name, rel string) (strin
 		return "", errSkillNotFound
 	}
 	rel = skillFilePath(rel)
-	srv, err := s.m.Server(ctx)
+	srv, err := s.m.baseServer(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -82,11 +82,11 @@ func NewLLMToolSet() *LLMToolSet {
 // Internal implementation of the MCP standard,
 // for exposing a Dagger environment to a LLM via tool calling.
 type MCP struct {
-	// workspace is the Workspace the LLM is bound to, if any. It is the source of
-	// the LLM's schema (MCP.Server) and the target of workspace-mutating tool
-	// results (Changeset overlays); the binding also threads the workspace into
-	// tool dispatch so contextual (+defaultPath) and Workspace-typed args resolve
-	// against it.
+	// workspace is the Workspace the LLM is bound to, if any. It selects the
+	// base schema in baseServer and receives workspace-mutating tool results
+	// (Changeset overlays). The binding also threads the workspace into tool
+	// dispatch so contextual (+defaultPath) and Workspace-typed args resolve
+	// against it. Bound module tools retain their own defining schemas.
 	workspace dagql.ObjectResult[*Workspace]
 	// boundTools are the objects bound via LLM.withTools. Each eligible method of
 	// a bound object becomes a tool; a tool that returns the bound object's own
@@ -280,26 +280,30 @@ func (m *MCP) LastResult() dagql.Typed {
 	return m.lastResult
 }
 
-// Server returns the stable GraphQL schema used for core builtins and tool
-// dispatch. When the LLM is bound to a Workspace (via LLM.withWorkspace), it
-// uses that workspace's served snapshot but deliberately does not compile
-// pending overlay module edits. Bound object tools use the defining schemas
-// captured at composition; explicit recomposition is what adopts an overlay.
-// Without a workspace binding it falls back to the current client's served deps.
-func (m *MCP) Server(ctx context.Context) (*dagql.Server, error) {
-	if m.workspace.Self() != nil {
-		return WorkspaceServedSchema(ctx, m.workspace)
-	}
-	// No workspace bound (e.g. a synthetic context with no current workspace):
-	// fall back to the current client's served deps — the same schema the CLI
-	// serves.
+// baseServer provides the schema for core tools and dispatch. Bound module
+// tools retain their own defining schemas. Value workspaces use only core here;
+// their modules are loaded from their trees during explicit agent composition.
+func (m *MCP) baseServer(ctx context.Context) (*dagql.Server, error) {
 	query, err := CurrentQuery(ctx)
 	if err != nil {
 		return nil, err
 	}
-	deps, err := query.CurrentServedDeps(ctx)
+
+	var deps *SchemaBuilder
+	switch {
+	case m.workspace.Self() == nil:
+		deps, err = query.CurrentServedDeps(ctx)
+	case m.workspace.Self().IsValueWorkspace():
+		deps, err = query.DefaultDeps(ctx)
+	default:
+		ctx, err = loadWorkspaceOwnerContext(ctx, m.workspace)
+		if err != nil {
+			return nil, err
+		}
+		deps, err = query.CurrentServedDeps(ctx)
+	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load tool base schema dependencies: %w", err)
 	}
 	return deps.Schema(ctx)
 }
@@ -319,7 +323,7 @@ func (m *MCP) WithSkills(dir dagql.ObjectResult[*Directory]) *MCP {
 }
 
 func (m *MCP) Tools(ctx context.Context) ([]LLMTool, error) {
-	srv, err := m.Server(ctx)
+	srv, err := m.baseServer(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1436,7 +1440,7 @@ func (m *MCP) callBatchMCPServer(ctx context.Context, tools []LLMTool, toolCalls
 	if m.workspace.Self() == nil {
 		return m.callBatchRegular(ctx, tools, toolCalls, toolCallDisplays)
 	}
-	srv, err := m.Server(ctx)
+	srv, err := m.baseServer(ctx)
 	if err != nil {
 		return m.callBatchRegular(ctx, tools, toolCalls, toolCallDisplays)
 	}
@@ -1515,7 +1519,7 @@ func (m *MCP) callBatchChangesets(ctx context.Context, tools []LLMTool, toolCall
 	var mergeErr error
 	var conflictNote string
 	if len(changes) > 0 {
-		srv, err := m.Server(ctx)
+		srv, err := m.baseServer(ctx)
 		if err != nil {
 			mergeErr = err
 		} else if err := m.guardStateChange(); err != nil {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -865,6 +865,18 @@ type directoryAsModuleArgs struct {
 	SourceRootPath string `default:"."`
 }
 
+type directoryAsModuleSourceArgs struct {
+	SourceRootPath string `default:"."`
+
+	// AllowNotExists tolerates a directory holding no dagger config file at
+	// the source root, returning a context-only source (ConfigExists=false)
+	// instead of erroring. Used when the directory is needed purely as a
+	// +defaultPath context, e.g. a value workspace root that is a Workspace
+	// (dagger.toml), not a Module (dagger.json). Mirrors the tolerance local
+	// and git module sources already have.
+	AllowNotExists bool `internal:"true" default:"false"`
+}
+
 func (s *moduleSourceSchema) directoryAsModule(
 	ctx context.Context,
 	contextDir dagql.ObjectResult[*core.Directory],
@@ -892,7 +904,7 @@ func (s *moduleSourceSchema) directoryAsModule(
 func (s *moduleSourceSchema) directoryAsModuleSource(
 	ctx context.Context,
 	contextDir dagql.ObjectResult[*core.Directory],
-	args directoryAsModuleArgs,
+	args directoryAsModuleSourceArgs,
 ) (inst dagql.Result[*core.ModuleSource], err error) {
 	sourceRootSubpath := args.SourceRootPath
 	if sourceRootSubpath == "" {
@@ -919,7 +931,11 @@ func (s *moduleSourceSchema) directoryAsModuleSource(
 		return inst, fmt.Errorf("failed to find dir module config: %w", err)
 	}
 	if !found {
-		return inst, fmt.Errorf("dir module source does not contain a dagger config file")
+		if !args.AllowNotExists {
+			return inst, fmt.Errorf("dir module source does not contain a dagger config file")
+		}
+		dirSrc.ConfigExists = false
+		return dagql.NewResultForCurrentCall(ctx, dirSrc)
 	}
 	dirSrc.ConfigFilename = configFilename
 	if err := s.loadConfiguredModuleSource(ctx, dirSrc); err != nil {
@@ -3432,6 +3448,79 @@ func (s *moduleSourceSchema) moduleSourceImplementationScoped(
 	}
 	return inst.WithContentDigest(ctx, scopedDigest)
 }
+
+// resolveDefaultPathContextSource selects the context for legacy default paths
+// and its module cache variant. Value contexts take precedence over refs.
+func resolveDefaultPathContextSource(
+	ctx context.Context,
+	dag *dagql.Server,
+	src dagql.ObjectResult[*core.ModuleSource],
+	contextSource dagql.Optional[core.ModuleSourceID],
+	contextRef, contextPin string,
+) (dagql.ObjectResult[*core.ModuleSource], string, error) {
+	var err error
+	defaultPathContextSrc := src
+	switch {
+	case contextSource.Valid:
+		defaultPathContextSrc, err = contextSource.Value.Load(ctx, dag)
+		if err != nil {
+			return defaultPathContextSrc, "", fmt.Errorf("failed to load defaultPath context source: %w", err)
+		}
+	case contextRef != "":
+		contextSourceArgs := []dagql.NamedInput{
+			{Name: "refString", Value: dagql.String(contextRef)},
+			// The context source is used only as a +defaultPath context
+			// directory, never served as a module, so tolerate a ref with no
+			// dagger config file. A migrated workspace root is a Workspace
+			// (dagger.toml), not a Module (dagger.json); without this, a remote
+			// (git) workspace fails to resolve legacy-default-path modules while
+			// a local one succeeds (local module sources already tolerate this).
+			{Name: "allowNotExists", Value: dagql.Boolean(true)},
+		}
+		if contextPin != "" {
+			contextSourceArgs = append(contextSourceArgs, dagql.NamedInput{
+				Name: "refPin", Value: dagql.String(contextPin),
+			})
+		}
+		err = dag.Select(ctx, dag.Root(), &defaultPathContextSrc, dagql.Selector{
+			Field: "moduleSource",
+			Args:  contextSourceArgs,
+		})
+		if err != nil {
+			return defaultPathContextSrc, "", fmt.Errorf("failed to load defaultPath context source: %w", err)
+		}
+	}
+	defaultPathContextSourceVariant := ""
+	switch {
+	case contextSource.Valid:
+		// A source passed by ID may not carry a recipe digest (handle-form
+		// IDs), and a Dir source has no ref string, so key the variant on the
+		// context tree's content instead.
+		if contextDir := defaultPathContextSrc.Self().ContextDirectory; contextDir.Self() != nil {
+			var contextDirDigest string
+			if err := dag.Select(ctx, contextDir, &contextDirDigest, dagql.Selector{Field: "digest"}); err != nil {
+				return defaultPathContextSrc, "", fmt.Errorf("defaultPath context source digest: %w", err)
+			}
+			defaultPathContextSourceVariant = hashutil.HashStrings(
+				"defaultPathContextSource",
+				contextDirDigest,
+			).String()
+		} else {
+			defaultPathContextSourceVariant = hashutil.HashStrings(
+				"defaultPathContextSource",
+				defaultPathContextSrc.Self().AsString(),
+				defaultPathContextSrc.Self().Pin(),
+			).String()
+		}
+	case contextRef != "":
+		defaultPathContextSourceVariant = hashutil.HashStrings(
+			contextRef,
+			contextPin,
+		).String()
+	}
+	return defaultPathContextSrc, defaultPathContextSourceVariant, nil
+}
+
 func (s *moduleSourceSchema) moduleSourceAsModule(
 	ctx context.Context,
 	src dagql.ObjectResult[*core.ModuleSource],
@@ -3470,6 +3559,14 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 
 		// DefaultPathContextSourcePin pins DefaultPathContextSourceRef when set.
 		DefaultPathContextSourcePin string `internal:"true" default:""`
+
+		// DefaultPathContextSource supplies an already-resolved source whose
+		// tree +defaultPath inputs resolve from, taking precedence over
+		// DefaultPathContextSourceRef. Value workspaces pass their own
+		// (possibly overlaid) root tree this way: no ref string names it, and
+		// a frozen workspace's commits may exist nowhere a ref could fetch
+		// from.
+		DefaultPathContextSource dagql.Optional[core.ModuleSourceID] `internal:"true"`
 	},
 ) (inst dagql.ObjectResult[*core.Module], err error) {
 	dag, err := core.CurrentDagqlServer(ctx)
@@ -3494,30 +3591,12 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 
 	originalSrc := src
 	execSrc := src
-	defaultPathContextSrc := src
-	if args.DefaultPathContextSourceRef != "" {
-		contextSourceArgs := []dagql.NamedInput{
-			{Name: "refString", Value: dagql.String(args.DefaultPathContextSourceRef)},
-			// The context source is used only as a +defaultPath context
-			// directory, never served as a module, so tolerate a ref with no
-			// dagger config file. A migrated workspace root is a Workspace
-			// (dagger.toml), not a Module (dagger.json); without this, a remote
-			// (git) workspace fails to resolve legacy-default-path modules while
-			// a local one succeeds (local module sources already tolerate this).
-			{Name: "allowNotExists", Value: dagql.Boolean(true)},
-		}
-		if args.DefaultPathContextSourcePin != "" {
-			contextSourceArgs = append(contextSourceArgs, dagql.NamedInput{
-				Name: "refPin", Value: dagql.String(args.DefaultPathContextSourcePin),
-			})
-		}
-		err = dag.Select(ctx, dag.Root(), &defaultPathContextSrc, dagql.Selector{
-			Field: "moduleSource",
-			Args:  contextSourceArgs,
-		})
-		if err != nil {
-			return inst, fmt.Errorf("failed to load defaultPath context source: %w", err)
-		}
+	defaultPathContextSrc, defaultPathContextSourceVariant, err := resolveDefaultPathContextSource(
+		ctx, dag, src, args.DefaultPathContextSource,
+		args.DefaultPathContextSourceRef, args.DefaultPathContextSourcePin,
+	)
+	if err != nil {
+		return inst, err
 	}
 	if src.Self().Blueprint.Self() != nil {
 		execSrc = src.Self().Blueprint
@@ -3564,13 +3643,6 @@ func (s *moduleSourceSchema) moduleSourceAsModule(
 	// apply ForceDefaultFunctionCaching if requested
 	if args.ForceDefaultFunctionCaching {
 		mod.DisableDefaultFunctionCaching = false
-	}
-	defaultPathContextSourceVariant := ""
-	if args.DefaultPathContextSourceRef != "" {
-		defaultPathContextSourceVariant = hashutil.HashStrings(
-			args.DefaultPathContextSourceRef,
-			args.DefaultPathContextSourcePin,
-		).String()
 	}
 	// Keep the per-session content cache distinct for module variants produced
 	// from the same source with different internal asModule options.

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -1090,10 +1090,6 @@ func requireLocalWorkspace(ws *core.Workspace, operation string) error {
 	return nil
 }
 
-func isSyntheticWorkspace(ws *core.Workspace) bool {
-	return ws != nil && ws.IsValueWorkspace()
-}
-
 func workspaceFilterWithDirectoryArgs(dirID *call.ID, filter core.CopyFilter, gitignore bool) []dagql.NamedInput {
 	withDirArgs := []dagql.NamedInput{
 		{Name: "path", Value: dagql.NewString("/")},
@@ -3638,9 +3634,6 @@ func (s *workspaceSchema) checks(
 	},
 ) (*core.CheckGroup, error) {
 	parent := parentResult.Self()
-	if isSyntheticWorkspace(parent) {
-		return &core.CheckGroup{}, nil
-	}
 
 	include := workspaceIncludePatterns(args.Include)
 	skip := workspaceIncludePatterns(args.Skip)
@@ -3662,10 +3655,7 @@ func (s *workspaceSchema) checks(
 	}
 
 	// check is strict: a module that can't load is a failure, by design.
-	if _, err := ensureWorkspaceModulesLoaded(ctx, include, false); err != nil {
-		return nil, err
-	}
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, _, err := s.workspacePrimaryModules(ctx, parentResult, include, false)
 	if err != nil {
 		return nil, err
 	}
@@ -3764,9 +3754,6 @@ func (s *workspaceSchema) generators(
 	},
 ) (*core.GeneratorGroup, error) {
 	parent := parentResult.Self()
-	if isSyntheticWorkspace(parent) {
-		return &core.GeneratorGroup{}, nil
-	}
 
 	include := workspaceIncludePatterns(args.Include)
 
@@ -3792,11 +3779,7 @@ func (s *workspaceSchema) generators(
 	// is skipped with a warning instead of failing the whole run, and its
 	// failure message is carried on loadFailures so the CLI can honor
 	// --require-load.
-	loadFailures, err := ensureWorkspaceModulesLoaded(ctx, include, true)
-	if err != nil {
-		return nil, err
-	}
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, loadFailures, err := s.workspacePrimaryModules(ctx, parentResult, include, true)
 	if err != nil {
 		return nil, err
 	}
@@ -3919,9 +3902,6 @@ func (s *workspaceSchema) services(
 	},
 ) (*core.UpGroup, error) {
 	parent := parentResult.Self()
-	if isSyntheticWorkspace(parent) {
-		return &core.UpGroup{}, nil
-	}
 
 	include := workspaceIncludePatterns(args.Include)
 
@@ -3931,10 +3911,7 @@ func (s *workspaceSchema) services(
 	}
 
 	// up is strict: a module that can't load is a failure, by design.
-	if _, err := ensureWorkspaceModulesLoaded(ctx, include, false); err != nil {
-		return nil, err
-	}
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, _, err := s.workspacePrimaryModules(ctx, parentResult, include, false)
 	if err != nil {
 		return nil, err
 	}
@@ -4013,10 +3990,6 @@ func (s *workspaceSchema) terminals(
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
 	},
 ) (*core.TerminalGroup, error) {
-	if isSyntheticWorkspace(parentResult.Self()) {
-		return &core.TerminalGroup{}, nil
-	}
-
 	allTerminals, err := collectWorkspaceModuleTargets(
 		ctx,
 		s,
@@ -4041,10 +4014,6 @@ func (s *workspaceSchema) agents(
 		Include dagql.Optional[dagql.ArrayInput[dagql.String]]
 	},
 ) (*core.AgentGroup, error) {
-	if isSyntheticWorkspace(parentResult.Self()) {
-		return &core.AgentGroup{}, nil
-	}
-
 	allAgents, err := collectWorkspaceModuleTargets(
 		ctx,
 		s,
@@ -4069,12 +4038,12 @@ func (s *workspaceSchema) workspaceTargetModules(
 	parentResult dagql.ObjectResult[*core.Workspace],
 	include []string,
 ) ([]dagql.ObjectResult[*core.Module], error) {
-	if _, err := ensureWorkspaceModulesLoaded(ctx, include, false); err != nil {
-		return nil, err
-	}
-	mods, err := currentWorkspacePrimaryModules(ctx)
+	mods, _, err := s.workspacePrimaryModules(ctx, parentResult, include, false)
 	if err != nil {
 		return nil, err
+	}
+	if parentResult.Self().IsValueWorkspace() {
+		return mods, nil
 	}
 
 	// The served modules above are the workspace as it was on disk when the
@@ -4449,6 +4418,9 @@ func (s *workspaceSchema) withWorkspaceHostReadContext(ctx context.Context, ws *
 // workspace's owning client ID. This ensures host filesystem operations route
 // through the correct client session, even when called from a module context.
 func withWorkspaceClientContext(ctx context.Context, ws *core.Workspace) (context.Context, error) {
+	if ws.IsValueWorkspace() {
+		return ctx, nil
+	}
 	if ws.ClientID == "" {
 		return nil, fmt.Errorf("workspace has no client ID")
 	}

--- a/core/schema/workspace_config.go
+++ b/core/schema/workspace_config.go
@@ -256,6 +256,9 @@ type workspaceConfigKeyArgs struct {
 }
 
 func selectedWorkspaceEnv(ctx context.Context, ws *core.Workspace) (string, bool) {
+	if ws != nil && ws.IsValueWorkspace() {
+		return ws.SelectedEnv(), ws.SelectedEnv() != ""
+	}
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err == nil && clientMetadata.WorkspaceEnv != nil && *clientMetadata.WorkspaceEnv != "" {
 		return *clientMetadata.WorkspaceEnv, true

--- a/core/schema/workspace_overlay_modules.go
+++ b/core/schema/workspace_overlay_modules.go
@@ -22,6 +22,33 @@ type overlayModule struct {
 	mod  dagql.ObjectResult[*core.Module]
 }
 
+// workspacePrimaryModules loads frozen workspaces from their own tree. A
+// value has no client module registry and must not borrow the caller's modules.
+func (s *workspaceSchema) workspacePrimaryModules(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	include []string,
+	bestEffort bool,
+) ([]dagql.ObjectResult[*core.Module], []core.ModuleLoadFailure, error) {
+	if parent.Self().IsValueWorkspace() {
+		loaded, failures, err := s.workspaceOverlayModulesWithLoadFailures(ctx, parent, include, bestEffort)
+		if err != nil {
+			return nil, nil, err
+		}
+		mods := make([]dagql.ObjectResult[*core.Module], len(loaded))
+		for i, mod := range loaded {
+			mods[i] = mod.mod
+		}
+		return mods, failures, nil
+	}
+	failures, err := ensureWorkspaceModulesLoaded(ctx, include, bestEffort)
+	if err != nil {
+		return nil, nil, err
+	}
+	mods, err := currentWorkspacePrimaryModules(ctx)
+	return mods, failures, err
+}
+
 // workspaceOverlayModules loads the workspace modules that the workspace's
 // pending overlay affects, resolving their source through the overlay instead
 // of the host checkout.
@@ -40,50 +67,63 @@ type overlayModule struct {
 // Only entries the overlay actually touches are re-resolved; everything else
 // keeps using the served module, so a clean workspace (or one whose edits are
 // unrelated to any module) behaves exactly as before.
+// Frozen value workspaces have no served modules: all their entries are loaded
+// from their own tree, even without an overlay.
 //
-// Known limitations, deliberate for now:
+// Known limitations of the live overlay path, deliberate for now:
 //   - an entry REMOVED from dagger.toml in the overlay still resolves through
 //     the served module: this only ever adds or replaces.
-//   - legacy +defaultPath entries (entry.LegacyDefaultPath) are left to the
-//     served path, whose host-ref based context resolution has no overlay
-//     equivalent.
+//   - for live workspaces, legacy +defaultPath entries (entry.LegacyDefaultPath)
+//     are left to the served path, whose host-ref based context resolution has
+//     no overlay equivalent. Value workspaces load them here, with their own
+//     tree as the +defaultPath context (see workspaceOverlayContextSource).
 func (s *workspaceSchema) workspaceOverlayModules(
 	ctx context.Context,
 	parent dagql.ObjectResult[*core.Workspace],
 	include []string,
 ) ([]overlayModule, error) {
+	loaded, _, err := s.workspaceOverlayModulesWithLoadFailures(ctx, parent, include, false)
+	return loaded, err
+}
+
+func (s *workspaceSchema) workspaceOverlayModulesWithLoadFailures(
+	ctx context.Context,
+	parent dagql.ObjectResult[*core.Workspace],
+	include []string,
+	bestEffort bool,
+) ([]overlayModule, []core.ModuleLoadFailure, error) {
 	ws := parent.Self()
 	if ws == nil || ws.ConfigFile == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
-	if _, ok := ws.OverlayChanges(); !ok {
-		return nil, nil
+	if _, ok := ws.OverlayChanges(); !ok && !ws.IsValueWorkspace() {
+		return nil, nil, nil
 	}
 
 	configFile, err := workspaceConfigFile(ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	configDir, err := workspaceConfigDirectory(ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// A config edit can add, remove or repoint any entry, so every entry is
 	// suspect; otherwise only the entries whose source tree was edited are.
-	configTouched := ws.OverlayPathTouched(configFile)
+	configTouched := ws.IsValueWorkspace() || ws.OverlayPathTouched(configFile)
 
 	cfg, err := readWorkspaceConfig(ctx, ws)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if envName, ok := selectedWorkspaceEnv(ctx, ws); ok {
 		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	if len(cfg.Modules) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	names := make([]string, 0, len(cfg.Modules))
@@ -99,10 +139,14 @@ func (s *workspaceSchema) workspaceOverlayModules(
 
 	srv, err := core.CurrentDagqlServer(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var loaded []overlayModule
+	var failures []core.ModuleLoadFailure
+	// The +defaultPath context for legacy entries, resolved lazily so
+	// workspaces with no such entries never materialize their root tree.
+	var legacyContextSource dagql.Optional[core.ModuleSourceID]
 	for _, name := range names {
 		if wanted != nil {
 			if _, ok := wanted[canonicalOverlayModuleName(name)]; !ok {
@@ -115,39 +159,120 @@ func (s *workspaceSchema) workspaceOverlayModules(
 		if sdkProviders[name] && coresdk.IsBuiltinSDKName(entry.Source) {
 			continue
 		}
-		if entry.LegacyDefaultPath {
+		// Legacy +defaultPath entries resolve their context from the
+		// workspace root. A live workspace leaves them to the served path,
+		// whose host-ref based context resolution has no overlay equivalent;
+		// a value workspace has no served path at all, so its own tree is
+		// supplied as the context instead.
+		if entry.LegacyDefaultPath && !ws.IsValueWorkspace() {
 			continue
 		}
 
-		src, relevant, err := s.workspaceOverlayModuleSource(ctx, srv, parent, entry, configDir, configTouched)
+		mod, relevant, err := func() (mod dagql.ObjectResult[*core.Module], _ bool, _ error) {
+			src, relevant, err := s.workspaceOverlayModuleSource(ctx, srv, parent, entry, configDir, configTouched)
+			if err != nil {
+				return mod, false, fmt.Errorf("module %q: %w", name, err)
+			}
+			if !relevant {
+				return mod, false, nil
+			}
+
+			mod, err = s.workspaceOverlayAsModule(ctx, srv, parent, src, name, entry, cfg.DefaultsFromDotEnv, &legacyContextSource)
+			return mod, true, err
+		}()
 		if err != nil {
-			return nil, fmt.Errorf("module %q: %w", name, err)
+			if !bestEffort {
+				return nil, nil, err
+			}
+			failure := core.ModuleLoadFailure{Name: name, Message: core.DescribeLoadFailure(err)}
+			if core.FastModuleSourceKindCheck(entry.Source, "") == core.ModuleSourceKindLocal {
+				failure.Dir = filepath.ToSlash(workspace.ResolveModuleEntrySource(configDir, entry.Source))
+			}
+			failures = append(failures, failure)
+			continue
 		}
 		if !relevant {
 			continue
 		}
-
-		asModuleArgs, err := BuildLegacyAsModuleArgs(
-			name,
-			false, // legacy +defaultPath entries are skipped above
-			"", "",
-			entry.Settings,
-			cfg.DefaultsFromDotEnv,
-			nil,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("module %q: %w", name, err)
-		}
-
-		var mod dagql.ObjectResult[*core.Module]
-		if err := srv.Select(ctx, src, &mod,
-			dagql.Selector{Field: "asModule", Args: asModuleArgs},
-		); err != nil {
-			return nil, fmt.Errorf("module %q: load from workspace overlay: %w", name, err)
-		}
 		loaded = append(loaded, overlayModule{name: name, mod: mod})
 	}
-	return loaded, nil
+	return loaded, failures, nil
+}
+
+// workspaceOverlayAsModule applies workspace settings and the shared legacy
+// context before instantiating a module from its resolved source.
+func (s *workspaceSchema) workspaceOverlayAsModule(
+	ctx context.Context,
+	srv *dagql.Server,
+	parent dagql.ObjectResult[*core.Workspace],
+	src dagql.ObjectResult[*core.ModuleSource],
+	name string,
+	entry workspace.ModuleEntry,
+	defaultsFromDotEnv bool,
+	legacyContextSource *dagql.Optional[core.ModuleSourceID],
+) (mod dagql.ObjectResult[*core.Module], _ error) {
+	asModuleArgs, err := BuildLegacyAsModuleArgs(
+		name,
+		entry.LegacyDefaultPath,
+		"", "",
+		entry.Settings,
+		defaultsFromDotEnv,
+		nil,
+	)
+	if err != nil {
+		return mod, fmt.Errorf("module %q: %w", name, err)
+	}
+	if entry.LegacyDefaultPath {
+		if !legacyContextSource.Valid {
+			*legacyContextSource, err = s.workspaceOverlayContextSource(ctx, srv, parent)
+			if err != nil {
+				return mod, fmt.Errorf("module %q: workspace +defaultPath context: %w", name, err)
+			}
+		}
+		asModuleArgs = append(asModuleArgs, dagql.NamedInput{
+			Name: "defaultPathContextSource", Value: *legacyContextSource,
+		})
+	}
+
+	if err := srv.Select(ctx, src, &mod,
+		dagql.Selector{Field: "asModule", Args: asModuleArgs},
+	); err != nil {
+		return mod, fmt.Errorf("module %q: load from workspace overlay: %w", name, err)
+	}
+	return mod, nil
+}
+
+// workspaceOverlayContextSource resolves the workspace root tree — overlay
+// included — as a context-only module source for legacy +defaultPath entries.
+// The root holds a Workspace config (dagger.toml), not a Module config, so the
+// source tolerates the missing dagger config file. Resolving from the tree
+// rather than a ref string keeps engine-side commits and pending overlay edits
+// in the context: a frozen workspace's history may exist nowhere a ref string
+// could fetch from.
+func (s *workspaceSchema) workspaceOverlayContextSource(
+	ctx context.Context,
+	srv *dagql.Server,
+	parent dagql.ObjectResult[*core.Workspace],
+) (none dagql.Optional[core.ModuleSourceID], _ error) {
+	root, err := s.workspaceOverlayRootfs(ctx, parent.Self())
+	if err != nil {
+		return none, err
+	}
+	var src dagql.ObjectResult[*core.ModuleSource]
+	if err := srv.Select(ctx, root, &src, dagql.Selector{
+		Field: "asModuleSource",
+		Args: []dagql.NamedInput{
+			{Name: "sourceRootPath", Value: dagql.String(".")},
+			{Name: "allowNotExists", Value: dagql.Boolean(true)},
+		},
+	}); err != nil {
+		return none, err
+	}
+	id, err := src.ID()
+	if err != nil {
+		return none, err
+	}
+	return dagql.Opt(dagql.NewID[*core.ModuleSource](id)), nil
 }
 
 // workspaceOverlayModuleSource resolves one config entry's module source, and
@@ -185,6 +310,9 @@ func (s *workspaceSchema) workspaceOverlayModuleSource(
 		}
 		if !configTouched {
 			return src, false, nil
+		}
+		if ws.IsValueWorkspace() {
+			return src, false, fmt.Errorf("module source %q is outside the frozen workspace", resolved)
 		}
 		return s.rootModuleSource(ctx, srv, resolved)
 	}

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -174,7 +174,12 @@ func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace
 	if err != nil {
 		return nil, err
 	}
-	deps, err := query.CurrentServedDeps(wsCtx)
+	var deps *SchemaBuilder
+	if ws.Self().IsValueWorkspace() {
+		deps, err = query.DefaultDeps(wsCtx)
+	} else {
+		deps, err = query.CurrentServedDeps(wsCtx)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("workspace served deps: %w", err)
 	}
@@ -189,6 +194,9 @@ func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace
 // callers that resolve those root fields directly (e.g. the LLM's inspect tool
 // enumerating module entrypoints) resolve them against the same workspace.
 func WorkspaceServedContext(ctx context.Context, ws dagql.ObjectResult[*Workspace]) (context.Context, error) {
+	if ws.Self().IsValueWorkspace() {
+		return ctx, nil
+	}
 	wsCtx, err := workspaceClientContext(ctx, ws.Self())
 	if err != nil {
 		return nil, err

--- a/core/workspace_context.go
+++ b/core/workspace_context.go
@@ -138,14 +138,11 @@ func boundWorkspaceInput(ctx context.Context, srv *dagql.Server, arg dagql.Input
 	return val, true
 }
 
-// workspaceClientContext switches ctx to the Workspace's owning client so that
-// client-scoped resolvers — CurrentServedDeps, EnsureWorkspaceModules — resolve
-// against the workspace's own served modules rather than whichever client is
-// currently executing. Synthetic/value workspaces have no owning client, so ctx
-// is returned unchanged and resolution falls back to the current client.
+// workspaceClientContext switches ctx to a live Workspace's owning client so
+// client-scoped resolvers use that client's served modules. Callers handle
+// value workspaces separately because they have no owning client.
 //
-// This mirrors core/schema's withWorkspaceClientContext, reimplemented here so
-// the LLM's schema derivation ([WorkspaceServedSchema]) needs no core→schema
+// This mirrors core/schema's withWorkspaceClientContext without a core→schema
 // import.
 func workspaceClientContext(ctx context.Context, ws *Workspace) (context.Context, error) {
 	if ws.ClientID == "" {
@@ -162,41 +159,10 @@ func workspaceClientContext(ctx context.Context, ws *Workspace) (context.Context
 	return engine.ContextWithClientMetadata(ctx, clientMetadata), nil
 }
 
-// WorkspaceServedSchema returns the stable served GraphQL schema for a
-// Workspace. Pending overlays are resolved only by explicit agent
-// recomposition; bound object tools retain the schema that defined them.
-func WorkspaceServedSchema(ctx context.Context, ws dagql.ObjectResult[*Workspace]) (*dagql.Server, error) {
-	wsCtx, err := WorkspaceServedContext(ctx, ws)
-	if err != nil {
-		return nil, err
-	}
-	query, err := CurrentQuery(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var deps *SchemaBuilder
-	if ws.Self().IsValueWorkspace() {
-		deps, err = query.DefaultDeps(wsCtx)
-	} else {
-		deps, err = query.CurrentServedDeps(wsCtx)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("workspace served deps: %w", err)
-	}
-	return deps.Schema(wsCtx)
-}
-
-// WorkspaceServedContext switches ctx to the Workspace's owning client and
-// forces its served modules to load, returning the switched context. Under this
-// context the client-scoped resolvers (CurrentServedDeps, currentTypeDefs,
-// currentModule) see the workspace's OWN served schema — the same switch
-// [WorkspaceServedSchema] makes for the schema server, exposed separately so
-// callers that resolve those root fields directly (e.g. the LLM's inspect tool
-// enumerating module entrypoints) resolve them against the same workspace.
-func WorkspaceServedContext(ctx context.Context, ws dagql.ObjectResult[*Workspace]) (context.Context, error) {
-	if ws.Self().IsValueWorkspace() {
-		return ctx, nil
-	}
+// loadWorkspaceOwnerContext switches to a live Workspace's owning client and
+// loads its served modules. MCP.baseServer calls this only for live workspaces;
+// value workspaces use core directly and never load the caller's modules.
+func loadWorkspaceOwnerContext(ctx context.Context, ws dagql.ObjectResult[*Workspace]) (context.Context, error) {
 	wsCtx, err := workspaceClientContext(ctx, ws.Self())
 	if err != nil {
 		return nil, err

--- a/hack/designs/workspace-agents.md
+++ b/hack/designs/workspace-agents.md
@@ -12,12 +12,13 @@ working docs for the individual pieces (the LLM object-tools proposal, the
 The LLM operates on the same `core.Workspace` a CLI user sees — not a separate
 I/O construct:
 
-- `LLM.withWorkspace` / `LLM.workspace` bind the workspace; `Query.llm` seeds
-  the client's current workspace by default, so every LLM starts bound.
-- The **schema the model sees derives from the bound workspace**
-  (`WorkspaceServedSchema`, `core/workspace_context.go`): the workspace's served
-  modules, exactly what the Dagger CLI would serve for that workspace — not the
-  outer client's schema.
+- `LLM.withWorkspace` / `LLM.workspace` bind the workspace explicitly.
+  `Query.llm` starts unbound; the CLI and agent composition select a workspace.
+- `MCP.baseServer` (`core/mcp.go`) selects the **base schema for core tools and
+  dispatch**: the current client's served modules when unbound, the owning
+  client's served modules for a live workspace, or just core for a value
+  workspace. Value-workspace modules load from their trees during explicit
+  agent composition. Bound object tools retain their own defining schemas.
 - The LLM's edits stage into the workspace's in-memory **overlay**
   (`Workspace.withChanges` etc., from the workspace overlay & export branch); a
   single `Workspace.export` writes the accumulated diff to the local checkout.


### PR DESCRIPTION
`Directory.asWorkspace` and `GitRef.asWorkspace` currently return empty checks, generators, services, terminals, and agents even when their trees contain configured modules. Load those modules from the value's own tree and use its schema and environment when resolving targets.

Legacy toolchains resolve `+defaultPath` from the workspace root, including pending edits. Pass that context as a module source ID and key module variants by the context tree's content, so editing workspace inputs cannot reuse a module bound to the previous tree. Generator loading reports broken modules and continues with healthy ones; check loading remains strict.

`MCP.baseServer` makes the base-schema choice explicit: the current client's served dependencies when unbound, the owner's served dependencies for live workspaces, and core dependencies for value workspaces. Bound module tools retain their own defining schemas.

This extracts value-module loading from #14056 so it can land independently of checkpoint capture, commits, and push. It also closes a legacy-toolchain gap present in the original implementation.

Validation:

- [Focused integration tests](https://dagger.cloud/dagger/traces/7b16daca0be34745bc1c1ec6682eda60) passed on the final implementation: module discovery and execution, agent composition, legacy contexts with pending edits, and best-effort generator loading with include filtering.
- [Synthetic-workspace and existing legacy-context regressions](https://dagger.cloud/dagger/traces/f41c2ea435b6b579b06e347e40b13114) passed before the helper extraction for lint.
- [Agent composition regressions](https://dagger.cloud/dagger/traces/7447f6742ca92d98c16563a6b9aeee7b) passed after the MCP refactor, covering live workspaces, Git/Directory value workspaces, workspace-bound seeds, and empty selections.
- `dagger check golang:lint-all` and `git diff --check` passed.

