### PR TITLE
cli: rename terminal to shell and shell to script

### DIFF
--- a/.changes/unreleased/Added-20260901-14031.yaml
+++ b/.changes/unreleased/Added-20260901-14031.yaml
@@ -1,2 +1,2 @@
 kind: Added
-body: Add `dagger terminal` and its `dagger tty` alias to list and open terminal targets from workspace modules.
+body: Add `dagger shell` and its `dagger sh` alias to list and open shells from workspace modules.

--- a/.changes/unreleased/Deprecated-20260723-014900.yaml
+++ b/.changes/unreleased/Deprecated-20260723-014900.yaml
@@ -1,6 +1,6 @@
 kind: Deprecated
 body: |
-  The `--mod` and `--no-mod` flags are deprecated in favor of `--load-module` and `--no-load-module`. The old names keep working as hidden aliases so existing scripts and shebangs (e.g. `dagger shell --no-mod`) do not break, but they now print a notice pointing at the new name.
+  The `--mod` and `--no-mod` flags are deprecated in favor of `--load-module` and `--no-load-module`. The old names keep working as hidden aliases so existing scripts and shebangs (e.g. `dagger script --no-mod`) do not break, but they now print a notice pointing at the new name.
 time: 2026-07-23T01:49:00Z
 custom:
   Author: vito

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -6042,7 +6042,7 @@ func (ContainerSuite) TestSaveHostDocker(ctx context.Context, t *testctx.T) {
 
 	t.Run("docker-image driver", func(ctx context.Context, t *testctx.T) {
 		imageName := "foobar:" + identity.NewID()
-		_, err := dockerc.WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).Sync(ctx)
+		_, err := dockerc.WithExec([]string{"dagger", "script", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).Sync(ctx)
 		require.NoError(t, err)
 
 		_, err = dockerc.WithExec([]string{"docker", "inspect", imageName}).Sync(ctx)
@@ -6058,7 +6058,7 @@ func (ContainerSuite) TestSaveHostDocker(ctx context.Context, t *testctx.T) {
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-container://dagger.test")
 
 		imageName := "foobar:" + identity.NewID()
-		_, err := alt.WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).Sync(ctx)
+		_, err := alt.WithExec([]string{"dagger", "script", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).Sync(ctx)
 		require.NoError(t, err)
 
 		_, err = alt.WithExec([]string{"docker", "inspect", imageName}).Sync(ctx)
@@ -6076,7 +6076,7 @@ func (ContainerSuite) TestSaveHostDocker(ctx context.Context, t *testctx.T) {
 		imageName := "foobar:" + identity.NewID()
 		_, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "docker-image").
-			WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).
+			WithExec([]string{"dagger", "script", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).
 			Sync(ctx)
 		require.NoError(t, err)
 
@@ -6107,7 +6107,7 @@ func (ContainerSuite) TestSaveHostContainerd(ctx context.Context, t *testctx.T) 
 		imageName := "foobar:" + identity.NewID()
 		_, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "containerd").
-			WithExec([]string{"dagger", "shell", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).
+			WithExec([]string{"dagger", "script", "-c", `container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`}).
 			Sync(ctx)
 		require.NoError(t, err)
 
@@ -6138,7 +6138,7 @@ func (ContainerSuite) TestLoadHostDocker(ctx context.Context, t *testctx.T) {
 		_, err := dockerc.WithExec([]string{"docker", "build", "-t", imageName, "-"}, dagger.ContainerWithExecOpts{Stdin: "FROM alpine\nRUN touch /foo\n"}).Sync(ctx)
 		require.NoError(t, err)
 
-		out, err := dockerc.WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).Stdout(ctx)
+		out, err := dockerc.WithExec([]string{"dagger", "script", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/foo\n", out)
 	})
@@ -6151,7 +6151,7 @@ func (ContainerSuite) TestLoadHostDocker(ctx context.Context, t *testctx.T) {
 		_, err := dockerc.WithExec([]string{"docker", "build", "-t", imageName, "-"}, dagger.ContainerWithExecOpts{Stdin: "FROM alpine\nRUN touch /foo\n"}).Sync(ctx)
 		require.NoError(t, err)
 
-		out, err := alt.WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).Stdout(ctx)
+		out, err := alt.WithExec([]string{"dagger", "script", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/foo\n", out)
 	})
@@ -6166,7 +6166,7 @@ func (ContainerSuite) TestLoadHostDocker(ctx context.Context, t *testctx.T) {
 
 		out, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "docker-image").
-			WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).
+			WithExec([]string{"dagger", "script", "-c", `host | container-image ` + imageName + ` | with-exec ls,/foo | stdout`}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/foo\n", out)
@@ -6205,7 +6205,7 @@ func (ContainerSuite) TestLoadHostContainerd(ctx context.Context, t *testctx.T) 
 
 		out, err := alt.
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_IMAGESTORE", "containerd").
-			WithExec([]string{"dagger", "shell", "-c", `host | container-image ` + imageName + ` | with-exec ls,/etc/fstab | stdout`}, dagger.ContainerWithExecOpts{
+			WithExec([]string{"dagger", "script", "-c", `host | container-image ` + imageName + ` | with-exec ls,/etc/fstab | stdout`}, dagger.ContainerWithExecOpts{
 				InsecureRootCapabilities: true,
 			}).Stdout(ctx)
 		require.NoError(t, err)
@@ -6229,7 +6229,7 @@ func (ContainerSuite) TestLoadSaveNone(ctx context.Context, t *testctx.T) {
 
 	imageName := "foobar:" + identity.NewID()
 	out, err := alt.WithExec([]string{
-		"dagger", "shell", "-c",
+		"dagger", "script", "-c",
 		`container | from "alpine" | with-exec touch,foo | export-image "` + imageName + `"`,
 	}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
 		Stderr(ctx)
@@ -6241,7 +6241,7 @@ func (ContainerSuite) TestLoadSaveNone(ctx context.Context, t *testctx.T) {
 	require.Contains(t, strings.ToLower(out), "no such object")
 
 	out, err = alt.WithExec([]string{
-		"dagger", "shell", "-c",
+		"dagger", "script", "-c",
 		`host | container-image ` + imageName + ` | with-exec echo,foo | stdout`,
 	}, dagger.ContainerWithExecOpts{Expect: dagger.ReturnTypeFailure}).
 		Stderr(ctx)

--- a/core/integration/llm_test.go
+++ b/core/integration/llm_test.go
@@ -1,7 +1,7 @@
 package core
 
 // These tests cover module functions that call Dagger's LLM API. They verify
-// direct calls, `dagger shell` argument handling, API limit errors, and the
+// direct calls, `dagger script` argument handling, API limit errors, and the
 // `--allow-llm` permission gate.
 
 import (
@@ -646,7 +646,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 
 	t.Run("shell allow all", func(ctx context.Context, t *testctx.T) {
 		_, err := daggerCliBase(t, c).
-			WithExec([]string{"dagger", "shell", "-m", indirectModuleRef, "--allow-llm=all"}, dagger.ContainerWithExecOpts{
+			WithExec([]string{"dagger", "script", "-m", indirectModuleRef, "--allow-llm=all"}, dagger.ContainerWithExecOpts{
 				Stdin:                         fmt.Sprintf(`. %s | prompt "greet me" %q`, modelFlag, identity.NewID()),
 				ExperimentalPrivilegedNesting: true,
 			}).
@@ -656,7 +656,7 @@ func (LLMSuite) TestAllowLLM(ctx context.Context, t *testctx.T) {
 
 	t.Run("shell interactive module loads", func(ctx context.Context, t *testctx.T) {
 		_, err := daggerCliBase(t, c).
-			WithExec([]string{"dagger", "shell", "--allow-llm", directModuleSymbolic}, dagger.ContainerWithExecOpts{
+			WithExec([]string{"dagger", "script", "--allow-llm", directModuleSymbolic}, dagger.ContainerWithExecOpts{
 				Stdin:                         fmt.Sprintf(`%s %s | prompt "greet me" %q`, indirectModuleRef, modelFlag, identity.NewID()),
 				ExperimentalPrivilegedNesting: true,
 			}).

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -54,8 +54,9 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		modDir := terminalFixtureMod(ctx, t, "terminal-default")
 		cacheTerminalModule(ctx, t, modDir, "-m", ".", "api", "functions")
 
-		out, err := hostDaggerExecRaw(ctx, t, modDir, "terminal", "-l")
+		out, err := hostDaggerExecRaw(ctx, t, modDir, "shell", "-l")
 		require.NoError(t, err)
+		require.Contains(t, string(out), "# select with 'dagger shell <NAME>'\n")
 		require.Contains(t, string(out), "test:ctr")
 
 		console, err := newTUIConsole(t, 60*time.Second)
@@ -66,7 +67,7 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 20})
 		require.NoError(t, err)
 
-		cmd := hostDaggerCommandRaw(ctx, t, modDir, "tty", "ctr")
+		cmd := hostDaggerCommandRaw(ctx, t, modDir, "shell", "ctr")
 		cmd.Stdin = tty
 		cmd.Stdout = tty
 		cmd.Stderr = tty
@@ -450,8 +451,9 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		modDir := terminalFixtureMod(ctx, t, "terminal-directory")
 		cacheTerminalModule(ctx, t, modDir, "-m", ".", "api", "functions")
 
-		out, err := hostDaggerExecRaw(ctx, t, modDir, "terminal", "-l")
+		out, err := hostDaggerExecRaw(ctx, t, modDir, "sh", "-l")
 		require.NoError(t, err)
+		require.Contains(t, string(out), "# select with 'dagger shell <NAME>'\n")
 		require.Contains(t, string(out), "test:dir")
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
@@ -467,7 +469,7 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 16})
 		require.NoError(t, err)
 
-		cmd := hostDaggerCommandRaw(ctx, t, modDir, "tty", "dir")
+		cmd := hostDaggerCommandRaw(ctx, t, modDir, "sh", "dir")
 		cmd.Stdin = tty
 		cmd.Stdout = tty
 		cmd.Stderr = tty

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -1,6 +1,6 @@
 package core
 
-// These tests cover `dagger call ... up` and `dagger shell ... up` for module
+// These tests cover `dagger call ... up` and `dagger script ... up` for module
 // functions that return containers or services. They verify endpoint discovery,
 // port mapping, and serving module results for local development.
 //
@@ -84,7 +84,7 @@ func (ModuleSuite) TestDaggerUp(ctx context.Context, t *testctx.T) {
 			name:         "shell container port map",
 			endpointFn:   daggerUpAndGetEndpoint,
 			trafficPort:  "23104",
-			daggerArgs:   []string{"-m", ".", "shell", "-c", fmt.Sprintf("ctr | up --ports 23104:%s", defaultTrafficPortForContainerTests)},
+			daggerArgs:   []string{"-m", ".", "script", "-c", fmt.Sprintf("ctr | up --ports 23104:%s", defaultTrafficPortForContainerTests)},
 			cachedModDir: modDirForAsContainerTests,
 		},
 		{

--- a/core/integration/shell_test.go
+++ b/core/integration/shell_test.go
@@ -1,6 +1,6 @@
 package core
 
-// These tests cover `dagger shell`, the command interpreter for composing
+// These tests cover `dagger script`, the command interpreter for composing
 // Dagger API calls. They verify module lookup, script mode, state variables,
 // arguments, exports, command errors, and shell builtins.
 //
@@ -37,7 +37,7 @@ func daggerShell(script string) dagger.WithContainerFunc {
 
 func daggerShellAt(modPath, script string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		execArgs := []string{"dagger", "shell"}
+		execArgs := []string{"dagger", "script"}
 		if modPath != "" {
 			execArgs = append(execArgs, "-m", modPath)
 		}
@@ -50,7 +50,7 @@ func daggerShellAt(modPath, script string) dagger.WithContainerFunc {
 
 func daggerShellNoMod(script string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
-		return c.WithExec([]string{"dagger", "shell", "-M"}, dagger.ContainerWithExecOpts{
+		return c.WithExec([]string{"dagger", "script", "-M"}, dagger.ContainerWithExecOpts{
 			Stdin:                         script,
 			ExperimentalPrivilegedNesting: true,
 		})
@@ -93,7 +93,7 @@ func (ShellSuite) TestCrossSessionSecretURICaching(ctx context.Context, t *testc
 	tmpdir := t.TempDir()
 	copyTestdataFixture(ctx, t, tmpdir, "modules", "go", "shell-secret-uri")
 
-	t.Run("dagger shell default cache key", func(ctx context.Context, t *testctx.T) {
+	t.Run("dagger script default cache key", func(ctx context.Context, t *testctx.T) {
 		c1 := connect(ctx, t)
 		c2 := connect(ctx, t)
 
@@ -123,7 +123,7 @@ func (ShellSuite) TestCrossSessionSecretURICaching(ctx context.Context, t *testc
 		}
 	})
 
-	t.Run("dagger shell custom cache key", func(ctx context.Context, t *testctx.T) {
+	t.Run("dagger script custom cache key", func(ctx context.Context, t *testctx.T) {
 		c1 := connect(ctx, t)
 		c2 := connect(ctx, t)
 
@@ -173,7 +173,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 		out, err := daggerCliBase(t, c).
 			WithNewFile("script.sh", ".echo foobar").
-			WithExec([]string{"dagger", "shell", "script.sh"}, dagger.ContainerWithExecOpts{
+			WithExec([]string{"dagger", "script", "script.sh"}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 			}).
 			Stdout(ctx)
@@ -460,7 +460,7 @@ func (ShellSuite) TestNoLoadModule(ctx context.Context, t *testctx.T) {
 
 func (ShellSuite) TestNoLoadModuleByName(ctx context.Context, t *testctx.T) {
 	// Regression test for https://github.com/dagger/dagger/issues/13728: with
-	// `dagger shell -M`, modules must be callable by their configured name, as
+	// `dagger script -M`, modules must be callable by their configured name, as
 	// in v0.2x, not only by their source path.
 
 	t.Run("workspace module by name", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/shell_test.go
+++ b/core/integration/shell_test.go
@@ -182,7 +182,7 @@ func (ShellSuite) TestScriptMode(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("shell script shebang", func(ctx context.Context, t *testctx.T) {
-		script := fmt.Sprintf("#!%s shell\n\n.echo foobar", testCLIBinPath)
+		script := fmt.Sprintf("#!%s script\n\n.echo foobar", testCLIBinPath)
 		c := connect(ctx, t)
 		out, err := daggerCliBase(t, c).
 			WithNewFile("script.sh", script, dagger.ContainerWithNewFileOpts{

--- a/core/integration/workspace_api_test.go
+++ b/core/integration/workspace_api_test.go
@@ -701,13 +701,13 @@ func (WorkspaceAPISuite) TestWorkspaceMounts(ctx context.Context, t *testctx.T) 
 		initGitRepo(ctx, t, workdir)
 		require.NoError(t, os.WriteFile(filepath.Join(workdir, "base.txt"), []byte("base"), 0o644))
 
-		out, err := hostDaggerExec(ctx, t, workdir, "shell", "-c",
+		out, err := hostDaggerExec(ctx, t, workdir, "script", "-c",
 			`current-workspace | with-mounted-directory .refs/deps $(directory | with-new-file vendored.txt "vendored") | file .refs/deps/vendored.txt | contents`)
 		require.NoError(t, err)
 		require.Contains(t, string(out), "vendored")
 
 		// The .refs parent exists only through the mount, never on the host.
-		out, err = hostDaggerExec(ctx, t, workdir, "shell", "-c",
+		out, err = hostDaggerExec(ctx, t, workdir, "script", "-c",
 			`current-workspace | with-mounted-directory .refs/deps $(directory | with-new-file vendored.txt "vendored") | directory .refs | entries`)
 		require.NoError(t, err)
 		require.Contains(t, string(out), "deps")
@@ -720,7 +720,7 @@ func (WorkspaceAPISuite) TestWorkspaceMounts(ctx context.Context, t *testctx.T) 
 		initGitRepo(ctx, t, workdir)
 		require.NoError(t, os.WriteFile(filepath.Join(workdir, "base.txt"), []byte("base"), 0o644))
 
-		_, err := hostDaggerExec(ctx, t, workdir, "shell", "-c",
+		_, err := hostDaggerExec(ctx, t, workdir, "script", "-c",
 			`current-workspace | with-mounted-directory .refs/deps $(directory | with-new-file vendored.txt "vendored") | with-new-file staged.txt "staged" | export`)
 		require.NoError(t, err)
 

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -15,7 +15,7 @@ dagger [options] [subcommand | file...]
 ### Options
 
 ```
-  -c, --command string   Execute a dagger shell command
+  -c, --command string   Execute a Dagger script
   -v, --verbose count    Increase verbosity (use -vv or -vvv for more)
 ```
 
@@ -32,7 +32,7 @@ dagger [options] [subcommand | file...]
 * [dagger sdk](#dagger-sdk)	 - Inspect and configure SDKs
 * [dagger settings](#dagger-settings)	 - Get, set, or unset module settings (use --env for an env overlay)
 * [dagger setup](#dagger-setup)	 - Ensure Dagger is properly set up and operational in the workspace
-* [dagger terminal](#dagger-terminal)	 - Open a terminal for a container or directory in your project
+* [dagger shell](#dagger-shell)	 - Open a terminal for a container or directory in your project
 * [dagger uninstall](#dagger-uninstall)	 - Uninstall a module from your workspace
 * [dagger up](#dagger-up)	 - Run your project's services for local development — databases, APIs, dev servers, etc.
 * [dagger version](#dagger-version)	 - Print dagger version
@@ -2016,7 +2016,7 @@ dagger setup
 
 * [dagger](#dagger)	 - A tool to run composable workflows in containers
 
-## dagger terminal
+## dagger shell
 
 Open a terminal for a container or directory in your project
 
@@ -2025,19 +2025,19 @@ Open a terminal for a container or directory in your project
 Open a terminal for a container or directory in your project.
 
 Examples:
-  dagger terminal -l                 # List all available terminal targets
-  dagger terminal go:dev             # Open the go:dev terminal target
-  dagger tty go:dev                  # Use the short command alias
+  dagger shell -l                   # List all available shells
+  dagger shell go:dev               # Open the go:dev shell
+  dagger sh go:dev                  # Use the short command alias
 
 
 ```
-dagger terminal [options] [pattern]
+dagger shell [options] [pattern]
 ```
 
 ### Options
 
 ```
-  -l, --list   List available terminal targets
+  -l, --list   List available shells
 ```
 
 ### Options inherited from parent commands

--- a/future/cli-global-flag-scoping.md
+++ b/future/cli-global-flag-scoping.md
@@ -114,8 +114,8 @@ no engine, selects no workspace, reads no workspace configuration, and renders
 no pipeline, so the front-door usage message stays free of those flags. It is
 left with `-c`, `--command` and `--verbose`. Shell-style root invocations still
 do all of that:
-`dagger FILE` and `dagger -c COMMAND` run `dagger shell`, so the CLI checks
-their flags against the capabilities of `dagger shell`. Thus,
+`dagger FILE` and `dagger -c COMMAND` run `dagger script`, so the CLI checks
+their flags against the capabilities of `dagger script`. Thus,
 `dagger --engine=cloud FILE` remains valid, and `dagger --engine=cloud` alone
 is an error.
 

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -191,7 +191,7 @@ func validateFlagCapabilities(root *cobra.Command, args []string) error {
 	_ = parsed.Parse(commandArgs)
 
 	// Bare `dagger` prints usage, but shell-style root invocations run the
-	// shell command, so they get the shell command's capabilities.
+	// script command, so they get the script command's capabilities.
 	effective := rootShellFallbackCommand(cmd, parsed)
 
 	var unsupported []string
@@ -211,14 +211,14 @@ func validateFlagCapabilities(root *cobra.Command, args []string) error {
 }
 
 // rootShellFallbackCommand reports the command that a root invocation runs.
-// `dagger -c ...` and `dagger file.dsh` fall back to `dagger shell`, so their
-// flags are checked against the shell command instead of the root command.
+// `dagger -c ...` and `dagger file.dsh` fall back to `dagger script`, so their
+// flags are checked against the script command instead of the root command.
 func rootShellFallbackCommand(cmd *cobra.Command, parsed *pflag.FlagSet) *cobra.Command {
 	if cmd != rootCmd {
 		return cmd
 	}
 	if args := parsed.Args(); len(args) > 0 && isFile(args[0]) {
-		return shellCmd
+		return scriptCmd
 	}
 	// Only root-local flags signal a shell-style invocation. Global flags are
 	// persistent, and they do not select the shell.
@@ -230,7 +230,7 @@ func rootShellFallbackCommand(cmd *cobra.Command, parsed *pflag.FlagSet) *cobra.
 		}
 	})
 	if shellStyle {
-		return shellCmd
+		return scriptCmd
 	}
 	return cmd
 }
@@ -259,7 +259,7 @@ func init() {
 	// calls no engine, selects no workspace, reads no workspace configuration,
 	// and renders no pipeline, so its usage message stays free of those flags.
 	// Shell-style invocations (`dagger -c ...`, `dagger FILE`) do all of that,
-	// but they run `dagger shell`, which declares the capabilities;
+	// but they run `dagger script`, which declares the capabilities;
 	// rootShellFallbackCommand routes the flag check there.
 	setLocalCommandCapabilities(workspaceCmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig)
 
@@ -279,8 +279,8 @@ func init() {
 		listenCmd,
 		apiSessionCmd,
 		sessionAliasCmd,
+		scriptCmd,
 		shellCmd,
-		terminalCmd,
 		mcpCmd,
 		moduleInitCmd,
 		moduleClientAddCmd,

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -197,6 +197,7 @@ func TestEngineFlagHelp(t *testing.T) {
 	root := testRootCommand()
 	for name, cmd := range map[string]*cobra.Command{
 		"api call": apiCallCmd.Command(),
+		"script":   scriptCmd,
 		"shell":    shellCmd,
 	} {
 		help := renderHelp(t, cmd)
@@ -278,8 +279,8 @@ func TestMayCallEngineCommands(t *testing.T) {
 		"dagger session",
 		"dagger settings",
 		"dagger setup",
+		"dagger script",
 		"dagger shell",
-		"dagger terminal",
 		"dagger uninstall",
 		"dagger up",
 		"dagger workspace",
@@ -315,7 +316,7 @@ func TestRootShellFallbackKeepsEngineFlags(t *testing.T) {
 	require.EqualError(t, validateFlagCapabilities(root, []string{"version", "--engine=cloud"}),
 		`flag --engine is not supported by command "dagger version"`)
 
-	// Shell-style root invocations run `dagger shell`, which calls the engine.
+	// Shell-style root invocations run `dagger script`, which calls the engine.
 	require.NoError(t, validateFlagCapabilities(root, []string{"--engine=cloud", "-c", "container"}))
 	require.NoError(t, validateFlagCapabilities(root, []string{"-i", "-c", "container"}))
 
@@ -323,7 +324,7 @@ func TestRootShellFallbackKeepsEngineFlags(t *testing.T) {
 	require.NoError(t, os.WriteFile(script, []byte("container\n"), 0o600))
 	require.NoError(t, validateFlagCapabilities(root, []string{"--engine=cloud", script}))
 
-	require.NoError(t, validateFlagCapabilities(root, []string{"shell", "--engine=cloud"}))
+	require.NoError(t, validateFlagCapabilities(root, []string{"script", "--engine=cloud"}))
 }
 
 func TestMaySelectWorkspaceCommands(t *testing.T) {
@@ -378,7 +379,7 @@ func TestModuleFlagsRequireMayCallEngine(t *testing.T) {
 		require.NotNil(t, flag, name)
 		require.Equal(t, []string{string(mayCallEngine)}, flag.Annotations[flagCapabilitiesAnnotation], name)
 		require.False(t, FlagAvailableForCommand(rootCmd, flag), name)
-		require.True(t, FlagAvailableForCommand(shellCmd, flag), name)
+		require.True(t, FlagAvailableForCommand(scriptCmd, flag), name)
 		require.True(t, FlagAvailableForCommand(checksCmd, flag), name)
 	}
 
@@ -394,7 +395,7 @@ func TestModuleFlagsRequireMayCallEngine(t *testing.T) {
 		require.NotContains(t, rootHelp, "--"+name, name)
 	}
 	require.Contains(t, rootHelp, "-c, --command")
-	require.Contains(t, renderHelp(t, shellCmd), "--model")
+	require.Contains(t, renderHelp(t, scriptCmd), "--model")
 	require.Contains(t, renderHelp(t, checksCmd), "--allow-llm")
 }
 
@@ -558,8 +559,8 @@ func TestWorkspaceConfigCommands(t *testing.T) {
 		"dagger sdk scope sdk",
 		"dagger session",
 		"dagger settings",
+		"dagger script",
 		"dagger shell",
-		"dagger terminal",
 		"dagger uninstall",
 		"dagger up",
 		"dagger workspace",
@@ -621,8 +622,8 @@ func TestMayRenderPipelineCommands(t *testing.T) {
 		"dagger query",
 		"dagger run",
 		"dagger session",
+		"dagger script",
 		"dagger shell",
-		"dagger terminal",
 		"dagger trace",
 		"dagger up",
 	}

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -172,7 +172,7 @@ func init() {
 	checksCmd.GroupID = "daily"
 	generateCmd.GroupID = "daily"
 	upCmd.GroupID = "daily"
-	terminalCmd.GroupID = "daily"
+	shellCmd.GroupID = "daily"
 	agentCmd.GroupID = "daily"
 
 	moduleCmd.GroupID = "workspace"
@@ -199,7 +199,7 @@ func init() {
 		traceCmd,
 		checksCmd,
 		upCmd,
-		terminalCmd,
+		shellCmd,
 		agentCmd,
 		generateCmd,
 		workspaceCmd,
@@ -213,7 +213,7 @@ func init() {
 		callModCmd.Command(),
 		functionsAliasCmd,
 		sessionAliasCmd,
-		shellCmd,
+		scriptCmd,
 		mcpCmd,
 	)
 
@@ -307,7 +307,7 @@ var rootCmd = &cobra.Command{
 		})
 
 		// Keep subscription OAuth tokens fresh for as long as this command
-		// runs: `dagger shell`/`agent` sessions outlive an hour-long access
+		// runs: `dagger script`/`agent` sessions outlive an hour-long access
 		// token, and refreshing ahead of expiry keeps the round-trip off the
 		// critical path. No-op unless a subscription provider is configured;
 		// the on-demand refresher hook stays the fallback.
@@ -329,17 +329,15 @@ var rootCmd = &cobra.Command{
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
-	// Historically, the root command fell back to the hidden shell command:
-	// `dagger`, `dagger -c ...`, and `dagger file.dsh` all executed shell.
-	// Bare `dagger` now prints regular CLI usage, but explicit shell-style root
-	// invocations still take the old fallback below.
+	// Bare `dagger` prints regular CLI usage. Explicit script invocations
+	// (`dagger -c ...` and `dagger file.dsh`) use the hidden script command.
 	if len(args) == 0 && !hasChangedRootShellFlag(cmd) {
 		return cmd.Usage()
 	}
 	if len(args) > 0 && !isFile(args[0]) {
 		return fmt.Errorf("unknown command or file %q for %q%s", args[0], cmd.CommandPath(), findSuggestions(cmd, args[0]))
 	}
-	cmd.SetArgs(append([]string{"shell"}, args...))
+	cmd.SetArgs(append([]string{"script"}, args...))
 	return cmd.Execute()
 }
 

--- a/internal/cmd/dagger/module.go
+++ b/internal/cmd/dagger/module.go
@@ -109,8 +109,8 @@ func init() {
 
 	moduleAddFlags(mcpCmd, mcpCmd.PersistentFlags(), true)
 
-	moduleAddFlags(shellCmd, shellCmd.PersistentFlags(), true)
-	shellAddFlags(shellCmd)
+	moduleAddFlags(scriptCmd, scriptCmd.PersistentFlags(), true)
+	shellAddFlags(scriptCmd)
 	moduleAddFlags(checksCmd, checksCmd.PersistentFlags(), false)
 	moduleAddFlags(rootCmd, rootCmd.Flags(), true)
 	shellAddFlags(rootCmd)

--- a/internal/cmd/dagger/shell.go
+++ b/internal/cmd/dagger/shell.go
@@ -39,16 +39,16 @@ var (
 func shellAddFlags(cmd *cobra.Command) {
 	// -c stays ungated: on the root command it is how a user reaches the shell
 	// at all, so the root usage message must keep naming it.
-	cmd.Flags().StringVarP(&shellCode, "command", "c", "", "Execute a dagger shell command")
+	cmd.Flags().StringVarP(&shellCode, "command", "c", "", "Execute a Dagger script")
 
 	// The model is an engine session parameter.
 	cmd.Flags().StringVar(&llmModel, "model", "", "LLM model to use (e.g., 'claude-sonnet-4-5', 'gpt-4.1')")
 	setFlagCapabilities(cmd.Flags().Lookup("model"), mayCallEngine)
 }
 
-var shellCmd = &cobra.Command{
-	Use:   "shell [options] [file...]",
-	Short: "Run an interactive dagger shell",
+var scriptCmd = &cobra.Command{
+	Use:   "script [options] [file...]",
+	Short: "Run Dagger scripts or start the interactive interpreter",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SetContext(idtui.WithPrintTraceLink(cmd.Context(), true))
 		return withEngine(cmd.Context(), initModuleParams(args), func(ctx context.Context, engineClient *client.Client) error {
@@ -263,14 +263,14 @@ func (h *shellCallHandler) RunAll(ctx context.Context, args []string) error {
 		return err
 	}
 
-	// Example: `dagger shell -c 'container | workdir'`
+	// Example: `dagger script -c 'container | workdir'`
 	if shellCode != "" {
 		return h.run(ctx, strings.NewReader(shellCode), "")
 	}
 
 	// Use stdin only when no file paths are provided
 	if len(args) == 0 {
-		// Example: `dagger shell`
+		// Example: `dagger script`
 		//
 		// Go interactive when stdin is a terminal, or when the TUI console
 		// (DAGGER_TUI_CONSOLE) is serving the prompt over HTTP -- there the
@@ -279,11 +279,11 @@ func (h *shellCallHandler) RunAll(ctx context.Context, args []string) error {
 		if isatty.IsTerminal(os.Stdin.Fd()) || os.Getenv("DAGGER_TUI_CONSOLE") != "" {
 			return h.runInteractive(ctx)
 		}
-		// Example: `echo 'container | workdir' | dagger shell`
+		// Example: `echo 'container | workdir' | dagger script`
 		return h.run(ctx, os.Stdin, "-")
 	}
 
-	// Example: `dagger shell job1.dsh job2.dsh`
+	// Example: `dagger script job1.dsh job2.dsh`
 	for _, path := range args {
 		if err := h.runPath(ctx, path); err != nil {
 			return err
@@ -299,7 +299,7 @@ func (h *shellCallHandler) Initialize(ctx context.Context) error {
 		interp.CallHandler(h.Call),
 		interp.ExecHandlers(h.Exec),
 
-		// The "Interactive" option is useful even when not running dagger shell
+		// The "Interactive" option is useful even when not running dagger script
 		// in interactive mode. It expands aliases and maybe more in the future.
 		interp.Interactive(true),
 	)

--- a/internal/cmd/dagger/suite_test.go
+++ b/internal/cmd/dagger/suite_test.go
@@ -58,7 +58,7 @@ func TestRunRootNoArgsShowsUsage(t *testing.T) {
 	}
 }
 
-func TestRunRootNoArgsWithLegacyRootShellFlagDispatchesShell(t *testing.T) {
+func TestRunRootNoArgsWithLegacyRootShellFlagDispatchesScript(t *testing.T) {
 	called := false
 	cmd := &cobra.Command{
 		Use:  rootCmd.Use,
@@ -67,7 +67,7 @@ func TestRunRootNoArgsWithLegacyRootShellFlagDispatchesShell(t *testing.T) {
 	cmd.Flags().String("command", "", "")
 	cmd.SetArgs([]string{"--command", "container"})
 	cmd.AddCommand(&cobra.Command{
-		Use:    "shell",
+		Use:    "script",
 		Hidden: true,
 		Run: func(*cobra.Command, []string) {
 			called = true
@@ -78,7 +78,7 @@ func TestRunRootNoArgsWithLegacyRootShellFlagDispatchesShell(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !called {
-		t.Fatal("expected shell command to run")
+		t.Fatal("expected script command to run")
 	}
 }
 
@@ -95,7 +95,7 @@ func TestRunRootNoArgsWithPersistentFlagShowsUsage(t *testing.T) {
 	cmd.PersistentFlags().Bool("debug", false, "")
 	cmd.SetArgs([]string{"--debug"})
 	cmd.AddCommand(&cobra.Command{
-		Use:    "shell",
+		Use:    "script",
 		Hidden: true,
 		Run: func(*cobra.Command, []string) {
 			called = true
@@ -106,7 +106,7 @@ func TestRunRootNoArgsWithPersistentFlagShowsUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 	if called {
-		t.Fatal("did not expect shell command to run")
+		t.Fatal("did not expect script command to run")
 	}
 	if !strings.Contains(out.String(), "USAGE") {
 		t.Fatalf("usage output missing USAGE:\n%s", out.String())

--- a/internal/cmd/dagger/terminal.go
+++ b/internal/cmd/dagger/terminal.go
@@ -20,30 +20,45 @@ var terminalListMode bool
 var loadTerminalsQuery string
 
 func init() {
-	terminalCmd.Flags().BoolVarP(&terminalListMode, "list", "l", false, "List available terminal targets")
+	shellCmd.Flags().BoolVarP(&terminalListMode, "list", "l", false, "List available shells")
+	shellCmd.Flags().StringP("command", "c", "", "Use 'dagger -c' to run Dagger scripts")
+	legacyCommand := shellCmd.Flags().Lookup("command")
+	legacyCommand.Hidden = true
+	// Accept a bare -c so it also gets the migration message.
+	legacyCommand.NoOptDefVal = "legacy"
 }
 
-var terminalCmd = &cobra.Command{
-	Use:     "terminal [options] [pattern]",
-	Aliases: []string{"tty"},
+var shellCmd = &cobra.Command{
+	Use:     "shell [options] [pattern]",
+	Aliases: []string{"sh"},
 	Annotations: map[string]string{
-		visibleAliasesAnnotation: "tty",
+		visibleAliasesAnnotation: "sh",
 	},
 	Short: "Open a terminal for a container or directory in your project",
 	Long: `Open a terminal for a container or directory in your project.
 
 Examples:
-  dagger terminal -l                 # List all available terminal targets
-  dagger terminal go:dev             # Open the go:dev terminal target
-  dagger tty go:dev                  # Use the short command alias
+  dagger shell -l                   # List all available shells
+  dagger shell go:dev               # Open the go:dev shell
+  dagger sh go:dev                  # Use the short command alias
 `,
-	Args: cobra.MaximumNArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("command") {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("'dagger shell -c' is no longer supported; use 'dagger -c' to run Dagger scripts")
+		}
+		return cobra.MaximumNArgs(1)(cmd, args)
+	},
 	RunE: runTerminalCommand,
 }
 
 func runTerminalCommand(cmd *cobra.Command, args []string) error {
 	if !terminalListMode && len(args) == 0 {
-		return fmt.Errorf("terminal target required; use 'dagger terminal -l' to list available targets")
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), `Choose a shell to open.
+
+  dagger shell -l       List available shells
+  dagger shell <NAME>   Open a shell from that list`)
+		return err
 	}
 
 	return withEngine(
@@ -76,7 +91,11 @@ func listTerminalTargets(ctx context.Context, dag *dagger.Client, terminals *dag
 			Comment: firstDescriptionLine(terminal.Description),
 		})
 	}
-	return writeCommandList(cmd.OutOrStdout(), items)
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintln(out, "# select with 'dagger shell <NAME>'"); err != nil {
+		return err
+	}
+	return writeCommandList(out, items)
 }
 
 var terminalMu sync.Mutex

--- a/internal/cmd/dagger/terminal_test.go
+++ b/internal/cmd/dagger/terminal_test.go
@@ -1,16 +1,90 @@
 package daggercmd
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTerminalCommandRequiresTarget(t *testing.T) {
+func TestShellCommandWithoutTargetShowsGuidance(t *testing.T) {
 	oldListMode := terminalListMode
 	t.Cleanup(func() { terminalListMode = oldListMode })
 	terminalListMode = false
 
-	err := runTerminalCommand(terminalCmd, nil)
-	require.EqualError(t, err, "terminal target required; use 'dagger terminal -l' to list available targets")
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: shellCmd.Use}
+	cmd.SetOut(&out)
+	err := runTerminalCommand(cmd, nil)
+	require.NoError(t, err)
+	require.Equal(t, `Choose a shell to open.
+
+  dagger shell -l       List available shells
+  dagger shell <NAME>   Open a shell from that list
+`, out.String())
+}
+
+func TestShellLegacyCommandStopsBeforeSetup(t *testing.T) {
+	parent := shellCmd.Parent()
+	oldListMode := terminalListMode
+	oldSilenceUsage := shellCmd.SilenceUsage
+	commandFlag := shellCmd.Flags().Lookup("command")
+	oldCommand := commandFlag.Value.String()
+	oldCommandChanged := commandFlag.Changed
+	listFlag := shellCmd.Flags().Lookup("list")
+	oldListChanged := listFlag.Changed
+	t.Cleanup(func() {
+		parent.AddCommand(shellCmd)
+		terminalListMode = oldListMode
+		shellCmd.SilenceUsage = oldSilenceUsage
+		require.NoError(t, commandFlag.Value.Set(oldCommand))
+		commandFlag.Changed = oldCommandChanged
+		listFlag.Changed = oldListChanged
+	})
+
+	setupCalled := false
+	root := &cobra.Command{
+		Use:           "dagger",
+		SilenceErrors: true,
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			setupCalled = true
+			return fmt.Errorf("setup must not run")
+		},
+	}
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.AddGroup(&cobra.Group{ID: shellCmd.GroupID})
+	parent.RemoveCommand(shellCmd)
+	root.AddCommand(shellCmd)
+
+	for _, args := range [][]string{
+		{"-c"},
+		{"-c", ".echo hello"},
+		{"-c", ""},
+		{"--command=.echo hello"},
+		{"--command"},
+		{"-l", "-c", ".echo hello"},
+		{"go:dev", "-c", ".echo hello"},
+	} {
+		t.Run(fmt.Sprint(args), func(t *testing.T) {
+			commandFlag.Changed = false
+			listFlag.Changed = false
+			terminalListMode = false
+			shellCmd.SilenceUsage = oldSilenceUsage
+			setupCalled = false
+			root.SetArgs(append([]string{"shell"}, args...))
+
+			err := root.Execute()
+			require.EqualError(t, err, "'dagger shell -c' is no longer supported; use 'dagger -c' to run Dagger scripts")
+			require.False(t, setupCalled)
+			require.True(t, shellCmd.SilenceUsage)
+		})
+	}
+
+	help := renderHelp(t, shellCmd)
+	require.NotContains(t, help, "--command")
+	require.Contains(t, help, "--list")
 }

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -236,7 +236,7 @@ func TestRootHelpShowsImplicitCommandGrouping(t *testing.T) {
 	require.NotContains(t, help, "function, fn")
 	require.Contains(t, help, "module, mod")
 	require.Contains(t, help, "workspace, ws")
-	require.Contains(t, help, "terminal, tty")
+	require.Contains(t, help, "shell, sh")
 	require.NotContains(t, help, "exec, run")
 
 	names := rootHelpCommandNames(help)

--- a/skills/tui-surfacing/SKILL.md
+++ b/skills/tui-surfacing/SKILL.md
@@ -7,7 +7,7 @@ description: How the Dagger pretty TUI surfaces deep spans (checks, tests, LLM c
 
 "Surfacing" is how the pretty frontend promotes spans buried deep in the trace
 tree up to the **top level** — so `dagger trace` on a CI run leads with its
-checks (sub-checks and tests rolled up beneath), and `dagger shell --model`
+checks (sub-checks and tests rolled up beneath), and `dagger script --model`
 leads with the LLM conversation, instead of the raw connect/load/exec tree.
 
 There are **two independent layers**. Get this distinction first — most
@@ -121,7 +121,7 @@ Checks reach `RevealedSpans` via `reveal` bubbling; the conversation does not se
 `reveal`, so `promoteConversationLocked` first calls `DB.PromoteConversationTo`
 to wire the reveal-independent `SurfacedConversation` tree into `RevealedSpans`
 (top-level turns under the host, a sub-agent's turns under the tool call that
-spawned them). This is the mechanism that replaced `dagger shell`'s old manual
+spawned them). This is the mechanism that replaced `dagger script`'s old manual
 `SetPrimary` zoom. `zoomKind` (`dagql/idtui/frontend_trace_policy.go`)
 distinguishes zoomRoot/zoomCheck/zoomTest/zoomSpan for the zoomed views.
 


### PR DESCRIPTION
- Rename `dagger terminal` to `dagger shell`.
- Remove the `tty` alias. Add a visible `sh` alias.
- Rename the hidden `dagger shell` command to `dagger script`. Keep it hidden.
- Keep `dagger -c` and `dagger <file>` working.
- Show shell selection instructions when no name is given.
- Add `# select with 'dagger shell <NAME>'` above the `-l` output.
- Reject `shell -c` and `sh -c` with a message that points to `dagger -c`.
