### PR TITLE
test: skip failing workspace module and command hint tests

### DIFF
--- a/core/integration/command_hints_test.go
+++ b/core/integration/command_hints_test.go
@@ -53,6 +53,7 @@ func (CommandHintsSuite) TestEmptySetupHint(ctx context.Context, t *testctx.T) {
 // `dagger generate`: it runs the SDK's generators itself, so the bindings are
 // already there (dagger/dagger#13714).
 func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t *testctx.T) {
+	t.Skip("FIXME: currently failing on main; re-enable once fixed")
 	workdir := t.TempDir()
 	initGitRepo(ctx, t, workdir)
 
@@ -77,6 +78,7 @@ func (CommandHintsSuite) TestSDKInstallAndClientInitHints(ctx context.Context, t
 // the SDK in the capability hints. The install name of a full ref is derived
 // engine-side, so the CLI only learns it back from the install.
 func (CommandHintsSuite) TestSDKInstallFullRefHints(ctx context.Context, t *testctx.T) {
+	t.Skip("FIXME: currently failing on main; re-enable once fixed")
 	workdir := t.TempDir()
 	initGitRepo(ctx, t, workdir)
 

--- a/core/integration/workspace_modules_test.go
+++ b/core/integration/workspace_modules_test.go
@@ -35,6 +35,7 @@ func TestWorkspaceModules(t *testing.T) {
 // TestWorkspaceModuleInstall covers module installation through both the CLI
 // and the Workspace overlay/export API.
 func (WorkspaceModulesSuite) TestWorkspaceModuleInstall(ctx context.Context, t *testctx.T) {
+	t.Skip("FIXME: currently failing on main; re-enable once fixed")
 	t.Run("module init creates its explicit path with standard permissions", func(ctx context.Context, t *testctx.T) {
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
@@ -253,6 +254,7 @@ entrypoint = true
 // TestWorkspaceModuleUninstall should cover removing modules from a workspace,
 // via both `dagger uninstall` and the `dagger mod uninstall` alias.
 func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t *testctx.T) {
+	t.Skip("FIXME: currently failing on main; re-enable once fixed")
 	t.Run("uninstall removes a module from config", func(ctx context.Context, t *testctx.T) {
 		workdir := t.TempDir()
 		depDir := filepath.Join(workdir, "dep")
@@ -340,6 +342,7 @@ func (WorkspaceModulesSuite) TestWorkspaceModuleUninstall(ctx context.Context, t
 // TestWorkspaceModuleGenerate covers generation for modules registered in a
 // workspace.
 func (WorkspaceModulesSuite) TestWorkspaceModuleGenerate(ctx context.Context, t *testctx.T) {
+	t.Skip("FIXME: currently failing on main; re-enable once fixed")
 	setupSDKManagedGoModule := func(ctx context.Context, t *testctx.T) (string, string) {
 		workdir := t.TempDir()
 		initGitRepo(ctx, t, workdir)
@@ -551,6 +554,7 @@ func readInstalledWorkspaceConfig(t *testctx.T, workdir string) *workspacecfg.Co
 // engine-owned changes here — dagger-module.toml missing, or myapp absent
 // from dagger.toml — is the historical failure shape.
 func (WorkspaceModulesSuite) TestWorkspaceModuleInitConcurrent(ctx context.Context, t *testctx.T) {
+	t.Skip("FIXME: currently failing on main; re-enable once fixed")
 	for i := range 12 {
 		t.Run(fmt.Sprintf("init %d", i), func(ctx context.Context, t *testctx.T) {
 			workdir := t.TempDir()


### PR DESCRIPTION
## Summary

These integration subtests are currently failing on `main`. This skips them with `t.Skip` so the exclusion applies whether the tests run through `test-split` or directly with `go test`:

- `TestWorkspaceModules/TestWorkspaceModuleInstall`
- `TestWorkspaceModules/TestWorkspaceModuleUninstall`
- `TestWorkspaceModules/TestWorkspaceModuleGenerate`
- `TestWorkspaceModules/TestWorkspaceModuleInitConcurrent`
- `TestCommandHints/TestSDKInstallAndClientInitHints`
- `TestCommandHints/TestSDKInstallFullRefHints`

Each skip carries a FIXME so they are easy to find when re-enabling.

## Verification

- `GOOS=linux go vet ./core/integration/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kx6ffupbMMVhn9zeS6m6Hr
