### PR TITLE
fix(workspace): reuse installed SDKs in migrate

### DIFF
--- a/.changes/unreleased/Fixed-20260911-224150.yaml
+++ b/.changes/unreleased/Fixed-20260911-224150.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Workspace migration reuses installed named SDK providers and their pins for unversioned module runtimes, including versioned and vanity SDK references.
+time: 2026-09-11T22:41:50.528026+00:00
+custom:
+    Author: vito

--- a/core/integration/workspace_migration_sdk_test.go
+++ b/core/integration/workspace_migration_sdk_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dagger/dagger/core/workspace"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+func (WorkspaceMigrationSuite) TestWorkspaceMigrateInstalledSDK(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	for _, source := range []string{"github.com/dagger/dang-sdk@v0.1", "dagger.io/sdk/dang@v1"} {
+		t.Run(source, func(ctx context.Context, t *testctx.T) {
+			original := fmt.Sprintf(`[modules.app]
+source = './app'
+[modules.provider]
+source = %q
+[modules.provider.as-sdk]
+name = 'dang'
+[[modules.provider.as-sdk.modules]]
+path = 'app'
+`, source)
+			module := "name = 'app'\n[runtime]\nsource = 'dang'\n"
+			base := workspaceBase(t, c).
+				WithNewFile("dagger.toml", original).
+				WithNewFile("app/dagger-module.toml", module)
+			preview := base.With(daggerExec("ws", "migrate", "--no-apply"))
+			unchanged, err := preview.File("dagger.toml").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, original, unchanged)
+
+			applied := preview.With(daggerExec("ws", "migrate", "--auto-apply"))
+			updated, err := applied.File("dagger.toml").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, updated, "as-sdk")
+			cfg, err := workspace.ParseConfig([]byte(updated))
+			require.NoError(t, err)
+			require.Len(t, cfg.Modules, 2)
+			require.Len(t, cfg.SDKs, 1)
+			require.Equal(t, source, cfg.Modules["provider"].Source)
+			require.Equal(t, "provider", cfg.SDKs["dang"].Module)
+			require.True(t, cfg.SDKs["dang"].Scopes["app"].IsModule)
+			unchanged, err = applied.File("app/dagger-module.toml").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, module, unchanged)
+
+			again := applied.With(daggerExec("ws", "migrate", "--auto-apply"))
+			repeated, err := again.File("dagger.toml").Contents(ctx)
+			require.NoError(t, err)
+			require.Equal(t, updated, repeated)
+		})
+	}
+}

--- a/core/schema/workspace_migrate_modules.go
+++ b/core/schema/workspace_migrate_modules.go
@@ -571,7 +571,16 @@ func (p *moduleMigrationPlanner) registerSDK(dir string, cfg *modules.ModuleConf
 	preferredInstallName := ""
 	base, version, _ := strings.Cut(sdkSource, "@")
 	if !strings.ContainsAny(base, "/\\") {
-		if resolved, installName, _, err := sdkmeta.ResolveInstall(base); err == nil {
+		if _, installed := p.config.SDKs[base]; installed && version == "" {
+			// An unversioned runtime name selects the workspace's named SDK.
+			// Preserve its provider and pin instead of resolving the name again
+			// through the registry and conflicting with its existing scopes.
+			_, _, source, err := installedSDKSource(p.config, base)
+			if err != nil {
+				return fmt.Errorf("resolve installed SDK for %s: %w", dir, err)
+			}
+			sdkSource = source
+		} else if resolved, installName, _, err := sdkmeta.ResolveInstall(base); err == nil {
 			sdkSource = resolved
 			preferredInstallName = installName
 			if version != "" {

--- a/core/schema/workspace_migrate_modules_test.go
+++ b/core/schema/workspace_migrate_modules_test.go
@@ -29,6 +29,54 @@ func testModuleMigrationPlanner(t *testing.T, files map[string]string) *moduleMi
 	return p
 }
 
+func TestModuleMigrationUsesInstalledSDK(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		source  string
+		pin     string
+		runtime string
+		owner   string
+		wantErr bool
+	}{
+		{name: "versioned provider", source: "github.com/dagger/dang-sdk@v0.1", runtime: "dang", owner: "dang"},
+		{name: "vanity provider", source: "dagger.io/sdk/dang@v1", runtime: "dang", owner: "dang"},
+		{name: "pinned provider", source: "github.com/dagger/dang-sdk", pin: "abc123", runtime: "dang", owner: "dang"},
+		{name: "custom named SDK", source: "./sdk", runtime: "custom", owner: "custom"},
+		{name: "explicit version conflicts", source: "github.com/dagger/dang-sdk@v0.1", runtime: "dang@v2", owner: "dang", wantErr: true},
+		{name: "different owner conflicts", source: "github.com/dagger/go-sdk@v1", runtime: "dang", owner: "go", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, native := range []bool{false, true} {
+				t.Run(fmt.Sprintf("native=%t", native), func(t *testing.T) {
+					filename := "app/dagger.json"
+					data := fmt.Sprintf(`{"name":"app","sdk":%q}`, tc.runtime)
+					if native {
+						filename = "app/dagger-module.toml"
+						data = fmt.Sprintf("name = 'app'\n[runtime]\nsource = %q\n", tc.runtime)
+					}
+					p := testModuleMigrationPlanner(t, map[string]string{filename: data})
+					provider := workspace.ModuleEntry{Source: tc.source, Pin: tc.pin}
+					p.config.Modules = map[string]workspace.ModuleEntry{"provider": provider}
+					p.config.SDKs = map[string]workspace.SDKEntry{tc.owner: {
+						Module: "provider", Scopes: map[string]workspace.SDKScope{
+							"app": {IsModule: true, Name: "app", Clients: []string{"./existing-client"}},
+						},
+					}}
+					err := p.module("app", false, true)
+					if tc.wantErr {
+						require.ErrorContains(t, err, "belongs to SDK")
+					} else {
+						require.NoError(t, err)
+					}
+					require.Equal(t, map[string]workspace.ModuleEntry{"provider": provider}, p.config.Modules)
+					require.Len(t, p.config.SDKs, 1)
+					require.Equal(t, []string{"./existing-client"}, p.config.SDKs[tc.owner].Scopes["app"].Clients)
+				})
+			}
+		})
+	}
+}
+
 func TestModuleMigrationGraph(t *testing.T) {
 	p := testModuleMigrationPlanner(t, map[string]string{
 		"a/dagger.json":        `{"name":"a","sdk":"github.com/acme/sdk@v1","dependencies":[{"name":"b","source":"../b"},{"name":"c","source":"../c"}]}`,


### PR DESCRIPTION
`dagger ws migrate` fails when a module uses an unversioned runtime such as `dang` and its existing SDK scope belongs to an installed versioned or vanity provider:

```text
scope ".dagger/modules/changelog" belongs to SDK "dang"
(github.com/dagger/dang-sdk@v0.1), not github.com/dagger/dang-sdk
```

Migration was resolving the runtime through the registry again, losing the workspace's installed provider identity. Resolve an unversioned named runtime through the installed SDK first, preserving its source and pin. Explicit version and conflicting scope ownership checks remain enforced.

This also handles `dagger.io/sdk/dang@v1` from #14119. I checked #14127's current dogfooding fixes; this addresses a separate provider-resolution failure and is based directly on main.

Validation:

- Regression tests reproduced the reported failure before the fix for native and legacy module configs.
- [Focused schema tests passed](https://dagger.cloud/dagger/traces/d6161c81bc0923f711bffdb138a0f273), covering versioned, vanity, pinned, and custom providers plus version and ownership conflicts.
- [CLI integration tests passed](https://dagger.cloud/dagger/traces/6c9e417074fc6f4e597119bb605aa3cf), covering preview, apply, idempotence, and the existing native-config migration cases.
