### PR TITLE
ci: load dang-sdk and go-sdk at versions 0.1

### DIFF
--- a/dagger.toml
+++ b/dagger.toml
@@ -117,10 +117,10 @@ source = ".dagger/modules/typescript-client-dev"
 legacy-default-path = true
 
 [modules.dagger-dang-sdk]
-source = "github.com/dagger/dang-sdk"
+source = "github.com/dagger/dang-sdk@v0.1"
 
 [modules.dagger-go-sdk]
-source = "github.com/dagger/go-sdk"
+source = "github.com/dagger/go-sdk@v0.1"
 
 [env.dev.modules.engine-lab]
 source = ".dagger/modules/engine-lab"


### PR DESCRIPTION
- later versions of these modules require engine 1.0.0-beta.12 or later
- in theory lockfile should protect against this, but Dagger Cloud's "module loader" doesn't use a standard engine and/or is not configured to honor lockfile


1. If Dagger Cloud correctly honors lockfiles at load, this should not be needed to un-break load
2. Even after Dagger Cloud honors lockfiles, this is more correct because it ensures running `dagger update` (lockfile refresh) doesn't update go-sdk and dang-sdk to a version that is too recent
