### PR TITLE
fix: report remote module resolution

### DIFF
--- a/core/gitref/display.go
+++ b/core/gitref/display.go
@@ -1,0 +1,52 @@
+package gitref
+
+import "strings"
+
+// LooksRemote distinguishes a host/path reference from a missing local path.
+// Callers must check for an existing local directory before using this hint.
+func LooksRemote(ref string) bool {
+	if FastKindCheck(ref, "") == KindLocal {
+		return false
+	}
+	if Scheme(ref) != NoScheme {
+		return true
+	}
+	host, _, hasPath := strings.Cut(ref, "/")
+	return hasPath && strings.Contains(host, ".")
+}
+
+// DisplayRef keeps the user's spelling while removing URL credentials. HTTP
+// usernames can themselves be tokens. SSH usernames are part of the address.
+func DisplayRef(ref string) string {
+	scheme := Scheme(ref)
+	start := len(scheme.Prefix())
+	end := strings.IndexByte(ref[start:], '/')
+	if end < 0 {
+		end = len(ref)
+	} else {
+		end += start
+	}
+	if at := strings.LastIndexByte(ref[start:end], '@'); at >= 0 {
+		at += start
+		user := ref[start:at]
+		if scheme != SchemeSSH && scheme != SchemeSCPLike {
+			ref = ref[:start] + "***" + ref[at:]
+		} else if colon := strings.IndexByte(user, ':'); colon >= 0 {
+			ref = ref[:start+colon+1] + "***" + ref[at:]
+		}
+	}
+	if query := strings.IndexByte(ref, '?'); query >= 0 {
+		_, fragment, hasFragment := strings.Cut(ref[query:], "#")
+		ref = ref[:query] + "?***"
+		if hasFragment {
+			ref += "#" + fragment
+		}
+	}
+	// A module path must not inject extra terminal lines or control sequences.
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return '\uFFFD'
+		}
+		return r
+	}, ref)
+}

--- a/core/gitref/display_test.go
+++ b/core/gitref/display_test.go
@@ -1,0 +1,31 @@
+package gitref
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLooksRemote(t *testing.T) {
+	for _, ref := range []string{"github.com/does/notexist@v1", "go.example/tools@v1", "https://host/repo", "git@github.com:team/repo"} {
+		require.True(t, LooksRemote(ref), ref)
+	}
+	for _, ref := range []string{"./github.com/does/notexist@v1", "../module", "/module", "missing/module", "module.go"} {
+		require.False(t, LooksRemote(ref), ref)
+	}
+}
+
+func TestDisplayRef(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{"go.example/tools@v1", "go.example/tools@v1"},
+		{"https://token@example.com/repo.git#v1", "https://***@example.com/repo.git#v1"},
+		{"https://user:password@example.com/repo@v1", "https://***@example.com/repo@v1"},
+		{"ssh://git@example.com/repo.git#main:tools", "ssh://git@example.com/repo.git#main:tools"},
+		{"ssh://git:password@example.com/repo.git#main", "ssh://git:***@example.com/repo.git#main"},
+		{"git@example.com:repo.git#main", "git@example.com:repo.git#main"},
+		{"https://example.com/repo?token=secret#v1", "https://example.com/repo?***#v1"},
+		{"https://example.com/repo\nsecret", "https://example.com/repo�secret"},
+	} {
+		require.Equal(t, tc.want, DisplayRef(tc.input))
+	}
+}

--- a/core/gitref/gitref.go
+++ b/core/gitref/gitref.go
@@ -153,10 +153,12 @@ type Parsed struct {
 // endpoint (callers may choose to fall back to treating it as a local path).
 type EndpointError struct{ error }
 
+func (e EndpointError) Unwrap() error { return e.error }
+
 // Parse parses a git ref string into its components.
 func Parse(ctx context.Context, refString string) (_ Parsed, rerr error) {
 	tracer := trace.SpanFromContext(ctx).TracerProvider().Tracer("dagger.io/core/gitref")
-	_, span := tracer.Start(ctx, fmt.Sprintf("parseGitRefString: %s", refString), telemetry.Internal())
+	_, span := tracer.Start(ctx, fmt.Sprintf("parseGitRefString: %s", DisplayRef(refString)), telemetry.Internal())
 	defer telemetry.EndWithCause(span, &rerr)
 
 	scheme, schemelessRef := parseScheme(refString)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -1733,11 +1733,13 @@ func (GitSuite) TestGitSchemeless(ctx context.Context, t *testctx.T) {
 		repo := c.Git("github.com/grouville/daggerverse-private.git")
 		err := checkAccess(ctx, repo)
 		require.Error(t, err)
-		requireErrOut(t, err, "failed to determine Git URL protocol")
+		requireErrOut(t, err, "cannot access Git repository")
+		requireErrOut(t, err, "git authentication failed")
 
 		_, err = repo.URL(ctx)
 		require.Error(t, err)
-		requireErrOut(t, err, "failed to determine Git URL protocol")
+		requireErrOut(t, err, "cannot access Git repository")
+		requireErrOut(t, err, "git authentication failed")
 	})
 }
 

--- a/core/integration/workspace_module_resolution_test.go
+++ b/core/integration/workspace_module_resolution_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceSuite) TestWorkspaceModuleResolution(ctx context.Context, t *testctx.T) {
+	t.Run("remote errors retain the requested source", func(ctx context.Context, t *testctx.T) {
+		for _, source := range []string{
+			"github.com/does/notexist@v1",
+			"https://github.com/dagger/dagger#this-version-does-not-exist:modules/wolfi",
+			"http://127.0.0.1:1/repo.git#main",
+		} {
+			workdir := newWorkspaceConfigWorkdir(ctx, t, "")
+			out, err := hostDaggerExec(ctx, t, workdir, "mod", "install", source)
+			require.Error(t, err)
+			require.Contains(t, string(out), source)
+			require.NotContains(t, string(out), "local path does not exist")
+			require.NotContains(t, string(out), "➡️")
+			if strings.HasPrefix(source, "http://127.0.0.1:") {
+				require.Contains(t, string(out), "cannot connect to git repository")
+			}
+		}
+	})
+
+	t.Run("explicit local error stays local", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceConfigWorkdir(ctx, t, "")
+		out, err := hostDaggerExec(ctx, t, workdir, "mod", "install", "./github.com/does/notexist@v1")
+		require.Error(t, err)
+		require.Contains(t, string(out), "local")
+		require.NotContains(t, string(out), "➡️")
+	})
+
+	t.Run("locked vanity source reports once on stderr", func(ctx context.Context, t *testctx.T) {
+		workdir := newWorkspaceConfigWorkdir(ctx, t, "")
+		lock := workspace.NewLock()
+		require.NoError(t, lock.SetLookup(workspace.CoreLockNamespace, workspace.LockOperationVanityURL,
+			[]any{"https://go.example/tools"}, "https://github.com/dagger/dagger/modules/wolfi"))
+		data, err := lock.Marshal()
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, workspace.LockFileName), data, 0o644))
+		const source = "go.example/tools@v0.20.2"
+		const resolution = source + " ➡️ https://github.com/dagger/dagger#v0.20.2:modules/wolfi"
+		for range 2 {
+			cmd := hostDaggerCommand(ctx, t, workdir, "mod", "install", source, "--name=wolfi")
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			stdout, err := cmd.Output()
+			require.NoError(t, err, "%s", stderr.String())
+			require.NotContains(t, string(stdout), "➡️")
+			require.Equal(t, 1, strings.Count(stderr.String(), resolution), stderr.String())
+			require.Equal(t, 1, strings.Count(stderr.String(), "➡️"), stderr.String())
+		}
+	})
+}

--- a/core/integration/workspace_module_resolution_test.go
+++ b/core/integration/workspace_module_resolution_test.go
@@ -26,7 +26,7 @@ func (WorkspaceSuite) TestWorkspaceModuleResolution(ctx context.Context, t *test
 			require.NotContains(t, string(out), "local path does not exist")
 			require.NotContains(t, string(out), "➡️")
 			if strings.HasPrefix(source, "http://127.0.0.1:") {
-				require.Contains(t, string(out), "cannot connect to git repository")
+				require.Regexp(t, "connection refused|cannot connect to git repository", string(out))
 			}
 		}
 	})

--- a/core/modulerefs.go
+++ b/core/modulerefs.go
@@ -53,8 +53,9 @@ func ParseRefString(
 	refString string,
 	refPin string,
 ) (_ *ParsedRefString, rerr error) {
-	ctx, span := Tracer(ctx).Start(ctx, fmt.Sprintf("parseRefString: %s", refString), telemetry.Internal())
+	ctx, span := Tracer(ctx).Start(ctx, fmt.Sprintf("parseRefString: %s", gitref.DisplayRef(refString)), telemetry.Internal())
 	defer telemetry.EndWithCause(span, &rerr)
+	originalRef := refString
 
 	kind := FastModuleSourceKindCheck(refString, refPin)
 	switch kind {
@@ -68,11 +69,11 @@ func ParseRefString(
 	case ModuleSourceKindGit:
 		refString, err := ResolveDaggerGetRedirect(ctx, refString)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve module ref string: %w", err)
+			return nil, fmt.Errorf("resolve remote module %q: %w", gitref.DisplayRef(originalRef), err)
 		}
 		parsedGitRef, err := ParseGitRefString(ctx, refString)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse git ref string: %w", err)
+			return nil, fmt.Errorf("resolve remote module %q: %w", gitref.DisplayRef(originalRef), err)
 		}
 		return &ParsedRefString{
 			Kind: kind,
@@ -95,7 +96,7 @@ func ParseRefString(
 	// Parse scheme and attempt to parse as git endpoint
 	refString, err := ResolveDaggerGetRedirect(ctx, refString)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve module ref string: %w", err)
+		return nil, fmt.Errorf("resolve remote module %q: %w", gitref.DisplayRef(originalRef), err)
 	}
 	parsedGitRef, err := ParseGitRefString(ctx, refString)
 	switch {
@@ -104,16 +105,16 @@ func ParseRefString(
 			Kind: ModuleSourceKindGit,
 			Git:  &parsedGitRef,
 		}, nil
-	case errors.As(err, &gitref.EndpointError{}):
+	case errors.As(err, &gitref.EndpointError{}) && !gitref.LooksRemote(originalRef):
 		// couldn't connect to git endpoint, fallback to local
 		return &ParsedRefString{
 			Kind: ModuleSourceKindLocal,
 			Local: &ParsedLocalRefString{
-				ModPath: refString,
+				ModPath: originalRef,
 			},
 		}, nil
 	default:
-		return nil, fmt.Errorf("failed to parse ref string: %w", err)
+		return nil, fmt.Errorf("resolve remote module %q: %w", gitref.DisplayRef(originalRef), err)
 	}
 }
 

--- a/core/modulerefs_test.go
+++ b/core/modulerefs_test.go
@@ -236,6 +236,27 @@ func TestParseRefString(t *testing.T) {
 	}
 }
 
+func TestParseRefStringRemoteFailure(t *testing.T) {
+	// A malformed known-host reference fails without needing network access.
+	remote := "github.com/missing@v1"
+	parsed, err := ParseRefString(t.Context(), neverExistsFS{}, remote, "")
+	require.Nil(t, parsed)
+	require.ErrorContains(t, err, `resolve remote module "github.com/missing@v1"`)
+	require.ErrorContains(t, err, "invalid github.com/ import path")
+	require.NotContains(t, err.Error(), "local path")
+
+	exists := StatFSFunc(func(context.Context, string) (string, *Stat, error) {
+		return remote, &Stat{FileType: FileTypeDirectory}, nil
+	})
+	parsed, err = ParseRefString(t.Context(), exists, remote, "")
+	require.NoError(t, err)
+	require.Equal(t, ModuleSourceKindLocal, parsed.Kind)
+
+	parsed, err = ParseRefString(t.Context(), neverExistsFS{}, "./"+remote, "")
+	require.NoError(t, err)
+	require.Equal(t, ModuleSourceKindLocal, parsed.Kind)
+}
+
 type neverExistsFS struct {
 }
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -437,16 +437,17 @@ func (src *ModuleSource) AttachDependencyResults(
 }
 
 type persistedGitModuleSourcePayload struct {
-	CloneRef     string              `json:"cloneRef,omitempty"`
-	Symbolic     string              `json:"symbolic,omitempty"`
-	HTMLRepoURL  string              `json:"htmlRepoURL,omitempty"`
-	HTMLURL      string              `json:"htmlURL,omitempty"`
-	RepoRootPath string              `json:"repoRootPath,omitempty"`
-	Version      string              `json:"version,omitempty"`
-	VersionQuery string              `json:"versionQuery,omitempty"`
-	Selector     gitref.SelectorType `json:"selector,omitempty"`
-	Commit       string              `json:"commit,omitempty"`
-	Ref          string              `json:"ref,omitempty"`
+	CloneRef         string              `json:"cloneRef,omitempty"`
+	ResolvedCloneRef string              `json:"resolvedCloneRef,omitempty"`
+	Symbolic         string              `json:"symbolic,omitempty"`
+	HTMLRepoURL      string              `json:"htmlRepoURL,omitempty"`
+	HTMLURL          string              `json:"htmlURL,omitempty"`
+	RepoRootPath     string              `json:"repoRootPath,omitempty"`
+	Version          string              `json:"version,omitempty"`
+	VersionQuery     string              `json:"versionQuery,omitempty"`
+	Selector         gitref.SelectorType `json:"selector,omitempty"`
+	Commit           string              `json:"commit,omitempty"`
+	Ref              string              `json:"ref,omitempty"`
 }
 
 type persistedDirModuleSourcePayload struct {
@@ -882,16 +883,17 @@ func (src *ModuleSource) EncodePersistedObject(ctx context.Context, cache dagql.
 	}
 	if src.Git != nil {
 		payload.Git = &persistedGitModuleSourcePayload{
-			CloneRef:     src.Git.CloneRef,
-			Symbolic:     src.Git.Symbolic,
-			HTMLRepoURL:  src.Git.HTMLRepoURL,
-			HTMLURL:      src.Git.HTMLURL,
-			RepoRootPath: src.Git.RepoRootPath,
-			Version:      src.Git.Version,
-			VersionQuery: src.Git.VersionQuery,
-			Selector:     src.Git.Selector,
-			Commit:       src.Git.Commit,
-			Ref:          src.Git.Ref,
+			CloneRef:         src.Git.CloneRef,
+			ResolvedCloneRef: src.Git.ResolvedCloneRef,
+			Symbolic:         src.Git.Symbolic,
+			HTMLRepoURL:      src.Git.HTMLRepoURL,
+			HTMLURL:          src.Git.HTMLURL,
+			RepoRootPath:     src.Git.RepoRootPath,
+			Version:          src.Git.Version,
+			VersionQuery:     src.Git.VersionQuery,
+			Selector:         src.Git.Selector,
+			Commit:           src.Git.Commit,
+			Ref:              src.Git.Ref,
 		}
 		if src.Git.UnfilteredContextDir.Self() != nil {
 			unfilteredID, err := encodePersistedObjectRef(cache, src.Git.UnfilteredContextDir, "module source git unfiltered context dir")
@@ -979,16 +981,17 @@ func (*ModuleSource) DecodePersistedObject(ctx context.Context, dag *dagql.Serve
 	}
 	if persisted.Git != nil {
 		src.Git = &GitModuleSource{
-			CloneRef:     persisted.Git.CloneRef,
-			Symbolic:     persisted.Git.Symbolic,
-			HTMLRepoURL:  persisted.Git.HTMLRepoURL,
-			HTMLURL:      persisted.Git.HTMLURL,
-			RepoRootPath: persisted.Git.RepoRootPath,
-			Version:      persisted.Git.Version,
-			VersionQuery: persisted.Git.VersionQuery,
-			Selector:     persisted.Git.Selector,
-			Commit:       persisted.Git.Commit,
-			Ref:          persisted.Git.Ref,
+			CloneRef:         persisted.Git.CloneRef,
+			ResolvedCloneRef: persisted.Git.ResolvedCloneRef,
+			Symbolic:         persisted.Git.Symbolic,
+			HTMLRepoURL:      persisted.Git.HTMLRepoURL,
+			HTMLURL:          persisted.Git.HTMLURL,
+			RepoRootPath:     persisted.Git.RepoRootPath,
+			Version:          persisted.Git.Version,
+			VersionQuery:     persisted.Git.VersionQuery,
+			Selector:         persisted.Git.Selector,
+			Commit:           persisted.Git.Commit,
+			Ref:              persisted.Git.Ref,
 		}
 		if persisted.GitUnfilteredContextDirResultID != 0 {
 			unfilteredContextDir, err := loadPersistedObjectResultByResultID[*Directory](ctx, dag, persisted.GitUnfilteredContextDirResultID, "module source git unfiltered context directory")
@@ -2036,6 +2039,10 @@ func (src LocalModuleSource) Clone() *LocalModuleSource {
 type GitModuleSource struct {
 	// The ref to clone the root of the git repo from
 	CloneRef string
+
+	// The URL after Git transport selection. Kept separately from the user's
+	// spelling so reports do not need another lookup or invent a protocol.
+	ResolvedCloneRef string
 
 	// Symbolic is the CloneRef plus the SourceRootSubpath (no version)
 	Symbolic string

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -513,6 +513,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 			}
 		}
 
+		var accessErrors []error
 		for _, selectArgs := range try {
 			var repo dagql.ObjectResult[*core.GitRepository]
 			err := srv.Select(ctx, parent, &repo, dagql.Selector{
@@ -522,12 +523,14 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 			})
 			if err != nil {
 				if errors.Is(err, gitutil.ErrGitAuthFailed) {
+					accessErrors = append(accessErrors, err)
 					continue
 				}
 				return inst, err
 			}
 			if _, err := repo.Self().LoadRemote(ctx); err != nil {
 				if errors.Is(err, gitutil.ErrGitAuthFailed) {
+					accessErrors = append(accessErrors, err)
 					continue
 				}
 				return inst, err
@@ -535,7 +538,7 @@ func (s *gitSchema) git(ctx context.Context, parent dagql.ObjectResult[*core.Que
 			return repo, nil
 		}
 
-		return inst, fmt.Errorf("failed to determine Git URL protocol")
+		return inst, fmt.Errorf("cannot access Git repository: %w", errors.Join(accessErrors...))
 	}
 	if err != nil {
 		return inst, fmt.Errorf("failed to parse Git URL: %w", err)

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -374,7 +374,7 @@ func (s *moduleSourceSchema) moduleSource(
 	case core.ModuleSourceKindGit:
 		inst, err = s.gitModuleSource(ctx, query, parsedRef.Git, args.RefPin, !args.DisableFindUp, args.AllowNotExists)
 		if err != nil {
-			return inst, err
+			return inst, fmt.Errorf("resolve remote module %q: %w", gitref.DisplayRef(args.RefString), err)
 		}
 	default:
 		return inst, fmt.Errorf("unknown module source kind: %s", parsedRef.Kind)
@@ -792,14 +792,15 @@ func (s *moduleSourceSchema) gitModuleSource(
 		ConfigFilename: modules.Filename,
 		Kind:           core.ModuleSourceKindGit,
 		Git: &core.GitModuleSource{
-			HTMLRepoURL:  parsed.RepoRoot.Repo,
-			RepoRootPath: parsed.RepoRoot.Root,
-			Version:      cmp.Or(gitRef.Self().Ref.ShortName(), gitRef.Self().Ref.SHA),
-			VersionQuery: versionQuery,
-			Selector:     parsed.Selector,
-			Commit:       gitRef.Self().Ref.SHA,
-			Ref:          gitRef.Self().Ref.Name,
-			CloneRef:     parsed.SourceCloneRef,
+			HTMLRepoURL:      parsed.RepoRoot.Repo,
+			RepoRootPath:     parsed.RepoRoot.Root,
+			Version:          cmp.Or(gitRef.Self().Ref.ShortName(), gitRef.Self().Ref.SHA),
+			VersionQuery:     versionQuery,
+			Selector:         parsed.Selector,
+			Commit:           gitRef.Self().Ref.SHA,
+			Ref:              gitRef.Self().Ref.Name,
+			CloneRef:         parsed.SourceCloneRef,
+			ResolvedCloneRef: gitRef.Self().Repo.Self().URL.Value.String(),
 		},
 	}
 
@@ -988,11 +989,12 @@ func (s *moduleSourceSchema) workspaceModuleSource(
 		cloneRef := ref.Repo.Self().URL.Value.String()
 		src.Kind = core.ModuleSourceKindGit
 		src.Git = &core.GitModuleSource{
-			CloneRef:    cloneRef,
-			HTMLRepoURL: cloneRef,
-			Version:     cmp.Or(ref.Ref.ShortName(), ref.Ref.SHA),
-			Commit:      ref.Ref.SHA,
-			Ref:         ref.Ref.Name,
+			CloneRef:         cloneRef,
+			ResolvedCloneRef: cloneRef,
+			HTMLRepoURL:      cloneRef,
+			Version:          cmp.Or(ref.Ref.ShortName(), ref.Ref.SHA),
+			Commit:           ref.Ref.SHA,
+			Ref:              ref.Ref.Name,
 		}
 		src.Git.Symbolic = cloneRef
 		if sourceRootPath != "." {

--- a/core/schema/workspace_install.go
+++ b/core/schema/workspace_install.go
@@ -259,6 +259,7 @@ func (s *workspaceSchema) resolveWorkspaceInstallSource(
 		if err := srv.Select(ctx, srv.Root(), &src, workspaceInstallModuleSourceSelector(ref)); err != nil {
 			return src, "", fmt.Errorf("load module source: %w", err)
 		}
+		reportWorkspaceModuleResolution(ctx, ref, src.Self())
 		return src, ref, nil
 	}
 

--- a/core/schema/workspace_module_resolution.go
+++ b/core/schema/workspace_module_resolution.go
@@ -1,0 +1,48 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/gitref"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
+	telemetry "github.com/dagger/otel-go"
+	"go.opentelemetry.io/otel/log"
+)
+
+// Report only explicitly resolved install/update sources. Dependency and SDK
+// loads use moduleSource directly and must not add more command output.
+func reportWorkspaceModuleResolution(ctx context.Context, original string, src *core.ModuleSource) {
+	line := workspaceModuleResolutionLine(original, src)
+	if line == "" {
+		return
+	}
+	md, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return
+	}
+	cache, err := dagql.EngineCache(ctx)
+	if err != nil {
+		return
+	}
+	// The session is one CLI command. A repeated materialization or load must
+	// not print the same source again. Reporting needs no remote request.
+	_, _ = cache.GetOrInitArbitrary(ctx, md.SessionID,
+		"module-resolution-report:"+md.SessionID+":"+original,
+		func(ctx context.Context) (any, error) {
+			writer := telemetry.GlobalWriter(ctx, core.InstrumentationLibrary,
+				log.Int(telemetry.StdioStreamAttr, 2))
+			_, _ = fmt.Fprintln(writer, line)
+			return true, nil
+		})
+}
+
+func workspaceModuleResolutionLine(original string, src *core.ModuleSource) string {
+	if src == nil || src.Git == nil || src.Git.ResolvedCloneRef == "" || src.Git.Version == "" {
+		return ""
+	}
+	resolved := gitref.GitURLRefString(src.Git.ResolvedCloneRef, src.SourceRootSubpath, src.Git.Version)
+	return gitref.DisplayRef(original) + " ➡️ " + gitref.DisplayRef(resolved)
+}

--- a/core/schema/workspace_module_resolution_test.go
+++ b/core/schema/workspace_module_resolution_test.go
@@ -1,0 +1,25 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/dagger/dagger/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceModuleResolutionLine(t *testing.T) {
+	src := &core.ModuleSource{SourceRootSubpath: ".", Git: &core.GitModuleSource{
+		CloneRef:         "vanity.example/tools",
+		ResolvedCloneRef: "https://github.com/acme/tools.git",
+		Version:          "v1.4.2",
+	}}
+	require.Equal(t, "go.example/tools@v1 ➡️ https://github.com/acme/tools.git#v1.4.2",
+		workspaceModuleResolutionLine("go.example/tools@v1", src))
+	src.Git.ResolvedCloneRef = "ssh://git@github.com/acme/tools.git"
+	src.SourceRootSubpath = "tools/go"
+	require.Equal(t, "go.example/tools@v1 ➡️ ssh://git@github.com/acme/tools.git#v1.4.2:tools/go",
+		workspaceModuleResolutionLine("go.example/tools@v1", src))
+	src.Git.Version = ""
+	require.Empty(t, workspaceModuleResolutionLine("go.example/tools@v1", src))
+	require.Empty(t, workspaceModuleResolutionLine("./local", &core.ModuleSource{}))
+}

--- a/engine/vcs/http.go
+++ b/engine/vcs/http.go
@@ -5,6 +5,7 @@
 package vcs
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -35,7 +36,7 @@ func httpGET(url string) ([]byte, error) {
 
 // httpsOrHTTP returns the body of either the importPath's
 // https resource or, if unavailable, the http resource.
-func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, err error) {
+func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, status string, err error) {
 	fetch := func(scheme string) (urlStr string, res *http.Response, err error) {
 		u, err := url.Parse(scheme + "://" + importPath)
 		if err != nil {
@@ -55,6 +56,7 @@ func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, err erro
 		}
 	}
 	urlStr, res, err := fetch("https")
+	httpsErr := err
 	if err != nil || res.StatusCode != 200 {
 		if Verbose {
 			if err != nil {
@@ -68,12 +70,12 @@ func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, err erro
 	}
 	if err != nil {
 		closeBody(res)
-		return "", nil, err
+		return "", nil, "", errors.Join(httpsErr, err)
 	}
 	// Note: accepting a non-200 OK here, so people can serve a
 	// meta import in their http 404 page.
 	if Verbose {
 		log.Printf("Parsing meta tags from %s (status code %d)", urlStr, res.StatusCode)
 	}
-	return urlStr, res.Body, nil
+	return urlStr, res.Body, res.Status, nil
 }

--- a/engine/vcs/resolution_errors_test.go
+++ b/engine/vcs/resolution_errors_test.go
@@ -1,0 +1,35 @@
+package vcs
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type resolutionTransport func(*http.Request) (*http.Response, error)
+
+func (f resolutionTransport) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestRepoDiscoveryKeepsFailureCause(t *testing.T) {
+	originalClient := httpClient
+	t.Cleanup(func() { httpClient = originalClient })
+	for _, code := range []int{http.StatusForbidden, http.StatusNotFound} {
+		status := http.StatusText(code)
+		httpClient = &http.Client{Transport: resolutionTransport(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: code, Status: status, Body: io.NopCloser(strings.NewReader("access unavailable"))}, nil
+		})}
+		_, err := RepoRootForImportPath("git.example.test/tools", false)
+		require.ErrorContains(t, err, status)
+		require.ErrorContains(t, err, "git.example.test/tools")
+	}
+	connectionErr := errors.New("connection refused")
+	httpClient = &http.Client{Transport: resolutionTransport(func(*http.Request) (*http.Response, error) {
+		return nil, connectionErr
+	})}
+	_, err := RepoRootForImportPath("git.example.test/tools", false)
+	require.ErrorIs(t, err, connectionErr)
+}

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -343,15 +343,11 @@ func RepoRootForImportPath(importPath string, verbose bool) (*RepoRoot, error) {
 	rr, err := RepoRootForImportPathStatic(importPath, "")
 	if err == errUnknownSite {
 		rr, err = RepoRootForImportDynamic(importPath, verbose)
-		// RepoRootForImportDynamic returns error detail
-		// that is irrelevant if the user didn't intend to use a
-		// dynamic import in the first place.
-		// Squelch it.
 		if err != nil {
 			if Verbose {
 				log.Printf("import %q: %v", importPath, err)
 			}
-			err = fmt.Errorf("unrecognized import path %q", importPath)
+			err = fmt.Errorf("unrecognized import path %q: %w", importPath, err)
 		}
 	}
 
@@ -456,7 +452,7 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 		return nil, errors.New("import path doesn't contain a hostname")
 	}
 
-	urlStr, body, err := httpsOrHTTP(importPath)
+	urlStr, body, responseStatus, err := httpsOrHTTP(importPath)
 	if err != nil {
 		return nil, fmt.Errorf("http/https fetch: %w", err)
 	}
@@ -470,7 +466,7 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 		if err != errNoMatch {
 			return nil, fmt.Errorf("parse %s: %w", urlStr, err)
 		}
-		return nil, fmt.Errorf("parse %s: no go-import meta tags", urlStr)
+		return nil, fmt.Errorf("parse %s (%s): no go-import meta tags", urlStr, responseStatus)
 	}
 	if verbose {
 		log.Printf("get %q: found meta tag %#v at %s", originalImportPath, metaImport, urlStr)
@@ -486,7 +482,7 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 			log.Printf("get %q: verifying non-authoritative meta tag", originalImportPath)
 		}
 		urlStr0 := urlStr
-		urlStr, body, err = httpsOrHTTP(metaImport.Prefix)
+		urlStr, body, responseStatus, err = httpsOrHTTP(metaImport.Prefix)
 		if err != nil {
 			return nil, fmt.Errorf("fetch %s: %w", urlStr, err)
 		}
@@ -495,7 +491,7 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 			return nil, fmt.Errorf("parsing %s: %w", originalImportPath, err)
 		}
 		if len(imports) == 0 {
-			return nil, fmt.Errorf("fetch %s: no go-import meta tag", urlStr)
+			return nil, fmt.Errorf("fetch %s (%s): no go-import meta tag", urlStr, responseStatus)
 		}
 		metaImport2, err := matchGoImport(imports, originalImportPath)
 		if err != nil || metaImport != metaImport2 {

--- a/util/gitutil/error.go
+++ b/util/gitutil/error.go
@@ -8,6 +8,8 @@ import (
 
 var (
 	ErrGitAuthFailed       = errors.New("git authentication failed")
+	ErrGitConnectionFailed = errors.New("cannot connect to git repository")
+	ErrGitHostNotFound     = errors.New("cannot resolve git hostname")
 	ErrGitNoRepo           = errors.New("not a git repository")
 	ErrShallowNotSupported = errors.New("shallow clone not supported")
 	// ErrSHAFetchUnsupported is a normalized signal that retry-by-named-ref may succeed.
@@ -30,9 +32,19 @@ func translateError(err error, stderr string) error {
 
 	if strings.Contains(stderr, "authentication failed") ||
 		strings.Contains(stderr, "authentication required") ||
+		strings.Contains(stderr, "permission denied (publickey") ||
 		strings.Contains(stderr, "fatal: could not read username") ||
 		strings.Contains(stderr, "fatal: could not read password") {
 		return ErrGitAuthFailed
+	}
+	if strings.Contains(stderr, "could not resolve host") || strings.Contains(stderr, "could not resolve hostname") {
+		return ErrGitHostNotFound
+	}
+	if strings.Contains(stderr, "failed to connect to") ||
+		strings.Contains(stderr, "connection refused") ||
+		strings.Contains(stderr, "connection timed out") ||
+		strings.Contains(stderr, "network is unreachable") {
+		return ErrGitConnectionFailed
 	}
 	if strings.Contains(stderr, "not a git repository") {
 		return ErrGitNoRepo

--- a/util/gitutil/error_test.go
+++ b/util/gitutil/error_test.go
@@ -33,3 +33,19 @@ func TestTranslateErrorContextPassthrough(t *testing.T) {
 	err := translateError(context.Canceled, "")
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestTranslateErrorRemoteAccess(t *testing.T) {
+	for _, tc := range []struct {
+		stderr string
+		want   error
+	}{
+		{"git@github.com: Permission denied (publickey).", ErrGitAuthFailed},
+		{"fatal: Could not resolve host: git.example.test", ErrGitHostNotFound},
+		{"ssh: Could not resolve hostname git.example.test", ErrGitHostNotFound},
+		{"fatal: Failed to connect to localhost port 1: Could not connect to server", ErrGitConnectionFailed},
+		{"ssh: connect to host localhost port 1: Connection refused", ErrGitConnectionFailed},
+		{"ssh: connect to host localhost port 22: Connection timed out", ErrGitConnectionFailed},
+	} {
+		require.ErrorIs(t, translateError(errors.New("exit status 128"), tc.stderr), tc.want)
+	}
+}


### PR DESCRIPTION
Remote module errors can look like missing local paths. Keep the remote error. Print the source and resolved Git URL during install and update.

Example:

```console
$ dagger mod install github.com/dagger/dagger/modules/wolfi@v0.20.2 --name=wolfi
github.com/dagger/dagger/modules/wolfi@v0.20.2 ➡️ https://github.com/dagger/dagger#v0.20.2:modules/wolfi
```
