### PR TITLE
feat: enable container nesting by default

### DIFF
--- a/.changes/unreleased/Changed-20260908-000000.yaml
+++ b/.changes/unreleased/Changed-20260908-000000.yaml
@@ -1,0 +1,10 @@
+kind: Changed
+body: |
+  Container commands and services can access the current Dagger engine by
+  default starting with API version v1.0.0-beta.12. Remove
+  `experimentalPrivilegedNesting: true` from calls using the new API. To disable
+  nesting (for example, when connecting to an independent engine), use
+  `disableNesting: true` instead. In Go, this is `ContainerWithExecOpts{DisableNesting: true}`.
+  The same option is available on `asService`, `up`, `terminal`, and
+  `withDefaultTerminalCmd`. Older API versions retain their opt-in behavior.
+time: 2026-09-08T00:00:00Z

--- a/core/container.go
+++ b/core/container.go
@@ -57,6 +57,9 @@ type DefaultTerminalCmdOpts struct {
 	// Provide dagger access to the executed command
 	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
 
+	// Disable access to the Dagger API from terminal commands.
+	DisableNesting bool `default:"false"`
+
 	// Grant the process all root capabilities
 	InsecureRootCapabilities dagql.Optional[dagql.Boolean] `default:"false"`
 }
@@ -7004,6 +7007,9 @@ type ContainerAsServiceArgs struct {
 
 	// Provide the executed command access back to the Dagger API
 	ExperimentalPrivilegedNesting bool `default:"false"`
+
+	// Disable access to the Dagger API from the service command.
+	DisableNesting bool `default:"false"`
 
 	// Grant the process all root capabilities
 	InsecureRootCapabilities bool `default:"false"`

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -68,6 +68,9 @@ type ContainerExecOpts struct {
 	// Provide the executed command access back to the Dagger API
 	ExperimentalPrivilegedNesting bool `default:"false"`
 
+	// Disable access to the Dagger API from the executed command.
+	DisableNesting bool `default:"false"`
+
 	// Grant the process all root capabilities
 	InsecureRootCapabilities bool `default:"false"`
 

--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -78,7 +78,7 @@ func (ClientSuite) TestSilentSessionExportsTelemetryToCloud(ctx context.Context,
 		WithEnvVariable("DAGGER_CLOUD_URL", "http://cloud:8080/"+eventsID).
 		WithEnvVariable("DAGGER_CLOUD_TOKEN", "test").
 		WithEnvVariable("DAGGER_SILENT", "true").
-		WithExec([]string{"go", "run", "./core/integration/testdata/basic-container/"}).
+		WithExec([]string{"go", "run", "./core/integration/testdata/basic-container/"}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 		Sync(ctx)
 	require.NoError(t, err, "silent SDK session handshake, query, and close must succeed")
 
@@ -200,7 +200,7 @@ func (ClientSuite) TestClientStableID(ctx context.Context, t *testctx.T) {
 		WithUser("auser").
 		WithWorkdir("/work").
 		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}).
+		WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 		File("/home/auser/.local/state/dagger/stable_client_id").
 		Contents(ctx)
 	require.NoError(t, err)
@@ -242,7 +242,7 @@ func (ClientSuite) TestWaitsForEngine(ctx context.Context, t *testctx.T) {
 	clientCtr := engineClientContainer(ctx, t, c, devEngineContainerAsService(devEngine))
 	_, err := clientCtr.
 		WithNewFile("/query.graphql", `{ version }`). // arbitrary valid query
-		WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}).Sync(ctx)
+		WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}, dagger.ContainerWithExecOpts{DisableNesting: true}).Sync(ctx)
 
 	require.NoError(t, err)
 }
@@ -300,7 +300,7 @@ func (ClientSuite) TestSendsLabelsInTelemetry(ctx context.Context, t *testctx.T)
 		WithExec([]string{"git", "init"}). // init a git repo to test git labels
 		WithExec([]string{"git", "add", "."}).
 		WithExec([]string{"git", "commit", "-m", "init test repo"}).
-		WithExec([]string{"dagger", "run", "go", "run", "./core/integration/testdata/basic-container/"}).
+		WithExec([]string{"dagger", "run", "go", "run", "./core/integration/testdata/basic-container/"}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 		Stderr(ctx)
 	require.NoError(t, err)
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -5107,15 +5107,80 @@ func (ContainerSuite) TestWithMountedSecretMode(ctx context.Context, t *testctx.
 }
 
 func (ContainerSuite) TestNestedExec(ctx context.Context, t *testctx.T) {
+	const nestingStatus = `if [ -n "$DAGGER_SESSION_PORT" ]; then echo enabled; else echo disabled; fi`
+
+	t.Run("legacy", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		// Open a CLI session against the legacy API and assert the selected version.
+		cli := c.Container().From(alpineImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v0.21.0")
+		const query = `query($image: String!, $command: String!, $enabled: Boolean) {
+			__schemaVersion
+			container {
+				from(address: $image) {
+					withExec(args: ["sh", "-c", $command], experimentalPrivilegedNesting: $enabled) {
+						stdout
+					}
+				}
+			}
+		}`
+		for _, tc := range []struct {
+			name    string
+			enabled bool
+			want    string
+		}{
+			{name: "default disabled", want: "disabled\n"},
+			{name: "explicitly enabled", enabled: true, want: "enabled\n"},
+		} {
+			t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+				variables, err := json.Marshal(struct {
+					Image   string `json:"image"`
+					Command string `json:"command"`
+					Enabled bool   `json:"enabled,omitempty"`
+				}{alpineImage, nestingStatus, tc.enabled})
+				require.NoError(t, err)
+				out, err := cli.WithExec([]string{"dagger", "query", "--var-json", string(variables)}, dagger.ContainerWithExecOpts{Stdin: query}).Stdout(ctx)
+				require.NoError(t, err)
+				var res struct {
+					Version   string `json:"__schemaVersion"`
+					Container struct {
+						From struct{ WithExec struct{ Stdout string } }
+					}
+				}
+				require.NoError(t, json.Unmarshal([]byte(out), &res))
+				require.Equal(t, "v0.21.0", res.Version)
+				require.Equal(t, tc.want, res.Container.From.WithExec.Stdout)
+			})
+		}
+	})
+
+	for _, tc := range []struct {
+		name           string
+		disableNesting bool
+		want           string
+	}{
+		{name: "default enabled", want: "enabled\n"},
+		{name: "nesting disabled", disableNesting: true, want: "disabled\n"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+			out, err := c.Container().From(alpineImage).
+				WithExec([]string{"sh", "-c", nestingStatus}, dagger.ContainerWithExecOpts{
+					DisableNesting: tc.disableNesting,
+				}).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, out)
+		})
+	}
+
 	t.Run("basic", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
 		_, err := c.Container().From(alpineImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithNewFile("/query.graphql", `{ defaultPlatform }`). // arbitrary valid query
-			WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"dagger", "query", "--doc", "/query.graphql"}).
 			Sync(ctx)
 		require.NoError(t, err)
 	})
@@ -6038,11 +6103,11 @@ func (ContainerSuite) TestSaveHostDocker(ctx context.Context, t *testctx.T) {
 	dockerc = dockerc.
 		WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-image://registry.dagger.io/engine:dev?container=dagger.test&port=1234").
-		WithExec([]string{"dagger", "core", "version"})
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 
 	t.Run("docker-image driver", func(ctx context.Context, t *testctx.T) {
 		imageName := "foobar:" + identity.NewID()
-		_, err := dockerc.WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).Sync(ctx)
+		_, err := dockerc.WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}, dagger.ContainerWithExecOpts{DisableNesting: true}).Sync(ctx)
 		require.NoError(t, err)
 
 		_, err = dockerc.WithExec([]string{"docker", "inspect", imageName}).Sync(ctx)
@@ -6058,7 +6123,7 @@ func (ContainerSuite) TestSaveHostDocker(ctx context.Context, t *testctx.T) {
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-container://dagger.test")
 
 		imageName := "foobar:" + identity.NewID()
-		_, err := alt.WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).Sync(ctx)
+		_, err := alt.WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}, dagger.ContainerWithExecOpts{DisableNesting: true}).Sync(ctx)
 		require.NoError(t, err)
 
 		_, err = alt.WithExec([]string{"docker", "inspect", imageName}).Sync(ctx)
@@ -6076,7 +6141,7 @@ func (ContainerSuite) TestSaveHostDocker(ctx context.Context, t *testctx.T) {
 		imageName := "foobar:" + identity.NewID()
 		_, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "docker-image").
-			WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).
+			WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 			Sync(ctx)
 		require.NoError(t, err)
 
@@ -6098,7 +6163,7 @@ func (ContainerSuite) TestSaveHostContainerd(ctx context.Context, t *testctx.T) 
 	nerdctl = nerdctl.
 		WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "image+nerdctl://registry.dagger.io/engine:dev?container=dagger.test&port=1234").
-		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{InsecureRootCapabilities: true})
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true, InsecureRootCapabilities: true})
 
 	t.Run("tcp driver", func(ctx context.Context, t *testctx.T) {
 		alt := nerdctl.
@@ -6107,7 +6172,7 @@ func (ContainerSuite) TestSaveHostContainerd(ctx context.Context, t *testctx.T) 
 		imageName := "foobar:" + identity.NewID()
 		_, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "containerd").
-			WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).
+			WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 			Sync(ctx)
 		require.NoError(t, err)
 
@@ -6131,14 +6196,14 @@ func (ContainerSuite) TestLoadHostDocker(ctx context.Context, t *testctx.T) {
 	dockerc = dockerc.
 		WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-image://registry.dagger.io/engine:dev?container=dagger.test&port=1234").
-		WithExec([]string{"dagger", "core", "version"})
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 
 	t.Run("docker-image driver", func(ctx context.Context, t *testctx.T) {
 		imageName := "foobar:" + identity.NewID()
 		_, err := dockerc.WithExec([]string{"docker", "build", "-t", imageName, "-"}, dagger.ContainerWithExecOpts{Stdin: "FROM alpine\nRUN touch /foo\n"}).Sync(ctx)
 		require.NoError(t, err)
 
-		out, err := dockerc.WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).Stdout(ctx)
+		out, err := dockerc.WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}, dagger.ContainerWithExecOpts{DisableNesting: true}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/foo\n", out)
 	})
@@ -6151,7 +6216,7 @@ func (ContainerSuite) TestLoadHostDocker(ctx context.Context, t *testctx.T) {
 		_, err := dockerc.WithExec([]string{"docker", "build", "-t", imageName, "-"}, dagger.ContainerWithExecOpts{Stdin: "FROM alpine\nRUN touch /foo\n"}).Sync(ctx)
 		require.NoError(t, err)
 
-		out, err := alt.WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).Stdout(ctx)
+		out, err := alt.WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}, dagger.ContainerWithExecOpts{DisableNesting: true}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/foo\n", out)
 	})
@@ -6166,7 +6231,7 @@ func (ContainerSuite) TestLoadHostDocker(ctx context.Context, t *testctx.T) {
 
 		out, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "docker-image").
-			WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).
+			WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/foo\n", out)
@@ -6183,7 +6248,7 @@ func (ContainerSuite) TestLoadHostContainerd(ctx context.Context, t *testctx.T) 
 		WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 		WithSymlink("/usr/local/bin/nerdctl", "/usr/local/bin/docker").
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-image://registry.dagger.io/engine:dev?container=dagger.test&port=1234").
-		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{InsecureRootCapabilities: true}).
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true, InsecureRootCapabilities: true}).
 		WithoutFile("/usr/local/bin/docker")
 
 	t.Run("tcp driver", func(ctx context.Context, t *testctx.T) {
@@ -6206,6 +6271,7 @@ func (ContainerSuite) TestLoadHostContainerd(ctx context.Context, t *testctx.T) 
 		out, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "containerd").
 			WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/etc/fstab | stdout`}, dagger.ContainerWithExecOpts{
+				DisableNesting:           true,
 				InsecureRootCapabilities: true,
 			}).Stdout(ctx)
 		require.NoError(t, err)
@@ -6222,7 +6288,7 @@ func (ContainerSuite) TestLoadSaveNone(ctx context.Context, t *testctx.T) {
 	dockerc = dockerc.
 		WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-image://registry.dagger.io/engine:dev?container=dagger.test&port=1234").
-		WithExec([]string{"dagger", "core", "version"})
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 
 	alt := dockerc.
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://docker:1234")
@@ -6231,7 +6297,7 @@ func (ContainerSuite) TestLoadSaveNone(ctx context.Context, t *testctx.T) {
 	out, err := alt.WithExec([]string{
 		"dagger", "shell", "-c",
 		`container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`,
-	}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
+	}, dagger.ContainerWithExecOpts{DisableNesting: true, Expect: dagger.ReturnTypeFailure}).
 		Stderr(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "client has no supported api for loading image")
@@ -6243,7 +6309,7 @@ func (ContainerSuite) TestLoadSaveNone(ctx context.Context, t *testctx.T) {
 	out, err = alt.WithExec([]string{
 		"dagger", "shell", "-c",
 		`host | container-image ` + imageName + ` | with-exec echo,foo | stdout`,
-	}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
+	}, dagger.ContainerWithExecOpts{DisableNesting: true, Expect: dagger.ReturnTypeFailure}).
 		Stderr(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "client has no supported api for loading image")
@@ -6263,7 +6329,7 @@ func (ContainerSuite) TestSaveInNested(ctx context.Context, t *testctx.T) {
 	out, err := dockerc.
 		With(withModuleFixture(t, c, "/src/test", "go/container-save-nested")).
 		WithWorkdir("/src/test").
-		WithExec([]string{"dagger", "call", "-m", ".", "try"}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
+		WithExec([]string{"dagger", "call", "-m", ".", "try"}, dagger.ContainerWithExecOpts{DisableNesting: true, Expect: dagger.ReturnTypeFailure}).
 		Stderr(ctx)
 	require.NoError(t, err)
 	require.Contains(t, out, "client has no supported api for loading image")

--- a/core/integration/contextual_workspace_test.go
+++ b/core/integration/contextual_workspace_test.go
@@ -31,8 +31,7 @@ func TestContextualWorkspace(t *testing.T) {
 func daggerReportCall(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "call"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 }

--- a/core/integration/dind_test.go
+++ b/core/integration/dind_test.go
@@ -39,7 +39,7 @@ curl \
 -u $DAGGER_SESSION_TOKEN: \
 -H "content-type:application/json" \
 -d '{"query":"{host{directory(path:\"/root/dir\"){entries}}}"}' http://127.0.0.1:$DAGGER_SESSION_PORT/query
-        """], experimentalPrivilegedNesting: true) {
+        """]) {
           stdout
         }
         }

--- a/core/integration/dockerfile_test.go
+++ b/core/integration/dockerfile_test.go
@@ -621,6 +621,15 @@ CMD ["cat", "/copied.txt"]
 		require.Equal(t, "non-sticky-bind", strings.TrimSpace(out))
 	})
 
+	t.Run("run-without-nesting", func(ctx context.Context, t *testctx.T) {
+		dir := c.Directory().WithNewFile("Dockerfile", fmt.Sprintf(`FROM %s
+RUN test -z "$DAGGER_SESSION_PORT" && test -z "$DAGGER_SESSION_TOKEN"
+`, alpineImage))
+
+		_, err := dir.DockerBuild().Sync(ctx)
+		require.NoError(t, err)
+	})
+
 	t.Run("run-network-none", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().WithNewFile("Dockerfile", fmt.Sprintf(`FROM %s
 RUN --network=none sh -c 'echo network-none > /status'

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -149,6 +149,7 @@ func engineWithBkConfig(ctx context.Context, t *testctx.T, cfgFns ...func(contex
 	}
 }
 
+// CLI execs on this container must disable nesting to connect to devEngine.
 func engineClientContainer(ctx context.Context, t *testctx.T, c *dagger.Client, devEngine *dagger.Service) *dagger.Container {
 	daggerCli := daggerCliFile(t, c)
 
@@ -230,7 +231,7 @@ func (EngineSuite) TestSetsNameFromEnv(ctx context.Context, t *testctx.T) {
 	// non-TTY default, doesn't render passing-span logs).
 	clientCtr = clientCtr.
 		WithEnvVariable("DAGGER_PROGRESS", "plain").
-		WithExec([]string{"dagger", "core", "version"})
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 
 	// version call
 	stdout, err := clientCtr.Stdout(ctx)
@@ -243,7 +244,7 @@ func (EngineSuite) TestSetsNameFromEnv(ctx context.Context, t *testctx.T) {
 	require.Contains(t, stderr, engineName)
 	require.Contains(t, stderr, engineVersion)
 
-	clientCtr = clientCtr.WithExec([]string{"dagger", "core", "engine", "name"})
+	clientCtr = clientCtr.WithExec([]string{"dagger", "core", "engine", "name"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 
 	// name call
 	stdout, err = clientCtr.Stdout(ctx)
@@ -286,7 +287,7 @@ func (EngineSuite) TestDaggerExec(ctx context.Context, t *testctx.T) {
 				// call-chain naming instead.
 				WithEnvVariable("DAGGER_PROGRESS", "plain").
 				WithExec([]string{"apk", "add", "jq", "curl"}).
-				WithExec([]string{"sh", "-c", command})
+				WithExec([]string{"sh", "-c", command}, dagger.ContainerWithExecOpts{DisableNesting: true})
 
 			stdout, err := clientCtr.Stdout(ctx)
 			require.NoError(t, err)
@@ -468,11 +469,11 @@ func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 			if tc.errs == nil {
 				clientCtr = clientCtr.
 					WithNewFile("/query.graphql", `{ version }`).
-					WithExec([]string{"sh", "-c", "dagger version && dagger query --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "dagger version && dagger query --doc /query.graphql"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 			} else {
 				clientCtr = clientCtr.
 					WithNewFile("/query.graphql", `{ version }`).
-					WithExec([]string{"sh", "-c", "! dagger query --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "! dagger query --doc /query.graphql"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 			}
 
 			if tc.errs == nil {
@@ -586,10 +587,10 @@ func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 
 			if tc.errs == nil {
 				clientCtr = clientCtr.
-					WithExec([]string{"sh", "-c", "dagger query -m . --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "dagger query -m . --doc /query.graphql"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 			} else {
 				clientCtr = clientCtr.
-					WithExec([]string{"sh", "-c", "! dagger query -m . --doc /query.graphql"})
+					WithExec([]string{"sh", "-c", "! dagger query -m . --doc /query.graphql"}, dagger.ContainerWithExecOpts{DisableNesting: true})
 			}
 
 			stderr, err := clientCtr.Stderr(ctx)
@@ -954,7 +955,7 @@ set -eu
 for i in $(seq 1 4); do
   dagger api functions >/dev/null
 done
-			`}).Sync(ctx)
+			`}, dagger.ContainerWithExecOpts{DisableNesting: true}).Sync(ctx)
 		return err
 	}
 

--- a/core/integration/env_helpers_test.go
+++ b/core/integration/env_helpers_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/dagger/testctx"
 )
 
-var nestedExec = dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true}
-
 func nestedDaggerContainer(t *testctx.T, c *dagger.Client, modLang, modName string) *dagger.Container {
 	ctr := c.Container().
 		From(alpineImage).

--- a/core/integration/envfile_test.go
+++ b/core/integration/envfile_test.go
@@ -408,7 +408,6 @@ func (EnvFileSuite) TestSystemVariables(ctx context.Context, t *testctx.T) {
 	output1, err := ctr.
 		WithExec([]string{
 			"dagger", "core", "host", "file", "--path=.env", "as-env-file", "get", "--name", "GREETING"},
-			nestedExec,
 		).
 		Stdout(ctx)
 	require.NoError(t, err)
@@ -416,7 +415,6 @@ func (EnvFileSuite) TestSystemVariables(ctx context.Context, t *testctx.T) {
 	output2, err := ctr.
 		WithExec([]string{
 			"dagger", "core", "host", "file", "--path=.env", "as-env-file", "variables", "value"},
-			nestedExec,
 		).
 		Stdout(ctx)
 	require.NoError(t, err)

--- a/core/integration/generators_test.go
+++ b/core/integration/generators_test.go
@@ -117,8 +117,7 @@ func (GeneratorsSuite) TestGeneratorsDirectSDK(ctx context.Context, t *testctx.T
 			t.Run("error", func(ctx context.Context, t *testctx.T) {
 				out, err := modGen.
 					WithExec([]string{"dagger", "generate", "changeset-failure", "-y", "--progress=plain"}, dagger.ContainerWithExecOpts{
-						Expect:                        dagger.ReturnTypeAny,
-						ExperimentalPrivilegedNesting: true,
+						Expect: dagger.ReturnTypeAny,
 					}).
 					CombinedOutput(ctx)
 				require.NoError(t, err)
@@ -240,8 +239,7 @@ func (GeneratorsSuite) TestGeneratorLazyExecFailureSurfacesStderr(ctx context.Co
 
 	out, err := modGen.
 		WithExec([]string{"dagger", "generate", "lazy-exec-failure", "-y", "--progress=plain"}, dagger.ContainerWithExecOpts{
-			Expect:                        dagger.ReturnTypeAny,
-			ExperimentalPrivilegedNesting: true,
+			Expect: dagger.ReturnTypeAny,
 		}).
 		CombinedOutput(ctx)
 	require.NoError(t, err)
@@ -1487,7 +1485,7 @@ func (GeneratorsSuite) TestWorkspaceCallNarrowsByCliNameAndEntrypoint(ctx contex
 		// introspection narrows; the second, bare listing must widen to every
 		// remaining module and surface the broken one.
 		out, err := base.
-			WithExec([]string{"sh", "-c", "set -e; dagger api call good-mod ping; if dagger api functions >/dev/null 2>&1; then echo BARE_LISTING_PASSED; else echo BARE_LISTING_FAILED; fi"}, dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true}).
+			WithExec([]string{"sh", "-c", "set -e; dagger api call good-mod ping; if dagger api functions >/dev/null 2>&1; then echo BARE_LISTING_PASSED; else echo BARE_LISTING_FAILED; fi"}).
 			CombinedOutput(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "pong from goodMod")

--- a/core/integration/llm_test.go
+++ b/core/integration/llm_test.go
@@ -647,8 +647,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 	t.Run("shell allow all", func(ctx context.Context, t *testctx.T) {
 		_, err := daggerCliBase(t, c).
 			WithExec([]string{"dagger", "shell", "-m", indirectModuleRef, "--allow-llm=all"}, dagger.ContainerWithExecOpts{
-				Stdin:                         fmt.Sprintf(`. %s | prompt "greet me" %q`, modelFlag, identity.NewID()),
-				ExperimentalPrivilegedNesting: true,
+				Stdin: fmt.Sprintf(`. %s | prompt "greet me" %q`, modelFlag, identity.NewID()),
 			}).
 			Stdout(ctx)
 		require.NoError(t, err)
@@ -657,8 +656,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 	t.Run("shell interactive module loads", func(ctx context.Context, t *testctx.T) {
 		_, err := daggerCliBase(t, c).
 			WithExec([]string{"dagger", "shell", "--allow-llm", directModuleSymbolic}, dagger.ContainerWithExecOpts{
-				Stdin:                         fmt.Sprintf(`%s %s | prompt "greet me" %q`, indirectModuleRef, modelFlag, identity.NewID()),
-				ExperimentalPrivilegedNesting: true,
+				Stdin: fmt.Sprintf(`%s %s | prompt "greet me" %q`, indirectModuleRef, modelFlag, identity.NewID()),
 			}).
 			Stdout(ctx)
 		require.NoError(t, err)

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -648,7 +648,7 @@ func (LocalCacheSuite) TestDagqlMetadataGCProtectsActiveZeroDiskResults(ctx cont
 	// Warm the static core schema first. Its typedef results are deliberately
 	// unpruneable and form the stable engine-lifetime floor for this test.
 	_, err := engineClientContainer(ctx, t, c, devEngine).
-		WithExec([]string{"dagger", "core", "version"}).
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 		Sync(ctx)
 	require.NoError(t, err)
 	waitForMetrics("warmup session close", 30*time.Second, func(metrics map[string]float64) bool {
@@ -686,7 +686,7 @@ func (LocalCacheSuite) TestDagqlMetadataGCProtectsActiveZeroDiskResults(ctx cont
   "http://127.0.0.1:$DAGGER_SESSION_PORT/query" >/tmp/response.json
 jq -e '.data != null and (.errors | not)' /tmp/response.json >/dev/null
 sleep 30`,
-		})
+		}, dagger.ContainerWithExecOpts{DisableNesting: true})
 	workloadDone := make(chan error, 1)
 	go func() {
 		_, err := workloadCtr.Sync(ctx)
@@ -746,7 +746,7 @@ sleep 30`,
 	// A fresh core call verifies that retaining the unpruneable floor was not
 	// merely visible in the gauge; the schema remains usable after the cut.
 	version, err := engineClientContainer(ctx, t, c, devEngine).
-		WithExec([]string{"dagger", "core", "version"}).
+		WithExec([]string{"dagger", "core", "version"}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, strings.TrimSpace(version))
@@ -763,7 +763,7 @@ func (LocalCacheSuite) TestLocalCacheManualMetadataPruneCLI(ctx context.Context,
 			"engine", "local-cache", "prune",
 			"--max-estimated-bytes=4294967296",
 			"--target-estimated-bytes=3221225472",
-		}).
+		}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 		Sync(ctx)
 	require.NoError(t, err, "the CLI must accept 64-bit structural thresholds when automatic GC is disabled")
 }

--- a/core/integration/module_helpers_test.go
+++ b/core/integration/module_helpers_test.go
@@ -72,9 +72,8 @@ func daggerCallFail(args ...string) dagger.WithContainerFunc {
 		return c.WithExec(
 			append([]string{"dagger", "--progress=report", "call"}, args...),
 			dagger.ContainerWithExecOpts{
-				UseEntrypoint:                 true,
-				ExperimentalPrivilegedNesting: true,
-				Expect:                        dagger.ReturnTypeFailure,
+				UseEntrypoint: true,
+				Expect:        dagger.ReturnTypeFailure,
 			},
 		)
 	}

--- a/core/integration/module_helpers_test.go
+++ b/core/integration/module_helpers_test.go
@@ -30,9 +30,7 @@ import (
 
 func daggerExecRaw(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger"}, args...))
 	}
 }
 
@@ -48,8 +46,7 @@ func daggerQueryAt(modPath string, query string, args ...any) dagger.WithContain
 			execArgs = append(execArgs, "-m", modPath)
 		}
 		return c.WithExec(execArgs, dagger.ContainerWithExecOpts{
-			Stdin:                         query,
-			ExperimentalPrivilegedNesting: true,
+			Stdin: query,
 		})
 	}
 }
@@ -65,8 +62,7 @@ func daggerCallAt(modPath string, args ...string) dagger.WithContainerFunc {
 			execArgs = append(execArgs, "-m", modPath)
 		}
 		return c.WithExec(append(execArgs, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 }
@@ -86,9 +82,7 @@ func daggerCallFail(args ...string) dagger.WithContainerFunc {
 
 func daggerFunctions(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "api", "functions"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger", "api", "functions"}, args...))
 	}
 }
 

--- a/core/integration/module_legacy_helpers_test.go
+++ b/core/integration/module_legacy_helpers_test.go
@@ -23,8 +23,7 @@ func daggerExec(args ...string) dagger.WithContainerFunc {
 func daggerExecFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			Expect: dagger.ReturnTypeFailure,
 		})
 	}
 }
@@ -35,7 +34,7 @@ func daggerNonNestedExec(args ...string) dagger.WithContainerFunc {
 			WithEnvVariable("XDG_STATE_HOME", "/tmp").
 			WithMountedTemp("/tmp").
 			WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: false,
+				DisableNesting: true,
 			})
 	}
 }
@@ -46,8 +45,8 @@ func daggerNonNestedExecFail(args ...string) dagger.WithContainerFunc {
 			WithEnvVariable("XDG_STATE_HOME", "/tmp").
 			WithMountedTemp("/tmp").
 			WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: false,
-				Expect:                        dagger.ReturnTypeFailure,
+				DisableNesting: true,
+				Expect:         dagger.ReturnTypeFailure,
 			})
 	}
 }

--- a/core/integration/module_loading_test.go
+++ b/core/integration/module_loading_test.go
@@ -35,8 +35,7 @@ func TestModuleLoading(t *testing.T) {
 func moduleLoadingDaggerExecFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			Expect: dagger.ReturnTypeFailure,
 		})
 	}
 }
@@ -44,8 +43,7 @@ func moduleLoadingDaggerExecFail(args ...string) dagger.WithContainerFunc {
 func moduleLoadingDaggerCall(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "call"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 }
@@ -53,26 +51,22 @@ func moduleLoadingDaggerCall(args ...string) dagger.WithContainerFunc {
 func moduleLoadingDaggerCallFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "call"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			UseEntrypoint: true,
+			Expect:        dagger.ReturnTypeFailure,
 		})
 	}
 }
 
 func moduleLoadingDaggerFunctions(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger", "api", "functions"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger", "api", "functions"}, args...))
 	}
 }
 
 func moduleLoadingDaggerQuery(query string, args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "query"}, args...), dagger.ContainerWithExecOpts{
-			Stdin:                         query,
-			ExperimentalPrivilegedNesting: true,
+			Stdin: query,
 		})
 	}
 }
@@ -80,9 +74,8 @@ func moduleLoadingDaggerQuery(query string, args ...string) dagger.WithContainer
 func moduleLoadingDaggerQueryFail(query string, args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "query"}, args...), dagger.ContainerWithExecOpts{
-			Stdin:                         query,
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			Stdin:  query,
+			Expect: dagger.ReturnTypeFailure,
 		})
 	}
 }

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -429,7 +429,7 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 41})
 		require.NoError(t, err)
 
-		cmd := hostDaggerCommandRaw(ctx, t, modDir, "-m", ".", "call", "--nested-src", nestedSrcDir, "ctr", "terminal", "--experimental-privileged-nesting")
+		cmd := hostDaggerCommandRaw(ctx, t, modDir, "-m", ".", "call", "--nested-src", nestedSrcDir, "ctr", "terminal")
 		cmd.Stdin = tty
 		cmd.Stdout = tty
 		cmd.Stderr = tty

--- a/core/integration/provision_test.go
+++ b/core/integration/provision_test.go
@@ -122,7 +122,7 @@ func (ProvisionSuite) TestImageDriverConfig(ctx context.Context, t *testctx.T) {
 				WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", tc.driver+"://registry.dagger.io/engine:dev")
 
 			// check that the config was used by the engine
-			out, err := dockerc.WithExec([]string{"dagger", "query", "-M"}, dagger.ContainerWithExecOpts{Stdin: "{engine{localCache{reservedSpace,maxUsedSpace,minFreeSpace}}}", InsecureRootCapabilities: true}).Stdout(ctx)
+			out, err := dockerc.WithExec([]string{"dagger", "query", "-M"}, dagger.ContainerWithExecOpts{Stdin: "{engine{localCache{reservedSpace,maxUsedSpace,minFreeSpace}}}", InsecureRootCapabilities: true, DisableNesting: true}).Stdout(ctx)
 			require.NoError(t, err)
 			require.JSONEq(t, `{"engine": {"localCache": {"reservedSpace": 1000, "maxUsedSpace": 2000, "minFreeSpace": 3000}}}`, out)
 
@@ -174,7 +174,7 @@ FAKE CERTIFICATE DATA
 						}
 					}
 				}
-			`, InsecureRootCapabilities: true}).Stdout(ctx)
+			`, InsecureRootCapabilities: true, DisableNesting: true}).Stdout(ctx)
 			require.NoError(t, err)
 			require.Contains(t, gjson.Get(out, "container.from.standalone.stdout").String(), fakeCACert)
 			require.Contains(t, gjson.Get(out, "container.from.bundle.stdout").String(), fakeCACert)
@@ -267,7 +267,7 @@ func detectEngineVersion(ctx context.Context, t *testctx.T, ctr *dagger.Containe
 	out, err := ctr.
 		// NOTE: we don't use any interesting functionality, so disable this check
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v0.0.0").
-		WithExec([]string{"dagger", "query", "-M"}, dagger.ContainerWithExecOpts{Stdin: "{version}", InsecureRootCapabilities: true}).
+		WithExec([]string{"dagger", "query", "-M"}, dagger.ContainerWithExecOpts{Stdin: "{version}", InsecureRootCapabilities: true, DisableNesting: true}).
 		Stdout(ctx)
 	require.NoError(t, err)
 

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -260,7 +260,7 @@ redirect ^(https?://)(.*).example(/.*)$		$1$2$3
 				"-test.timeout", "20m",
 				"-test.count", "1",
 				"-test.run", exactName,
-			}).Sync(ctx)
+			}, dagger.ContainerWithExecOpts{DisableNesting: true}).Sync(ctx)
 		require.NoError(t, err)
 
 		require.NoError(t, err)
@@ -570,7 +570,7 @@ func (ContainerSuite) TestSystemGoProxy(ctx context.Context, t *testctx.T) {
 				"-test.timeout", "20m",
 				"-test.count", "1",
 				"-test.run", fmt.Sprintf("^%s$", t.Name()),
-			}).
+			}, dagger.ContainerWithExecOpts{DisableNesting: true}).
 			Sync(ctx)
 		require.NoError(t, err)
 

--- a/core/integration/secretprovider_test.go
+++ b/core/integration/secretprovider_test.go
@@ -41,7 +41,6 @@ func (SecretProvider) TestUnknown(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"wtf://foobar",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, `unsupported secret provider: "wtf"`)
 
@@ -49,7 +48,6 @@ func (SecretProvider) TestUnknown(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"wtf",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, `malformed id`)
 }
@@ -65,7 +63,6 @@ func (SecretProvider) TestEnv(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr.WithEnvVariable("TOPSECRET", secretValue),
 		"env://TOPSECRET",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -74,7 +71,6 @@ func (SecretProvider) TestEnv(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"env://TOPSECRET",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, `secret env var not found: "TOP..."`)
 }
@@ -90,7 +86,6 @@ func (SecretProvider) TestFile(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr.WithNewFile("/tmp/topsecret", secretValue),
 		"file:///tmp/topsecret",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -99,7 +94,6 @@ func (SecretProvider) TestFile(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"file:///tmp/topsecret",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "no such file or directory")
 }
@@ -116,7 +110,6 @@ func (SecretProvider) TestCmd(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		`cmd://echo `+secretValueEncoded+` | base64 -d`,
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -125,7 +118,6 @@ func (SecretProvider) TestCmd(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"cmd://exit 1",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "failed to run secret command")
 }
@@ -291,7 +283,6 @@ func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"vault://secret/testsecret.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -300,7 +291,6 @@ func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"vault://secret/testsecret.bar",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, `secret "bar" not found in path "secret/testsecret"`)
 
@@ -308,7 +298,6 @@ func (SecretProvider) TestVault(ctx context.Context, t *testctx.T) {
 		ctx,
 		ctr,
 		"vault://secret/nosecret.baz",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, `secret not found`)
 }
@@ -326,7 +315,6 @@ func (SecretProvider) TestVaultOIDCFallbackError(ctx context.Context, t *testctx
 		ctx,
 		ctr,
 		"vault://secret/testsecret.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrRegexp(t, err, `(?i)vault oidc login failed`)
 	requireErrRegexp(t, err, `(?i)(oidc/auth_url|OIDC auth URL)`)
@@ -343,7 +331,6 @@ func (SecretProvider) TestVaultOIDCMissingVaultAddr(ctx context.Context, t *test
 		ctx,
 		ctr,
 		"vault://secret/testsecret.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "VAULT_ADDR must be set when using Vault OIDC fallback auth")
 }
@@ -364,7 +351,6 @@ func (SecretProvider) TestVaultOIDCTokenPriority(ctx context.Context, t *testctx
 		ctx,
 		ctr,
 		"vault://secret/testsecret.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -385,7 +371,6 @@ func (SecretProvider) TestVaultOIDCCachedToken(ctx context.Context, t *testctx.T
 		ctx,
 		ctr,
 		"vault://secret/testsecret.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -405,7 +390,6 @@ func (SecretProvider) TestVaultOIDCExpiredCachedToken(ctx context.Context, t *te
 		ctx,
 		ctr,
 		"vault://secret/testsecret.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrRegexp(t, err, `(?i)vault oidc login failed`)
 	requireErrRegexp(t, err, `(?i)(oidc/auth_url|OIDC auth URL)`)
@@ -439,7 +423,6 @@ func (SecretProvider) TestVaultOIDCEndToEnd(ctx context.Context, t *testctx.T) {
 		queryCtx,
 		ctr,
 		"vault://secret/oidctest.foo",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -497,9 +480,8 @@ func (SecretProvider) TestVaultTTL(ctx context.Context, t *testctx.T) {
 				}).
 				WithExposedPort(8200).
 				AsService(dagger.ContainerAsServiceOpts{
-					UseEntrypoint:                 true,
-					ExperimentalPrivilegedNesting: true,
-					InsecureRootCapabilities:      true,
+					UseEntrypoint:            true,
+					InsecureRootCapabilities: true,
 				}).Start(ctx)
 			require.NoError(t, err)
 
@@ -529,6 +511,7 @@ sleep 5 # wait for gnome-keyring-daemon to be ready
 	opts := dagger.ContainerWithExecOpts{
 		UseEntrypoint:            true,
 		InsecureRootCapabilities: true,
+		DisableNesting:           true,
 	}
 
 	ctr := c.Container().
@@ -671,7 +654,6 @@ floci:
 		ctx,
 		ctr,
 		"aws+sm://test/string-secret",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -681,7 +663,6 @@ floci:
 		ctx,
 		ctr,
 		"aws+sm://test/json-secret?field=password",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, out)
@@ -691,7 +672,6 @@ floci:
 		ctx,
 		ctr,
 		"aws+ps://test/parameter",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, paramValue, out)
@@ -701,7 +681,6 @@ floci:
 		ctx,
 		ctr,
 		"aws+sm://nonexistent/secret",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "secret not found")
 
@@ -710,7 +689,6 @@ floci:
 		ctx,
 		ctr,
 		"aws+ps://nonexistent/parameter",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "parameter not found")
 
@@ -719,7 +697,6 @@ floci:
 		ctx,
 		ctr,
 		"aws+sm://test/json-secret?field=nonexistent",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	requireErrOut(t, err, "not found in JSON secret")
 
@@ -728,24 +705,22 @@ floci:
 		ctx,
 		ctr,
 		"aws+sm://test/string-secret",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	out2, err := fetchSecret(
 		ctx,
 		ctr,
 		"aws+sm://test/string-secret",
-		dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true},
 	)
 	require.NoError(t, err)
 	require.Equal(t, out1, out2)
 }
 
-func fetchSecret(ctx context.Context, ctr *dagger.Container, url string, opts dagger.ContainerWithExecOpts) (string, error) {
+func fetchSecret(ctx context.Context, ctr *dagger.Container, url string, opts ...dagger.ContainerWithExecOpts) (string, error) {
 	query := fmt.Sprintf(`{secret(uri: %q) {plaintext}}`, url)
-	opts.Stdin = query
+	opts = append([]dagger.ContainerWithExecOpts{{Stdin: query}}, opts...)
 
-	out, err := ctr.WithExec([]string{"dagger", "query"}, opts).Stdout(ctx)
+	out, err := ctr.WithExec([]string{"dagger", "query"}, opts...).Stdout(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -884,7 +859,7 @@ vault policy write oidc-read /tmp/oidc-read.hcl`}).
 	require.NoError(t, err)
 }
 
-func querySecretWithOIDCBrowserSimulation(ctx context.Context, ctr *dagger.Container, url string, opts dagger.ContainerWithExecOpts) (string, error) {
+func querySecretWithOIDCBrowserSimulation(ctx context.Context, ctr *dagger.Container, url string) (string, error) {
 	script := fmt.Sprintf(`set -eu
 
 query=%q
@@ -1017,7 +992,7 @@ cat "$secret_out"
 
 	out, err := ctr.
 		WithNewFile("/tmp/run-vault-oidc-flow.sh", script, dagger.ContainerWithNewFileOpts{Permissions: 0o755}).
-		WithExec([]string{"sh", "/tmp/run-vault-oidc-flow.sh"}, opts).
+		WithExec([]string{"sh", "/tmp/run-vault-oidc-flow.sh"}).
 		Stdout(ctx)
 	if err != nil {
 		var execErr *dagger.ExecError

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -57,6 +57,32 @@ func TestServices(t *testing.T) {
 	testctx.New(t, Middleware()...).RunTests(ServiceSuite{})
 }
 
+func (ServiceSuite) TestNesting(ctx context.Context, t *testctx.T) {
+	for _, tc := range []struct {
+		name           string
+		disableNesting bool
+		want           string
+	}{
+		{name: "default enabled", want: "enabled\n"},
+		{name: "nesting disabled", disableNesting: true, want: "disabled\n"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
+			svc := c.Container().From(busyboxImage).
+				WithExposedPort(8080).
+				AsService(dagger.ContainerAsServiceOpts{
+					Args:           []string{"sh", "-c", `mkdir -p /www; if [ -n "$DAGGER_SESSION_PORT" ]; then echo enabled; else echo disabled; fi > /www/index.html; exec httpd -f -p 8080 -h /www`},
+					DisableNesting: tc.disableNesting,
+				})
+			out, err := c.Container().From(alpineImage).
+				WithServiceBinding("nested", svc).
+				WithExec([]string{"wget", "-qO-", "http://nested:8080"}).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, out)
+		})
+	}
+}
+
 func (ServiceSuite) TestHostnamesAreStable(ctx context.Context, t *testctx.T) {
 	hostname := func(ctx context.Context, c *dagger.Client) string {
 		www := c.Directory().WithNewFile("index.html", "Hello, world!")
@@ -901,8 +927,6 @@ func (ServiceSuite) TestExecServicesNestedExec(ctx context.Context, t *testctx.T
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested-c2c/",
 			"exec", strconv.Itoa(nestingLimit), svcURL,
-		}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
 		}).
 		Stdout(ctx)
 	require.NoError(t, err)
@@ -936,8 +960,6 @@ func (ServiceSuite) TestExecServicesNestedHTTP(ctx context.Context, t *testctx.T
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested-c2c/",
 			"http", strconv.Itoa(nestingLimit), svcURL,
-		}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
 		}).
 		Stdout(ctx)
 	require.NoError(t, err)
@@ -971,8 +993,6 @@ func (ServiceSuite) TestExecServicesNestedGit(ctx context.Context, t *testctx.T)
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested-c2c/",
 			"git", strconv.Itoa(nestingLimit), svcURL,
-		}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
 		}).
 		Stdout(ctx)
 	require.NoError(t, err)

--- a/core/integration/shell_test.go
+++ b/core/integration/shell_test.go
@@ -42,8 +42,7 @@ func daggerShellAt(modPath, script string) dagger.WithContainerFunc {
 			execArgs = append(execArgs, "-m", modPath)
 		}
 		return c.WithExec(execArgs, dagger.ContainerWithExecOpts{
-			Stdin:                         script,
-			ExperimentalPrivilegedNesting: true,
+			Stdin: script,
 		})
 	}
 }
@@ -51,8 +50,7 @@ func daggerShellAt(modPath, script string) dagger.WithContainerFunc {
 func daggerShellNoMod(script string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec([]string{"dagger", "shell", "-M"}, dagger.ContainerWithExecOpts{
-			Stdin:                         script,
-			ExperimentalPrivilegedNesting: true,
+			Stdin: script,
 		})
 	}
 }
@@ -161,9 +159,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := daggerCliBase(t, c).
 			WithNewFile("script.sh", ".echo foobar").
-			WithExec([]string{"dagger", "script.sh"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"dagger", "script.sh"}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foobar\n", out)
@@ -173,9 +169,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := daggerCliBase(t, c).
 			WithNewFile("script.sh", ".echo foobar").
-			WithExec([]string{"dagger", "shell", "script.sh"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"dagger", "shell", "script.sh"}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foobar\n", out)
@@ -188,9 +182,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 			WithNewFile("script.sh", script, dagger.ContainerWithNewFileOpts{
 				Permissions: 0750,
 			}).
-			WithExec([]string{"./script.sh"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"./script.sh"}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foobar\n", out)
@@ -203,9 +195,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 			WithNewFile("script.sh", script, dagger.ContainerWithNewFileOpts{
 				Permissions: 0750,
 			}).
-			WithExec([]string{"./script.sh"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"./script.sh"}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foobar\n", out)
@@ -214,9 +204,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 	t.Run("root error", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		_, err := daggerCliBase(t, c).
-			WithExec([]string{"dagger", "wokspace"}, dagger.ContainerWithExecOpts{
-				ExperimentalPrivilegedNesting: true,
-			}).
+			WithExec([]string{"dagger", "wokspace"}).
 			Sync(ctx)
 		requireErrOut(t, err, `unknown command or file "wokspace" for "dagger"`)
 		requireErrOut(t, err, "Did you mean this?\n\tworkspace")

--- a/core/integration/testdata/modules/go/workspace-selection-nester/main.go
+++ b/core/integration/testdata/modules/go/workspace-selection-nester/main.go
@@ -21,25 +21,22 @@ func (m *Nester) Greeting() string {
 
 func (m *Nester) NestedWorkspace(ctx context.Context, cli *dagger.File) (string, error) {
 	return m.nested(ctx, cli, []string{"query"}, dagger.ContainerWithExecOpts{
-		ExperimentalPrivilegedNesting: true,
-		Stdin:                         "{currentWorkspace{cwd configFile}}",
+		Stdin: "{currentWorkspace{cwd configFile}}",
 	})
 }
 
 func (m *Nester) NestedGreeting(ctx context.Context, cli *dagger.File) (string, error) {
-	return m.nested(ctx, cli, []string{"call", "greeting"}, dagger.ContainerWithExecOpts{
-		ExperimentalPrivilegedNesting: true,
-	})
+	return m.nested(ctx, cli, []string{"call", "greeting"})
 }
 
-func (m *Nester) nested(ctx context.Context, cli *dagger.File, args []string, opts dagger.ContainerWithExecOpts) (string, error) {
+func (m *Nester) nested(ctx context.Context, cli *dagger.File, args []string, opts ...dagger.ContainerWithExecOpts) (string, error) {
 	execArgs := append([]string{"dagger", "--progress=report"}, args...)
 	out, err := dag.Container().
 		From("alpine:3.22.1").
 		WithMountedFile("/bin/dagger", cli).
 		WithExec([]string{"mkdir", "-p", "/empty"}).
 		WithWorkdir("/empty").
-		WithExec(execArgs, opts).
+		WithExec(execArgs, opts...).
 		Stdout(ctx)
 	if err != nil {
 		return "", err

--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -94,9 +94,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 		WithEnvVariable("NOW", rand.Text()).
 		WithExec([]string{"cat", "/etc/resolv.conf"}).
 		WithServiceBinding("mirror", mirrorSvc).
-		WithExec(args, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		}).
+		WithExec(args).
 		Stdout(ctx)
 	if err != nil {
 		fatal(err)

--- a/core/integration/up_test.go
+++ b/core/integration/up_test.go
@@ -66,9 +66,7 @@ func daggerUpVerify(upArgs, url, expectBodyContains, okMsg string, timeoutSecs i
 			wait $DAGGER_PID 2>/dev/null
 			exit 0
 		`, upArgs, timeoutSecs, url, url, expectBodyContains, expectBodyContains, okMsg,
-		)}, dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		)})
 	}
 }
 

--- a/core/integration/workspace_compat_env_test.go
+++ b/core/integration/workspace_compat_env_test.go
@@ -30,7 +30,7 @@ func (WorkspaceCompatSuite) TestRemoteFile(ctx context.Context, t *testctx.T) {
 	output, err := nestedDaggerContainer(t, c, "go", "defaults").
 		WithWorkdir("defaults").
 		WithNewFile(".env", `DEFAULTS_FILE=https://github.com/dagger/dagger#main:cmd/dagger/main.go`).
-		WithExec(daggerCallCmd(".", "file", "contents"), nestedExec).
+		WithExec(daggerCallCmd(".", "file", "contents")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, output, "package main")
@@ -42,7 +42,7 @@ func (WorkspaceCompatSuite) TestLocalFile(ctx context.Context, t *testctx.T) {
 		WithNewFile("hello.txt", "well hello!").
 		WithWorkdir("defaults").
 		WithNewFile(".env", `DEFAULTS_FILE=../hello.txt`).
-		WithExec(daggerCallCmd(".", "file", "contents"), nestedExec).
+		WithExec(daggerCallCmd(".", "file", "contents")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "well hello!", output)
@@ -54,7 +54,7 @@ func (WorkspaceCompatSuite) TestLocalDirectory(ctx context.Context, t *testctx.T
 		WithDirectory("data", dag.Directory().WithNewFile("hello.txt", "well hello!")).
 		WithWorkdir("defaults").
 		WithNewFile(".env", `DEFAULTS_DIR=../data`).
-		WithExec(daggerCallCmd(".", "dir", "file", "--path=hello.txt", "contents"), nestedExec).
+		WithExec(daggerCallCmd(".", "dir", "file", "--path=hello.txt", "contents")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "well hello!", output)
@@ -65,7 +65,7 @@ func (WorkspaceCompatSuite) TestRemoteDirectory(ctx context.Context, t *testctx.
 	output, err := nestedDaggerContainer(t, c, "go", "defaults").
 		WithWorkdir("defaults").
 		WithNewFile(".env", `DIR=https://github.com/dagger/dagger#main:cmd/dagger`).
-		WithExec(daggerCallCmd(".", "dir", "file", "--path=main.go", "contents"), nestedExec).
+		WithExec(daggerCallCmd(".", "dir", "file", "--path=main.go", "contents")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, output, "package main")
@@ -137,8 +137,7 @@ DEFAULTS_MESSAGE_NAME=planete-outer
 					return c
 				}).
 				WithExec(tc.command, dagger.ContainerWithExecOpts{
-					Expect:                        tc.expect,
-					ExperimentalPrivilegedNesting: true,
+					Expect: tc.expect,
 				}).
 				Stdout(ctx)
 			require.NoError(t, err)
@@ -213,8 +212,7 @@ DEFAULTS_MESSAGE_NAME=planete-outer
 					return c
 				}).
 				WithExec(tc.command, dagger.ContainerWithExecOpts{
-					Expect:                        tc.expect,
-					ExperimentalPrivilegedNesting: true,
+					Expect: tc.expect,
 				}).
 				Stdout(ctx)
 			require.NoError(t, err)
@@ -289,7 +287,7 @@ func (WorkspaceCompatSuite) TestSystemVariables(ctx context.Context, t *testctx.
 		WithWorkdir("defaults").
 		WithNewFile(".env", `GREETING="${SYSTEM_GREETING}"`).
 		WithEnvVariable("SYSTEM_GREETING", "live long and prosper").
-		WithExec(daggerCallCmd(".", "message"), nestedExec).
+		WithExec(daggerCallCmd(".", "message")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "live long and prosper, world!", output)
@@ -301,7 +299,7 @@ func (WorkspaceCompatSuite) TestRequiredDirectory(ctx context.Context, t *testct
 		WithWorkdir("defaults").
 		WithNewFile("/foo/dir/hello.txt", "").
 		WithNewFile(".env", `LS_DIR=/foo/dir`).
-		WithExec(daggerCallCmd(".", "ls"), nestedExec).
+		WithExec(daggerCallCmd(".", "ls")).
 		Stdout(ctx)
 	require.NoError(t, err, "user default should successfully apply to required argument")
 	require.Equal(t, "hello.txt\n", output, "user default should successfully apply to required argument")
@@ -312,7 +310,7 @@ func (WorkspaceCompatSuite) TestRequiredString(ctx context.Context, t *testctx.T
 	output, err := nestedDaggerContainer(t, c, "go", "defaults").
 		WithNewFile(".env", `DEFAULTS_CAPITALIZE_S=hello world`).
 		WithWorkdir("defaults").
-		WithExec(daggerCallCmd(".", "capitalize"), nestedExec).
+		WithExec(daggerCallCmd(".", "capitalize")).
 		Stdout(ctx)
 	require.NoError(t, err, "user default should successfully apply to required argument")
 	require.Equal(t, "HELLO WORLD", output, "user default should successfully apply to required argument")
@@ -344,8 +342,7 @@ ECHO_httpUrl=function-url
 http_url=constructor-url
 `).
 			WithExec(daggerCallCmd(".", "constructor-values"), dagger.ContainerWithExecOpts{
-				Expect:                        dagger.ReturnTypeFailure,
-				ExperimentalPrivilegedNesting: true,
+				Expect: dagger.ReturnTypeFailure,
 			}).
 			CombinedOutput(ctx)
 		require.NoError(t, err)
@@ -358,8 +355,7 @@ ECHO_snake_case=function-snake
 ECHO_http_url=function-url
 `).
 			WithExec(daggerCallCmd(".", "echo"), dagger.ContainerWithExecOpts{
-				Expect:                        dagger.ReturnTypeFailure,
-				ExperimentalPrivilegedNesting: true,
+				Expect: dagger.ReturnTypeFailure,
 			}).
 			CombinedOutput(ctx)
 		require.NoError(t, err)
@@ -373,7 +369,7 @@ func (WorkspaceCompatSuite) TestDependencies(ctx context.Context, t *testctx.T) 
 	output, err := nestedDaggerContainer(t, c, "go", "defaults").
 		WithNewFile(".env", `FOOBAR_EXCLAIM_COUNT=4`).
 		WithWorkdir("defaults").
-		WithExec(daggerCallCmd(".", "message"), nestedExec).
+		WithExec(daggerCallCmd(".", "message")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "hello, world!!!!", output, "User defaults should apply to nested dependencies")
@@ -388,7 +384,7 @@ func (WorkspaceCompatSuite) TestOptionalDirectoryWithIgnore(ctx context.Context,
 		WithDirectory("/foo/mydocs", docs).
 		WithWorkdir("defaults").
 		WithNewFile(".env", `docs=/foo/mydocs`).
-		WithExec(daggerCallCmd(".", "docs", "entries"), nestedExec).
+		WithExec(daggerCallCmd(".", "docs", "entries")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "README.md\n", output)
@@ -402,7 +398,7 @@ func (WorkspaceCompatSuite) TestRequiredDirectoryWithIgnore(ctx context.Context,
 	controlOutput, err := nestedDaggerContainer(t, c, "go", "defaults").
 		WithDirectory("/foo/mydocs", docs).
 		WithWorkdir("defaults").
-		WithExec(daggerCallCmd(".", "ls-text", "--dir=/foo/mydocs"), nestedExec).
+		WithExec(daggerCallCmd(".", "ls-text", "--dir=/foo/mydocs")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "README.md\n", controlOutput, "control - if this fails, something else is wrong")
@@ -410,7 +406,7 @@ func (WorkspaceCompatSuite) TestRequiredDirectoryWithIgnore(ctx context.Context,
 		WithDirectory("/foo/mydocs", docs).
 		WithWorkdir("defaults").
 		WithNewFile(".env", `lsText_dir=/foo/mydocs`).
-		WithExec(daggerCallCmd(".", "ls-text"), nestedExec).
+		WithExec(daggerCallCmd(".", "ls-text")).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "README.md\n", output)
@@ -458,7 +454,7 @@ func (WorkspaceCompatSuite) TestModuleWithDash(ctx context.Context, t *testctx.T
 		tc := tc
 		t.Run(tc.name+" introspect", func(ctx context.Context, t *testctx.T) {
 			out, err := tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "--help"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "--help")).
 				Stdout(ctx)
 			out = trimDaggerFunctionUsageText(out)
 			require.NoError(t, err)
@@ -466,7 +462,7 @@ func (WorkspaceCompatSuite) TestModuleWithDash(ctx context.Context, t *testctx.T
 		})
 		t.Run(tc.name+" call", func(ctx context.Context, t *testctx.T) {
 			out, err := tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "message"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "message")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "yay, bob!", out)
@@ -521,7 +517,7 @@ func (WorkspaceCompatSuite) TestConstructorOptional(ctx context.Context, t *test
 		tc := tc
 		t.Run(tc.name+" introspect", func(ctx context.Context, t *testctx.T) {
 			out, err := tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "--help"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "--help")).
 				Stdout(ctx)
 			out = trimDaggerFunctionUsageText(out)
 			require.NoError(t, err)
@@ -533,25 +529,25 @@ func (WorkspaceCompatSuite) TestConstructorOptional(ctx context.Context, t *test
 		t.Run(tc.name+" call", func(ctx context.Context, t *testctx.T) {
 			// Test that 'greeting' is used
 			out, err := tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "message"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "message")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "yay, world!", out)
 			// Test that 'file' is used
 			out, err = tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "file", "contents"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "file", "contents")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "hello there!", out)
 			// Test that 'dir' is used
 			out, err = tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "dir", "entries"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "dir", "entries")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "hello.txt\n", out)
 			// Test that 'password' is used
 			out, err = tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "password", "plaintext"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "password", "plaintext")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "topsecret", out)
@@ -565,7 +561,7 @@ func (WorkspaceCompatSuite) TestConstructorOptionalEmptySecret(ctx context.Conte
 		WithEnvVariable("PASSWORD", "").
 		WithWorkdir("defaults").
 		WithNewFile(".env", "password=env://PASSWORD").
-		WithExec([]string{"dagger", "call", "-m", ".", "password", "plaintext"}, nestedExec).
+		WithExec([]string{"dagger", "call", "-m", ".", "password", "plaintext"}).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "", out)
@@ -591,7 +587,7 @@ type Test struct{}
 		WithNewFile(".env", "password=topsecret\nsomekey=somevalue\n")
 
 	out, err := ctr.
-		WithExec([]string{"dagger", "call", "-m", ".", "--help"}, nestedExec).
+		WithExec([]string{"dagger", "call", "-m", ".", "--help"}).
 		Stderr(ctx)
 	require.NoError(t, err)
 	require.NotContains(t, out, "topsecret")
@@ -676,7 +672,7 @@ func (WorkspaceCompatSuite) TestConstructorRequired(ctx context.Context, t *test
 		tc := tc
 		t.Run(tc.name+" introspect", func(ctx context.Context, t *testctx.T) {
 			out, err := tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "--help"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "--help")).
 				Stdout(ctx)
 			out = trimDaggerFunctionUsageText(out)
 			require.NoError(t, err)
@@ -691,22 +687,22 @@ func (WorkspaceCompatSuite) TestConstructorRequired(ctx context.Context, t *test
 		})
 		t.Run(tc.name+" call", func(ctx context.Context, t *testctx.T) {
 			out, err := tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "greeting"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "greeting")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "yay", out, "user default should be applied")
 			out, err = tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "count"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "count")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "42", out, "user default should be applied")
 			out, err = tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "file", "contents"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "file", "contents")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "hello there!", out, "user default should be applied")
 			out, err = tc.ctr.
-				WithExec(daggerCallCmd(tc.modPath, "dir", "entries"), nestedExec).
+				WithExec(daggerCallCmd(tc.modPath, "dir", "entries")).
 				Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "hello.txt\n", out, "user default should be applied")
@@ -795,7 +791,7 @@ superDashDash_MESSAGE_NAME=camel-name
 				ctr = ctr.WithWorkdir(tc.workdir)
 			}
 
-			stdout, err := ctr.WithExec(tc.command, nestedExec).Stdout(ctx)
+			stdout, err := ctr.WithExec(tc.command).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, tc.stdout, stdout)
 		})
@@ -808,14 +804,14 @@ func (WorkspaceCompatSuite) TestCaching(ctx context.Context, t *testctx.T) {
 	// First run
 	output1, err := ctr.
 		WithNewFile(`.env`, `DEFAULTS_GREETING=greeting1`).
-		WithExec([]string{"dagger", "-m", "./defaults", "call", "message"}, nestedExec).
+		WithExec([]string{"dagger", "-m", "./defaults", "call", "message"}).
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "greeting1, world!", output1)
 	// Second run. Only the .env changes
 	output2, err := ctr.
 		WithNewFile(`.env`, `DEFAULTS_GREETING=greeting2`).
-		WithExec([]string{"dagger", "-m", "./defaults", "call", "message"}, nestedExec).
+		WithExec([]string{"dagger", "-m", "./defaults", "call", "message"}).
 		Stdout(ctx)
 	require.NoError(t, err)
 	// The two outputs MUST BE DIFFERENT
@@ -943,8 +939,7 @@ DEFAULTS_GREETING='{"foo":"bar"}'
 					return c
 				}).
 				WithExec(tc.command, dagger.ContainerWithExecOpts{
-					Expect:                        tc.expect,
-					ExperimentalPrivilegedNesting: true,
+					Expect: tc.expect,
 				}).
 				Stdout(ctx)
 			require.NoError(t, err)

--- a/core/integration/workspace_compat_test.go
+++ b/core/integration/workspace_compat_test.go
@@ -44,17 +44,14 @@ func TestWorkspaceCompat(t *testing.T) {
 
 func compatDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger"}, args...))
 	}
 }
 
 func compatDaggerExecFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			Expect: dagger.ReturnTypeFailure,
 		})
 	}
 }
@@ -62,8 +59,7 @@ func compatDaggerExecFail(args ...string) dagger.WithContainerFunc {
 func compatDaggerCall(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "call"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 }
@@ -667,8 +663,7 @@ source = "`+remoteRef+`"
 		ctr := legacyCompatDangSource(t, c, "hello from explicit workspace")
 
 		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "-W", ".", "call", "greet"}, dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "hello from explicit workspace", strings.TrimSpace(out))

--- a/core/integration/workspace_config_test.go
+++ b/core/integration/workspace_config_test.go
@@ -195,7 +195,7 @@ password = "env://PASSWORD"
 service = "tcp://www:80"
 `)
 
-		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "dir", "entries"}, nestedExec).Stdout(ctx)
+		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "dir", "entries"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "README.md")
 	})
@@ -214,34 +214,34 @@ password = "env://PASSWORD"
 service = "tcp://www:80"
 `)
 
-		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "--help"}, nestedExec).Stdout(ctx)
+		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "--help"}).Stdout(ctx)
 		out = trimDaggerFunctionUsageText(out)
 		require.NoError(t, err)
 		require.Regexp(t, `(?m)--count int *\(default 7\)\s*$`, out)
 		require.Regexp(t, `(?m)--greeting string *\(default "yay"\)\s*$`, out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "yay", out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}, nestedExec).CombinedOutput(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}).CombinedOutput(ctx)
 		require.NoError(t, err)
 		require.NotContains(t, out, "user default:")
 		require.Contains(t, out, "yay")
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "count"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "count"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "7", out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "--greeting=bonjour", "greeting"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "--greeting=bonjour", "greeting"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "bonjour", out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "file", "contents"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "file", "contents"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "hello there!", out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "dir", "entries"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "dir", "entries"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "hello.txt\n", out)
 	})
@@ -260,8 +260,7 @@ service = "tcp://www:80"
 `).WithNewFile(".env", "SUPERCONSTRUCTOR_greeting=from-env")
 
 		stderr, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}, dagger.ContainerWithExecOpts{
-			Expect:                        dagger.ReturnTypeFailure,
-			ExperimentalPrivilegedNesting: true,
+			Expect: dagger.ReturnTypeFailure,
 		}).Stderr(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stderr, "required")
@@ -347,7 +346,7 @@ service = "tcp://www:80"
 unknown = "ignored"
 `)
 
-		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}, nestedExec).Stdout(ctx)
+		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "configured", out)
 	})
@@ -370,11 +369,11 @@ PASSWORD = "env://PASSWORD"
 SERVICE = "tcp://www:80"
 `)
 
-		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}, nestedExec).Stdout(ctx)
+		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "greeting"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "case-insensitive", out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "count"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "count"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "9", out)
 	})
@@ -417,8 +416,7 @@ service = "tcp://www:80"
 `)
 
 		errOut, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "count"}, dagger.ContainerWithExecOpts{
-			Expect:                        dagger.ReturnTypeFailure,
-			ExperimentalPrivilegedNesting: true,
+			Expect: dagger.ReturnTypeFailure,
 		}).CombinedOutput(ctx)
 		require.NoError(t, err)
 		require.Contains(t, errOut, "count")
@@ -441,11 +439,11 @@ password = "env://PASSWORD"
 service = "tcp://www:80"
 `)
 
-		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "--greeting=override", "count"}, nestedExec).Stdout(ctx)
+		out, err := ctr.WithExec([]string{"dagger", "--progress=report", "call", "--greeting=override", "count"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "7", out)
 
-		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "--count=11", "greeting"}, nestedExec).Stdout(ctx)
+		out, err = ctr.WithExec([]string{"dagger", "--progress=report", "call", "--count=11", "greeting"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "configured", out)
 	})
@@ -547,8 +545,7 @@ service = %s
 
 				args := append([]string{"dagger", "--progress=report", "call"}, tc.call...)
 				errOut, err := ctr.WithExec(args, dagger.ContainerWithExecOpts{
-					Expect:                        dagger.ReturnTypeFailure,
-					ExperimentalPrivilegedNesting: true,
+					Expect: dagger.ReturnTypeFailure,
 				}).CombinedOutput(ctx)
 				require.NoError(t, err)
 				for _, want := range tc.assert {

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -69,7 +69,6 @@ type Myapp {
     }
   }
 }`,
-			ExperimentalPrivilegedNesting: true,
 		})
 		out, err := preview.Stdout(ctx)
 		require.NoError(t, err)

--- a/core/integration/workspace_selection_test.go
+++ b/core/integration/workspace_selection_test.go
@@ -33,17 +33,14 @@ func TestWorkspaceSelection(t *testing.T) {
 
 func workspaceSelectionDaggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			ExperimentalPrivilegedNesting: true,
-		})
+		return c.WithExec(append([]string{"dagger"}, args...))
 	}
 }
 
 func workspaceSelectionDaggerCall(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "call"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 }
@@ -51,9 +48,8 @@ func workspaceSelectionDaggerCall(args ...string) dagger.WithContainerFunc {
 func workspaceSelectionDaggerCallFail(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "call"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			UseEntrypoint: true,
+			Expect:        dagger.ReturnTypeFailure,
 		})
 	}
 }
@@ -61,8 +57,7 @@ func workspaceSelectionDaggerCallFail(args ...string) dagger.WithContainerFunc {
 func workspaceSelectionDaggerQuery(query string, args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "query"}, args...), dagger.ContainerWithExecOpts{
-			Stdin:                         query,
-			ExperimentalPrivilegedNesting: true,
+			Stdin: query,
 		})
 	}
 }
@@ -70,9 +65,8 @@ func workspaceSelectionDaggerQuery(query string, args ...string) dagger.WithCont
 func workspaceSelectionDaggerQueryFail(query string, args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--progress=report", "query"}, args...), dagger.ContainerWithExecOpts{
-			Stdin:                         query,
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			Stdin:  query,
+			Expect: dagger.ReturnTypeFailure,
 		})
 	}
 }

--- a/core/integration/workspace_test.go
+++ b/core/integration/workspace_test.go
@@ -88,9 +88,8 @@ func (WorkspaceSuite) TestSingleQueryWorkspaceModuleLoadingSkipsUnreferencedBrok
 
 	t.Run("full schema query still loads every workspace module", func(ctx context.Context, t *testctx.T) {
 		fullSchema := base.WithExec([]string{"dagger", "query"}, dagger.ContainerWithExecOpts{
-			Stdin:                         `{ __schema { queryType { name } } }`,
-			ExperimentalPrivilegedNesting: true,
-			Expect:                        dagger.ReturnTypeFailure,
+			Stdin:  `{ __schema { queryType { name } } }`,
+			Expect: dagger.ReturnTypeFailure,
 		})
 
 		errOut, err := fullSchema.Stderr(ctx)

--- a/core/integration/workspace_user_config_test.go
+++ b/core/integration/workspace_user_config_test.go
@@ -393,8 +393,7 @@ region = "us-east-1"
 
 	userConfigDaggerExec := func(ctr *dagger.Container, args ...string) *dagger.Container {
 		return ctr.WithExec(append([]string{"dagger"}, args...), dagger.ContainerWithExecOpts{
-			UseEntrypoint:                 true,
-			ExperimentalPrivilegedNesting: true,
+			UseEntrypoint: true,
 		})
 	}
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -4723,6 +4723,7 @@ func (s *containerSchema) terminalLegacy(
 	err = srv.Select(ctx, ctr, new(dagql.Result[*core.Container]),
 		dagql.Selector{
 			Field: "terminal",
+			View:  "v0.12.0",
 			Args:  inputs,
 		},
 	)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1671,6 +1671,7 @@ func (s *containerSchema) stdoutLegacy(ctx context.Context, parent dagql.ObjectR
 		var ctr dagql.ObjectResult[*core.Container]
 		if err := srv.Select(ctx, parent, &ctr, dagql.Selector{
 			Field: "withExec",
+			View:  "v0.12.0",
 			Args: []dagql.NamedInput{
 				{
 					Name:  "args",
@@ -1712,6 +1713,7 @@ func (s *containerSchema) stderrLegacy(ctx context.Context, parent dagql.ObjectR
 		var ctr dagql.ObjectResult[*core.Container]
 		if err := srv.Select(ctx, parent, &ctr, dagql.Selector{
 			Field: "withExec",
+			View:  "v0.12.0",
 			Args: []dagql.NamedInput{
 				{
 					Name:  "args",

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -654,10 +654,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				dagql.Arg("redirectStderr").Doc(
 					`Redirect the command's standard error to a file in the container. Example: "./stderr.txt"`),
 				dagql.Arg("expect").Doc(`Exit codes this command is allowed to exit with without error`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
-					`Provides Dagger access to the executed command.`),
-				dagql.Arg("expect").Doc(`Exit codes this command is allowed to exit with without error`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. Like --privileged in Docker`,
@@ -935,10 +933,12 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 				`This is the initial state of all containers.`),
 
 		dagql.NodeFunc("withDefaultTerminalCmd", s.withDefaultTerminalCmd).
+			View(AllVersion).
 			Doc(`Set the default command to invoke for the container's terminal API.`).
 			Args(
 				dagql.Arg("args").Doc(`The args of the command.`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
@@ -954,7 +954,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			Doc(`Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
 			Args(
 				dagql.Arg("cmd").Doc(`If set, override the container's default terminal command and invoke these command arguments instead.`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
@@ -968,7 +969,8 @@ func (s *containerSchema) Install(srv *dagql.Server) {
 			Doc(`Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
 			Args(
 				dagql.Arg("cmd").Doc(`If set, override the container's default terminal command and invoke these command arguments instead.`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
@@ -1618,6 +1620,9 @@ func (s *containerSchema) withExec(ctx context.Context, parent dagql.ObjectResul
 
 	if args.SkipEntrypoint != nil {
 		args.UseEntrypoint = !*args.SkipEntrypoint
+	}
+	if core.Supports(ctx, defaultNestingVersion) {
+		args.ExperimentalPrivilegedNesting = !args.DisableNesting
 	}
 
 	var md *engineutil.ExecutionMetadata
@@ -4611,6 +4616,9 @@ func (s *containerSchema) withDefaultTerminalCmd(
 	parent dagql.ObjectResult[*core.Container],
 	args containerWithDefaultTerminalCmdArgs,
 ) (*core.Container, error) {
+	if core.Supports(ctx, defaultNestingVersion) {
+		args.ExperimentalPrivilegedNesting = dagql.Opt(dagql.Boolean(!args.DisableNesting))
+	}
 	ctr, parentPendingLazy, err := cloneContainerForSchemaChild(ctx, parent)
 	if err != nil {
 		return nil, err
@@ -4647,7 +4655,10 @@ func (s *containerSchema) terminal(
 		args.Cmd = ctr.Self().DefaultTerminalCmd.Args
 	}
 
-	if !args.ExperimentalPrivilegedNesting.Valid {
+	if core.Supports(ctx, defaultNestingVersion) {
+		defaults := ctr.Self().DefaultTerminalCmd.ExperimentalPrivilegedNesting.GetOr(dagql.Boolean(true))
+		args.ExperimentalPrivilegedNesting = dagql.Opt(dagql.Boolean(defaults.Bool() && !args.DisableNesting))
+	} else if !args.ExperimentalPrivilegedNesting.Valid {
 		args.ExperimentalPrivilegedNesting = ctr.Self().DefaultTerminalCmd.ExperimentalPrivilegedNesting
 	}
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -305,7 +305,8 @@ func (s *directorySchema) Install(srv *dagql.Server) {
 			Args(
 				dagql.Arg("container").Doc(`If set, override the default container used for the terminal.`),
 				dagql.Arg("cmd").Doc(`If set, override the container's default terminal command and invoke these command arguments instead.`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
@@ -1777,6 +1778,9 @@ func (s *directorySchema) terminal(
 
 	if len(args.Cmd) == 0 {
 		args.Cmd = []string{"sh"}
+	}
+	if core.Supports(ctx, defaultNestingVersion) {
+		args.ExperimentalPrivilegedNesting = dagql.Opt(dagql.Boolean(!args.DisableNesting))
 	}
 
 	var ctr dagql.ObjectResult[*core.Container]

--- a/core/schema/nesting_test.go
+++ b/core/schema/nesting_test.go
@@ -2,14 +2,89 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNestingLegacyTerminalForwarding(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		arg  []dagql.NamedInput
+		want bool
+	}{
+		{name: "omitted"},
+		{name: "disabled", arg: []dagql.NamedInput{{Name: "experimentalPrivilegedNesting", Value: dagql.Opt(dagql.Boolean(false))}}},
+		{name: "enabled", arg: []dagql.NamedInput{{Name: "experimentalPrivilegedNesting", Value: dagql.Opt(dagql.Boolean(true))}}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, dag := newNestingTestServer(t, "v0.11.0")
+			obj, ok := dag.ObjectType("Container")
+			require.True(t, ok)
+			field, ok := obj.FieldSpec("terminal", "v0.12.0")
+			require.True(t, ok)
+			stopped := errors.New("terminal forwarding inspected")
+			called := false
+			// Intercept the terminal attach boundary while retaining the real
+			// schema arguments and version filter. No interactive client is needed.
+			obj.Extend(field, func(ctx context.Context, _ dagql.AnyResult, inputs map[string]dagql.Input) (dagql.AnyResult, error) {
+				called = true
+				assert.False(t, core.Supports(ctx, defaultNestingVersion))
+				var args containerTerminalArgs
+				require.NoError(t, field.Args.Decode(inputs, &args, dagql.CurrentCall(ctx).View))
+				assert.Equal(t, tc.want, args.ExperimentalPrivilegedNesting.GetOr(false).Bool())
+				return nil, stopped
+			})
+			var terminal dagql.ObjectResult[*core.TerminalLegacy]
+			err := dag.Select(ctx, dag.Root(), &terminal,
+				dagql.Selector{Field: "container"},
+				dagql.Selector{Field: "terminal", View: "v0.11.0", Args: tc.arg},
+			)
+			require.ErrorContains(t, err, stopped.Error())
+			require.True(t, called)
+		})
+	}
+}
+
+func TestNestingLegacyOutputForwarding(t *testing.T) {
+	for _, output := range []string{"stdout", "stderr"} {
+		t.Run(output, func(t *testing.T) {
+			ctx, dag := newNestingTestServer(t, "v0.11.0")
+			obj, ok := dag.ObjectType("Container")
+			require.True(t, ok)
+			field, ok := obj.(dagql.Class[*core.Container]).Field("withExec", "v0.12.0")
+			require.True(t, ok)
+			stopped := errors.New("implicit exec inspected")
+			called := false
+			obj.Extend(*field.Spec, func(ctx context.Context, self dagql.AnyResult, inputs map[string]dagql.Input) (dagql.AnyResult, error) {
+				called = true
+				// Run the real resolver and inspect its execution plan without
+				// starting a container or requiring a BuildKit backend.
+				res, err := field.Func(ctx, self.(dagql.ObjectResult[*core.Container]), inputs, dagql.CurrentCall(ctx).View)
+				require.NoError(t, err)
+				ctr := res.(dagql.ObjectResult[*core.Container])
+				lazy, ok := ctr.Self().Lazy.(*core.ContainerExecLazy)
+				require.True(t, ok)
+				assert.False(t, lazy.State.Opts.ExperimentalPrivilegedNesting)
+				assert.True(t, lazy.State.Opts.UseEntrypoint)
+				return nil, stopped
+			})
+			var result dagql.String
+			err := dag.Select(ctx, dag.Root(), &result,
+				dagql.Selector{Field: "container"},
+				dagql.Selector{Field: output, View: "v0.11.0"},
+			)
+			require.ErrorContains(t, err, stopped.Error())
+			require.True(t, called)
+		})
+	}
+}
 
 func newNestingTestServer(t *testing.T, view call.View) (context.Context, *dagql.Server) {
 	t.Helper()

--- a/core/schema/nesting_test.go
+++ b/core/schema/nesting_test.go
@@ -1,0 +1,119 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func newNestingTestServer(t *testing.T, view call.View) (context.Context, *dagql.Server) {
+	t.Helper()
+	ctx := t.Context()
+	cache, err := dagql.NewCache(ctx, "", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cache.Close(context.Background())) })
+	ctx = dagql.ContextWithCache(ctx, cache)
+	ctx = engine.ContextWithClientMetadata(ctx, &engine.ClientMetadata{ClientID: "nesting-call", SessionID: "nesting-call"})
+	srv := &currentTypeDefsTestServer{platform: core.Platform{OS: "linux", Architecture: "amd64"}}
+	base, err := NewCoreSchemaBase(ctx, srv)
+	require.NoError(t, err)
+	dag, err := base.Fork(ctx, core.NewRoot(srv), view)
+	require.NoError(t, err)
+	srv.dag = dag
+	return ctx, dag
+}
+
+// Internal calls use the latest API even on a legacy server.
+func TestNestingExecCallView(t *testing.T) {
+	ctx, dag := newNestingTestServer(t, "v0.21.0")
+	for _, tc := range []struct {
+		name string
+		view call.View
+		arg  []dagql.NamedInput
+		want bool
+	}{
+		{name: "internal default", want: true},
+		{name: "internal opt-out", arg: []dagql.NamedInput{{Name: "disableNesting", Value: dagql.Boolean(true)}}},
+		{name: "legacy default", view: "v0.21.0"},
+		{name: "legacy opt-in", view: "v0.21.0", arg: []dagql.NamedInput{{Name: "experimentalPrivilegedNesting", Value: dagql.Boolean(true)}}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ctr dagql.ObjectResult[*core.Container]
+			require.NoError(t, dag.Select(ctx, dag.Root(), &ctr,
+				dagql.Selector{Field: "container"},
+				dagql.Selector{Field: "withExec", View: tc.view, Args: append([]dagql.NamedInput{
+					{Name: "args", Value: dagql.ArrayInput[dagql.String]{"true"}},
+				}, tc.arg...)},
+			))
+			lazy, ok := ctr.Self().Lazy.(*core.ContainerExecLazy)
+			require.True(t, ok)
+			require.Equal(t, tc.want, lazy.State.Opts.ExperimentalPrivilegedNesting)
+		})
+	}
+}
+
+func TestNestingTerminalDefaultsCallView(t *testing.T) {
+	ctx, dag := newNestingTestServer(t, "v0.21.0")
+	for _, tc := range []struct {
+		name string
+		view call.View
+		arg  []dagql.NamedInput
+		want bool
+	}{
+		{name: "internal default", want: true},
+		{name: "internal opt-out", arg: []dagql.NamedInput{{Name: "disableNesting", Value: dagql.Boolean(true)}}},
+		{name: "legacy default", view: "v0.21.0"},
+		{name: "legacy opt-in", view: "v0.21.0", arg: []dagql.NamedInput{{Name: "experimentalPrivilegedNesting", Value: dagql.Opt(dagql.Boolean(true))}}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ctr dagql.ObjectResult[*core.Container]
+			require.NoError(t, dag.Select(ctx, dag.Root(), &ctr,
+				dagql.Selector{Field: "container"},
+				dagql.Selector{Field: "withDefaultTerminalCmd", View: tc.view, Args: append([]dagql.NamedInput{
+					{Name: "args", Value: dagql.ArrayInput[dagql.String]{"sh"}},
+				}, tc.arg...)},
+			))
+			require.Equal(t, tc.want, ctr.Self().DefaultTerminalCmd.ExperimentalPrivilegedNesting.GetOr(false).Bool())
+		})
+	}
+}
+
+func TestNestingSchemaVersions(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		present string
+		absent  string
+	}{
+		{version: "v0.21.0", present: "experimentalPrivilegedNesting", absent: "disableNesting"},
+		{version: "v1.0.0-beta.11", present: "experimentalPrivilegedNesting", absent: "disableNesting"},
+		{version: "v1.0.0-beta.12", present: "disableNesting", absent: "experimentalPrivilegedNesting"},
+		{version: "v1.0.0", present: "disableNesting", absent: "experimentalPrivilegedNesting"},
+	} {
+		t.Run(tc.version, func(t *testing.T) {
+			_, dag := newNestingTestServer(t, call.View(tc.version))
+			data, err := getSchemaJSON(nil, nil, dag.View, dag)
+			require.NoError(t, err)
+			schema := decodeSchemaResponse(t, data).Schema
+			for _, target := range [][2]string{
+				{"Container", "withExec"}, {"Container", "asService"}, {"Container", "up"},
+				{"Container", "terminal"}, {"Container", "withDefaultTerminalCmd"}, {"Directory", "terminal"},
+			} {
+				t.Run(target[0]+"/"+target[1], func(t *testing.T) {
+					field := schemaField(schema.Types.Get(target[0]), target[1])
+					require.NotNil(t, field)
+					arg := schemaArgument(t, field, tc.present)
+					require.NotNil(t, arg.DefaultValue)
+					require.Equal(t, "false", *arg.DefaultValue)
+					for _, arg := range field.Args {
+						require.NotEqual(t, tc.absent, arg.Name, "%s.%s", target[0], target[1])
+					}
+				})
+			}
+		})
+	}
+}

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -31,7 +31,8 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 					`If empty, the container's default command is used.`),
 				dagql.Arg("useEntrypoint").Doc(
 					`If the container has an entrypoint, prepend it to the args.`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
@@ -74,7 +75,8 @@ func (s *serviceSchema) Install(srv *dagql.Server) {
 					`If empty, the container's default command is used.`),
 				dagql.Arg("useEntrypoint").Doc(
 					`If the container has an entrypoint, prepend it to the args.`),
-				dagql.Arg("experimentalPrivilegedNesting").Doc(
+				dagql.Arg("disableNesting").View(AfterVersion(defaultNestingVersion)).Doc(`Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.`),
+				dagql.Arg("experimentalPrivilegedNesting").View(BeforeVersion(defaultNestingVersion)).Doc(
 					`Provides Dagger access to the executed command.`),
 				dagql.Arg("insecureRootCapabilities").Doc(
 					`Execute the command with all root capabilities. This is similar to
@@ -279,6 +281,9 @@ func (s *serviceSchema) containerAsServiceLegacy(ctx context.Context, parent dag
 }
 
 func (s *serviceSchema) containerAsService(ctx context.Context, parent dagql.ObjectResult[*core.Container], args core.ContainerAsServiceArgs) (*core.Service, error) {
+	if core.Supports(ctx, defaultNestingVersion) {
+		args.ExperimentalPrivilegedNesting = !args.DisableNesting
+	}
 	cache, err := dagql.EngineCache(ctx)
 	if err != nil {
 		return nil, err
@@ -323,7 +328,11 @@ func (s *serviceSchema) containerUp(ctx context.Context, ctr dagql.ObjectResult[
 			Value: dagql.Boolean(true),
 		})
 	}
-	if args.ExperimentalPrivilegedNesting {
+	if core.Supports(ctx, defaultNestingVersion) {
+		inputs = append(inputs, dagql.NamedInput{
+			Name: "disableNesting", Value: dagql.Boolean(args.DisableNesting),
+		})
+	} else if args.ExperimentalPrivilegedNesting {
 		inputs = append(inputs, dagql.NamedInput{
 			Name:  "experimentalPrivilegedNesting",
 			Value: dagql.Boolean(true),

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -15,6 +15,10 @@ type SchemaResolvers interface {
 	Install(*dagql.Server)
 }
 
+// Nesting is opt-out starting with this API version. Older views retain the
+// experimentalPrivilegedNesting opt-in argument and behavior.
+const defaultNestingVersion = "v1.0.0-beta.12"
+
 func Syncer[T dagql.Typed]() dagql.Field[T] {
 	return dagql.NodeFunc("sync", func(ctx context.Context, self dagql.ObjectResult[T], args struct {
 		Recipe bool `default:"false" internal:"true"`

--- a/core/sdk/go_sdk.go
+++ b/core/sdk/go_sdk.go
@@ -215,10 +215,6 @@ func (sdk *goSDK) GenerateClient(
 						"codegen",
 					}, codegenArgs...),
 				},
-				{
-					Name:  "experimentalPrivilegedNesting",
-					Value: dagql.NewBoolean(true),
-				},
 			},
 		},
 	)
@@ -621,12 +617,6 @@ func (sdk *goSDK) baseWithCodegen(
 					Value: append(dagql.ArrayInput[dagql.String]{
 						"codegen",
 					}, codegenArgs...),
-				},
-				{
-					// The self-calls schema merge dials the engine from inside
-					// the codegen container.
-					Name:  "experimentalPrivilegedNesting",
-					Value: dagql.NewBoolean(true),
 				},
 			},
 		},

--- a/core/sdk/module_typedefs.go
+++ b/core/sdk/module_typedefs.go
@@ -103,7 +103,6 @@ func (sdk *moduleTypes) ModuleTypes(
 			Args: []dagql.NamedInput{
 				{Name: "args", Value: dagql.ArrayInput[dagql.String]{}},
 				{Name: "useEntrypoint", Value: dagql.NewBoolean(true)},
-				{Name: "experimentalPrivilegedNesting", Value: dagql.NewBoolean(true)},
 				{Name: "execMD", Value: dagql.NewDigestedSerializedString(&execMD, moduleTypesExecMDDigest)},
 				{Name: "moduleContext", Value: dagql.Opt(moduleContextID)},
 			},

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -121,6 +121,9 @@ type TerminalArgs struct {
 	// Provide dagger access to the executed command
 	ExperimentalPrivilegedNesting dagql.Optional[dagql.Boolean] `default:"false"`
 
+	// Disable access to the Dagger API from the terminal command.
+	DisableNesting bool `default:"false"`
+
 	// Grant the process all root capabilities
 	InsecureRootCapabilities dagql.Optional[dagql.Boolean] `default:"false"`
 }

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build
@@ -28,19 +28,19 @@ $ viztest: Viztest! X.Xs CACHED
   │
   ├╴$ Container.from(address: "docker.io/library/busybox:1.35@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"): Container! X.Xs CACHED
   │
-  ├╴✔ withExec /bin/sh -c 'echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' X.Xs
+  ├╴✔ withExec /bin/sh -c 'echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' (disableNesting: true) X.Xs
   │ ┃ the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X
   ├╴✔ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs
   ├╴✔ withWorkdir / X.Xs
-  ├╴✔ withExec /bin/sh -c 'echo hello, world!' X.Xs
+  ├╴✔ withExec /bin/sh -c 'echo hello, world!' (disableNesting: true) X.Xs
   │ ┃ hello, world!
   ├╴✔ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs
   ├╴✔ withWorkdir / X.Xs
-  ├╴✔ withExec /bin/sh -c 'echo what is up?' X.Xs
+  ├╴✔ withExec /bin/sh -c 'echo what is up?' (disableNesting: true) X.Xs
   │ ┃ what is up?
   ├╴✔ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs
   ├╴✔ withWorkdir / X.Xs
-  ├╴✔ withExec /bin/sh -c 'echo im another layer' X.Xs
+  ├╴✔ withExec /bin/sh -c 'echo im another layer' (disableNesting: true) X.Xs
   │ ┃ im another layer
   ├╴✔ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs
   ├╴✔ .withoutEntrypoint(keepDefaultArgs: true): Container! X.Xs

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/docker-build-fail
@@ -25,15 +25,15 @@ $ viztest: Viztest! X.Xs CACHED
   │
   ├╴$ Container.from(address: "docker.io/library/busybox:1.34@sha256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"): Container! X.Xs CACHED
   │
-  ├╴✔ withExec /bin/sh -c 'echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' X.Xs
+  ├╴✔ withExec /bin/sh -c 'echo the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X' (disableNesting: true) X.Xs
   │ ┃ the time is currently 20XX-XX-XX XX:XX:XX.XXXX +XXXX UTC m=+X.X
   ├╴✔ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs
   ├╴✔ withWorkdir / X.Xs
-  ├╴✔ withExec /bin/sh -c 'echo hello, world!' X.Xs
+  ├╴✔ withExec /bin/sh -c 'echo hello, world!' (disableNesting: true) X.Xs
   │ ┃ hello, world!
   ├╴✔ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs
   ├╴✔ withWorkdir / X.Xs
-  ├╴✘ withExec /bin/sh -c 'echo im failing && false' X.Xs ERROR
+  ├╴✘ withExec /bin/sh -c 'echo im failing && false' (disableNesting: true) X.Xs ERROR
   │ ┃ im failing
   │ ! exit code: 1
   ├╴○ withEnvVariable PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin X.Xs

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -370,8 +370,10 @@ type Container implements Exportable & Node & Syncer {
     """If the container has an entrypoint, prepend it to the args."""
     useEntrypoint: Boolean = false
 
-    """Provides Dagger access to the executed command."""
-    experimentalPrivilegedNesting: Boolean = false
+    """
+    Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    """
+    disableNesting: Boolean = false
 
     """
     Execute the command with all root capabilities. This is similar to running a
@@ -837,8 +839,10 @@ type Container implements Exportable & Node & Syncer {
     """
     cmd: [String!] = []
 
-    """Provides Dagger access to the executed command."""
-    experimentalPrivilegedNesting: Boolean = false
+    """
+    Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    """
+    disableNesting: Boolean = false
 
     """
     Execute the command with all root capabilities. This is similar to running a
@@ -876,8 +880,10 @@ type Container implements Exportable & Node & Syncer {
     """If the container has an entrypoint, prepend it to the args."""
     useEntrypoint: Boolean = false
 
-    """Provides Dagger access to the executed command."""
-    experimentalPrivilegedNesting: Boolean = false
+    """
+    Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    """
+    disableNesting: Boolean = false
 
     """
     Execute the command with all root capabilities. This is similar to running a
@@ -931,8 +937,10 @@ type Container implements Exportable & Node & Syncer {
     """The args of the command."""
     args: [String!]!
 
-    """Provides Dagger access to the executed command."""
-    experimentalPrivilegedNesting: Boolean = false
+    """
+    Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    """
+    disableNesting: Boolean = false
 
     """
     Execute the command with all root capabilities. This is similar to running a
@@ -1111,8 +1119,10 @@ type Container implements Exportable & Node & Syncer {
     """Exit codes this command is allowed to exit with without error"""
     expect: ReturnType = SUCCESS
 
-    """Provides Dagger access to the executed command."""
-    experimentalPrivilegedNesting: Boolean = false
+    """
+    Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    """
+    disableNesting: Boolean = false
 
     """
     Execute the command with all root capabilities. Like --privileged in Docker
@@ -2104,8 +2114,10 @@ type Directory implements Exportable & Node & Syncer {
     """
     cmd: [String!] = []
 
-    """Provides Dagger access to the executed command."""
-    experimentalPrivilegedNesting: Boolean = false
+    """
+    Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    """
+    disableNesting: Boolean = false
 
     """
     Execute the command with all root capabilities. This is similar to running a

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -2872,8 +2872,8 @@
                                 <p>If the container has an entrypoint, prepend it to the args.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Provides Dagger access to the executed command.</p>
+                                <h6 class="field-argument-name"><span class="property-name"><code>disableNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -3397,8 +3397,8 @@
                                 <p>If set, override the container&#39;s default terminal command and invoke these command arguments instead.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Provides Dagger access to the executed command.</p>
+                                <h6 class="field-argument-name"><span class="property-name"><code>disableNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -3439,8 +3439,8 @@
                                 <p>If the container has an entrypoint, prepend it to the args.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Provides Dagger access to the executed command.</p>
+                                <h6 class="field-argument-name"><span class="property-name"><code>disableNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -3515,8 +3515,8 @@
                                 <p>The args of the command.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Provides Dagger access to the executed command.</p>
+                                <h6 class="field-argument-name"><span class="property-name"><code>disableNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -3737,8 +3737,8 @@
                                 <p>Exit codes this command is allowed to exit with without error</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Provides Dagger access to the executed command.</p>
+                                <h6 class="field-argument-name"><span class="property-name"><code>disableNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
@@ -5281,8 +5281,8 @@
                                 <p>If set, override the container&#39;s default terminal command and invoke these command arguments instead.</p>
                               </div>
                               <div class="field-argument">
-                                <h6 class="field-argument-name"><span class="property-name"><code>experimentalPrivilegedNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
-                                <p>Provides Dagger access to the executed command.</p>
+                                <h6 class="field-argument-name"><span class="property-name"><code>disableNesting</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>
+                                <p>Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>insecureRootCapabilities</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span></h6>

--- a/docs/static/reference/php/Dagger/Container.html
+++ b/docs/static/reference/php/Dagger/Container.html
@@ -146,7 +146,7 @@
                     <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_asService">asService</a>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+                    <a href="#method_asService">asService</a>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         
                                             <p><p>Turn the container into a Service.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -476,7 +476,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_terminal">terminal</a>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+                    <a href="#method_terminal">terminal</a>(array|null $cmd = [], bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false)
         
                                             <p><p>Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -486,7 +486,7 @@
                     void
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_up">up</a>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+                    <a href="#method_up">up</a>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         
                                             <p><p>Starts a Service and creates a tunnel that forwards traffic from the caller's network to that service.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -526,7 +526,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withDefaultTerminalCmd">withDefaultTerminalCmd</a>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+                    <a href="#method_withDefaultTerminalCmd">withDefaultTerminalCmd</a>(array $args, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false)
         
                                             <p><p>Set the default command to invoke for the container's terminal API.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -596,7 +596,7 @@
                     <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_withExec">withExec</a>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+                    <a href="#method_withExec">withExec</a>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         
                                             <p><p>Execute a command in the container, and return a new snapshot of the container state after execution.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1080,7 +1080,7 @@
                     <h3 id="method_asService">
         <div class="location">at line 21</div>
         <code>                    <a href="../Dagger/Service.html"><abbr title="Dagger\Service">Service</abbr></a>
-    <strong>asService</strong>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+    <strong>asService</strong>(array|null $args = [], bool|null $useEntrypoint = false, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
     <div class="details">    
@@ -1106,7 +1106,7 @@
             </tr>
                     <tr>
                 <td>bool|null</td>
-                <td>$experimentalPrivilegedNesting</td>
+                <td>$disableNesting</td>
                 <td></td>
             </tr>
                     <tr>
@@ -2468,7 +2468,7 @@
                     <h3 id="method_terminal">
         <div class="location">at line 520</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>terminal</strong>(array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+    <strong>terminal</strong>(array|null $cmd = [], bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
     <div class="details">    
@@ -2489,7 +2489,7 @@
             </tr>
                     <tr>
                 <td>bool|null</td>
-                <td>$experimentalPrivilegedNesting</td>
+                <td>$disableNesting</td>
                 <td></td>
             </tr>
                     <tr>
@@ -2520,7 +2520,7 @@
                     <h3 id="method_up">
         <div class="location">at line 543</div>
         <code>                    void
-    <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+    <strong>up</strong>(bool|null $random = false, array|null $ports = null, array|null $args = [], bool|null $useEntrypoint = false, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
     <div class="details">    
@@ -2556,7 +2556,7 @@
             </tr>
                     <tr>
                 <td>bool|null</td>
-                <td>$experimentalPrivilegedNesting</td>
+                <td>$disableNesting</td>
                 <td></td>
             </tr>
                     <tr>
@@ -2718,7 +2718,7 @@
                     <h3 id="method_withDefaultTerminalCmd">
         <div class="location">at line 614</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+    <strong>withDefaultTerminalCmd</strong>(array $args, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
     <div class="details">    
@@ -2739,7 +2739,7 @@
             </tr>
                     <tr>
                 <td>bool|null</td>
-                <td>$experimentalPrivilegedNesting</td>
+                <td>$disableNesting</td>
                 <td></td>
             </tr>
                     <tr>
@@ -3107,7 +3107,7 @@
                     <h3 id="method_withExec">
         <div class="location">at line 756</div>
         <code>                    <a href="../Dagger/Container.html"><abbr title="Dagger\Container">Container</abbr></a>
-    <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
+    <strong>withExec</strong>(array $args, bool|null $useEntrypoint = false, string|null $stdin = &#039;&#039;, string|null $redirectStdin = &#039;&#039;, string|null $redirectStdout = &#039;&#039;, string|null $redirectStderr = &#039;&#039;, <abbr title="Dagger\Dagger\ReturnType">ReturnType</abbr>|null $expect = null, bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false, bool|null $expand = false, bool|null $noInit = false)
         </code>
     </h3>
     <div class="details">    
@@ -3158,7 +3158,7 @@
             </tr>
                     <tr>
                 <td>bool|null</td>
-                <td>$experimentalPrivilegedNesting</td>
+                <td>$disableNesting</td>
                 <td></td>
             </tr>
                     <tr>

--- a/docs/static/reference/php/Dagger/Directory.html
+++ b/docs/static/reference/php/Dagger/Directory.html
@@ -366,7 +366,7 @@
                     <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
                 </div>
                 <div class="col-md-8">
-                    <a href="#method_terminal">terminal</a>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+                    <a href="#method_terminal">terminal</a>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false)
         
                                             <p><p>Opens an interactive terminal in new container with this directory mounted inside.</p></p>                </div>
                 <div class="col-md-2"></div>
@@ -1604,7 +1604,7 @@
                     <h3 id="method_terminal">
         <div class="location">at line 342</div>
         <code>                    <a href="../Dagger/Directory.html"><abbr title="Dagger\Directory">Directory</abbr></a>
-    <strong>terminal</strong>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $experimentalPrivilegedNesting = false, bool|null $insecureRootCapabilities = false)
+    <strong>terminal</strong>(<abbr title="Dagger\Dagger\Container">Container</abbr>|null $container = null, array|null $cmd = [], bool|null $disableNesting = false, bool|null $insecureRootCapabilities = false)
         </code>
     </h3>
     <div class="details">    
@@ -1630,7 +1630,7 @@
             </tr>
                     <tr>
                 <td>bool|null</td>
-                <td>$experimentalPrivilegedNesting</td>
+                <td>$disableNesting</td>
                 <td></td>
             </tr>
                     <tr>

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -23,7 +23,7 @@ defmodule Dagger.Container do
   @spec as_service(t(), [
           {:args, [String.t()]},
           {:use_entrypoint, boolean() | nil},
-          {:experimental_privileged_nesting, boolean() | nil},
+          {:disable_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil},
           {:expand, boolean() | nil},
           {:no_init, boolean() | nil}
@@ -34,10 +34,7 @@ defmodule Dagger.Container do
       |> QB.select("asService")
       |> QB.maybe_put_arg("args", optional_args[:args])
       |> QB.maybe_put_arg("useEntrypoint", optional_args[:use_entrypoint])
-      |> QB.maybe_put_arg(
-        "experimentalPrivilegedNesting",
-        optional_args[:experimental_privileged_nesting]
-      )
+      |> QB.maybe_put_arg("disableNesting", optional_args[:disable_nesting])
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
       |> QB.maybe_put_arg("noInit", optional_args[:no_init])
@@ -674,7 +671,7 @@ defmodule Dagger.Container do
   """
   @spec terminal(t(), [
           {:cmd, [String.t()]},
-          {:experimental_privileged_nesting, boolean() | nil},
+          {:disable_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil}
         ]) :: Dagger.Container.t()
   def terminal(%__MODULE__{} = container, optional_args \\ []) do
@@ -682,10 +679,7 @@ defmodule Dagger.Container do
       container.query_builder
       |> QB.select("terminal")
       |> QB.maybe_put_arg("cmd", optional_args[:cmd])
-      |> QB.maybe_put_arg(
-        "experimentalPrivilegedNesting",
-        optional_args[:experimental_privileged_nesting]
-      )
+      |> QB.maybe_put_arg("disableNesting", optional_args[:disable_nesting])
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
 
     %Dagger.Container{
@@ -704,7 +698,7 @@ defmodule Dagger.Container do
           {:ports, [Dagger.PortForward.t()]},
           {:args, [String.t()]},
           {:use_entrypoint, boolean() | nil},
-          {:experimental_privileged_nesting, boolean() | nil},
+          {:disable_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil},
           {:expand, boolean() | nil},
           {:no_init, boolean() | nil}
@@ -717,10 +711,7 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg("ports", optional_args[:ports])
       |> QB.maybe_put_arg("args", optional_args[:args])
       |> QB.maybe_put_arg("useEntrypoint", optional_args[:use_entrypoint])
-      |> QB.maybe_put_arg(
-        "experimentalPrivilegedNesting",
-        optional_args[:experimental_privileged_nesting]
-      )
+      |> QB.maybe_put_arg("disableNesting", optional_args[:disable_nesting])
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
       |> QB.maybe_put_arg("noInit", optional_args[:no_init])
@@ -777,7 +768,7 @@ defmodule Dagger.Container do
   Set the default command to invoke for the container's terminal API.
   """
   @spec with_default_terminal_cmd(t(), [String.t()], [
-          {:experimental_privileged_nesting, boolean() | nil},
+          {:disable_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil}
         ]) :: Dagger.Container.t()
   def with_default_terminal_cmd(%__MODULE__{} = container, args, optional_args \\ []) do
@@ -785,10 +776,7 @@ defmodule Dagger.Container do
       container.query_builder
       |> QB.select("withDefaultTerminalCmd")
       |> QB.put_arg("args", args)
-      |> QB.maybe_put_arg(
-        "experimentalPrivilegedNesting",
-        optional_args[:experimental_privileged_nesting]
-      )
+      |> QB.maybe_put_arg("disableNesting", optional_args[:disable_nesting])
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
 
     %Dagger.Container{
@@ -935,7 +923,7 @@ defmodule Dagger.Container do
           {:redirect_stdout, String.t() | nil},
           {:redirect_stderr, String.t() | nil},
           {:expect, Dagger.ReturnType.t() | nil},
-          {:experimental_privileged_nesting, boolean() | nil},
+          {:disable_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil},
           {:expand, boolean() | nil},
           {:no_init, boolean() | nil}
@@ -951,10 +939,7 @@ defmodule Dagger.Container do
       |> QB.maybe_put_arg("redirectStdout", optional_args[:redirect_stdout])
       |> QB.maybe_put_arg("redirectStderr", optional_args[:redirect_stderr])
       |> QB.maybe_put_arg("expect", optional_args[:expect])
-      |> QB.maybe_put_arg(
-        "experimentalPrivilegedNesting",
-        optional_args[:experimental_privileged_nesting]
-      )
+      |> QB.maybe_put_arg("disableNesting", optional_args[:disable_nesting])
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
       |> QB.maybe_put_arg("expand", optional_args[:expand])
       |> QB.maybe_put_arg("noInit", optional_args[:no_init])

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -426,7 +426,7 @@ defmodule Dagger.Directory do
   @spec terminal(t(), [
           {:container, Dagger.Container.t() | nil},
           {:cmd, [String.t()]},
-          {:experimental_privileged_nesting, boolean() | nil},
+          {:disable_nesting, boolean() | nil},
           {:insecure_root_capabilities, boolean() | nil}
         ]) :: Dagger.Directory.t()
   def terminal(%__MODULE__{} = directory, optional_args \\ []) do
@@ -438,10 +438,7 @@ defmodule Dagger.Directory do
         if(optional_args[:container], do: Dagger.ID.id!(optional_args[:container]), else: nil)
       )
       |> QB.maybe_put_arg("cmd", optional_args[:cmd])
-      |> QB.maybe_put_arg(
-        "experimentalPrivilegedNesting",
-        optional_args[:experimental_privileged_nesting]
-      )
+      |> QB.maybe_put_arg("disableNesting", optional_args[:disable_nesting])
       |> QB.maybe_put_arg("insecureRootCapabilities", optional_args[:insecure_root_capabilities])
 
     %Dagger.Directory{

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1503,8 +1503,8 @@ type ContainerAsServiceOpts struct {
 	Args []string
 	// If the container has an entrypoint, prepend it to the args.
 	UseEntrypoint bool
-	// Provides Dagger access to the executed command.
-	ExperimentalPrivilegedNesting bool
+	// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+	DisableNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 	// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -1529,9 +1529,9 @@ func (r *Container) AsService(opts ...ContainerAsServiceOpts) *Service {
 		if !querybuilder.IsZeroValue(opts[i].UseEntrypoint) {
 			q = q.Arg("useEntrypoint", opts[i].UseEntrypoint)
 		}
-		// `experimentalPrivilegedNesting` optional argument
-		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
-			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		// `disableNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableNesting) {
+			q = q.Arg("disableNesting", opts[i].DisableNesting)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2363,8 +2363,8 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 type ContainerTerminalOpts struct {
 	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
-	// Provides Dagger access to the executed command.
-	ExperimentalPrivilegedNesting bool
+	// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+	DisableNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 }
@@ -2377,9 +2377,9 @@ func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Container {
 		if !querybuilder.IsZeroValue(opts[i].Cmd) {
 			q = q.Arg("cmd", opts[i].Cmd)
 		}
-		// `experimentalPrivilegedNesting` optional argument
-		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
-			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		// `disableNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableNesting) {
+			q = q.Arg("disableNesting", opts[i].DisableNesting)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2406,8 +2406,8 @@ type ContainerUpOpts struct {
 	Args []string
 	// If the container has an entrypoint, prepend it to the args.
 	UseEntrypoint bool
-	// Provides Dagger access to the executed command.
-	ExperimentalPrivilegedNesting bool
+	// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+	DisableNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 	// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
@@ -2443,9 +2443,9 @@ func (r *Container) Up(ctx context.Context, opts ...ContainerUpOpts) error {
 		if !querybuilder.IsZeroValue(opts[i].UseEntrypoint) {
 			q = q.Arg("useEntrypoint", opts[i].UseEntrypoint)
 		}
-		// `experimentalPrivilegedNesting` optional argument
-		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
-			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		// `disableNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableNesting) {
+			q = q.Arg("disableNesting", opts[i].DisableNesting)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2500,8 +2500,8 @@ func (r *Container) WithDefaultArgs(args []string) *Container {
 
 // ContainerWithDefaultTerminalCmdOpts contains options for Container.WithDefaultTerminalCmd
 type ContainerWithDefaultTerminalCmdOpts struct {
-	// Provides Dagger access to the executed command.
-	ExperimentalPrivilegedNesting bool
+	// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+	DisableNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 }
@@ -2510,9 +2510,9 @@ type ContainerWithDefaultTerminalCmdOpts struct {
 func (r *Container) WithDefaultTerminalCmd(args []string, opts ...ContainerWithDefaultTerminalCmdOpts) *Container {
 	q := r.query.Select("withDefaultTerminalCmd")
 	for i := len(opts) - 1; i >= 0; i-- {
-		// `experimentalPrivilegedNesting` optional argument
-		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
-			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		// `disableNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableNesting) {
+			q = q.Arg("disableNesting", opts[i].DisableNesting)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -2724,8 +2724,8 @@ type ContainerWithExecOpts struct {
 	//
 	// Default: SUCCESS
 	Expect ReturnType
-	// Provides Dagger access to the executed command.
-	ExperimentalPrivilegedNesting bool
+	// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+	DisableNesting bool
 	// Execute the command with all root capabilities. Like --privileged in Docker
 	//
 	// DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.
@@ -2766,9 +2766,9 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 		if !querybuilder.IsZeroValue(opts[i].Expect) {
 			q = q.Arg("expect", opts[i].Expect)
 		}
-		// `experimentalPrivilegedNesting` optional argument
-		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
-			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		// `disableNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableNesting) {
+			q = q.Arg("disableNesting", opts[i].DisableNesting)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
@@ -4595,8 +4595,8 @@ type DirectoryTerminalOpts struct {
 	Container *Container
 	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
-	// Provides Dagger access to the executed command.
-	ExperimentalPrivilegedNesting bool
+	// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+	DisableNesting bool
 	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
 	InsecureRootCapabilities bool
 }
@@ -4613,9 +4613,9 @@ func (r *Directory) Terminal(opts ...DirectoryTerminalOpts) *Directory {
 		if !querybuilder.IsZeroValue(opts[i].Cmd) {
 			q = q.Arg("cmd", opts[i].Cmd)
 		}
-		// `experimentalPrivilegedNesting` optional argument
-		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
-			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		// `disableNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DisableNesting) {
+			q = q.Arg("disableNesting", opts[i].DisableNesting)
 		}
 		// `insecureRootCapabilities` optional argument
 		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -21,7 +21,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
     public function asService(
         ?array $args = [],
         ?bool $useEntrypoint = false,
-        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $disableNesting = false,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
         ?bool $noInit = false,
@@ -33,8 +33,8 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         if (null !== $useEntrypoint) {
         $innerQueryBuilder->setArgument('useEntrypoint', $useEntrypoint);
         }
-        if (null !== $experimentalPrivilegedNesting) {
-        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        if (null !== $disableNesting) {
+        $innerQueryBuilder->setArgument('disableNesting', $disableNesting);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -519,15 +519,15 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
      */
     public function terminal(
         ?array $cmd = [],
-        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $disableNesting = false,
         ?bool $insecureRootCapabilities = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
         if (null !== $cmd) {
         $innerQueryBuilder->setArgument('cmd', $cmd);
         }
-        if (null !== $experimentalPrivilegedNesting) {
-        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        if (null !== $disableNesting) {
+        $innerQueryBuilder->setArgument('disableNesting', $disableNesting);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -545,7 +545,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         ?array $ports = null,
         ?array $args = [],
         ?bool $useEntrypoint = false,
-        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $disableNesting = false,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
         ?bool $noInit = false,
@@ -563,8 +563,8 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         if (null !== $useEntrypoint) {
         $leafQueryBuilder->setArgument('useEntrypoint', $useEntrypoint);
         }
-        if (null !== $experimentalPrivilegedNesting) {
-        $leafQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        if (null !== $disableNesting) {
+        $leafQueryBuilder->setArgument('disableNesting', $disableNesting);
         }
         if (null !== $insecureRootCapabilities) {
         $leafQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -613,13 +613,13 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
      */
     public function withDefaultTerminalCmd(
         array $args,
-        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $disableNesting = false,
         ?bool $insecureRootCapabilities = false,
     ): Container {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDefaultTerminalCmd');
         $innerQueryBuilder->setArgument('args', $args);
-        if (null !== $experimentalPrivilegedNesting) {
-        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        if (null !== $disableNesting) {
+        $innerQueryBuilder->setArgument('disableNesting', $disableNesting);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
@@ -761,7 +761,7 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         ?string $redirectStdout = '',
         ?string $redirectStderr = '',
         ?ReturnType $expect = null,
-        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $disableNesting = false,
         ?bool $insecureRootCapabilities = false,
         ?bool $expand = false,
         ?bool $noInit = false,
@@ -786,8 +786,8 @@ class Container extends Client\AbstractObject implements Client\IdAble, Exportab
         if (null !== $expect) {
         $innerQueryBuilder->setArgument('expect', $expect);
         }
-        if (null !== $experimentalPrivilegedNesting) {
-        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        if (null !== $disableNesting) {
+        $innerQueryBuilder->setArgument('disableNesting', $disableNesting);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -342,7 +342,7 @@ class Directory extends Client\AbstractObject implements Client\IdAble, Exportab
     public function terminal(
         ?Container $container = null,
         ?array $cmd = [],
-        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $disableNesting = false,
         ?bool $insecureRootCapabilities = false,
     ): Directory {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
@@ -352,8 +352,8 @@ class Directory extends Client\AbstractObject implements Client\IdAble, Exportab
         if (null !== $cmd) {
         $innerQueryBuilder->setArgument('cmd', $cmd);
         }
-        if (null !== $experimentalPrivilegedNesting) {
-        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        if (null !== $disableNesting) {
+        $innerQueryBuilder->setArgument('disableNesting', $disableNesting);
         }
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1510,7 +1510,7 @@ class Container(Type):
         *,
         args: list[str] | None = None,
         use_entrypoint: bool | None = False,
-        experimental_privileged_nesting: bool | None = False,
+        disable_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
         no_init: bool | None = False,
@@ -1527,8 +1527,9 @@ class Container(Type):
             If empty, the container's default command is used.
         use_entrypoint:
             If the container has an entrypoint, prepend it to the args.
-        experimental_privileged_nesting:
-            Provides Dagger access to the executed command.
+        disable_nesting:
+            Disable Dagger API access for the executed command. By default,
+            commands can connect to the current Dagger engine.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -1548,9 +1549,7 @@ class Container(Type):
         _args = [
             Arg("args", [] if args is None else args, []),
             Arg("useEntrypoint", use_entrypoint, False),
-            Arg(
-                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
-            ),
+            Arg("disableNesting", disable_nesting, False),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
             Arg("noInit", no_init, False),
@@ -2426,7 +2425,7 @@ class Container(Type):
         self,
         *,
         cmd: list[str] | None = None,
-        experimental_privileged_nesting: bool | None = False,
+        disable_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
     ) -> Self:
         """Opens an interactive terminal for this container using its configured
@@ -2438,8 +2437,9 @@ class Container(Type):
         cmd:
             If set, override the container's default terminal command and
             invoke these command arguments instead.
-        experimental_privileged_nesting:
-            Provides Dagger access to the executed command.
+        disable_nesting:
+            Disable Dagger API access for the executed command. By default,
+            commands can connect to the current Dagger engine.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -2449,9 +2449,7 @@ class Container(Type):
         """
         _args = [
             Arg("cmd", [] if cmd is None else cmd, []),
-            Arg(
-                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
-            ),
+            Arg("disableNesting", disable_nesting, False),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("terminal", _args)
@@ -2464,7 +2462,7 @@ class Container(Type):
         ports: list[PortForward] | None = None,
         args: list[str] | None = None,
         use_entrypoint: bool | None = False,
-        experimental_privileged_nesting: bool | None = False,
+        disable_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
         no_init: bool | None = False,
@@ -2488,8 +2486,9 @@ class Container(Type):
             If empty, the container's default command is used.
         use_entrypoint:
             If the container has an entrypoint, prepend it to the args.
-        experimental_privileged_nesting:
-            Provides Dagger access to the executed command.
+        disable_nesting:
+            Disable Dagger API access for the executed command. By default,
+            commands can connect to the current Dagger engine.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -2524,9 +2523,7 @@ class Container(Type):
             Arg("ports", [] if ports is None else ports, []),
             Arg("args", [] if args is None else args, []),
             Arg("useEntrypoint", use_entrypoint, False),
-            Arg(
-                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
-            ),
+            Arg("disableNesting", disable_nesting, False),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
             Arg("noInit", no_init, False),
@@ -2592,7 +2589,7 @@ class Container(Type):
         self,
         args: list[str],
         *,
-        experimental_privileged_nesting: bool | None = False,
+        disable_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
     ) -> Self:
         """Set the default command to invoke for the container's terminal API.
@@ -2601,8 +2598,9 @@ class Container(Type):
         ----------
         args:
             The args of the command.
-        experimental_privileged_nesting:
-            Provides Dagger access to the executed command.
+        disable_nesting:
+            Disable Dagger API access for the executed command. By default,
+            commands can connect to the current Dagger engine.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -2612,9 +2610,7 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
-            Arg(
-                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
-            ),
+            Arg("disableNesting", disable_nesting, False),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("withDefaultTerminalCmd", _args)
@@ -2817,7 +2813,7 @@ class Container(Type):
         redirect_stdout: str | None = "",
         redirect_stderr: str | None = "",
         expect: ReturnType | None = ReturnType.SUCCESS,
-        experimental_privileged_nesting: bool | None = False,
+        disable_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
         expand: bool | None = False,
         no_init: bool | None = False,
@@ -2851,8 +2847,9 @@ class Container(Type):
             Example: "./stderr.txt"
         expect:
             Exit codes this command is allowed to exit with without error
-        experimental_privileged_nesting:
-            Provides Dagger access to the executed command.
+        disable_nesting:
+            Disable Dagger API access for the executed command. By default,
+            commands can connect to the current Dagger engine.
         insecure_root_capabilities:
             Execute the command with all root capabilities. Like --privileged
             in Docker
@@ -2877,9 +2874,7 @@ class Container(Type):
             Arg("redirectStdout", redirect_stdout, ""),
             Arg("redirectStderr", redirect_stderr, ""),
             Arg("expect", expect, ReturnType.SUCCESS),
-            Arg(
-                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
-            ),
+            Arg("disableNesting", disable_nesting, False),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
             Arg("expand", expand, False),
             Arg("noInit", no_init, False),
@@ -4704,7 +4699,7 @@ class Directory(Type):
         *,
         container: Container | None = None,
         cmd: list[str] | None = None,
-        experimental_privileged_nesting: bool | None = False,
+        disable_nesting: bool | None = False,
         insecure_root_capabilities: bool | None = False,
     ) -> Self:
         """Opens an interactive terminal in new container with this directory
@@ -4717,8 +4712,9 @@ class Directory(Type):
         cmd:
             If set, override the container's default terminal command and
             invoke these command arguments instead.
-        experimental_privileged_nesting:
-            Provides Dagger access to the executed command.
+        disable_nesting:
+            Disable Dagger API access for the executed command. By default,
+            commands can connect to the current Dagger engine.
         insecure_root_capabilities:
             Execute the command with all root capabilities. This is similar to
             running a command with "sudo" or executing "docker run" with the "
@@ -4729,9 +4725,7 @@ class Directory(Type):
         _args = [
             Arg("container", container, None),
             Arg("cmd", [] if cmd is None else cmd, []),
-            Arg(
-                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
-            ),
+            Arg("disableNesting", disable_nesting, False),
             Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("terminal", _args)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1309,12 +1309,12 @@ pub struct ContainerAsServiceOpts<'a> {
     /// If empty, the container's default command is used.
     #[builder(setter(into, strip_option), default)]
     pub args: Option<Vec<&'a str>>,
+    /// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    #[builder(setter(into, strip_option), default)]
+    pub disable_nesting: Option<bool>,
     /// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
-    /// Provides Dagger access to the executed command.
-    #[builder(setter(into, strip_option), default)]
-    pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1478,9 +1478,9 @@ pub struct ContainerTerminalOpts<'a> {
     /// If set, override the container's default terminal command and invoke these command arguments instead.
     #[builder(setter(into, strip_option), default)]
     pub cmd: Option<Vec<&'a str>>,
-    /// Provides Dagger access to the executed command.
+    /// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
     #[builder(setter(into, strip_option), default)]
-    pub experimental_privileged_nesting: Option<bool>,
+    pub disable_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1491,12 +1491,12 @@ pub struct ContainerUpOpts<'a> {
     /// If empty, the container's default command is used.
     #[builder(setter(into, strip_option), default)]
     pub args: Option<Vec<&'a str>>,
+    /// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    #[builder(setter(into, strip_option), default)]
+    pub disable_nesting: Option<bool>,
     /// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
-    /// Provides Dagger access to the executed command.
-    #[builder(setter(into, strip_option), default)]
-    pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1517,9 +1517,9 @@ pub struct ContainerUpOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDefaultTerminalCmdOpts {
-    /// Provides Dagger access to the executed command.
+    /// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
     #[builder(setter(into, strip_option), default)]
-    pub experimental_privileged_nesting: Option<bool>,
+    pub disable_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -1584,15 +1584,15 @@ pub struct ContainerWithEnvVariableOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExecOpts<'a> {
+    /// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
+    #[builder(setter(into, strip_option), default)]
+    pub disable_nesting: Option<bool>,
     /// Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
     /// Exit codes this command is allowed to exit with without error
     #[builder(setter(into, strip_option), default)]
     pub expect: Option<ReturnType>,
-    /// Provides Dagger access to the executed command.
-    #[builder(setter(into, strip_option), default)]
-    pub experimental_privileged_nesting: Option<bool>,
     /// Execute the command with all root capabilities. Like --privileged in Docker
     /// DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.
     #[builder(setter(into, strip_option), default)]
@@ -1888,11 +1888,8 @@ impl Container {
         if let Some(use_entrypoint) = opts.use_entrypoint {
             query = query.arg("useEntrypoint", use_entrypoint);
         }
-        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+        if let Some(disable_nesting) = opts.disable_nesting {
+            query = query.arg("disableNesting", disable_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -2619,11 +2616,8 @@ impl Container {
         if let Some(cmd) = opts.cmd {
             query = query.arg("cmd", cmd);
         }
-        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+        if let Some(disable_nesting) = opts.disable_nesting {
+            query = query.arg("disableNesting", disable_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -2664,11 +2658,8 @@ impl Container {
         if let Some(use_entrypoint) = opts.use_entrypoint {
             query = query.arg("useEntrypoint", use_entrypoint);
         }
-        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+        if let Some(disable_nesting) = opts.disable_nesting {
+            query = query.arg("disableNesting", disable_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -2753,11 +2744,8 @@ impl Container {
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+        if let Some(disable_nesting) = opts.disable_nesting {
+            query = query.arg("disableNesting", disable_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -3081,11 +3069,8 @@ impl Container {
         if let Some(expect) = opts.expect {
             query = query.arg("expect", expect);
         }
-        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+        if let Some(disable_nesting) = opts.disable_nesting {
+            query = query.arg("disableNesting", disable_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -4786,9 +4771,9 @@ pub struct DirectoryTerminalOpts<'a> {
     /// If set, override the default container used for the terminal.
     #[builder(setter(into, strip_option), default)]
     pub container: Option<Id>,
-    /// Provides Dagger access to the executed command.
+    /// Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
     #[builder(setter(into, strip_option), default)]
-    pub experimental_privileged_nesting: Option<bool>,
+    pub disable_nesting: Option<bool>,
     /// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
     #[builder(setter(into, strip_option), default)]
     pub insecure_root_capabilities: Option<bool>,
@@ -5445,11 +5430,8 @@ impl Directory {
         if let Some(cmd) = opts.cmd {
             query = query.arg("cmd", cmd);
         }
-        if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+        if let Some(disable_nesting) = opts.disable_nesting {
+            query = query.arg("disableNesting", disable_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -265,9 +265,9 @@ export type ContainerAsServiceOpts = {
   useEntrypoint?: boolean
 
   /**
-   * Provides Dagger access to the executed command.
+   * Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    */
-  experimentalPrivilegedNesting?: boolean
+  disableNesting?: boolean
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -509,9 +509,9 @@ export type ContainerTerminalOpts = {
   cmd?: string[]
 
   /**
-   * Provides Dagger access to the executed command.
+   * Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    */
-  experimentalPrivilegedNesting?: boolean
+  disableNesting?: boolean
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -545,9 +545,9 @@ export type ContainerUpOpts = {
   useEntrypoint?: boolean
 
   /**
-   * Provides Dagger access to the executed command.
+   * Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    */
-  experimentalPrivilegedNesting?: boolean
+  disableNesting?: boolean
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -569,9 +569,9 @@ export type ContainerUpOpts = {
 
 export type ContainerWithDefaultTerminalCmdOpts = {
   /**
-   * Provides Dagger access to the executed command.
+   * Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    */
-  experimentalPrivilegedNesting?: boolean
+  disableNesting?: boolean
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -694,9 +694,9 @@ export type ContainerWithExecOpts = {
   expect?: ReturnType
 
   /**
-   * Provides Dagger access to the executed command.
+   * Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    */
-  experimentalPrivilegedNesting?: boolean
+  disableNesting?: boolean
 
   /**
    * Execute the command with all root capabilities. Like --privileged in Docker
@@ -1304,9 +1304,9 @@ export type DirectoryTerminalOpts = {
   cmd?: string[]
 
   /**
-   * Provides Dagger access to the executed command.
+   * Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    */
-  experimentalPrivilegedNesting?: boolean
+  disableNesting?: boolean
 
   /**
    * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -4435,7 +4435,7 @@ export class Container extends BaseClient {
    *
    * If empty, the container's default command is used.
    * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
-   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.disableNesting Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
@@ -5035,7 +5035,7 @@ export class Container extends BaseClient {
   /**
    * Opens an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
-   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.disableNesting Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   terminal = (opts?: ContainerTerminalOpts): Container => {
@@ -5055,7 +5055,7 @@ export class Container extends BaseClient {
    *
    * If empty, the container's default command is used.
    * @param opts.useEntrypoint If the container has an entrypoint, prepend it to the args.
-   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.disableNesting Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    * @param opts.expand Replace "${VAR}" or "$VAR" in the args according to the current environment variables defined in the container (e.g. "/$VAR/foo").
    * @param opts.noInit If set, skip the automatic init process injected into containers by default.
@@ -5109,7 +5109,7 @@ export class Container extends BaseClient {
   /**
    * Set the default command to invoke for the container's terminal API.
    * @param args The args of the command.
-   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.disableNesting Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   withDefaultTerminalCmd = (
@@ -5221,7 +5221,7 @@ export class Container extends BaseClient {
    * @param opts.redirectStdout Redirect the command's standard output to a file in the container. Example: "./stdout.txt"
    * @param opts.redirectStderr Redirect the command's standard error to a file in the container. Example: "./stderr.txt"
    * @param opts.expect Exit codes this command is allowed to exit with without error
-   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.disableNesting Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. Like --privileged in Docker
    *
    * DANGER: this grants the command full access to the host system. Only use when 1) you trust the command being executed and 2) you specifically need this level of access.
@@ -6406,7 +6406,7 @@ export class Directory extends BaseClient {
    * Opens an interactive terminal in new container with this directory mounted inside.
    * @param opts.container If set, override the default container used for the terminal.
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
-   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
+   * @param opts.disableNesting Disable Dagger API access for the executed command. By default, commands can connect to the current Dagger engine.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   terminal = (opts?: DirectoryTerminalOpts): Directory => {

--- a/sdk/typescript/src/api/test/api.spec.ts
+++ b/sdk/typescript/src/api/test/api.spec.ts
@@ -103,12 +103,12 @@ describe("TypeScript SDK api", function () {
   it("Build a query with positionnal and optionals arguments", function () {
     const image = new Client().container().from("alpine:3.16.2")
     const pkg = image.withExec(["apk", "add", "curl"], {
-      experimentalPrivilegedNesting: true,
+      disableNesting: true,
     })
 
     assert.strictEqual(
       querySanitizer(buildQuery(pkg["_ctx"]["_queryTree"])),
-      `{ container { from (address: "alpine:3.16.2") { withExec (args: ["apk","add","curl"],experimentalPrivilegedNesting: true) } } }`,
+      `{ container { from (address: "alpine:3.16.2") { withExec (args: ["apk","add","curl"],disableNesting: true) } } }`,
     )
   })
 

--- a/util/llbtodagger/exec.go
+++ b/util/llbtodagger/exec.go
@@ -265,6 +265,8 @@ func (c *converter) convertExec(exec *engineutil.ExecOp) (*call.ID, error) {
 
 	withExecArgs := []*call.Argument{
 		argStringList("args", exec.Meta.Args),
+		// Dockerfile RUN steps must not inherit Dagger API access.
+		argBool("disableNesting", true),
 	}
 	if exec.Network == pb.NetMode_NONE {
 		withExecArgs = append(withExecArgs, argBool("noNetwork", true))


### PR DESCRIPTION
Enable nesting by default, with `disableNesting: true` to opt out.

Applies to `withExec`, `asService`, `up`, `terminal`, and `withDefaultTerminalCmd`. API views before v1.0.0-beta.12 keep `experimentalPrivilegedNesting` and their existing opt-in behavior.

Regenerate SDKs and remove redundant opt-ins from current callers. Keep legacy fixtures unchanged.

Compatibility uses the call's API view: internal SDK calls use the latest view even when loading older modules.

### Verification

Schema regressions cover the version boundary, internal calls, and terminal defaults:

```sh
go test ./core/schema -run 'TestBaseSchemaAllowlist|TestNesting' -count=1
```

Engine-backed checks cover exec/service nesting, opt-out, legacy opt-in, nested services, module versions, terminals, and SDK startup:

```sh
./bin/dagger api call engine-dev test --pkg ./core/integration --run='Test(Container|Services|Module|Up)/Test(NestedExec|Nesting|ExecServicesNestedExec|ExecServicesNestedHTTP|ExecServicesNestedGit|ModuleSchemaVersion|DaggerTerminal|UpDirectSDK)$'
```

Fixes #13668
