### PR TITLE
Migrate legacy SDK fields in workspace configuration

### DIFF
--- a/core/integration/workspace_migration_config_test.go
+++ b/core/integration/workspace_migration_config_test.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"context"
+	"strings"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceMigrationSuite) TestWorkspaceMigrateNativeConfig(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	original := `# workspace
+ignore = [
+  'node_modules', # keep
+]
+future = true
+
+[modules.app]
+source = './app'
+
+[modules.dagger-custom-sdk]
+source = './sdk' # keep
+
+[modules.dagger-custom-sdk.as-sdk]
+name = 'custom'
+[[modules.dagger-custom-sdk.as-sdk.modules]]
+path = './app'
+[[modules.dagger-custom-sdk.as-sdk.clients]]
+path = './client'
+module = './app'
+package = 'bindings'
+`
+	base := workspaceBase(t, c).
+		WithNewFile("dagger.toml", original).
+		WithNewFile("sdk/dagger-module.toml", "name = 'custom-sdk'\n").
+		WithNewFile("app/dagger.json", `{"name":"app","sdk":"../sdk"}`).
+		WithNewFile("child/dagger.json", `{"name":"child","sdk":{"source":"go"}}`).
+		WithNewFile("child/main.go", "package main\ntype Child struct{}\n")
+
+	t.Run("required module conflict leaves all files unchanged", func(ctx context.Context, t *testctx.T) {
+		legacy := `{"name":"app","sdk":"go"}`
+		failed := base.WithNewFile("app/dagger.json", legacy).
+			With(daggerExecFail("ws", "migrate", "--auto-apply"))
+		out, err := failed.CombinedOutput(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "belongs to SDK")
+		data, err := failed.File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, original, data)
+		data, err = failed.File("app/dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, legacy, data)
+	})
+
+	preview := base.With(daggerExec("ws", "migrate", "--no-apply"))
+	out, err := preview.CombinedOutput(ctx)
+	require.NoError(t, err, out)
+	require.Contains(t, out, "dagger.toml")
+	unchanged, err := preview.File("dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, original, unchanged)
+	legacyApp, err := preview.File("app/dagger.json").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"app","sdk":"../sdk"}`, legacyApp)
+
+	applied := preview.With(daggerExec("ws", "migrate", "--auto-apply"))
+	out, err = applied.CombinedOutput(ctx)
+	require.NoError(t, err, out)
+	updated, err := applied.File("dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(updated, strings.Split(original, "[modules.dagger-custom-sdk.as-sdk]")[0]))
+	require.NotContains(t, updated, "as-sdk")
+	cfg, err := workspace.ParseConfig([]byte(updated))
+	require.NoError(t, err)
+	require.Equal(t, "dagger-custom-sdk", cfg.SDKs["custom"].Module)
+	require.True(t, cfg.SDKs["custom"].Scopes["./app"].IsModule)
+	require.Equal(t, []string{"./app"}, cfg.SDKs["custom"].Scopes["./client"].Clients)
+	require.Equal(t, map[string]any{"package": "bindings"}, cfg.SDKs["custom"].Scopes["./client"].Settings)
+	nativeApp, err := applied.File("app/dagger-module.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Contains(t, nativeApp, `name = "app"`)
+	_, err = applied.File("app/dagger.json").Contents(ctx)
+	require.Error(t, err)
+	legacyChild, err := applied.File("child/dagger.json").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"child","sdk":{"source":"go"}}`, legacyChild)
+
+	again := applied.With(daggerExec("ws", "migrate", "--auto-apply"))
+	repeated, err := again.File("dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, updated, repeated)
+	empty, err := again.WithExec([]string{"dagger", "query"}, dagger.ContainerWithExecOpts{
+		Stdin:                         `{currentWorkspace { migrate { changes { isEmpty } } }}`,
+		ExperimentalPrivilegedNesting: true,
+	}).Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, empty, `"isEmpty": true`)
+}
+
+func (WorkspaceMigrationSuite) TestWorkspaceUnsupportedConfigWarning(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	original := `[modules.provider]
+source = './sdk'
+future = true
+[modules.provider.as-sdk]
+name = 'custom'
+[modules.provider.settings]
+arbitrary = { nested = true }
+`
+	ctr := workspaceBase(t, c).
+		WithNewFile("dagger.toml", original).
+		With(daggerExec("ws", "config"))
+	out, err := ctr.CombinedOutput(ctx)
+	require.NoError(t, err, out)
+	require.Contains(t, out, "dagger.toml:4:1: unsupported field modules.provider.as-sdk is ignored")
+	require.Contains(t, out, "dagger ws migrate")
+	require.Contains(t, out, "unsupported field modules.provider.future")
+	require.NotContains(t, out, "unsupported field modules.provider.settings")
+	unchanged, err := ctr.File("dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, original, unchanged)
+}

--- a/core/schema/workspace_migrate_config.go
+++ b/core/schema/workspace_migrate_config.go
@@ -1,0 +1,42 @@
+package schema
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/workspace"
+)
+
+// Migrate the selected config before the installed-module phase. Both phases
+// share the same snapshot and are exported as one reviewed changeset.
+func (stage *workspaceMigrationStage) migrateConfig(ctx context.Context) error {
+	data, err := core.DirectoryReadFile(ctx, stage.staged, filepath.ToSlash(stage.configPath))
+	if err != nil {
+		return err
+	}
+	updated, err := workspace.MigrateConfigBytes(data, filepath.Dir(stage.configPath))
+	if err != nil {
+		return fmt.Errorf("migrate %s: %w", stage.configPath, err)
+	}
+	if bytes.Equal(data, updated) {
+		return nil
+	}
+	after, err := withWorkspaceMigrationFile(ctx, stage.staged, stage.configPath, updated, "migrate SDK configuration")
+	if err != nil {
+		return err
+	}
+	changes, err := workspaceMigrationChanges(ctx, after, stage.staged)
+	if err != nil {
+		return err
+	}
+	stage.staged = after
+	stage.legacy.Steps = append(stage.legacy.Steps, &core.WorkspaceMigrationStep{
+		Code:        "legacy-sdk-config",
+		Description: "Moved legacy SDK configuration to sdks",
+		Changes:     changes.Self(),
+	})
+	return nil
+}

--- a/core/schema/workspace_migrate_config.go
+++ b/core/schema/workspace_migrate_config.go
@@ -36,7 +36,7 @@ func (stage *workspaceMigrationStage) migrateConfig(ctx context.Context) error {
 	stage.legacy.Steps = append(stage.legacy.Steps, &core.WorkspaceMigrationStep{
 		Code:        "legacy-sdk-config",
 		Description: "Moved legacy SDK configuration to sdks",
-		Changes:     changes.Self(),
+		Changes:     changes,
 	})
 	return nil
 }

--- a/core/schema/workspace_migrate_modules.go
+++ b/core/schema/workspace_migrate_modules.go
@@ -34,6 +34,9 @@ func (s *workspaceSchema) migrate(ctx context.Context, ws *core.Workspace, args 
 	if stage.configPath == "" {
 		return stage.legacy, nil
 	}
+	if err := stage.migrateConfig(ctx); err != nil {
+		return nil, err
+	}
 	planner, err := s.newModuleMigrationPlanner(ctx, ws, stage.staged, stage.configPath)
 	if err != nil {
 		return nil, err

--- a/core/workspace/config_diagnostics.go
+++ b/core/workspace/config_diagnostics.go
@@ -30,11 +30,8 @@ func ConfigWarnings(data []byte, filename string) ([]string, error) {
 				if name != "" && name != "-" {
 					// Match go-toml's field lookup order, including accepted
 					// case variants. Only the first present key is consumed.
-					for _, key := range []string{name, strings.ToLower(name), strings.ToTitle(name), strings.ToLower(name[:1]) + name[1:]} {
-						if tree.HasPath([]string{key}) {
-							fields[key] = field.Type
-							break
-						}
+					if key, ok := configDecoderKey(tree, name); ok {
+						fields[key] = field.Type
 					}
 				}
 			}
@@ -64,6 +61,28 @@ func ConfigWarnings(data []byte, filename string) ([]string, error) {
 }
 
 func legacySDKConfigPath(parts []string) bool {
-	return len(parts) == 3 && parts[0] == "modules" && parts[2] == "as-sdk" ||
-		len(parts) == 5 && parts[0] == "env" && parts[2] == "modules" && parts[4] == "as-sdk"
+	return len(parts) == 3 && configDecoderKeyMatches(parts[0], "modules") && configDecoderKeyMatches(parts[2], "as-sdk") ||
+		len(parts) == 5 && configDecoderKeyMatches(parts[0], "env") && configDecoderKeyMatches(parts[2], "modules") && configDecoderKeyMatches(parts[4], "as-sdk")
+}
+
+// configDecoderKey returns the key go-toml consumes for a tagged struct field.
+// Keep this order synchronized with go-toml's Decoder.valueFromTree.
+func configDecoderKey(tree *toml.Tree, name string) (string, bool) {
+	if tree == nil {
+		return "", false
+	}
+	for _, key := range configDecoderKeys(name) {
+		if tree.HasPath([]string{key}) {
+			return key, true
+		}
+	}
+	return "", false
+}
+
+func configDecoderKeyMatches(key, name string) bool {
+	return slices.Contains(configDecoderKeys(name), key)
+}
+
+func configDecoderKeys(name string) []string {
+	return []string{name, strings.ToLower(name), strings.ToTitle(name), strings.ToLower(name[:1]) + name[1:]}
 }

--- a/core/workspace/config_diagnostics.go
+++ b/core/workspace/config_diagnostics.go
@@ -1,0 +1,69 @@
+package workspace
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	toml "github.com/pelletier/go-toml"
+)
+
+// ConfigWarnings reports unsupported workspace fields without interpreting them.
+// Settings maps belong to modules and SDKs, so their contents are unrestricted.
+func ConfigWarnings(data []byte, filename string) ([]string, error) {
+	tree, err := toml.LoadBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filename, err)
+	}
+	var warnings []string
+	var visit func(*toml.Tree, reflect.Type, []string)
+	visit = func(tree *toml.Tree, typ reflect.Type, prefix []string) {
+		for typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
+		fields := map[string]reflect.Type{}
+		if typ.Kind() == reflect.Struct {
+			for i := range typ.NumField() {
+				field := typ.Field(i)
+				name := strings.Split(field.Tag.Get("toml"), ",")[0]
+				if name != "" && name != "-" {
+					// Match go-toml's field lookup order, including accepted
+					// case variants. Only the first present key is consumed.
+					for _, key := range []string{name, strings.ToLower(name), strings.ToTitle(name), strings.ToLower(name[:1]) + name[1:]} {
+						if tree.HasPath([]string{key}) {
+							fields[key] = field.Type
+							break
+						}
+					}
+				}
+			}
+		}
+		for _, key := range sortedConfigKeys(tree) {
+			parts := append(slices.Clone(prefix), key)
+			childType, known := fields[key]
+			if typ.Kind() == reflect.Map {
+				childType, known = typ.Elem(), true
+			}
+			if !known {
+				pos := tree.GetPositionPath([]string{key})
+				message := fmt.Sprintf("%s:%d:%d: unsupported field %s is ignored", filename, pos.Line, pos.Col, JoinConfigPath(parts...))
+				if legacySDKConfigPath(parts) {
+					message += "; run `dagger ws migrate` to migrate it"
+				}
+				warnings = append(warnings, message)
+				continue
+			}
+			if child, ok := tree.GetPath([]string{key}).(*toml.Tree); ok && childType.Kind() != reflect.Interface {
+				visit(child, childType, parts)
+			}
+		}
+	}
+	visit(tree, reflect.TypeFor[Config](), nil)
+	return warnings, nil
+}
+
+func legacySDKConfigPath(parts []string) bool {
+	return len(parts) == 3 && parts[0] == "modules" && parts[2] == "as-sdk" ||
+		len(parts) == 5 && parts[0] == "env" && parts[2] == "modules" && parts[4] == "as-sdk"
+}

--- a/core/workspace/config_migrate.go
+++ b/core/workspace/config_migrate.go
@@ -261,13 +261,13 @@ func configSDKScopeIsModule(tree *toml.Tree, sdkName, scopeKey string) (bool, bo
 		return false, false
 	}
 	sdks, _ := tree.Get(sdksKey).(*toml.Tree)
-	sdk, _ := sdks.Get(sdkName).(*toml.Tree)
+	sdk, _ := sdks.GetPath([]string{sdkName}).(*toml.Tree)
 	scopesKey, found := configDecoderKey(sdk, "scopes")
 	if !found {
 		return false, false
 	}
 	scopes, _ := sdk.Get(scopesKey).(*toml.Tree)
-	scope, _ := scopes.Get(scopeKey).(*toml.Tree)
+	scope, _ := scopes.GetPath([]string{scopeKey}).(*toml.Tree)
 	isModuleKey, found := configDecoderKey(scope, "is-module")
 	if !found {
 		return false, false

--- a/core/workspace/config_migrate.go
+++ b/core/workspace/config_migrate.go
@@ -23,12 +23,16 @@ func MigrateConfigBytes(data []byte, configDir string) ([]byte, error) {
 	}
 	// The current schema has no environment-specific SDK registry. Moving an
 	// environment's role into the base config would change other environments.
-	if envs, ok := tree.Get("env").(*toml.Tree); ok {
+	if envKey, found := configDecoderKey(tree, "env"); found {
+		envs, _ := tree.Get(envKey).(*toml.Tree)
 		for _, env := range sortedConfigKeys(envs) {
-			if mods, ok := envs.GetPath([]string{env, "modules"}).(*toml.Tree); ok {
+			envTree, _ := envs.Get(env).(*toml.Tree)
+			if modulesKey, found := configDecoderKey(envTree, "modules"); found {
+				mods, _ := envTree.Get(modulesKey).(*toml.Tree)
 				for _, name := range sortedConfigKeys(mods) {
-					if mods.HasPath([]string{name, "as-sdk"}) {
-						return nil, fmt.Errorf("cannot migrate %s: environment-specific SDK roles have no current replacement; field retained", JoinConfigPath("env", env, "modules", name, "as-sdk"))
+					module, _ := mods.Get(name).(*toml.Tree)
+					if asSDKKey, found := configDecoderKey(module, "as-sdk"); found {
+						return nil, fmt.Errorf("cannot migrate %s: environment-specific SDK roles have no current replacement; field retained", JoinConfigPath(envKey, env, modulesKey, name, asSDKKey))
 					}
 				}
 			}
@@ -36,12 +40,16 @@ func MigrateConfigBytes(data []byte, configDir string) ([]byte, error) {
 	}
 
 	var remove [][]string
+	modulesKey, _ := configDecoderKey(tree, "modules")
+	modules, _ := tree.Get(modulesKey).(*toml.Tree)
 	for _, moduleName := range slices.Sorted(maps.Keys(cfg.Modules)) {
-		parts := []string{"modules", moduleName, "as-sdk"}
-		if !tree.HasPath(parts) {
+		module, _ := modules.Get(moduleName).(*toml.Tree)
+		asSDKKey, found := configDecoderKey(module, "as-sdk")
+		if !found {
 			continue
 		}
-		legacy, ok := tree.GetPath(parts).(*toml.Tree)
+		parts := []string{modulesKey, moduleName, asSDKKey}
+		legacy, ok := module.Get(asSDKKey).(*toml.Tree)
 		if !ok {
 			return nil, fmt.Errorf("cannot migrate %s: expected a table; field retained", JoinConfigPath(parts...))
 		}
@@ -126,7 +134,7 @@ func migrateLegacySDKScopes(tree, legacy *toml.Tree, sdk *SDKEntry, configDir, s
 				if err := checkLegacySDKFields(record, recordPath, "path"); err != nil {
 					return err
 				}
-				if explicit, ok := tree.GetPath([]string{"sdks", sdkName, "scopes", key, "is-module"}).(bool); ok && !explicit {
+				if explicit, ok := configSDKScopeIsModule(tree, sdkName, key); ok && !explicit {
 					return fmt.Errorf("cannot migrate %s: SDK %q scope %q explicitly sets is-module = false; field retained", JoinConfigPath(recordPath...), sdkName, key)
 				}
 				scope.IsModule = true
@@ -154,8 +162,14 @@ func sortedConfigKeys(tree *toml.Tree) []string {
 }
 
 func checkLegacySDKFields(tree *toml.Tree, parts []string, allowed ...string) error {
+	known := map[string]bool{}
+	for _, name := range allowed {
+		if key, found := configDecoderKey(tree, name); found {
+			known[key] = true
+		}
+	}
 	for _, key := range sortedConfigKeys(tree) {
-		if !slices.Contains(allowed, key) {
+		if !known[key] {
 			return fmt.Errorf("cannot migrate %s: unsupported legacy field %s; field retained", JoinConfigPath(parts...), JoinConfigPath(append(slices.Clone(parts), key)...))
 		}
 	}
@@ -163,7 +177,11 @@ func checkLegacySDKFields(tree *toml.Tree, parts []string, allowed ...string) er
 }
 
 func legacySDKString(tree *toml.Tree, key string, parts []string, required bool) (string, error) {
-	value := tree.GetPath([]string{key})
+	actual, found := configDecoderKey(tree, key)
+	var value any
+	if found {
+		value = tree.Get(actual)
+	}
 	if value == nil && !required {
 		return "", nil
 	}
@@ -178,7 +196,11 @@ func legacySDKString(tree *toml.Tree, key string, parts []string, required bool)
 }
 
 func legacySDKRecords(tree *toml.Tree, key string, parts []string) ([]*toml.Tree, error) {
-	value := tree.GetPath([]string{key})
+	actual, found := configDecoderKey(tree, key)
+	var value any
+	if found {
+		value = tree.Get(actual)
+	}
 	if value == nil {
 		return nil, nil
 	}
@@ -213,8 +235,14 @@ func legacySDKClient(tree *toml.Tree, parts []string) (string, map[string]any, e
 		target += "@" + pin
 	}
 	settings := map[string]any{}
+	known := map[string]bool{}
+	for _, name := range []string{"path", "module", "pin"} {
+		if key, found := configDecoderKey(tree, name); found {
+			known[key] = true
+		}
+	}
 	for _, key := range sortedConfigKeys(tree) {
-		if key == "path" || key == "module" || key == "pin" {
+		if known[key] {
 			continue
 		}
 		// The beta schema stored client options as extra string fields.
@@ -225,4 +253,25 @@ func legacySDKClient(tree *toml.Tree, parts []string) (string, map[string]any, e
 		settings[key] = value
 	}
 	return target, settings, nil
+}
+
+func configSDKScopeIsModule(tree *toml.Tree, sdkName, scopeKey string) (bool, bool) {
+	sdksKey, found := configDecoderKey(tree, "sdks")
+	if !found {
+		return false, false
+	}
+	sdks, _ := tree.Get(sdksKey).(*toml.Tree)
+	sdk, _ := sdks.Get(sdkName).(*toml.Tree)
+	scopesKey, found := configDecoderKey(sdk, "scopes")
+	if !found {
+		return false, false
+	}
+	scopes, _ := sdk.Get(scopesKey).(*toml.Tree)
+	scope, _ := scopes.Get(scopeKey).(*toml.Tree)
+	isModuleKey, found := configDecoderKey(scope, "is-module")
+	if !found {
+		return false, false
+	}
+	explicit, ok := scope.Get(isModuleKey).(bool)
+	return explicit, ok
 }

--- a/core/workspace/config_migrate.go
+++ b/core/workspace/config_migrate.go
@@ -26,11 +26,11 @@ func MigrateConfigBytes(data []byte, configDir string) ([]byte, error) {
 	if envKey, found := configDecoderKey(tree, "env"); found {
 		envs, _ := tree.Get(envKey).(*toml.Tree)
 		for _, env := range sortedConfigKeys(envs) {
-			envTree, _ := envs.Get(env).(*toml.Tree)
+			envTree, _ := envs.GetPath([]string{env}).(*toml.Tree)
 			if modulesKey, found := configDecoderKey(envTree, "modules"); found {
 				mods, _ := envTree.Get(modulesKey).(*toml.Tree)
 				for _, name := range sortedConfigKeys(mods) {
-					module, _ := mods.Get(name).(*toml.Tree)
+					module, _ := mods.GetPath([]string{name}).(*toml.Tree)
 					if asSDKKey, found := configDecoderKey(module, "as-sdk"); found {
 						return nil, fmt.Errorf("cannot migrate %s: environment-specific SDK roles have no current replacement; field retained", JoinConfigPath(envKey, env, modulesKey, name, asSDKKey))
 					}
@@ -43,7 +43,7 @@ func MigrateConfigBytes(data []byte, configDir string) ([]byte, error) {
 	modulesKey, _ := configDecoderKey(tree, "modules")
 	modules, _ := tree.Get(modulesKey).(*toml.Tree)
 	for _, moduleName := range slices.Sorted(maps.Keys(cfg.Modules)) {
-		module, _ := modules.Get(moduleName).(*toml.Tree)
+		module, _ := modules.GetPath([]string{moduleName}).(*toml.Tree)
 		asSDKKey, found := configDecoderKey(module, "as-sdk")
 		if !found {
 			continue

--- a/core/workspace/config_migrate.go
+++ b/core/workspace/config_migrate.go
@@ -1,0 +1,228 @@
+package workspace
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	toml "github.com/pelletier/go-toml"
+)
+
+// MigrateConfigBytes moves beta SDK declarations into the SDK registry. It
+// changes only fields with a known replacement; unsupported legacy data aborts
+// the migration before any file is written.
+func MigrateConfigBytes(data []byte, configDir string) ([]byte, error) {
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		return nil, err
+	}
+	tree, err := toml.LoadBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	// The current schema has no environment-specific SDK registry. Moving an
+	// environment's role into the base config would change other environments.
+	if envs, ok := tree.Get("env").(*toml.Tree); ok {
+		for _, env := range sortedConfigKeys(envs) {
+			if mods, ok := envs.GetPath([]string{env, "modules"}).(*toml.Tree); ok {
+				for _, name := range sortedConfigKeys(mods) {
+					if mods.HasPath([]string{name, "as-sdk"}) {
+						return nil, fmt.Errorf("cannot migrate %s: environment-specific SDK roles have no current replacement; field retained", JoinConfigPath("env", env, "modules", name, "as-sdk"))
+					}
+				}
+			}
+		}
+	}
+
+	var remove [][]string
+	for _, moduleName := range slices.Sorted(maps.Keys(cfg.Modules)) {
+		parts := []string{"modules", moduleName, "as-sdk"}
+		if !tree.HasPath(parts) {
+			continue
+		}
+		legacy, ok := tree.GetPath(parts).(*toml.Tree)
+		if !ok {
+			return nil, fmt.Errorf("cannot migrate %s: expected a table; field retained", JoinConfigPath(parts...))
+		}
+		if err := checkLegacySDKFields(legacy, parts, "name", "modules", "clients"); err != nil {
+			return nil, err
+		}
+		sdkName, err := legacySDKString(legacy, "name", parts, false)
+		if err != nil {
+			return nil, err
+		}
+		if sdkName == "" {
+			sdkName = ConventionalSDKName(moduleName)
+		}
+		if cfg.SDKs == nil {
+			cfg.SDKs = map[string]SDKEntry{}
+		}
+		sdk, exists := cfg.SDKs[sdkName]
+		if exists && sdk.Module != moduleName {
+			return nil, fmt.Errorf("cannot migrate %s: SDK %q already uses module %q; field retained", JoinConfigPath(parts...), sdkName, sdk.Module)
+		}
+		if name, found := SDKNameForModule(cfg, moduleName); found && name != sdkName {
+			return nil, fmt.Errorf("cannot migrate %s: module already provides SDK %q, but legacy SDK name is %q; field retained", JoinConfigPath(parts...), name, sdkName)
+		}
+		sdk.Module = moduleName
+		if err := migrateLegacySDKScopes(tree, legacy, &sdk, configDir, sdkName, parts); err != nil {
+			return nil, err
+		}
+		cfg.SDKs[sdkName] = sdk
+		remove = append(remove, parts)
+	}
+	if len(remove) == 0 {
+		return data, nil
+	}
+	updated, err := UpdateConfigBytes(data, cfg)
+	if err != nil {
+		return nil, err
+	}
+	for _, parts := range remove {
+		doc, err := parseConfigText(updated)
+		if err != nil {
+			return nil, err
+		}
+		updated, err = doc.remove(parts)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if _, err := ParseConfig(updated); err != nil {
+		return nil, fmt.Errorf("validate migrated config: %w", err)
+	}
+	return updated, nil
+}
+
+func migrateLegacySDKScopes(tree, legacy *toml.Tree, sdk *SDKEntry, configDir, sdkName string, parts []string) error {
+	if sdk.Scopes == nil {
+		sdk.Scopes = map[string]SDKScope{}
+	}
+	for _, kind := range []string{"modules", "clients"} {
+		records, err := legacySDKRecords(legacy, kind, parts)
+		if err != nil {
+			return err
+		}
+		for i, record := range records {
+			recordPath := append(slices.Clone(parts), kind, fmt.Sprint(i))
+			p, err := legacySDKString(record, "path", recordPath, true)
+			if err != nil {
+				return err
+			}
+			resolved, err := ResolveSDKManagedPath(configDir, p)
+			if err != nil {
+				return fmt.Errorf("cannot migrate %s: %w", JoinConfigPath(recordPath...), err)
+			}
+			key, found, err := SDKScopeKey(*sdk, configDir, resolved)
+			if err != nil {
+				return err
+			}
+			if !found {
+				key = p // Preserve the recorded path spelling.
+			}
+			scope := sdk.Scopes[key]
+			if kind == "modules" {
+				if err := checkLegacySDKFields(record, recordPath, "path"); err != nil {
+					return err
+				}
+				if explicit, ok := tree.GetPath([]string{"sdks", sdkName, "scopes", key, "is-module"}).(bool); ok && !explicit {
+					return fmt.Errorf("cannot migrate %s: SDK %q scope %q explicitly sets is-module = false; field retained", JoinConfigPath(recordPath...), sdkName, key)
+				}
+				scope.IsModule = true
+			} else {
+				target, settings, err := legacySDKClient(record, recordPath)
+				if err != nil {
+					return err
+				}
+				merged, conflicts := mergeSDKScopes(scope, SDKScope{IsModule: scope.IsModule, Clients: []string{target}, Settings: settings})
+				if len(conflicts) > 0 {
+					return fmt.Errorf("cannot migrate %s: SDK %q scope %q conflicts in %s; field retained", JoinConfigPath(recordPath...), sdkName, key, strings.Join(conflicts, ", "))
+				}
+				scope = merged
+			}
+			sdk.Scopes[key] = scope
+		}
+	}
+	return nil
+}
+
+func sortedConfigKeys(tree *toml.Tree) []string {
+	keys := tree.Keys()
+	slices.Sort(keys)
+	return keys
+}
+
+func checkLegacySDKFields(tree *toml.Tree, parts []string, allowed ...string) error {
+	for _, key := range sortedConfigKeys(tree) {
+		if !slices.Contains(allowed, key) {
+			return fmt.Errorf("cannot migrate %s: unsupported legacy field %s; field retained", JoinConfigPath(parts...), JoinConfigPath(append(slices.Clone(parts), key)...))
+		}
+	}
+	return nil
+}
+
+func legacySDKString(tree *toml.Tree, key string, parts []string, required bool) (string, error) {
+	value := tree.GetPath([]string{key})
+	if value == nil && !required {
+		return "", nil
+	}
+	if str, ok := value.(string); ok && (!required || str != "") {
+		return str, nil
+	}
+	qualifier := ""
+	if required {
+		qualifier = "non-empty "
+	}
+	return "", fmt.Errorf("cannot migrate %s: %s must be a %sstring; field retained", JoinConfigPath(parts...), key, qualifier)
+}
+
+func legacySDKRecords(tree *toml.Tree, key string, parts []string) ([]*toml.Tree, error) {
+	value := tree.GetPath([]string{key})
+	if value == nil {
+		return nil, nil
+	}
+	if records, ok := value.([]*toml.Tree); ok {
+		return records, nil
+	}
+	// TOML represents an empty array without an element type.
+	if records, ok := value.([]any); ok && len(records) == 0 {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("cannot migrate %s: %s must be an array of tables; field retained", JoinConfigPath(parts...), key)
+}
+
+func legacySDKClient(tree *toml.Tree, parts []string) (string, map[string]any, error) {
+	target, err := legacySDKString(tree, "module", parts, true)
+	if err != nil {
+		return "", nil, err
+	}
+	pin, err := legacySDKString(tree, "pin", parts, false)
+	if err != nil {
+		return "", nil, err
+	}
+	if pin != "" {
+		if IsLocalRef(target, "") {
+			return "", nil, fmt.Errorf("cannot migrate %s: a local client target has a pin; field retained", JoinConfigPath(parts...))
+		}
+		// Preserve an immutable pin instead of silently changing the generated
+		// client's target. An earlier @ may be SSH userinfo and must remain.
+		if i := strings.LastIndex(target, "@"); i > strings.LastIndex(target, "/") {
+			target = target[:i]
+		}
+		target += "@" + pin
+	}
+	settings := map[string]any{}
+	for _, key := range sortedConfigKeys(tree) {
+		if key == "path" || key == "module" || key == "pin" {
+			continue
+		}
+		// The beta schema stored client options as extra string fields.
+		value, ok := tree.GetPath([]string{key}).(string)
+		if !ok {
+			return "", nil, fmt.Errorf("cannot migrate %s: unsupported legacy client field %s; field retained", JoinConfigPath(parts...), key)
+		}
+		settings[key] = value
+	}
+	return target, settings, nil
+}

--- a/core/workspace/config_migrate_test.go
+++ b/core/workspace/config_migrate_test.go
@@ -1,0 +1,160 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigWarnings(t *testing.T) {
+	data := []byte(`future = true
+[modules."custom.sdk"]
+source = './sdk'
+unknown = 1
+[modules."custom.sdk".as-sdk]
+name = 'custom'
+[modules."custom.sdk".settings]
+anything = { nested = [1, 2] }
+[sdks.custom]
+module = 'custom.sdk'
+future = 'keep'
+[sdks.custom.scopes.'.']
+is-module = true
+future = false
+[sdks.custom.scopes.'.'.settings]
+anything = { nested = true }
+[env.test.modules."custom.sdk".settings]
+anything = false
+[ports.8080]
+backendPort = 80
+backendService = 'web'
+future = 'keep'
+`)
+	warnings, err := ConfigWarnings(data, "nested/dagger.toml")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"nested/dagger.toml:1:1: unsupported field future is ignored",
+		"nested/dagger.toml:5:1: unsupported field modules.\"custom.sdk\".as-sdk is ignored; run `dagger ws migrate` to migrate it",
+		"nested/dagger.toml:4:1: unsupported field modules.\"custom.sdk\".unknown is ignored",
+		"nested/dagger.toml:22:1: unsupported field ports.8080.future is ignored",
+		"nested/dagger.toml:11:1: unsupported field sdks.custom.future is ignored",
+		"nested/dagger.toml:14:1: unsupported field sdks.custom.scopes.\".\".future is ignored",
+	}, warnings)
+	cfg, err := ParseConfig(data)
+	require.NoError(t, err)
+	require.Equal(t, "custom.sdk", cfg.SDKs["custom"].Module)
+	updated, err := UpdateConfigBytes(data, cfg)
+	require.NoError(t, err)
+	require.Equal(t, data, updated)
+}
+
+func TestConfigWarningsMatchDecoder(t *testing.T) {
+	data := []byte("[modules.provider]\nSOURCE = './sdk'\n[ports.8080]\nbackendservice = 'web'\nbackendPort = 80\n")
+	warnings, err := ConfigWarnings(data, "dagger.toml")
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	cfg, err := ParseConfig(data)
+	require.NoError(t, err)
+	require.Equal(t, "./sdk", cfg.Modules["provider"].Source)
+	require.Equal(t, "web", cfg.Ports["8080"].BackendService)
+
+	warnings, err = ConfigWarnings([]byte("[modules.provider]\nsource = './sdk'\nSOURCE = './ignored'\n"), "dagger.toml")
+	require.NoError(t, err)
+	require.Equal(t, []string{"dagger.toml:3:1: unsupported field modules.provider.SOURCE is ignored"}, warnings)
+}
+
+func TestMigrateConfigBytes(t *testing.T) {
+	t.Run("preserves unrelated text and removes SDK marker", func(t *testing.T) {
+		original := "# workspace\nignore = [\n  'node_modules', # keep\n]\nfuture = true\n\n[modules.dagger-go-sdk]\nsource = './sdk' # keep\npin = 'abc'\n\n[modules.dagger-go-sdk.as-sdk]\nname = 'golang'\n"
+		updated, err := MigrateConfigBytes([]byte(original), ".")
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(original, "[modules.dagger-go-sdk.as-sdk]\nname = 'golang'\n", "", 1)+"\n[sdks.golang]\nmodule = \"dagger-go-sdk\"\n", string(updated))
+		again, err := MigrateConfigBytes(updated, ".")
+		require.NoError(t, err)
+		require.Equal(t, updated, again)
+	})
+
+	t.Run("managed modules clients options and pins", func(t *testing.T) {
+		data := []byte(`[modules.provider]
+source = './sdk'
+[modules.provider.as-sdk]
+name = 'custom'
+[[modules.provider.as-sdk.modules]]
+path = '/api'
+[[modules.provider.as-sdk.clients]]
+path = '/api'
+module = '../target'
+package = 'bindings'
+[[modules.provider.as-sdk.clients]]
+path = './client'
+module = 'ssh://git@github.com/org/repo@main'
+pin = '0123456789abcdef'
+[sdks.custom]
+module = 'provider'
+future = 'keep'
+[sdks.custom.scopes.'/api']
+name = 'original'
+clients = ['existing']
+[sdks.custom.scopes.'/api'.settings]
+package = 'bindings'
+`)
+		updated, err := MigrateConfigBytes(data, "nested")
+		require.NoError(t, err)
+		require.NotContains(t, string(updated), "as-sdk")
+		require.Contains(t, string(updated), "future = 'keep'")
+		cfg, err := ParseConfig(updated)
+		require.NoError(t, err)
+		require.Equal(t, SDKScope{IsModule: true, Name: "original", Clients: []string{"existing", "../target"}, Settings: map[string]any{"package": "bindings"}}, cfg.SDKs["custom"].Scopes["/api"])
+		require.Equal(t, []string{"ssh://git@github.com/org/repo@0123456789abcdef"}, cfg.SDKs["custom"].Scopes["./client"].Clients)
+		again, err := MigrateConfigBytes(updated, "nested")
+		require.NoError(t, err)
+		require.Equal(t, updated, again)
+	})
+
+	t.Run("inline and quoted SDK markers", func(t *testing.T) {
+		data := []byte("modules.'dagger-custom-sdk' = { source = './sdk', as-sdk = { modules = [{path = '.'}], clients = [] }, future = true }\r\n")
+		updated, err := MigrateConfigBytes(data, ".")
+		require.NoError(t, err)
+		require.NotContains(t, string(updated), "as-sdk")
+		require.Contains(t, string(updated), "future = true")
+		require.NotContains(t, strings.ReplaceAll(string(updated), "\r\n", ""), "\n")
+		cfg, err := ParseConfig(updated)
+		require.NoError(t, err)
+		require.Equal(t, "dagger-custom-sdk", cfg.SDKs["custom"].Module)
+		require.True(t, cfg.SDKs["custom"].Scopes["."].IsModule)
+	})
+
+	t.Run("current config makes no change", func(t *testing.T) {
+		data := []byte("# keep\nfuture = [ 1, 2 ]\n[modules]\n")
+		updated, err := MigrateConfigBytes(data, ".")
+		require.NoError(t, err)
+		require.Equal(t, data, updated)
+	})
+}
+
+func TestMigrateConfigConflicts(t *testing.T) {
+	for _, tc := range []struct{ name, legacy, extra, want string }{
+		{"provider", "name = 'custom'", "[modules.other]\nsource = './other'\n[sdks.custom]\nmodule = 'other'", "already uses module"},
+		{"SDK name", "name = 'custom'", "[sdks.other]\nmodule = 'provider'", "legacy SDK name"},
+		{"unknown legacy field", "future = true", "", "unsupported legacy field"},
+		{"unknown module field", "[[modules.provider.as-sdk.modules]]\npath = '.'\nfuture = true", "", "unsupported legacy field"},
+		{"unknown client data", "[[modules.provider.as-sdk.clients]]\npath = '.'\nmodule = '.'\nfuture = true", "", "unsupported legacy client field"},
+		{"missing module path", "[[modules.provider.as-sdk.modules]]", "", "path must be a non-empty string"},
+		{"invalid module list", "modules = ['.']", "", "must be an array of tables"},
+		{"escaping scope", "[[modules.provider.as-sdk.modules]]\npath = '../outside'", "", "escapes the workspace root"},
+		{"local pin", "[[modules.provider.as-sdk.clients]]\npath = '.'\nmodule = './local'\npin = 'abc'", "", "local client target has a pin"},
+		{"scope module flag", "[[modules.provider.as-sdk.modules]]\npath = '.'", "[sdks.provider]\nmodule = 'provider'\n[sdks.provider.scopes.'.']\nis-module = false", "explicitly sets is-module = false"},
+		{"settings", "[[modules.provider.as-sdk.clients]]\npath = '.'\nmodule = '.'\npackage = 'new'", "[sdks.provider]\nmodule = 'provider'\n[sdks.provider.scopes.'.'.settings]\npackage = 'old'", "conflicts in settings.package"},
+		{"environment", "", "[env.test.modules.provider.as-sdk]\nname = 'test'", "environment-specific SDK roles"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte("[modules.provider]\nsource = './sdk'\n[modules.provider.as-sdk]\n" + tc.legacy + "\n" + tc.extra + "\n")
+			original := string(data)
+			updated, err := MigrateConfigBytes(data, ".")
+			require.ErrorContains(t, err, tc.want)
+			require.Nil(t, updated)
+			require.Equal(t, original, string(data))
+		})
+	}
+}

--- a/core/workspace/config_migrate_test.go
+++ b/core/workspace/config_migrate_test.go
@@ -152,6 +152,26 @@ package = 'bindings'
 		require.Equal(t, map[string]any{"package": "bindings"}, cfg.SDKs["custom"].Scopes["./client"].Settings)
 	})
 
+	t.Run("dotted module name", func(t *testing.T) {
+		data := []byte(`[modules."custom.sdk"]
+source = './sdk'
+[modules."custom.sdk".as-sdk]
+name = 'custom'
+[[modules."custom.sdk".as-sdk.modules]]
+path = '.'
+`)
+		updated, err := MigrateConfigBytes(data, ".")
+		require.NoError(t, err)
+		require.NotContains(t, string(updated), "as-sdk")
+		cfg, err := ParseConfig(updated)
+		require.NoError(t, err)
+		require.Equal(t, "custom.sdk", cfg.SDKs["custom"].Module)
+		require.True(t, cfg.SDKs["custom"].Scopes["."].IsModule)
+
+		_, err = MigrateConfigBytes([]byte(string(data)+"[env.test.modules.\"custom.sdk\".as-sdk]\nname = 'test'\n"), ".")
+		require.ErrorContains(t, err, "environment-specific SDK roles")
+	})
+
 	t.Run("current config makes no change", func(t *testing.T) {
 		data := []byte("# keep\nfuture = [ 1, 2 ]\n[modules]\n")
 		updated, err := MigrateConfigBytes(data, ".")
@@ -175,6 +195,7 @@ func TestMigrateConfigConflicts(t *testing.T) {
 		{"settings", "[[modules.provider.as-sdk.clients]]\npath = '.'\nmodule = '.'\npackage = 'new'", "[sdks.provider]\nmodule = 'provider'\n[sdks.provider.scopes.'.'.settings]\npackage = 'old'", "conflicts in settings.package"},
 		{"environment", "", "[env.test.modules.provider.as-sdk]\nname = 'test'", "environment-specific SDK roles"},
 		{"environment aliases", "", "[ENV.test.MODULES.provider.AS-SDK]\nNAME = 'test'", "environment-specific SDK roles"},
+		{"dotted environment", "", "[env.'ci.test'.modules.provider.as-sdk]\nname = 'test'", "environment-specific SDK roles"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			data := []byte("[modules.provider]\nsource = './sdk'\n[modules.provider.as-sdk]\n" + tc.legacy + "\n" + tc.extra + "\n")

--- a/core/workspace/config_migrate_test.go
+++ b/core/workspace/config_migrate_test.go
@@ -62,6 +62,10 @@ func TestConfigWarningsMatchDecoder(t *testing.T) {
 	warnings, err = ConfigWarnings([]byte("[modules.provider]\nsource = './sdk'\nSOURCE = './ignored'\n"), "dagger.toml")
 	require.NoError(t, err)
 	require.Equal(t, []string{"dagger.toml:3:1: unsupported field modules.provider.SOURCE is ignored"}, warnings)
+
+	warnings, err = ConfigWarnings([]byte("[MODULES.provider.AS-SDK]\nNAME = 'custom'\n"), "dagger.toml")
+	require.NoError(t, err)
+	require.Equal(t, []string{"dagger.toml:1:1: unsupported field MODULES.provider.AS-SDK is ignored; run `dagger ws migrate` to migrate it"}, warnings)
 }
 
 func TestMigrateConfigBytes(t *testing.T) {
@@ -125,6 +129,29 @@ package = 'bindings'
 		require.True(t, cfg.SDKs["custom"].Scopes["."].IsModule)
 	})
 
+	t.Run("decoder field aliases", func(t *testing.T) {
+		data := []byte(`[MODULES.provider]
+SOURCE = './sdk'
+[MODULES.provider.AS-SDK]
+NAME = 'custom'
+[[MODULES.provider.AS-SDK.MODULES]]
+PATH = '.'
+[[MODULES.provider.AS-SDK.CLIENTS]]
+PATH = './client'
+MODULE = '../target'
+package = 'bindings'
+`)
+		updated, err := MigrateConfigBytes(data, ".")
+		require.NoError(t, err)
+		require.NotContains(t, string(updated), "AS-SDK")
+		cfg, err := ParseConfig(updated)
+		require.NoError(t, err)
+		require.Equal(t, "provider", cfg.SDKs["custom"].Module)
+		require.True(t, cfg.SDKs["custom"].Scopes["."].IsModule)
+		require.Equal(t, []string{"../target"}, cfg.SDKs["custom"].Scopes["./client"].Clients)
+		require.Equal(t, map[string]any{"package": "bindings"}, cfg.SDKs["custom"].Scopes["./client"].Settings)
+	})
+
 	t.Run("current config makes no change", func(t *testing.T) {
 		data := []byte("# keep\nfuture = [ 1, 2 ]\n[modules]\n")
 		updated, err := MigrateConfigBytes(data, ".")
@@ -147,6 +174,7 @@ func TestMigrateConfigConflicts(t *testing.T) {
 		{"scope module flag", "[[modules.provider.as-sdk.modules]]\npath = '.'", "[sdks.provider]\nmodule = 'provider'\n[sdks.provider.scopes.'.']\nis-module = false", "explicitly sets is-module = false"},
 		{"settings", "[[modules.provider.as-sdk.clients]]\npath = '.'\nmodule = '.'\npackage = 'new'", "[sdks.provider]\nmodule = 'provider'\n[sdks.provider.scopes.'.'.settings]\npackage = 'old'", "conflicts in settings.package"},
 		{"environment", "", "[env.test.modules.provider.as-sdk]\nname = 'test'", "environment-specific SDK roles"},
+		{"environment aliases", "", "[ENV.test.MODULES.provider.AS-SDK]\nNAME = 'test'", "environment-specific SDK roles"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			data := []byte("[modules.provider]\nsource = './sdk'\n[modules.provider.as-sdk]\n" + tc.legacy + "\n" + tc.extra + "\n")

--- a/core/workspace/sdk_scopes.go
+++ b/core/workspace/sdk_scopes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -113,6 +114,13 @@ func ParseConfigAt(ctx context.Context, data []byte, configDir string) (*Config,
 	cfg, err := ParseConfig(data)
 	if err != nil {
 		return nil, err
+	}
+	warnings, err := ConfigWarnings(data, filepath.ToSlash(filepath.Join(configDir, ConfigFileName)))
+	if err != nil {
+		return nil, err
+	}
+	for _, warning := range warnings {
+		slog.GlobalLogger(ctx, "dagger/workspace").Warn(warning)
 	}
 	if err := reconcileSDKScopes(ctx, cfg, configDir); err != nil {
 		return nil, err


### PR DESCRIPTION
`dagger ws migrate` leaves legacy SDK fields in `dagger.toml`. Convert them to `sdks`, warn about unsupported fields, and preserve unrelated text. Stop on conflicts.

```sh
dagger ws migrate --no-apply  # Preview changes
dagger ws migrate -y         # Apply changes
```

Based on #14109. Depends on #14111. Refs #14110.
