### PR TITLE
core: normalize Git lock identities

### DIFF
--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -44,6 +44,7 @@ const containerFromQuery = `{
 
 const (
 	lockTestGitRepoURL      = "https://github.com/dagger/dagger.git"
+	lockTestGitRepoIdentity = "github.com/dagger/dagger"
 	lockTestGitBranchName   = "main"
 	lockTestGitBranchCommit = "c80ac2c13df7d573a069938e01ca13f7a81f0345"
 	lockTestGitTagName      = "v0.18.2"
@@ -242,7 +243,7 @@ func (LockfileSuite) TestUpdateRefreshesExistingGitEntry(ctx context.Context, t 
 	require.NoError(t, err)
 	require.NotEqual(t, originalLock, string(lockBytes))
 	assertGitLockEntry(t, lockBytes, []any{
-		lockTestGitRepoURL,
+		lockTestGitRepoIdentity,
 		"refs/heads/" + lockTestGitBranchName,
 	})
 	require.NotContains(t, string(lockBytes), lockTestGitBranchCommit)
@@ -276,11 +277,11 @@ func (LockfileSuite) TestDefaultDiscoversGitEntries(ctx context.Context, t *test
 	lockBytes, err := os.ReadFile(lockPath)
 	require.NoError(t, err)
 	assertGitLockEntry(t, lockBytes, []any{
-		lockTestGitRepoURL,
+		lockTestGitRepoIdentity,
 		"refs/heads/" + lockTestGitBranchName,
 	})
 	assertGitLockEntry(t, lockBytes, []any{
-		lockTestGitRepoURL,
+		lockTestGitRepoIdentity,
 		"refs/tags/" + lockTestGitTagName,
 	})
 }
@@ -575,14 +576,14 @@ func (LockfileSuite) TestGitLatestVersionQueryCreatesPin(ctx context.Context, t 
 			continue
 		}
 		require.Equal(t, workspace.LookupInputs(
-			[]any{lockTestGitRepoURL},
+			[]any{lockTestGitRepoIdentity},
 			workspace.LookupOption{Name: "version", Value: "v0.18"},
 		), entry.Inputs)
 		selectedRef = entry.Value
 	}
 	require.True(t, strings.HasPrefix(selectedRef, "refs/tags/v0.18."), selectedRef)
 	require.Contains(t, string(out), selectedRef)
-	assertGitLockEntry(t, lockBytes, []any{lockTestGitRepoURL, selectedRef})
+	assertGitLockEntry(t, lockBytes, []any{lockTestGitRepoIdentity, selectedRef})
 }
 
 func (LockfileSuite) TestGitLatestUsesPin(ctx context.Context, t *testctx.T) {
@@ -765,7 +766,7 @@ func (LockfileSuite) TestUpdateRefreshesExistingGitLatestEntry(ctx context.Conte
 	require.NotEqual(t, originalLock, string(lockBytes))
 	assertGitLatestLockEntry(t, lockBytes)
 	assertGitLockEntryResult(t, lockBytes, []any{
-		lockTestGitRepoURL,
+		lockTestGitRepoIdentity,
 		"refs/tags/" + lockTestGitTagName,
 	}, lockTestGitTagCommit)
 	require.NotContains(t, string(lockBytes), staleCommit)
@@ -835,13 +836,13 @@ func assertGitLatestLockEntry(t *testctx.T, lockBytes []byte) {
 		if entry.Namespace != "" || entry.Operation != "git-latest" {
 			continue
 		}
-		require.Equal(t, []any{lockTestGitRepoURL}, entry.Inputs)
+		require.Equal(t, []any{lockTestGitRepoIdentity}, entry.Inputs)
 		selectedRef = entry.Value
 		require.True(t, strings.HasPrefix(selectedRef, "refs/tags/"), selectedRef)
 		break
 	}
 	require.NotEmpty(t, selectedRef, "expected git-latest entry in lockfile")
-	assertGitLockEntry(t, lockBytes, []any{lockTestGitRepoURL, selectedRef})
+	assertGitLockEntry(t, lockBytes, []any{lockTestGitRepoIdentity, selectedRef})
 }
 
 const ociLatestImageRefQuery = `{

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -1070,6 +1070,10 @@ func gitLockInputs(repo *core.GitRepository, name string) ([]any, error) {
 }
 
 func gitRemoteHasWorkspacePin(ctx context.Context, remote string) bool {
+	remote = workspace.NormalizeGitRemote(remote)
+	if remote == "" {
+		return false
+	}
 	query, err := core.CurrentQuery(ctx)
 	if err != nil {
 		return false
@@ -1086,7 +1090,7 @@ func gitRemoteHasWorkspacePin(ctx context.Context, remote string) bool {
 			continue
 		}
 		entryRemote, ok := entry.Inputs[0].(string)
-		if ok && entryRemote == remote {
+		if ok && workspace.NormalizeGitRemote(entryRemote) == remote {
 			return true
 		}
 	}

--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -27,6 +27,10 @@ const (
 	VersionQueriesVersion = "v1.0.0-beta.12"
 )
 
+// ErrGitLockIdentityConflict indicates that transport-specific entries for the
+// same Git repository contain different values and cannot be normalized safely.
+var ErrGitLockIdentityConflict = errors.New("conflicting Git lock identities")
+
 // CanonicalLockFilePath maps the legacy .dagger/lock path to its dagger.lock
 // sibling. Other paths are already canonical.
 func CanonicalLockFilePath(lockFile string) string {
@@ -124,7 +128,28 @@ func ParseLock(data []byte) (*Lock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Lock{file: file}, nil
+
+	// Git transports are local access details, not part of a repository's
+	// identity. Rebuild parsed locks so legacy transport-qualified entries remain
+	// readable and the next lockfile write uses the canonical scheme-less key.
+	normalized := lockfile.New()
+	for _, entry := range file.Entries() {
+		inputs := normalizeLookupInputs(entry.Operation, entry.Inputs)
+		if existing, ok := normalized.Get(entry.Namespace, entry.Operation, inputs); ok && existing != entry.Value {
+			return nil, fmt.Errorf(
+				"%w: different values for %s inputs %v: %q and %q",
+				ErrGitLockIdentityConflict,
+				entry.Operation,
+				inputs,
+				existing,
+				entry.Value,
+			)
+		}
+		if err := normalized.Set(entry.Namespace, entry.Operation, inputs, entry.Value); err != nil {
+			return nil, err
+		}
+	}
+	return &Lock{file: normalized}, nil
 }
 
 // FutureLockfileVersionError turns an unsupported future lockfile version into
@@ -144,12 +169,15 @@ func FutureLockfileVersionError(err error) error {
 // LockfileMergeConflictError turns lockfile conflict markers into actionable
 // guidance. It returns nil for all other parse errors.
 func LockfileMergeConflictError(err error) error {
-	if !errors.Is(err, lockfile.ErrMergeConflict) {
-		return nil
+	if errors.Is(err, lockfile.ErrMergeConflict) {
+		return fmt.Errorf(
+			"workspace lockfile contains merge conflict markers; resolve the conflict before running Dagger",
+		)
 	}
-	return fmt.Errorf(
-		"workspace lockfile contains merge conflict markers; resolve the conflict before running Dagger",
-	)
+	if errors.Is(err, ErrGitLockIdentityConflict) {
+		return fmt.Errorf("workspace lockfile contains conflicting pins for the same Git repository; resolve the conflict before running Dagger: %w", err)
+	}
+	return nil
 }
 
 // NewLock returns an empty workspace lock.
@@ -215,7 +243,7 @@ func (l *Lock) GetLookup(namespace, operation string, inputs []any) (string, boo
 	if l.file == nil {
 		return "", false
 	}
-	value, ok := l.file.Get(namespace, operation, inputs)
+	value, ok := l.file.Get(namespace, operation, normalizeLookupInputs(operation, inputs))
 	if !ok {
 		return "", false
 	}
@@ -239,7 +267,27 @@ func (l *Lock) setLookup(namespace, operation string, inputs []any, value string
 	if l.file == nil {
 		return fmt.Errorf("nil lock")
 	}
-	return l.file.Set(namespace, operation, inputs, value)
+	return l.file.Set(namespace, operation, normalizeLookupInputs(operation, inputs), value)
+}
+
+func normalizeLookupInputs(operation string, inputs []any) []any {
+	if operation != LockOperationGitLatest && operation != LockOperationGitSHA {
+		return inputs
+	}
+	if len(inputs) == 0 {
+		return inputs
+	}
+	remote, ok := inputs[0].(string)
+	if !ok {
+		return inputs
+	}
+	remote = NormalizeGitRemote(remote)
+	if remote == "" {
+		return inputs
+	}
+	normalized := append([]any(nil), inputs...)
+	normalized[0] = remote
+	return normalized
 }
 
 // Entries returns a deterministic snapshot of all lookup entries.

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -28,6 +28,84 @@ func TestLookupSetGet(t *testing.T) {
 	require.Equal(t, "sha256:deadbeef", result)
 }
 
+func TestGitLookupNormalizesTransport(t *testing.T) {
+	t.Parallel()
+
+	lock := NewLock()
+	const commit = "0123456789abcdef0123456789abcdef01234567"
+	reference := []any{"https://GitHub.com/acme/api.git", "refs/heads/main"}
+	require.NoError(t, lock.SetLookup("", LockOperationGitSHA, reference, commit))
+
+	for _, remote := range []string{
+		"github.com/acme/api",
+		"https://github.com/acme/api.git",
+		"ssh://git@github.com/acme/api.git",
+		"git@github.com:acme/api.git",
+	} {
+		value, ok := lock.GetLookup("", LockOperationGitSHA, []any{remote, "refs/heads/main"})
+		require.True(t, ok, remote)
+		require.Equal(t, commit, value)
+	}
+
+	entries := lock.Entries()
+	require.Len(t, entries, 1)
+	require.Equal(t, []any{"github.com/acme/api", "refs/heads/main"}, entries[0].Inputs)
+}
+
+func TestParseGitLookupNormalizesLegacyTransport(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`[["version","2"]]`,
+		`["","git-latest",["https://github.com/acme/api.git"],"refs/heads/main"]`,
+		`["","git-sha",["git@github.com:acme/api.git","refs/heads/main"],"0123456789abcdef0123456789abcdef01234567"]`,
+	}, "\n")
+
+	lock, err := ParseLock([]byte(input))
+	require.NoError(t, err)
+	value, ok := lock.GetLookup("", LockOperationGitLatest, []any{"ssh://git@github.com/acme/api"})
+	require.True(t, ok)
+	require.Equal(t, "refs/heads/main", value)
+	value, ok = lock.GetLookup("", LockOperationGitSHA, []any{"https://github.com/acme/api", "refs/heads/main"})
+	require.True(t, ok)
+	require.Equal(t, "0123456789abcdef0123456789abcdef01234567", value)
+
+	output, err := lock.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, string(output), `"github.com/acme/api"`)
+	require.NotContains(t, string(output), `https://github.com/acme/api.git`)
+	require.NotContains(t, string(output), `git@github.com:acme/api.git`)
+}
+
+func TestParseGitLookupCollapsesEquivalentLegacyEntries(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`[["version","2"]]`,
+		`["","git-latest",["https://github.com/acme/api.git"],"refs/heads/main"]`,
+		`["","git-latest",["ssh://git@github.com/acme/api"],"refs/heads/main"]`,
+	}, "\n")
+
+	lock, err := ParseLock([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, lock.Entries(), 1)
+}
+
+func TestParseGitLookupRejectsConflictingEquivalentEntries(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`[["version","2"]]`,
+		`["","git-latest",["https://github.com/acme/api.git"],"refs/heads/main"]`,
+		`["","git-latest",["ssh://git@github.com/acme/api"],"refs/heads/release"]`,
+	}, "\n")
+
+	_, err := ParseLock([]byte(input))
+	require.ErrorIs(t, err, ErrGitLockIdentityConflict)
+	require.ErrorContains(t, err, "different values for git-latest inputs")
+	require.ErrorContains(t, LockfileMergeConflictError(err), "workspace lockfile contains conflicting pins for the same Git repository")
+}
+
 func TestLookupConcurrentWrites(t *testing.T) {
 	t.Parallel()
 

--- a/engine/server/trash_test.go
+++ b/engine/server/trash_test.go
@@ -143,7 +143,9 @@ func TestStartLocalCacheTrashSweeperBlocksUnderDiskPressure(t *testing.T) {
 		rootDir:     rootDir,
 		shutdownCtx: context.Background(),
 		workerGCPolicies: []dagqlCachePrunePolicy{
-			{MinFreeSpace: dstat.Available + 1},
+			// More than the filesystem can provide, so concurrent disk activity
+			// cannot make the pressure condition false between disk stat calls.
+			{MinFreeSpace: dstat.Total + 1},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Store git-latest and git-sha repository inputs as scheme-less host/path identities.
- Read old HTTPS, SSH, SCP-style, and scheme-less entries as the same repository.
- Normalize old entries on the next lockfile write, and report an error if equivalent old entries contain different pins.
- Stabilize the disk-pressure trash test that failed on the first CI run.

For example, https://github.com/acme/api.git and git@github.com:acme/api.git now use github.com/acme/api as the Git lock key. The caller still controls the transport. A scheme-less caller still tries HTTPS and then SSH when remote access is necessary.

Vanity URL entries are unchanged.

This is a follow-up to #14015.

## Validation

- Focused core workspace and schema tests
- Race-enabled trash pressure test
- Engine integration tests for Git lock creation, version queries, and unavailable HTTPS remotes