### PR TITLE
Use short names for entrypoint targets

### DIFF
--- a/core/agents.go
+++ b/core/agents.go
@@ -137,9 +137,9 @@ func (a *Agent) Path() []string {
 	return a.Node.Path()
 }
 
-// Name is the fully qualified module:fn path of the agent.
+// Name is the command name of the agent.
 func (a *Agent) Name() string {
-	return a.Node.PathString()
+	return a.Node.CommandName()
 }
 
 func (a *Agent) Description() string {

--- a/core/checks.go
+++ b/core/checks.go
@@ -223,7 +223,7 @@ func (c *Check) ResultEmoji() string {
 }
 
 func (c *Check) Name() string {
-	return c.Node.PathString()
+	return c.Node.CommandName()
 }
 
 func (c *Check) CheckType() string {

--- a/core/generators.go
+++ b/core/generators.go
@@ -67,7 +67,7 @@ func (g *Generator) Name() string {
 	if g.Synthetic != nil {
 		return g.Synthetic.Name
 	}
-	return g.Node.PathString()
+	return g.Node.CommandName()
 }
 
 func (g *Generator) OriginalModule() *Module {

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -455,7 +455,8 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		out, err := hostDaggerExecRaw(ctx, t, modDir, "sh", "-l")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "# select with 'dagger shell <NAME>'\n")
-		require.Contains(t, string(out), "test:dir")
+		require.Contains(t, string(out), "\ndir")
+		require.NotContains(t, string(out), "test:dir")
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
 		console, err := newTUIConsole(t, 60*time.Second)

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -57,7 +57,8 @@ func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
 		out, err := hostDaggerExecRaw(ctx, t, modDir, "shell", "-l")
 		require.NoError(t, err)
 		require.Contains(t, string(out), "# select with 'dagger shell <NAME>'\n")
-		require.Contains(t, string(out), "test:ctr")
+		require.Contains(t, string(out), "\nctr")
+		require.NotContains(t, string(out), "test:ctr")
 
 		console, err := newTUIConsole(t, 60*time.Second)
 		require.NoError(t, err)

--- a/core/integration/workspace_entrypoint_targets_test.go
+++ b/core/integration/workspace_entrypoint_targets_test.go
@@ -1,0 +1,142 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceSuite) TestEntrypointTargetNames(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	base := workspaceBase(t, c).WithNewFile("dagger.toml", `
+[modules.app]
+source = "app"
+entrypoint = true
+
+[modules.other]
+source = "other"
+`)
+	for _, name := range []string{"app", "other"} {
+		verify := "null"
+		if name == "other" {
+			verify = `raise "the other module must be selected explicitly"`
+		}
+		base = base.
+			WithNewFile(name+"/dagger-module.toml", fmt.Sprintf("name = %q\nengineVersion = \"latest\"\n[runtime]\nsource = \"dang\"\n", name)).
+			WithNewFile(name+"/main.dang", fmt.Sprintf(`type %s {
+  pub verify: Void @check { %s }
+  pub files(ws: Workspace!): Changeset! @generate {
+    ws.withNewFile(%q, "generated").changes(ws)
+  }
+  pub dev: Container! { container.from("alpine:3.22") }
+  pub web: Service! @up {
+    container.from("nginx:alpine").withExposedPort(80).asService
+  }
+}
+`, strings.ToUpper(name[:1])+name[1:], verify, name+".txt"))
+	}
+	base = base.
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", testCLIBinPath).
+		With(nonNestedDevEngine(c))
+	config, err := base.File("dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+
+	for _, test := range []struct{ command, target string }{
+		{"check", "verify"},
+		{"generate", "files"},
+		{"shell", "dev"},
+		{"up", "web"},
+	} {
+		t.Run(test.command, func(ctx context.Context, t *testctx.T) {
+			for _, selection := range []struct {
+				args []string
+				want []string
+			}{
+				{want: []string{test.target, "other:" + test.target}},
+				{args: []string{test.target}, want: []string{test.target}},
+				{args: []string{"app:" + test.target}, want: []string{test.target}},
+				{args: []string{"other:" + test.target}, want: []string{"other:" + test.target}},
+				{args: []string{"*:" + test.target}, want: []string{test.target, "other:" + test.target}},
+			} {
+				args := append([]string{test.command, "-l"}, selection.args...)
+				if test.command == "check" {
+					args = append(args, "--no-generate")
+				}
+				out, err := base.With(daggerNonNestedExec(args...)).Stdout(ctx)
+				require.NoError(t, err, strings.Join(args, " "))
+				var names []string
+				for line := range strings.SplitSeq(out, "\n") {
+					fields := strings.Fields(line)
+					if len(fields) > 0 && !strings.HasPrefix(fields[0], "#") {
+						names = append(names, fields[0])
+					}
+				}
+				require.ElementsMatch(t, selection.want, names, strings.Join(args, " "))
+			}
+
+			ordinary := base.WithNewFile("dagger.toml", strings.Replace(config, "entrypoint = true", "entrypoint = false", 1))
+			out, err := ordinary.With(daggerNonNestedExec(test.command, "-l", test.target)).Stdout(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, out, test.target)
+
+			out, err = ordinary.With(daggerNonNestedExec("-m", "./app", test.command, "-l", test.target)).Stdout(ctx)
+			require.NoError(t, err)
+			require.Contains(t, out, test.target)
+			require.NotContains(t, out, "app:"+test.target)
+			require.NotContains(t, out, "other:"+test.target)
+		})
+	}
+
+	t.Run("caller skip only excludes the entrypoint", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerNonNestedExec("check", "-l", "--no-generate", "--skip=verify")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "other:verify", strings.TrimSpace(out))
+	})
+
+	t.Run("module settings keep local skip names", func(ctx context.Context, t *testctx.T) {
+		out, err := base.WithNewFile("dagger.toml", config+"\ncheck.skip = [\"verify\"]\n").
+			With(daggerNonNestedExec("check", "-l", "--no-generate")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "verify", strings.TrimSpace(out))
+	})
+
+	t.Run("value workspace uses its own entrypoint", func(ctx context.Context, t *testctx.T) {
+		ws := base.Directory("/work").AsWorkspace()
+		checks, err := ws.Checks(dagger.WorkspaceChecksOpts{Include: []string{"verify"}, NoGenerate: true}).List(ctx)
+		require.NoError(t, err)
+		require.Len(t, checks, 1)
+		name, err := checks[0].Name(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "verify", name)
+
+		changed := ws.WithNewFile("dagger.toml", strings.Replace(config, "entrypoint = true", "entrypoint = false", 1))
+		checks, err = changed.Checks(dagger.WorkspaceChecksOpts{Include: []string{"verify"}, NoGenerate: true}).List(ctx)
+		require.NoError(t, err)
+		require.Empty(t, checks)
+	})
+
+	t.Run("run the entrypoint generator only", func(ctx context.Context, t *testctx.T) {
+		generated := base.With(daggerNonNestedExec("generate", "files", "-y"))
+		out, err := generated.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "files")
+		require.NotContains(t, out, "app:files")
+		exists, err := generated.Exists(ctx, "app.txt")
+		require.NoError(t, err)
+		require.True(t, exists)
+		exists, err = generated.Exists(ctx, "other.txt")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("run the entrypoint check only", func(ctx context.Context, t *testctx.T) {
+		out, err := base.With(daggerNonNestedExec("check", "verify", "--no-generate")).CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.NotContains(t, out, "app:verify")
+		require.NotContains(t, out, "other:verify")
+	})
+}

--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -145,6 +145,17 @@ func (b *SchemaBuilder) PrimaryMods() []Mod {
 	return mods
 }
 
+// EntrypointMods returns the modules whose fields are exposed at the root.
+func (b *SchemaBuilder) EntrypointMods() []Mod {
+	var mods []Mod
+	for _, entry := range b.entries {
+		if entry.opts.Entrypoint {
+			mods = append(mods, entry.mod)
+		}
+	}
+	return mods
+}
+
 func (b *SchemaBuilder) Schema(ctx context.Context) (*dagql.Server, error) {
 	srv, err := b.lazilyLoadSchema(ctx)
 	if err != nil {

--- a/core/modtree.go
+++ b/core/modtree.go
@@ -37,6 +37,10 @@ type ModTreeNode struct {
 	IsGenerator    bool
 	IsUp           bool
 	IsAgent        bool
+
+	// WorkspaceEntrypoint is set on the module root when its targets are
+	// exposed without a module prefix. Path retains the qualified identity.
+	WorkspaceEntrypoint bool
 }
 
 func (node *ModTreeNode) Path() ModTreePath {
@@ -154,11 +158,11 @@ func (node *ModTreeNode) runAsCheck(
 					return err
 				}
 			}
-			ctx, span := Tracer(ctx).Start(ctx, n.PathString(),
+			ctx, span := Tracer(ctx).Start(ctx, n.CommandName(),
 				trace.WithAttributes(
 					attribute.Bool(telemetry.UIRollUpLogsAttr, true),
 					attribute.Bool(telemetry.UIRollUpSpansAttr, true),
-					attribute.String(telemetry.CheckNameAttr, n.PathString()),
+					attribute.String(telemetry.CheckNameAttr, n.CommandName()),
 				),
 			)
 			defer func() {
@@ -330,10 +334,10 @@ func (node *ModTreeNode) PrepareUp(ctx context.Context, portMappings []PortForwa
 	if !node.IsUp {
 		return nil, fmt.Errorf("%s is not a service function", node.PathString())
 	}
-	ctx, span := Tracer(ctx).Start(ctx, node.PathString(),
+	ctx, span := Tracer(ctx).Start(ctx, node.CommandName(),
 		trace.WithAttributes(
 			attribute.Bool(telemetry.UIRollUpLogsAttr, true),
-			attribute.String(ServiceNameAttr, node.PathString()),
+			attribute.String(ServiceNameAttr, node.CommandName()),
 		),
 	)
 	defer func() {
@@ -381,7 +385,7 @@ func (node *ModTreeNode) PrepareUp(ctx context.Context, portMappings []PortForwa
 				portStrs = append(portStrs, fmt.Sprintf(":%d", p.port))
 			}
 		}
-		span.SetName(fmt.Sprintf("%s %s", node.PathString(), strings.Join(portStrs, ", ")))
+		span.SetName(fmt.Sprintf("%s %s", node.CommandName(), strings.Join(portStrs, ", ")))
 	}
 
 	return &preparedUp{
@@ -405,7 +409,7 @@ type preparedUp struct {
 }
 
 func (p *preparedUp) Name() string {
-	return p.node.PathString()
+	return p.node.CommandName()
 }
 
 // Abort ends the display span without starting the service — the group's
@@ -546,11 +550,11 @@ func (node *ModTreeNode) RunGenerator(ctx context.Context, include, exclude []st
 	err := node.Run(ctx,
 		func(n *ModTreeNode) bool { return n.IsGenerator },
 		func(ctx context.Context, n *ModTreeNode, _ *engine.ClientMetadata) (rerr error) {
-			ctx, span := Tracer(ctx).Start(ctx, node.PathString(),
+			ctx, span := Tracer(ctx).Start(ctx, node.CommandName(),
 				trace.WithAttributes(
 					attribute.Bool(telemetry.UIRollUpLogsAttr, true),
 					attribute.Bool(telemetry.UIRollUpSpansAttr, true),
-					attribute.String(telemetry.GeneratorNameAttr, node.PathString()),
+					attribute.String(telemetry.GeneratorNameAttr, node.CommandName()),
 				),
 			)
 			defer telemetry.EndWithCause(span, &rerr)
@@ -1002,6 +1006,21 @@ func (node *ModTreeNode) Match(ctx context.Context, patterns []string) (bool, er
 
 func (node *ModTreeNode) PathString() string {
 	return strings.Join(node.Path().CliCase(), ":")
+}
+
+// CommandPath is the path users type to select this target.
+func (node *ModTreeNode) CommandPath() ModTreePath {
+	path := node.Path()
+	for parent := node; parent != nil; parent = parent.Parent {
+		if parent.WorkspaceEntrypoint && len(path) > 0 {
+			return path[1:]
+		}
+	}
+	return path
+}
+
+func (node *ModTreeNode) CommandName() string {
+	return strings.Join(node.CommandPath().CliCase(), ":")
 }
 
 func (node *ModTreeNode) moduleLocalPathString() string {

--- a/core/modtree_test.go
+++ b/core/modtree_test.go
@@ -33,6 +33,20 @@ func TestModTreeNode(t *testing.T) {
 	testctx.New(t).RunTests(ModTreeNodeTestSuite{})
 }
 
+func TestModTreeCommandNamePreservesQualifiedPath(t *testing.T) {
+	root := &ModTreeNode{
+		Parent:              &ModTreeNode{},
+		Name:                "myProjectDev",
+		WorkspaceEntrypoint: true,
+	}
+	node := &ModTreeNode{Parent: &ModTreeNode{Parent: root, Name: "unitTests"}, Name: "verify"}
+	require.Equal(t, "unit-tests:verify", node.CommandName())
+	require.Equal(t, "my-project-dev:unit-tests:verify", node.PathString())
+	require.Equal(t, "unit-tests:verify", node.Clone().CommandName())
+	root.WorkspaceEntrypoint = false
+	require.Equal(t, "my-project-dev:unit-tests:verify", node.CommandName())
+}
+
 func (s *ModTreeNodeTestSuite) TestBuildScaleOutModuleQueryForModuleLoadedFromDirectory(ctx context.Context, t *testctx.T) {
 	cache, err := dagql.NewCache(ctx, "", nil, nil)
 	require.NoError(t, err)

--- a/core/schema/agents.go
+++ b/core/schema/agents.go
@@ -30,7 +30,7 @@ func (s agentsSchema) Install(srv *dagql.Server) {
 
 	dagql.Fields[*core.Agent]{
 		dagql.Func("name", s.name).
-			Doc("Return the fully qualified name of the agent"),
+			Doc("Return the command name of the agent. Entrypoint targets omit the module prefix."),
 		dagql.Func("description", s.description).
 			Doc("The description of the agent"),
 		dagql.Func("path", s.path).

--- a/core/schema/checks.go
+++ b/core/schema/checks.go
@@ -29,7 +29,7 @@ func (s checksSchema) Install(srv *dagql.Server) {
 	// Check methods
 	dagql.Fields[*core.Check]{
 		dagql.Func("name", s.name).
-			Doc("Return the fully qualified name of the check"),
+			Doc("Return the command name of the check. Entrypoint targets omit the module prefix."),
 		dagql.Func("description", s.description).
 			Doc("The description of the check"),
 		dagql.Func("path", s.path).

--- a/core/schema/generators.go
+++ b/core/schema/generators.go
@@ -48,7 +48,7 @@ func (s generatorsSchema) Install(srv *dagql.Server) {
 
 	dagql.Fields[*core.Generator]{
 		dagql.Func("name", s.name).
-			Doc("Return the fully qualified name of the generator"),
+			Doc("Return the command name of the generator. Entrypoint targets omit the module prefix."),
 
 		dagql.Func("path", s.path).
 			Doc("The path of the generator within its module"),

--- a/core/schema/terminals.go
+++ b/core/schema/terminals.go
@@ -25,7 +25,7 @@ func (s terminalsSchema) Install(srv *dagql.Server) {
 
 	dagql.Fields[*core.TerminalTarget]{
 		dagql.Func("name", s.name).
-			Doc("Return the fully qualified name of the terminal target"),
+			Doc("Return the command name of the terminal target. Entrypoint targets omit the module prefix."),
 		dagql.Func("description", s.description).
 			Doc("The description of the terminal target"),
 		dagql.Func("path", s.path).

--- a/core/schema/testdata/base_schema.graphqls
+++ b/core/schema/testdata/base_schema.graphqls
@@ -237,7 +237,9 @@ type Check implements Node {
   """A unique identifier for this Check."""
   id: ID!
 
-  """Return the fully qualified name of the check"""
+  """
+  Return the command name of the check. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """The original module in which the check has been defined"""
@@ -2809,7 +2811,9 @@ type Generator implements Node {
   """Whether changeset from the last generator run is empty or not"""
   isEmpty: Boolean!
 
-  """Return the fully qualified name of the generator"""
+  """
+  Return the command name of the generator. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """
@@ -4884,7 +4888,9 @@ type Up implements Node {
   """A unique identifier for this Up."""
   id: ID!
 
-  """Return the fully qualified name of the service"""
+  """
+  Return the command name of the service. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """The original module in which the service has been defined"""

--- a/core/schema/up.go
+++ b/core/schema/up.go
@@ -21,7 +21,7 @@ func (s upSchema) Install(srv *dagql.Server) {
 
 	dagql.Fields[*core.Up]{
 		dagql.Func("name", s.name).
-			Doc("Return the fully qualified name of the service"),
+			Doc("Return the command name of the service. Entrypoint targets omit the module prefix."),
 		dagql.Func("description", s.description).
 			Doc("The description of the service"),
 		dagql.Func("path", s.path).

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -3659,6 +3659,10 @@ func (s *workspaceSchema) checks(
 	if err != nil {
 		return nil, err
 	}
+	entrypoints, err := workspaceEntrypointNames(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
 
 	ignoreChecks := workspaceConfigSkipPatternsFromConfig(cfg, func(e workspace.ModuleEntry) []string {
 		return e.Check.Skip
@@ -3670,7 +3674,7 @@ func (s *workspaceSchema) checks(
 		if err != nil {
 			return nil, fmt.Errorf("checks from module %q: %w", mod.Self().Name(), err)
 		}
-		reparentWorkspaceTreeRoot(checkGroup.Node, mod.Self().Name())
+		reparentWorkspaceTreeRoot(checkGroup.Node, mod.Self().Name(), entrypoints[mod.Self().Name()])
 		filtered, err := filterNodesByInclude(
 			ctx,
 			checkGroup.Checks,
@@ -3688,6 +3692,7 @@ func (s *workspaceSchema) checks(
 				ctx,
 				filtered,
 				skip,
+				false,
 				func(check *core.Check) *core.ModTreeNode { return check.Node },
 				func(check *core.Check) string { return check.Name() },
 				"check",
@@ -3702,6 +3707,7 @@ func (s *workspaceSchema) checks(
 				ctx,
 				filtered,
 				exclude,
+				true,
 				func(check *core.Check) *core.ModTreeNode { return check.Node },
 				func(check *core.Check) string { return check.Name() },
 				"check",
@@ -3783,6 +3789,10 @@ func (s *workspaceSchema) generators(
 	if err != nil {
 		return nil, err
 	}
+	entrypoints, err := workspaceEntrypointNames(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
 
 	ignoreGenerators, err := workspaceConfigSkipPatterns(ctx, parent, func(e workspace.ModuleEntry) []string {
 		return e.Generate.Skip
@@ -3845,14 +3855,12 @@ func (s *workspaceSchema) generators(
 	moduleGenerators = selectVisibleGeneratorModules(moduleGenerators)
 
 	var allGenerators []*core.Generator
-	allowSingleModuleCompat := len(moduleGenerators) == 1
 	for _, entry := range moduleGenerators {
-		reparentWorkspaceTreeRoot(entry.group.Node, entry.name)
+		reparentWorkspaceTreeRoot(entry.group.Node, entry.name, entrypoints[entry.name])
 		filtered, err := filterGeneratorsByInclude(
 			ctx,
 			entry.group.Generators,
 			include,
-			allowSingleModuleCompat,
 		)
 		if err != nil {
 			return nil, err
@@ -3868,6 +3876,7 @@ func (s *workspaceSchema) generators(
 				ctx,
 				filtered,
 				exclude,
+				true,
 				func(generator *core.Generator) *core.ModTreeNode { return generator.Node },
 				func(generator *core.Generator) string { return generator.Name() },
 				"generator",
@@ -3880,7 +3889,7 @@ func (s *workspaceSchema) generators(
 	}
 
 	if staged != nil {
-		syntheticGenerators, err := s.syntheticSDKGenerators(ctx, staged, include)
+		syntheticGenerators, err := s.syntheticSDKGenerators(ctx, staged, include, entrypoints)
 		if err != nil {
 			return nil, err
 		}
@@ -3922,6 +3931,10 @@ func (s *workspaceSchema) services(
 	if err != nil {
 		return nil, err
 	}
+	entrypoints, err := workspaceEntrypointNames(ctx, parent)
+	if err != nil {
+		return nil, err
+	}
 
 	var allUps []*core.Up
 	for _, mod := range mods {
@@ -3929,7 +3942,7 @@ func (s *workspaceSchema) services(
 		if err != nil {
 			return nil, fmt.Errorf("services from module %q: %w", mod.Self().Name(), err)
 		}
-		reparentWorkspaceTreeRoot(upGroup.Node, mod.Self().Name())
+		reparentWorkspaceTreeRoot(upGroup.Node, mod.Self().Name(), entrypoints[mod.Self().Name()])
 		filtered, err := filterNodesByInclude(
 			ctx,
 			upGroup.Ups,
@@ -3946,6 +3959,7 @@ func (s *workspaceSchema) services(
 				ctx,
 				filtered,
 				exclude,
+				true,
 				func(up *core.Up) *core.ModTreeNode { return up.Node },
 				func(up *core.Up) string { return up.Name() },
 				"service",
@@ -3969,7 +3983,7 @@ func (s *workspaceSchema) services(
 			return nil, fmt.Errorf("workspace port key %q: %w", hostStr, err)
 		}
 		for _, up := range allUps {
-			if up.Name() != pm.BackendService {
+			if up.Name() != pm.BackendService && up.Node.PathString() != pm.BackendService {
 				continue
 			}
 			up.PortMappings = append(up.PortMappings, core.PortForward{
@@ -4081,6 +4095,10 @@ func collectWorkspaceModuleTargets[T any](
 	if err != nil {
 		return nil, err
 	}
+	entrypoints, err := workspaceEntrypointNames(ctx, parentResult.Self())
+	if err != nil {
+		return nil, err
+	}
 
 	var all []T
 	for _, mod := range mods {
@@ -4088,7 +4106,7 @@ func collectWorkspaceModuleTargets[T any](
 		if err != nil {
 			return nil, fmt.Errorf("%s from module %q: %w", groupLabel, mod.Self().Name(), err)
 		}
-		reparentWorkspaceTreeRoot(root, mod.Self().Name())
+		reparentWorkspaceTreeRoot(root, mod.Self().Name(), entrypoints[mod.Self().Name()])
 		filtered, err := filterNodesByInclude(
 			ctx,
 			targets,
@@ -4142,7 +4160,6 @@ func filterGeneratorsByInclude(
 	ctx context.Context,
 	generators []*core.Generator,
 	include []string,
-	allowSingleModuleCompat bool,
 ) ([]*core.Generator, error) {
 	if len(include) == 0 {
 		return generators, nil
@@ -4153,12 +4170,6 @@ func filterGeneratorsByInclude(
 		match, err := matchWorkspaceInclude(ctx, generator.Node, include)
 		if err != nil {
 			return nil, fmt.Errorf("generator %q include match: %w", generator.Name(), err)
-		}
-		if !match && allowSingleModuleCompat {
-			match, err = matchSingleModuleInclude(ctx, generator.Node, include)
-			if err != nil {
-				return nil, fmt.Errorf("generator %q compat include match: %w", generator.Name(), err)
-			}
 		}
 		if match {
 			filtered = append(filtered, generator)
@@ -4299,13 +4310,13 @@ func workspaceConfigSkipPatternsFromConfig(
 	return result
 }
 
-// filterNodesByExclude removes items whose nodes match any of the exclude
-// patterns. Matching uses the same single-module compat fallback as include
-// filtering (stripping the leading module name segment).
+// filterNodesByExclude uses command names and qualified paths. Module-local
+// patterns are also accepted for skips configured on an individual module.
 func filterNodesByExclude[T any](
 	ctx context.Context,
 	items []T,
 	exclude []string,
+	moduleLocal bool,
 	nodeOf func(T) *core.ModTreeNode,
 	nameOf func(T) string,
 	itemKind string,
@@ -4320,8 +4331,7 @@ func filterNodesByExclude[T any](
 		if err != nil {
 			return nil, fmt.Errorf("%s %q exclude match: %w", itemKind, nameOf(item), err)
 		}
-		if !match {
-			// Also try without module prefix for single-module compat.
+		if !match && moduleLocal {
 			match, err = matchSingleModuleInclude(ctx, nodeOf(item), exclude)
 			if err != nil {
 				return nil, fmt.Errorf("%s %q exclude compat match: %w", itemKind, nameOf(item), err)
@@ -4334,12 +4344,13 @@ func filterNodesByExclude[T any](
 	return filtered, nil
 }
 
-func reparentWorkspaceTreeRoot(root *core.ModTreeNode, modName string) {
+func reparentWorkspaceTreeRoot(root *core.ModTreeNode, modName string, entrypoint bool) {
 	if root == nil {
 		return
 	}
 	root.Parent = &core.ModTreeNode{}
 	root.Name = modName
+	root.WorkspaceEntrypoint = entrypoint
 }
 
 func matchWorkspaceInclude(ctx context.Context, node *core.ModTreeNode, include []string) (bool, error) {
@@ -4349,7 +4360,11 @@ func matchWorkspaceInclude(ctx context.Context, node *core.ModTreeNode, include 
 	if node == nil {
 		return false, nil
 	}
-	return node.Match(ctx, include)
+	match, err := node.Match(ctx, include)
+	if err != nil || match {
+		return match, err
+	}
+	return matchWorkspaceIncludePath(ctx, node.CommandPath(), include)
 }
 
 func filterNodesByInclude[T any](
@@ -4369,15 +4384,6 @@ func filterNodesByInclude[T any](
 		match, err := matchWorkspaceInclude(ctx, nodeOf(item), include)
 		if err != nil {
 			return nil, fmt.Errorf("%s %q include match: %w", itemKind, nameOf(item), err)
-		}
-		// Preserve old single-module semantics: if the pattern doesn't match
-		// the full workspace path (module:check), retry against just the
-		// check path without the leading module name segment.
-		if !match {
-			match, err = matchSingleModuleInclude(ctx, nodeOf(item), include)
-			if err != nil {
-				return nil, fmt.Errorf("%s %q compat include match: %w", itemKind, nameOf(item), err)
-			}
 		}
 		if match {
 			filtered = append(filtered, item)

--- a/core/schema/workspace_sdk_generator.go
+++ b/core/schema/workspace_sdk_generator.go
@@ -17,6 +17,7 @@ func (s *workspaceSchema) syntheticSDKGenerators(
 	ctx context.Context,
 	staged *stagedWorkspaceConfig,
 	include []string,
+	entrypoints map[string]bool,
 ) ([]*core.Generator, error) {
 	names := make([]string, 0, len(staged.Config.SDKs))
 	for name := range staged.Config.SDKs {
@@ -33,7 +34,7 @@ func (s *workspaceSchema) syntheticSDKGenerators(
 
 		providerName := selected.entry.Module
 		leafName := "generate"
-		root := &core.ModTreeNode{Parent: &core.ModTreeNode{}, Name: providerName}
+		root := &core.ModTreeNode{Parent: &core.ModTreeNode{}, Name: providerName, WorkspaceEntrypoint: entrypoints[providerName]}
 		node := &core.ModTreeNode{
 			Parent:      root,
 			Name:        leafName,
@@ -43,14 +44,14 @@ func (s *workspaceSchema) syntheticSDKGenerators(
 		generator := &core.Generator{
 			Node: node,
 			Synthetic: &core.SyntheticGeneratorSpec{
-				Name:        providerName + ":" + leafName,
+				Name:        node.CommandName(),
 				Path:        []string{providerName, leafName},
 				Description: node.Description,
 				Provider:    sdkName,
 				Kind:        syntheticSDKScopesGenerator,
 			},
 		}
-		filtered, err := filterGeneratorsByInclude(ctx, []*core.Generator{generator}, include, false)
+		filtered, err := filterGeneratorsByInclude(ctx, []*core.Generator{generator}, include)
 		if err != nil {
 			return nil, err
 		}

--- a/core/schema/workspace_targets.go
+++ b/core/schema/workspace_targets.go
@@ -1,0 +1,51 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
+)
+
+// workspaceEntrypointNames uses the active install policy, including explicit
+// -m modules and legacy workspaces. A value workspace owns its configuration;
+// a pending config edit also takes precedence over the session snapshot.
+func workspaceEntrypointNames(ctx context.Context, ws *core.Workspace) (map[string]bool, error) {
+	names := map[string]bool{}
+	if !ws.IsValueWorkspace() {
+		query, err := core.CurrentQuery(ctx)
+		if err != nil {
+			return nil, err
+		}
+		served, err := query.Server.CurrentServedDeps(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("current served deps: %w", err)
+		}
+		for _, mod := range served.EntrypointMods() {
+			names[mod.Name()] = true
+		}
+		if ws.ConfigFile == "" || !ws.OverlayPathTouched(ws.ConfigFile) {
+			return names, nil
+		}
+	}
+
+	cfg, err := workspaceConfigWithCompatFallback(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err = workspace.ApplyUserOverlay(cfg, ws.UserConfigOverlay())
+	if err != nil {
+		return nil, err
+	}
+	if envName, ok := selectedWorkspaceEnv(ctx, ws); ok {
+		cfg, err = workspace.ApplyEnvOverlay(cfg, envName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for name, entry := range cfg.Modules {
+		names[name] = entry.Entrypoint
+	}
+	return names, nil
+}

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -263,43 +263,57 @@ func TestWorkspaceConfigSkipPatterns(t *testing.T) {
 
 func TestFilterGeneratorsByInclude(t *testing.T) {
 	ctx := context.Background()
-	generators := []*core.Generator{
-		{Node: modTreeNode("hello-with-generators-java", "generate-files")},
-		{Node: modTreeNode("hello-with-generators-java", "generate-other-files")},
+	for _, test := range []struct {
+		name       string
+		entrypoint bool
+		include    []string
+		want       int
+	}{
+		{"qualified", false, []string{"app:generate-*"}, 2},
+		{"entrypoint", true, []string{"generate-*"}, 2},
+		{"entrypoint qualified alias", true, []string{"app:generate-*"}, 2},
+		{"single ordinary module requires prefix", false, []string{"generate-*"}, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			generators := []*core.Generator{
+				{Node: modTreeNode("app", "generate-files")},
+				{Node: modTreeNode("app", "generate-other-files")},
+			}
+			for _, generator := range generators {
+				generator.Node.Parent.WorkspaceEntrypoint = test.entrypoint
+			}
+			filtered, err := filterGeneratorsByInclude(ctx, generators, test.include)
+			require.NoError(t, err)
+			require.Len(t, filtered, test.want)
+		})
 	}
+}
 
-	t.Run("workspace-qualified patterns still match", func(t *testing.T) {
-		filtered, err := filterGeneratorsByInclude(
-			ctx,
-			generators,
-			[]string{"hello-with-generators-java:generate-*"},
-			false,
-		)
-		require.NoError(t, err)
-		require.Len(t, filtered, 2)
-	})
-
-	t.Run("single generator module keeps legacy include semantics", func(t *testing.T) {
-		filtered, err := filterGeneratorsByInclude(
-			ctx,
-			generators,
-			[]string{"generate-*"},
-			true,
-		)
-		require.NoError(t, err)
-		require.Len(t, filtered, 2)
-	})
-
-	t.Run("legacy include does not match without compat fallback", func(t *testing.T) {
-		filtered, err := filterGeneratorsByInclude(
-			ctx,
-			generators,
-			[]string{"generate-*"},
-			false,
-		)
-		require.NoError(t, err)
-		require.Empty(t, filtered)
-	})
+func TestWorkspaceTargetSkipNames(t *testing.T) {
+	ctx := context.Background()
+	app := modTreeNode("app", "verify")
+	app.Parent.WorkspaceEntrypoint = true
+	other := modTreeNode("other", "verify")
+	for _, test := range []struct {
+		name        string
+		exclude     []string
+		moduleLocal bool
+		want        []*core.ModTreeNode
+	}{
+		{"short skip only excludes entrypoint", []string{"verify"}, false, []*core.ModTreeNode{other}},
+		{"qualified skip", []string{"app:verify"}, false, []*core.ModTreeNode{other}},
+		{"skip other module", []string{"other:verify"}, false, []*core.ModTreeNode{app}},
+		{"explicit wildcard", []string{"*:verify"}, false, nil},
+		{"module settings use local names", []string{"verify"}, true, nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			filtered, err := filterNodesByExclude(ctx, []*core.ModTreeNode{app, other}, test.exclude, test.moduleLocal,
+				func(node *core.ModTreeNode) *core.ModTreeNode { return node },
+				func(node *core.ModTreeNode) string { return node.CommandName() }, "test")
+			require.NoError(t, err)
+			require.ElementsMatch(t, test.want, filtered)
+		})
+	}
 }
 
 func TestSelectVisibleGeneratorModules(t *testing.T) {

--- a/core/terminals.go
+++ b/core/terminals.go
@@ -90,7 +90,7 @@ func (t *TerminalTarget) Path() []string {
 }
 
 func (t *TerminalTarget) Name() string {
-	return t.Node.PathString()
+	return t.Node.CommandName()
 }
 
 func (t *TerminalTarget) Description() string {

--- a/core/up.go
+++ b/core/up.go
@@ -224,7 +224,7 @@ func (*Up) Type() *ast.Type {
 }
 
 func (u *Up) Name() string {
-	return u.Node.PathString()
+	return u.Node.CommandName()
 }
 
 func (u *Up) Clone() *Up {

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/generate-fail
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/generate-fail
@@ -1,6 +1,6 @@
 Expected stderr:
 
 GENERATORS  ✘ 1 failed
-✘ viztest:generate-fail X.Xs ERROR
+✘ generate-fail X.Xs ERROR
   ┃ boom
   ! exit code: 3

--- a/dagql/idtui/testdata/TestTelemetry/TestGolden/test-summary-check
+++ b/dagql/idtui/testdata/TestTelemetry/TestGolden/test-summary-check
@@ -1,7 +1,7 @@
 Expected stderr:
 
 CHECKS  ✔ 1 passed
-✔ viztest:test-summary X.Xs OK
+✔ test-summary X.Xs OK
   TESTS
     ✘ viztest summary suite › failed test 01 FAIL
           failed test 01 log line 1

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -106,7 +106,9 @@ type Agent implements Node {
   """A unique identifier for this Agent."""
   id: ID!
 
-  """Return the fully qualified name of the agent"""
+  """
+  Return the command name of the agent. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """The original module in which the agent has been defined"""
@@ -301,7 +303,9 @@ type Check implements Node {
   """A unique identifier for this Check."""
   id: ID!
 
-  """Return the fully qualified name of the check"""
+  """
+  Return the command name of the check. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """The original module in which the check has been defined"""
@@ -3065,7 +3069,9 @@ type Generator implements Node {
   """Whether changeset from the last generator run is empty or not"""
   isEmpty: Boolean!
 
-  """Return the fully qualified name of the generator"""
+  """
+  Return the command name of the generator. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """
@@ -5319,7 +5325,9 @@ type TerminalTarget implements Node {
   """A unique identifier for this TerminalTarget."""
   id: ID!
 
-  """Return the fully qualified name of the terminal target"""
+  """
+  Return the command name of the terminal target. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """The module in which the terminal target is defined"""
@@ -5609,7 +5617,9 @@ type Up implements Node {
   """A unique identifier for this Up."""
   id: ID!
 
-  """Return the fully qualified name of the service"""
+  """
+  Return the command name of the service. Entrypoint targets omit the module prefix.
+  """
   name: String!
 
   """The original module in which the service has been defined"""

--- a/docs/static/reference/php/Dagger/Agent.html
+++ b/docs/static/reference/php/Dagger/Agent.html
@@ -166,7 +166,7 @@
                 <div class="col-md-8">
                     <a href="#method_name">name</a>()
         
-                                            <p><p>Return the fully qualified name of the agent</p></p>                </div>
+                                            <p><p>Return the command name of the agent. Entrypoint targets omit the module prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -360,7 +360,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return the fully qualified name of the agent</p></p>                        
+                            <p><p>Return the command name of the agent. Entrypoint targets omit the module prefix.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/Dagger/Check.html
+++ b/docs/static/reference/php/Dagger/Check.html
@@ -196,7 +196,7 @@
                 <div class="col-md-8">
                     <a href="#method_name">name</a>()
         
-                                            <p><p>Return the fully qualified name of the check</p></p>                </div>
+                                            <p><p>Return the command name of the check. Entrypoint targets omit the module prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -516,7 +516,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return the fully qualified name of the check</p></p>                        
+                            <p><p>Return the command name of the check. Entrypoint targets omit the module prefix.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/Dagger/Generator.html
+++ b/docs/static/reference/php/Dagger/Generator.html
@@ -196,7 +196,7 @@
                 <div class="col-md-8">
                     <a href="#method_name">name</a>()
         
-                                            <p><p>Return the fully qualified name of the generator</p></p>                </div>
+                                            <p><p>Return the command name of the generator. Entrypoint targets omit the module prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -496,7 +496,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return the fully qualified name of the generator</p></p>                        
+                            <p><p>Return the command name of the generator. Entrypoint targets omit the module prefix.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/Dagger/TerminalTarget.html
+++ b/docs/static/reference/php/Dagger/TerminalTarget.html
@@ -166,7 +166,7 @@
                 <div class="col-md-8">
                     <a href="#method_name">name</a>()
         
-                                            <p><p>Return the fully qualified name of the terminal target</p></p>                </div>
+                                            <p><p>Return the command name of the terminal target. Entrypoint targets omit the module prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -360,7 +360,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return the fully qualified name of the terminal target</p></p>                        
+                            <p><p>Return the command name of the terminal target. Entrypoint targets omit the module prefix.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/Dagger/Up.html
+++ b/docs/static/reference/php/Dagger/Up.html
@@ -166,7 +166,7 @@
                 <div class="col-md-8">
                     <a href="#method_name">name</a>()
         
-                                            <p><p>Return the fully qualified name of the service</p></p>                </div>
+                                            <p><p>Return the command name of the service. Entrypoint targets omit the module prefix.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -370,7 +370,7 @@
             
 
         <div class="method-description">
-                            <p><p>Return the fully qualified name of the service</p></p>                        
+                            <p><p>Return the command name of the service. Entrypoint targets omit the module prefix.</p></p>                        
         </div>
         <div class="tags">
             

--- a/docs/static/reference/php/doc-index.html
+++ b/docs/static/reference/php/doc-index.html
@@ -1214,11 +1214,11 @@
                     <dd><p>Modules authored with this SDK.</p></dd>        </dl><h2 id="letterN">N</h2>
         <dl id="indexN"><dt><a href="Dagger/Agent.html#method_name">
 <abbr title="Dagger\Agent">Agent</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Agent.html"><abbr title="Dagger\Agent">Agent</abbr></a></em></dt>
-                    <dd><p>Return the fully qualified name of the agent</p></dd><dt><a href="Dagger/Binding.html#method_name">
+                    <dd><p>Return the command name of the agent. Entrypoint targets omit the module prefix.</p></dd><dt><a href="Dagger/Binding.html#method_name">
 <abbr title="Dagger\Binding">Binding</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Binding.html"><abbr title="Dagger\Binding">Binding</abbr></a></em></dt>
                     <dd><p>Returns the binding name</p></dd><dt><a href="Dagger/Check.html#method_name">
 <abbr title="Dagger\Check">Check</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Check.html"><abbr title="Dagger\Check">Check</abbr></a></em></dt>
-                    <dd><p>Return the fully qualified name of the check</p></dd><dt><a href="Dagger/Client.html#method_node">
+                    <dd><p>Return the command name of the check. Entrypoint targets omit the module prefix.</p></dd><dt><a href="Dagger/Client.html#method_node">
 <abbr title="Dagger\Client">Client</abbr>::node</a>() &mdash; <em>Method in class <a href="Dagger/Client.html"><abbr title="Dagger\Client">Client</abbr></a></em></dt>
                     <dd><p>Load any object by its ID.</p></dd><dt><a href="Dagger/Connection.html#method_newEnvSession">
 <abbr title="Dagger\Connection">Connection</abbr>::newEnvSession</a>() &mdash; <em>Method in class <a href="Dagger/Connection.html"><abbr title="Dagger\Connection">Connection</abbr></a></em></dt>
@@ -1256,7 +1256,7 @@
 <abbr title="Dagger\Function_">Function_</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Function_.html"><abbr title="Dagger\Function_">Function_</abbr></a></em></dt>
                     <dd><p>The name of the function.</p></dd><dt><a href="Dagger/Generator.html#method_name">
 <abbr title="Dagger\Generator">Generator</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Generator.html"><abbr title="Dagger\Generator">Generator</abbr></a></em></dt>
-                    <dd><p>Return the fully qualified name of the generator</p></dd><dt><a href="Dagger/GitBundleRef.html#method_name">
+                    <dd><p>Return the command name of the generator. Entrypoint targets omit the module prefix.</p></dd><dt><a href="Dagger/GitBundleRef.html#method_name">
 <abbr title="Dagger\GitBundleRef">GitBundleRef</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/GitBundleRef.html"><abbr title="Dagger\GitBundleRef">GitBundleRef</abbr></a></em></dt>
                     <dd><p>The advertised ref name.</p></dd><dt><a href="Dagger/GitRef.html#method_name">
 <abbr title="Dagger\GitRef">GitRef</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/GitRef.html"><abbr title="Dagger\GitRef">GitRef</abbr></a></em></dt>
@@ -1288,11 +1288,11 @@
 <abbr title="Dagger\Stat">Stat</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Stat.html"><abbr title="Dagger\Stat">Stat</abbr></a></em></dt>
                     <dd><p>file name</p></dd><dt><a href="Dagger/TerminalTarget.html#method_name">
 <abbr title="Dagger\TerminalTarget">TerminalTarget</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/TerminalTarget.html"><abbr title="Dagger\TerminalTarget">TerminalTarget</abbr></a></em></dt>
-                    <dd><p>Return the fully qualified name of the terminal target</p></dd><dt><a href="Dagger/TypeDef.html#method_name">
+                    <dd><p>Return the command name of the terminal target. Entrypoint targets omit the module prefix.</p></dd><dt><a href="Dagger/TypeDef.html#method_name">
 <abbr title="Dagger\TypeDef">TypeDef</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/TypeDef.html"><abbr title="Dagger\TypeDef">TypeDef</abbr></a></em></dt>
                     <dd><p>The canonical non-optional name of the type.</p></dd><dt><a href="Dagger/Up.html#method_name">
 <abbr title="Dagger\Up">Up</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/Up.html"><abbr title="Dagger\Up">Up</abbr></a></em></dt>
-                    <dd><p>Return the fully qualified name of the service</p></dd><dt><a href="Dagger/WorkspaceModule.html#method_name">
+                    <dd><p>Return the command name of the service. Entrypoint targets omit the module prefix.</p></dd><dt><a href="Dagger/WorkspaceModule.html#method_name">
 <abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceModule.html"><abbr title="Dagger\WorkspaceModule">WorkspaceModule</abbr></a></em></dt>
                     <dd><p>The module name.</p></dd><dt><a href="Dagger/WorkspaceSDK.html#method_name">
 <abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr>::name</a>() &mdash; <em>Method in class <a href="Dagger/WorkspaceSDK.html"><abbr title="Dagger\WorkspaceSDK">WorkspaceSDK</abbr></a></em></dt>

--- a/docs/static/reference/php/doctum-search.json
+++ b/docs/static/reference/php/doctum-search.json
@@ -2070,7 +2070,7 @@
 			"t": "M",
 			"n": "Dagger\\Agent::name",
 			"p": "Dagger/Agent.html#method_name",
-			"d": "<p>Return the fully qualified name of the agent</p>"
+			"d": "<p>Return the command name of the agent. Entrypoint targets omit the module prefix.</p>"
 		},
 		{
 			"t": "M",
@@ -2592,7 +2592,7 @@
 			"t": "M",
 			"n": "Dagger\\Check::name",
 			"p": "Dagger/Check.html#method_name",
-			"d": "<p>Return the fully qualified name of the check</p>"
+			"d": "<p>Return the command name of the check. Entrypoint targets omit the module prefix.</p>"
 		},
 		{
 			"t": "M",
@@ -5310,7 +5310,7 @@
 			"t": "M",
 			"n": "Dagger\\Generator::name",
 			"p": "Dagger/Generator.html#method_name",
-			"d": "<p>Return the fully qualified name of the generator</p>"
+			"d": "<p>Return the command name of the generator. Entrypoint targets omit the module prefix.</p>"
 		},
 		{
 			"t": "M",
@@ -7248,7 +7248,7 @@
 			"t": "M",
 			"n": "Dagger\\TerminalTarget::name",
 			"p": "Dagger/TerminalTarget.html#method_name",
-			"d": "<p>Return the fully qualified name of the terminal target</p>"
+			"d": "<p>Return the command name of the terminal target. Entrypoint targets omit the module prefix.</p>"
 		},
 		{
 			"t": "M",
@@ -7410,7 +7410,7 @@
 			"t": "M",
 			"n": "Dagger\\Up::name",
 			"p": "Dagger/Up.html#method_name",
-			"d": "<p>Return the fully qualified name of the service</p>"
+			"d": "<p>Return the command name of the service. Entrypoint targets omit the module prefix.</p>"
 		},
 		{
 			"t": "M",

--- a/sdk/elixir/lib/dagger/gen/agent.ex
+++ b/sdk/elixir/lib/dagger/gen/agent.ex
@@ -38,7 +38,7 @@ defmodule Dagger.Agent do
   end
 
   @doc """
-  Return the fully qualified name of the agent
+  Return the command name of the agent. Entrypoint targets omit the module prefix.
   """
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = agent) do

--- a/sdk/elixir/lib/dagger/gen/check.ex
+++ b/sdk/elixir/lib/dagger/gen/check.ex
@@ -88,7 +88,7 @@ defmodule Dagger.Check do
   end
 
   @doc """
-  Return the fully qualified name of the check
+  Return the command name of the check. Entrypoint targets omit the module prefix.
   """
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = check) do

--- a/sdk/elixir/lib/dagger/gen/generator.ex
+++ b/sdk/elixir/lib/dagger/gen/generator.ex
@@ -74,7 +74,7 @@ defmodule Dagger.Generator do
   end
 
   @doc """
-  Return the fully qualified name of the generator
+  Return the command name of the generator. Entrypoint targets omit the module prefix.
   """
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = generator) do

--- a/sdk/elixir/lib/dagger/gen/terminal_target.ex
+++ b/sdk/elixir/lib/dagger/gen/terminal_target.ex
@@ -38,7 +38,7 @@ defmodule Dagger.TerminalTarget do
   end
 
   @doc """
-  Return the fully qualified name of the terminal target
+  Return the command name of the terminal target. Entrypoint targets omit the module prefix.
   """
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = terminal_target) do

--- a/sdk/elixir/lib/dagger/gen/up.ex
+++ b/sdk/elixir/lib/dagger/gen/up.ex
@@ -38,7 +38,7 @@ defmodule Dagger.Up do
   end
 
   @doc """
-  Return the fully qualified name of the service
+  Return the command name of the service. Entrypoint targets omit the module prefix.
   """
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = up) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -497,7 +497,7 @@ func (r *Agent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// Return the fully qualified name of the agent
+// Return the command name of the agent. Entrypoint targets omit the module prefix.
 func (r *Agent) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
@@ -1116,7 +1116,7 @@ func (r *Check) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// Return the fully qualified name of the check
+// Return the command name of the check. Entrypoint targets omit the module prefix.
 func (r *Check) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
@@ -7915,7 +7915,7 @@ func (r *Generator) IsEmpty(ctx context.Context) (bool, error) {
 	return response, q.Execute(ctx)
 }
 
-// Return the fully qualified name of the generator
+// Return the command name of the generator. Entrypoint targets omit the module prefix.
 func (r *Generator) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
@@ -15471,7 +15471,7 @@ func (r *TerminalTarget) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// Return the fully qualified name of the terminal target
+// Return the command name of the terminal target. Entrypoint targets omit the module prefix.
 func (r *TerminalTarget) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
@@ -16077,7 +16077,7 @@ func (r *Up) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
-// Return the fully qualified name of the service
+// Return the command name of the service. Entrypoint targets omit the module prefix.
 func (r *Up) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil

--- a/sdk/php/generated/Agent.php
+++ b/sdk/php/generated/Agent.php
@@ -29,7 +29,7 @@ class Agent extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
-     * Return the fully qualified name of the agent
+     * Return the command name of the agent. Entrypoint targets omit the module prefix.
      */
     public function name(): string
     {

--- a/sdk/php/generated/Check.php
+++ b/sdk/php/generated/Check.php
@@ -61,7 +61,7 @@ class Check extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
-     * Return the fully qualified name of the check
+     * Return the command name of the check. Entrypoint targets omit the module prefix.
      */
     public function name(): string
     {

--- a/sdk/php/generated/Generator.php
+++ b/sdk/php/generated/Generator.php
@@ -56,7 +56,7 @@ class Generator extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
-     * Return the fully qualified name of the generator
+     * Return the command name of the generator. Entrypoint targets omit the module prefix.
      */
     public function name(): string
     {

--- a/sdk/php/generated/TerminalTarget.php
+++ b/sdk/php/generated/TerminalTarget.php
@@ -29,7 +29,7 @@ class TerminalTarget extends Client\AbstractObject implements Client\IdAble, Nod
     }
 
     /**
-     * Return the fully qualified name of the terminal target
+     * Return the command name of the terminal target. Entrypoint targets omit the module prefix.
      */
     public function name(): string
     {

--- a/sdk/php/generated/Up.php
+++ b/sdk/php/generated/Up.php
@@ -29,7 +29,7 @@ class Up extends Client\AbstractObject implements Client\IdAble, Node
     }
 
     /**
-     * Return the fully qualified name of the service
+     * Return the command name of the service. Entrypoint targets omit the module prefix.
      */
     public function name(): string
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -761,7 +761,8 @@ class Agent(Type):
         return await _ctx.execute(str)
 
     async def name(self) -> str:
-        """Return the fully qualified name of the agent
+        """Return the command name of the agent. Entrypoint targets omit the
+        module prefix.
 
         Returns
         -------
@@ -1249,7 +1250,8 @@ class Check(Type):
         return await _ctx.execute(str)
 
     async def name(self) -> str:
-        """Return the fully qualified name of the check
+        """Return the command name of the check. Entrypoint targets omit the
+        module prefix.
 
         Returns
         -------
@@ -7687,7 +7689,8 @@ class Generator(Type):
         return await _ctx.execute(bool)
 
     async def name(self) -> str:
-        """Return the fully qualified name of the generator
+        """Return the command name of the generator. Entrypoint targets omit the
+        module prefix.
 
         Returns
         -------
@@ -14572,7 +14575,8 @@ class TerminalTarget(Type):
         return await _ctx.execute(str)
 
     async def name(self) -> str:
-        """Return the fully qualified name of the terminal target
+        """Return the command name of the terminal target. Entrypoint targets
+        omit the module prefix.
 
         Returns
         -------
@@ -15057,7 +15061,8 @@ class Up(Type):
         return await _ctx.execute(str)
 
     async def name(self) -> str:
-        """Return the fully qualified name of the service
+        """Return the command name of the service. Entrypoint targets omit the
+        module prefix.
 
         Returns
         -------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -554,7 +554,7 @@ impl Agent {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Return the fully qualified name of the agent
+    /// Return the command name of the agent. Entrypoint targets omit the module prefix.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
         query.execute(self.graphql_client.clone()).await
@@ -1056,7 +1056,7 @@ impl Check {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Return the fully qualified name of the check
+    /// Return the command name of the check. Entrypoint targets omit the module prefix.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
         query.execute(self.graphql_client.clone()).await
@@ -8202,7 +8202,7 @@ impl Generator {
         let query = self.selection.select("isEmpty");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Return the fully qualified name of the generator
+    /// Return the command name of the generator. Entrypoint targets omit the module prefix.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
         query.execute(self.graphql_client.clone()).await
@@ -14568,7 +14568,7 @@ impl TerminalTarget {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Return the fully qualified name of the terminal target
+    /// Return the command name of the terminal target. Entrypoint targets omit the module prefix.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
         query.execute(self.graphql_client.clone()).await
@@ -15227,7 +15227,7 @@ impl Up {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Return the fully qualified name of the service
+    /// Return the command name of the service. Entrypoint targets omit the module prefix.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
         query.execute(self.graphql_client.clone()).await

--- a/sdk/typescript/src/api/client.gen.ts
+++ b/sdk/typescript/src/api/client.gen.ts
@@ -3662,7 +3662,7 @@ export class Agent extends BaseClient {
   }
 
   /**
-   * Return the fully qualified name of the agent
+   * Return the command name of the agent. Entrypoint targets omit the module prefix.
    */
   name = async (): Promise<string> => {
     if (this._name) {
@@ -4117,7 +4117,7 @@ export class Check extends BaseClient {
   }
 
   /**
-   * Return the fully qualified name of the check
+   * Return the command name of the check. Entrypoint targets omit the module prefix.
    */
   name = async (): Promise<string> => {
     if (this._name) {
@@ -8942,7 +8942,7 @@ export class Generator extends BaseClient {
   }
 
   /**
-   * Return the fully qualified name of the generator
+   * Return the command name of the generator. Entrypoint targets omit the module prefix.
    */
   name = async (): Promise<string> => {
     if (this._name) {
@@ -14713,7 +14713,7 @@ export class TerminalTarget extends BaseClient {
   }
 
   /**
-   * Return the fully qualified name of the terminal target
+   * Return the command name of the terminal target. Entrypoint targets omit the module prefix.
    */
   name = async (): Promise<string> => {
     if (this._name) {
@@ -15110,7 +15110,7 @@ export class Up extends BaseClient {
   }
 
   /**
-   * Return the fully qualified name of the service
+   * Return the command name of the service. Entrypoint targets omit the module prefix.
    */
   name = async (): Promise<string> => {
     if (this._name) {


### PR DESCRIPTION
Show entrypoint targets as `foo` in lists and run output. Both `foo` and `myproject-dev:foo` remain valid input.

Other modules keep their prefixes. `foo` still selects `foo:bar`, but no longer selects `other:foo`.
