### PR TITLE
cli: add workspace find command

### DIFF
--- a/.changes/unreleased/Added-20260910-150000.yaml
+++ b/.changes/unreleased/Added-20260910-150000.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add `dagger workspace find [PATH...]` to find files and directories in the selected workspace. Use repeatable `--name GLOB` options to match base names. The command also works through the `ws` alias.
+time: 2026-09-10T15:00:00-07:00
+custom:
+  Author: shykes
+  PR: "14108"

--- a/core/integration/workspace_find_test.go
+++ b/core/integration/workspace_find_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"strings"
+
+	"dagger.io/dagger"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceSuite) TestFindCLI(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	source := c.Directory().
+		WithNewFile("dagger.toml", "[modules.broken]\nsource = \"does-not-exist\"\n").
+		WithNewFile("root.txt", "root").
+		WithNewFile("items/.hidden", "hidden").
+		WithNewFile("items/a.txt", "a").
+		WithNewFile("items/file with spaces.txt", "spaces").
+		WithNewFile("items/sub/deep/nested.txt", "nested").
+		WithNewFile("items/z.txt", "z")
+	base := c.Container().From(alpineImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithNewFile("/caller/local-only.txt", "caller").
+		WithWorkdir("/caller")
+
+	for _, kind := range []string{"local", "remote"} {
+		t.Run(kind, func(ctx context.Context, t *testctx.T) {
+			ctr := base
+			var workspace string
+			if kind == "local" {
+				ctr = ctr.WithDirectory("/selected", source.
+					WithNewDirectory(".git").
+					WithNewDirectory("empty"))
+				workspace = "/selected/items"
+			} else {
+				ref := workspaceSelectionRemoteRef(ctx, t, c, source)
+				workspace = strings.Replace(ref, "/repo.git@", "/repo.git/items@", 1)
+			}
+
+			const entries = ".\n" +
+				"./.hidden\n" +
+				"./a.txt\n" +
+				"./file with spaces.txt\n" +
+				"./sub/\n" +
+				"./sub/deep/\n" +
+				"./sub/deep/nested.txt\n" +
+				"./z.txt\n"
+			for _, tc := range []struct {
+				name string
+				args []string
+				want string
+			}{
+				{"default directory", nil, entries},
+				{"explicit directory", []string{"."}, entries},
+				{"nested directory", []string{"sub"}, "sub\nsub/deep/\nsub/deep/nested.txt\n"},
+				{"root relative directory", []string{"/items/sub"}, "/items/sub\n/items/sub/deep/\n/items/sub/deep/nested.txt\n"},
+				{"file", []string{"a.txt"}, "a.txt\n"},
+				{"file with spaces", []string{"file with spaces.txt"}, "file with spaces.txt\n"},
+				{"parent relative file", []string{"../root.txt"}, "../root.txt\n"},
+				{"root relative file", []string{"/root.txt"}, "/root.txt\n"},
+				{"multiple paths", []string{"a.txt", "sub", "/root.txt"}, "a.txt\nsub\nsub/deep/\nsub/deep/nested.txt\n/root.txt\n"},
+				{"name filter", []string{"--name", "*.txt"}, "./a.txt\n./file with spaces.txt\n./sub/deep/nested.txt\n./z.txt\n"},
+				{"repeatable name filter", []string{"--name", "*.txt", "--name", "sub"}, "./a.txt\n./file with spaces.txt\n./sub/\n./sub/deep/nested.txt\n./z.txt\n"},
+			} {
+				t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+					args := append([]string{"-W", workspace, "workspace", "find"}, tc.args...)
+					out, err := ctr.With(workspaceSelectionDaggerExec(args...)).Stdout(ctx)
+					require.NoError(t, err)
+					require.Equal(t, tc.want, out)
+				})
+			}
+
+			t.Run("continue after missing path", func(ctx context.Context, t *testctx.T) {
+				result := ctr.WithExec([]string{"dagger", "-W", workspace, "ws", "find", "missing", "a.txt", "sub"}, dagger.ContainerWithExecOpts{
+					ExperimentalPrivilegedNesting: true,
+					Expect:                        dagger.ReturnTypeFailure,
+				})
+				out, err := result.Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "a.txt\nsub\nsub/deep/\nsub/deep/nested.txt\n", out)
+				stderr, err := result.Stderr(ctx)
+				require.NoError(t, err)
+				require.Contains(t, stderr, "no such file or directory")
+			})
+
+			if kind == "local" {
+				t.Run("empty directory", func(ctx context.Context, t *testctx.T) {
+					out, err := ctr.With(workspaceSelectionDaggerExec("-W", workspace, "workspace", "find", "/empty")).Stdout(ctx)
+					require.NoError(t, err)
+					require.Equal(t, "/empty\n", out)
+				})
+			}
+		})
+	}
+}

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2204,6 +2204,7 @@ the source of truth.
 * [dagger workspace cwd](#dagger-workspace-cwd)	 - Print the workspace cwd
 * [dagger workspace exec](#dagger-workspace-exec)	 - Execute a command in a container with the selected workspace mounted
 * [dagger workspace export](#dagger-workspace-export)	 - Export a file or directory from the selected workspace
+* [dagger workspace find](#dagger-workspace-find)	 - Find paths in the selected workspace
 * [dagger workspace git](#dagger-workspace-git)	 - Inspect Git metadata for the selected workspace
 * [dagger workspace grep](#dagger-workspace-grep)	 - Search file contents in the selected workspace
 * [dagger workspace ls](#dagger-workspace-ls)	 - List directories or files in the selected workspace
@@ -2444,6 +2445,47 @@ dagger workspace export [PATH] -o DEST [flags]
       --exclude stringArray   Exclude directory paths that match the glob pattern (repeatable)
       --include stringArray   Include directory paths that match the glob pattern (repeatable)
   -o, --output string         Local destination path
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug              Enable engine and trace diagnostics
+      --engine string      Select the engine: cloud, image://, container://, tcp://, tls://, ssh://, kube-pod://, unix:// (or set DAGGER_ENGINE; run 'dagger help engine' for details)
+  -i, --shell-on-error     Open a shell when a container exec fails (needs an interactive terminal)
+  -v, --verbose count      Increase verbosity (use -vv or -vvv for more)
+  -W, --workspace string   Select the workspace location to load from (local path or git ref)
+```
+
+### SEE ALSO
+
+* [dagger workspace](#dagger-workspace)	 - Inspect or configure your workspace (cwd, remotes, config, etc.)
+
+## dagger workspace find
+
+Find paths in the selected workspace
+
+### Synopsis
+
+Find files and directories in the selected workspace.
+
+PATH defaults to the workspace's current directory. Relative paths start
+at that directory. Absolute paths start at the workspace root.
+
+Without --name, print each target followed by its contents, one path per line.
+Directory entries end with /. Hidden entries are included.
+
+Use --name to print paths with a base name that matches a glob pattern.
+Use --name more than once to match any of the patterns.
+
+```
+dagger workspace find [PATH...] [flags]
+```
+
+### Options
+
+```
+      --name stringArray   Print paths with a base name that matches the glob pattern
 ```
 
 ### Options inherited from parent commands
@@ -2833,4 +2875,3 @@ dagger workspace update [flags]
 ### SEE ALSO
 
 * [dagger workspace](#dagger-workspace)	 - Inspect or configure your workspace (cwd, remotes, config, etc.)
-

--- a/docs/current_docs/reference/cli/index.mdx
+++ b/docs/current_docs/reference/cli/index.mdx
@@ -2875,3 +2875,4 @@ dagger workspace update [flags]
 ### SEE ALSO
 
 * [dagger workspace](#dagger-workspace)	 - Inspect or configure your workspace (cwd, remotes, config, etc.)
+

--- a/internal/cmd/dagger/capabilities.go
+++ b/internal/cmd/dagger/capabilities.go
@@ -333,6 +333,7 @@ func init() {
 	for _, cmd := range []*cobra.Command{
 		workspaceRootCmd,
 		workspaceCwdCmd,
+		workspaceFindCmd,
 		workspaceLsCmd,
 		workspaceCatCmd,
 		workspaceExportCmd,

--- a/internal/cmd/dagger/capabilities_test.go
+++ b/internal/cmd/dagger/capabilities_test.go
@@ -306,6 +306,7 @@ func TestMayCallEngineCommands(t *testing.T) {
 		"dagger workspace cwd",
 		"dagger workspace exec",
 		"dagger workspace export",
+		"dagger workspace find",
 		"dagger workspace git",
 		"dagger workspace grep",
 		"dagger workspace ls",

--- a/internal/cmd/dagger/workspace.go
+++ b/internal/cmd/dagger/workspace.go
@@ -266,6 +266,7 @@ func init() {
 	workspaceCmd.AddCommand(workspaceCwdCmd)
 	workspaceCmd.AddCommand(workspaceExecCmd)
 	workspaceCmd.AddCommand(workspaceExportCmd)
+	workspaceCmd.AddCommand(workspaceFindCmd)
 	workspaceCmd.AddCommand(workspaceLsCmd)
 	workspaceCmd.AddCommand(workspaceCatCmd)
 	workspaceCmd.AddCommand(workspaceGitCmd)

--- a/internal/cmd/dagger/workspace_find.go
+++ b/internal/cmd/dagger/workspace_find.go
@@ -1,0 +1,117 @@
+package daggercmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dagger/dagger/engine/client"
+)
+
+var workspaceFindNames []string
+
+var workspaceFindCmd = &cobra.Command{
+	Use:   "find [PATH...]",
+	Short: "Find paths in the selected workspace",
+	Long: `Find files and directories in the selected workspace.
+
+PATH defaults to the workspace's current directory. Relative paths start
+at that directory. Absolute paths start at the workspace root.
+
+Without --name, print each target followed by its contents, one path per line.
+Directory entries end with /. Hidden entries are included.
+
+Use --name to print paths with a base name that matches a glob pattern.
+Use --name more than once to match any of the patterns.`,
+	Args: cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, pattern := range workspaceFindNames {
+			if _, err := path.Match(pattern, ""); err != nil {
+				return fmt.Errorf("invalid name pattern %q: %w", pattern, err)
+			}
+		}
+		if len(args) == 0 {
+			args = []string{"."}
+		}
+		return withEngine(cmd.Context(), client.Params{
+			SkipWorkspaceModules: true,
+		}, func(ctx context.Context, engineClient *client.Client) error {
+			ws := engineClient.Dagger().CurrentWorkspace()
+			var errs []error
+			for _, target := range args {
+				displayTarget := path.Clean(target)
+				entries, err := ws.Directory(target).Glob(ctx, "**/*")
+				if err != nil {
+					// A file cannot be searched as a directory. Validate it before
+					// printing its path, retaining the directory error if both fail.
+					if _, fileErr := ws.File(target).Sync(ctx); fileErr != nil {
+						errs = append(errs, fmt.Errorf("find workspace path %q: %w", target, err))
+						continue
+					}
+					entries = nil
+				}
+
+				if workspaceFindNameMatches(displayTarget, workspaceFindNames) {
+					if _, err := fmt.Fprintln(cmd.OutOrStdout(), displayTarget); err != nil {
+						return err
+					}
+				}
+				for _, entry := range entries {
+					displayPath := workspaceFindDisplayPath(displayTarget, entry)
+					if !workspaceFindNameMatches(displayPath, workspaceFindNames) {
+						continue
+					}
+					if _, err := fmt.Fprintln(cmd.OutOrStdout(), displayPath); err != nil {
+						return err
+					}
+				}
+			}
+			return errors.Join(errs...)
+		})
+	},
+}
+
+func workspaceFindNameMatches(target string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	nameTarget := strings.TrimSuffix(target, "/")
+	if nameTarget == "" {
+		nameTarget = "/"
+	}
+	name := path.Base(nameTarget)
+	for _, pattern := range patterns {
+		matched, _ := path.Match(pattern, name)
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	workspaceFindCmd.Flags().StringArrayVar(&workspaceFindNames, "name", nil, "Print paths with a base name that matches the glob pattern")
+}
+
+func workspaceFindDisplayPath(target, entry string) string {
+	isDir := strings.HasSuffix(entry, "/")
+	entry = strings.TrimSuffix(entry, "/")
+
+	var result string
+	switch target {
+	case ".":
+		result = "./" + entry
+	case "/":
+		result = "/" + entry
+	default:
+		result = target + "/" + entry
+	}
+	if isDir {
+		result += "/"
+	}
+	return result
+}

--- a/internal/cmd/dagger/workspace_find_test.go
+++ b/internal/cmd/dagger/workspace_find_test.go
@@ -1,0 +1,48 @@
+package daggercmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceFindDisplayPath(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target string
+		entry  string
+		want   string
+	}{
+		{"current directory file", ".", "file.txt", "./file.txt"},
+		{"current directory child", ".", "sub/", "./sub/"},
+		{"relative target", "sub", "deep/file.txt", "sub/deep/file.txt"},
+		{"absolute target", "/sub", "deep/file.txt", "/sub/deep/file.txt"},
+		{"workspace root", "/", "sub/file.txt", "/sub/file.txt"},
+		{"parent target", "..", "file.txt", "../file.txt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, workspaceFindDisplayPath(tc.target, tc.entry))
+		})
+	}
+}
+
+func TestWorkspaceFindNameMatches(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		target   string
+		patterns []string
+		want     bool
+	}{
+		{"no patterns", "sub/file.go", nil, true},
+		{"file match", "sub/file.go", []string{"*.go"}, true},
+		{"directory match", "sub/vendor/", []string{"vendor"}, true},
+		{"hidden match", "sub/.hidden", []string{".*"}, true},
+		{"base name only", "sub/file.go", []string{"sub/*"}, false},
+		{"any pattern", "sub/file.go", []string{"*.md", "*.go"}, true},
+		{"no match", "sub/file.go", []string{"*.md"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, workspaceFindNameMatches(tc.target, tc.patterns))
+		})
+	}
+}

--- a/internal/cmd/dagger/workspace_test.go
+++ b/internal/cmd/dagger/workspace_test.go
@@ -100,6 +100,19 @@ func TestWorkspaceCatCommand(t *testing.T) {
 	require.NoError(t, validateFlagCapabilities(testRootCommand(), []string{"workspace", "cat", "README.md", "-W", "github.com/dagger/dagger"}))
 }
 
+func TestWorkspaceFindCommand(t *testing.T) {
+	for _, command := range []string{"workspace", "ws"} {
+		cmd, _, err := rootCmd.Find([]string{command, "find"})
+		require.NoError(t, err)
+		require.Same(t, workspaceFindCmd, cmd)
+		require.NoError(t, cmd.ValidateArgs(nil))
+		require.NoError(t, cmd.ValidateArgs([]string{"src"}))
+		require.NoError(t, cmd.ValidateArgs([]string{"src", "other"}))
+	}
+	require.NotNil(t, workspaceFindCmd.Flags().Lookup("name"))
+	require.NoError(t, validateFlagCapabilities(testRootCommand(), []string{"workspace", "find", "-W", "github.com/dagger/dagger"}))
+}
+
 func TestWorkspaceExportCommand(t *testing.T) {
 	for _, command := range []string{"workspace", "ws"} {
 		cmd, _, err := rootCmd.Find([]string{command, "export"})


### PR DESCRIPTION
`dagger workspace find` prints files and directories in the selected workspace. It accepts multiple paths. It includes hidden entries. Use repeatable `--name` options to match base names.

```
dagger ws find
dagger ws find README.md docs
dagger -W github.com/dagger/dagger ws find sdk --name '*.go'
```
