### PR TITLE
cli: update `dagger mod search` to show more modules, and use `dagger.io` addresses

### DIFF
--- a/internal/cmd/dagger/mod.go
+++ b/internal/cmd/dagger/mod.go
@@ -78,7 +78,7 @@ func loadSDKSearchRegistry() ([]registryModule, error) {
 		mods = append(mods, registryModule{
 			Name:        entry.Name,
 			Description: entry.Description,
-			Repo:        entry.Repo,
+			Repo:        "dagger.io/sdk/" + entry.Name,
 			Aliases:     entry.Aliases,
 		})
 	}

--- a/internal/cmd/dagger/mod_test.go
+++ b/internal/cmd/dagger/mod_test.go
@@ -69,8 +69,11 @@ func TestLoadSearchRegistryIncludesSDKsUnlessFiltered(t *testing.T) {
 		}
 		return out
 	}
-	require.Contains(t, repos(all), "github.com/dagger/go")
-	require.Contains(t, repos(all), "github.com/dagger/go-sdk")
-	require.NotContains(t, repos(sdkOnly), "github.com/dagger/go")
-	require.Contains(t, repos(sdkOnly), "github.com/dagger/go-sdk")
+	require.Contains(t, repos(all), "dagger.io/go")
+	require.Contains(t, repos(all), "dagger.io/sdk/go")
+	require.NotContains(t, repos(sdkOnly), "dagger.io/go")
+	require.Contains(t, repos(sdkOnly), "dagger.io/sdk/go")
+	for _, repo := range repos(all) {
+		require.Regexp(t, `^dagger\.io/`, repo)
+	}
 }

--- a/internal/cmd/dagger/modules.json
+++ b/internal/cmd/dagger/modules.json
@@ -30,6 +30,11 @@
     "recommend": ["**/jest.config.*"]
   },
   {
+    "name": "mochajs",
+    "description": "Run JavaScript and TypeScript tests with Mocha",
+    "repo": "dagger.io/js/mocha"
+  },
+  {
     "name": "vitest",
     "description": "Run JavaScript and TypeScript tests with Vitest",
     "repo": "dagger.io/js/vitest",
@@ -40,6 +45,26 @@
     "description": "Run Python tests with pytest",
     "repo": "dagger.io/python/pytest",
     "recommend": ["**/pytest.ini", "**/pyproject.toml"]
+  },
+  {
+    "name": "mypy",
+    "description": "Type-check Python projects with mypy",
+    "repo": "dagger.io/python/mypy"
+  },
+  {
+    "name": "ruff",
+    "description": "Lint and format Python projects with Ruff",
+    "repo": "dagger.io/python/ruff"
+  },
+  {
+    "name": "ty",
+    "description": "Type-check Python projects with ty",
+    "repo": "dagger.io/python/ty"
+  },
+  {
+    "name": "uv",
+    "description": "Lock, build, and audit Python projects with uv",
+    "repo": "dagger.io/python/uv"
   },
   {
     "name": "biomejs",

--- a/internal/cmd/dagger/modules.json
+++ b/internal/cmd/dagger/modules.json
@@ -2,55 +2,55 @@
   {
     "name": "go",
     "description": "Build, test, and lint Go projects with the Go toolchain",
-    "repo": "github.com/dagger/go",
+    "repo": "dagger.io/go",
     "recommend": ["**/go.mod"]
   },
   {
     "name": "deno",
     "description": "Test, lint, format, and type-check Deno projects with Dagger",
-    "repo": "github.com/dagger/deno",
+    "repo": "dagger.io/js/deno",
     "recommend": ["**/deno.json", "**/deno.jsonc", "**/deno.lock"]
   },
   {
     "name": "eslint",
     "description": "Lint JavaScript and TypeScript with ESLint",
-    "repo": "github.com/dagger/eslint",
+    "repo": "dagger.io/js/eslint",
     "recommend": ["**/.eslintrc*", "**/eslint.config.*"]
   },
   {
     "name": "prettier",
     "description": "Format code with Prettier",
-    "repo": "github.com/dagger/prettier",
+    "repo": "dagger.io/js/prettier",
     "recommend": ["**/.prettierrc*", "**/prettier.config.*"]
   },
   {
     "name": "jest",
     "description": "Run JavaScript and TypeScript tests with Jest",
-    "repo": "github.com/dagger/jest",
+    "repo": "dagger.io/js/jest",
     "recommend": ["**/jest.config.*"]
   },
   {
     "name": "vitest",
     "description": "Run JavaScript and TypeScript tests with Vitest",
-    "repo": "github.com/dagger/vitest",
+    "repo": "dagger.io/js/vitest",
     "recommend": ["**/vitest.config.*"]
   },
   {
     "name": "pytest",
     "description": "Run Python tests with pytest",
-    "repo": "github.com/dagger/pytest",
+    "repo": "dagger.io/python/pytest",
     "recommend": ["**/pytest.ini", "**/pyproject.toml"]
   },
   {
     "name": "biomejs",
     "description": "Format and lint JavaScript and TypeScript with Biome",
-    "repo": "github.com/dagger/biomejs",
+    "repo": "dagger.io/js/biome",
     "recommend": ["**/biome.json*"]
   },
   {
     "name": "playwright",
     "description": "Run end-to-end browser tests with Playwright",
-    "repo": "github.com/dagger/playwright",
+    "repo": "dagger.io/js/playwright",
     "recommend": ["**/playwright.config.*"]
   }
 ]


### PR DESCRIPTION
- `dagger module search` uses only dagger.io addresses.
- Search lists 20 modules: 14 tools and 6 SDKs.
- Mocha, mypy, Ruff, ty, and uv are added to search.
- Both `mocha` and `mochajs` queries find the Mocha module.
- The shared module list also changes the addresses used by `dagger setup` recommendations and installs.
- pytest now selects `github.com/dagger/python/pytest` instead of `github.com/dagger/pytest`.
- Module root addresses require [dagger/dagger.io#5265](https://github.com/dagger/dagger.io/pull/5265) to be deployed first. It corrects the root destinations from #5264 in that repository.
- The table compares search results before and after this PR. ❌ means absent from search.

| Module | Search before | Search after | Change |
|---|---|---|---|
| go | `github.com/dagger/go` | `dagger.io/go` | Use dagger.io address. |
| go SDK | `github.com/dagger/go-sdk` | `dagger.io/sdk/go` | Use dagger.io address. |
| python SDK | `github.com/dagger/python-sdk` | `dagger.io/sdk/python` | Use dagger.io address. |
| dang SDK | `github.com/dagger/dang-sdk` | `dagger.io/sdk/dang` | Use dagger.io address. |
| java SDK | `github.com/dagger/java-sdk` | `dagger.io/sdk/java` | Use dagger.io address. |
| php SDK | `github.com/dagger/php-sdk` | `dagger.io/sdk/php` | Use dagger.io address. |
| typescript SDK | `github.com/dagger/typescript-sdk` | `dagger.io/sdk/typescript` | Use dagger.io address. |
| mypy | ❌ | `dagger.io/python/mypy` | Add to search. |
| pytest | `github.com/dagger/pytest` | `dagger.io/python/pytest` | Select the module in `dagger/python`. |
| ruff | ❌ | `dagger.io/python/ruff` | Add to search. |
| ty | ❌ | `dagger.io/python/ty` | Add to search. |
| uv | ❌ | `dagger.io/python/uv` | Add to search. |
| deno | `github.com/dagger/deno` | `dagger.io/js/deno` | Use dagger.io address. |
| jest | `github.com/dagger/jest` | `dagger.io/js/jest` | Use dagger.io address. |
| vitest | `github.com/dagger/vitest` | `dagger.io/js/vitest` | Use dagger.io address. |
| eslint | `github.com/dagger/eslint` | `dagger.io/js/eslint` | Use dagger.io address. |
| prettier | `github.com/dagger/prettier` | `dagger.io/js/prettier` | Use dagger.io address. |
| playwright | `github.com/dagger/playwright` | `dagger.io/js/playwright` | Use dagger.io address. |
| mochajs | ❌ | `dagger.io/js/mocha` | Add to search. |
| biomejs | `github.com/dagger/biomejs` | `dagger.io/js/biome` | Use dagger.io address. |

- Search and registry tests passed: `go test internal/cmd/dagger/mod.go internal/cmd/dagger/module_init.go internal/cmd/dagger/mod_test.go -count=1`.
- The CLI build passed. Search returned 20 addresses. `--sdk` returned 6 addresses.
- All 20 addresses passed checks against the proposed redirect rules.
- [Full audit](https://gist.github.com/shykes/cb4bf1e369c1790e15b0a30b0fc2ecd7).
