### PR TITLE
core: move module dependency pins to dagger.lock

### DIFF
--- a/core/integration/lockfile_test.go
+++ b/core/integration/lockfile_test.go
@@ -344,6 +344,56 @@ func (LockfileSuite) TestWorkspaceModuleLockUpdate(ctx context.Context, t *testc
 	})
 }
 
+func (LockfileSuite) TestWorkspaceLockContainsFlatModuleDependencyResolution(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+
+	depRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
+		WithNewFile("dagger-module.toml", `name = "dep"
+
+[runtime]
+source = "dang"
+`).
+		WithNewFile("main.dang", `type Dep {
+  pub hello: String! { "hello from dep" }
+}
+`))
+
+	upstreamRef := workspaceSelectionRemoteRef(ctx, t, c, c.Directory().
+		WithNewFile("dagger-module.toml", `name = "upstream"
+
+[runtime]
+source = "dang"
+
+[[dependencies]]
+name = "dep"
+source = "`+depRef+`"
+pin = "this-old-pin-must-be-ignored"
+`).
+		WithNewFile("main.dang", `type Upstream {
+  pub hello: String! { dep.hello }
+}
+`))
+
+	ctr := workspaceBase(t, c).
+		WithNewFile("dagger.toml", `[modules.upstream]
+source = "`+upstreamRef+`"
+entrypoint = true
+`).
+		With(daggerExecRaw("--silent", "call", "hello"))
+	out, err := ctr.Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "hello from dep", strings.TrimSpace(out))
+
+	lockContents, err := ctr.File("dagger.lock").Contents(ctx)
+	require.NoError(t, err)
+	depURL, found := strings.CutSuffix(depRef, "@main")
+	require.True(t, found)
+	upstreamURL, found := strings.CutSuffix(upstreamRef, "@main")
+	require.True(t, found)
+	assertGitLockEntry(t, []byte(lockContents), []any{upstreamURL, "main"})
+	assertGitLockEntry(t, []byte(lockContents), []any{depURL, "main"})
+}
+
 func writeContainerFromQuery(t *testctx.T, workdir string) string {
 	return writeQueryDoc(t, workdir, "query.graphql", containerFromQuery)
 }

--- a/core/modules/config_format.go
+++ b/core/modules/config_format.go
@@ -57,9 +57,6 @@ type CurrentModuleConfigDependency struct {
 
 	// The source ref of the module dependency.
 	Source string `json:"source" toml:"source"`
-
-	// The pinned version of the module dependency.
-	Pin string `json:"pin,omitempty" toml:"pin,omitempty"`
 }
 
 // LegacyModuleConfigWithUserFields is the frozen public schema for dagger.json.
@@ -124,7 +121,6 @@ func currentModuleConfigDependencies(deps []*ModuleConfigDependency) []*CurrentM
 		current = append(current, &CurrentModuleConfigDependency{
 			Name:   dep.Name,
 			Source: dep.Source,
-			Pin:    dep.Pin,
 		})
 	}
 	return current
@@ -142,7 +138,6 @@ func moduleConfigDependenciesFromCurrent(deps []*CurrentModuleConfigDependency) 
 		current = append(current, &ModuleConfigDependency{
 			Name:   dep.Name,
 			Source: dep.Source,
-			Pin:    dep.Pin,
 		})
 	}
 	return current

--- a/core/modules/config_test.go
+++ b/core/modules/config_test.go
@@ -147,8 +147,20 @@ func TestParseLegacyModuleConfigRejectsRuntime(t *testing.T) {
 	require.ErrorContains(t, err, "uses sdk instead of runtime")
 }
 
-func TestMarshalCurrentModuleConfigUsesRuntimeAndPreservesPins(t *testing.T) {
+func TestCurrentModuleConfigIgnoresDependencyPins(t *testing.T) {
 	t.Parallel()
+
+	cfg, err := ParseModuleConfigForFilename([]byte(`
+name = "mod"
+
+[[dependencies]]
+name = "dep"
+source = "github.com/acme/dep@main"
+pin = "sha256:old"
+`), Filename)
+	require.NoError(t, err)
+	require.Len(t, cfg.Dependencies, 1)
+	require.Empty(t, cfg.Dependencies[0].Pin)
 
 	out, err := MarshalModuleConfigForFilename(&ModuleConfigWithUserFields{
 		ModuleConfig: ModuleConfig{
@@ -167,14 +179,14 @@ func TestMarshalCurrentModuleConfigUsesRuntimeAndPreservesPins(t *testing.T) {
 	require.Contains(t, string(out), "[[dependencies]]")
 	require.Contains(t, string(out), `name = "dep"`)
 	require.Contains(t, string(out), `source = "github.com/acme/dep"`)
-	require.Contains(t, string(out), `pin = "sha256:abc"`)
+	require.NotContains(t, string(out), `pin =`)
 	require.NotContains(t, string(out), "sdk")
 
-	cfg, err := ParseModuleConfigForFilename(out, Filename)
+	cfg, err = ParseModuleConfigForFilename(out, Filename)
 	require.NoError(t, err)
 	require.Equal(t, "go", cfg.SDK.Source)
 	require.Equal(t, "src", cfg.Source)
-	require.Equal(t, "sha256:abc", cfg.Dependencies[0].Pin)
+	require.Empty(t, cfg.Dependencies[0].Pin)
 }
 
 func TestMarshalCurrentModuleConfigOmitsEmptyDependencyName(t *testing.T) {
@@ -208,7 +220,7 @@ func TestModuleConfigSchemasKeepLegacyFrozenFieldsOutOfCurrentConfig(t *testing.
 
 	currentSchema := reflectedSchemaJSON(t, &CurrentModuleConfigWithUserFields{})
 	require.Contains(t, currentSchema, `"runtime"`)
-	require.Contains(t, currentSchema, `"pin"`)
+	require.NotContains(t, currentSchema, "The pinned version of the module dependency.")
 	require.NotContains(t, currentSchema, `"sdk"`)
 	require.NotContains(t, currentSchema, `"blueprint"`)
 	require.NotContains(t, currentSchema, `"toolchains"`)

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -2102,6 +2102,13 @@ func (s *moduleSourceSchema) moduleConfigDependencyForRelatedSource(
 		return nil, fmt.Errorf("unhandled module source kind: %s", parentSrc.Kind.HumanString())
 	}
 
+	// Exact dependency resolutions belong to the consuming workspace's
+	// dagger.lock. The legacy dagger.json format keeps its frozen pin behavior,
+	// but dagger-module.toml only records the declared source/version query.
+	if modules.ConfigFormatForFilename(moduleSourceConfigFilename(parentSrc)) == modules.ConfigFormatCurrent {
+		depCfg.Pin = ""
+	}
+
 	return depCfg, nil
 }
 

--- a/core/schema/modulesource_test.go
+++ b/core/schema/modulesource_test.go
@@ -128,7 +128,7 @@ func TestLegacyWorkspaceFieldHandling(t *testing.T) {
 	)
 }
 
-func TestLoadCurrentModuleSourceConfigPreservesGitDependencySourceAndPin(t *testing.T) {
+func TestLoadCurrentModuleSourceConfigPreservesGitDependencySourceWithoutPin(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -165,7 +165,7 @@ func TestLoadCurrentModuleSourceConfigPreservesGitDependencySourceAndPin(t *test
 	cfg, err := (&moduleSourceSchema{}).loadModuleSourceConfig(parent)
 	require.NoError(t, err)
 	require.Len(t, cfg.Dependencies, 1)
-	require.Equal(t, "1234567890abcdef", cfg.Dependencies[0].Pin)
+	require.Empty(t, cfg.Dependencies[0].Pin)
 
 	out, err := modules.MarshalModuleConfigForFilename(cfg, modules.Filename)
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestLoadCurrentModuleSourceConfigPreservesGitDependencySourceAndPin(t *test
 	require.Contains(t, string(out), `engineVersion = "`+engine.Version+`"`)
 	require.Contains(t, string(out), `name = "dep"`)
 	require.Contains(t, string(out), `source = "https://github.com/acme/dep/sdk@v1.2"`)
-	require.Contains(t, string(out), `pin = "1234567890abcdef"`)
+	require.NotContains(t, string(out), `pin =`)
 	require.NotContains(t, string(out), `version =`)
 }
 

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -733,7 +733,8 @@ func TestWorkspaceMigrationModuleConfigConversions(t *testing.T) {
 	require.Equal(t, "video", cfg.Name)
 	require.Equal(t, "go", cfg.SDK.Source)
 	require.Equal(t, "github.com/acme/dep@main", cfg.Dependencies[0].Source)
-	require.Equal(t, "sha256:abc", cfg.Dependencies[0].Pin)
+	require.Empty(t, cfg.Dependencies[0].Pin)
+	require.NotContains(t, string(conversions[0].ConfigData), "pin =")
 	require.Equal(t, "./local", cfg.Dependencies[1].Source)
 
 	// A root sdk-only config is the "repo is just a dagger module" shape and

--- a/docs/static/reference/dagger-module.schema.json
+++ b/docs/static/reference/dagger-module.schema.json
@@ -12,10 +12,6 @@
         "source": {
           "type": "string",
           "description": "The source ref of the module dependency."
-        },
-        "pin": {
-          "type": "string",
-          "description": "The pinned version of the module dependency."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- remove dependency pins from dagger-module.toml
- accept old pin fields but ignore their values
- keep exact resolutions for the full dependency graph in dagger.lock
- keep legacy dagger.json behavior unchanged

An author can still require one commit by putting it in the source:

    source = "github.com/acme/tool@<commit>"

## Tests

- go test ./core/modules ./core/schema

Refs #14087