### PR TITLE
cli: sort module search output by source

### DIFF
--- a/internal/cmd/dagger/mod.go
+++ b/internal/cmd/dagger/mod.go
@@ -68,7 +68,8 @@ func loadSDKSearchRegistry() ([]registryModule, error) {
 }
 
 // searchModuleRegistry returns modules whose name or description match query
-// (case-insensitive substring), sorted by name. An empty query returns all.
+// (case-insensitive substring), sorted by the displayed source. An empty query
+// returns all.
 func searchModuleRegistry(mods []registryModule, query string) []registryModule {
 	out := make([]registryModule, 0, len(mods))
 	q := strings.ToLower(query)
@@ -84,10 +85,10 @@ func searchModuleRegistry(mods []registryModule, query string) []registryModule 
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Name != out[j].Name {
-			return out[i].Name < out[j].Name
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
 		}
-		return out[i].Repo < out[j].Repo
+		return out[i].Name < out[j].Name
 	})
 	return out
 }

--- a/internal/cmd/dagger/mod_test.go
+++ b/internal/cmd/dagger/mod_test.go
@@ -1,6 +1,8 @@
 package daggercmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,9 +10,9 @@ import (
 
 func TestSearchModuleRegistry(t *testing.T) {
 	reg := []registryModule{
-		{Name: "wolfi", Description: "Wolfi Linux base images", Repo: "github.com/dagger/wolfi"},
-		{Name: "apko", Description: "Build OCI images with apko", Repo: "github.com/example/apko"},
-		{Name: "golang", Description: "Go toolchain helpers", Repo: "github.com/example/golang"},
+		{Name: "wolfi", Description: "Wolfi Linux base images", Repo: "dagger.io/wolfi"},
+		{Name: "apko", Description: "Build OCI images with apko", Repo: "dagger.io/apko"},
+		{Name: "golang", Description: "Go toolchain helpers", Repo: "dagger.io/golang"},
 	}
 
 	tests := []struct {
@@ -35,6 +37,20 @@ func TestSearchModuleRegistry(t *testing.T) {
 			require.Equal(t, tt.want, names)
 		})
 	}
+}
+
+func TestModuleSearchOutputSortedBySource(t *testing.T) {
+	reg := []registryModule{
+		{Name: "alpha", Description: "First module", Repo: "dagger.io/zulu"},
+		{Name: "zulu", Description: "Second module", Repo: "dagger.io/alpha"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, printModuleSearchResults(&output, searchModuleRegistry(reg, "")))
+	require.Less(t,
+		strings.Index(output.String(), "dagger.io/alpha"),
+		strings.Index(output.String(), "dagger.io/zulu"),
+	)
 }
 
 func TestLoadSearchRegistryIncludesSDKsUnlessFiltered(t *testing.T) {


### PR DESCRIPTION
The `dagger mod search` command now sorts rows alphabetically by the displayed `SOURCE` value.