### PR TITLE
fix(workspace): avoid redundant parent snapshots

### DIFF
--- a/core/integration/workspace_overlay_layers_test.go
+++ b/core/integration/workspace_overlay_layers_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (LockfileSuite) TestRepeatedNestedEditsKeepParents(ctx context.Context, t *testctx.T) {
+	workdir := t.TempDir()
+	hostGitInit(t, workdir)
+	writeEmptyWorkspaceConfig(t, workdir)
+
+	// Each edit adds another scope to the cumulative touched paths. Reseeding
+	// every earlier scope on each edit exhausts the overlay mount options.
+	const scopes = 24
+	var query strings.Builder
+	query.WriteString("{ currentWorkspace {")
+	for i := range scopes {
+		scope := fmt.Sprintf("modules/scope-%02d", i)
+		parent := filepath.Join(workdir, scope, "generated")
+		require.NoError(t, os.MkdirAll(parent, 0o755))
+		require.NoError(t, os.Chmod(filepath.Dir(parent), 0o750))
+		require.NoError(t, os.Chmod(parent, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(parent, "keep.txt"), []byte("keep"), 0o600))
+		fmt.Fprintf(&query, "withNewFile(path: %q, contents: %q) {", scope+"/generated/client.go", "generated")
+	}
+	query.WriteString("export")
+	query.WriteString(strings.Repeat("}", scopes+2))
+
+	queryPath := writeQueryDoc(t, workdir, "edits.graphql", query.String())
+	_, err := hostDaggerExec(ctx, t, workdir, "--silent", "query", "--doc", queryPath)
+	require.NoError(t, err)
+
+	for i := range scopes {
+		parent := filepath.Join(workdir, fmt.Sprintf("modules/scope-%02d/generated", i))
+		for name, want := range map[string]string{"client.go": "generated", "keep.txt": "keep"} {
+			contents, err := os.ReadFile(filepath.Join(parent, name))
+			require.NoError(t, err)
+			require.Equal(t, want, string(contents))
+		}
+		for dir, want := range map[string]os.FileMode{filepath.Dir(parent): 0o750, parent: 0o700} {
+			info, err := os.Stat(dir)
+			require.NoError(t, err)
+			require.Equal(t, want, info.Mode().Perm(), "%s permissions", dir)
+		}
+	}
+}

--- a/core/schema/workspace.go
+++ b/core/schema/workspace.go
@@ -2610,6 +2610,24 @@ func (s *workspaceSchema) seedDeltaRootParents(
 		if !exists {
 			continue
 		}
+
+		// Parents from earlier edits are already in the accumulated delta.
+		// withNewDirectory commits a snapshot even when MkdirAll is a no-op,
+		// so only seed parents that are currently missing from the delta.
+		var alreadySeeded dagql.Boolean
+		if err := srv.Select(ctx, delta, &alreadySeeded, dagql.Selector{
+			Field: "exists",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.NewString(dir)},
+				{Name: "expectedType", Value: dagql.Opt(core.ExistsTypeDirectory)},
+			},
+		}); err != nil {
+			return delta, fmt.Errorf("inspect overlay delta root parent %q: %w", dir, err)
+		}
+		if alreadySeeded {
+			continue
+		}
+
 		var info *core.Stat
 		if err := srv.Select(ctx, base, &info, dagql.Selector{
 			Field: "stat",


### PR DESCRIPTION
Repeated host-workspace edits seeded every previously touched parent directory again. Each `withNewDirectory` committed a snapshot even when the directory already existed, eventually failing SDK generation with `mount options is too long`.

Check the accumulated delta before seeding a parent. Existing directories keep their contents and permissions; missing parents still use the sparse host base's permissions. This is the engine fix from the [trace investigation](https://gist.github.com/vito/06ee97e0e399fb0164ef0d7df296d0d8); [dagger/go-sdk#41](https://github.com/dagger/go-sdk/pull/41) addresses the Go SDK's duplicate manifest writes and per-client workspace merges.

Validation:

- Added a regression with 24 nested scope edits. It reproduces `mount options is too long` before the fix and passes afterward, checking generated files, untouched siblings, and parent permissions.
- Passed the regression plus `TestUpdateFromNestedConfigKeepsSiblings`, `TestWithoutFileKeepsSiblings`, and `TestNestedEditKeepsDirectoryPermissions` via `dagger api call engine-dev test` ([passing trace](https://dagger.cloud/dagger/traces/cf6ef1391d45700d8f31506ed703d099)).

This prevents redundant snapshot creation; the helper still scans cumulative parent paths.
