### PR TITLE
fix(workspace): migrate modules registered only as SDK scopes

### DIFF
--- a/.changes/unreleased/Fixed-20260911-231500.yaml
+++ b/.changes/unreleased/Fixed-20260911-231500.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Workspace migration now converts local modules registered only as SDK module scopes, recording their name and clients, instead of reaching only installed modules and their dependencies.
+time: 2026-09-11T23:15:00.000000+00:00
+custom:
+    Author: grouville

--- a/core/integration/workspace_migration_config_test.go
+++ b/core/integration/workspace_migration_config_test.go
@@ -123,3 +123,46 @@ arbitrary = { nested = true }
 	require.NoError(t, err)
 	require.Equal(t, original, unchanged)
 }
+
+// TestWorkspaceMigrateSDKScopeOnlyModule covers a module that the workspace
+// reaches only through an SDK's module list: no [modules.*] install entry
+// points at it and no installed module depends on it. Migration must still
+// convert it and record its name and clients on the scope.
+func (WorkspaceMigrationSuite) TestWorkspaceMigrateSDKScopeOnlyModule(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	original := `[modules.dagger-custom-sdk]
+source = './sdk'
+
+[modules.dagger-custom-sdk.as-sdk]
+name = 'custom'
+[[modules.dagger-custom-sdk.as-sdk.modules]]
+path = './tools/reporter'
+`
+	applied := workspaceBase(t, c).
+		WithNewFile("dagger.toml", original).
+		WithNewFile("sdk/dagger-module.toml", "name = 'custom-sdk'\n").
+		WithNewFile("tools/reporter/dagger.json", `{"name":"reporter","sdk":"../../sdk","dependencies":[{"name":"helper","source":"../helper"}]}`).
+		WithNewFile("tools/helper/dagger.json", `{"name":"helper","sdk":"../../sdk"}`).
+		With(daggerExec("ws", "migrate", "--auto-apply"))
+
+	out, err := applied.CombinedOutput(ctx)
+	require.NoError(t, err, out)
+
+	updated, err := applied.File("dagger.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, updated, "as-sdk")
+	cfg, err := workspace.ParseConfig([]byte(updated))
+	require.NoError(t, err)
+	scope := cfg.SDKs["custom"].Scopes["./tools/reporter"]
+	require.True(t, scope.IsModule)
+	require.Equal(t, "reporter", scope.Name, updated)
+	require.Equal(t, []string{"./tools/helper"}, scope.Clients, updated)
+
+	native, err := applied.File("tools/reporter/dagger-module.toml").Contents(ctx)
+	require.NoError(t, err)
+	require.Contains(t, native, `name = "reporter"`)
+	_, err = applied.File("tools/reporter/dagger.json").Contents(ctx)
+	require.Error(t, err)
+	_, err = applied.File("tools/helper/dagger-module.toml").Contents(ctx)
+	require.NoError(t, err)
+}

--- a/core/schema/workspace_migrate_modules.go
+++ b/core/schema/workspace_migrate_modules.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -294,6 +296,42 @@ func (p *moduleMigrationPlanner) requiredModules(convertedModules []string) erro
 		}
 		if err := p.module(dir, false, true); err != nil {
 			return fmt.Errorf("required installed module %q (%s): %w", name, source, err)
+		}
+	}
+	return p.requiredSDKScopeModules()
+}
+
+// requiredSDKScopeModules visits every local module an SDK manages. A module
+// registered only as an SDK module scope is reached by neither an install entry
+// nor a dependency edge, so without this it keeps an is-module scope with no
+// name and no clients, and its legacy config is never converted.
+func (p *moduleMigrationPlanner) requiredSDKScopeModules() error {
+	if p.config == nil {
+		return nil
+	}
+	configDir := path.Dir(p.configPath)
+	for _, sdkName := range slices.Sorted(maps.Keys(p.config.SDKs)) {
+		scopes := p.config.SDKs[sdkName].Scopes
+		for _, key := range slices.Sorted(maps.Keys(scopes)) {
+			if !scopes[key].IsModule {
+				continue
+			}
+			dir, err := workspace.ResolveSDKManagedPath(configDir, key)
+			if err != nil {
+				return fmt.Errorf("SDK %q module scope %q: %w", sdkName, key, err)
+			}
+			if p.visited[dir] {
+				continue
+			}
+			if !p.files[path.Join(dir, workspace.LegacyModuleConfigFileName)] &&
+				!p.files[path.Join(dir, workspace.ModuleConfigFileName)] {
+				// A stale scope must not block the rest of the migration.
+				p.warnings = append(p.warnings, fmt.Sprintf("SDK %q declares module scope %q, but %s has no module configuration; its module name and clients were not recorded.", sdkName, key, dir))
+				continue
+			}
+			if err := p.module(dir, false, true); err != nil {
+				return fmt.Errorf("required SDK %q module scope %q (%s): %w", sdkName, key, dir, err)
+			}
 		}
 	}
 	return nil

--- a/core/schema/workspace_migrate_modules_test.go
+++ b/core/schema/workspace_migrate_modules_test.go
@@ -279,3 +279,63 @@ func TestModuleMigrationCleansEveryConvertedModule(t *testing.T) {
 	require.NoError(t, p.module("app", true, false))
 	require.Len(t, cleaned, 2)
 }
+
+func TestModuleMigrationVisitsSDKScopeModules(t *testing.T) {
+	p := testModuleMigrationPlanner(t, map[string]string{
+		"tools/dagger.json": `{"name":"tools","sdk":"github.com/acme/sdk@v1","dependencies":[{"name":"dep","source":"../dep"}]}`,
+		"dep/dagger.json":   `{"name":"dep","sdk":"go"}`,
+	})
+	p.config.Modules = map[string]workspace.ModuleEntry{"acme-sdk": {Source: "github.com/acme/sdk@v1"}}
+	p.config.SDKs = map[string]workspace.SDKEntry{"acme": {
+		Module: "acme-sdk",
+		Scopes: map[string]workspace.SDKScope{"tools": {IsModule: true}},
+	}}
+	require.NoError(t, p.requiredModules(nil))
+	require.Equal(t, "tools", p.config.SDKs["acme"].Scopes["tools"].Name)
+	require.Equal(t, []string{"./dep"}, p.config.SDKs["acme"].Scopes["tools"].Clients)
+	require.Contains(t, p.writes, "tools/dagger-module.toml")
+	require.Contains(t, p.writes, "dep/dagger-module.toml")
+}
+
+func TestModuleMigrationSDKScopeWithoutModuleConfigWarns(t *testing.T) {
+	p := testModuleMigrationPlanner(t, nil)
+	p.config.Modules = map[string]workspace.ModuleEntry{"acme-sdk": {Source: "github.com/acme/sdk@v1"}}
+	p.config.SDKs = map[string]workspace.SDKEntry{"acme": {
+		Module: "acme-sdk",
+		Scopes: map[string]workspace.SDKScope{"gone": {IsModule: true}},
+	}}
+	require.NoError(t, p.requiredModules(nil))
+	require.Empty(t, p.writes)
+	require.Len(t, p.warnings, 1)
+	require.Contains(t, p.warnings[0], `SDK "acme" declares module scope "gone"`)
+}
+
+func TestModuleMigrationSDKScopeSkipsNonModuleScopes(t *testing.T) {
+	p := testModuleMigrationPlanner(t, map[string]string{
+		"client/dagger.json": `{"name":"client","sdk":"go"}`,
+	})
+	p.config.Modules = map[string]workspace.ModuleEntry{"acme-sdk": {Source: "github.com/acme/sdk@v1"}}
+	p.config.SDKs = map[string]workspace.SDKEntry{"acme": {
+		Module: "acme-sdk",
+		Scopes: map[string]workspace.SDKScope{"client": {Clients: []string{"./lib"}}},
+	}}
+	require.NoError(t, p.requiredModules(nil))
+	require.Empty(t, p.writes)
+	require.Empty(t, p.warnings)
+	require.Empty(t, p.config.SDKs["acme"].Scopes["client"].Name)
+}
+
+func TestModuleMigrationSDKScopeFailureStopsMigration(t *testing.T) {
+	p := testModuleMigrationPlanner(t, map[string]string{
+		"tools/dagger.json": `{"name":"tools","sdk":{"source":"go","debug":true}}`,
+	})
+	p.config.Modules = map[string]workspace.ModuleEntry{"acme-sdk": {Source: "github.com/acme/sdk@v1"}}
+	p.config.SDKs = map[string]workspace.SDKEntry{"acme": {
+		Module: "acme-sdk",
+		Scopes: map[string]workspace.SDKScope{"./tools": {IsModule: true}},
+	}}
+	err := p.requiredModules(nil)
+	require.ErrorContains(t, err, `required SDK "acme" module scope "./tools" (tools)`)
+	require.ErrorContains(t, err, "deprecated SDK settings")
+	require.Empty(t, p.writes)
+}


### PR DESCRIPTION
**What's wrong**

`dagger ws migrate` finds the modules to convert by starting from the ones listed under `[modules.*]` and following their dependencies. Anything the walk reaches that way gets converted. Anything it can't reach gets skipped: its old `dagger.json` is left untouched, no new config file is written, and its entry in `dagger.toml` ends up with `is-module = true` but no name.

A skipped module still shows up in the list of optional candidates, so nothing is lost. With an interactive run you get asked about it. With `--auto-apply` or in CI it just stays unconverted.

**When it happens**

The walk reaches a module in two ways: it is listed under `[modules.*]`, or something listed there depends on it. Almost every module in a workspace comes in through one of those doors. In this repo, of the 28 modules listed under an SDK, 27 do.

The one exception is a module that comes in through a third door only: it is listed under an SDK, in the old `as-sdk.modules` list or as a scope with `is-module = true`, and that is the only place it appears. Nothing installs it, nothing depends on it. In this repo that is `.dagger/modules/dotnet-client-dev`. The walk has no door for it.

For the skip to cost anything, the module also still has to have an old `dagger.json`. A module that already has the new config file loses nothing by being skipped, and a scope with no name is normal for a module registered that way.

The third door is a normal one, not a mistake. `dagger sdk module init --path <dir>` creates a module listed under an SDK with no `[modules.*]` entry, on purpose. Those modules already have the new config file though, so there is nothing to convert. The people most likely to hit this are migrating from the beta `as-sdk` config and listed a module there without installing it.

**What this does**

Give the walk a third door: also start from the modules listed under each SDK. If one of those points at a folder with no module config at all, print a warning and keep going instead of stopping the whole migration.

Works together with #14129. With both applied, migrating this repo's own `dagger.toml` gives every module its name.
