### PR TITLE
fix: preserve unrelated dagger.toml content

### DIFF
--- a/core/integration/workspace_config_preservation_test.go
+++ b/core/integration/workspace_config_preservation_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceSuite) TestWorkspaceConfigPreservation(ctx context.Context, t *testctx.T) {
+	const config = `# Keep this layout
+ignore = [
+    'dist', # generated output
+    "node_modules",
+]
+future = { enabled = true }
+
+[modules.go-sdk]
+source = 'github.com/dagger/go-sdk'
+entrypoint = false # keep this comment
+
+[modules.go-sdk.as-sdk]
+name = 'go'
+
+[sdks.go]
+module = 'go-sdk'
+
+[sdks.go.scopes."apps/api"]
+name = 'api' # scope notes
+clients = [
+    './database',
+]
+`
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		before, after string
+	}{
+		{"config set", []string{"ws", "config", "modules.go-sdk.entrypoint", "true"}, "entrypoint = false", "entrypoint = true"},
+		{"config unset", []string{"ws", "config", "modules.go-sdk.entrypoint", "--unset"}, "entrypoint = false # keep this comment\n", ""},
+		{"SDK scope", []string{"sdk", "scope", "--path=apps/api", "name", "service"}, "name = 'api'", "name = 'service'"},
+	} {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			workdir := newWorkspaceConfigWorkdir(ctx, t, config)
+			_, err := hostDaggerExec(ctx, t, workdir, tc.args...)
+			require.NoError(t, err)
+			contents, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
+			require.NoError(t, err)
+			require.Equal(t, strings.Replace(config, tc.before, tc.after, 1), string(contents))
+		})
+	}
+
+	t.Run("uninstall preserves other modules", func(ctx context.Context, t *testctx.T) {
+		const extra = "\n[modules.extra]\nsource = './extra'\nfuture = 'remove with module'\n"
+		workdir := newWorkspaceConfigWorkdir(ctx, t, config+extra)
+		_, err := hostDaggerExec(ctx, t, workdir, "mod", "uninstall", "extra")
+		require.NoError(t, err)
+		contents, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
+		require.NoError(t, err)
+		require.Equal(t, config+"\n", string(contents))
+	})
+}

--- a/core/workspace/config.go
+++ b/core/workspace/config.go
@@ -790,11 +790,56 @@ func writeConfigValueAtKey(existingData []byte, key string, valueFor func(parts 
 		cfg = &Config{}
 	}
 
-	if err := setConfigValue(cfg, parts, valueFor(parts)); err != nil {
+	value := valueFor(parts)
+	if err := setConfigValue(cfg, parts, value); err != nil {
 		return nil, err
 	}
+	if err := ValidateSDKs(cfg); err != nil {
+		return nil, err
+	}
+	// setConfigValue coerces schema fields such as ignore and skip to arrays,
+	// and sources to strings. Write the resulting typed value.
+	value, err = configValueAtPath(reflect.ValueOf(cfg), parts)
+	if err != nil {
+		return nil, err
+	}
+	// The requested key is explicit, even if its value equals an implicit
+	// default and therefore produces no difference between typed configs.
+	doc, err := parseConfigText(existingData)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := doc.set(parts, value)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := ParseConfig(updated); err != nil {
+		return nil, fmt.Errorf("validate edited config: %w", err)
+	}
+	return updated, nil
+}
 
-	return UpdateConfigBytes(existingData, cfg)
+func configValueAtPath(value reflect.Value, parts []string) (any, error) {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		value = value.Elem()
+	}
+	if value.IsValid() {
+		if len(parts) == 0 {
+			return value.Interface(), nil
+		}
+		switch value.Kind() {
+		case reflect.Map:
+			return configValueAtPath(value.MapIndex(reflect.ValueOf(parts[0])), parts[1:])
+		case reflect.Struct:
+			for i := 0; i < value.NumField(); i++ {
+				name, _, _ := strings.Cut(value.Type().Field(i).Tag.Get("toml"), ",")
+				if name == parts[0] {
+					return configValueAtPath(value.Field(i), parts[1:])
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("config value %q was not set", JoinConfigPath(parts...))
 }
 
 // DeleteConfigValue removes the value at the given dotted key from config TOML.
@@ -846,23 +891,6 @@ func DeleteConfigValue(existingData []byte, key string) ([]byte, error) {
 
 	collapsed := collapseEmptiedConfigTables(tree, parts)
 
-	if configPathRequiresSerializeFallback(collapsed) {
-		// Same trade-off as writes: document edits can't address quoted or
-		// all-digit path segments, so fall back to a full canonical rewrite.
-		if err := tree.DeletePath(collapsed); err != nil {
-			return nil, fmt.Errorf("delete config path %q: %w", JoinConfigPath(collapsed...), err)
-		}
-		rendered, err := tree.ToTomlString()
-		if err != nil {
-			return nil, fmt.Errorf("render config after delete: %w", err)
-		}
-		cfg, err := ParseConfig([]byte(rendered))
-		if err != nil {
-			return nil, err
-		}
-		return SerializeConfig(cfg), nil
-	}
-
 	return deleteConfigDocumentPath(existingData, parts, collapsed)
 }
 
@@ -900,15 +928,6 @@ func collapseEmptiedConfigTables(tree *toml.Tree, parts []string) []string {
 		del = parent
 	}
 	return del
-}
-
-func configPathRequiresSerializeFallback(parts []string) bool {
-	for _, part := range parts {
-		if pathSegmentUnsafeForDocumentUpdate(part) {
-			return true
-		}
-	}
-	return false
 }
 
 func flattenTOMLTree(prefix string, tree *toml.Tree) string {

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -1,17 +1,15 @@
 package workspace
 
 import (
-	"bytes"
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
-
-	"github.com/creachadair/tomledit"
-	"github.com/creachadair/tomledit/parser"
-	neontoml "github.com/neongreen/mono/lib/toml"
 )
 
-// UpdateConfigBytes rewrites config bytes while preserving existing comments
-// and formatting when a prior file exists.
+// UpdateConfigBytes applies the differences between the old and new typed
+// config to the original document. Fields absent from both typed configs are
+// left alone, including unknown fields and explicitly written defaults.
 func UpdateConfigBytes(existingData []byte, cfg *Config) ([]byte, error) {
 	if cfg == nil {
 		cfg = &Config{}
@@ -19,119 +17,105 @@ func UpdateConfigBytes(existingData []byte, cfg *Config) ([]byte, error) {
 	if err := ValidateSDKs(cfg); err != nil {
 		return nil, err
 	}
-
 	if len(existingData) == 0 {
 		return SerializeConfig(cfg), nil
 	}
-	if configRequiresQuotedPathSegments(cfg) {
-		return SerializeConfig(cfg), nil
-	}
-
-	doc, err := neontoml.Parse(existingData)
-	if err != nil {
-		return nil, fmt.Errorf("parse existing config: %w", err)
-	}
-
-	existingCfg, err := ParseConfig(existingData)
-	if err != nil {
-		return nil, fmt.Errorf("parse existing config state: %w", err)
-	}
-	if configRequiresQuotedPathSegments(existingCfg) {
-		return SerializeConfig(cfg), nil
-	}
-
-	desiredValues := configDocumentMap(cfg)
-	if err := deleteRemovedManagedConfigPaths(doc, configDocumentMap(existingCfg), desiredValues); err != nil {
-		return nil, err
-	}
-	if err := deleteRemovedConfigRoots(doc, existingCfg, cfg); err != nil {
-		return nil, err
-	}
-	if err := doc.ApplyMap(desiredValues); err != nil {
-		return nil, fmt.Errorf("rewrite config document: %w", err)
-	}
-	if err := ensureEmptyEnvSections(doc, cfg.Env); err != nil {
-		return nil, err
-	}
-
-	out, err := pruneUnwantedEmptySections(doc.Bytes(), keepEmptyConfigSectionHeaders(cfg))
+	existing, err := ParseConfig(existingData)
 	if err != nil {
 		return nil, err
 	}
-	out, err = rewriteSDKSections(out, cfg.SDKs)
+	updated, err := updateConfigTable(existingData, nil, configDocumentMap(existing), configDocumentMap(cfg))
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	if _, err := ParseConfig(updated); err != nil {
+		return nil, fmt.Errorf("validate edited config: %w", err)
+	}
+	return updated, nil
 }
 
-// deleteConfigDocumentPath removes the value at parts from the raw document,
-// preserving surrounding formatting and comments. collapsed is the topmost
-// table the removal empties (a prefix of parts, or parts itself).
+func updateConfigTable(data []byte, prefix []string, before, after map[string]any) ([]byte, error) {
+	keys := make([]string, 0, len(before)+len(after))
+	for key := range before {
+		keys = append(keys, key)
+	}
+	for key := range after {
+		if _, ok := before[key]; !ok {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		old, had := before[key]
+		value, has := after[key]
+		if had == has && configValuesEqual(old, value) {
+			continue
+		}
+		parts := append(slices.Clone(prefix), key)
+		var err error
+		oldMap, oldTable := old.(map[string]any)
+		newMap, newTable := value.(map[string]any)
+		if oldTable && !has && !configEntryPath(parts) {
+			// Removing the last known field does not remove unknown siblings
+			// in the same table. Whole-entry removal is explicit below.
+			data, err = updateConfigTable(data, parts, oldMap, nil)
+		} else if newTable && (!had || oldTable) {
+			data, err = updateConfigTable(data, parts, oldMap, newMap)
+			if err == nil && len(newMap) == 0 {
+				var doc *configText
+				doc, err = parseConfigText(data)
+				if err == nil {
+					data, err = doc.ensureTable(parts)
+				}
+			}
+		} else {
+			var doc *configText
+			doc, err = parseConfigText(data)
+			if err == nil {
+				if !has {
+					data, err = doc.remove(parts)
+				} else {
+					data, err = doc.set(parts, value)
+				}
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("edit config %q: %w", JoinConfigPath(parts...), err)
+		}
+	}
+	return data, nil
+}
+
+func configEntryPath(parts []string) bool {
+	if len(parts) == 2 {
+		return parts[0] == "modules" || parts[0] == "sdks" || parts[0] == "env" || parts[0] == "ports"
+	}
+	return len(parts) == 4 && (parts[0] == "sdks" && parts[2] == "scopes" || parts[0] == "env" && parts[2] == "modules")
+}
+
 func deleteConfigDocumentPath(data []byte, parts, collapsed []string) ([]byte, error) {
-	del := parts
-	if len(collapsed) < len(parts) {
-		// The document can only drop leaf keys or whole section headers —
-		// deleting an implied intermediate table path is a silent no-op — so
-		// widen to the shortest emptied prefix that is an actual section.
-		// Any levels implied by that section's dotted header vanish with it.
-		sections, err := configSectionSet(data)
+	doc, err := parseConfigText(data)
+	if err != nil {
+		return nil, err
+	}
+	data, err = doc.remove(collapsed)
+	if err != nil {
+		return nil, err
+	}
+	if parts[0] == "env" {
+		doc, err = parseConfigText(data)
 		if err != nil {
 			return nil, err
 		}
-		for probe := collapsed; len(probe) < len(parts); probe = parts[:len(probe)+1] {
-			if sections[JoinConfigPath(probe...)] {
-				del = probe
-				break
-			}
-		}
-	}
-
-	doc, err := neontoml.Parse(data)
-	if err != nil {
-		return nil, fmt.Errorf("parse existing config: %w", err)
-	}
-	path := JoinConfigPath(del...)
-	if err := doc.Delete(path); err != nil {
-		return nil, fmt.Errorf("delete config path %q: %w", path, err)
-	}
-
-	// Removing an env's last overlay may take its only section header with
-	// it; the env must stay defined so --env selection keeps working.
-	if parts[0] == "env" {
-		cfg, err := ParseConfig(doc.Bytes())
+		data, err = doc.ensureTable(parts[:2])
 		if err != nil {
-			return nil, fmt.Errorf("parse config after delete: %w", err)
-		}
-		if env, ok := cfg.Env[parts[1]]; !ok || len(env.Modules) == 0 {
-			if err := ensureEmptyEnvSections(doc, map[string]EnvOverlay{parts[1]: {}}); err != nil {
-				return nil, err
-			}
-			// The placeholder trick also creates an empty [env] parent
-			// header; deleting an exact section only drops that header.
-			if err := doc.Delete("env"); err != nil {
-				return nil, fmt.Errorf("drop empty env header: %w", err)
-			}
+			return nil, err
 		}
 	}
-
-	return doc.Bytes(), nil
-}
-
-// configSectionSet returns the dotted paths of the document's section headers.
-func configSectionSet(data []byte) (map[string]bool, error) {
-	doc, err := tomledit.Parse(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("parse config sections: %w", err)
+	if _, err := ParseConfig(data); err != nil {
+		return nil, fmt.Errorf("validate edited config: %w", err)
 	}
-	set := map[string]bool{}
-	for _, section := range doc.Sections {
-		if section.Heading == nil {
-			continue
-		}
-		set[JoinConfigPath(section.Heading.Name...)] = true
-	}
-	return set, nil
+	return data, nil
 }
 
 func configDocumentMap(cfg *Config) map[string]any {
@@ -151,6 +135,9 @@ func configDocumentMap(cfg *Config) map[string]any {
 		for name, entry := range cfg.Modules {
 			module := map[string]any{
 				"source": entry.Source,
+			}
+			if entry.Pin != "" {
+				module["pin"] = entry.Pin
 			}
 			if entry.Entrypoint {
 				module["entrypoint"] = true
@@ -209,268 +196,35 @@ func configDocumentMap(cfg *Config) map[string]any {
 		}
 		values["ports"] = ports
 	}
-	// SDK declarations are intentionally not included here. They are CLI-managed
-	// state with canonical inline-array formatting, so rewriteSDKSections owns
-	// both legacy removal and canonical rendering after other config formatting
-	// has been preserved.
-
+	if len(cfg.SDKs) > 0 {
+		sdks := make(map[string]any, len(cfg.SDKs))
+		for name, entry := range cfg.SDKs {
+			sdk := map[string]any{"module": entry.Module}
+			if len(entry.Scopes) > 0 {
+				scopes := make(map[string]any, len(entry.Scopes))
+				for name, entry := range entry.Scopes {
+					scope := map[string]any{}
+					if entry.IsModule {
+						scope["is-module"] = true
+					}
+					if entry.Name != "" {
+						scope["name"] = entry.Name
+					}
+					if len(entry.Clients) > 0 {
+						scope["clients"] = slices.Clone(entry.Clients)
+					}
+					if len(entry.Settings) > 0 {
+						scope["settings"] = cloneConfigMap(entry.Settings)
+					}
+					scopes[name] = scope
+				}
+				sdk["scopes"] = scopes
+			}
+			sdks[name] = sdk
+		}
+		values["sdks"] = sdks
+	}
 	return values
-}
-
-func configRequiresQuotedPathSegments(cfg *Config) bool {
-	if cfg == nil {
-		return false
-	}
-	for moduleName, module := range cfg.Modules {
-		if pathSegmentUnsafeForDocumentUpdate(moduleName) || configMapRequiresQuotedPathSegments(module.Settings) {
-			return true
-		}
-	}
-	for sdkName := range cfg.SDKs {
-		if pathSegmentUnsafeForDocumentUpdate(sdkName) {
-			return true
-		}
-	}
-	for envName, env := range cfg.Env {
-		if pathSegmentUnsafeForDocumentUpdate(envName) {
-			return true
-		}
-		for moduleName, module := range env.Modules {
-			if pathSegmentUnsafeForDocumentUpdate(moduleName) || configMapRequiresQuotedPathSegments(module.Settings) {
-				return true
-			}
-		}
-	}
-	for host := range cfg.Ports {
-		if pathSegmentUnsafeForDocumentUpdate(host) {
-			return true
-		}
-	}
-	return false
-}
-
-func configMapRequiresQuotedPathSegments(values map[string]any) bool {
-	for key := range values {
-		if pathSegmentUnsafeForDocumentUpdate(key) {
-			return true
-		}
-	}
-	return false
-}
-
-// pathSegmentUnsafeForDocumentUpdate reports whether segment cannot be used as a
-// dotted-path segment when updating an existing config document in place (via
-// neontoml's doc.Set/Delete/ApplyMap). Beyond non-bare characters, an all-digit
-// segment — e.g. a port host like "3000" — is unsafe because the dotted-path
-// parser reads it as a number ("invalid float"). Configs containing such a
-// segment fall back to a full re-serialization, which still writes the segment
-// unquoted as a TOML section header (e.g. [ports.3000]).
-func pathSegmentUnsafeForDocumentUpdate(segment string) bool {
-	return !isBareConfigPathSegment(segment) || isAllDigitConfigPathSegment(segment)
-}
-
-func isAllDigitConfigPathSegment(segment string) bool {
-	if segment == "" {
-		return false
-	}
-	for i := 0; i < len(segment); i++ {
-		if segment[i] < '0' || segment[i] > '9' {
-			return false
-		}
-	}
-	return true
-}
-
-func deleteRemovedManagedConfigPaths(doc *neontoml.Document, existingValues, desiredValues map[string]any) error {
-	existingFlat := flattenConfigValues(existingValues)
-	desiredFlat := flattenConfigValues(desiredValues)
-
-	for path := range existingFlat {
-		if _, ok := desiredFlat[path]; ok {
-			continue
-		}
-		if err := doc.Delete(path); err != nil {
-			return fmt.Errorf("delete config path %q: %w", path, err)
-		}
-	}
-
-	return nil
-}
-
-func flattenConfigValues(values map[string]any) map[string]any {
-	flat := map[string]any{}
-	flattenConfigValuesInto(flat, "", values)
-	return flat
-}
-
-func flattenConfigValuesInto(flat map[string]any, prefix string, values map[string]any) {
-	for key, value := range values {
-		fullKey := formatConfigPathSegment(key)
-		if prefix != "" {
-			fullKey = prefix + "." + fullKey
-		}
-
-		nested, ok := value.(map[string]any)
-		if ok {
-			flattenConfigValuesInto(flat, fullKey, nested)
-			continue
-		}
-
-		flat[fullKey] = value
-	}
-}
-
-func deleteRemovedConfigRoots(doc *neontoml.Document, existingCfg, desiredCfg *Config) error {
-	for name := range existingCfg.Modules {
-		if _, ok := desiredCfg.Modules[name]; ok {
-			continue
-		}
-		if err := doc.Delete("modules." + formatConfigPathSegment(name)); err != nil {
-			return fmt.Errorf("delete module %q: %w", name, err)
-		}
-	}
-
-	for envName := range existingCfg.Env {
-		if _, ok := desiredCfg.Env[envName]; ok {
-			continue
-		}
-		if err := doc.Delete("env." + formatConfigPathSegment(envName)); err != nil {
-			return fmt.Errorf("delete env %q: %w", envName, err)
-		}
-	}
-
-	for host := range existingCfg.Ports {
-		if _, ok := desiredCfg.Ports[host]; ok {
-			continue
-		}
-		if err := doc.Delete("ports." + formatConfigPathSegment(host)); err != nil {
-			return fmt.Errorf("delete port %q: %w", host, err)
-		}
-	}
-
-	return nil
-}
-
-func ensureEmptyEnvSections(doc *neontoml.Document, envs map[string]EnvOverlay) error {
-	for envName, env := range envs {
-		if len(env.Modules) > 0 {
-			continue
-		}
-
-		placeholderPath := "env." + formatConfigPathSegment(envName) + ".__dagger_empty_section__"
-		if err := doc.Set(placeholderPath, true); err != nil {
-			return fmt.Errorf("create env %q section: %w", envName, err)
-		}
-		if err := doc.Delete(placeholderPath); err != nil {
-			return fmt.Errorf("finalize env %q section: %w", envName, err)
-		}
-	}
-
-	return nil
-}
-
-func keepEmptyConfigSectionHeaders(cfg *Config) map[string]bool {
-	keep := map[string]bool{}
-	for envName, env := range cfg.Env {
-		if len(env.Modules) > 0 {
-			continue
-		}
-		keep["[env."+formatConfigPathSegment(envName)+"]"] = true
-	}
-	return keep
-}
-
-// rewriteSDKSections removes both beta-era [modules.*.as-sdk] declarations and
-// current [sdks.*] declarations, then appends the canonical top-level SDK
-// registry. SDK state is CLI-managed; everything else retains its formatting
-// and comments.
-func rewriteSDKSections(data []byte, sdks map[string]SDKEntry) ([]byte, error) {
-	doc, err := tomledit.Parse(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("parse config for SDK rewrite: %w", err)
-	}
-
-	stripSDKConfigItems(doc.Global)
-	kept := doc.Sections[:0]
-	for _, section := range doc.Sections {
-		if section.Heading != nil && isSDKConfigHeading(section.Heading.Name) {
-			continue
-		}
-		stripSDKConfigItems(section)
-		kept = append(kept, section)
-	}
-	doc.Sections = kept
-
-	var buf bytes.Buffer
-	var formatter tomledit.Formatter
-	if err := formatter.Format(&buf, doc); err != nil {
-		return nil, fmt.Errorf("format config after SDK rewrite: %w", err)
-	}
-	if len(sdks) > 0 {
-		if buf.Len() > 0 {
-			trimmed := bytes.TrimRight(buf.Bytes(), "\n")
-			buf.Reset()
-			buf.Write(trimmed)
-			buf.WriteString("\n\n")
-		}
-		var rendered strings.Builder
-		writeSDKEntries(&rendered, sdks)
-		buf.WriteString(rendered.String())
-	}
-	return buf.Bytes(), nil
-}
-
-func stripSDKConfigItems(section *tomledit.Section) {
-	if section == nil {
-		return
-	}
-	base := section.TableName()
-	kept := section.Items[:0]
-	for _, item := range section.Items {
-		kv, ok := item.(*parser.KeyValue)
-		if ok {
-			full := make([]string, 0, len(base)+len(kv.Name))
-			full = append(full, base...)
-			full = append(full, kv.Name...)
-			if isSDKConfigHeading(full) {
-				continue
-			}
-		}
-		kept = append(kept, item)
-	}
-	section.Items = kept
-}
-
-// isSDKConfigHeading reports canonical [sdks.*] sections and legacy
-// [modules.*.as-sdk] sections.
-func isSDKConfigHeading(key []string) bool {
-	if len(key) >= 1 && key[0] == "sdks" {
-		return true
-	}
-	return len(key) >= 3 && key[0] == "modules" && key[2] == "as-sdk"
-}
-
-func pruneUnwantedEmptySections(data []byte, keepEmptySections map[string]bool) ([]byte, error) {
-	doc, err := tomledit.Parse(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("parse rewritten config document: %w", err)
-	}
-
-	sections := doc.Sections[:0]
-	for _, section := range doc.Sections {
-		if len(section.Items) == 0 && !keepEmptySections[section.Heading.String()] {
-			continue
-		}
-		sections = append(sections, section)
-	}
-	doc.Sections = sections
-
-	var buf bytes.Buffer
-	var formatter tomledit.Formatter
-	if err := formatter.Format(&buf, doc); err != nil {
-		return nil, fmt.Errorf("format pruned config document: %w", err)
-	}
-	return buf.Bytes(), nil
 }
 
 // FormatConfigPathSegment formats one TOML dotted-key path segment.

--- a/core/workspace/config_document.go
+++ b/core/workspace/config_document.go
@@ -55,9 +55,10 @@ func updateConfigTable(data []byte, prefix []string, before, after map[string]an
 		var err error
 		oldMap, oldTable := old.(map[string]any)
 		newMap, newTable := value.(map[string]any)
-		if oldTable && !has && !configEntryPath(parts) {
+		if oldTable && !has && !configEntryPath(parts) && !configSettingsPath(parts) {
 			// Removing the last known field does not remove unknown siblings
-			// in the same table. Whole-entry removal is explicit below.
+			// in schema-owned tables. Whole-entry removal is explicit, and
+			// arbitrary settings include every key, so both can be removed whole.
 			data, err = updateConfigTable(data, parts, oldMap, nil)
 		} else if newTable && (!had || oldTable) {
 			data, err = updateConfigTable(data, parts, oldMap, newMap)
@@ -91,6 +92,16 @@ func configEntryPath(parts []string) bool {
 		return parts[0] == "modules" || parts[0] == "sdks" || parts[0] == "env" || parts[0] == "ports"
 	}
 	return len(parts) == 4 && (parts[0] == "sdks" && parts[2] == "scopes" || parts[0] == "env" && parts[2] == "modules")
+}
+
+// Settings maps include every user key, so absent tables within them must be
+// deleted rather than retained for potentially unknown schema fields.
+func configSettingsPath(parts []string) bool {
+	if len(parts) >= 3 && parts[0] == "modules" && parts[2] == "settings" {
+		return true
+	}
+	return len(parts) >= 5 && parts[4] == "settings" &&
+		(parts[0] == "sdks" && parts[2] == "scopes" || parts[0] == "env" && parts[2] == "modules")
 }
 
 func deleteConfigDocumentPath(data []byte, parts, collapsed []string) ([]byte, error) {

--- a/core/workspace/config_edit.go
+++ b/core/workspace/config_edit.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -439,6 +440,21 @@ func configValuesEqual(a, b any) bool {
 
 func renderConfigLiteral(value any) (string, error) {
 	switch v := value.(type) {
+	case json.Number:
+		// SDK settings retain JSON numbers when decoded. Preserve integer
+		// precision instead of routing every number through float64.
+		if strings.ContainsAny(v.String(), ".eE") {
+			n, err := v.Float64()
+			if err != nil {
+				return "", err
+			}
+			return renderConfigLiteral(n)
+		}
+		n, err := v.Int64()
+		if err != nil {
+			return "", err
+		}
+		return renderConfigLiteral(n)
 	case string:
 		return "\"" + string(scanner.Escape(v)) + "\"", nil
 	case bool:

--- a/core/workspace/config_edit.go
+++ b/core/workspace/config_edit.go
@@ -1,0 +1,631 @@
+package workspace
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/creachadair/tomledit/parser"
+	"github.com/creachadair/tomledit/scanner"
+	toml "github.com/pelletier/go-toml"
+)
+
+// configText retains the original bytes. The parser supplies logical keys;
+// the scanner supplies byte ranges. Neither is used to format the document.
+// Re-indexing after each edit keeps offsets local to one immutable input.
+type configText struct {
+	data       []byte
+	statements []configStatement
+}
+
+type configStatement struct {
+	path                 []string
+	section              []string
+	start, end           int
+	valueStart, valueEnd int
+	table, arrayTable    bool
+}
+
+type configToken struct {
+	kind       scanner.Token
+	start, end int
+}
+
+func configTokens(data []byte) ([]configToken, error) {
+	sc := scanner.New(bytes.NewReader(data))
+	var tokens []configToken
+	for {
+		err := sc.Next()
+		if err == io.EOF {
+			return tokens, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		span := sc.Span()
+		tokens = append(tokens, configToken{sc.Token(), span.Pos, span.End})
+	}
+}
+
+func parseConfigText(data []byte) (*configText, error) {
+	tokens, err := configTokens(data)
+	if err != nil {
+		return nil, fmt.Errorf("scan config: %w", err)
+	}
+	doc := &configText{data: data}
+	var section []string
+	start, depth := -1, 0
+	flush := func(end int) error {
+		if start < 0 {
+			return nil
+		}
+		first := tokens[start]
+		last := tokens[end-1]
+		items, err := parser.New(bytes.NewReader(data[first.start:last.end])).Items()
+		if err != nil {
+			return fmt.Errorf("parse config statement: %w", err)
+		}
+		if len(items) != 1 {
+			return fmt.Errorf("expected one config statement, got %d", len(items))
+		}
+		stmt := configStatement{start: configLineStart(data, first.start), end: last.end}
+		switch item := items[0].(type) {
+		case *parser.Heading:
+			section = slices.Clone(item.Name)
+			stmt.path, stmt.table, stmt.arrayTable = section, true, item.IsArray
+		case *parser.KeyValue:
+			stmt.path = append(slices.Clone(section), item.Name...)
+			stmt.section = slices.Clone(section)
+			for i := start; i < end; i++ {
+				if tokens[i].kind == scanner.Equal {
+					stmt.valueStart = tokens[i+1].start
+					break
+				}
+			}
+			for i := end - 1; i >= start; i-- {
+				if tokens[i].kind != scanner.Comment && tokens[i].kind != scanner.Newline {
+					stmt.valueEnd = tokens[i].end
+					break
+				}
+			}
+		default:
+			return fmt.Errorf("unsupported config statement %T", item)
+		}
+		doc.statements = append(doc.statements, stmt)
+		start = -1
+		return nil
+	}
+	for i, token := range tokens {
+		if start < 0 {
+			if token.kind == scanner.Comment || token.kind == scanner.Newline {
+				continue
+			}
+			start = i
+		}
+		switch token.kind {
+		case scanner.LBracket, scanner.LInline:
+			depth++
+		case scanner.RBracket, scanner.RInline:
+			depth--
+		}
+		// Comment tokens include their terminating newline.
+		if depth == 0 && (token.kind == scanner.Newline || token.kind == scanner.Comment) {
+			if err := flush(i + 1); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := flush(len(tokens)); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func configLineStart(data []byte, offset int) int {
+	return bytes.LastIndexByte(data[:offset], '\n') + 1
+}
+
+func configNewline(data []byte) string {
+	if i := bytes.IndexByte(data, '\n'); i > 0 && data[i-1] == '\r' {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+func configPathPrefix(path, prefix []string) bool {
+	return len(path) >= len(prefix) && slices.Equal(path[:len(prefix)], prefix)
+}
+
+func replaceConfigText(data []byte, start, end int, replacement string) []byte {
+	out := make([]byte, 0, len(data)-(end-start)+len(replacement))
+	out = append(out, data[:start]...)
+	out = append(out, replacement...)
+	return append(out, data[end:]...)
+}
+
+func (doc *configText) set(parts []string, value any) ([]byte, error) {
+	replaceTable := false
+	for _, stmt := range doc.statements {
+		if stmt.arrayTable && configPathPrefix(parts, stmt.path) {
+			return nil, fmt.Errorf("cannot edit %q inside an array of tables", JoinConfigPath(parts...))
+		}
+		if stmt.table {
+			if configPathPrefix(stmt.path, parts) {
+				replaceTable = true
+			}
+			continue
+		}
+		if slices.Equal(stmt.path, parts) {
+			rendered, err := renderConfigEdit(value, doc.data[stmt.valueStart:stmt.valueEnd])
+			if err != nil {
+				return nil, err
+			}
+			return replaceConfigText(doc.data, stmt.valueStart, stmt.valueEnd, rendered), nil
+		}
+		if configPathPrefix(parts, stmt.path) {
+			return doc.editInline(stmt, parts[len(stmt.path):], value, false)
+		}
+		if configPathPrefix(stmt.path, parts) {
+			replaceTable = true
+		}
+	}
+	if replaceTable {
+		updated, err := doc.remove(parts)
+		if err != nil {
+			return nil, err
+		}
+		doc, err = parseConfigText(updated)
+		if err != nil {
+			return nil, err
+		}
+		return doc.set(parts, value)
+	}
+
+	// Insert into an existing table, after its last assignment and before
+	// comments belonging to the next table. New tables are appended.
+	parent := parts[:len(parts)-1]
+	writtenKey := parts[len(parts)-1:]
+	position, found := 0, len(parent) == 0
+	for _, stmt := range doc.statements {
+		if stmt.table && slices.Equal(stmt.path, parent) {
+			position, found = stmt.end, true
+		}
+		if !stmt.table && slices.Equal(stmt.path[:len(stmt.path)-1], parent) {
+			position, found = stmt.end, true
+			writtenKey = parts[len(stmt.section):]
+		}
+	}
+	rendered, err := renderConfigEdit(value, nil)
+	if err != nil {
+		return nil, err
+	}
+	nl := configNewline(doc.data)
+	line := JoinConfigPath(writtenKey...) + " = " + rendered + nl
+	if !found {
+		return doc.appendTable(parent, line), nil
+	}
+	if position == 0 && len(parent) == 0 {
+		// Keep leading comments at the beginning of the file.
+		position = len(doc.data)
+		if len(doc.statements) > 0 {
+			position = doc.statements[0].start
+		}
+	}
+	if position > 0 && doc.data[position-1] != '\n' {
+		line = nl + line
+	}
+	return replaceConfigText(doc.data, position, position, line), nil
+}
+
+func (doc *configText) appendTable(parts []string, body string) []byte {
+	nl := configNewline(doc.data)
+	prefix := ""
+	if len(doc.data) > 0 {
+		if doc.data[len(doc.data)-1] != '\n' {
+			prefix += nl
+		}
+		if !bytes.HasSuffix(doc.data, []byte(nl+nl)) {
+			prefix += nl
+		}
+	}
+	return replaceConfigText(doc.data, len(doc.data), len(doc.data), prefix+"["+JoinConfigPath(parts...)+"]"+nl+body)
+}
+
+func (doc *configText) ensureTable(parts []string) ([]byte, error) {
+	for _, stmt := range doc.statements {
+		if configPathPrefix(stmt.path, parts) {
+			return doc.data, nil
+		}
+		if !stmt.table && configPathPrefix(parts, stmt.path) {
+			tree, err := toml.LoadBytes(doc.data)
+			if err != nil {
+				return nil, err
+			}
+			if tree.GetPath(parts) != nil {
+				return doc.data, nil
+			}
+			return doc.set(parts, map[string]any{})
+		}
+	}
+	return doc.appendTable(parts, ""), nil
+}
+
+func (doc *configText) remove(parts []string) ([]byte, error) {
+	out := doc.data
+	for i := len(doc.statements) - 1; i >= 0; i-- {
+		stmt := doc.statements[i]
+		if configPathPrefix(stmt.path, parts) {
+			out = replaceConfigText(out, stmt.start, stmt.end, "")
+		} else if !stmt.table && configPathPrefix(parts, stmt.path) {
+			return doc.editInline(stmt, parts[len(stmt.path):], nil, true)
+		}
+	}
+	return out, nil
+}
+
+// Inline tables are edited through a temporary table body. Only the resulting
+// value is spliced back; sibling fields retain their original bytes.
+func (doc *configText) editInline(stmt configStatement, parts []string, value any, remove bool) ([]byte, error) {
+	raw := doc.data[stmt.valueStart:stmt.valueEnd]
+	rendered, err := editInlineConfigValue(raw, parts, value, remove)
+	if err != nil {
+		return nil, err
+	}
+	return replaceConfigText(doc.data, stmt.valueStart, stmt.valueEnd, rendered), nil
+}
+
+func editInlineConfigValue(raw []byte, parts []string, value any, remove bool) (string, error) {
+	tokens, err := configTokens(raw)
+	if err != nil {
+		return "", err
+	}
+	if len(tokens) < 2 || tokens[0].kind != scanner.LInline {
+		return "", fmt.Errorf("cannot edit %q inside a scalar config value", JoinConfigPath(parts...))
+	}
+	// Split on commas belonging to this table, not to nested values.
+	start, depth := 1, 0
+	for i := 1; i < len(tokens); i++ {
+		tok := tokens[i]
+		if depth == 0 && (tok.kind == scanner.Comma || tok.kind == scanner.RInline) {
+			if i > start {
+				first, last := tokens[start].start, tokens[i-1].end
+				child, err := parseConfigText(raw[first:last])
+				if err != nil {
+					return "", err
+				}
+				if len(child.statements) != 1 {
+					return "", fmt.Errorf("invalid inline config entry")
+				}
+				entry := child.statements[0]
+				if configPathPrefix(parts, entry.path) || remove && configPathPrefix(entry.path, parts) {
+					if remove && configPathPrefix(entry.path, parts) {
+						if tok.kind == scanner.Comma {
+							last = tok.end
+						} else if start > 1 {
+							first = tokens[start-1].start
+						}
+						updated := replaceConfigText(raw, first, last, "")
+						// Dotted keys can define several entries under the
+						// removed table in one inline value.
+						return editInlineConfigValue(updated, parts, nil, true)
+					}
+					var updated []byte
+					if remove {
+						updated, err = child.remove(parts)
+					} else {
+						updated, err = child.set(parts, value)
+					}
+					if err != nil {
+						return "", err
+					}
+					return string(replaceConfigText(raw, tokens[start].start, tokens[i-1].end, string(updated))), nil
+				}
+			}
+			start = i + 1
+		}
+		switch tok.kind {
+		case scanner.LBracket, scanner.LInline:
+			depth++
+		case scanner.RBracket, scanner.RInline:
+			depth--
+		}
+	}
+	if remove {
+		return string(raw), nil
+	}
+	rendered, err := renderConfigEdit(value, nil)
+	if err != nil {
+		return "", err
+	}
+	separator := ""
+	if len(tokens) > 2 {
+		separator = ", "
+	}
+	at := tokens[len(tokens)-1].start
+	return string(replaceConfigText(raw, at, at, separator+JoinConfigPath(parts...)+" = "+rendered)), nil
+}
+
+func renderConfigEdit(value any, old []byte) (string, error) {
+	// Compare decoded values so []string and []any, and integer widths, have
+	// the same meaning. An unchanged value retains even unusual literal forms.
+	plain, err := renderConfigLiteral(value)
+	if err != nil {
+		return "", err
+	}
+	if len(old) > 0 {
+		before, beforeErr := toml.LoadBytes(append([]byte("v = "), old...))
+		after, afterErr := toml.Load("v = " + plain)
+		if beforeErr == nil && afterErr == nil && configValuesEqual(before.Get("v"), after.Get("v")) {
+			return string(old), nil
+		}
+	}
+	if text, ok := value.(string); ok && len(old) > 0 {
+		candidate := ""
+		switch {
+		case bytes.HasPrefix(old, []byte("'''")) && !strings.Contains(text, "'''"):
+			candidate = "'''" + configStringOpeningNewline(old) + text + "'''"
+		case bytes.HasPrefix(old, []byte("\"\"\"")):
+			candidate = "\"\"\"" + configStringOpeningNewline(old) + string(scanner.EscapeMultiline(text)) + "\"\"\""
+		case old[0] == '\'' && !strings.ContainsRune(text, '\''):
+			candidate = "'" + text + "'"
+		}
+		if candidate != "" {
+			// Literal strings cannot contain every control character, and
+			// multiline strings trim an initial newline. Keep the style only
+			// if it represents the requested value without changing it.
+			if _, err := parser.ParseValue(candidate); err == nil {
+				if decoded, err := toml.Load("v = " + candidate); err == nil && decoded.Get("v") == text {
+					return candidate, nil
+				}
+			}
+		}
+	}
+	v := reflect.ValueOf(value)
+	if v.IsValid() && (v.Kind() == reflect.Slice || v.Kind() == reflect.Array) && len(old) > 0 && old[0] == '[' {
+		return renderConfigArray(v, old)
+	}
+	return plain, nil
+}
+
+// TOML tree positions and NaN's Go equality rules do not change a value's
+// meaning. Ignore them when deciding whether an edit is necessary.
+func configValuesEqual(a, b any) bool {
+	if tree, ok := a.(*toml.Tree); ok {
+		a = tree.ToMap()
+	}
+	if tree, ok := b.(*toml.Tree); ok {
+		b = tree.ToMap()
+	}
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
+	switch a := a.(type) {
+	case float64:
+		b, ok := b.(float64)
+		return ok && math.IsNaN(a) && math.IsNaN(b)
+	case map[string]any:
+		b, ok := b.(map[string]any)
+		if !ok || len(a) != len(b) {
+			return false
+		}
+		for key, value := range a {
+			other, ok := b[key]
+			if !ok || !configValuesEqual(value, other) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		b, ok := b.([]any)
+		if !ok || len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if !configValuesEqual(a[i], b[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func renderConfigLiteral(value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return "\"" + string(scanner.Escape(v)) + "\"", nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	case time.Time:
+		return v.Format(time.RFC3339Nano), nil
+	}
+	v := reflect.ValueOf(value)
+	if !v.IsValid() {
+		return "", fmt.Errorf("cannot write a null TOML value")
+	}
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(v.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		f := v.Float()
+		if math.IsNaN(f) {
+			return "nan", nil
+		}
+		if math.IsInf(f, 1) {
+			return "inf", nil
+		}
+		if math.IsInf(f, -1) {
+			return "-inf", nil
+		}
+		text := strconv.FormatFloat(f, 'g', -1, v.Type().Bits())
+		if !strings.ContainsAny(text, ".eE") {
+			text += ".0"
+		}
+		return text, nil
+	case reflect.Slice, reflect.Array:
+		items := make([]string, v.Len())
+		for i := range items {
+			var err error
+			items[i], err = renderConfigLiteral(v.Index(i).Interface())
+			if err != nil {
+				return "", err
+			}
+		}
+		return "[" + strings.Join(items, ", ") + "]", nil
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String {
+			break
+		}
+		var keys []string
+		for _, key := range v.MapKeys() {
+			keys = append(keys, key.String())
+		}
+		sort.Strings(keys)
+		var entries []string
+		for _, key := range keys {
+			text, err := renderConfigLiteral(v.MapIndex(reflect.ValueOf(key).Convert(v.Type().Key())).Interface())
+			if err != nil {
+				return "", err
+			}
+			entries = append(entries, formatConfigPathSegment(key)+" = "+text)
+		}
+		return "{" + strings.Join(entries, ", ") + "}", nil
+	}
+	return "", fmt.Errorf("unsupported TOML value %T", value)
+}
+
+func renderConfigArray(value reflect.Value, old []byte) (string, error) {
+	tokens, err := configTokens(old)
+	if err != nil {
+		return "", err
+	}
+	var elements []configToken
+	start, depth := -1, 0
+	for i := 1; i < len(tokens)-1; i++ {
+		token := tokens[i]
+		if start < 0 {
+			if token.kind == scanner.Comment || token.kind == scanner.Newline || token.kind == scanner.Comma {
+				continue
+			}
+			start = i
+		}
+		switch token.kind {
+		case scanner.LBracket, scanner.LInline:
+			depth++
+		case scanner.RBracket, scanner.RInline:
+			depth--
+		}
+		if depth == 0 {
+			elements = append(elements, configToken{start: tokens[start].start, end: token.end})
+			start = -1
+		}
+	}
+	out := old
+	if value.Len() > len(elements) {
+		out, err = appendConfigArray(value, old, tokens, elements)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	for i := len(elements) - 1; i >= 0; i-- {
+		element := elements[i]
+		if i < value.Len() {
+			text, err := renderConfigEdit(value.Index(i).Interface(), old[element.start:element.end])
+			if err != nil {
+				return "", err
+			}
+			out = replaceConfigText(out, element.start, element.end, text)
+		} else {
+			for _, tok := range tokens {
+				if tok.start < element.end || tok.kind == scanner.Comment || tok.kind == scanner.Newline {
+					continue
+				}
+				if tok.kind == scanner.Comma {
+					// A comment can separate a value from its comma.
+					out = replaceConfigText(out, tok.start, tok.end, "")
+				}
+				break
+			}
+			out = replaceConfigText(out, element.start, element.end, "")
+		}
+	}
+	return string(out), nil
+}
+
+// appendConfigArray retains the existing layout, elements, and comments.
+func appendConfigArray(value reflect.Value, old []byte, tokens, elements []configToken) ([]byte, error) {
+	out := old
+	at := len(old) - 1
+	separator, suffix := ", ", ""
+	hasComma := false
+	if len(elements) > 0 {
+		last := elements[len(elements)-1]
+		for _, tok := range tokens {
+			if tok.start >= last.end && tok.kind == scanner.Comma {
+				hasComma = true
+			}
+		}
+	}
+	multiline := bytes.ContainsRune(old, '\n')
+	if multiline {
+		at = configLineStart(old, at)
+		if len(bytes.TrimSpace(old[at:len(old)-1])) != 0 {
+			at = len(old) - 1
+		}
+		indent := "  "
+		if len(elements) > 0 {
+			leading := old[configLineStart(old, elements[0].start):elements[0].start]
+			if len(bytes.TrimSpace(leading)) == 0 {
+				indent = string(leading)
+			}
+		}
+		separator, suffix = indent, ","+configNewline(old)
+	}
+	var added strings.Builder
+	for i := len(elements); i < value.Len(); i++ {
+		text, err := renderConfigLiteral(value.Index(i).Interface())
+		if err != nil {
+			return nil, err
+		}
+		if multiline {
+			added.WriteString(separator)
+		} else if i == len(elements) && hasComma {
+			added.WriteString(" ")
+		} else if i > 0 {
+			added.WriteString(separator)
+		}
+		added.WriteString(text)
+		added.WriteString(suffix)
+	}
+	if !multiline && hasComma {
+		added.WriteString(",")
+	}
+	out = replaceConfigText(out, at, at, added.String())
+	if len(elements) > 0 {
+		last := elements[len(elements)-1]
+		if multiline && !hasComma {
+			out = replaceConfigText(out, last.end, last.end, ",")
+		}
+	}
+	return out, nil
+}
+
+func configStringOpeningNewline(old []byte) string {
+	if bytes.HasPrefix(old[3:], []byte("\r\n")) {
+		return "\r\n"
+	}
+	if bytes.HasPrefix(old[3:], []byte("\n")) {
+		return "\n"
+	}
+	return ""
+}

--- a/core/workspace/config_json_numbers_test.go
+++ b/core/workspace/config_json_numbers_test.go
@@ -1,0 +1,33 @@
+package workspace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateConfigJSONNumbers(t *testing.T) {
+	const input = "[modules.sdk]\nsource = './sdk'\n\n[sdks.test]\nmodule = 'sdk'\n"
+	cfg, err := ParseConfig([]byte(input))
+	require.NoError(t, err)
+	var settings map[string]any
+	decoder := json.NewDecoder(strings.NewReader(`{"integer":42,"large":9223372036854775807,"negative":-42,"float":1.5,"exponent":1e3,"array":[1,2.5],"nested":{"number":3}}`))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&settings))
+	entry := cfg.SDKs["test"]
+	entry.Scopes = map[string]SDKScope{"demo": {Settings: settings}}
+	cfg.SDKs["test"] = entry
+	out, err := UpdateConfigBytes([]byte(input), cfg)
+	require.NoError(t, err)
+	parsed, err := ParseConfig(out)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"integer": int64(42), "large": int64(9223372036854775807),
+		"negative": int64(-42), "float": float64(1.5), "exponent": float64(1000),
+		"array":  []any{int64(1), float64(2.5)},
+		"nested": map[string]any{"number": int64(3)},
+	}, parsed.SDKs["test"].Scopes["demo"].Settings)
+	require.Contains(t, string(out), "source = './sdk'")
+}

--- a/core/workspace/config_preservation_test.go
+++ b/core/workspace/config_preservation_test.go
@@ -1,0 +1,355 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const preservationConfig = `# Workspace notes
+ignore = [
+    'dist', # generated output
+    "node_modules",
+]
+defaults_from_dotenv = false
+future = { enabled = true }
+
+[modules."my.module"] # module notes
+source = './module'
+entrypoint = false # keep this comment
+pin = 'abc123'
+future = [1, 2]
+
+[modules."my.module".as-sdk]
+name = 'legacy'
+
+[modules."my.module".settings]
+"some.key" = 'old' # setting notes
+empty = []
+
+[sdks.go]
+module = 'my.module'
+
+[sdks.go.scopes."."]
+is-module = false
+clients = [
+  'one', # client notes
+  'two',
+]
+
+[ports.3000]
+backendService = 'web'
+backendPort = 8080
+
+# Keep this environment
+[env.local]
+`
+
+func TestConfigPreservation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unchanged config is byte identical", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(preservationConfig))
+		require.NoError(t, err)
+		out, err := UpdateConfigBytes([]byte(preservationConfig), cfg)
+		require.NoError(t, err)
+		require.Equal(t, preservationConfig, string(out))
+	})
+
+	t.Run("set one value", func(t *testing.T) {
+		out, err := WriteConfigValue([]byte(preservationConfig), `modules."my.module".entrypoint`, "true")
+		require.NoError(t, err)
+		want := strings.Replace(preservationConfig, "entrypoint = false", "entrypoint = true", 1)
+		require.Equal(t, want, string(out))
+		again, err := WriteConfigValue(out, `modules."my.module".entrypoint`, "true")
+		require.NoError(t, err)
+		require.Equal(t, out, again)
+	})
+
+	t.Run("quoted setting keeps quotes and comment", func(t *testing.T) {
+		out, err := WriteConfigValue([]byte(preservationConfig), `modules."my.module".settings."some.key"`, "new")
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(preservationConfig, "'old'", "'new'", 1), string(out))
+	})
+
+	t.Run("unset one value", func(t *testing.T) {
+		out, err := DeleteConfigValue([]byte(preservationConfig), `modules."my.module".entrypoint`)
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(preservationConfig, "entrypoint = false # keep this comment\n", "", 1), string(out))
+	})
+
+	t.Run("SDK edit preserves other declarations", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(preservationConfig))
+		require.NoError(t, err)
+		sdk := cfg.SDKs["go"]
+		scope := sdk.Scopes["."]
+		scope.IsModule = true
+		sdk.Scopes["."] = scope
+		cfg.SDKs["go"] = sdk
+		out, err := UpdateConfigBytes([]byte(preservationConfig), cfg)
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(preservationConfig, "is-module = false", "is-module = true", 1), string(out))
+	})
+
+	t.Run("numeric key edit", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(preservationConfig))
+		require.NoError(t, err)
+		port := cfg.Ports["3000"]
+		port.BackendPort = 9090
+		cfg.Ports["3000"] = port
+		out, err := UpdateConfigBytes([]byte(preservationConfig), cfg)
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(preservationConfig, "8080", "9090", 1), string(out))
+	})
+
+	t.Run("line endings and missing final newline", func(t *testing.T) {
+		input := strings.ReplaceAll(strings.TrimSuffix(preservationConfig, "\n"), "\n", "\r\n")
+		out, err := WriteConfigValue([]byte(input), `modules."my.module".entrypoint`, "true")
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(input, "entrypoint = false", "entrypoint = true", 1), string(out))
+	})
+
+	t.Run("explicit default is written", func(t *testing.T) {
+		input := "# empty workspace\n"
+		out, err := WriteConfigValue([]byte(input), "defaults_from_dotenv", "false")
+		require.NoError(t, err)
+		require.Equal(t, input+"defaults_from_dotenv = false\n", string(out))
+	})
+
+	t.Run("changed array keeps layout and comments", func(t *testing.T) {
+		out, err := WriteConfigValues([]byte(preservationConfig), "ignore", []string{"dist", "vendor"})
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(preservationConfig, `"node_modules"`, `"vendor"`, 1), string(out))
+	})
+
+	t.Run("adding a module preserves existing text", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(preservationConfig))
+		require.NoError(t, err)
+		cfg.Modules["new"] = ModuleEntry{Source: "./new"}
+		out, err := UpdateConfigBytes([]byte(preservationConfig), cfg)
+		require.NoError(t, err)
+		require.Equal(t, preservationConfig+"\n[modules.new]\nsource = \"./new\"\n", string(out))
+		parsed, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.Equal(t, cfg, parsed)
+	})
+
+	t.Run("removal includes unknown fields in removed module", func(t *testing.T) {
+		input := "# keep\n[modules.old]\nsource = './old'\nfuture = true\n[modules.old.as-sdk]\nname = 'old'\n\n[modules.kept]\nsource = './kept'\nfuture = 'kept'\n"
+		cfg, err := ParseConfig([]byte(input))
+		require.NoError(t, err)
+		delete(cfg.Modules, "old")
+		out, err := UpdateConfigBytes([]byte(input), cfg)
+		require.NoError(t, err)
+		require.Equal(t, "# keep\n\n[modules.kept]\nsource = './kept'\nfuture = 'kept'\n", string(out))
+	})
+}
+
+func TestConfigPreservationSyntax(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, input, key, value, want string
+		remove                        bool
+	}{
+		{
+			name:  "dotted module at root",
+			input: "modules.foo.source = './foo'\n# keep\n",
+			key:   "modules.foo.entrypoint", value: "true",
+			want: "modules.foo.source = './foo'\nmodules.foo.entrypoint = true\n# keep\n",
+		},
+		{
+			name:  "dotted module in table",
+			input: "[modules]\nfoo.source = './foo'\n",
+			key:   "modules.foo.entrypoint", value: "true",
+			want: "[modules]\nfoo.source = './foo'\nfoo.entrypoint = true\n",
+		},
+		{
+			name:  "inline module",
+			input: "[modules]\nfoo = {source = './foo', entrypoint = false} # keep\n",
+			key:   "modules.foo.entrypoint", value: "true",
+			want: "[modules]\nfoo = {source = './foo', entrypoint = true} # keep\n",
+		},
+		{
+			name:  "nested inline addition",
+			input: "modules = {foo = {source = './foo'}}\n",
+			key:   "modules.foo.entrypoint", value: "true",
+			want: "modules = {foo = {source = './foo', entrypoint = true}}\n",
+		},
+		{
+			name:  "inline removal",
+			input: "[modules]\nfoo = {source = './foo', entrypoint = false}\n",
+			key:   "modules.foo.entrypoint", remove: true,
+			want: "[modules]\nfoo = {source = './foo'}\n",
+		},
+		{
+			name:  "whitespace in quoted path",
+			input: "[ modules . 'my.module' ]\nsource = './foo'\nentrypoint = false\n",
+			key:   `modules."my.module".entrypoint`, value: "true",
+			want: "[ modules . 'my.module' ]\nsource = './foo'\nentrypoint = true\n",
+		},
+		{
+			name:  "unknown array of tables",
+			input: "defaults_from_dotenv = false\n[[future]]\nvalue = 1\n[[future]]\nvalue = 2\n",
+			key:   "defaults_from_dotenv", value: "true",
+			want: "defaults_from_dotenv = true\n[[future]]\nvalue = 1\n[[future]]\nvalue = 2\n",
+		},
+		{
+			name:  "multiline string with config syntax",
+			input: "[modules.foo]\nsource = './foo'\n[modules.foo.settings]\ntext = '''\n[not-a-table]\nkey = 'value'\n'''\nenabled = false\n",
+			key:   "modules.foo.settings.enabled", value: "true",
+			want: "[modules.foo]\nsource = './foo'\n[modules.foo.settings]\ntext = '''\n[not-a-table]\nkey = 'value'\n'''\nenabled = true\n",
+		},
+		{
+			name:  "replace expanded table with scalar",
+			input: "[modules.foo]\nsource = './foo'\n[modules.foo.settings.value]\nnested = true\n",
+			key:   "modules.foo.settings.value", value: "replacement",
+			want: "[modules.foo]\nsource = './foo'\n\n[modules.foo.settings]\nvalue = \"replacement\"\n",
+		},
+		{
+			name:  "replace dotted table with scalar",
+			input: "[modules.foo]\nsource = './foo'\nsettings.value.nested = true\n",
+			key:   "modules.foo.settings.value", value: "replacement",
+			want: "[modules.foo]\nsource = './foo'\n\n[modules.foo.settings]\nvalue = \"replacement\"\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out []byte
+			var err error
+			if tc.remove {
+				out, err = DeleteConfigValue([]byte(tc.input), tc.key)
+			} else {
+				out, err = WriteConfigValue([]byte(tc.input), tc.key, tc.value)
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(out))
+		})
+	}
+}
+
+func TestConfigPreservationArrays(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, array string
+		value       []string
+	}{
+		{"append", `['one']`, []string{"one", "two"}},
+		{"append with trailing comma", `['one',]`, []string{"one", "two"}},
+		{"append to empty", `[]`, []string{"one"}},
+		{"append to empty multiline", "[\n]", []string{"one"}},
+		{"append with comment", "[\n 'one' # keep\n]", []string{"one", "two"}},
+		{"append with closing bracket on same line", "[\n 'one']", []string{"one", "two"}},
+		{"remove all", `['one', 'two']`, []string{}},
+		{"remove with comment", "[\n 'one', # keep\n 'two',\n]", []string{"one"}},
+		{"remove with comment before comma", "[\n 'one' # keep\n , 'two',\n]", []string{}},
+		{"replace and append", `['one']`, []string{"new", "two"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := "# before\nignore = " + tc.array + " # after\nfuture = 'keep'\n"
+			out, err := WriteConfigValues([]byte(input), "ignore", tc.value)
+			require.NoError(t, err)
+			parsed, err := ParseConfig(out)
+			require.NoError(t, err)
+			require.Equal(t, tc.value, parsed.Ignore)
+			require.True(t, strings.HasPrefix(string(out), "# before\nignore = "))
+			require.True(t, strings.HasSuffix(string(out), " # after\nfuture = 'keep'\n"))
+			if strings.Contains(tc.array, "# keep") {
+				require.Contains(t, string(out), "# keep")
+			}
+			if strings.Contains(tc.array, "\n") {
+				require.Contains(t, string(out), "ignore = [\n")
+			}
+			again, err := WriteConfigValues(out, "ignore", tc.value)
+			require.NoError(t, err)
+			require.Equal(t, out, again)
+		})
+	}
+}
+
+func TestConfigPreservationUnknownSibling(t *testing.T) {
+	input := "[modules.foo]\nsource = './foo'\n[modules.foo.check]\nskip = ['slow']\nfuture = 'keep'\n"
+	cfg, err := ParseConfig([]byte(input))
+	require.NoError(t, err)
+	entry := cfg.Modules["foo"]
+	entry.Check.Skip = nil
+	cfg.Modules["foo"] = entry
+	out, err := UpdateConfigBytes([]byte(input), cfg)
+	require.NoError(t, err)
+	require.Equal(t, strings.Replace(input, "skip = ['slow']\n", "", 1), string(out))
+}
+
+func TestConfigPreservationInlineRemoval(t *testing.T) {
+	input := "modules = {old.source = './old', old.future = true, kept.source = './kept'} # keep\n"
+	cfg, err := ParseConfig([]byte(input))
+	require.NoError(t, err)
+	delete(cfg.Modules, "old")
+	out, err := UpdateConfigBytes([]byte(input), cfg)
+	require.NoError(t, err)
+	require.Equal(t, "modules = {  kept.source = './kept'} # keep\n", string(out))
+	parsed, err := ParseConfig(out)
+	require.NoError(t, err)
+	require.Equal(t, cfg, parsed)
+}
+
+func TestConfigPreservationStringStyles(t *testing.T) {
+	for _, tc := range []struct{ old, value, want string }{
+		{"'old'", "new", "'new'"},
+		{"'''\nold'''", "new\nvalue", "'''\nnew\nvalue'''"},
+		{"\"\"\"\nold\"\"\"", "new\nvalue", "\"\"\"\nnew\nvalue\"\"\""},
+		{"'old'", "quote'value", "\"quote'value\""},
+		{"'old'", "control\x1f", "\"control\\u001f\""},
+		{"'''old'''", "\nnew", "\"\\nnew\""},
+		{"\"\"\"old\"\"\"", "\nnew", "\"\\nnew\""},
+	} {
+		t.Run(tc.old+tc.value, func(t *testing.T) {
+			input := "[modules.foo]\nsource = './foo'\n[modules.foo.settings]\ntext = " + tc.old + " # keep\n"
+			out, err := WriteConfigValue([]byte(input), "modules.foo.settings.text", tc.value)
+			require.NoError(t, err)
+			require.Equal(t, strings.Replace(input, tc.old, tc.want, 1), string(out))
+			cfg, err := ParseConfig(out)
+			require.NoError(t, err)
+			require.Equal(t, tc.value, cfg.Modules["foo"].Settings["text"])
+		})
+	}
+}
+
+func FuzzConfigPreservation(f *testing.F) {
+	for _, input := range []string{
+		preservationConfig,
+		"defaults_from_dotenv = false # final comment",
+		"[modules.foo]\nsource = './foo'\n[modules.foo.settings]\nvalue = +nan\n",
+		"modules = {foo = {source = './foo'}}\n",
+		"future = [{key = 'value'}]\n",
+	} {
+		f.Add(input)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		cfg, err := ParseConfig([]byte(input))
+		if err != nil {
+			return
+		}
+		out, err := UpdateConfigBytes([]byte(input), cfg)
+		require.NoError(t, err)
+		require.Equal(t, input, string(out))
+		// Editing a supported root field must either leave the input alone
+		// with an error, or produce a valid config with the requested value.
+		out, err = WriteConfigValue([]byte(input), "defaults_from_dotenv", "true")
+		if err != nil {
+			require.Nil(t, out)
+			return
+		}
+		changed, err := ParseConfig(out)
+		require.NoError(t, err)
+		require.True(t, changed.DefaultsFromDotEnv)
+	})
+}
+
+func TestConfigPreservationInlineEnvironment(t *testing.T) {
+	input := "modules = {foo = {source = './foo'}}\nenv = {ci = {modules = {foo = {settings = {value = 'old'}}}}}\n"
+	out, err := DeleteConfigValue([]byte(input), "env.ci.modules.foo.settings.value")
+	require.NoError(t, err)
+	require.Equal(t, "modules = {foo = {source = './foo'}}\nenv = {ci = {}}\n", string(out))
+	cfg, err := ParseConfig(out)
+	require.NoError(t, err)
+	require.Contains(t, cfg.Env, "ci")
+}

--- a/core/workspace/config_settings_removal_test.go
+++ b/core/workspace/config_settings_removal_test.go
@@ -1,0 +1,48 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateConfigRemovesTableSettings(t *testing.T) {
+	for _, location := range []struct {
+		name, prefix string
+		settings     func(*Config) map[string]any
+	}{
+		{"module", "modules.foo", func(cfg *Config) map[string]any { return cfg.Modules["foo"].Settings }},
+		{"environment", "env.ci.modules.foo", func(cfg *Config) map[string]any { return cfg.Env["ci"].Modules["foo"].Settings }},
+		{"sdk", "sdks.test.scopes.demo", func(cfg *Config) map[string]any { return cfg.SDKs["test"].Scopes["demo"].Settings }},
+	} {
+		for _, replacement := range []string{"remove", "remove with sibling", "empty object"} {
+			t.Run(location.name+"/"+replacement, func(t *testing.T) {
+				input := "[modules.foo]\nsource = './foo'\nfuture = 'keep'\n\n[sdks.test]\nmodule = 'foo'\n\n[" + location.prefix + ".settings.options.nested]\nenabled = true\n"
+				if replacement == "remove with sibling" {
+					input += "\n[" + location.prefix + ".settings]\nsibling = 'keep'\n"
+				}
+				cfg, err := ParseConfig([]byte(input))
+				require.NoError(t, err)
+				settings := location.settings(cfg)
+				if replacement != "empty object" {
+					delete(settings, "options")
+				} else {
+					settings["options"] = map[string]any{}
+				}
+				out, err := UpdateConfigBytes([]byte(input), cfg)
+				require.NoError(t, err)
+				parsed, err := ParseConfig(out)
+				require.NoError(t, err)
+				if replacement != "empty object" {
+					require.NotContains(t, location.settings(parsed), "options")
+				} else {
+					require.Equal(t, map[string]any{}, location.settings(parsed)["options"])
+				}
+				if replacement == "remove with sibling" {
+					require.Equal(t, "keep", location.settings(parsed)["sibling"])
+				}
+				require.Contains(t, string(out), "future = 'keep'")
+			})
+		}
+	}
+}


### PR DESCRIPTION
Config edits can change unrelated text and remove unsupported fields. Change only the requested fields. Preserve all other text.

Part of #14110.
