### PR TITLE
cli: fix setup prompts hanging after the TUI exits

### DIFF
--- a/.changes/unreleased/Fixed-20260911-170000.yaml
+++ b/.changes/unreleased/Fixed-20260911-170000.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: The plain-text prompts `dagger ws migrate` and `dagger init` ask after the TUI closes, such as "Run this command? [Y/n]" before enabling Cloud checks, now accept input. They previously ignored every keystroke because the TUI's stdin reader kept consuming and discarding it.
+time: 2026-09-11T17:00:00.000000+00:00
+custom:
+    Author: grouville

--- a/core/integration/setup_prompt_tui_test.go
+++ b/core/integration/setup_prompt_tui_test.go
@@ -58,7 +58,6 @@ func (WorkspaceSuite) TestSetupPromptReadsInputAfterTUI(ctx context.Context, t *
 	// The TUI is gone now; this prompt reads stdin directly.
 	_, err = console.ExpectString("Run this command? [Y/n]")
 	require.NoError(t, err)
-	time.Sleep(300 * time.Millisecond)
 	_, err = console.SendLine("n")
 	require.NoError(t, err)
 

--- a/core/integration/setup_prompt_tui_test.go
+++ b/core/integration/setup_prompt_tui_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"os/exec"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/dagger/testctx"
+	"github.com/stretchr/testify/require"
+)
+
+// The setup flow asks its last questions as plain text after the TUI has
+// closed. The TUI's terminal keeps reading stdin for the life of the process,
+// so those prompts must read through it; reading os.Stdin directly never
+// returns. Only a real pty exercises this.
+func (WorkspaceSuite) TestSetupPromptReadsInputAfterTUI(ctx context.Context, t *testctx.T) {
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"remote", "add", "origin", "https://github.com/example/project.git"},
+	} {
+		git := exec.Command("git", args...)
+		git.Dir = repo
+		out, err := git.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	console, err := newTUIConsole(t, 60*time.Second)
+	require.NoError(t, err)
+	defer console.Close()
+
+	tty := console.Tty()
+	require.NoError(t, pty.Setsize(tty, &pty.Winsize{Rows: 40, Cols: 120}))
+
+	cmd := hostDaggerCommand(ctx, t, repo, "--progress=tty", "init")
+	// No Cloud credentials, so enabling checks stops at the signup prompt.
+	cmd.Env = append(cmd.Env, "HOME="+t.TempDir(), "XDG_CONFIG_HOME="+t.TempDir(), "DAGGER_CLOUD_TOKEN=")
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+	require.NoError(t, cmd.Start())
+
+	// Forms inside the TUI: Enter takes the preselected Skip; left arrow
+	// moves to Run.
+	_, err = console.ExpectString("Find and install suitable modules?")
+	require.NoError(t, err)
+	time.Sleep(300 * time.Millisecond)
+	_, err = console.Send("\r")
+	require.NoError(t, err)
+
+	_, err = console.ExpectString("Enable cloud checks?")
+	require.NoError(t, err)
+	time.Sleep(300 * time.Millisecond)
+	_, err = console.Send("\x1b[D\r")
+	require.NoError(t, err)
+
+	// The TUI is gone now; this prompt reads stdin directly.
+	_, err = console.ExpectString("Run this command? [Y/n]")
+	require.NoError(t, err)
+	time.Sleep(300 * time.Millisecond)
+	_, err = console.SendLine("n")
+	require.NoError(t, err)
+
+	_, err = console.ExpectString("Complete the prerequisite")
+	require.NoError(t, err, "the prompt never read the answer")
+
+	go console.ExpectEOF()
+	require.Error(t, cmd.Wait(), "declining the prerequisite exits non-zero")
+}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -92,6 +92,9 @@ type frontendPretty struct {
 	consoleMu sync.Mutex
 
 	// updated by Run
+	term        tuist.Terminal
+	termStopped bool
+	termStdin   io.Reader
 	tui         *tuist.TUI
 	run         func(context.Context) (cleanups.CleanupF, error)
 	runCtx      context.Context
@@ -889,6 +892,7 @@ func newWithTerminalProfile(w io.Writer, db *dagui.DB, term tuist.Terminal, prof
 		rows:     &dagui.Rows{BySpan: map[dagui.SpanID]*dagui.TraceRow{}},
 
 		// initial TUI state
+		term:          term,
 		tui:           tui,
 		spinnerEpoch:  time.Now(),
 		window:        windowSize{Width: -1, Height: -1}, // be clear that it's not set
@@ -1966,6 +1970,7 @@ func (fe *frontendPretty) runWithTUI(ctx context.Context, run func(context.Conte
 		select {
 		case <-fe.quit:
 			fe.tui.Stop()
+			fe.termStopped = true
 
 			// if the ctx was canceled, we don't need to return whatever random garbage
 			// error string we got back; just return the ctx err.
@@ -2396,6 +2401,27 @@ func (fe FrontendMetricExporter) Aggregation(ik sdkmetric.InstrumentKind) sdkmet
 
 func (fe FrontendMetricExporter) ForceFlush(context.Context) error {
 	return nil
+}
+
+// TerminalStdin is implemented by frontends whose terminal keeps the only
+// reader on stdin after they stop.
+type TerminalStdin interface {
+	Stdin() io.Reader
+}
+
+// Stdin returns the input the terminal reader forwards. tuist's reader lives
+// for the process and discards input once the TUI stops, so a prompt reading
+// os.Stdin after Run never sees a key.
+func (fe *frontendPretty) Stdin() io.Reader {
+	if !fe.termStopped {
+		return os.Stdin
+	}
+	if fe.termStdin == nil {
+		pr, pw := io.Pipe()
+		fe.term.SetInputPassthrough(pw)
+		fe.termStdin = pr
+	}
+	return fe.termStdin
 }
 
 func (fe *frontendPretty) Background(cmd ExecCommand, raw bool) error {

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/internal/cmd/dagger/llmconfig"
 	telemetry "github.com/dagger/otel-go"
 	"github.com/mattn/go-isatty"
@@ -194,7 +195,7 @@ func confirm(cmd *cobra.Command, question string) bool {
 	}
 	done := make(chan readResult, 1)
 	go func() {
-		reader := bufio.NewReader(cmd.InOrStdin())
+		reader := bufio.NewReader(promptInput(cmd))
 		line, err := reader.ReadString('\n')
 		done <- readResult{line: line, err: err}
 	}()
@@ -212,4 +213,18 @@ func confirm(cmd *cobra.Command, question string) bool {
 		line := strings.TrimSpace(strings.ToLower(r.line))
 		return line == "" || line == "y" || line == "yes"
 	}
+}
+
+// promptInput is stdin for prompts that run after the TUI. Its terminal keeps
+// the only reader on stdin and discards input once stopped, so read what it
+// forwards instead.
+func promptInput(cmd *cobra.Command) io.Reader {
+	in := cmd.InOrStdin()
+	if in != os.Stdin {
+		return in
+	}
+	if fe, ok := Frontend.(idtui.TerminalStdin); ok {
+		return fe.Stdin()
+	}
+	return in
 }

--- a/internal/cmd/dagger/setup.go
+++ b/internal/cmd/dagger/setup.go
@@ -187,6 +187,8 @@ func confirm(cmd *cobra.Command, question string) bool {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s [skipped: non-interactive — use --auto-apply to accept]\n", question)
 		return false
 	}
+	// Install the TUI passthrough before advertising that input is accepted.
+	in := promptInput(cmd)
 	fmt.Fprintf(cmd.OutOrStdout(), "%s [Y/n] ", question)
 
 	type readResult struct {
@@ -195,7 +197,7 @@ func confirm(cmd *cobra.Command, question string) bool {
 	}
 	done := make(chan readResult, 1)
 	go func() {
-		reader := bufio.NewReader(promptInput(cmd))
+		reader := bufio.NewReader(in)
 		line, err := reader.ReadString('\n')
 		done <- readResult{line: line, err: err}
 	}()


### PR DESCRIPTION
**What's wrong**

`dagger ws migrate` and `dagger init` run their offers inside the TUI, then ask a couple of follow-up questions as plain text once the TUI has closed. Say **Run** to "Enable cloud checks?" and you land here:

```
✔ Selected command:
┃   dagger cloud checks on

Run:
dagger cloud checks on

Connect this repository to Dagger Cloud in the browser?

dagger cloud integration create github --open

Run this command? [Y/n] n        ← y, n, Enter, Ctrl-J: nothing happens
```

The only way out is Ctrl-C. It reproduces on `v1.0.0-beta.12` and on `main`, in an ordinary terminal, and it looks like `dagger cloud checks on` hanging, which is how it gets reported.

**Why it happens**

It is not a hang in the command and not a terminal mode problem. It is two readers on one stdin.

tuist, the toolkit behind the pretty frontend, starts a goroutine that reads stdin for the whole life of the process. Its own comment says so: *"This goroutine lives for the process lifetime."* Stopping the TUI does not stop it. `Stop()` just points its output at nil, which the interface doc describes as *"discard subsequent input"*. So once the TUI is gone, every keystroke is still read by tuist and thrown away. `confirm()` reads `os.Stdin` too, which puts it behind that goroutine on the file's read lock. It never gets a byte.

```
  keyboard ──► tty ──► os.Stdin ──► tuist readStdin ──► sink = nil   (discarded)
                                        │
                                        │ holds the fd read lock
                                        ▼
                                    confirm()  ──► waits on the lock, forever
```

The forms that run *inside* the TUI were never affected. They get their input through that same reader. That was the clue that pointed at the reader rather than at `confirm()`. A SIGQUIT dump at the stuck prompt shows the pair: `tuist.(*StdTerminal).readStdin` in `syscall.read` on `os.Stdin`, and `daggercmd.confirm` in `internal/poll.(*fdMutex).rwlock` on the same `*os.File`.

**What this does**

Read from the reader instead of competing with it. tuist's `Terminal` has `SetInputPassthrough(w)` for exactly this; `TUI.Exec` already uses it to hand stdin to a foreground process. The pretty frontend now exposes it as `Stdin()`: `os.Stdin` while the TUI runs, and afterwards the read end of a pipe installed once as the passthrough. `confirm()` reads from that when stdin is the terminal and the frontend implements the new `TerminalStdin` interface. A `cmd.SetIn` from tests still wins, and the plain, report and other frontends do not implement it, so nothing changes for them.

```
  keyboard ──► tty ──► os.Stdin ──► tuist readStdin ──► passthrough pipe ──► confirm()
```

```
Run this command? [Y/n] n
Cloud checks need GitHub access to this repository.
Complete the prerequisite, then retry:

dagger cloud integration create github
dagger cloud checks on
```

Moving the prompts inside the TUI would also work, but it pulls the browser login and the GitHub handoff, which print to stderr and wait on a browser, under the TUI's screen. Starting a second TUI after the first has the same stdin problem: it renders but never sees a key. Fixing the reader's lifetime in tuist is the cleaner long-term answer, but a blocking read on a tty cannot be cancelled without restructuring that reader, and the passthrough is the API tuist offers today.

**How to reproduce**

Checked with a scripted pseudo-terminal that drives the forms with arrow keys and Enter, then writes `n\r` at the prompt: the process stayed blocked before and now exits with the prerequisite message. With `y\r` it reaches the GitHub prompt and reads it through the same pipe. `tcgetattr` at the prompt reports `ICANON`, `ECHO` and `ICRNL` set, ruling out a raw-mode or line-ending cause.

**Test**

`TestWorkspace/TestSetupPromptReadsInputAfterTUI` drives `dagger init` on a pty with go-expect, the way `TestInteractiveFinalRenderEmitsProgress` does: skip the module recommendation, accept "Enable cloud checks?", answer `n` at the `[Y/n]` prompt, expect the prerequisite message. Against `main` it fails on that last expectation after the 60 second timeout (`the prompt never read the answer`); with the fix it finishes in a few seconds.
