### PR TITLE
chore(deps): bump catwalk to v0.52.31

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 )
 
 require (
-	charm.land/catwalk v0.52.12
+	charm.land/catwalk v0.52.31
 	charm.land/lipgloss/v2 v2.0.5
 	cloud.google.com/go/secretmanager v1.16.0
 	github.com/1password/onepassword-sdk-go v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-charm.land/catwalk v0.52.12 h1:g3CqM3yNqjr2ryFW3rg2EI6ZJgNAIq445Xja1jcAlhk=
-charm.land/catwalk v0.52.12/go.mod h1:T0YPUZkPd60T9bvvHwEqALivY+0FoHmMWvaUGTJalHk=
+charm.land/catwalk v0.52.31 h1:A43K1aIBQRgo1atK47x3pai7p9KLhusF6IgTVtmuxdc=
+charm.land/catwalk v0.52.31/go.mod h1:T0YPUZkPd60T9bvvHwEqALivY+0FoHmMWvaUGTJalHk=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
 charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=


### PR DESCRIPTION
Bumps `charm.land/catwalk` from v0.52.12 to v0.52.31 to pick up the newest entries in the embedded model catalog.

New models for the providers we map onto the catalog:

- **Anthropic:** `claude-fable-5-1`, `claude-mythos-5-1`
- **OpenAI:** `gpt-6-astra`
- **Google:** `gemini-3.8-flash`
- **OpenRouter:** 17 additions (incl. `anthropic/claude-fable-5.1`, `openai/gpt-6-astra`, `openai/gpt-6-astra-pro`, `google/gemini-3.8-flash`) and 12 removals of retired/renamed entries

No existing entries for Anthropic or OpenAI changed. One Gemini model had its cached-token pricing corrected.

Nothing else needs bumping: catwalk's Go API and `go.mod` are byte-identical between the two versions, `go mod tidy` produced no further changes, and the Anthropic/OpenAI/Google clients pass the model ID through to their SDKs as a plain string, so the new models work without touching any other pin. `core/modelcatalog` and `internal/cmd/dagger/llmconfig` tests pass, and the CLI and engine build.
