### PR TITLE
engine: squash snapshot chains too deep to mount

### DIFF
--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -136,6 +136,32 @@ func (DirectorySuite) TestWithNewFile(ctx context.Context, t *testctx.T) {
 	require.Equal(t, []string{"some-file"}, res.Directory.WithNewFile.Entries)
 }
 
+func (DirectorySuite) TestDeepLayerChain(ctx context.Context, t *testctx.T) {
+	// Each edit stacks one overlay layer; past about 440 layers the mount
+	// options no longer fit in one page and the kernel refuses the mount.
+	const edits = 600
+	c := connect(ctx, t)
+	dir := c.Directory()
+	for i := range edits {
+		dir = dir.WithNewFile(fmt.Sprintf("f-%03d", i), fmt.Sprint(i))
+		if i%100 == 99 {
+			var err error
+			dir, err = dir.Sync(ctx)
+			require.NoError(t, err)
+		}
+	}
+
+	entries, err := dir.Entries(ctx)
+	require.NoError(t, err)
+	require.Len(t, entries, edits)
+	first, err := dir.File("f-000").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "0", first)
+	last, err := dir.File("f-599").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "599", last)
+}
+
 func (DirectorySuite) TestEntries(ctx context.Context, t *testctx.T) {
 	res, err := testutil.Query[struct {
 		Directory struct {

--- a/dagger.toml
+++ b/dagger.toml
@@ -117,10 +117,10 @@ source = ".dagger/modules/typescript-client-dev"
 legacy-default-path = true
 
 [modules.dagger-dang-sdk]
-source = "github.com/dagger/dang-sdk"
+source = "github.com/dagger/dang-sdk@v0.1"
 
 [modules.dagger-go-sdk]
-source = "github.com/dagger/go-sdk"
+source = "github.com/dagger/go-sdk@v0.1"
 
 [env.dev.modules.engine-lab]
 source = ".dagger/modules/engine-lab"

--- a/engine/snapshots/manager.go
+++ b/engine/snapshots/manager.go
@@ -345,18 +345,26 @@ func (cm *snapshotManager) getRecord(ctx context.Context, id string, opts ...Ref
 	return rec, nil
 }
 
+// Overlay refuses to mount a snapshot whose parent chain is too deep: past 500
+// lower layers, or once the lowerdir option outgrows one page (about 440
+// layers with 5-digit snapshot IDs).
+const maxParentChainDepth = 128
+
 func (cm *snapshotManager) New(ctx context.Context, s ImmutableRef, opts ...RefOption) (mr MutableRef, err error) {
 	id := identity.NewID()
-
-	var parentSnapshotID string
-	if s != nil {
-		parentSnapshotID = s.SnapshotID()
-	}
 
 	snapshotID := id
 	ctx, err = EnsureLease(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "ensure lease for snapshot prepare")
+	}
+
+	var parentSnapshotID string
+	if s != nil {
+		parentSnapshotID, err = cm.mountableParent(ctx, s.SnapshotID())
+		if err != nil {
+			return nil, err
+		}
 	}
 	err = cm.Snapshotter.Prepare(ctx, snapshotID, parentSnapshotID)
 	if err != nil {
@@ -393,6 +401,27 @@ func (cm *snapshotManager) New(ctx context.Context, s ImmutableRef, opts ...RefO
 	}
 	bklog.G(context.TODO()).WithFields(ref.traceLogFields()).Trace("acquired cache ref")
 	return ref, nil
+}
+
+// mountableParent returns parentSnapshotID, or a single-layer copy of it when
+// its chain has reached maxParentChainDepth.
+func (cm *snapshotManager) mountableParent(ctx context.Context, parentSnapshotID string) (string, error) {
+	depth := 0
+	for id := parentSnapshotID; id != "" && depth < maxParentChainDepth; depth++ {
+		info, err := cm.Snapshotter.Stat(ctx, id)
+		if err != nil {
+			return "", errors.Wrapf(err, "stat snapshot %s", id)
+		}
+		id = info.Parent
+	}
+	if depth < maxParentChainDepth {
+		return parentSnapshotID, nil
+	}
+	squashedID := identity.NewID()
+	if err := cm.Snapshotter.Merge(ctx, squashedID, []Diff{{Upper: parentSnapshotID}}); err != nil {
+		return "", errors.Wrapf(err, "squash snapshot %s", parentSnapshotID)
+	}
+	return squashedID, nil
 }
 
 func (cm *snapshotManager) GetMutable(ctx context.Context, id string, opts ...RefOption) (MutableRef, error) {

--- a/engine/snapshots/manager_test.go
+++ b/engine/snapshots/manager_test.go
@@ -559,3 +559,52 @@ func TestMergeContract(t *testing.T) {
 		}, cm.Snapshotter.(*applySnapshotDiffTestSnapshotter).mergeCalls[0])
 	})
 }
+
+func TestNewKeepsParentChainsMountable(t *testing.T) {
+	commitChain := func(t *testing.T, cm *snapshotManager, length int) ImmutableRef {
+		t.Helper()
+		var parent ImmutableRef
+		for range length {
+			mr, err := cm.New(context.Background(), parent)
+			require.NoError(t, err)
+			parent, err = mr.Commit(context.Background())
+			require.NoError(t, err)
+		}
+		return parent
+	}
+	chainDepth := func(t *testing.T, sn *applySnapshotDiffTestSnapshotter, snapshotID string) int {
+		t.Helper()
+		depth := 0
+		for id := snapshotID; id != ""; depth++ {
+			info, err := sn.Stat(context.Background(), id)
+			require.NoError(t, err)
+			id = info.Parent
+		}
+		return depth
+	}
+
+	t.Run("deep chains are squashed", func(t *testing.T) {
+		cm := newApplySnapshotDiffTestManager(t)
+		sn := cm.Snapshotter.(*applySnapshotDiffTestSnapshotter)
+
+		tip := commitChain(t, cm, 500)
+
+		// Overlay refuses mounts past about 440 lower layers.
+		require.LessOrEqual(t, chainDepth(t, sn, tip.SnapshotID()), 256)
+		require.NotEmpty(t, sn.mergeCalls)
+		for _, diffs := range sn.mergeCalls {
+			require.Len(t, diffs, 1)
+			require.Empty(t, diffs[0].Lower, "a squash must copy the full view of the parent")
+		}
+	})
+
+	t.Run("shallow chains are left alone", func(t *testing.T) {
+		cm := newApplySnapshotDiffTestManager(t)
+		sn := cm.Snapshotter.(*applySnapshotDiffTestSnapshotter)
+
+		tip := commitChain(t, cm, 10)
+
+		require.Equal(t, 10, chainDepth(t, sn, tip.SnapshotID()))
+		require.Empty(t, sn.mergeCalls)
+	})
+}


### PR DESCRIPTION
Overlay refuses to mount a snapshot whose parent chain is too deep. Past 500 lower layers, the kernel returns `invalid argument`. Once the `lowerdir` option outgrows one page (about 440 layers with 5-digit snapshot IDs), containerd returns `mount options is too long`.

Every Directory edit stacks one layer on its parent, and nothing squashes the chain, so a long sequence of edits eventually fails to mount. `dagger generate` on a workspace with many SDK scopes hits this: the edits of every scope accumulate on one workspace.

## Changes

- Before `snapshotManager.New` prepares a new snapshot, it walks the chain of the parent.
- When the chain reaches 128 layers, `New` first squashes the parent into a single layer with the existing merge snapshotter, which uses hardlinks on overlayfs. `New` then prepares the new snapshot on top of the squashed layer.
- 128 stays well below both limits.

## Tests

- `TestDirectory/TestDeepLayerChain` builds a directory from 600 sequential `withNewFile` edits.
  - Before this change, the test fails at about 500 layers with `invalid argument`.
  - With this change, the test passes, and the first and last files keep their contents.
- `TestNewKeepsParentChainsMountable` checks three behaviors:
  - A 500-layer chain stays at 256 layers or fewer.
  - Each squash copies the full view of the parent.
  - Short chains are not squashed.
- `TestChangeset` passes.
- In `TestDirectory`, only `TestStat/file-dir-exists` fails. It fails the same way on `main`: an engine backed by xfs reports a directory size of 6 instead of 4096.
- Manual test with this branch: passes.

## Notes

- Each call to `New` now stats up to 128 snapshots of the parent chain. If this shows up in profiles, storing the depth in snapshot metadata makes the check constant-time.
- The squashed snapshot has no cache record, so size accounting does not count it. On overlayfs, it shares inodes with the original layers through hardlinks. Without cross-snapshot hardlinks (a user namespace without `userxattr`), the squash is a full copy.
- Two new snapshots on the same deep parent squash it twice. This happens only when work branches off a deep parent.
