### PR TITLE
fix(directory): reuse existing mkdir results

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -1098,7 +1098,7 @@ func (lazy *DirectoryWithTimestampsLazy) EncodePersisted(ctx context.Context, ca
 
 func (lazy *DirectoryWithNewDirectoryLazy) Evaluate(ctx context.Context, dir *Directory) error {
 	return lazy.LazyState.Evaluate(ctx, "Directory.withNewDirectory", func(ctx context.Context) error {
-		return dir.WithNewDirectory(ctx, lazy.Parent, lazy.Dest, lazy.Permissions)
+		return dir.WithNewDirectory(ctx, lazy.Parent, dagql.CurrentCall(ctx), lazy.Dest, lazy.Permissions)
 	})
 }
 
@@ -2885,7 +2885,7 @@ func (dir *Directory) WithTimestamps(ctx context.Context, parent dagql.ObjectRes
 	return nil
 }
 
-func (dir *Directory) WithNewDirectory(ctx context.Context, parent dagql.ObjectResult[*Directory], dest string, permissions fs.FileMode) error {
+func (dir *Directory) WithNewDirectory(ctx context.Context, parent dagql.ObjectResult[*Directory], opCall *dagql.ResultCall, dest string, permissions fs.FileMode) error {
 	dest = path.Clean(dest)
 	if strings.HasPrefix(dest, "../") {
 		return fmt.Errorf("cannot create directory outside parent: %s", dest)
@@ -2914,6 +2914,59 @@ func (dir *Directory) WithNewDirectory(ctx context.Context, parent dagql.ObjectR
 	parentSnapshot, err := parent.Self().Snapshot.GetOrEval(ctx, parent.Result)
 	if err != nil {
 		return err
+	}
+	// MkdirAll leaves existing directories (including their permissions) alone.
+	// Check before allocating a mutable snapshot so repeated calls cannot grow
+	// the overlay layer chain without changing any files.
+	var alreadyExists bool
+	err = MountRef(ctx, parentSnapshot, func(root string, _ *mount.Mount) error {
+		resolvedDir, err := containerdfs.RootPath(root, path.Join(parentDir, dest))
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(resolvedDir)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return TrimErrPathPrefix(err, root)
+		}
+		alreadyExists = info.IsDir()
+		return nil
+	}, mountRefAsReadOnly)
+	if err != nil {
+		return err
+	}
+	if alreadyExists {
+		if parentSnapshot == nil {
+			scratchDir, scratchSnapshot, err := loadCanonicalScratchDirectory(ctx)
+			if err != nil {
+				return err
+			}
+			dir.Dir.setValue(scratchDir)
+			dir.Snapshot.setValue(scratchSnapshot)
+		} else {
+			// Each Directory owns its snapshot handle. Reopen it so collecting
+			// this result cannot release the parent's still-cached handle.
+			reopened, err := query.SnapshotManager().GetBySnapshotID(ctx, parentSnapshot.SnapshotID(), bkcache.NoUpdateLastUsed)
+			if err != nil {
+				return err
+			}
+			dir.Snapshot.setValue(reopened)
+		}
+		if opCall != nil {
+			clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+			if err != nil {
+				return fmt.Errorf("directory no-op equivalence client metadata: %w", err)
+			}
+			if clientMetadata.SessionID == "" {
+				return fmt.Errorf("directory no-op equivalence: empty session ID")
+			}
+			if err := cache.TeachCallEquivalentToResult(ctx, clientMetadata.SessionID, opCall, parent); err != nil {
+				return fmt.Errorf("teach directory withNewDirectory no-op equivalence: %w", err)
+			}
+		}
+		return nil
 	}
 	newRef, err := query.SnapshotManager().New(
 		ctx,

--- a/core/integration/directory_mkdir_test.go
+++ b/core/integration/directory_mkdir_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/buildkit/identity"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (DirectorySuite) TestWithNewDirectoryNoop(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	parent := c.Directory().
+		WithNewDirectory("scope/existing", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o750}).
+		WithNewFile("scope/existing/keep.txt", "keep").
+		Directory("scope")
+
+	// Even though MkdirAll does nothing, committing a snapshot per call used
+	// to exceed overlay mount limits before this chain could be read.
+	result := parent
+	for range 600 {
+		result = result.WithNewDirectory("existing", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o700})
+	}
+	contents, err := result.File("existing/keep.txt").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "keep", contents)
+
+	stat, err := result.Stat(ctx, "existing")
+	require.NoError(t, err)
+	permissions, err := stat.Permissions(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0o750, permissions)
+
+	// Reusing the snapshot must leave both branches usable for later writes.
+	for _, branch := range []*dagger.Directory{parent, result} {
+		contents, err := branch.WithNewFile("existing/next.txt", "next").File("existing/next.txt").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "next", contents)
+	}
+}
+
+func (DirectorySuite) TestWithNewDirectoryPaths(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	parent := c.Directory().
+		WithNewFile("scope/existing/keep.txt", "keep").
+		WithSymlink("existing", "scope/link").
+		WithSymlink("missing", "scope/dangling").
+		Directory("scope")
+
+	for _, target := range []string{".", "/", "existing", "/existing", "link"} {
+		t.Run(target, func(ctx context.Context, t *testctx.T) {
+			result := parent.WithNewDirectory(target)
+			empty, err := result.Changes(parent).IsEmpty(ctx)
+			require.NoError(t, err)
+			require.True(t, empty)
+		})
+	}
+
+	t.Run("creates through symlinks", func(ctx context.Context, t *testctx.T) {
+		for target, created := range map[string]string{"link/new": "existing/new", "dangling": "missing"} {
+			result := parent.WithNewDirectory(target, dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o700})
+			stat, err := result.Stat(ctx, created)
+			require.NoError(t, err)
+			permissions, err := stat.Permissions(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 0o700, permissions)
+		}
+	})
+
+	t.Run("file conflicts still fail", func(ctx context.Context, t *testctx.T) {
+		for _, target := range []string{"existing/keep.txt", "existing/keep.txt/child"} {
+			_, err := parent.WithNewDirectory(target).Sync(ctx)
+			require.Error(t, err)
+		}
+	})
+
+	t.Run("scratch root", func(ctx context.Context, t *testctx.T) {
+		entries, err := c.Directory().WithNewDirectory(".").Entries(ctx)
+		require.NoError(t, err)
+		require.Empty(t, entries)
+	})
+}
+
+func (DirectorySuite) TestWithNewDirectoryNoopCache(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	parent := c.Directory().WithNewFile("existing/keep.txt", identity.NewID())
+	run := func(dir *dagger.Directory) string {
+		out, err := c.Container().From(alpineImage).
+			WithMountedDirectory("/input", dir).
+			WithExec([]string{"sh", "-c", "head -c 32 /dev/urandom | base64"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return out
+	}
+	want := run(parent)
+
+	// Evaluation discovers the no-op. Downstream calls should then reuse the
+	// parent's cached results instead of treating it as a different input.
+	result := parent.WithNewDirectory("existing")
+	_, err := result.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, run(result))
+}


### PR DESCRIPTION
Repeated `Directory.withNewDirectory` calls for an existing directory committed empty snapshots until the overlay could no longer be mounted. A regression repeating the operation 600 times fails on the base branch with an overlay mount containing 501 lower directories.

During lazy evaluation, inspect the destination in the parent snapshot before allocating a mutable snapshot. When it is already a directory, reopen the parent snapshot with an independently owned reference and teach the cache that the call is equivalent to its parent. Missing directories retain the existing creation path. Existing permissions, scoped paths, symlink resolution, and file-conflict errors are preserved.

This complements the workspace-specific fix in #14122: that fix avoids redundant calls from parent seeding, while this makes no-op directory creation avoid new layers for any caller. See the [original trace investigation](https://gist.github.com/vito/06ee97e0e399fb0164ef0d7df296d0d8).

The check stays in lazy evaluation, so building a directory recipe does not force filesystem evaluation. Creating a missing directory now incurs an additional read-only parent inspection before the mutable mount.

Validation:

- The 600-call regression fails before the change with an overlay mount error ([baseline trace](https://dagger.cloud/dagger/traces/da9834cfb264eb9e67b296741d76251e)) and passes afterward.
- All 21 selected tests passed via `dagger api call engine-dev test --pkg ./core/integration --run='(TestDirectory|TestLockfile)/(TestWithNewDirectory.*|TestWithoutPaths|TestStat|TestRepeatedNestedEditsKeepParents)$'` ([passing trace](https://dagger.cloud/dagger/traces/aea2c6c9e298229f492bacb83add8333)). Coverage includes the new no-op, path-semantics, and downstream-cache checks; existing directory creation, stat, and removal checks; and the workspace overlay-growth regression.
