### PR TITLE
core: inline lockfile options with inputs

### DIFF
--- a/core/workspace/lock.go
+++ b/core/workspace/lock.go
@@ -68,7 +68,7 @@ type LookupEntry struct {
 }
 
 // LookupOption is an optional input to a lock operation. Options are encoded
-// as ordered key-value pairs after the entry value.
+// as ordered key-value pairs after the required positional inputs.
 type LookupOption struct {
 	Name  string
 	Value any
@@ -84,7 +84,7 @@ func LookupInputs(required []any, options ...LookupOption) []any {
 	for _, option := range options {
 		pairs = append(pairs, []any{option.Name, option.Value})
 	}
-	return append(inputs, pairs)
+	return append(inputs, pairs...)
 }
 
 // ParseLookupInputs separates required positional inputs from optional named
@@ -95,25 +95,30 @@ func ParseLookupInputs(inputs []any) ([]any, map[string]any, error) {
 	if len(inputs) == 0 {
 		return required, options, nil
 	}
-	pairs, ok := inputs[len(inputs)-1].([]any)
-	if !ok || len(pairs) == 0 {
-		return required, options, nil
-	}
-	for _, rawPair := range pairs {
-		pair, ok := rawPair.([]any)
+	optionStart := len(inputs)
+	for optionStart > 0 {
+		pair, ok := inputs[optionStart-1].([]any)
 		if !ok || len(pair) != 2 {
-			return inputs, nil, nil
+			break
 		}
 		name, ok := pair[0].(string)
 		if !ok || name == "" {
-			return inputs, nil, nil
+			break
 		}
+		optionStart--
+	}
+	for _, rawPair := range inputs[optionStart:] {
+		pair, ok := rawPair.([]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("invalid lock option")
+		}
+		name := pair[0].(string)
 		if _, exists := options[name]; exists {
 			return nil, nil, fmt.Errorf("duplicate lock option %q", name)
 		}
 		options[name] = pair[1]
 	}
-	return inputs[:len(inputs)-1], options, nil
+	return inputs[:optionStart], options, nil
 }
 
 // Lock is the workspace lockfile wrapper.

--- a/core/workspace/lock_test.go
+++ b/core/workspace/lock_test.go
@@ -106,6 +106,22 @@ func TestParseGitLookupRejectsConflictingEquivalentEntries(t *testing.T) {
 	require.ErrorContains(t, LockfileMergeConflictError(err), "workspace lockfile contains conflicting pins for the same Git repository")
 }
 
+func TestLookupInputs(t *testing.T) {
+	inputs := LookupInputs(
+		[]any{"github.com/dagger/sdk-helpers"},
+		LookupOption{Name: "version", Value: "v1"},
+	)
+	require.Equal(t, []any{
+		"github.com/dagger/sdk-helpers",
+		[]any{"version", "v1"},
+	}, inputs)
+
+	required, options, err := ParseLookupInputs(inputs)
+	require.NoError(t, err)
+	require.Equal(t, []any{"github.com/dagger/sdk-helpers"}, required)
+	require.Equal(t, map[string]any{"version": "v1"}, options)
+}
+
 func TestLookupConcurrentWrites(t *testing.T) {
 	t.Parallel()
 

--- a/hack/designs/lockfile.md
+++ b/hack/designs/lockfile.md
@@ -51,7 +51,7 @@ a parse/marshal round trip; only the fixed header is ever written.
 Each entry is an ordered tuple:
 
 ```json
-[namespace, operation, required-inputs, value, optional-options]
+[namespace, operation, inputs, value]
 ```
 
 Examples:
@@ -61,7 +61,7 @@ Examples:
 ["","oci-sha",["docker.io/library/alpine:3.22.1"],"sha256:3d23f8"]
 ["","git-latest",["https://github.com/dagger/dagger.git"],"refs/tags/v1.2.3"]
 ["","git-sha",["https://github.com/dagger/dagger.git","refs/tags/v1.2.3"],"495a8c8ce85670e58560a9561626297a436225c0"]
-["","oci-latest",["registry.example/acme/image"],"2.0.0",[["protocol","http"]]]
+["","oci-latest",["registry.example/acme/image",["protocol","http"]],"2.0.0"]
 ```
 
 Rules:
@@ -71,8 +71,9 @@ Rules:
   requested it.
 - required inputs are positional values in the third-element array.
 - `value` is always a single operation-specific string.
-- optional inputs are encoded after `value` as one array of key-value pairs.
-- the optional array is omitted when every option has its default value.
+- optional inputs are encoded as key-value pairs after the required inputs in
+  the third-element array.
+- optional pairs are omitted when every option has its default value.
 - option pairs are unique and sorted by name.
 - dictionaries, maps, and named-argument objects are forbidden.
 - ordering is deterministic by `(namespace, operation, inputs-json)`
@@ -257,7 +258,7 @@ Notes:
 ### Implemented
 
 - [x] tuple lockfile substrate in `util/lockfile`
-- [x] v2 entries with grouped required inputs and trailing options
+- [x] v2 entries with required inputs and inline option pairs
 - [x] ordered positional tuple keys with operation-specific result values
 - [x] API-view gating for pinned-by-default locking
 - [x] local workspace lockfile read/write helpers

--- a/util/lockfile/lockfile.go
+++ b/util/lockfile/lockfile.go
@@ -152,15 +152,11 @@ func (l *Lockfile) Marshal() ([]byte, error) {
 	lines = append(lines, header)
 
 	for _, entry := range l.sortedEntries() {
-		requiredInputs, options := splitOptions(entry.inputs)
 		tuple := []any{
 			entry.namespace,
 			entry.operation,
-			requiredInputs,
+			entry.inputs,
 			entry.value,
-		}
-		if len(options) > 0 {
-			tuple = append(tuple, options)
 		}
 		line, err := json.Marshal(tuple)
 		if err != nil {
@@ -266,9 +262,9 @@ func parseEntry(line []byte, version string) (lockEntry, error) {
 	if err := decodeJSON(line, &tuple); err != nil {
 		return lockEntry{}, fmt.Errorf("invalid tuple JSON: %w", err)
 	}
-	if len(tuple) < 4 || len(tuple) > 5 {
+	if len(tuple) != 4 {
 		return lockEntry{}, fmt.Errorf(
-			"invalid tuple length %d: expected 4 or 5 for lockfile version %s",
+			"invalid tuple length %d: expected 4 for lockfile version %s",
 			len(tuple),
 			version,
 		)
@@ -287,18 +283,6 @@ func parseEntry(line []byte, version string) (lockEntry, error) {
 	var inputs []any
 	if err := decodeJSON(tuple[2], &inputs); err != nil {
 		return lockEntry{}, fmt.Errorf("invalid inputs: %w", err)
-	}
-	if len(tuple) == 5 {
-		var options []any
-		if err := decodeJSON(tuple[4], &options); err != nil {
-			return lockEntry{}, fmt.Errorf("invalid options: %w", err)
-		}
-		if err := validateOptions(options); err != nil {
-			return lockEntry{}, fmt.Errorf("invalid options: %w", err)
-		}
-		if len(options) > 0 {
-			inputs = append(inputs, options)
-		}
 	}
 	canonicalInputs, inputsJSON, err := canonicalizeInputs(inputs)
 	if err != nil {
@@ -337,10 +321,13 @@ func canonicalizeInputs(inputs []any) ([]any, string, error) {
 		return nil, "", err
 	}
 	if required, options := splitOptions(canonical); len(options) > 0 {
+		if err := validateOptions(options); err != nil {
+			return nil, "", err
+		}
 		sort.Slice(options, func(i, j int) bool {
 			return options[i].([]any)[0].(string) < options[j].([]any)[0].(string)
 		})
-		required = append(required, options)
+		required = append(required, options...)
 		canonical = required
 	}
 	data, err = json.Marshal(canonical)
@@ -351,18 +338,20 @@ func canonicalizeInputs(inputs []any) ([]any, string, error) {
 }
 
 func splitOptions(inputs []any) ([]any, []any) {
-	if len(inputs) == 0 || !isOptions(inputs[len(inputs)-1]) {
-		return inputs, nil
+	optionStart := len(inputs)
+	for optionStart > 0 && isOption(inputs[optionStart-1]) {
+		optionStart--
 	}
-	return inputs[:len(inputs)-1], inputs[len(inputs)-1].([]any)
+	return inputs[:optionStart], inputs[optionStart:]
 }
 
-func isOptions(value any) bool {
-	options, ok := value.([]any)
-	if !ok || len(options) == 0 {
+func isOption(value any) bool {
+	pair, ok := value.([]any)
+	if !ok || len(pair) != 2 {
 		return false
 	}
-	return validateOptions(options) == nil
+	name, ok := pair[0].(string)
+	return ok && name != ""
 }
 
 func validateOptions(options []any) error {

--- a/util/lockfile/lockfile_test.go
+++ b/util/lockfile/lockfile_test.go
@@ -67,14 +67,12 @@ func TestMarshalDeterministicOrdering(t *testing.T) {
 	}, "\n"), string(output))
 }
 
-func TestOptionsFollowValueAndAreCanonical(t *testing.T) {
+func TestOptionsAreInlineWithInputsAndCanonical(t *testing.T) {
 	lock := New()
 	inputs := []any{
 		"registry.example/acme/image",
-		[]any{
-			[]any{"protocol", "https"},
-			[]any{"insecureSkipTLSVerify", true},
-		},
+		[]any{"protocol", "https"},
+		[]any{"insecureSkipTLSVerify", true},
 	}
 	require.NoError(t, lock.Set("", "oci-latest", inputs, "2.0.0"))
 
@@ -83,7 +81,7 @@ func TestOptionsFollowValueAndAreCanonical(t *testing.T) {
 	require.Equal(t, strings.Join([]string{
 		HeaderComment,
 		`[["version","2"]]`,
-		`["","oci-latest",["registry.example/acme/image"],"2.0.0",[["insecureSkipTLSVerify",true],["protocol","https"]]]`,
+		`["","oci-latest",["registry.example/acme/image",["insecureSkipTLSVerify",true],["protocol","https"]],"2.0.0"]`,
 	}, "\n"), string(output))
 
 	reparsed, err := Parse(output)
@@ -91,6 +89,31 @@ func TestOptionsFollowValueAndAreCanonical(t *testing.T) {
 	value, ok := reparsed.Get("", "oci-latest", inputs)
 	require.True(t, ok)
 	require.Equal(t, "2.0.0", value)
+}
+
+func TestInputFormatWithAndWithoutOptions(t *testing.T) {
+	lock := New()
+	require.NoError(t, lock.Set(
+		"",
+		"git-latest",
+		[]any{"github.com/dagger/sdk-helpers", []any{"version", "v1"}},
+		"refs/tags/v1.2.3",
+	))
+	require.NoError(t, lock.Set(
+		"",
+		"git-latest",
+		[]any{"github.com/dagger/sdk-helpers"},
+		"refs/tags/v1.3.0",
+	))
+
+	output, err := lock.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, string(output),
+		`["","git-latest",["github.com/dagger/sdk-helpers",["version","v1"]],"refs/tags/v1.2.3"]`,
+	)
+	require.Contains(t, string(output),
+		`["","git-latest",["github.com/dagger/sdk-helpers"],"refs/tags/v1.3.0"]`,
+	)
 }
 
 func TestParseDuplicateTupleOverwrites(t *testing.T) {
@@ -145,6 +168,14 @@ func TestParseMalformedAndEmpty(t *testing.T) {
 		require.ErrorContains(t, err, "invalid tuple length")
 	})
 
+	t.Run("options after output", func(t *testing.T) {
+		_, err := Parse([]byte(strings.Join([]string{
+			`[["version","2"]]`,
+			`["","oci-sha",["alpine:latest"],"sha256:abc",[["protocol","https"]]]`,
+		}, "\n")))
+		require.ErrorContains(t, err, "invalid tuple length 5: expected 4")
+	})
+
 	t.Run("invalid json", func(t *testing.T) {
 		_, err := Parse([]byte(strings.Join([]string{
 			`[["version","2"]]`,
@@ -163,28 +194,12 @@ func TestParseMalformedAndEmpty(t *testing.T) {
 		require.ErrorContains(t, err, "unordered object/map/dict in lock inputs")
 	})
 
-	t.Run("empty options are omitted", func(t *testing.T) {
-		lock, err := Parse([]byte(strings.Join([]string{
-			`[["version","2"]]`,
-			`["","oci-sha",["alpine:latest"],"sha256:abc",[]]`,
-		}, "\n")))
-		require.NoError(t, err)
-
-		data, err := lock.Marshal()
-		require.NoError(t, err)
-		require.Equal(t, strings.Join([]string{
-			HeaderComment,
-			`[["version","2"]]`,
-			`["","oci-sha",["alpine:latest"],"sha256:abc"]`,
-		}, "\n"), string(data))
-	})
-
-	t.Run("malformed options", func(t *testing.T) {
+	t.Run("duplicate options", func(t *testing.T) {
 		_, err := Parse([]byte(strings.Join([]string{
 			`[["version","2"]]`,
-			`["","oci-sha",["alpine:latest"],"sha256:abc",[["protocol"]]]`,
+			`["","oci-sha",["alpine:latest",["protocol","http"],["protocol","https"]],"sha256:abc"]`,
 		}, "\n")))
-		require.ErrorContains(t, err, "option must be a key-value pair")
+		require.ErrorContains(t, err, `duplicate option "protocol"`)
 	})
 
 	t.Run("non-string value", func(t *testing.T) {


### PR DESCRIPTION
Lockfile options now live next to required inputs:

```json
["github.com/dagger/sdk-helpers", ["version", "v1"]]
```

Inputs without options remain a single list:

```json
["github.com/dagger/sdk-helpers"]
```

This keeps every lockfile entry as a four-element tuple and removes the
separate options field after the output.

Tests:

- `go test ./util/lockfile ./core/workspace`
- `go test ./core -run 'Test(UpdateWorkspaceLock|SelectedSHAEntry)' -count=1`
- `dagger api call engine-dev test --pkg ./core/integration
  --run='TestLockfile/TestGitLatestVersionQueryCreatesPin'`
