### PR TITLE
test(typescript): allow cold engine provisioning

### DIFF
--- a/sdk/typescript/src/test/connect.spec.ts
+++ b/sdk/typescript/src/test/connect.spec.ts
@@ -192,7 +192,8 @@ describe("TypeScript sdk Connect", function () {
     })
 
     it("Should download and unpack the CLI binary automatically", async function () {
-      this.timeout(30000)
+      // Provisioning includes downloading and starting an uncached engine image.
+      this.timeout(300000)
 
       // ignore DAGGER_SESSION_PORT
       delete process.env.DAGGER_SESSION_PORT


### PR DESCRIPTION
The TypeScript provisioning test has a 30-second timeout that includes downloading and starting an uncached engine image. In the [failed publish follow-up job](https://github.com/dagger/dagger/actions/runs/34515150846/job/103001716210), the CLI downloaded successfully, but the engine pull took 38.6 seconds. The `defaultPlatform()` query completed after Mocha had already timed out.

Raise this test's timeout to five minutes, consistent with the SDK's existing connection timeout, and explain the cold-start requirement. This changes only the test timeout.

Validation against the published CLI and engine from `56e1fa451dd7a0261eda9a1da0e3c7a5e34f9489`, with a separate disposable Docker daemon and empty engine cache for each runtime:

- Node 22.23.2: `yarn test:node -g 'Automatic Provisioned CLI Binary'` passed in 47 seconds (engine pull: 43.1 seconds).
- Bun 1.1.26: `yarn test:bun -g 'Automatic Provisioned CLI Binary'` passed in 39 seconds.
- ESLint on `sdk/typescript/src/test/connect.spec.ts` and `git diff --check` passed.
