### PR TITLE
feat(cli): add 'dagger cloud usage' command

### DIFF
--- a/docs/proposals/cloud-onboarding-cli.md
+++ b/docs/proposals/cloud-onboarding-cli.md
@@ -1,0 +1,113 @@
+# Proposal: Ergonomic CLI-first Cloud onboarding
+
+Goal: an anonymous user can go from "just installed dagger" to a working Dagger
+Cloud account with checks + telemetry **without leaving the terminal**, except
+for the two consent screens that genuinely require a browser (identity provider
+login and, only for paid plans, the payment page).
+
+## Target cold-start flow
+
+```
+$ dagger setup            # or first `dagger` invocation
+  1. Cloud login/signup   → device auth (browser consent, already works)
+  2. Ensure an org        → createQuickstartOrg (NO browser) instead of dagger.cloud/traces/setup
+  3. Connect Git source   → GitHub OAuth via loopback redirect (browser consent only)
+  4. Enable checks        → configureSource + startFeatureTrial(CLOUD_CHECKS)
+  5. Telemetry            → automatic once org is selected (already works)
+```
+
+Everything except steps 1 and 3's provider consent screens is pure CLI.
+
+## Key finding: the backend already supports this
+
+The Cloud GraphQL API (`dagger.io: cloud/api/schema.graphql`) already exposes
+CLI-friendly mutations the current CLI does **not** use:
+
+| Mutation | Use in onboarding | CLI status |
+|---|---|---|
+| `createQuickstartOrg(name)` | Create a free org, no browser | **not wired** |
+| `createQuickstartOrgWithSourceSelections(name, sources)` | Org + auto-checked repos in one call | not wired |
+| `createQuickstartOrgWithMappings(name, installationIds)` | Org + mapped installations | not wired |
+| `githubOAuthURL(redirectURI)` | OAuth URL; `localhost` is an allowed redirect host | wired (browser-only) |
+| `connectGitHub(code, state)` | Finish GitHub OAuth from a code | **not wired** |
+| `configureSource(source)` | Toggle autocheck on a repo set | wired (`cloud check on`) |
+| `startFeatureTrial(org, CLOUD_CHECKS, days)` | Turn on the Checks feature | **not wired** |
+| `createOrg(items, paymentInfo, coupon)` / `createPortalSession(org)` | Paid plans / Stripe portal | portal wired |
+
+`AllowedRedirectHosts` defaults to `dagger.cloud,localhost`, so the CLI can run
+a **loopback OAuth flow** (spin up `http://localhost:PORT/callback`, capture
+`code`+`state`, call `connectGitHub`) — the same pattern `dagger login` already
+uses for device auth. The GitHub authorize/app-install consent screen is the
+only unavoidable browser hop for source connection.
+
+## Current gaps (what to build)
+
+1. **Org creation opens a browser.** `internal/cmd/dagger/cloud.go:createNewOrg`
+   opens `https://dagger.cloud/traces/setup` and polls `client.User` for up to
+   5 minutes. Replace with a `client.CreateQuickstartOrg(name)` call. Derive the
+   default org name from the account (GitHub login / email local-part) so the
+   user isn't asked to invent one (Solomon: "org names really do not matter").
+
+2. **No CLI GitHub connect.** `integration_cloud.go:integrationSetupGitHub` only
+   prints the OAuth URL. Add a loopback flow + `connectGitHub(code,state)` so
+   the CLI completes the connection and can immediately `configureSource`.
+
+3. **`dagger cloud check on` dead-ends.** When no source mapping exists it errors
+   `no Cloud source mapping found for <repo>` (`workspace.go:1309/1317`). It
+   should offer to run the GitHub connect flow, then enable the check — and call
+   `startFeatureTrial(CLOUD_CHECKS)` if the feature is off.
+
+4. **`setup` login step is isolated.** `setup.go:setupStepLogin` stops at login.
+   Extend the setup walker with steps 2–4 above so a single `dagger setup`
+   reaches a working checks + telemetry state.
+
+5. **Known bugs from the thread** (track, don't regress):
+   - "Already logged in" false positive — fixed in PR #13948 (verify merged).
+   - Empty org switcher on first signup / possible race in auto-created org.
+   - `dagger cloud rerun` naming vs `dagger cloud check rerun` (bikeshed, defer).
+
+## Proposed implementation slices
+
+### Slice A — CLI-only org creation (highest value, lowest risk) — ✅ IMPLEMENTED
+- Added `internal/cloud`: `CreateQuickstartOrg(ctx, name) (*OrgResponse, error)`
+  (GraphQL op mirroring `createQuickstartOrg`).
+- Rewrote `createNewOrg` (`internal/cmd/dagger/cloud.go`): removed the
+  `dagger.cloud/traces/setup` browser open + 5-minute poll loop; it now derives
+  a default org name from the account (`nickname` → email local-part → `my-org`)
+  and calls `CreateQuickstartOrg`. A `dagger login <org>` / `--org` value still
+  overrides the derived name.
+- Extended `UserResponse` with `nickname`/`email` for name derivation.
+- Tests: `sanitizeOrgName` / `defaultOrgName` unit tests
+  (`internal/cmd/dagger/cloud_org_name_test.go`); the browser poll path is gone.
+
+### Slice B — GitHub connect via loopback
+- Add `client.ConnectGitHub(ctx, code, state)`.
+- Add a small loopback OAuth helper (reuse `dagger login`'s browser-open + local
+  listener patterns): request `githubOAuthURL(http://localhost:PORT/callback)`,
+  open it, capture `code`/`state`, exchange via `ConnectGitHub`.
+- Wire into `dagger cloud integration create github` (default) with the existing
+  `--open`/manual-URL path as fallback for headless environments.
+
+### Slice C — one-shot checks enablement
+- Add `client.StartFeatureTrial(ctx, orgID, feature, days)`.
+- `dagger cloud check on`: if `no source mapping`, run Slice B connect, then
+  `configureSource(..., SELECTED, [repo])`; ensure `CLOUD_CHECKS` via
+  `startFeatureTrial` when absent.
+
+### Slice D — unified `dagger setup` walkthrough
+- Extend the setup step machine: after login, ensure org (A), offer source
+  connect (B), offer checks (C). Each step is skippable and idempotent, matching
+  the existing huh-form TUI style. Non-interactive/CI: skip prompts, respect
+  `DAGGER_CLOUD_TOKEN`/OIDC.
+
+### Slice E — paid plans (later)
+- `createOrg(items, paymentInfo)` + `createPortalSession` for the single
+  necessary payment browser roundtrip; `dagger billing plans` already lists
+  plans. Out of scope for the initial anonymous free-tier onboarding.
+
+## Open questions for the team
+- Default org-name policy: account-derived silently, or confirm once? Backend
+  auto-creates an org on signup already — do we adopt that org instead of
+  creating a second one? (Ties to the "empty org switcher" bug.)
+- Headless/CI story for GitHub connect (loopback needs a browser+localhost).
+- Feature-trial length + what happens at expiry for `CLOUD_CHECKS`.

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -85,8 +85,10 @@ func NewClient(
 }
 
 type UserResponse struct {
-	ID   string     `json:"id"`
-	Orgs []auth.Org `json:"orgs"`
+	ID       string     `json:"id"`
+	Nickname string     `json:"nickname"`
+	Email    string     `json:"email"`
+	Orgs     []auth.Org `json:"orgs"`
 }
 
 func (c *Client) User(ctx context.Context) (*UserResponse, error) {

--- a/internal/cloud/github_connection_test.go
+++ b/internal/cloud/github_connection_test.go
@@ -1,0 +1,68 @@
+package cloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/dagger/dagger/internal/cloud/auth"
+)
+
+func testClient(t *testing.T, url string) *Client {
+	t.Helper()
+	t.Setenv("DAGGER_CLOUD_URL", url)
+	c, err := NewClient(context.Background(), &auth.Cloud{
+		Token: &oauth2.Token{AccessToken: "tok", TokenType: "Basic"},
+	})
+	require.NoError(t, err)
+	return c
+}
+
+func TestGitHubConnection(t *testing.T) {
+	t.Run("returns connection when connected", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			require.Contains(t, string(body), "githubConnection")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":{"githubConnection":{"githubLogin":"octocat","connectedAt":"2026-01-01T00:00:00Z"}}}`)
+		}))
+		defer srv.Close()
+
+		conn, err := testClient(t, srv.URL).GitHubConnection(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		require.Equal(t, "octocat", conn.GitHubLogin)
+		require.Equal(t, "2026-01-01T00:00:00Z", conn.ConnectedAt)
+	})
+
+	t.Run("returns nil when not connected", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":{"githubConnection":null}}`)
+		}))
+		defer srv.Close()
+
+		conn, err := testClient(t, srv.URL).GitHubConnection(context.Background())
+		require.NoError(t, err)
+		require.Nil(t, conn)
+	})
+
+	t.Run("propagates API errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"errors":[{"message":"unauthorized"}]}`)
+		}))
+		defer srv.Close()
+
+		conn, err := testClient(t, srv.URL).GitHubConnection(context.Background())
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "unauthorized"))
+		require.Nil(t, conn)
+	})
+}

--- a/internal/cloud/org_sources.go
+++ b/internal/cloud/org_sources.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -215,6 +216,34 @@ func (c *Client) ConfigureSource(ctx context.Context, installationID, mode strin
 		return nil, err
 	}
 	return &data.ConfigureSource, nil
+}
+
+const createQuickstartOrgOperation = `
+mutation CreateQuickstartOrg($name: String!) {
+	createQuickstartOrg(name: $name) {
+		id
+		name
+	}
+}
+`
+
+// CreateQuickstartOrg creates a free "quickstart" org for the authenticated
+// user without any browser interaction, returning the new org's id and name.
+// The requested name may be adjusted server-side (e.g. to resolve collisions),
+// so callers must use the returned name rather than the requested one.
+func (c *Client) CreateQuickstartOrg(ctx context.Context, name string) (*OrgResponse, error) {
+	if c.g == nil {
+		return nil, errors.New("no user logged in")
+	}
+	var data struct {
+		CreateQuickstartOrg OrgResponse `json:"createQuickstartOrg"`
+	}
+	if err := c.doGraphQL(ctx, "CreateQuickstartOrg", createQuickstartOrgOperation, map[string]any{
+		"name": name,
+	}, &data); err != nil {
+		return nil, err
+	}
+	return &data.CreateQuickstartOrg, nil
 }
 
 const getGithubOAuthURLOperation = `

--- a/internal/cloud/org_sources.go
+++ b/internal/cloud/org_sources.go
@@ -246,6 +246,33 @@ func (c *Client) CreateQuickstartOrg(ctx context.Context, name string) (*OrgResp
 	return &data.CreateQuickstartOrg, nil
 }
 
+// GitHubConnection is a user's linked GitHub identity in Dagger Cloud.
+type GitHubConnection struct {
+	GitHubLogin string `json:"githubLogin"`
+	ConnectedAt string `json:"connectedAt"`
+}
+
+const getGithubConnectionOperation = `
+query GetGithubConnection {
+	githubConnection {
+		githubLogin
+		connectedAt
+	}
+}
+`
+
+// GitHubConnection returns the authenticated user's GitHub connection, or nil
+// when no GitHub account is connected yet.
+func (c *Client) GitHubConnection(ctx context.Context) (*GitHubConnection, error) {
+	var data struct {
+		GitHubConnection *GitHubConnection `json:"githubConnection"`
+	}
+	if err := c.doGraphQL(ctx, "GetGithubConnection", getGithubConnectionOperation, nil, &data); err != nil {
+		return nil, err
+	}
+	return data.GitHubConnection, nil
+}
+
 const getGithubOAuthURLOperation = `
 query GetGithubOAuthURL($redirectURI: String!) {
 	githubOAuthURL(redirectURI: $redirectURI)

--- a/internal/cloud/org_sources.go
+++ b/internal/cloud/org_sources.go
@@ -273,6 +273,35 @@ func (c *Client) GitHubConnection(ctx context.Context) (*GitHubConnection, error
 	return data.GitHubConnection, nil
 }
 
+const configureOrgSourceOperation = `
+mutation ConfigureOrgSource($org: ID!, $installationId: ID!, $mode: SourceMode!, $repositories: [String!]!) {
+	configureOrgSource(org: $org, source: { installationId: $installationId, mode: $mode, repositories: $repositories }) {
+		sourceName
+		installationId
+		mode
+	}
+}
+`
+
+// ConfigureOrgSource maps the given GitHub App installation to org (creating the
+// mapping if needed) and applies the repo selection. Unlike ConfigureSource, it
+// does not require the installation to already be mapped, so it is used to
+// onboard a freshly installed app into the user's org. Requires org admin.
+func (c *Client) ConfigureOrgSource(ctx context.Context, orgID, installationID, mode string, repositories []string) (*MappedSource, error) {
+	var data struct {
+		ConfigureOrgSource MappedSource `json:"configureOrgSource"`
+	}
+	if err := c.doGraphQL(ctx, "ConfigureOrgSource", configureOrgSourceOperation, map[string]any{
+		"org":            orgID,
+		"installationId": installationID,
+		"mode":           mode,
+		"repositories":   repositories,
+	}, &data); err != nil {
+		return nil, err
+	}
+	return &data.ConfigureOrgSource, nil
+}
+
 const getGithubOAuthURLOperation = `
 query GetGithubOAuthURL($redirectURI: String!) {
 	githubOAuthURL(redirectURI: $redirectURI)

--- a/internal/cloud/usage.go
+++ b/internal/cloud/usage.go
@@ -1,0 +1,56 @@
+package cloud
+
+import "context"
+
+// MonthlyUsage is the telemetry ingestion usage for a billing period. Usage and
+// Cap count spans and log lines ingested (Cap is the plan allowance, 0 when the
+// plan is unlimited).
+type MonthlyUsage struct {
+	Usage int `json:"usage"`
+	Cap   int `json:"cap"`
+}
+
+const monthUsageOperation = `
+query MonthUsage($org: ID!, $month: String!) {
+	monthUsage(org: $org, month: $month) {
+		usage
+		cap
+	}
+}
+`
+
+// MonthUsage returns the telemetry ingestion usage (spans + log lines) for the
+// given org and billing month. month is a date string in the "2006-01-02" form
+// identifying the period (e.g. "2026-09-01" for September 2026).
+func (c *Client) MonthUsage(ctx context.Context, orgID, month string) (*MonthlyUsage, error) {
+	var data struct {
+		MonthUsage MonthlyUsage `json:"monthUsage"`
+	}
+	if err := c.doGraphQL(ctx, "MonthUsage", monthUsageOperation, map[string]any{
+		"org":   orgID,
+		"month": month,
+	}, &data); err != nil {
+		return nil, err
+	}
+	return &data.MonthUsage, nil
+}
+
+const orgUsedMinutesOperation = `
+query OrgUsedMinutes($org: ID!) {
+	orgUsedMinutes(org: $org)
+}
+`
+
+// OrgUsedMinutes returns the number of Cloud compute (engine) minutes the org
+// has consumed in the current billing period.
+func (c *Client) OrgUsedMinutes(ctx context.Context, orgID string) (int, error) {
+	var data struct {
+		OrgUsedMinutes int `json:"orgUsedMinutes"`
+	}
+	if err := c.doGraphQL(ctx, "OrgUsedMinutes", orgUsedMinutesOperation, map[string]any{
+		"org": orgID,
+	}, &data); err != nil {
+		return 0, err
+	}
+	return data.OrgUsedMinutes, nil
+}

--- a/internal/cloud/usage.go
+++ b/internal/cloud/usage.go
@@ -35,22 +35,22 @@ func (c *Client) MonthUsage(ctx context.Context, orgID, month string) (*MonthlyU
 	return &data.MonthUsage, nil
 }
 
-const orgUsedMinutesOperation = `
-query OrgUsedMinutes($org: ID!) {
-	orgUsedMinutes(org: $org)
+const orgComputeMinutesOperation = `
+query OrgComputeMinutes($org: ID!) {
+	orgComputeMinutes(org: $org)
 }
 `
 
-// OrgUsedMinutes returns the number of Cloud compute (engine) minutes the org
+// OrgComputeMinutes returns the number of Cloud compute (engine) minutes the org
 // has consumed in the current billing period.
-func (c *Client) OrgUsedMinutes(ctx context.Context, orgID string) (int, error) {
+func (c *Client) OrgComputeMinutes(ctx context.Context, orgID string) (int, error) {
 	var data struct {
-		OrgUsedMinutes int `json:"orgUsedMinutes"`
+		OrgComputeMinutes int `json:"orgComputeMinutes"`
 	}
-	if err := c.doGraphQL(ctx, "OrgUsedMinutes", orgUsedMinutesOperation, map[string]any{
+	if err := c.doGraphQL(ctx, "OrgComputeMinutes", orgComputeMinutesOperation, map[string]any{
 		"org": orgID,
 	}, &data); err != nil {
 		return 0, err
 	}
-	return data.OrgUsedMinutes, nil
+	return data.OrgComputeMinutes, nil
 }

--- a/internal/cloud/usage_test.go
+++ b/internal/cloud/usage_test.go
@@ -42,16 +42,16 @@ func TestMonthUsage(t *testing.T) {
 	})
 }
 
-func TestOrgUsedMinutes(t *testing.T) {
+func TestOrgComputeMinutes(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		require.Contains(t, string(body), "orgUsedMinutes")
+		require.Contains(t, string(body), "orgComputeMinutes")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"orgUsedMinutes":137}}`)
+		_, _ = io.WriteString(w, `{"data":{"orgComputeMinutes":137}}`)
 	}))
 	defer srv.Close()
 
-	minutes, err := testClient(t, srv.URL).OrgUsedMinutes(context.Background(), "org-1")
+	minutes, err := testClient(t, srv.URL).OrgComputeMinutes(context.Background(), "org-1")
 	require.NoError(t, err)
 	require.Equal(t, 137, minutes)
 }

--- a/internal/cloud/usage_test.go
+++ b/internal/cloud/usage_test.go
@@ -1,0 +1,57 @@
+package cloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonthUsage(t *testing.T) {
+	t.Run("returns telemetry usage", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			require.Contains(t, string(body), "monthUsage")
+			require.Contains(t, string(body), "2026-09-01")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":{"monthUsage":{"usage":1200,"cap":5000}}}`)
+		}))
+		defer srv.Close()
+
+		u, err := testClient(t, srv.URL).MonthUsage(context.Background(), "org-1", "2026-09-01")
+		require.NoError(t, err)
+		require.NotNil(t, u)
+		require.Equal(t, 1200, u.Usage)
+		require.Equal(t, 5000, u.Cap)
+	})
+
+	t.Run("propagates API errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"errors":[{"message":"unauthorized"}]}`)
+		}))
+		defer srv.Close()
+
+		_, err := testClient(t, srv.URL).MonthUsage(context.Background(), "org-1", "2026-09-01")
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "unauthorized"))
+	})
+}
+
+func TestOrgUsedMinutes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.Contains(t, string(body), "orgUsedMinutes")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"orgUsedMinutes":137}}`)
+	}))
+	defer srv.Close()
+
+	minutes, err := testClient(t, srv.URL).OrgUsedMinutes(context.Background(), "org-1")
+	require.NoError(t, err)
+	require.Equal(t, 137, minutes)
+}

--- a/internal/cmd/dagger/cloud.go
+++ b/internal/cmd/dagger/cloud.go
@@ -2,12 +2,10 @@ package daggercmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"time"
+	"strings"
 
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
@@ -25,11 +23,15 @@ var cloudCmd = &cobra.Command{
 	Short: "Manage Dagger Cloud",
 }
 
-var cloudLoginCmd = newLoginCmd(false)
-var loginCmd = newLoginCmd(true)
+var (
+	cloudLoginCmd = newLoginCmd(false)
+	loginCmd      = newLoginCmd(true)
+)
 
-var cloudLogoutCmd = newLogoutCmd(false)
-var logoutCmd = newLogoutCmd(true)
+var (
+	cloudLogoutCmd = newLogoutCmd(false)
+	logoutCmd      = newLogoutCmd(true)
+)
 
 func init() {
 	cloudCmd.AddCommand(cloudLoginCmd, cloudLogoutCmd)
@@ -100,14 +102,9 @@ func (cli *CloudCLI) Login(cmd *cobra.Command, args []string) error {
 	var selectedOrg *auth.Org
 	switch len(user.Orgs) {
 	case 0:
-		fmt.Fprintln(errW, "You are not a member of any Dagger Cloud organizations.")
-		selectedOrg, err = createNewOrg(ctx, client, errW)
+		selectedOrg, err = createNewOrg(ctx, client, user, orgName, errW)
 		if err != nil {
-			// logging out user here so terminal is not filled with 403
-			// errors the next time `dagger login` is called since the user
-			// still doesn't have an org set
-			auth.Logout()
-			fmt.Fprintf(errW, "Error setting up new organization: %v", err)
+			fmt.Fprintf(errW, "Error setting up new organization: %v\n", err)
 			return idtui.Fail
 		}
 	case 1:
@@ -148,41 +145,67 @@ func (cli *CloudCLI) Login(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createNewOrg(ctx context.Context, cli *cloud.Client, w io.Writer) (*auth.Org, error) {
-	url := "https://dagger.cloud/traces/setup"
-	fmt.Fprintf(w, "Create or select an organization here: %s\n", url)
-	err := browser.OpenURL(url)
-	if err != nil {
-		fmt.Fprintf(w, "Unable to open browser automatically; open the URL above to continue.\n")
+// createNewOrg creates a free Dagger Cloud organization entirely from the CLI
+// (no browser round-trip). The org name is taken from the requested name when
+// provided, otherwise derived from the account so the user isn't forced to
+// invent one. The server may adjust the name (e.g. to resolve collisions), so
+// the returned org reflects the actual name.
+func createNewOrg(ctx context.Context, cli *cloud.Client, user *cloud.UserResponse, requestedName string, w io.Writer) (*auth.Org, error) {
+	name := requestedName
+	if name == "" {
+		name = defaultOrgName(user)
 	}
 
-	timer := time.After(5 * time.Minute)
-	t := time.NewTicker(1 * time.Second)
+	fmt.Fprintln(w, "You are not a member of any Dagger Cloud organizations.")
+	fmt.Fprintf(w, "Creating a new organization %q...\n", name)
 
-	defer t.Stop()
+	org, err := cli.CreateQuickstartOrg(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if org.Name != name {
+		fmt.Fprintf(w, "Created organization %q.\n", org.Name)
+	}
+	return &auth.Org{ID: org.ID, Name: org.Name}, nil
+}
 
-	for {
-		select {
-		case <-timer:
-			return nil, errors.New("timed out waiting to create an organization")
-		case <-t.C:
-			u, err := cli.User(ctx)
-			if err != nil {
-				return nil, err
+// defaultOrgName derives an org name from the authenticated account, preferring
+// the account nickname (typically the GitHub login), then the email local part,
+// falling back to a generic name. Org names are not user-facing identifiers, so
+// a sensible default avoids an unnecessary prompt.
+func defaultOrgName(user *cloud.UserResponse) string {
+	if user != nil {
+		if name := sanitizeOrgName(user.Nickname); name != "" {
+			return name
+		}
+		if local, _, ok := strings.Cut(user.Email, "@"); ok {
+			if name := sanitizeOrgName(local); name != "" {
+				return name
 			}
-			if len(u.Orgs) == 0 {
-				continue
-			}
-
-			user, err := cli.User(ctx)
-			if err != nil {
-				return nil, err
-			}
-			return &user.Orgs[0], nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
 		}
 	}
+	return "my-org"
+}
+
+// sanitizeOrgName reduces an arbitrary string to a lowercase slug of ASCII
+// alphanumerics and single hyphens, suitable as a default org name.
+func sanitizeOrgName(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastHyphen = false
+		case r == '-' || r == '_' || r == '.' || r == ' ':
+			if b.Len() > 0 && !lastHyphen {
+				b.WriteRune('-')
+				lastHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 func (cli *CloudCLI) Logout(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/dagger/cloud_check.go
+++ b/internal/cmd/dagger/cloud_check.go
@@ -12,9 +12,10 @@ import (
 )
 
 var cloudCheckCmd = &cobra.Command{
-	Use:   "check",
-	Short: "Manage Cloud-side automated checks for this workspace",
-	Args:  cobra.NoArgs,
+	Use:     "checks",
+	Aliases: []string{"check"},
+	Short:   "Manage Cloud-side automated checks for this workspace",
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},

--- a/internal/cmd/dagger/cloud_checks.go
+++ b/internal/cmd/dagger/cloud_checks.go
@@ -388,13 +388,49 @@ func cloudDimensionMatches(dim, got string, values []string) bool {
 	return false
 }
 
+// normalizeGitHubRepo reduces the many ways a GitHub repo can be spelled to a
+// bare "owner/name". It accepts https/http/ssh/git URLs, the scp-like
+// git@github.com:owner/name form (with or without a port), optional userinfo
+// (e.g. git@), and a trailing .git, as well as an already-bare owner/name.
 func normalizeGitHubRepo(repo string) string {
 	repo = strings.TrimSpace(repo)
-	repo = strings.TrimPrefix(repo, "https://")
-	repo = strings.TrimPrefix(repo, "http://")
+	repo = strings.TrimSuffix(repo, "/")
+	// Strip any URL scheme (https://, http://, ssh://, git://, ...).
+	if i := strings.Index(repo, "://"); i != -1 {
+		repo = repo[i+len("://"):]
+	}
+	// Strip userinfo that precedes the host (e.g. "git@" in git@github.com/...).
+	// Only when the '@' comes before the first path separator, so an '@' inside
+	// the path is left alone.
+	if at := strings.IndexByte(repo, '@'); at != -1 {
+		if slash := strings.IndexByte(repo, '/'); slash == -1 || at < slash {
+			repo = repo[at+1:]
+		}
+	}
+	// Normalize the scp-like "github.com:owner/name" separator (and drop an
+	// optional "github.com:port/") to the regular "github.com/owner/name" form.
+	if rest, ok := strings.CutPrefix(repo, "github.com:"); ok {
+		if slash := strings.IndexByte(rest, '/'); slash != -1 && isAllDigits(rest[:slash]) {
+			repo = "github.com" + rest[slash:] // github.com:port/owner/name -> github.com/owner/name
+		} else {
+			repo = "github.com/" + rest // github.com:owner/name -> github.com/owner/name
+		}
+	}
 	repo = strings.TrimPrefix(repo, "github.com/")
 	repo = strings.TrimSuffix(repo, ".git")
 	return repo
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func cloudResultForStatus(status string) string {

--- a/internal/cmd/dagger/cloud_org_name_test.go
+++ b/internal/cmd/dagger/cloud_org_name_test.go
@@ -1,0 +1,60 @@
+package daggercmd
+
+import (
+	"testing"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeOrgName(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"notnotvito", "notnotvito"},
+		{"NotNotVito", "notnotvito"},
+		{"  Marcos Nils  ", "marcos-nils"},
+		{"foo_bar.baz", "foo-bar-baz"},
+		{"--weird__name--", "weird-name"},
+		{"a@b", "ab"},
+		{"", ""},
+		{"!!!", ""},
+		{"123", "123"},
+	} {
+		require.Equal(t, tc.want, sanitizeOrgName(tc.in), "sanitizeOrgName(%q)", tc.in)
+	}
+}
+
+func TestDefaultOrgName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		user *cloudapi.UserResponse
+		want string
+	}{
+		{
+			name: "prefers nickname",
+			user: &cloudapi.UserResponse{Nickname: "notnotvito", Email: "vito@example.com"},
+			want: "notnotvito",
+		},
+		{
+			name: "falls back to email local part",
+			user: &cloudapi.UserResponse{Email: "marcos.nils@example.com"},
+			want: "marcos-nils",
+		},
+		{
+			name: "falls back to generic when nothing usable",
+			user: &cloudapi.UserResponse{Nickname: "!!!", Email: "@example.com"},
+			want: "my-org",
+		},
+		{
+			name: "nil user",
+			user: nil,
+			want: "my-org",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, defaultOrgName(tc.user))
+		})
+	}
+}

--- a/internal/cmd/dagger/engines_cloud.go
+++ b/internal/cmd/dagger/engines_cloud.go
@@ -1,0 +1,22 @@
+package daggercmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// cloudEnginesCmd is the `dagger cloud engines` group. It is a placeholder for
+// now: the subcommands (list, provision, etc.) are not implemented yet, so the
+// group only prints its help. It exists so the command surface is discoverable
+// and stable while the engines feature is built out.
+var cloudEnginesCmd = &cobra.Command{
+	Use:   "engines",
+	Short: "Manage Dagger Cloud engines",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+func init() {
+	cloudCmd.AddCommand(cloudEnginesCmd)
+}

--- a/internal/cmd/dagger/integration_cloud.go
+++ b/internal/cmd/dagger/integration_cloud.go
@@ -14,7 +14,7 @@ import (
 
 var githubOpen bool
 
-const githubOAuthRedirect = "https://dagger.cloud/github/callback"
+const githubOAuthRedirect = "http://localhost:3000/github/callback"
 
 // cloudIntegrationCmd is the `dagger cloud integration` group. The original
 // top-level `dagger integration` was singleton-shaped (one provider per type,
@@ -119,6 +119,23 @@ func (cli *CloudCLI) integrationSetupGitHub(cmd *cobra.Command) error {
 	client, _, err := cli.cloudClient(cmd.Context())
 	if err != nil {
 		return err
+	}
+	// If GitHub is already connected there's nothing to set up: skip the OAuth
+	// URL entirely rather than sending the user through the flow again.
+	conn, err := client.GitHubConnection(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if conn != nil {
+		if cloudJSON {
+			return writeCloudJSON(cmd, map[string]string{
+				"status":      "connected",
+				"githubLogin": conn.GitHubLogin,
+				"connectedAt": conn.ConnectedAt,
+			})
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "GitHub is already connected as %s.\n", conn.GitHubLogin)
+		return nil
 	}
 	setup, err := cli.githubConnectHandoff(cmd.Context(), client)
 	if err != nil {

--- a/internal/cmd/dagger/integration_cloud.go
+++ b/internal/cmd/dagger/integration_cloud.go
@@ -120,21 +120,17 @@ func (cli *CloudCLI) integrationSetupGitHub(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	// If GitHub is already connected there's nothing to set up: skip the OAuth
-	// URL entirely rather than sending the user through the flow again.
-	conn, err := client.GitHubConnection(cmd.Context())
-	if err != nil {
-		return err
-	}
-	if conn != nil {
+	// If GitHub is already usable there's nothing to set up: skip the OAuth URL
+	// rather than sending the user through the flow again.
+	if connected, login := cli.githubConnected(cmd.Context(), client); connected {
 		if cloudJSON {
-			return writeCloudJSON(cmd, map[string]string{
-				"status":      "connected",
-				"githubLogin": conn.GitHubLogin,
-				"connectedAt": conn.ConnectedAt,
-			})
+			return writeCloudJSON(cmd, map[string]string{"status": "connected", "githubLogin": login})
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "GitHub is already connected as %s.\n", conn.GitHubLogin)
+		if login != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "GitHub is already connected as %s.\n", login)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "GitHub is already connected.")
+		}
 		return nil
 	}
 	setup, err := cli.githubConnectHandoff(cmd.Context(), client)
@@ -149,6 +145,30 @@ func (cli *CloudCLI) integrationSetupGitHub(cmd *cobra.Command) error {
 	fmt.Fprintln(out, "Open this URL to set up the GitHub integration:")
 	fmt.Fprintln(out, setup.URL)
 	return nil
+}
+
+// githubConnected reports whether the user already has a usable GitHub identity,
+// along with the connected login when known.
+//
+// A GitHub identity can come from two places (see the Cloud API's Sources
+// resolver): an explicit connection stored in user_github_connections, or the
+// Auth0 GitHub identity of a user who logged into Cloud with GitHub. The latter
+// has no stored row, so a githubConnection lookup alone misses it. Since
+// Sources() needs a working GitHub token from either path, a successful
+// Sources() call is the definitive "GitHub is usable" signal.
+//
+// Best-effort: any lookup error is treated as "not connected", so the caller
+// falls back to offering the OAuth flow.
+func (cli *CloudCLI) githubConnected(ctx context.Context, client *cloudapi.Client) (bool, string) {
+	// Explicit connection: cheap, and carries the login for a nicer message.
+	if conn, err := client.GitHubConnection(ctx); err == nil && conn != nil {
+		return true, conn.GitHubLogin
+	}
+	// No stored connection, but a GitHub identity may be available via Auth0.
+	if _, err := client.Sources(ctx); err == nil {
+		return true, ""
+	}
+	return false, ""
 }
 
 func (cli *CloudCLI) githubConnectHandoff(ctx context.Context, client *cloudapi.Client) (*githubSetupHandoff, error) {

--- a/internal/cmd/dagger/integration_github_connected_test.go
+++ b/internal/cmd/dagger/integration_github_connected_test.go
@@ -1,0 +1,74 @@
+package daggercmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// fakeCloudClient builds a cloud client pointed at a test server that answers
+// the githubConnection and sources queries per the provided responders.
+func fakeCloudClient(t *testing.T, githubConnectionJSON, sourcesJSON string) *cloudapi.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(string(body), "githubConnection"):
+			_, _ = io.WriteString(w, githubConnectionJSON)
+		case strings.Contains(string(body), "GetSources"), strings.Contains(string(body), "sources"):
+			_, _ = io.WriteString(w, sourcesJSON)
+		default:
+			_, _ = io.WriteString(w, `{"data":{}}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("DAGGER_CLOUD_URL", srv.URL)
+	c, err := cloudapi.NewClient(context.Background(), &cloudauth.Cloud{
+		Token: &oauth2.Token{AccessToken: "tok", TokenType: "Basic"},
+	})
+	require.NoError(t, err)
+	return c
+}
+
+func TestGithubConnected(t *testing.T) {
+	cli := &CloudCLI{}
+
+	t.Run("stored connection returns login", func(t *testing.T) {
+		client := fakeCloudClient(t,
+			`{"data":{"githubConnection":{"githubLogin":"octocat","connectedAt":"2026-01-01T00:00:00Z"}}}`,
+			`{"data":{"sources":[]}}`,
+		)
+		connected, login := cli.githubConnected(context.Background(), client)
+		require.True(t, connected)
+		require.Equal(t, "octocat", login)
+	})
+
+	t.Run("no stored connection but sources listable (Auth0 identity)", func(t *testing.T) {
+		client := fakeCloudClient(t,
+			`{"data":{"githubConnection":null}}`,
+			`{"data":{"sources":[{"name":"acme","id":"1","type":"Organization","configuredAt":"","orgName":null,"configUrl":""}]}}`,
+		)
+		connected, login := cli.githubConnected(context.Background(), client)
+		require.True(t, connected)
+		require.Empty(t, login)
+	})
+
+	t.Run("no connection and no GitHub identity", func(t *testing.T) {
+		client := fakeCloudClient(t,
+			`{"data":{"githubConnection":null}}`,
+			`{"errors":[{"message":"no GitHub identity found"}]}`,
+		)
+		connected, login := cli.githubConnected(context.Background(), client)
+		require.False(t, connected)
+		require.Empty(t, login)
+	})
+}

--- a/internal/cmd/dagger/main.go
+++ b/internal/cmd/dagger/main.go
@@ -169,7 +169,8 @@ func init() {
 	upCmd.GroupID = "daily"
 	terminalCmd.GroupID = "daily"
 	agentCmd.GroupID = "daily"
-	activityCmd.GroupID = "daily"
+	// activityCmd now lives under `dagger cloud workspaces activity`; its
+	// GroupID is cleared there so it isn't tied to a root command group.
 
 	moduleDepInstallCmd.GroupID = "workspace"
 	moduleDepUninstallCmd.GroupID = "workspace"
@@ -195,7 +196,6 @@ func init() {
 		versionRoot,
 		queryCmd,
 		apiCmd,
-		traceCmd,
 		settingsCmd,
 		checksCmd,
 		upCmd,
@@ -209,7 +209,6 @@ func init() {
 		setupCmd,
 		searchCmd,
 		installedCmd,
-		activityCmd,
 		moduleCmd,
 		sdkCmd,
 		callCoreCmd.Command(),

--- a/internal/cmd/dagger/normalize_github_repo_test.go
+++ b/internal/cmd/dagger/normalize_github_repo_test.go
@@ -1,0 +1,47 @@
+package daggercmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeGitHubRepo(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		// already bare
+		{"marcosnils/hello-dagger", "marcosnils/hello-dagger"},
+		{"marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		// host, no scheme
+		{"github.com/marcosnils/hello-dagger", "marcosnils/hello-dagger"},
+		// https / http
+		{"https://github.com/marcosnils/hello-dagger", "marcosnils/hello-dagger"},
+		{"https://github.com/marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		{"http://github.com/marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		// https with userinfo (token)
+		{"https://user:token@github.com/marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		// ssh URL form
+		{"ssh://git@github.com/marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		// ssh URL form with port
+		{"ssh://git@github.com:22/marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		// scp-like form
+		{"git@github.com:marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		{"git@github.com:marcosnils/hello-dagger", "marcosnils/hello-dagger"},
+		// git:// scheme
+		{"git://github.com/marcosnils/hello-dagger.git", "marcosnils/hello-dagger"},
+		// whitespace + trailing slash
+		{"  https://github.com/marcosnils/hello-dagger/  ", "marcosnils/hello-dagger"},
+	} {
+		require.Equal(t, tc.want, normalizeGitHubRepo(tc.in), "normalizeGitHubRepo(%q)", tc.in)
+	}
+}
+
+func TestIsAllDigits(t *testing.T) {
+	require.True(t, isAllDigits("22"))
+	require.True(t, isAllDigits("0"))
+	require.False(t, isAllDigits(""))
+	require.False(t, isAllDigits("2a"))
+	require.False(t, isAllDigits("owner"))
+}

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dagger/dagger/dagql/dagui"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
+	cloud "github.com/dagger/dagger/internal/cloud"
 	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
 	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	telemetry "github.com/dagger/otel-go"
@@ -249,7 +250,7 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 		} else {
 			ui.setLoginComplete("Already logged in.")
 		}
-		return nil
+		return setupFinishLogin(ctx, cmd, ui, auth)
 	}
 	if !autoApply {
 		disabled, err := setupCloudLoginPromptDisabled()
@@ -304,7 +305,72 @@ func setupStepLogin(ctx context.Context, cmd *cobra.Command, getCloudAuth func(c
 	} else {
 		ui.setLoginComplete("Logged in.")
 	}
+	// Re-read auth so the org step sees the freshly saved credentials.
+	auth, _ := getCloudAuth(ctx)
+	return setupFinishLogin(ctx, cmd, ui, auth)
+}
+
+// setupFinishLogin runs the post-authentication work shared by the "already
+// logged in" and "just logged in" paths: ensure the account has a current org,
+// creating a free one when it has none. Org setup is best-effort — a failure is
+// surfaced but does not fail the login step — except for interruption.
+func setupFinishLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI, auth *cloudauth.Cloud) error {
+	if err := setupEnsureOrg(ctx, cmd, ui, auth); err != nil {
+		if errors.Is(err, idtui.ErrInterrupted) || errors.Is(err, context.Canceled) {
+			return err
+		}
+		msg := fmt.Sprintf("Could not set up organization: %v", err)
+		if ui == nil {
+			fmt.Fprintln(cmd.OutOrStdout(), "  "+msg)
+		} else {
+			ui.appendLoginDetail(msg + "\n")
+		}
+	}
 	return nil
+}
+
+// setupEnsureOrg makes sure the authenticated account has a current Dagger Cloud
+// org selected. When the account has no org it creates a free one from the CLI
+// (no browser); when it has orgs but none is selected yet it adopts the first.
+// It is a no-op for token-based auth (DAGGER_CLOUD_TOKEN / OIDC), where the org
+// is implied by the token, when a current org is already set, and when there is
+// no usable credential (e.g. login was skipped).
+func setupEnsureOrg(ctx context.Context, cmd *cobra.Command, ui *setupUI, auth *cloudauth.Cloud) error {
+	if os.Getenv("DAGGER_CLOUD_TOKEN") != "" {
+		return nil
+	}
+	if auth == nil || auth.Token == nil {
+		// No usable credential to talk to Cloud with; nothing to do.
+		return nil
+	}
+	if auth.Org != nil && auth.Org.ID != "" {
+		// A current org is already selected.
+		return nil
+	}
+
+	client, err := cloud.NewClient(ctx, auth)
+	if err != nil {
+		return err
+	}
+	user, err := client.User(ctx)
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = cmd.ErrOrStderr()
+	if ui != nil && ui.live {
+		w = setupLoginWriter{ui: ui}
+	}
+	if len(user.Orgs) == 0 {
+		org, err := createNewOrg(ctx, client, user, cloudOrgFlag, w)
+		if err != nil {
+			return err
+		}
+		return cloudauth.SetCurrentOrg(org)
+	}
+	// Has org(s) but none selected yet: adopt the first so subsequent Cloud
+	// commands have a default without another prompt.
+	return cloudauth.SetCurrentOrg(&user.Orgs[0])
 }
 
 type setupLoginChoice string

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -319,14 +319,25 @@ func setupFinishLogin(ctx context.Context, cmd *cobra.Command, ui *setupUI, auth
 		if errors.Is(err, idtui.ErrInterrupted) || errors.Is(err, context.Canceled) {
 			return err
 		}
-		msg := fmt.Sprintf("Could not set up organization: %v", err)
-		if ui == nil {
-			fmt.Fprintln(cmd.OutOrStdout(), "  "+msg)
-		} else {
-			ui.appendLoginDetail(msg + "\n")
-		}
+		setupOrgStatus(ui, cmd, fmt.Sprintf("Could not set up organization: %v", err), false)
 	}
 	return nil
+}
+
+// setupOrgStatus reports the outcome of the org-ensure step so it is visible in
+// the setup output. The TUI clears the login detail on completion and the final
+// summary omits it, so a message written there would never be seen; this routes
+// through a dedicated, always-rendered org status line instead.
+func setupOrgStatus(ui *setupUI, cmd *cobra.Command, message string, ok bool) {
+	if ui != nil {
+		ui.setOrgStatus(message, ok)
+		return
+	}
+	prefix := "  "
+	if !ok {
+		prefix = "  ! "
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), prefix+message)
 }
 
 // setupEnsureOrg makes sure the authenticated account has a current Dagger Cloud
@@ -357,20 +368,27 @@ func setupEnsureOrg(ctx context.Context, cmd *cobra.Command, ui *setupUI, auth *
 		return err
 	}
 
-	var w io.Writer = cmd.ErrOrStderr()
-	if ui != nil && ui.live {
-		w = setupLoginWriter{ui: ui}
-	}
 	if len(user.Orgs) == 0 {
-		org, err := createNewOrg(ctx, client, user, cloudOrgFlag, w)
+		// createNewOrg's inline writer is discarded here; the outcome is reported
+		// through setupOrgStatus so it renders in both the live and final views.
+		org, err := createNewOrg(ctx, client, user, cloudOrgFlag, io.Discard)
 		if err != nil {
 			return err
 		}
-		return cloudauth.SetCurrentOrg(org)
+		if err := cloudauth.SetCurrentOrg(org); err != nil {
+			return err
+		}
+		setupOrgStatus(ui, cmd, fmt.Sprintf("Created organization %q.", org.Name), true)
+		return nil
 	}
 	// Has org(s) but none selected yet: adopt the first so subsequent Cloud
 	// commands have a default without another prompt.
-	return cloudauth.SetCurrentOrg(&user.Orgs[0])
+	first := user.Orgs[0]
+	if err := cloudauth.SetCurrentOrg(&first); err != nil {
+		return err
+	}
+	setupOrgStatus(ui, cmd, fmt.Sprintf("Using organization %q.", first.Name), true)
+	return nil
 }
 
 type setupLoginChoice string

--- a/internal/cmd/dagger/setup_ensure_org_test.go
+++ b/internal/cmd/dagger/setup_ensure_org_test.go
@@ -1,0 +1,119 @@
+package daggercmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/adrg/xdg"
+	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// backupCloudConfig saves and restores the on-disk org/credentials files so the
+// test's SetCurrentOrg writes don't clobber the developer's real Cloud config.
+func backupCloudConfig(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"org", "credentials.json"} {
+		path := filepath.Join(xdg.ConfigHome, "dagger", name)
+		orig, err := os.ReadFile(path)
+		existed := err == nil
+		t.Cleanup(func() {
+			if existed {
+				_ = os.WriteFile(path, orig, 0o600)
+			} else {
+				_ = os.Remove(path)
+			}
+		})
+	}
+}
+
+func TestSetupEnsureOrg(t *testing.T) {
+	t.Run("creates org when account has none", func(t *testing.T) {
+		backupCloudConfig(t)
+		var createCalled bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(string(body), "createQuickstartOrg") {
+				createCalled = true
+				_, _ = io.WriteString(w, `{"data":{"createQuickstartOrg":{"id":"org-123","name":"tester"}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"data":{"user":{"id":"u1","nickname":"tester","email":"t@example.com","orgs":[]}}}`)
+		}))
+		defer srv.Close()
+		t.Setenv("DAGGER_CLOUD_URL", srv.URL)
+		t.Setenv("DAGGER_CLOUD_TOKEN", "")
+
+		auth := &cloudauth.Cloud{Token: &oauth2.Token{AccessToken: "tok", TokenType: "Basic"}}
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var out bytes.Buffer
+		cmd.SetErr(&out)
+
+		err := setupEnsureOrg(context.Background(), cmd, nil, auth)
+		require.NoError(t, err)
+		require.True(t, createCalled, "expected createQuickstartOrg to be called")
+
+		org, err := cloudauth.CurrentOrg()
+		require.NoError(t, err)
+		require.Equal(t, "org-123", org.ID)
+		require.Equal(t, "tester", org.Name)
+	})
+
+	t.Run("adopts first org when account already has one", func(t *testing.T) {
+		backupCloudConfig(t)
+		var createCalled bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(string(body), "createQuickstartOrg") {
+				createCalled = true
+			}
+			_, _ = io.WriteString(w, `{"data":{"user":{"id":"u1","nickname":"tester","email":"t@example.com","orgs":[{"id":"org-existing","name":"acme"}]}}}`)
+		}))
+		defer srv.Close()
+		t.Setenv("DAGGER_CLOUD_URL", srv.URL)
+		t.Setenv("DAGGER_CLOUD_TOKEN", "")
+
+		auth := &cloudauth.Cloud{Token: &oauth2.Token{AccessToken: "tok", TokenType: "Basic"}}
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+
+		err := setupEnsureOrg(context.Background(), cmd, nil, auth)
+		require.NoError(t, err)
+		require.False(t, createCalled, "should not create an org when one exists")
+
+		org, err := cloudauth.CurrentOrg()
+		require.NoError(t, err)
+		require.Equal(t, "org-existing", org.ID)
+	})
+
+	t.Run("no-op when a current org is already selected", func(t *testing.T) {
+		backupCloudConfig(t)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("unexpected Cloud request: setupEnsureOrg should have short-circuited")
+		}))
+		defer srv.Close()
+		t.Setenv("DAGGER_CLOUD_URL", srv.URL)
+		t.Setenv("DAGGER_CLOUD_TOKEN", "")
+
+		auth := &cloudauth.Cloud{
+			Token: &oauth2.Token{AccessToken: "tok", TokenType: "Basic"},
+			Org:   &cloudauth.Org{ID: "org-current", Name: "current"},
+		}
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+
+		require.NoError(t, setupEnsureOrg(context.Background(), cmd, nil, auth))
+	})
+}

--- a/internal/cmd/dagger/setup_tui.go
+++ b/internal/cmd/dagger/setup_tui.go
@@ -115,6 +115,16 @@ func (ui *setupUI) appendLoginDetail(detail string) {
 	ui.update(func(view *setupView) { view.loginDetail += detail })
 }
 
+// setOrgStatus records the outcome of the post-login org-ensure step so it is
+// rendered in both the live and final setup views. ok distinguishes a created/
+// selected org (green check) from a failure (warning).
+func (ui *setupUI) setOrgStatus(message string, ok bool) {
+	ui.update(func(view *setupView) {
+		view.orgMessage = message
+		view.orgOK = ok
+	})
+}
+
 func (ui *setupUI) setMigration(id dagui.SpanID) {
 	ui.update(func(view *setupView) { view.migrationID = id })
 }
@@ -163,6 +173,8 @@ type setupView struct {
 	loginMessage string
 	loginDetail  string
 	loginSpinner *tuist.Spinner
+	orgMessage   string
+	orgOK        bool
 
 	rootID           dagui.SpanID
 	migrationID      dagui.SpanID
@@ -246,6 +258,24 @@ func (view *setupView) renderLogin(ctx tuist.Context) {
 	if detail := strings.TrimSpace(view.loginDetail); detail != "" {
 		ctx.Lines(strings.Split(detail, "\n")...)
 	}
+	if view.loginState == setupLoginComplete {
+		view.renderOrg(ctx)
+	}
+}
+
+// renderOrg renders the org-ensure outcome as a sub-line under the Cloud
+// account status: a green check on success, a yellow warning on failure. It is
+// a no-op until the step has reported a message.
+func (view *setupView) renderOrg(ctx tuist.Context) {
+	if strings.TrimSpace(view.orgMessage) == "" {
+		return
+	}
+	if view.orgOK {
+		view.renderSuccess(ctx, view.orgMessage)
+		return
+	}
+	warn := lipgloss.NewStyle().Foreground(lipgloss.Yellow).Render("!")
+	ctx.Line("  " + warn + " " + view.orgMessage)
 }
 
 func (view *setupView) renderSuccess(ctx tuist.Context, message string) {
@@ -295,6 +325,7 @@ func (view *setupView) renderFinal(ctx tuist.Context) {
 	switch view.loginState {
 	case setupLoginComplete:
 		ctx.Line("Cloud account: " + view.loginMessage)
+		view.renderOrg(ctx)
 	case setupLoginSkipped:
 		ctx.Line("Cloud account: " + view.loginMessage)
 	case setupLoginFailed:

--- a/internal/cmd/dagger/trace.go
+++ b/internal/cmd/dagger/trace.go
@@ -31,14 +31,13 @@ var (
 )
 
 var traceCmd = &cobra.Command{
-	Use:    "trace [trace ID]",
-	Hidden: true,
-	Args:   cobra.ExactArgs(1),
+	Use:  "traces [trace ID]",
+	Args: cobra.ExactArgs(1),
 	Annotations: map[string]string{
 		"experimental":       "true",
 		showFinalProgressKey: "true",
 	},
-	Aliases: []string{"t", "analyze", "diagnose"},
+	Aliases: []string{"trace", "t", "analyze", "diagnose"},
 	Short:   "Diagnose or view a Dagger Cloud trace.",
 	Long: `Stream and render a Dagger Cloud trace: the overall pass/fail verdict, the
 command(s) that caused a failure, check results, and failed tests, each with the
@@ -55,6 +54,9 @@ func init() {
 	traceCmd.Flags().StringVar(&traceSpan, "span", "", "Scope and zoom the view to a span ID (fetches its subtree and logs)")
 	traceCmd.Flags().StringVar(&traceCheck, "check", "", "Scope and zoom the view to a check by name")
 	traceCmd.Flags().StringVar(&traceTest, "test", "", "Scope and zoom the view to a test by name")
+
+	// Lives under `dagger cloud` as `dagger cloud traces` (with a `trace` alias).
+	cloudCmd.AddCommand(traceCmd)
 }
 
 func traceRun(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/dagger/usage_cloud.go
+++ b/internal/cmd/dagger/usage_cloud.go
@@ -1,0 +1,141 @@
+package daggercmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+)
+
+var usageMonth string
+
+var cloudUsageCmd = newUsageCmd()
+
+func init() {
+	cloudCmd.AddCommand(cloudUsageCmd)
+}
+
+func newUsageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "usage [org]",
+		Short: "Show Dagger Cloud usage",
+		Long:  "Show Dagger Cloud usage for the current billing period, including telemetry ingestion (spans and log lines) and Cloud compute minutes.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  cloudCLI.Usage,
+	}
+	cmd.Flags().BoolVar(&cloudJSON, "json", false, "Print JSON output")
+	cmd.Flags().StringVar(&usageMonth, "month", "", "Billing month to report in YYYY-MM form (default current month)")
+	return cmd
+}
+
+// usageReport is the resolved usage for an org, used for both text and JSON
+// rendering.
+type usageReport struct {
+	Org          string                 `json:"org"`
+	Month        string                 `json:"month"`
+	Telemetry    *cloudapi.MonthlyUsage `json:"telemetry"`
+	CloudMinutes int                    `json:"cloudMinutes"`
+}
+
+func (cli *CloudCLI) Usage(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	month, err := resolveUsageMonth(usageMonth, time.Now())
+	if err != nil {
+		return err
+	}
+
+	client, cloudAuth, err := cli.cloudClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	var org *cloudapi.OrgResponse
+	if len(args) > 0 {
+		org, err = client.OrgByName(ctx, args[0])
+	} else {
+		org, err = cli.resolveCloudOrg(ctx, client, cloudAuth)
+	}
+	if err != nil {
+		return err
+	}
+
+	telemetry, err := client.MonthUsage(ctx, org.ID, month+"-01")
+	if err != nil {
+		return err
+	}
+	minutes, err := client.OrgUsedMinutes(ctx, org.ID)
+	if err != nil {
+		return err
+	}
+
+	report := usageReport{
+		Org:          org.Name,
+		Month:        month,
+		Telemetry:    telemetry,
+		CloudMinutes: minutes,
+	}
+
+	if cloudJSON {
+		return writeCloudJSON(cmd, report)
+	}
+	printUsage(cmd.OutOrStdout(), report)
+	return nil
+}
+
+// resolveUsageMonth validates the optional --month flag (YYYY-MM) and falls back
+// to the given now's month, returning the month in YYYY-MM form.
+func resolveUsageMonth(flag string, now time.Time) (string, error) {
+	if flag == "" {
+		return now.UTC().Format("2006-01"), nil
+	}
+	t, err := time.Parse("2006-01", flag)
+	if err != nil {
+		return "", fmt.Errorf("invalid --month %q: expected YYYY-MM", flag)
+	}
+	return t.Format("2006-01"), nil
+}
+
+func printUsage(out io.Writer, r usageReport) {
+	fmt.Fprintf(out, "Org:    %s\n", r.Org)
+	fmt.Fprintf(out, "Period: %s\n\n", r.Month)
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "Telemetry (spans + logs):\t%s\n", formatTelemetryUsage(r.Telemetry))
+	fmt.Fprintf(w, "Cloud minutes:\t%s\n", formatCloudMinutes(r.CloudMinutes))
+	_ = w.Flush()
+}
+
+// formatTelemetryUsage renders ingestion usage as "used / cap (pct, left)",
+// omitting the cap details when the plan is unlimited (cap <= 0).
+func formatTelemetryUsage(u *cloudapi.MonthlyUsage) string {
+	if u == nil {
+		return "n/a"
+	}
+	if u.Cap <= 0 {
+		return fmt.Sprintf("%s used (unlimited)", humanize.Comma(int64(u.Usage)))
+	}
+	pct := float64(u.Usage) / float64(u.Cap) * 100
+	left := u.Cap - u.Usage
+	if left < 0 {
+		left = 0
+	}
+	return fmt.Sprintf("%s / %s (%.1f%% used, %s left)",
+		humanize.Comma(int64(u.Usage)),
+		humanize.Comma(int64(u.Cap)),
+		pct,
+		humanize.Comma(int64(left)),
+	)
+}
+
+func formatCloudMinutes(minutes int) string {
+	unit := "minutes"
+	if minutes == 1 {
+		unit = "minute"
+	}
+	return fmt.Sprintf("%s %s used", humanize.Comma(int64(minutes)), unit)
+}

--- a/internal/cmd/dagger/usage_cloud.go
+++ b/internal/cmd/dagger/usage_cloud.go
@@ -68,7 +68,7 @@ func (cli *CloudCLI) Usage(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	minutes, err := client.OrgUsedMinutes(ctx, org.ID)
+	minutes, err := client.OrgComputeMinutes(ctx, org.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/dagger/usage_cloud_test.go
+++ b/internal/cmd/dagger/usage_cloud_test.go
@@ -1,0 +1,62 @@
+package daggercmd
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUsageMonth(t *testing.T) {
+	now := time.Date(2026, 9, 15, 10, 0, 0, 0, time.UTC)
+
+	t.Run("defaults to current month", func(t *testing.T) {
+		m, err := resolveUsageMonth("", now)
+		require.NoError(t, err)
+		require.Equal(t, "2026-09", m)
+	})
+
+	t.Run("accepts explicit month", func(t *testing.T) {
+		m, err := resolveUsageMonth("2026-03", now)
+		require.NoError(t, err)
+		require.Equal(t, "2026-03", m)
+	})
+
+	t.Run("rejects invalid month", func(t *testing.T) {
+		_, err := resolveUsageMonth("2026/03", now)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "YYYY-MM")
+	})
+}
+
+func TestFormatTelemetryUsage(t *testing.T) {
+	require.Equal(t, "n/a", formatTelemetryUsage(nil))
+	require.Equal(t, "1,000 used (unlimited)", formatTelemetryUsage(&cloudapi.MonthlyUsage{Usage: 1000, Cap: 0}))
+	require.Equal(t, "2,500 / 5,000 (50.0% used, 2,500 left)", formatTelemetryUsage(&cloudapi.MonthlyUsage{Usage: 2500, Cap: 5000}))
+	// Over cap clamps "left" to zero.
+	require.Equal(t, "6,000 / 5,000 (120.0% used, 0 left)", formatTelemetryUsage(&cloudapi.MonthlyUsage{Usage: 6000, Cap: 5000}))
+}
+
+func TestFormatCloudMinutes(t *testing.T) {
+	require.Equal(t, "0 minutes used", formatCloudMinutes(0))
+	require.Equal(t, "1 minute used", formatCloudMinutes(1))
+	require.Equal(t, "1,234 minutes used", formatCloudMinutes(1234))
+}
+
+func TestPrintUsage(t *testing.T) {
+	var buf bytes.Buffer
+	printUsage(&buf, usageReport{
+		Org:          "acme",
+		Month:        "2026-09",
+		Telemetry:    &cloudapi.MonthlyUsage{Usage: 2500, Cap: 5000},
+		CloudMinutes: 120,
+	})
+	out := buf.String()
+	require.Contains(t, out, "Org:")
+	require.Contains(t, out, "acme")
+	require.Contains(t, out, "2026-09")
+	require.Contains(t, out, "2,500 / 5,000")
+	require.Contains(t, out, "120 minutes used")
+}

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -1308,6 +1308,13 @@ func workspaceAutocheckStateFromSource(ctx context.Context, client *cloudapi.Cli
 	if !ok || source.OrgName == nil {
 		return workspaceAutocheckState{}, fmt.Errorf("no Cloud source mapping found for %s", repo)
 	}
+	// The source is owned by a Dagger Cloud org. If the current user isn't a
+	// member of that org, the mapped-sources lookup below is denied with an
+	// opaque "unauthorized"; check membership first and surface a clear
+	// ownership error instead.
+	if err := ensureUserInOrg(ctx, client, *source.OrgName, repo); err != nil {
+		return workspaceAutocheckState{}, err
+	}
 	mappedSources, err := client.OrgMappedSources(ctx, *source.OrgName)
 	if err != nil {
 		return workspaceAutocheckState{}, fmt.Errorf("lookup Cloud mapped sources for org %q: %w", *source.OrgName, err)
@@ -1324,6 +1331,38 @@ func workspaceAutocheckStateFromSource(ctx context.Context, client *cloudapi.Cli
 		SourceMode:     "SELECTED",
 		SelectedRepos:  selected,
 	}, nil
+}
+
+// ensureUserInOrg verifies the authenticated user is a member of orgName, the
+// Dagger Cloud org that owns the source backing repo. When they are not a
+// member it returns a clear ownership error rather than letting an org-scoped
+// query fail later with an opaque "unauthorized".
+func ensureUserInOrg(ctx context.Context, client *cloudapi.Client, orgName, repo string) error {
+	user, err := client.User(ctx)
+	if err != nil {
+		return fmt.Errorf("lookup Cloud user: %w", err)
+	}
+	return userOrgMembershipError(user, orgName, repo)
+}
+
+// userOrgMembershipError returns nil when the user is a member of orgName, and
+// otherwise a clear error explaining that repo is owned by a different Dagger
+// Cloud organization (listing the user's own orgs for context).
+func userOrgMembershipError(user *cloudapi.UserResponse, orgName, repo string) error {
+	names := make([]string, 0, len(user.Orgs))
+	for _, org := range user.Orgs {
+		if strings.EqualFold(org.Name, orgName) {
+			return nil
+		}
+		names = append(names, org.Name)
+	}
+	msg := fmt.Sprintf("%s is owned by Dagger Cloud organization %q, which you are not a member of", repo, orgName)
+	if len(names) > 0 {
+		msg += fmt.Sprintf("; your organizations: %s", strings.Join(names, ", "))
+	} else {
+		msg += "; you are not a member of any Dagger Cloud organizations"
+	}
+	return errors.New(msg)
 }
 
 func workspaceSourceForRepo(sources []cloudapi.Source, repo string) (cloudapi.Source, bool) {

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine/client"
 	cloudapi "github.com/dagger/dagger/internal/cloud"
+	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
 	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	"github.com/dagger/dagger/util/gitutil"
 )
@@ -1257,6 +1258,11 @@ type workspaceAutocheckState struct {
 	InstallationID string
 	SourceMode     string
 	SelectedRepos  []string
+	// Mapped reports whether the installation is already mapped to a Dagger org.
+	// When false the installation exists (app installed) but isn't linked to any
+	// org yet, so it must be onboarded with configureOrgSource rather than the
+	// no-org configureSource (which requires an existing mapping).
+	Mapped bool
 }
 
 func loadWorkspaceAutocheckState(ctx context.Context, remote workspaceRemoteAddress) (workspaceAutocheckState, bool, error) {
@@ -1288,12 +1294,44 @@ func setWorkspaceAutocheckState(ctx context.Context, remote workspaceRemoteAddre
 		return current, nil
 	}
 	selected := setWorkspaceAutocheckRepoSelected(current.SelectedRepos, current.Repo, enabled)
-	if _, err := client.ConfigureSource(ctx, current.InstallationID, "SELECTED", selected); err != nil {
-		return workspaceAutocheckState{}, fmt.Errorf("turn workspace autocheck %s: %w", onOff(enabled), err)
+	if current.Mapped {
+		// Installation already mapped to an org: configureSource resolves the
+		// target org from the existing mapping.
+		if _, err := client.ConfigureSource(ctx, current.InstallationID, "SELECTED", selected); err != nil {
+			return workspaceAutocheckState{}, fmt.Errorf("turn workspace autocheck %s: %w", onOff(enabled), err)
+		}
+	} else {
+		// Installation not mapped yet (app installed but never linked to an org):
+		// map it to the current org and apply the selection in one call.
+		orgID, err := currentCloudOrgID(ctx, client)
+		if err != nil {
+			return workspaceAutocheckState{}, err
+		}
+		if _, err := client.ConfigureOrgSource(ctx, orgID, current.InstallationID, "SELECTED", selected); err != nil {
+			return workspaceAutocheckState{}, fmt.Errorf("turn workspace autocheck %s: %w", onOff(enabled), err)
+		}
 	}
 	current.Enabled = enabled
 	current.SelectedRepos = selected
+	current.Mapped = true
 	return current, nil
+}
+
+// currentCloudOrgID resolves the org to onboard an unmapped installation into:
+// the --org flag when set, otherwise the currently selected Cloud org.
+func currentCloudOrgID(ctx context.Context, client *cloudapi.Client) (string, error) {
+	if cloudOrgFlag != "" {
+		org, err := client.OrgByName(ctx, cloudOrgFlag)
+		if err != nil {
+			return "", err
+		}
+		return org.ID, nil
+	}
+	org, err := cloudauth.CurrentOrg()
+	if err != nil || org == nil || org.ID == "" {
+		return "", fmt.Errorf("no current Dagger Cloud organization; run 'dagger login' or pass --org")
+	}
+	return org.ID, nil
 }
 
 // workspaceAutocheckStateFromSource locates the installation backing repo by
@@ -1305,32 +1343,61 @@ func workspaceAutocheckStateFromSource(ctx context.Context, client *cloudapi.Cli
 		return workspaceAutocheckState{}, fmt.Errorf("lookup Cloud sources: %w", err)
 	}
 	source, ok := workspaceSourceForRepo(sources, repo)
-	if !ok || source.OrgName == nil {
-		return workspaceAutocheckState{}, fmt.Errorf("no Cloud source mapping found for %s", repo)
-	}
-	// The source is owned by a Dagger Cloud org. If the current user isn't a
-	// member of that org, the mapped-sources lookup below is denied with an
-	// opaque "unauthorized"; check membership first and surface a clear
-	// ownership error instead.
-	if err := ensureUserInOrg(ctx, client, *source.OrgName, repo); err != nil {
-		return workspaceAutocheckState{}, err
-	}
-	mappedSources, err := client.OrgMappedSources(ctx, *source.OrgName)
-	if err != nil {
-		return workspaceAutocheckState{}, fmt.Errorf("lookup Cloud mapped sources for org %q: %w", *source.OrgName, err)
-	}
-	mapped, ok := workspaceMappedSourceByInstallation(mappedSources, source.ID)
 	if !ok {
-		return workspaceAutocheckState{}, fmt.Errorf("no Cloud source mapping found for %s", repo)
+		// No source for the repo's owner means the Dagger Cloud GitHub App is
+		// not installed on that user/org yet. Point the user at the install page
+		// rather than failing with an opaque "no mapping" error.
+		return workspaceAutocheckState{}, gitHubAppNotInstalledError(repo)
 	}
-	selected, enabled := workspaceSelectedRepos(mapped.Repositories, repo)
+
+	// The app is installed for this owner (the source exists). Read the repos it
+	// currently has selected so we can add this one without dropping the others;
+	// setWorkspaceAutocheckState then enables it via configureSource. When the
+	// source is mapped to a Dagger org, verify the user belongs to it first —
+	// otherwise the org-scoped lookup below is denied with an opaque
+	// "unauthorized" — and read that org's current selection.
+	var selectedRepos []string
+	if source.OrgName != nil {
+		if err := ensureUserInOrg(ctx, client, *source.OrgName, repo); err != nil {
+			return workspaceAutocheckState{}, err
+		}
+		mappedSources, err := client.OrgMappedSources(ctx, *source.OrgName)
+		if err != nil {
+			return workspaceAutocheckState{}, fmt.Errorf("lookup Cloud mapped sources for org %q: %w", *source.OrgName, err)
+		}
+		if mapped, ok := workspaceMappedSourceByInstallation(mappedSources, source.ID); ok {
+			selectedRepos = mapped.Repositories
+		}
+	}
+
+	selected, enabled := workspaceSelectedRepos(selectedRepos, repo)
 	return workspaceAutocheckState{
 		Repo:           repo,
 		Enabled:        enabled,
 		InstallationID: source.ID,
 		SourceMode:     "SELECTED",
 		SelectedRepos:  selected,
+		Mapped:         source.OrgName != nil,
 	}, nil
+}
+
+// gitHubAppInstallURL returns the URL for installing the Dagger Cloud GitHub
+// App on a user/org. It targets the dev app when talking to a non-production
+// Cloud (DAGGER_CLOUD_URL points somewhere other than api.dagger.cloud), and
+// the production app otherwise.
+func gitHubAppInstallURL() string {
+	app := "dagger-cloud"
+	if url := os.Getenv("DAGGER_CLOUD_URL"); url != "" && !strings.Contains(url, "://api.dagger.cloud") {
+		app = "dagger-cloud-dev"
+	}
+	return "https://github.com/apps/" + app + "/installations/select_target"
+}
+
+// gitHubAppNotInstalledError tells the user to install the Dagger Cloud GitHub
+// App on the repo's owner before checks can be enabled.
+func gitHubAppNotInstalledError(repo string) error {
+	owner, _, _ := strings.Cut(normalizeGitHubRepo(repo), "/")
+	return fmt.Errorf("the Dagger Cloud GitHub App is not installed on the %q GitHub account. Install it here: %s", owner, gitHubAppInstallURL())
 }
 
 // ensureUserInOrg verifies the authenticated user is a member of orgName, the
@@ -1356,12 +1423,7 @@ func userOrgMembershipError(user *cloudapi.UserResponse, orgName, repo string) e
 		}
 		names = append(names, org.Name)
 	}
-	msg := fmt.Sprintf("%s is owned by Dagger Cloud organization %q, which you are not a member of", repo, orgName)
-	if len(names) > 0 {
-		msg += fmt.Sprintf("; your organizations: %s", strings.Join(names, ", "))
-	} else {
-		msg += "; you are not a member of any Dagger Cloud organizations"
-	}
+	msg := fmt.Sprintf("%s is owned by another Dagger Cloud organization which you are not a member of. Contact the organization administrator to get access", repo)
 	return errors.New(msg)
 }
 
@@ -1413,6 +1475,7 @@ func findWorkspaceAutocheckState(ctx context.Context, client *cloudapi.Client, r
 		state.InstallationID = mapped.InstallationID
 		state.SourceMode = mapped.Mode
 		state.SelectedRepos, state.Enabled = workspaceSelectedRepos(mapped.Repositories, repo)
+		state.Mapped = true
 	}
 	return state, true, nil
 }

--- a/internal/cmd/dagger/workspace_autocheck_org_test.go
+++ b/internal/cmd/dagger/workspace_autocheck_org_test.go
@@ -1,0 +1,45 @@
+package daggercmd
+
+import (
+	"testing"
+
+	cloudapi "github.com/dagger/dagger/internal/cloud"
+	cloudauth "github.com/dagger/dagger/internal/cloud/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func user(orgs ...string) *cloudapi.UserResponse {
+	u := &cloudapi.UserResponse{}
+	for _, name := range orgs {
+		u.Orgs = append(u.Orgs, cloudauth.Org{Name: name})
+	}
+	return u
+}
+
+func TestUserOrgMembershipError(t *testing.T) {
+	repo := "github.com/dagger/dagger"
+
+	t.Run("member returns nil", func(t *testing.T) {
+		require.NoError(t, userOrgMembershipError(user("acme", "dagger"), "dagger", repo))
+	})
+
+	t.Run("member match is case-insensitive", func(t *testing.T) {
+		require.NoError(t, userOrgMembershipError(user("Dagger"), "dagger", repo))
+	})
+
+	t.Run("non-member with other orgs", func(t *testing.T) {
+		err := userOrgMembershipError(user("acme", "widgets"), "dagger", repo)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), repo)
+		require.Contains(t, err.Error(), `owned by Dagger Cloud organization "dagger"`)
+		require.Contains(t, err.Error(), "not a member")
+		require.Contains(t, err.Error(), "your organizations: acme, widgets")
+	})
+
+	t.Run("non-member with no orgs", func(t *testing.T) {
+		err := userOrgMembershipError(user(), "dagger", repo)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `owned by Dagger Cloud organization "dagger"`)
+		require.Contains(t, err.Error(), "not a member of any Dagger Cloud organizations")
+	})
+}

--- a/internal/cmd/dagger/workspace_autocheck_org_test.go
+++ b/internal/cmd/dagger/workspace_autocheck_org_test.go
@@ -27,19 +27,46 @@ func TestUserOrgMembershipError(t *testing.T) {
 		require.NoError(t, userOrgMembershipError(user("Dagger"), "dagger", repo))
 	})
 
-	t.Run("non-member with other orgs", func(t *testing.T) {
+	t.Run("non-member", func(t *testing.T) {
 		err := userOrgMembershipError(user("acme", "widgets"), "dagger", repo)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), repo)
-		require.Contains(t, err.Error(), `owned by Dagger Cloud organization "dagger"`)
+		require.Contains(t, err.Error(), "owned by another Dagger Cloud organization")
 		require.Contains(t, err.Error(), "not a member")
-		require.Contains(t, err.Error(), "your organizations: acme, widgets")
 	})
 
 	t.Run("non-member with no orgs", func(t *testing.T) {
 		err := userOrgMembershipError(user(), "dagger", repo)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `owned by Dagger Cloud organization "dagger"`)
-		require.Contains(t, err.Error(), "not a member of any Dagger Cloud organizations")
+		require.Contains(t, err.Error(), "owned by another Dagger Cloud organization")
 	})
+}
+
+func TestGitHubAppInstallURL(t *testing.T) {
+	const prod = "https://github.com/apps/dagger-cloud/installations/select_target"
+	const dev = "https://github.com/apps/dagger-cloud-dev/installations/select_target"
+
+	t.Run("production when DAGGER_CLOUD_URL unset", func(t *testing.T) {
+		t.Setenv("DAGGER_CLOUD_URL", "")
+		require.Equal(t, prod, gitHubAppInstallURL())
+	})
+
+	t.Run("production for api.dagger.cloud", func(t *testing.T) {
+		t.Setenv("DAGGER_CLOUD_URL", "https://api.dagger.cloud")
+		require.Equal(t, prod, gitHubAppInstallURL())
+	})
+
+	t.Run("dev for a local/non-prod API", func(t *testing.T) {
+		t.Setenv("DAGGER_CLOUD_URL", "http://localhost:8020")
+		require.Equal(t, dev, gitHubAppInstallURL())
+	})
+}
+
+func TestGitHubAppNotInstalledError(t *testing.T) {
+	t.Setenv("DAGGER_CLOUD_URL", "")
+	err := gitHubAppNotInstalledError("github.com/dagger/hello-dagger")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"dagger"`) // owner
+	require.Contains(t, err.Error(), "not installed")
+	require.Contains(t, err.Error(), "https://github.com/apps/dagger-cloud/installations/select_target")
 }

--- a/internal/cmd/dagger/workspaces_cloud.go
+++ b/internal/cmd/dagger/workspaces_cloud.go
@@ -1,0 +1,28 @@
+package daggercmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// cloudWorkspacesCmd is the `dagger cloud workspaces` group. Aside from the
+// `activity` subcommand (moved here from the top-level `dagger activity`), it is
+// a placeholder for now and only prints its help. The `workspace` alias accepts
+// the singular spelling too (`dagger cloud workspace activity`).
+var cloudWorkspacesCmd = &cobra.Command{
+	Use:     "workspaces",
+	Aliases: []string{"workspace"},
+	Short:   "Manage Dagger Cloud workspaces",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+func init() {
+	// `dagger activity` now lives under `dagger cloud workspaces activity`.
+	// activityCmd is defined in workspace.go; its root command group is cleared
+	// (it was "daily") so it isn't tied to a group its new parent lacks.
+	activityCmd.GroupID = ""
+	cloudWorkspacesCmd.AddCommand(activityCmd)
+	cloudCmd.AddCommand(cloudWorkspacesCmd)
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #14044 (base branch `cloud-onboarding-cli`). Review/merge #14044 first.

Adds a new `dagger cloud usage` command that reports Dagger Cloud usage for the
current billing period directly from the CLI, covering both dimensions the Cloud
API exposes:

- **Telemetry ingestion** (spans + log lines) via `monthUsage`, rendered as
  `used / cap` with percentage and remaining allowance. Unlimited plans (cap 0)
  omit the cap.
- **Cloud compute minutes** via `orgUsedMinutes`.

Details:

- add `cloud.Client.MonthUsage` and `cloud.Client.OrgUsedMinutes`
- `--json` output mode and a `--month YYYY-MM` selector (defaults to the current
  month)
- registered under `dagger cloud usage` only, matching the convention used for
  the other new cloud subcommands (`engines`, `workspaces`)
- unit tests for the client methods, month resolution, and usage formatting

Part of the CLI-first Cloud onboarding effort.