### PR TITLE
migrate: fixes from dogfooding beta.12

### DIFF
--- a/.changes/unreleased/Fixed-20260911-124500.yaml
+++ b/.changes/unreleased/Fixed-20260911-124500.yaml
@@ -1,0 +1,8 @@
+kind: Fixed
+body: |
+  `dagger workspace migrate` and `dagger module migrate` no longer hang on an
+  interactive prompt when run by a coding agent. Like `dagger generate`, they
+  now require `-y`/`--auto-apply` or `--no-apply` in that case.
+time: 2026-09-11T12:45:00Z
+custom:
+  Author: shykes

--- a/.changes/unreleased/Fixed-20260911-131500.yaml
+++ b/.changes/unreleased/Fixed-20260911-131500.yaml
@@ -1,0 +1,8 @@
+kind: Fixed
+body: |
+  Migration no longer writes a redundant `name` on SDK module scopes. The
+  scope name is only written when it differs from the inferred name, matching
+  `dagger module init`.
+time: 2026-09-11T13:15:00Z
+custom:
+  Author: shykes

--- a/.changes/unreleased/Fixed-20260911-205036.yaml
+++ b/.changes/unreleased/Fixed-20260911-205036.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  `dagger workspace migrate` and `dagger config unset` no longer leave blank
+  lines or out-of-date comments in `dagger.toml` when they remove a table.
+  The comment block directly above a removed table is removed with it. A
+  comment block at the top of the file stays.
+time: 2026-09-11T20:50:36Z
+custom:
+  Author: shykes

--- a/core/integration/workspace_config_preservation_test.go
+++ b/core/integration/workspace_config_preservation_test.go
@@ -61,6 +61,7 @@ clients = [
 		require.NoError(t, err)
 		contents, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
 		require.NoError(t, err)
-		require.Equal(t, config+"\n", string(contents))
+		// The blank line before the removed table goes with it.
+		require.Equal(t, config, string(contents))
 	})
 }

--- a/core/integration/workspace_migration_config_test.go
+++ b/core/integration/workspace_migration_config_test.go
@@ -123,3 +123,55 @@ arbitrary = { nested = true }
 	require.NoError(t, err)
 	require.Equal(t, original, unchanged)
 }
+
+func (WorkspaceMigrationSuite) TestWorkspaceMigrateAgentDisposition(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	original := `[modules.dagger-custom-sdk]
+source = './sdk'
+
+[modules.dagger-custom-sdk.as-sdk]
+name = 'custom'
+[[modules.dagger-custom-sdk.as-sdk.modules]]
+path = './app'
+`
+	agent := workspaceBase(t, c).
+		WithNewFile("dagger.toml", original).
+		WithNewFile("sdk/dagger-module.toml", "name = 'custom-sdk'\n").
+		WithNewFile("app/dagger.json", `{"name":"app","sdk":"../sdk"}`).
+		WithEnvVariable("CODEX_CI", "1")
+
+	requireUnchanged := func(t *testctx.T, ctr *dagger.Container) {
+		data, err := ctr.File("dagger.toml").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, original, data)
+		data, err = ctr.File("app/dagger.json").Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, `{"name":"app","sdk":"../sdk"}`, data)
+	}
+
+	t.Run("workspace migrate requires an explicit choice", func(ctx context.Context, t *testctx.T) {
+		failed := agent.With(daggerExecFail("ws", "migrate"))
+		out, err := failed.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "dagger workspace migrate requires an explicit changeset choice")
+		require.Contains(t, out, "-y/--auto-apply")
+		require.Contains(t, out, "--no-apply")
+		requireUnchanged(t, failed)
+	})
+
+	t.Run("module migrate requires an explicit choice", func(ctx context.Context, t *testctx.T) {
+		failed := agent.With(daggerExecFail("module", "migrate", "app"))
+		out, err := failed.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "dagger module migrate requires an explicit changeset choice")
+		requireUnchanged(t, failed)
+	})
+
+	t.Run("no apply previews without exporting", func(ctx context.Context, t *testctx.T) {
+		previewed := agent.With(daggerExec("ws", "migrate", "--no-apply"))
+		out, err := previewed.CombinedOutput(ctx)
+		require.NoError(t, err, out)
+		require.Contains(t, out, "dagger.toml")
+		requireUnchanged(t, previewed)
+	})
+}

--- a/core/integration/workspace_migration_test.go
+++ b/core/integration/workspace_migration_test.go
@@ -735,7 +735,8 @@ type Myapp {
 		require.Contains(t, wsOut, `[modules.dagger-dang-sdk]`)
 		require.Contains(t, wsOut, `[sdks.dang.scopes."libs/foo"]`)
 		require.Contains(t, wsOut, `is-module = true`)
-		require.Contains(t, wsOut, `name = "foo"`)
+		// "foo" is the scope directory name, so it is inferred and not written.
+		require.NotContains(t, wsOut, `name = "foo"`)
 		// The runtime is resolved to its real ref, matching a generic SDK-module install,
 		// not left as the bare "dang" short name.
 		require.Contains(t, wsOut, `source = "github.com/dagger/dang-sdk"`)

--- a/core/integration/workspace_module_versions_test.go
+++ b/core/integration/workspace_module_versions_test.go
@@ -94,7 +94,8 @@ source = 'github.com/does/notexist/tools@v2'
 		require.Contains(t, string(out), `Matched installed module "tools" by source "github.com/does/notexist/tools".`)
 		data, err := os.ReadFile(filepath.Join(workdir, workspace.ConfigFileName))
 		require.NoError(t, err)
-		require.Equal(t, strings.Replace(config, "[modules.tools]\nsource = 'github.com/does/notexist/tools@v1'\n", "", 1), string(data))
+		// The blank line before the removed table goes with it.
+		require.Equal(t, strings.Replace(config, "\n[modules.tools]\nsource = 'github.com/does/notexist/tools@v1'\n", "", 1), string(data))
 	})
 	t.Run("source version does not select one of two installations", func(ctx context.Context, t *testctx.T) {
 		workdir := newWorkspaceConfigWorkdir(ctx, t, config+"\n[modules.older]\nsource = 'github.com/does/notexist/tools@v0'\n")

--- a/core/schema/workspace_sdk_module.go
+++ b/core/schema/workspace_sdk_module.go
@@ -223,29 +223,10 @@ func resolveSDKModuleInit(ws *core.Workspace, pathArg, nameArg string) (string, 
 // Default init records an entrypoint installation, which preserves its name
 // even when the SDK chooses a different directory for the module.
 func resolveSDKModuleName(ws *core.Workspace, cfg *workspace.Config, configDir, scopePath, name string) (string, error) {
-	if name == "" && cfg != nil && scopePath != "" {
-		var entrypoints []string
-		for installedName, entry := range cfg.Modules {
-			if !entry.Entrypoint || !workspace.IsLocalRef(entry.Source, entry.Pin) {
-				continue
-			}
-			sourcePath, err := workspace.ResolveSDKManagedPath(configDir, entry.Source)
-			if err != nil {
-				return "", fmt.Errorf("entrypoint module %q: %w", installedName, err)
-			}
-			if sourcePath == cleanWorkspaceRelPath(scopePath) {
-				entrypoints = append(entrypoints, installedName)
-			}
-		}
-		if len(entrypoints) > 1 {
-			sort.Strings(entrypoints)
-			return "", fmt.Errorf("module scope %q has multiple entrypoint names %q; set an explicit scope name", scopePath, entrypoints)
-		}
-		if len(entrypoints) == 1 {
-			name = entrypoints[0]
-		}
+	if name != "" {
+		return workspace.ModuleInitName(name, scopePath, configDir, workspaceRootDirectoryName(ws))
 	}
-	return workspace.ModuleInitName(name, scopePath, configDir, workspaceRootDirectoryName(ws))
+	return workspace.InferSDKModuleName(cfg, configDir, scopePath, workspaceRootDirectoryName(ws))
 }
 
 func workspaceRootDirectoryName(ws *core.Workspace) string {

--- a/core/schema/workspace_test.go
+++ b/core/schema/workspace_test.go
@@ -701,7 +701,8 @@ source = "github.com/acme/custom-go-sdk"
 		scope, ok := cfg.SDKs["go"].Scopes[filepath.ToSlash(filepath.Join("services", "api", "libs", "dep"))]
 		require.True(t, ok)
 		require.True(t, scope.IsModule)
-		require.Equal(t, "dep", scope.Name)
+		// "dep" matches the scope directory name, so it is inferred and not written.
+		require.Empty(t, scope.Name)
 	})
 }
 

--- a/core/workspace/config_edit.go
+++ b/core/workspace/config_edit.go
@@ -263,12 +263,75 @@ func (doc *configText) remove(parts []string) ([]byte, error) {
 	for i := len(doc.statements) - 1; i >= 0; i-- {
 		stmt := doc.statements[i]
 		if configPathPrefix(stmt.path, parts) {
-			out = replaceConfigText(out, stmt.start, stmt.end, "")
+			floor := 0
+			if i > 0 {
+				floor = doc.statements[i-1].end
+			}
+			start := stmt.start
+			if stmt.table {
+				start = configAttachedCommentStart(out, floor, start)
+			}
+			start, end := configRemovalSpan(out, floor, start, stmt.end)
+			out = replaceConfigText(out, start, end, "")
 		} else if !stmt.table && configPathPrefix(parts, stmt.path) {
 			return doc.editInline(stmt, parts[len(stmt.path):], nil, true)
 		}
 	}
 	return out, nil
+}
+
+// configRemovalSpan widens a removed statement over the blank lines around it.
+// Without this, each removed table leaves its separator behind, so removing
+// several tables leaves a run of blank lines. Blank lines on both sides become
+// one run; blank lines at either end of the document are dropped. floor is the
+// end of the preceding statement, and data after end may already be edited.
+func configRemovalSpan(data []byte, floor, start, end int) (int, int) {
+	before := start
+	for before > floor {
+		line := configLineStart(data, before-1)
+		if line < floor || len(bytes.TrimSpace(data[line:before])) != 0 {
+			break
+		}
+		before = line
+	}
+	after := end
+	for after < len(data) {
+		next := len(data)
+		if i := bytes.IndexByte(data[after:], '\n'); i >= 0 {
+			next = after + i + 1
+		}
+		if len(bytes.TrimSpace(data[after:next])) != 0 {
+			break
+		}
+		after = next
+	}
+	switch {
+	case before == 0 || after == len(data):
+		return before, after
+	case before < start && after > end:
+		return before, end
+	}
+	return start, end
+}
+
+// configAttachedCommentStart returns the start of the comment block directly
+// above a table heading, with no blank line between them. That block
+// documents the table, so it goes when the table goes. A block at the top of
+// the file stays, because it usually documents the whole file.
+func configAttachedCommentStart(data []byte, floor, start int) int {
+	block := start
+	for block > floor {
+		line := configLineStart(data, block-1)
+		text := bytes.TrimSpace(data[line:block])
+		if line < floor || len(text) == 0 || text[0] != '#' {
+			break
+		}
+		block = line
+	}
+	if len(bytes.TrimSpace(data[:block])) == 0 {
+		return start
+	}
+	return block
 }
 
 // Inline tables are edited through a temporary table body. Only the resulting

--- a/core/workspace/config_migrate_test.go
+++ b/core/workspace/config_migrate_test.go
@@ -73,7 +73,41 @@ func TestMigrateConfigBytes(t *testing.T) {
 		original := "# workspace\nignore = [\n  'node_modules', # keep\n]\nfuture = true\n\n[modules.dagger-go-sdk]\nsource = './sdk' # keep\npin = 'abc'\n\n[modules.dagger-go-sdk.as-sdk]\nname = 'golang'\n"
 		updated, err := MigrateConfigBytes([]byte(original), ".")
 		require.NoError(t, err)
-		require.Equal(t, strings.Replace(original, "[modules.dagger-go-sdk.as-sdk]\nname = 'golang'\n", "", 1)+"\n[sdks.golang]\nmodule = \"dagger-go-sdk\"\n", string(updated))
+		require.Equal(t, strings.Replace(original, "[modules.dagger-go-sdk.as-sdk]\nname = 'golang'\n", "", 1)+"[sdks.golang]\nmodule = \"dagger-go-sdk\"\n", string(updated))
+		again, err := MigrateConfigBytes(updated, ".")
+		require.NoError(t, err)
+		require.Equal(t, updated, again)
+	})
+
+	t.Run("removed SDK sections take their comment and leave one blank line", func(t *testing.T) {
+		original := `[modules.dagger-go-sdk]
+source = './sdk'
+
+# Legacy SDK roles.
+[modules.dagger-go-sdk.as-sdk]
+name = 'go'
+
+[[modules.dagger-go-sdk.as-sdk.modules]]
+path = 'a'
+
+[[modules.dagger-go-sdk.as-sdk.modules]]
+path = 'b'
+
+[modules.editor]
+source = './editor'
+`
+		updated, err := MigrateConfigBytes([]byte(original), ".")
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(string(updated), `[modules.dagger-go-sdk]
+source = './sdk'
+
+[modules.editor]
+source = './editor'
+
+[sdks.go]
+`), string(updated))
+		require.NotContains(t, string(updated), "\n\n\n")
+		require.False(t, strings.HasSuffix(string(updated), "\n\n"))
 		again, err := MigrateConfigBytes(updated, ".")
 		require.NoError(t, err)
 		require.Equal(t, updated, again)

--- a/core/workspace/config_preservation_test.go
+++ b/core/workspace/config_preservation_test.go
@@ -79,6 +79,14 @@ func TestConfigPreservation(t *testing.T) {
 		require.Equal(t, strings.Replace(preservationConfig, "entrypoint = false # keep this comment\n", "", 1), string(out))
 	})
 
+	t.Run("unset last setting removes its section and separator", func(t *testing.T) {
+		out, err := DeleteConfigValue([]byte(preservationConfig), `modules."my.module".settings."some.key"`)
+		require.NoError(t, err)
+		out, err = DeleteConfigValue(out, `modules."my.module".settings.empty`)
+		require.NoError(t, err)
+		require.Equal(t, strings.Replace(preservationConfig, "[modules.\"my.module\".settings]\n\"some.key\" = 'old' # setting notes\nempty = []\n\n", "", 1), string(out))
+	})
+
 	t.Run("SDK edit preserves other declarations", func(t *testing.T) {
 		cfg, err := ParseConfig([]byte(preservationConfig))
 		require.NoError(t, err)
@@ -133,6 +141,16 @@ func TestConfigPreservation(t *testing.T) {
 		parsed, err := ParseConfig(out)
 		require.NoError(t, err)
 		require.Equal(t, cfg, parsed)
+	})
+
+	t.Run("removal takes the comment attached to a removed module", func(t *testing.T) {
+		input := "# header\n\n[modules.kept]\nsource = './kept'\n\n# about old\n[modules.old]\nsource = './old'\n\n# separate\n\n[modules.last]\nsource = './last'\n"
+		cfg, err := ParseConfig([]byte(input))
+		require.NoError(t, err)
+		delete(cfg.Modules, "old")
+		out, err := UpdateConfigBytes([]byte(input), cfg)
+		require.NoError(t, err)
+		require.Equal(t, "# header\n\n[modules.kept]\nsource = './kept'\n\n# separate\n\n[modules.last]\nsource = './last'\n", string(out))
 	})
 
 	t.Run("removal includes unknown fields in removed module", func(t *testing.T) {

--- a/core/workspace/deptree_test.go
+++ b/core/workspace/deptree_test.go
@@ -50,8 +50,36 @@ func TestAddMigratedModuleSDK(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "go", entry.Source)
 		require.Equal(t, SDKEntry{Module: "dagger-go-sdk", Scopes: map[string]SDKScope{
-			"libs/foo": {IsModule: true, Name: "foo"},
+			"libs/foo": {IsModule: true},
 		}}, cfg.SDKs["go"])
+	})
+
+	t.Run("writes the name only when it differs from the directory name", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{}}
+		AddMigratedModuleSDK(cfg, "go", "libs/foo", "bar")
+		require.Equal(t, map[string]SDKScope{
+			"libs/foo": {IsModule: true, Name: "bar"},
+		}, cfg.SDKs["go"].Scopes)
+	})
+
+	t.Run("root scope infers the local entrypoint name", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{
+			"myapp": {Source: ".", Entrypoint: true},
+		}}
+		AddMigratedModuleSDK(cfg, "go", ".", "myapp")
+		require.Equal(t, map[string]SDKScope{
+			".": {IsModule: true},
+		}, cfg.SDKs["go"].Scopes)
+	})
+
+	t.Run("root scope without an entrypoint keeps its name", func(t *testing.T) {
+		cfg := &Config{Modules: map[string]ModuleEntry{
+			"myapp": {Source: "."},
+		}}
+		AddMigratedModuleSDK(cfg, "go", ".", "myapp")
+		require.Equal(t, map[string]SDKScope{
+			".": {IsModule: true, Name: "myapp"},
+		}, cfg.SDKs["go"].Scopes)
 	})
 
 	t.Run("shares one entry across modules with the same runtime", func(t *testing.T) {
@@ -60,8 +88,8 @@ func TestAddMigratedModuleSDK(t *testing.T) {
 		AddMigratedModuleSDK(cfg, "go", "libs/foo", "foo")
 		require.Len(t, cfg.Modules, 1)
 		require.Equal(t, map[string]SDKScope{
-			".dagger/modules/myapp": {IsModule: true, Name: "myapp"},
-			"libs/foo":              {IsModule: true, Name: "foo"},
+			".dagger/modules/myapp": {IsModule: true},
+			"libs/foo":              {IsModule: true},
 		}, cfg.SDKs["go"].Scopes)
 	})
 
@@ -80,7 +108,7 @@ func TestAddMigratedModuleSDK(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "github.com/acme/custom-sdk", entry.Source)
 		require.Equal(t, SDKEntry{Module: "custom-sdk", Scopes: map[string]SDKScope{
-			"libs/foo": {IsModule: true, Name: "foo"},
+			"libs/foo": {IsModule: true},
 		}}, cfg.SDKs["custom"])
 	})
 }

--- a/core/workspace/migrate.go
+++ b/core/workspace/migrate.go
@@ -68,7 +68,9 @@ func addMigratedModuleSDK(wsCfg *Config, sdkSource, preferredInstallName, module
 	}
 	scope := sdk.Scopes[modulePath]
 	scope.IsModule = true
-	scope.Name = migratedModuleName
+	if scope.Name == "" && migratedScopeNeedsName(wsCfg, modulePath, migratedModuleName) {
+		scope.Name = migratedModuleName
+	}
 	for _, client := range clients {
 		if !slices.Contains(scope.Clients, client) {
 			scope.Clients = append(scope.Clients, client)
@@ -76,6 +78,17 @@ func addMigratedModuleSDK(wsCfg *Config, sdkSource, preferredInstallName, module
 	}
 	sdk.Scopes[modulePath] = scope
 	wsCfg.SDKs[sdkName] = sdk
+}
+
+// migratedScopeNeedsName reports whether a migrated module keeps its name only
+// through an explicit scope name. The inferred name is not written, matching
+// module init: the scope directory name, or the installed name of the local
+// entrypoint at that path, already resolves to the module's name. Inference is
+// evaluated relative to the config directory, so a root scope with no
+// entrypoint cannot be inferred here and keeps its explicit name.
+func migratedScopeNeedsName(wsCfg *Config, modulePath, migratedModuleName string) bool {
+	inferred, err := InferSDKModuleName(wsCfg, ".", modulePath, "")
+	return err != nil || inferred != migratedModuleName
 }
 
 // RegisterMigratedModuleSDK adds the migrated module's scope without replacing

--- a/core/workspace/migrate_test.go
+++ b/core/workspace/migrate_test.go
@@ -331,7 +331,9 @@ func TestPlanMigrationWritesSDK(t *testing.T) {
 	require.Contains(t, configData, `module = "dagger-go-sdk"`)
 	require.Contains(t, configData, "[sdks.go.scopes.\".\"]")
 	require.Contains(t, configData, `is-module = true`)
-	require.Contains(t, configData, `name = "myapp"`)
+	// The scope is the entrypoint's source, so "myapp" is inferred at load
+	// time and is not written as an override.
+	require.NotContains(t, configData, `name = "myapp"`)
 }
 
 func TestMigrationSDKInstallName(t *testing.T) {

--- a/core/workspace/module_init.go
+++ b/core/workspace/module_init.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -35,6 +36,45 @@ func PlanModuleInit(explicitPath, explicitName bool, install, entrypoint *bool) 
 	plan.AutomaticInstall = plan.Install && install == nil && (entrypoint == nil || !*entrypoint)
 	plan.AutomaticEntrypoint = plan.Entrypoint && entrypoint == nil
 	return plan, nil
+}
+
+// InferSDKModuleName returns the name an unnamed module scope resolves to. A
+// scope that is the source of exactly one local entrypoint install takes that
+// installed name. Otherwise it takes the scope directory name, falling back to
+// a "-dev" name derived from configDir or rootName for a root scope. Multiple
+// matching entrypoint names are an error: such a scope needs an explicit name.
+func InferSDKModuleName(cfg *Config, configDir, scopePath, rootName string) (string, error) {
+	name := ""
+	if cfg != nil && scopePath != "" {
+		var entrypoints []string
+		for installedName, entry := range cfg.Modules {
+			if !entry.Entrypoint || !IsLocalRef(entry.Source, entry.Pin) {
+				continue
+			}
+			sourcePath, err := ResolveSDKManagedPath(configDir, entry.Source)
+			if err != nil {
+				return "", fmt.Errorf("entrypoint module %q: %w", installedName, err)
+			}
+			if sourcePath == cleanScopeRelPath(scopePath) {
+				entrypoints = append(entrypoints, installedName)
+			}
+		}
+		if len(entrypoints) > 1 {
+			sort.Strings(entrypoints)
+			return "", fmt.Errorf("module scope %q has multiple entrypoint names %q; set an explicit scope name", scopePath, entrypoints)
+		}
+		if len(entrypoints) == 1 {
+			name = entrypoints[0]
+		}
+	}
+	return ModuleInitName(name, scopePath, configDir, rootName)
+}
+
+func cleanScopeRelPath(p string) string {
+	if p == "" || p == "." {
+		return "."
+	}
+	return filepath.Clean(p)
 }
 
 // ModuleInitName infers a module name before the SDK chooses its default path.

--- a/docs/current_docs/config/migrate-dagger-json.mdx
+++ b/docs/current_docs/config/migrate-dagger-json.mdx
@@ -42,6 +42,16 @@ This will interpret your `dagger.json` as a workspace configuration, and transla
 | `toolchains` | Each installed toolchain is migrated as a 1.0 module (see "migrating a module") then installed in `dagger.toml`. Its customizations are converted to module settings, when possible |
 | `blueprint` | This field cannot be migrated |
 
+## Coding agents
+
+When Dagger detects that a coding agent is running `dagger workspace migrate` or `dagger module migrate`, it requires an explicit choice up front. Pass `-y` to apply the migration, or `--no-apply` to show the changes without writing them:
+
+```shell
+dagger workspace migrate --no-apply
+```
+
+Optional module candidates are skipped in both cases. Use `dagger module migrate PATH` to migrate one explicitly.
+
 ## Migration report
 
 After migration, a report is written to `.dagger/migration-report.md`. Read it to know which parts of your `dagger.json` may not have been successfully migrated.

--- a/docs/current_docs/config/migrate-dagger-json.mdx
+++ b/docs/current_docs/config/migrate-dagger-json.mdx
@@ -36,6 +36,8 @@ dagger workspace migrate
 
 This will interpret your `dagger.json` as a workspace configuration, and translate it to an equivalent `dagger.toml`.
 
+Each migrated module is registered as a scope of its SDK. The scope gets an explicit `name` only when the module's name differs from the name Dagger infers from the scope directory or its entrypoint installation. See the [`[sdks.<name>]` reference](../reference/config-files/dagger-toml.mdx#sdksname).
+
 | `dagger.json` field | Translation |
 | -- | -- |
 | `sdk` | Create a module at `.dagger/modules/<name>`, install it in `dagger.toml`, make it the workspace entrypoint |

--- a/internal/cmd/dagger/migrate.go
+++ b/internal/cmd/dagger/migrate.go
@@ -38,7 +38,7 @@ prompt, or --no-apply to preview without changing files.`,
 		Args:        cobra.NoArgs,
 		Annotations: map[string]string{showFinalProgressKey: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			disposition, err := workspaceExecDisposition(autoApply, noApply)
+			disposition, err := migrationDisposition(cmd, autoApply, noApply, idtui.RunningInAgent())
 			if err != nil {
 				return err
 			}
@@ -94,6 +94,22 @@ without a prompt, or --no-apply to preview without changing files.`
 	setCommandCapabilities(cmd, mayCallEngine, maySelectWorkspace, mayReadWorkspaceConfig, mayWriteWorkspaceConfig, mayProduceOutput, mayRenderPipeline)
 	setWorkspaceFlagPolicy(cmd)
 	return cmd
+}
+
+// migrationDisposition resolves the changeset choice for a migration command.
+// A coding agent cannot answer the interactive prompts, so it must choose
+// --auto-apply or --no-apply explicitly, as dagger generate already requires.
+func migrationDisposition(cmd *cobra.Command, apply, noApply, runningInAgent bool) (changesetDisposition, error) {
+	disposition, err := workspaceExecDisposition(apply, noApply)
+	if err != nil {
+		return disposition, err
+	}
+	if disposition == changesetDispositionPrompt && runningInAgent {
+		return disposition, fmt.Errorf(`%s requires an explicit changeset choice when run by a coding agent:
+  pass -y/--auto-apply to apply the migration
+  pass --no-apply to preview the migration without applying it`, cmd.CommandPath())
+	}
+	return disposition, nil
 }
 
 // runMigration presents an engine-owned plan and exports it only after approval.

--- a/internal/cmd/dagger/migrate_test.go
+++ b/internal/cmd/dagger/migrate_test.go
@@ -20,6 +20,38 @@ func TestMigrationCommands(t *testing.T) {
 	}
 }
 
+func TestMigrationDisposition(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		apply          bool
+		noApply        bool
+		runningInAgent bool
+		want           changesetDisposition
+		wantErr        string
+	}{
+		{name: "human prompt", want: changesetDispositionPrompt},
+		{name: "agent requires choice", runningInAgent: true, want: changesetDispositionPrompt, wantErr: "dagger workspace migrate requires an explicit changeset choice"},
+		{name: "agent apply", apply: true, runningInAgent: true, want: changesetDispositionApply},
+		{name: "agent no apply", noApply: true, runningInAgent: true, want: changesetDispositionNoApply},
+		{name: "human apply", apply: true, want: changesetDispositionApply},
+		{name: "human no apply", noApply: true, want: changesetDispositionNoApply},
+		{name: "conflicting choices", apply: true, noApply: true, want: changesetDispositionPrompt, wantErr: "cannot be used together"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := testRootCommand()
+			cmd, _, err := root.Find([]string{"workspace", "migrate"})
+			require.NoError(t, err)
+			got, err := migrationDisposition(cmd, tc.apply, tc.noApply, tc.runningInAgent)
+			require.Equal(t, tc.want, got)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestOptionalModuleCandidatesSkippedWithAutoApply(t *testing.T) {
 	old := autoApply
 	autoApply = true


### PR DESCRIPTION
Individual fixes found while running `dagger ws migrate` on the dagger repo with 1.0.0-beta.12. One fix per commit, each standalone.

## 1. Require an explicit changeset choice for migrate under coding agents

`dagger generate` already refuses to open the interactive apply prompt when a coding agent drives the CLI (`idtui.RunningInAgent`), because the agent cannot answer it and the command hangs. `dagger workspace migrate` and `dagger module migrate` had no such guard.

Both migrate commands now go through the same detector and fail early with the same guidance: pass `-y`/`--auto-apply` to apply, or `--no-apply` to preview.

## 2. Do not write inferred SDK scope names during migration

The `dagger.toml` reference says a module scope's `name` is only written as an override, and `module init` follows that. Migration always wrote the module name, so every migrated scope in a large workspace carried a redundant `name = "<dirname>"`.

The name inference moves into the workspace package as `InferSDKModuleName`, the schema resolver delegates to it, and migration writes the scope name only when it differs from the inferred name. A root scope that is not the entrypoint keeps its explicit name, since its inferred name depends on the workspace root. An existing explicit scope name is preserved.

## 3. Remove blank lines and stale comments left by removed config tables

When a `dagger.toml` edit removes a table, the blank line that separated it and the comment block directly above it stayed behind. On the dagger repo, migration removes 30 legacy `[modules.*.as-sdk]` tables and left 30 consecutive blank lines plus a stale TODO comment. `dagger config unset` had the same problem. The config text editor's remove function now drops the leading blank lines and the attached comment block, keeping a comment block at the top of the file.
