### PR TITLE
cli: guide users through unavailable engine runtimes

### DIFF
--- a/.changes/unreleased/Fixed-20260908-181300.yaml
+++ b/.changes/unreleased/Fixed-20260908-181300.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Explain how to proceed when a local engine cannot start because a container
+  runtime is missing or unavailable. Errors name the runtime, suggest a
+  diagnostic command when applicable, and point to `dagger help engine` for
+  other engine options.
+time: 2026-09-08T18:13:00Z
+custom:
+  Author: grouville

--- a/engine/client/drivers/apple.go
+++ b/engine/client/drivers/apple.go
@@ -20,17 +20,7 @@ type apple struct{}
 var _ containerBackend = apple{}
 
 func (apple) Available(ctx context.Context) (bool, error) {
-	// check binary exists
-	if _, err := exec.LookPath("container"); err != nil {
-		return false, nil //nolint:nilerr
-	}
-
-	// check daemon is running
-	cmd := exec.CommandContext(ctx, "container", "system", "status")
-	if err := traceexec.Exec(ctx, cmd, telemetry.Encapsulated()); err != nil {
-		return false, err
-	}
-	return true, nil
+	return containerRuntimeAvailable(ctx, "container", "system", "status")
 }
 
 func (apple) ImagePull(ctx context.Context, image string) error {

--- a/engine/client/drivers/availability.go
+++ b/engine/client/drivers/availability.go
@@ -1,0 +1,47 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/dagger/dagger/util/traceexec"
+	telemetry "github.com/dagger/otel-go"
+)
+
+// runtimeUnavailableError keeps diagnostic details in the trace while the CLI
+// displays only the guidance, using its existing quiet-error convention.
+type runtimeUnavailableError struct {
+	err     error
+	message string
+}
+
+func (e *runtimeUnavailableError) Error() string {
+	return e.message + "\n\nDetails: " + e.err.Error()
+}
+
+func (e *runtimeUnavailableError) Unwrap() error { return e.err }
+
+func (e *runtimeUnavailableError) Extensions() map[string]any {
+	return map[string]any{"_quiet": true, "_message": e.message}
+}
+
+func containerRuntimeAvailable(ctx context.Context, command string, args ...string) (bool, error) {
+	if _, err := exec.LookPath(command); err != nil {
+		return false, nil //nolint:nilerr
+	}
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	if err := traceexec.Exec(ctx, cmd, telemetry.Encapsulated()); err != nil {
+		if ctx.Err() != nil {
+			return false, err
+		}
+		message := fmt.Sprintf("Dagger could not start the local engine using %s.\n\n"+
+			"Make sure the runtime is running and your user can access it.\n"+
+			"Run `%s` to diagnose the problem.\n"+
+			"To select another engine, see `dagger help engine`.", command, strings.Join(cmd.Args, " "))
+		return false, &runtimeUnavailableError{err: err, message: message}
+	}
+	return true, nil
+}

--- a/engine/client/drivers/availability_test.go
+++ b/engine/client/drivers/availability_test.go
@@ -1,0 +1,124 @@
+package drivers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDriverMissingRuntimes(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	for _, scheme := range []string{"image", "image+podman", "container+podman"} {
+		t.Run(scheme, func(t *testing.T) {
+			_, err := GetDriver(t.Context(), scheme)
+			require.ErrorContains(t, err, scheme)
+			var unavailable *runtimeUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+			require.Equal(t, true, unavailable.Extensions()["_quiet"])
+			require.Equal(t, unavailable.message, unavailable.Extensions()["_message"])
+			require.Contains(t, unavailable.message, "Install a compatible container runtime")
+			require.Contains(t, unavailable.message, "PATH")
+			require.Contains(t, unavailable.message, "dagger help engine")
+		})
+	}
+}
+
+func TestGetDriverSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		commands []string
+		want     Driver
+	}{
+		{"skip missing runtimes", []string{"podman"}, podmanImageDriver},
+		{"prefer first available runtime", []string{"docker", "podman"}, dockerImageDriver},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := runtimeTestPath(t)
+			for _, command := range tc.commands {
+				writeRuntimeCommand(t, dir, command, `test "$*" = version`)
+			}
+			driver, err := GetDriver(t.Context(), "image")
+			require.NoError(t, err)
+			require.Same(t, tc.want, driver)
+		})
+	}
+}
+
+func TestGetDriverUnavailableRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		command string
+		args    string
+	}{
+		{"docker", "version"},
+		{"container", "system status"},
+	} {
+		t.Run(tc.command, func(t *testing.T) {
+			dir := runtimeTestPath(t)
+			writeRuntimeCommand(t, dir, tc.command, fmt.Sprintf("test \"$*\" = %q || exit 2\nexit 1", tc.args))
+			writeRuntimeCommand(t, dir, "podman", "exit 0")
+
+			// A failed probe must not silently select another backend.
+			driver, err := GetDriver(t.Context(), "image")
+			require.Nil(t, driver)
+			var unavailable *runtimeUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+			require.Equal(t, true, unavailable.Extensions()["_quiet"])
+			require.Equal(t, unavailable.message, unavailable.Extensions()["_message"])
+			require.Contains(t, unavailable.message, "using "+tc.command)
+			require.Contains(t, unavailable.message, "Run `"+tc.command+" "+tc.args+"`")
+			require.NotContains(t, unavailable.message, "exit status")
+			require.ErrorContains(t, err, "exit status 1")
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			require.Equal(t, 1, exitErr.ExitCode())
+		})
+	}
+}
+
+func TestContainerRuntimeLookupFailure(t *testing.T) {
+	dir := runtimeTestPath(t)
+	// Preserve the original false, nil result for non-executable files too.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "docker"), nil, 0644))
+	available, err := containerRuntimeAvailable(t.Context(), "docker", "version")
+	require.False(t, available)
+	require.NoError(t, err)
+}
+
+func TestContainerRuntimeCanceled(t *testing.T) {
+	dir := runtimeTestPath(t)
+	writeRuntimeCommand(t, dir, "docker", "exit 0")
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cause := errors.New("user canceled setup")
+	cancel(cause)
+
+	available, err := containerRuntimeAvailable(ctx, "docker", "version")
+	require.False(t, available)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, cause)
+	require.NotContains(t, err.Error(), "diagnose")
+	var unavailable *runtimeUnavailableError
+	require.False(t, errors.As(err, &unavailable))
+}
+
+func runtimeTestPath(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake runtime commands use /bin/sh")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	return dir
+}
+
+func writeRuntimeCommand(t *testing.T, dir, name, script string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"+script+"\n"), 0755))
+}

--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -22,17 +22,7 @@ type docker struct {
 var _ containerBackend = docker{}
 
 func (d docker) Available(ctx context.Context) (bool, error) {
-	// check binary exists
-	if _, err := exec.LookPath(d.cmd); err != nil {
-		return false, nil //nolint:nilerr
-	}
-
-	// check daemon is running
-	cmd := exec.CommandContext(ctx, d.cmd, "version")
-	if err := traceexec.Exec(ctx, cmd, telemetry.Encapsulated()); err != nil {
-		return false, err
-	}
-	return true, nil
+	return containerRuntimeAvailable(ctx, d.cmd, "version")
 }
 
 func (d docker) ImagePull(ctx context.Context, image string) error {

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -74,5 +74,10 @@ func GetDriver(ctx context.Context, name string) (Driver, error) {
 			return driver, nil
 		}
 	}
-	return nil, fmt.Errorf("driver for scheme %q was not available", name)
+	return nil, &runtimeUnavailableError{
+		err: fmt.Errorf("no container runtime is available for engine scheme %q", name),
+		message: "Dagger needs a container runtime to start the local engine.\n\n" +
+			"Install a compatible container runtime and make sure its command is in PATH.\n" +
+			"To choose a local or remote engine, run `dagger help engine`.",
+	}
 }


### PR DESCRIPTION
#14027 introduced `--engine` and `dagger help engine`. This is a proposed next step for #14020: help users who cannot start a local engine because Docker (or another supported runtime) is missing or not working.

Instead of stopping at “driver was not available” or “exit status 1”, the error now explains what to check and points to `dagger help engine` for alternatives. Runtime selection stays unchanged; this does not install anything or add automatic Cloud fallback.

Uses the existing quiet-error convention to show the guidance once, without the failed trace tree. Diagnostic details remain in the error and trace; no frontend changes are needed.

Two separate CLI runs, rendered from recorded terminal output:

Run 1: an empty `PATH` hides Docker, reproducing the missing-runtime error.

![Run 1: no runtime on PATH](https://raw.githubusercontent.com/grouville/dagger/dcbe3b85deeb03b7f51ab9fc104541695216ea09/missing.png)

Run 2: a fake `docker` executable exits 1, simulating a failed `docker version`. This is not a real Docker daemon failure.

![Run 2: simulated docker version failure](https://raw.githubusercontent.com/grouville/dagger/dcbe3b85deeb03b7f51ab9fc104541695216ea09/unavailable.png)

<details>
<summary>Local repro (Linux/macOS)</summary>

Run from this branch. This hides installed runtimes from one CLI invocation without touching your Docker installation or configuration. No test engine is needed: startup fails before an engine can run.

```sh
repro_dir=$(mktemp -d)
mkdir "$repro_dir/bin"
go build -o "$repro_dir/dagger" ./cmd/dagger

env -i \
  PATH="$repro_dir/bin" \
  XDG_CONFIG_HOME="$repro_dir" \
  XDG_CACHE_HOME="$repro_dir" \
  XDG_STATE_HOME="$repro_dir" \
  DAGGER_CONFIG="$repro_dir/config.json" \
  NO_COLOR=1 \
  "$repro_dir/dagger" -m core api call \
    --engine=image+docker://registry.dagger.io/engine:test version
```

Expect the missing-runtime error and exit code 1. For the second case, create a fake failing command and repeat the `env -i` invocation:

```sh
printf '#!/bin/sh\nexit 1\n' > "$repro_dir/bin/docker"
chmod +x "$repro_dir/bin/docker"
```

</details>

Verified with the CLI repro above and focused driver tests covering selection order, failed commands, lookup errors, and cancellation:

```sh
env -u DRIVER_TEST go test -race ./engine/client/drivers -count=1
dagger check golang:lint-all
```
